### PR TITLE
fmtowns_cd.xml: serials, 6 new dumps, 7 replacements

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -16,7 +16,6 @@ Items with * are in the list, but are bad dumps or incomplete.
 TODO:
 
 - Confirm if the "Car Marty Exciting CD" is the same thing as the "Exciting CD" alredy in the list.
-- Is "Ms. Detective File #1" the Marty-compatible edition or not? Keeping both for now.
 
                             Title                                         Publisher             Release date  Media
 4D Boxing (Marty compatible)                                  Electronic Arts Victor            1993/7     CD
@@ -89,7 +88,6 @@ Computer Zukan: Shokubutsu-hen CD-ROM-ban                     Ratio Internationa
 Config Rom                                                    Glams                             1995/12    CD
 Cover Girls Vol. 1                                            Janis                             1994/2     CD
 Crayonnage                                                    CSK Research Institute (CRI)      1991/8     SET(CD+FD)
-CRI 5-kan Pack                                                CSK Research Institute (CRI)      1994/11    CD
 CRI Postman                                                   CSK Research Institute (CRI)      1990/3     CD
 CRI StacCard                                                  CSK Research Institute (CRI)      1991/5     SET(CD+FD)
 Criss                                                         CSK Research Institute (CRI)      1989/7     CD
@@ -155,7 +153,6 @@ Dynamic English 3B Pack                                       DynEd Japan       
 Dynamic English 3B Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
 Dynamic English 3C Pack                                       DynEd Japan                       1992/2     SET(CD+FD)
 E to Oto ga Deru Ongaku Yougo Jiten                           Rittor Music                      1992/4     SET(CD+FD)
-Ed Bogas' Music Machine                                       Fujitsu                           1993/11    CD
 Ed Bogas' Music Machine (Marty-compatible)                    Fujitsu                           1994/4     CD
 Ehon Writer Pro                                               Fujitsu                           1995/5     CD
 Ehon Writer V1.1                                              Fujitsu                           1993/12    CD
@@ -259,7 +256,6 @@ High School War                                               ISC               
 Hiragana no Ehon                                              Fujitsu Ooita Software Laboratory 1993/8     CD
 Hirou                                                         Toshiba EMI                       1989/11    CD
 HomeSTUDIO V1.1                                               Fujitsu                           1992/12    SET(CD+FD)
-HomeSTUDIO V1.2                                               Fujitsu                           1994/2     SET(CD+FD)
 Hot de Art na Barcelona                                       Media Art                         1991/9     CD
 Hyoutan Shima Kouryaku-ki                                     Nihon Dennou Koubou               1994/?     ?
 Hyper Address Ver. 2.0                                        Datt Japan                        1991/4     SET(CD+FD)
@@ -351,7 +347,6 @@ Kazu ya Kimi Tashizan / Hikizan Hen                           Media Art         
 Kenkyuusha Readers Eiwa CD-ROM                                Fujitsu                           1993/2     CD
 Kerokero Keroppi to Origami no Tabibito                       Fujitsu Parex                     1995/7     CD
 Kid Pix Companion                                             Fujitsu Parex                     1995/3     CD
-Kid Pix Jr.                                                   Fujitsu                           1993/3     CD
 Kikai Jikake no Marian                                        Janis                             1994/8     CD
 Kikou Shidan 2                                                Artdink                           1993/3     SET(CD+FD)
 Kitty Town no Nakama-tachi: Tanoshii Seikatsuka               Fujitsu Parex                     1995/10    CD
@@ -414,8 +409,7 @@ Monster Planet 2255                                           Nihon Media Progra
 Moon Crystal                                                  Orange House                      1992/6     ?
 Moonlight Energy                                              Interheart                        1992/12    CD
 Mori no Ninkimono                                             Fujitsu Social Science Laboratory 1993/12    CD
-Ms. Detective File #1: Iwami Ginzan Satsujin Jiken            Data West                         1992/9     CD×02
-Ms. Detective File #1: Iwami Ginzan Satsujin Jiken (Marty compatible)   Data West                         1992/9     CD×02
+* Ms. Detective File #1: Iwami Ginzan Satsujin Jiken (Marty compatible)   Data West                         1992/9     CD×02
 * Ms. Detective File #2: Sugata-naki Irainin                  Data West                         1993/10    SET(CD+FD)
 Multimedia Nihon no Rekishi Dai-1-Shou: Kariya-ryou no Kurashi  Tokyo Shoseki                     ?          CD
 Multimedia Nihon no Rekishi Dai-2-Shou: Kome-zukuri no Mura kara Kofun no Kuni e    Tokyo Shoseki                     1995/4     CD
@@ -547,7 +541,6 @@ Saishin Igaku Daijiten Standard-ban CD-ROM                    Fujitsu           
 * Samurai Spirits                                             Japan Home Video (JHV)            1995/9     SET(CD+FD)
 Sangokushi 4                                                  Koei                              1994/6     SET(CD+FD)
 Sanseido Word Hunter Multi CD-ROM Jiten                       Fujitsu                           1991/10    CD
-Sargon 5                                                      GAM                               1992/11    CD
 Sayonara no Mukougawa                                         Foster                            1997/8     CD
 School Accessory Illust-hen V1.0                              Fujitsu                           1993/2     CD
 School Navi Nihon no Rekishi CD: Heian, Kamakura             Unitybell                         1995/8     CD
@@ -809,69 +802,6 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="fbas1120">
-		<!--
-		 Origin: redump.org
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 01).bin" size="55389600" crc="661d4cfb" sha1="614dfc9829ff5896d611f24a6f0cc6a912c9e7eb"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 02).bin" size="41729184" crc="17f838e9" sha1="faef4319da96fe3ea061b19e7c5a79a56604d090"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 03).bin" size="14765856" crc="f5a2bfbc" sha1="feec18ce8a1250704f2c9e8c66671568b50655a4"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 04).bin" size="24049200" crc="23d46b62" sha1="f3fc81272c05f6473d0dc9e00bc3da35658b0fd6"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 05).bin" size="37213344" crc="67350f17" sha1="00b992141bd49aeaa6cf52d5fdc479c9be3906ea"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 06).bin" size="8968176" crc="00282ec8" sha1="43bec43cd44be78a014becc94ac2c33126eb0f6b"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 07).bin" size="5374320" crc="a4d5c277" sha1="620ad28f7e21abd38cb9af378d892330ad6cd7a7"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 08).bin" size="5002704" crc="e688b514" sha1="068af1d56da66a8ee8b3adfdcd8f4c5902d790a3"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 09).bin" size="9360960" crc="e966f3ec" sha1="4245e9492a0a2660380b11dfa458c06b4041b2a3"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 10).bin" size="4675776" crc="c90f1de0" sha1="139630c7a5aaf478110cd77bd1d4e5c218bc68fb"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 11).bin" size="16793280" crc="65bb0664" sha1="85a7e637bf3385266c1bf4cc80f3972b41369d17"/>
-		<rom name="F-BASIC 386 V1.1L20 (Japan).cue" size="1347" crc="66f2a827" sha1="8bd2347f7b20890a10bc139ec4d3027db3f3b049"/>
-		 -->
-		<description>F-BASIC386 v1.1 L20</description>
-		<year>1989</year>
-		<publisher>富士通 (Fujitsu)</publisher>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="f-basic 386 v1.1l20 (japan)" sha1="2c18dc8b8193ed5c5b41a6caba8103ea41da0bcc" />
-			</diskarea>
-		</part>
-	</software>
-
-	<software name="fbas2110">
-		<!--
-		 Origin: Neo Kobe Collection
-		 <rom name="[OS] F-BASIC386 v2.1 L10.ccd" size="3071" crc="64bd4d99" sha1="2c76405c25dff4e953d8c606621133052aea1672"/>
-		 <rom name="[OS] F-BASIC386 v2.1 L10.cue" size="560" crc="cddd018e" sha1="9ca85c05b3c4924e7ad27ecdbc08d2e00a5217e1"/>
-		 <rom name="[OS] F-BASIC386 v2.1 L10.img" size="488628000" crc="0b7a6c2a" sha1="8f0124c6b2d00be0a5f340960e7e408130bba993"/>
-		 <rom name="[OS] F-BASIC386 v2.1 L10.sub" size="19944000" crc="1f33b8a9" sha1="fc5a64a01b80fedd4f5e39e3102cf38946b47a45"/>
-		 -->
-		<description>F-BASIC386 v2.1 L10</description>
-		<year>1992</year>
-		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="usage" value="Requires 2 MB RAM"/>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="[os] f-basic386 v2.1 l10" sha1="e69f917dc978dea9a602adf3864db4543d314c9a" />
-			</diskarea>
-		</part>
-	</software>
-
-	<software name="fbc1121">
-		<!--
-		 Origin: P2P
-		<rom name="IMAGE.CCD" size="4739" crc="07402a20" sha1="376a14d20416fa7f59aab0f36a514b01353cdf6e"/>
-		<rom name="IMAGE.cue" size="1243" crc="f920c1b0" sha1="664fa6f17de2261dae1f235026b796cea6947a84"/>
-		<rom name="IMAGE.img" size="514429440" crc="a41e8093" sha1="fb2f641ce75e31a756fbb8387c87b43a0228af41"/>
-		<rom name="IMAGE.sub" size="20997120" crc="0db76ce5" sha1="7ec6d6a578de84315ce574ec7a86803e4dbab10a"/>
-		 -->
-		<description>F-BASIC386 Compiler v1.1 L21</description>
-		<year>1991</year>
-		<publisher>富士通 (Fujitsu)</publisher>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="fbc1121" sha1="5ea72d3c25554a3bdcd64085ff4271cb5b0aac46" />
-			</diskarea>
-		</part>
-	</software>
-
 	<software name="gnutowns">
 		<!--
 		 Origin: Neo Kobe Collection
@@ -978,6 +908,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>OASYS/Win v2.0</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B28C7020"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oasys-win v2.0 (japan)" sha1="be7d9e04397684be94e93db57039ab4f61e11055" />
@@ -1010,6 +941,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v1.1 L10</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A010"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns system software v1.1l10 (japan)" sha1="98807c8ff948ed200cbd3199a32ae1edfdfae542" />
@@ -1046,6 +978,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v1.1 L20</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A010"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="[os] towns system software v1.1 l20" sha1="d866918df900ff885e50da7ab96354cf4b9aae24" />
@@ -1070,6 +1003,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v1.1 L30</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A010"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns system software v1.1l30 (japan)" sha1="79e193ca5c92cde61382c97f46b8cf843492e758" />
@@ -1096,6 +1030,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v2.1 L10A</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A011"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1121,6 +1056,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns System Software v2.1 L51</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A011"/>
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1145,6 +1081,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Windows 3.1 L12</description>
 		<year>1994</year>
 		<publisher>Microsoft</publisher>
+		<info name="serial" value="B276A520"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Setup Disk" />
 			<dataarea name="flop" size="1261568">
@@ -1176,6 +1113,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Windows 3.1 L11</description>
 		<year>1994</year>
 		<publisher>Microsoft</publisher>
+		<info name="serial" value="B276A520"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<feature name="part_id" value="Setup CD-ROM" />
 			<diskarea name="cdrom">
@@ -1216,6 +1154,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Hyakunin Isshu</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-242"/>
 		<info name="alt_title" value="ＴＯＷＮＳ百人一首" />
 		<info name="release" value="198911xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1235,6 +1174,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>3x3 Eyes - Sanjiyan Henjou</description>
 		<year>1993</year>
 		<publisher>日本クリエイト (Nihon Create)</publisher>
+		<info name="serial" value="HME-195 / MTC-1059"/>
 		<info name="alt_title" value="３×３ＥＹＥＳ 三只眼變成" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1262,6 +1202,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Boxing</description>
 		<year>1992</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMD-201 / EFT-7001"/>
 		<info name="alt_title" value="4D ボクシング" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1292,6 +1233,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Driving</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMD-222 / EFT-7002"/>
 		<info name="alt_title" value="4D ドライビング" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1313,6 +1255,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>4D Tennis</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HME-160"/>
 		<info name="alt_title" value="4D テニス" />
 		<info name="release" value="199307xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1334,6 +1277,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 1-2 Towns - Linkage</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-204"/>
 		<info name="release" value="198907xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1354,6 +1298,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 3 - Dual Targets</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-216"/>
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1373,6 +1318,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 4 - Zero</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-247"/>
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1402,6 +1348,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 5 - D-Again</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-109"/>
 		<info name="release" value="199004xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1431,6 +1378,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 5 - D-Again (Demo)</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-902"/>
 		<info name="release" value="199004xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1456,6 +1404,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 6 - Merry-Go-Round</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-215"/>
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1480,6 +1429,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The 4th Unit 7 - Wyatt</description>
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT2003"/>
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -1537,6 +1487,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>38-man Kilo no Kokuu</description>
 		<year>1989</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="serial" value="HMA-229"/>
 		<info name="alt_title" value="38万キロの虚空" />
 		<info name="release" value="198912xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -1554,21 +1505,21 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="aressh3">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="A Ressha de Ikou III.ccd" size="957" crc="dad259ec" sha1="143515c746dbf2ff878c714b5e4f2c2b0047f4bb"/>
-		<rom name="A Ressha de Ikou III.cue" size="123" crc="868356a6" sha1="b2f19ac6130c018f888ac9b60d6bc7012fa3c4ec"/>
-		<rom name="A Ressha de Ikou III.img" size="412599600" crc="0005daaf" sha1="3b826dd5f7a61f13e8dc4bd14ba0b8d6392a127e"/>
-		<rom name="A Ressha de Ikou III.sub" size="16840800" crc="f010e847" sha1="1e42321175135cb33ffa5c0c138c5ee2ea7bc270"/>
+		Origin: redump.org
+		<rom name="A.III. - A Ressha de Ikou III (Japan) (Track 1).bin" size="105487200" crc="ede3c43e" sha1="68498feabb7ea1a17eb4d2dfacf5112c4c90a666"/>
+		<rom name="A.III. - A Ressha de Ikou III (Japan) (Track 2).bin" size="307112400" crc="6c79a5bd" sha1="9845fd669a4e38ddaff3904f3f5730bae36cf825"/>
+		<rom name="A.III. - A Ressha de Ikou III (Japan).cue" size="244" crc="9ccb4f35" sha1="7c77c46d7adbd379ade9f35a0541a78fda467660"/>
 		-->
 		<description>A Ressha de Ikou III</description>
 		<year>1991</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMC-118"/>
 		<info name="alt_title" value="A列車で行こうIII" />
 		<info name="release" value="199104xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="a ressha de ikou iii" sha1="095710f80f004917dce963719cb1c4bae4d5fc49" />
+				<disk name="a.iii. - a ressha de ikou iii (japan)" sha1="c5aaad3efb280ff432a251eeeee1dc4a0f0fd79b" />
 			</diskarea>
 		</part>
 	</software>
@@ -1584,6 +1535,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>A Ressha de Ikou IV</description>
 		<year>1993</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HME-256"/>
 		<info name="alt_title" value="A列車で行こうIV" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1614,7 +1566,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ファミリーソフト (Family Soft)</publisher>
 		<info name="alt_title" value="ＡＢＥＬ 真・黙示録大戦" />
 		<info name="release" value="199511xx" />
-		<info name="usage" value="Requires 2 MB RAM"/>
+		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="abel" sha1="5fb92a84f3d1e7530b6dce9060f9814ec2fa6d2b" />
@@ -1641,6 +1593,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Advantage Tennis</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-171 / A2760320"/>
 		<info name="alt_title" value="アドバンテージテニス" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1665,6 +1618,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ehon Writer - Denshi Ehon - Aesop World Dai-1-shuu</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-518 / FMB-3015 / A276CFA0"/>
 		<info name="alt_title" value="えほんらいた　電子絵本　イソップワールド　第１集" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1687,6 +1641,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Aeternam</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-205 / A2760370 / TSC270"/>
 		<info name="alt_title" value="エターナム" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1714,6 +1669,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner (v1.02)</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMA-101 / T-2007-906"/>
 		<info name="alt_title" value="アフターバーナー" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1739,6 +1695,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner (v1.02, alt)</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMA-101"/>
 		<info name="alt_title" value="アフターバーナー" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1764,6 +1721,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner (v1.01)</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMA-101"/>
 		<info name="alt_title" value="アフターバーナー" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1793,6 +1751,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>After Burner III</description>
 		<year>1992</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMD-119 / T2061-206"/>
 		<info name="alt_title" value="アフターバーナーIII" />
 		<info name="release" value="199206xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1817,6 +1776,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Combat II Special</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMD-228 / F-5507"/>
 		<info name="alt_title" value="エアーコンバット2スペシャル" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -1837,6 +1797,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Management - Oozora ni Kakeru</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-159"/>
 		<info name="alt_title" value="エアマネジメント 大空に賭ける" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1864,6 +1825,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Warrior V2.1L10</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-109D / A2760232"/>
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -1896,6 +1858,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Warrior V1.2</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-109A"/>
 		<info name="release" value="199311xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1915,6 +1878,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Air Warrior V1.1</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-109"/>
 		<info name="release" value="199203xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -1933,6 +1897,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alice no Yakata CD</description>
 		<year>1991</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HMC-138"/>
 		<info name="alt_title" value="アリスの館CD" />
 		<info name="release" value="199107xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -1954,6 +1919,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alice no Yakata II</description>
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HMD-182"/>
 		<info name="alt_title" value="アリスの館2" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2005,6 +1971,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alone in the Dark</description>
 		<year>1993</year>
 		<publisher>アローマイクロテックス (Arrow Micro-Techs)</publisher>
+		<info name="serial" value="AMT-001"/>
 		<info name="alt_title" value="アローン・イン・ザ・ダーク" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2047,6 +2014,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Alshark</description>
 		<year>1993</year>
 		<publisher>ライトスタッフ (Right Stuff)</publisher>
+		<info name="serial" value="HME-140"/>
 		<info name="alt_title" value="アルシャーク" />
 		<info name="release" value="199305xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2123,8 +2091,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Asks for a save disk, but doesn't accept a blank one -->
-	<software name="angel" supported="no">
+	<software name="angel">
 		<!--
 		Origin: Neo Kobe Collection
 		<rom name="Angel.ccd" size="2812" crc="5269b2c9" sha1="4fff4210e42536faa001b659721aeaaffe1f5d5c"/>
@@ -2148,8 +2115,15 @@ User/save disks that can be created from the game itself are not included.
 		<description>Angel</description>
 		<year>1993</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HME-214"/>
 		<info name="alt_title" value="エンジェル" />
 		<info name="release" value="199310xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Save Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="angel (save disk).hdm" size="1261568" crc="8ea3389b" sha1="60792d763d3cac54d19b04673b1f1811cf19b9a8" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="angel" sha1="e8da3eae3b949459751fd027579aee52b167dc2f" />
@@ -2197,20 +2171,40 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="appare1">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="4898" crc="0b4cb169" sha1="ecbca01b234847a14e6b8f55c6daf19302bc51d4"/>
-		<rom name="Image.cue" size="955" crc="0b2c709e" sha1="fa59b24673f52ef2aac7ea405b55423b511f3303"/>
-		<rom name="Image.img" size="658677600" crc="786b67fb" sha1="79a7b6ff9ece0339e93a2fc32a12fd0fd953040a"/>
-		<rom name="Image.sub" size="26884800" crc="3f131e25" sha1="e2a29c832f81efa437e71c5a652d4b252cef7484"/>
+		Origin: redump.org
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 01).bin" size="264247200" crc="e31e6ffe" sha1="a370c1502222bef37bbb4aa9a707c1e17c8f3c63"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 02).bin" size="34398000" crc="36f57789" sha1="32ac0facc8e10766cd05190aab7c584fdd0a5a6d"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 03).bin" size="47451600" crc="0ec44d10" sha1="dd9e17633f4ae3d45571a015ce8b2d7a4be74c2e"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 04).bin" size="38808000" crc="3c466e69" sha1="8c6a252f044c311570822412326b619c40115609"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 05).bin" size="6526800" crc="43c72aeb" sha1="a31e15c62648224f68e6549714761b9f63149194"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 06).bin" size="29635200" crc="8674774a" sha1="0fbd69c00afed48ee048370d6400d4536fa7edca"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 07).bin" size="10584000" crc="47f6ac5b" sha1="caeed966b002d654ab5101b1c2a3eae396e1c669"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 08).bin" size="26636400" crc="5185f35b" sha1="666992d5619a0ef5649ade6f4055c046cdbb782d"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 09).bin" size="13406400" crc="81b8341d" sha1="f4f5e8103fa6d57041aec48e93cbdb6c7f74453b"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 10).bin" size="13759200" crc="6576bb3c" sha1="a8e49b78dcec7bdbb866c3be92459e3469ff5d25"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 11).bin" size="4586400" crc="80c45112" sha1="ba076a57ba26a015c6209fa5e217299646b92045"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 12).bin" size="6703200" crc="f03ef6de" sha1="37ca09751e32631324315068ac43e730332864c5"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 13).bin" size="1058400" crc="3295ce64" sha1="456eb0ef75e9ea1c6291c099557f1a1064bad6e7"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 14).bin" size="1234800" crc="16e7629e" sha1="1fcecb819a533f09fa17f7cac4eb8e03e4e04fd9"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 15).bin" size="17640000" crc="6b294533" sha1="59f160a6ed77c22bfeb5e4a170db37648bb53eef"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 16).bin" size="14464800" crc="18a6128d" sha1="796f07f29ba9f1c564b995e73d756725118652d8"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 17).bin" size="16405200" crc="1a59b90c" sha1="ddb878e4a601ba6bdc61465130162b5814c50509"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 18).bin" size="22402800" crc="059cdc78" sha1="bc0999300da6400627d134c1cc95deca053fadef"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 19).bin" size="21168000" crc="3e370a3c" sha1="ef003399e33e016fdc24763b5cada70e13cbc6e2"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 20).bin" size="21520800" crc="83422810" sha1="8c862929d0217dee41a0f2e2170bd62458e39afd"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 21).bin" size="21873600" crc="e670a8e5" sha1="4582a65f25367791f4ecf0221c3556056175ee99"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan) (Track 22).bin" size="24166800" crc="dafc972b" sha1="0fcba50dd858edb894d42603d0263340314bc5a0"/>
+		<rom name="Appare CD Vol. 1 - Hiryuu no Maki (Japan).cue" size="2974" crc="7e67dc46" sha1="39ef46e0b88f3bf2bfafa6732dee048965637049"/>
 		-->
 		<description>Appare CD Vol. 1 - Hiryuu no Maki</description>
 		<year>1994</year>
 		<publisher>ソフトバンク (Softbank)</publisher>
+		<info name="serial" value="HMF-916 / OFMT-001"/>
 		<info name="alt_title" value="天晴CD Vol.1 飛龍の巻" />
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="appare1" sha1="b597d3b3b593ba395c5c132200bde2b98db5a4ab" />
+				<disk name="appare cd vol. 1 - hiryuu no maki (japan)" sha1="21551c98c9b484a0d1b5bb5aa6437a4d2e33a353" />
 			</diskarea>
 		</part>
 	</software>
@@ -2246,6 +2240,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Aoki Ookami to Shiroki Mejika - Genchou Hishi</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-211"/>
 		<info name="alt_title" value="蒼き狼と白き牝鹿 元朝秘史" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2267,6 +2262,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMF-131"/>
 		<info name="alt_title" value="ア・ラ・ベ・ス・ク ～少女たちの織りなす愛の物語～" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2288,6 +2284,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Aska Towns</description>
 		<year>1989</year>
 		<publisher>Algo Software</publisher>
+		<info name="serial" value="HMA-248A"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="aska towns" sha1="027d5a8920980d5eccff93df192148b9acf51309" />
@@ -2321,18 +2318,19 @@ User/save disks that can be created from the game itself are not included.
 		<description>Asuka 120% Burning Fest. Excellent</description>
 		<year>1994</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="MTC-1114"/>
 		<info name="alt_title" value="あすか 120% BURNING Fest. エクセレント" />
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="asuka 120% burning fest. excellent (boot disk).hdm" size="1261568" crc="12c7d6e2" sha1="0eb696be9666300d76863ae08882485eb69725d4" offset="000000" />
+				<rom name="asuka 120 burning fest. excellent (boot disk).hdm" size="1261568" crc="12c7d6e2" sha1="0eb696be9666300d76863ae08882485eb69725d4" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asuka 120% excellent - burning fest. excellent (japan)" sha1="8f355528fc46706bc856848665186115c2275fad" />
+				<disk name="asuka 120 excellent - burning fest. excellent (japan)" sha1="8f355528fc46706bc856848665186115c2275fad" />
 			</diskarea>
 		</part>
 	</software>
@@ -2348,6 +2346,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Atlas</description>
 		<year>1991</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMC-167"/>
 		<info name="alt_title" value="ジ・アトラス" />
 		<info name="release" value="199110xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2369,6 +2368,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Atlas II</description>
 		<year>1993</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HME-147"/>
 		<info name="alt_title" value="ジ・アトラスII" />
 		<info name="release" value="199305xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2398,6 +2398,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Awesome</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-186 / A2760200 / TSC190"/>
 		<info name="release" value="199203xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -2421,6 +2422,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hatchake Ayayo-san 1-2-3</description>
 		<year>1993</year>
 		<publisher>ハード (Hard)</publisher>
+		<info name="serial" value="HMD-223"/>
 		<info name="alt_title" value="はっちゃけあやよさん 1-2-3" />
 		<info name="release" value="199307xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2469,6 +2471,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ayumi-chan Monogatari Jissha-ban</description>
 		<year>1995</year>
 		<publisher>Core Magazine</publisher>
+		<info name="serial" value="HMF-204"/>
 		<info name="alt_title" value="あゆみちゃん物語 実写版" />
 		<info name="release" value="199501xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2499,6 +2502,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Azure</description>
 		<year>1993</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="HMD-213"/>
 		<info name="alt_title" value="アジャ" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2540,6 +2544,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ballade for Maria</description>
 		<year>1995</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMG-125"/>
 		<info name="alt_title" value="マリアに捧げるバラード" />
 		<info name="release" value="199506xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2586,6 +2591,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Battle Chess</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-123 / A2760070 / TSC080"/>
 		<info name="alt_title" value="バトル・チェス" />
 		<info name="release" value="199109xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2688,6 +2694,45 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="bighonor">
+		<!--
+		Origin: redump.org
+		<rom name="Big Honour (Japan) (Track 01).bin" size="52214400" crc="7668b256" sha1="56a6071b5d97be8c0f6b33676a6a34b8e23f1c1f"/>
+		<rom name="Big Honour (Japan) (Track 02).bin" size="14288400" crc="c6bb1d1a" sha1="6d3d4e429b0f7afde1d0ad111b04a4f0b2d6b83c"/>
+		<rom name="Big Honour (Japan) (Track 03).bin" size="32281200" crc="bb6c0f99" sha1="fc91184047f0e411680b14450bd7c31ea839a8b0"/>
+		<rom name="Big Honour (Japan) (Track 04).bin" size="29811600" crc="ed84d8d8" sha1="b3d5feac1c8b130b184a93d26d686409d60c4c0c"/>
+		<rom name="Big Honour (Japan) (Track 05).bin" size="111484800" crc="f6518321" sha1="bb44b8b3b43873b7dfb74a983572dc8c5b87eff5"/>
+		<rom name="Big Honour (Japan) (Track 06).bin" size="32104800" crc="4a4f5557" sha1="6a2d9856fed6c179b12a2a83b478d967109f08f5"/>
+		<rom name="Big Honour (Japan) (Track 07).bin" size="17287200" crc="37d88648" sha1="b8557788e5022cb165f9d67f0f14566ec52f692b"/>
+		<rom name="Big Honour (Japan) (Track 08).bin" size="22050000" crc="33206a77" sha1="3b7757947166c229d46dc27f609af52cb6814715"/>
+		<rom name="Big Honour (Japan) (Track 09).bin" size="21873600" crc="fe832e75" sha1="9e035a3d321c2017b95992e23e7d1ca98a2f2271"/>
+		<rom name="Big Honour (Japan) (Track 10).bin" size="21873600" crc="ffbef88b" sha1="383502e48e0442e082074840a42293b6126d5ede"/>
+		<rom name="Big Honour (Japan) (Track 11).bin" size="21873600" crc="d8c26622" sha1="3892bd5aa00360f04649aec20fcd16617fa4b741"/>
+		<rom name="Big Honour (Japan) (Track 12).bin" size="22050000" crc="6d2bb4ca" sha1="c0a53de2b2f8093ccf540a871a09dbd27de484d0"/>
+		<rom name="Big Honour (Japan) (Track 13).bin" size="22050000" crc="b02b3bab" sha1="272f97f485134c1e1681e83e4c88a6dd8104a35b"/>
+		<rom name="Big Honour (Japan) (Track 14).bin" size="22050000" crc="42b3410b" sha1="dd87bdf4169671fd6391a6cd86972499f652fe7b"/>
+		<rom name="Big Honour (Japan) (Track 15).bin" size="21873600" crc="9f575e1f" sha1="289ab94d09ecfd7e589bc98a4a37146307cb8181"/>
+		<rom name="Big Honour (Japan) (Track 16).bin" size="21873600" crc="b1985bed" sha1="eb9183901896c23019860b91ebc8a237252cf3f7"/>
+		<rom name="Big Honour (Japan) (Track 17).bin" size="22050000" crc="96c10f8c" sha1="b4640fd2b958720a948820f38a04f8c6c4ca3194"/>
+		<rom name="Big Honour (Japan) (Track 18).bin" size="71089200" crc="de0d9053" sha1="d46e1b9fe5810ad4b975d67d53be37c37eae273d"/>
+		<rom name="Big Honour (Japan) (Track 19).bin" size="34221600" crc="05f7b170" sha1="64a00f30abe5f34ed3ae7031afae46c9ea3d2097"/>
+		<rom name="Big Honour (Japan) (Track 20).bin" size="40219200" crc="5b734a55" sha1="c83e7fbc8df9c178b38517a3be0e1a0bd1e28473"/>
+		<rom name="Big Honour (Japan).cue" size="2242" crc="12372db6" sha1="1367977999c872e216044631f5741a5835b77e62"/>
+		-->
+		<description>Big Honour</description>
+		<year>1992</year>
+		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMD-158 / MTC-1014"/>
+		<info name="alt_title" value="ビッグオナー" />
+		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="big honour (japan)" sha1="e810dcd4ee51a464abcf5274ff708bd0b9e53f2e" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Visible area is cut off -->
 	<software name="blandia" supported="partial">
 		<!--
@@ -2761,6 +2806,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Blandia</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-126"/>
 		<info name="alt_title" value="ブランディア" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2782,6 +2828,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Blue - Will to Power</description>
 		<year>1992</year>
 		<publisher>Sofcom</publisher>
+		<info name="serial" value="HMD-124"/>
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -2813,50 +2860,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Bomberman - Panic Bomber</description>
 		<year>1995</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMG-108"/>
 		<info name="alt_title" value="ボンバーマンぱにっくボンバー" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="bomberman - panic bomber (japan)" sha1="019a1d0b207d6f3492fcbe230638740857a00c12" />
-			</diskarea>
-		</part>
-	</software>
-
-	<software name="bighonor">
-		<!--
-		Origin: redump.org
-		<rom name="Big Honour (Japan) (Track 01).bin" size="52214400" crc="7668b256" sha1="56a6071b5d97be8c0f6b33676a6a34b8e23f1c1f"/>
-		<rom name="Big Honour (Japan) (Track 02).bin" size="14288400" crc="c6bb1d1a" sha1="6d3d4e429b0f7afde1d0ad111b04a4f0b2d6b83c"/>
-		<rom name="Big Honour (Japan) (Track 03).bin" size="32281200" crc="bb6c0f99" sha1="fc91184047f0e411680b14450bd7c31ea839a8b0"/>
-		<rom name="Big Honour (Japan) (Track 04).bin" size="29811600" crc="ed84d8d8" sha1="b3d5feac1c8b130b184a93d26d686409d60c4c0c"/>
-		<rom name="Big Honour (Japan) (Track 05).bin" size="111484800" crc="f6518321" sha1="bb44b8b3b43873b7dfb74a983572dc8c5b87eff5"/>
-		<rom name="Big Honour (Japan) (Track 06).bin" size="32104800" crc="4a4f5557" sha1="6a2d9856fed6c179b12a2a83b478d967109f08f5"/>
-		<rom name="Big Honour (Japan) (Track 07).bin" size="17287200" crc="37d88648" sha1="b8557788e5022cb165f9d67f0f14566ec52f692b"/>
-		<rom name="Big Honour (Japan) (Track 08).bin" size="22050000" crc="33206a77" sha1="3b7757947166c229d46dc27f609af52cb6814715"/>
-		<rom name="Big Honour (Japan) (Track 09).bin" size="21873600" crc="fe832e75" sha1="9e035a3d321c2017b95992e23e7d1ca98a2f2271"/>
-		<rom name="Big Honour (Japan) (Track 10).bin" size="21873600" crc="ffbef88b" sha1="383502e48e0442e082074840a42293b6126d5ede"/>
-		<rom name="Big Honour (Japan) (Track 11).bin" size="21873600" crc="d8c26622" sha1="3892bd5aa00360f04649aec20fcd16617fa4b741"/>
-		<rom name="Big Honour (Japan) (Track 12).bin" size="22050000" crc="6d2bb4ca" sha1="c0a53de2b2f8093ccf540a871a09dbd27de484d0"/>
-		<rom name="Big Honour (Japan) (Track 13).bin" size="22050000" crc="b02b3bab" sha1="272f97f485134c1e1681e83e4c88a6dd8104a35b"/>
-		<rom name="Big Honour (Japan) (Track 14).bin" size="22050000" crc="42b3410b" sha1="dd87bdf4169671fd6391a6cd86972499f652fe7b"/>
-		<rom name="Big Honour (Japan) (Track 15).bin" size="21873600" crc="9f575e1f" sha1="289ab94d09ecfd7e589bc98a4a37146307cb8181"/>
-		<rom name="Big Honour (Japan) (Track 16).bin" size="21873600" crc="b1985bed" sha1="eb9183901896c23019860b91ebc8a237252cf3f7"/>
-		<rom name="Big Honour (Japan) (Track 17).bin" size="22050000" crc="96c10f8c" sha1="b4640fd2b958720a948820f38a04f8c6c4ca3194"/>
-		<rom name="Big Honour (Japan) (Track 18).bin" size="71089200" crc="de0d9053" sha1="d46e1b9fe5810ad4b975d67d53be37c37eae273d"/>
-		<rom name="Big Honour (Japan) (Track 19).bin" size="34221600" crc="05f7b170" sha1="64a00f30abe5f34ed3ae7031afae46c9ea3d2097"/>
-		<rom name="Big Honour (Japan) (Track 20).bin" size="40219200" crc="5b734a55" sha1="c83e7fbc8df9c178b38517a3be0e1a0bd1e28473"/>
-		<rom name="Big Honour (Japan).cue" size="2242" crc="12372db6" sha1="1367977999c872e216044631f5741a5835b77e62"/>
-		-->
-		<description>Big Honour</description>
-		<year>1992</year>
-		<publisher>アートディンク (Artdink)</publisher>
-		<info name="alt_title" value="ビッグオナー" />
-		<info name="release" value="199209xx" />
-		<info name="usage" value="Requires 2 MB RAM"/>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="big honour (japan)" sha1="e810dcd4ee51a464abcf5274ff708bd0b9e53f2e" />
 			</diskarea>
 		</part>
 	</software>
@@ -2872,6 +2882,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Best Play Baseball</description>
 		<year>1992</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMD-118"/>
 		<info name="alt_title" value="ベストプレーベースボール" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2891,6 +2902,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Branmarker</description>
 		<year>1991</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-247 / MTC-1067"/>
 		<info name="alt_title" value="ブランマーカー" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2942,6 +2954,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Bubble Bobble</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-191"/>
 		<info name="alt_title" value="バブルボブル" />
 		<info name="release" value="199010xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -2963,6 +2976,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Burai Joukan</description>
 		<year>1990</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMB-122"/>
 		<info name="alt_title" value="ブライ -上巻-" />
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -2983,6 +2997,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Burai Kanketsu-hen</description>
 		<year>1991</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMC-113"/>
 		<info name="alt_title" value="ブライ -完結編-" />
 		<info name="release" value="199105xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3004,6 +3019,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cal Towns</description>
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="serial" value="HMD-167"/>
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3057,6 +3073,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Can Can Bunny Premiere</description>
 		<year>1992</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HMD-202 / IDES-001"/>
 		<info name="alt_title" value="きゃんきゃんバニー・プルミエール" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3078,6 +3095,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Can Can Bunny Extra</description>
 		<year>1993</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HME-192"/>
 		<info name="alt_title" value="きゃんきゃんバニー・エクストラ" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3099,6 +3117,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Castles</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMD-173"/>
 		<info name="alt_title" value="キャッスルズ" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3127,6 +3146,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cat's Part-1</description>
 		<year>1993</year>
 		<publisher>Cat's Pro.</publisher>
+		<info name="serial" value="HME-138 / PAND 001"/>
 		<info name="alt_title" value="キャッツ・パート１" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3148,6 +3168,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Centurion</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HME-234"/>
 		<info name="alt_title" value="センチュリオン" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3167,6 +3188,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>CG Syndicate Vol. 1 - Lisa Northpoint</description>
 		<year>1991</year>
 		<publisher>R-Key</publisher>
+		<info name="serial" value="HMC-160 / DWFT1801"/>
 		<info name="alt_title" value="CGシンジケート Vol.1 リサ・ノースポイント" />
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3204,6 +3226,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taito Chase H.Q.</description>
 		<year>1991</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMC-142"/>
 		<info name="alt_title" value="TAITO チェイスＨＱ" />
 		<info name="release" value="199108xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3242,6 +3265,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taito Chase H.Q. (Demo)</description>
 		<year>1991</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMC-919"/>
 		<info name="alt_title" value="TAITO チェイスＨＱ" />
 		<info name="release" value="1991xxxx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3263,6 +3287,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Chuumon no Ooi Ryouriten</description>
 		<year>1990</year>
 		<publisher>トップビジネスシステム (Top Business System)</publisher>
+		<info name="serial" value="HMB-162"/>
 		<info name="alt_title" value="注文の多い料理店" />
 		<info name="release" value="199108xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3283,6 +3308,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Classic Road</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HME-260 / F-5513"/>
 		<info name="alt_title" value="クラシック・ロード" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3304,6 +3330,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Case of the Cautious Condor</description>
 		<year>1989</year>
 		<publisher>東芝EMI (Toshiba EMI)</publisher>
+		<info name="serial" value="HMA-235-Y"/>
 		<info name="release" value="198911xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3324,6 +3351,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Crystal Rinal - Ouma no Meikyuu</description>
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="2TD-3016"/>
 		<info name="alt_title" value="クリスタルリナール －逢魔の迷宮－" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3343,6 +3371,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>CubicSketch V1.1 L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="FMB-4006 / B276E240"/>
 		<info name="usage" value="Requires 4 MB RAM" />
 		<info name="release" value="199405xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3415,6 +3444,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cyberia</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-205"/>
 		<info name="alt_title" value="サイベリア" />
 		<info name="release" value="199505xx" />
 		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
@@ -3434,6 +3464,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Cyber Sculpt V1.0 (HMC-140A)</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-140A / A2760180 / TTC010"/>
 		<info name="alt_title" value="サイバー・スカルプト" />
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3493,6 +3524,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daikoukai Jidai</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMB-118"/>
 		<info name="alt_title" value="大航海時代" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3520,6 +3552,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daikoukai Jidai II</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HME-123"/>
 		<info name="alt_title" value="大航海時代II" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3548,6 +3581,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Daisenryaku III '90</description>
 		<year>1991</year>
 		<publisher>ペガサスジャパン (Pegasus Japan)</publisher>
+		<info name="serial" value="HMC-183"/>
 		<info name="alt_title" value="大戦略III'90" />
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3587,6 +3621,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dalk</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HME-128"/>
 		<info name="alt_title" value="ダルク" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -3611,6 +3646,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dangel</description>
 		<year>1996</year>
 		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="2TD-3027"/>
 		<info name="release" value="199606xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3651,6 +3687,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Debut Shimasu... - Nakagawa Yuuko</description>
 		<year>1994</year>
 		<publisher>アイリスプラン (Ilis Plan)</publisher>
+		<info name="serial" value="MTC-1090"/>
 		<info name="alt_title" value="デビューします･･･ 中川裕子" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3713,6 +3750,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dead of the Brain</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HME-102"/>
 		<info name="alt_title" value="デッド・オブ・ザ・ブレイン" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3743,6 +3781,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Death Brade</description>
 		<year>1992</year>
 		<publisher>KID</publisher>
+		<info name="serial" value="HMD-192 / KID-002"/>
 		<info name="alt_title" value="デスブレイド" />
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3791,6 +3830,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>De-Ja II</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMD-157"/>
 		<info name="release" value="199208xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3808,6 +3848,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dengeki Nurse</description>
 		<year>1992</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HMD-210"/>
 		<info name="alt_title" value="電撃ナース" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3856,6 +3897,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Derby Stallion</description>
 		<year>1993</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HME-177"/>
 		<info name="alt_title" value="ダービースタリオン" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3936,6 +3978,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Digital Pinup Girls Vol. 1</description>
 		<year>1993</year>
 		<publisher>Transpegasus</publisher>
+		<info name="serial" value="HME-107"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -3955,6 +3998,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doda Mega-Mix!!!</description>
 		<year>1989</year>
 		<publisher>FNC</publisher>
+		<info name="serial" value="HMA-250"/>
 		<info name="release" value="198911xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3972,9 +4016,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Doki Doki Disk CD Vol.1.img" size="449279040" crc="aa713eac" sha1="9c8b878fef675162d5cfce4c114c7243ec1ce83d"/>
 		<rom name="Doki Doki Disk CD Vol.1.sub" size="18337920" crc="d361dfac" sha1="eb1ecead88f16e39040a6f0f672193acfd83db3b"/>
 		-->
-		<description>Doki Doki Disk CD-ban Dai-1-kan: Club D.O. Jimukyoku</description>
+		<description>Doki Doki Disk CD-ban Dai-1-kan - Club D.O. Jimukyoku</description>
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HMF-130"/>
 		<info name="alt_title" value="どきどきディスクＣＤ版　第１巻　クラブＤ．Ｏ．事務局" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4007,6 +4052,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doki Doki Vacation - Kirameku Kisetsu no Naka de</description>
 		<year>1995</year>
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HMG-109 / IDES-030"/>
 		<info name="alt_title" value="Ｄｏｋｉ　Ｄｏｋｉ　バケーション　～きらめく季節の中で～" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4033,6 +4079,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Best Selection Gekan</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-149-1 / HME-149-2 / MTC-1045 / MTC-1046"/>
 		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 下巻" />
 		<info name="release" value="199305xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4070,6 +4117,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Best Selection Joukan</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-143-1 / HME-143-2 / MTC-1042 / MTC-1043"/>
 		<info name="alt_title" value="ＤＯＲ ～ ベストセレクション ～ 上巻" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4096,6 +4144,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Special Edition '93</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-255 / 2TD-3004"/>
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4116,6 +4165,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Special Edition '93 (alt)</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-255"/>
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4136,6 +4186,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>DOR Special Edition Sakigake</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-163"/>
 		<info name="alt_title" value="DOR SPECIAL EDITION 魁" />
 		<info name="release" value="199306xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4157,6 +4208,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doukyuusei</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMD-229"/>
 		<info name="alt_title" value="同級生" />
 		<info name="release" value="199303xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4177,6 +4229,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Doukyuusei 2</description>
 		<year>1995</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMG-110"/>
 		<info name="alt_title" value="同級生2" />
 		<info name="release" value="199502xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4217,6 +4270,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Knight III</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMD-108"/>
 		<info name="alt_title" value="ドラゴンナイトIII" />
 		<info name="release" value="199202xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4238,6 +4292,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Knight 4</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMF-128"/>
 		<info name="alt_title" value="ドラゴンナイト4" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4259,6 +4314,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragons of Flame</description>
 		<year>1992</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
+		<info name="serial" value="HMC-195"/>
 		<info name="alt_title" value="ドラゴン・オブ・フレイム" />
 		<info name="release" value="199201xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4285,6 +4341,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dragon Shock</description>
 		<year>1989</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="serial" value="HMA-232"/>
 		<info name="alt_title" value="ドラゴンショック" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4339,6 +4396,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Drakkhen</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-213 / A2760140"/>
 		<info name="alt_title" value="ドラッケン" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4358,6 +4416,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dungeon Master</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-240 / A2760020 / TSC020"/>
 		<info name="alt_title" value="ダンジョンマスター" />
 		<info name="release" value="198911xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4379,6 +4438,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dungeon Master II - Skullkeep</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HME-242"/>
 		<info name="alt_title" value="ダンジョンマスターII スカルキープ" />
 		<info name="release" value="199401xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4437,6 +4497,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>ElFish</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-144 / A2760521 / TSC450"/>
 		<info name="alt_title" value="エル・フィッシュ" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires HDD installation, 4 MB RAM and a 486 CPU"/>
@@ -4449,21 +4510,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="elfishlt">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Elfish Lite.ccd" size="751" crc="ea2bdac2" sha1="62a9f7f9d82e1084e35e01212a84464b5c1838bb"/>
-		<rom name="Elfish Lite.cue" size="93" crc="edfeaf37" sha1="94eeab0829635eb2331bde508076a2fcf3d0b5d0"/>
-		<rom name="Elfish Lite.img" size="126655200" crc="8515a508" sha1="2440ea0d2ff9a7dd587987726e38c9de265468c1"/>
-		<rom name="Elfish Lite.sub" size="5169600" crc="c7a5fcd9" sha1="7996e1b60962de0b4ca65371e87889e3fcde1195"/>
+		Origin: redump.org
+		<rom name="ElFish Lite (Japan).bin" size="126655200" crc="8515a508" sha1="2440ea0d2ff9a7dd587987726e38c9de265468c1"/>
+		<rom name="ElFish Lite (Japan).cue" size="85" crc="1da3496c" sha1="085b9460bcf7e2a7855ee9cde1a9a9d90d21cb2d"/>
 		-->
 		<description>ElFish Lite</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-218 / A2760520 / TSC380"/>
 		<info name="alt_title" value="エル・フィッシュ LITE" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="elfish lite" sha1="1667eb91450e756ae37910aa9291957430fc588b" />
+				<disk name="elfish lite (japan)" sha1="2c203a5dc86bfa2752e17bc89c7bfc1cb1f5b53d" />
 			</diskarea>
 		</part>
 	</software>
@@ -4479,6 +4539,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Elm Knight - A Living Body Armor</description>
 		<year>1992</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="serial" value="HMD-198"/>
 		<info name="alt_title" value="エルムナイト" />
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4500,6 +4561,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Emerald Dragon</description>
 		<year>1992</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="serial" value="HMD-137"/>
 		<info name="alt_title" value="エメラルド・ドラゴン" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4532,6 +4594,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Emit Vol. 1 - Toki no Maigo</description>
 		<year>1994</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMF-115 / KN10601010"/>
 		<info name="release" value="199403xx" />
 		<info name="alt_title" value="エミット Vol. 1 時の迷子" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4564,6 +4627,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Emit Vol. 2 - Inochigake no Tabi</description>
 		<year>1994</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMF-157 / KN10701010"/>
 		<info name="release" value="199407xx" />
 		<info name="alt_title" value="エミット Vol. 2 命がけの旅" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4595,6 +4659,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Emit Vol. 3 - Watashi ni Sayonara o</description>
 		<year>1994</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMF-178 / KN10741010"/>
 		<info name="release" value="199409xx" />
 		<info name="alt_title" value="エミット Vol. 3 私にさよならを" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4612,7 +4677,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="enkaio">
 		<!--
-		Origin: redump.org / r09
+		Origin: redump.org
 		<rom name="Enkaiou (Japan) (Track 01).bin" size="105134400" crc="304cbfed" sha1="8c310e390bd0c4fd2ecc2c3eb842381fff549c1b"/>
 		<rom name="Enkaiou (Japan) (Track 02).bin" size="8079120" crc="2eeba401" sha1="6df382c1e3ae30af7e9f409660fe593ea2a84d64"/>
 		<rom name="Enkaiou (Japan) (Track 03).bin" size="7879200" crc="913a540c" sha1="0a5f3f815b1abc0b09044186ed1029634bda52e2"/>
@@ -4708,6 +4773,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Enkaiou</description>
 		<year>1989</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="serial" value="HMA-223"/>
 		<info name="alt_title" value="宴会王" />
 		<info name="release" value="198910xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4728,6 +4794,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Enkaiou no Gyakushuu</description>
 		<year>1991</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="serial" value="HMC-129"/>
 		<info name="alt_title" value="宴会王の逆襲" />
 		<info name="release" value="199108xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4749,6 +4816,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Etsuraku no Gakuen</description>
 		<year>1994</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="serial" value="HMF-171"/>
 		<info name="alt_title" value="悦楽の学園" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4770,12 +4838,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Europa Sensen</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-132"/>
 		<info name="alt_title" value="ヨーロッパ戦線" />
 		<info name="release" value="199207xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
-			<dataarea name="flop" size="1261568">
+			<dataarea name="flop" size="1281968">
 				<rom name="opeurope.d88" size="1281968" crc="32174842" sha1="12fd4e6558e0bf7e47a9a27fa5c33db9c3a60cfd" offset="000000" />
 			</dataarea>
 		</part>
@@ -4816,6 +4885,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Excellent 10</description>
 		<year>1990</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="serial" value="HMB-201"/>
 		<info name="alt_title" value="エクセレント10" />
 		<info name="release" value="199010xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4842,6 +4912,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Exciting CD</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-901-1 / HMF-901-2"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4871,6 +4942,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Exciting CD '94 Summer</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-913-1 / HMF-913-2"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -4895,6 +4967,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Eye of the Beholder II - The Legend of Darkmoon</description>
 		<year>1993</year>
 		<publisher>サイベル (Cybelle)</publisher>
+		<info name="serial" value="HME-201"/>
 		<info name="alt_title" value="アイ・オブ・ザ・ビホルダー2 ザ・レジェンド・オブ・ダークムーン" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4916,6 +4989,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>F29 Retaliator</description>
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HME-126"/>
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -4944,11 +5018,76 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pro Yakyuu Family Stadium - 90-nendo Pennant Race-ban</description>
 		<year>1990</year>
 		<publisher>ゲームアーツ (Game Arts)</publisher>
+		<info name="serial" value="HMB-135"/>
 		<info name="alt_title" value="プロ野球ファミリー・スタジアム　９０年度　ペナント・レース版" />
 		<info name="release" value="199009xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="pro yakyuu family stadium - 90-nendo pennant race-ban (japan)" sha1="da59ba87b6ebd5ded5dbad2576466ef2d377e370" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="fbas1120">
+		<!--
+		 Origin: redump.org
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 01).bin" size="55389600" crc="661d4cfb" sha1="614dfc9829ff5896d611f24a6f0cc6a912c9e7eb"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 02).bin" size="41729184" crc="17f838e9" sha1="faef4319da96fe3ea061b19e7c5a79a56604d090"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 03).bin" size="14765856" crc="f5a2bfbc" sha1="feec18ce8a1250704f2c9e8c66671568b50655a4"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 04).bin" size="24049200" crc="23d46b62" sha1="f3fc81272c05f6473d0dc9e00bc3da35658b0fd6"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 05).bin" size="37213344" crc="67350f17" sha1="00b992141bd49aeaa6cf52d5fdc479c9be3906ea"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 06).bin" size="8968176" crc="00282ec8" sha1="43bec43cd44be78a014becc94ac2c33126eb0f6b"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 07).bin" size="5374320" crc="a4d5c277" sha1="620ad28f7e21abd38cb9af378d892330ad6cd7a7"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 08).bin" size="5002704" crc="e688b514" sha1="068af1d56da66a8ee8b3adfdcd8f4c5902d790a3"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 09).bin" size="9360960" crc="e966f3ec" sha1="4245e9492a0a2660380b11dfa458c06b4041b2a3"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 10).bin" size="4675776" crc="c90f1de0" sha1="139630c7a5aaf478110cd77bd1d4e5c218bc68fb"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan) (Track 11).bin" size="16793280" crc="65bb0664" sha1="85a7e637bf3385266c1bf4cc80f3972b41369d17"/>
+		<rom name="F-BASIC 386 V1.1L20 (Japan).cue" size="1347" crc="66f2a827" sha1="8bd2347f7b20890a10bc139ec4d3027db3f3b049"/>
+		 -->
+		<description>F-BASIC386 v1.1 L20</description>
+		<year>1989</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276C010"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="f-basic 386 v1.1l20 (japan)" sha1="2c18dc8b8193ed5c5b41a6caba8103ea41da0bcc" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="fbas2110">
+		<!--
+		 Origin: Neo Kobe Collection
+		 <rom name="[OS] F-BASIC386 v2.1 L10.ccd" size="3071" crc="64bd4d99" sha1="2c76405c25dff4e953d8c606621133052aea1672"/>
+		 <rom name="[OS] F-BASIC386 v2.1 L10.cue" size="560" crc="cddd018e" sha1="9ca85c05b3c4924e7ad27ecdbc08d2e00a5217e1"/>
+		 <rom name="[OS] F-BASIC386 v2.1 L10.img" size="488628000" crc="0b7a6c2a" sha1="8f0124c6b2d00be0a5f340960e7e408130bba993"/>
+		 <rom name="[OS] F-BASIC386 v2.1 L10.sub" size="19944000" crc="1f33b8a9" sha1="fc5a64a01b80fedd4f5e39e3102cf38946b47a45"/>
+		 -->
+		<description>F-BASIC386 v2.1 L10</description>
+		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="[os] f-basic386 v2.1 l10" sha1="e69f917dc978dea9a602adf3864db4543d314c9a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="fbc1121">
+		<!--
+		 Origin: P2P
+		<rom name="IMAGE.CCD" size="4739" crc="07402a20" sha1="376a14d20416fa7f59aab0f36a514b01353cdf6e"/>
+		<rom name="IMAGE.cue" size="1243" crc="f920c1b0" sha1="664fa6f17de2261dae1f235026b796cea6947a84"/>
+		<rom name="IMAGE.img" size="514429440" crc="a41e8093" sha1="fb2f641ce75e31a756fbb8387c87b43a0228af41"/>
+		<rom name="IMAGE.sub" size="20997120" crc="0db76ce5" sha1="7ec6d6a578de84315ce574ec7a86803e4dbab10a"/>
+		 -->
+		<description>F-BASIC386 Compiler v1.1 L21</description>
+		<year>1991</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fbc1121" sha1="5ea72d3c25554a3bdcd64085ff4271cb5b0aac46" />
 			</diskarea>
 		</part>
 	</software>
@@ -4966,6 +5105,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Final Blow</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-134"/>
 		<info name="alt_title" value="ファイナル・ブロー" />
 		<info name="release" value="199003xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4987,6 +5127,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Flashback</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMF-105"/>
 		<info name="alt_title" value="フラッシュバック" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5007,6 +5148,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>FM Towns Hyper CD Demo Futoppara No. 1</description>
 		<year>1989</year>
 		<publisher>SoftBank</publisher>
+		<info name="serial" value="HMA-208"/>
 		<info name="alt_title" value="太っ腹 Ｎｏ．１" />
 		<info name="release" value="198907xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5027,6 +5169,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>FM Towns Super Technology Demo 1993</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-219"/>
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5102,6 +5245,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Fractal Engine Demo</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-198 / A2760210 / TSC200"/>
 		<info name="release" value="199202xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5122,6 +5266,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Will: Knight of Argent</description>
 		<year>1992</year>
 		<publisher>Sofcom</publisher>
+		<info name="serial" value="HMD-185"/>
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5168,6 +5313,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 4</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-175-1 / HMC-175-2 / A2760132"/>
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
@@ -5200,6 +5346,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 5</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-117 / A2760240"/>
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5218,6 +5365,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 6</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-141 / A2760241"/>
 		<info name="release" value="199306xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5236,6 +5384,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 7</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-225 / A2760242"/>
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5254,6 +5403,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 8</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-141 / A2760243"/>
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5272,6 +5422,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 9</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-185 / A2760244"/>
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5290,6 +5441,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 10</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMG-119 / A2760245"/>
 		<info name="release" value="199506xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5308,6 +5460,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection 11</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMG-140 / A2760246"/>
 		<info name="release" value="199506xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5326,6 +5479,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Free Software Collection Marty 1</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-224 / A2760490"/>
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5346,6 +5500,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hishouzame / Flying Shark</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-194"/>
 		<info name="alt_title" value="飛翔鮫" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5406,6 +5561,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 1</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-233"/>
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5427,6 +5583,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 2</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-165"/>
 		<info name="release" value="199006xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -5454,6 +5611,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Freeware Collection 3</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-105 / A2760131"/>
 		<info name="release" value="199103xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5480,6 +5638,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Fujitsu Habitat V2.1L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-183"/>
 		<info name="alt_title" value="富士通 Habitat V2.1L10" />
 		<info name="release" value="199405xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5491,6 +5650,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fujitsu habitat v2.1l10 (japan)" sha1="5704f482ca0bb17e0a01f82bfc4ea272a7534bda" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hstudio">
+		<!--
+		Origin: redump.org
+		<rom name="HomeStudio V1.2L10 (Japan).bin" size="52567200" crc="92e93784" sha1="abc6e6e30fb071e5ddcf1502e698f20b2b0cca62"/>
+		<rom name="HomeStudio V1.2L10 (Japan).cue" size="92" crc="a0c37387" sha1="f5944a5a92898f72bdf027b99aed48e41c796151"/>
+		-->
+		<description>HomeStudio V1.2L10</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="FMB-3018 / B276D061"/>
+		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="homestudio v1.2l10 (japan)" sha1="2248f1e971cd4f96f40b57cd6659af2fe64d531d" />
 			</diskarea>
 		</part>
 	</software>
@@ -5511,6 +5689,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>G5</description>
 		<year>1989</year>
 		<publisher>エー・エム・アール (AMR)</publisher>
+		<info name="serial" value="HMA-206A"/>
 		<info name="alt_title" value="ジーファイヴ" />
 		<info name="release" value="198907xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5531,6 +5710,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gadget - Invention, Travel, &amp; Adventure</description>
 		<year>1993</year>
 		<publisher>東芝EMI (Toshiba EMI)</publisher>
+		<info name="serial" value="TONP-2002"/>
 		<info name="alt_title" value="ガジェット" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires HDD installation, Windows 3.1 and 8 MB RAM. According to the packaging, the FM Towns II MA is the recommended model."/>
@@ -5580,6 +5760,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Galaxy Force II</description>
 		<year>1991</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-168 / T2034-104"/>
 		<info name="alt_title" value="ギャラクシーフォースII" />
 		<info name="release" value="199103xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5601,6 +5782,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Game Technopolis Super Collection 1</description>
 		<year>1992</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
+		<info name="serial" value="HMD-134"/>
 		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション1" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5619,6 +5801,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Game Technopolis Super Collection 2</description>
 		<year>1993</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
+		<info name="serial" value="HME-184"/>
 		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション2" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5668,6 +5851,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gekirin - Ushinawareshi Houken</description>
 		<year>1994</year>
 		<publisher>日本アプリケーション (Nihon Application)</publisher>
+		<info name="serial" value="HMF-193"/>
 		<info name="alt_title" value="ＧＥＫＩＲＩＮ 失なわれし宝剣" />
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5710,6 +5894,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gendai Daisenryaku EX Special</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-148"/>
 		<info name="alt_title" value="現代大戦略ＥＸスペシャル" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5729,6 +5914,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Genocide Square</description>
 		<year>1993</year>
 		<publisher>Zoom</publisher>
+		<info name="serial" value="HME-117 / MTC-1040"/>
 		<info name="alt_title" value="ジェノサイド・スクウエア" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5762,13 +5948,14 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="ginga3sp">
 		<!--
-		Origin: Private dump (r09)
-		<rom name="gingaed3sp.cue" size="99" crc="0a99439a" sha1="299c921e39ccc248ae8ca7f73b1e34ef6832d157"/>
-		<rom name="gingaed3sp.bin" size="11830560" crc="c48bb3ab" sha1="afb6dd9762aa849f13393f0f488a61198b71bf7b"/>
+		Origin: redump.org
+		<rom name="Ginga Eiyuu Densetsu III SP (Japan).bin" size="11830560" crc="c48bb3ab" sha1="afb6dd9762aa849f13393f0f488a61198b71bf7b"/>
+		<rom name="Ginga Eiyuu Densetsu III SP (Japan).cue" size="124" crc="48020355" sha1="1c05dc4ef1437b93513e99c741f7aa11386020b2"/>
 		-->
 		<description>Ginga Eiyuu Densetsu III SP</description>
 		<year>1993</year>
 		<publisher>ボーステック (Bothtec)</publisher>
+		<info name="serial" value="QR-9353"/>
 		<info name="alt_title" value="銀河英雄伝説III SP" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5780,7 +5967,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gingaed3sp" sha1="a490e0279fbb11f6e0b3d97e1cceb74c0cc09c09" />
+				<disk name="ginga eiyuu densetsu iii sp (japan)" sha1="a490e0279fbb11f6e0b3d97e1cceb74c0cc09c09" />
 			</diskarea>
 		</part>
 	</software>
@@ -5796,6 +5983,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Goh II Towns Special</description>
 		<year>1993</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HME-120"/>
 		<info name="alt_title" value="轟2タウンズスペシャル" />
 		<info name="release" value="198909xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5821,6 +6009,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gokko Vol. 01 - Doctor</description>
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="HMF-191"/>
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5839,6 +6028,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gokko Vol. 02 - School Gal's</description>
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="HMF-196"/>
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5857,6 +6047,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gokko Vol. 03 - Etcetera</description>
 		<year>1994</year>
 		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="HMF-198"/>
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -5877,6 +6068,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Märchen Toshokan - Grimm Douwa - Akazukin</description>
 		<year>1989</year>
 		<publisher>ぎょうせい (Gyousei)</publisher>
+		<info name="serial" value="HMA-271"/>
 		<info name="alt_title" value="メルヘン図書館　グリム童話　赤ずきん" />
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5889,13 +6081,14 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="gulfwar">
 		<!--
-		Origin: Private dump (r09)
-		<rom name="gulfwar.cue" size="73" crc="b26630b6" sha1="e30f87162664eb70b085517809b7dcddde4d4ea6"/>
-		<rom name="gulfwar.bin" size="10231200" crc="d93096ec" sha1="f570fce35e8f5beafa3e373cbae67b58aadce3db"/>
+		Origin: redump.org
+		<rom name="Gulf War - Soukouden (Japan).bin" size="10231200" crc="d93096ec" sha1="f570fce35e8f5beafa3e373cbae67b58aadce3db"/>
+		<rom name="Gulf War - Soukouden (Japan).cue" size="94" crc="a2718ca2" sha1="4391c7c122ead232b7214a77f6366a90533e9380"/>
 		-->
 		<description>Gulf War - Soukouden</description>
 		<year>1993</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HME-230 / CD-W23-TO"/>
 		<info name="alt_title" value="ＧＵＬＦ ＷＡＲ 蒼鋼伝" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5961,6 +6154,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mobile Suit Gundam - Hyper Classic Operation</description>
 		<year>1992</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="HMD-154 / MTC-1013"/>
 		<info name="alt_title" value="機動戦士ガンダム ハイパー クラシック オペレーション" />
 		<info name="release" value="199208xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -5982,6 +6176,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mobile Suit Gundam - Hyper Desert Operation</description>
 		<year>1992</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="HMD-170"/>
 		<info name="alt_title" value="機動戦士ガンダム ハイパー デザート オペレーション" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6008,6 +6203,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Gunship - The Helicopter Simulation</description>
 		<year>1990</year>
 		<publisher>マイクロプローズジャパン (MicroProse Japan)</publisher>
+		<info name="serial" value="HMB-132 / FWFJ 34109"/>
 		<info name="release" value="199010xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6028,6 +6224,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hana no Kioku</description>
 		<year>1995</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="serial" value="CBF-0001"/>
 		<info name="alt_title" value="花の記憶" />
 		<info name="release" value="199512xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6055,12 +6252,12 @@ User/save disks that can be created from the game itself are not included.
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="hanafuda de pon! (boot disk).hdm" size="1261568" crc="cad3cfe6" sha1="3d4eb251057b7a82cabb683114731013ced571ad" offset="000000" />
+				<rom name="hanafuda de pon (boot disk).hdm" size="1261568" crc="cad3cfe6" sha1="3d4eb251057b7a82cabb683114731013ced571ad" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hanafuda de pon!" sha1="e6c9322b57da82c08ac7a7d91e50771214820806" />
+				<disk name="hanafuda de pon" sha1="e6c9322b57da82c08ac7a7d91e50771214820806" />
 			</diskarea>
 		</part>
 	</software>
@@ -6074,6 +6271,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hana yori Dango 2</description>
 		<year>1993</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="HME-115"/>
 		<info name="alt_title" value="花よりダンゴ２" />
 		<info name="release" value="19930417" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6100,7 +6298,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heart de ron!!" sha1="1c95cf153e055068b71f8fd6fffe760d1ddd2ac0" />
+				<disk name="heart de ron" sha1="1c95cf153e055068b71f8fd6fffe760d1ddd2ac0" />
 			</diskarea>
 		</part>
 	</software>
@@ -6134,6 +6332,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>High C Compiler Multimedia Kit v1.7 L12</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D220"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6181,6 +6380,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kotoba Asobi - CDView HiP Catch</description>
 		<year>1992</year>
 		<publisher>CRC総合研究所 (CRC Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMC-190"/>
 		<info name="alt_title" value="ことばあそび　ＣＤＶＩＥＷ　ＨｉＰ　ＣＡＴＣＨ" />
 		<info name="release" value="199203xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6200,6 +6400,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hiouden II</description>
 		<year>1994</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HMF-104 / CD-W24-TO"/>
 		<info name="alt_title" value="緋王伝II" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6235,6 +6436,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hoshi no Suna Monogatari</description>
 		<year>1992</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HMD-164"/>
 		<info name="alt_title" value="星の砂物語" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6296,6 +6498,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Address (HMB-106A)</description>
 		<year>1990</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HMB-106A"/>
 		<info name="release" value="199006xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -6319,6 +6522,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Address (HMB-106)</description>
 		<year>1990</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HMB-106"/>
 		<info name="release" value="199003xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
@@ -6384,6 +6588,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Channel - Towns TV</description>
 		<year>1990</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="serial" value="HMA-260"/>
 		<info name="alt_title" value="ハイパー・チャンネル　ＴＯＷＮＳ　ＴＶ" />
 		<info name="release" value="199001xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6458,6 +6663,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Media NHK Zoku Kiso Eigo - Dai-3-kan</description>
 		<year>1991</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMC-151"/>
 		<info name="alt_title" value="ハイパー・メディア　ＮＨＫ続基礎英語　第３巻" />
 		<info name="release" value="199109xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6480,6 +6686,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Ocean</description>
 		<year>1993</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HME-109"/>
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6525,6 +6732,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>if 2 - Invitations from Fantastic Stories</description>
 		<year>1993</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="HMF-228 / 2TD-3003"/>
 		<info name="alt_title" value="イフ2" />
 		<info name="release" value="19931119" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6546,6 +6754,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Igo II</description>
 		<year>1989</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMA-219"/>
 		<info name="alt_title" value="囲碁II" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -6587,6 +6796,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Image Fight</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-202"/>
 		<info name="alt_title" value="イメージファイト" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6622,6 +6832,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Incredible Machine</description>
 		<year>1994</year>
 		<publisher>サイベル (Cybelle)</publisher>
+		<info name="serial" value="HMF-122"/>
 		<info name="alt_title" value="インクレディブル・マシーン" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6657,6 +6868,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Indiana Jones and the Last Crusade</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-142 / A2760060 / TSC170"/>
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6679,6 +6891,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Indiana Jones and the Fate of Atlantis</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HME-185"/>
 		<info name="release" value="199308xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6698,6 +6911,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Infestation - Chinmoku no Wakusei</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMC-199 / F-5504"/>
 		<info name="alt_title" value="インフェステーション 沈黙の惑星" />
 		<info name="release" value="199203xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6719,12 +6933,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Inindou - Datou Nobunaga</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMC-188"/>
 		<info name="alt_title" value="伊忍道・打倒信長" />
 		<info name="release" value="199202xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
-			<dataarea name="flop" size="1261568">
+			<dataarea name="flop" size="1281968">
 				<rom name="inindo.d88" size="1281968" crc="8228d430" sha1="074d1fb23eb31b6d388deeeded545c4202cd5dee" offset="000000" />
 			</dataarea>
 		</part>
@@ -6746,6 +6961,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Injuu Gakuen - La Blue Girl</description>
 		<year>1994</year>
 		<publisher>DEZ</publisher>
+		<info name="serial" value="HMF-152"/>
 		<info name="alt_title" value="淫獣学園 Laブルーガール" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6801,6 +7017,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ishin no Arashi</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMB-115"/>
 		<info name="alt_title" value="維新の嵐" />
 		<info name="release" value="199003xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -6826,6 +7043,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jan Jaka Jan</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMD-206"/>
 		<info name="alt_title" value="雀ジャカ雀" />
 		<info name="release" value="199301xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6846,6 +7064,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jangou 4</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMF-184"/>
 		<info name="alt_title" value="雀豪４" />
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
@@ -6867,6 +7086,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Jankirou</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMF-156"/>
 		<info name="alt_title" value="雀妃楼" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6900,13 +7120,14 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="joker">
 		<!--
-		Origin: redump.org / r09
+		Origin: redump.org
 		<rom name="Joker Towns (Japan).bin" size="20815200" crc="2b3c7c6d" sha1="d9c07fdb96b0110020e3544d1fa1d14c22acd0fb"/>
 		<rom name="Joker Towns (Japan).cue" size="85" crc="df7897a1" sha1="2e27bb3a4d74326880501d3d7bb621694db9d229"/>
 		-->
 		<description>Joker Towns</description>
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="serial" value="HMD-152 / MTC-1006"/>
 		<info name="release" value="199207xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -6927,6 +7148,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshikousei Shoujo Hatsunetsu</description>
 		<year>1993</year>
 		<publisher>Byakuya-Shobo</publisher>
+		<info name="serial" value="HME-231"/>
 		<info name="alt_title" value="女子高生少女発熱" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6946,6 +7168,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshikou Seifuku Monogatari</description>
 		<year>1995</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="serial" value="JSGF60026"/>
 		<info name="alt_title" value="女子校制服物語" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6972,6 +7195,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Joshua</description>
 		<year>1992</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
+		<info name="serial" value="HMD-196"/>
 		<info name="alt_title" value="ジョシュア" />
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -6992,6 +7216,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kanade V1.1L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276E210"/>
 		<info name="alt_title" value="奏　Ｖ１．１Ｌ１０" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -7013,6 +7238,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Katakana no Ehon</description>
 		<year>1995</year>
 		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
+		<info name="serial" value="HMG-104"/>
 		<info name="alt_title" value="カタカナのえほん" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7033,6 +7259,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kanji no Ehon</description>
 		<year>1992</year>
 		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
+		<info name="serial" value="HMD-139"/>
 		<info name="alt_title" value="かんじのえほん" />
 		<info name="release" value="199207xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7056,6 +7283,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kanji Land 3-nen</description>
 		<year>1995</year>
 		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
+		<info name="serial" value="OSL-010A"/>
 		<info name="alt_title" value="漢字ランド３年" />
 		<info name="release" value="199507xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7077,11 +7305,31 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kid Pix</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-114"/>
 		<info name="release" value="199208xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kid pix" sha1="090939e80a209292d6b606e3e7b2b44bbd3585be" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="kidpixjr">
+		<!--
+		Origin: redump.org
+		<rom name="Kid Pix Jr. (Japan).bin" size="50803200" crc="a4c4efdc" sha1="f0d0b3320b2dcf6f144f191de9a5b5d1fae4e6dd"/>
+		<rom name="Kid Pix Jr. (Japan).cue" size="85" crc="999adc54" sha1="f23c245c8471e49b7af9977e3844481f83813fcf"/>
+		-->
+		<description>Kid Pix Jr.</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-116 / A2760390 / TSC-300"/>
+		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="kid pix jr. (japan)" sha1="d04476f773b16a14bc53ca2f19695b5db7bd789a" />
 			</diskarea>
 		</part>
 	</software>
@@ -7095,6 +7343,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kigen - Kagayaki no Hasha</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMD-122"/>
 		<info name="alt_title" value="ＫＩＧＥＮ 輝きの覇者" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7116,6 +7365,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kindan no Ketsuzoku</description>
 		<year>1993</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="serial" value="HMF-155"/>
 		<info name="alt_title" value="禁断の血族" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7137,6 +7387,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>King's Bounty - Nusumareta Chitsujo</description>
 		<year>1994</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMF-154"/>
 		<info name="alt_title" value="キングス バウンティ 盗まれた秩序" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7180,6 +7431,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kiwame</description>
 		<year>1992</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="serial" value="HMD-172 / MTC-1016"/>
 		<info name="alt_title" value="極" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7201,6 +7453,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kiwame II</description>
 		<year>1994</year>
 		<publisher>ログ (Log)</publisher>
+		<info name="serial" value="HMF-158"/>
 		<info name="alt_title" value="極II" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7222,6 +7475,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Koko wa Rakuensou</description>
 		<year>1996</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="serial" value="CBF-0003"/>
 		<info name="alt_title" value="ここは楽園荘" />
 		<info name="release" value="199603xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7241,6 +7495,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Koko wa Rakuensou 2</description>
 		<year>1996</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="serial" value="HMA-236 / CBF-0004"/>
 		<info name="alt_title" value="ここは楽園荘2" />
 		<info name="release" value="199604xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7262,6 +7517,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kyan Kyan Collection</description>
 		<year>1989</year>
 		<publisher>I-Cell</publisher>
+		<info name="serial" value="HMA-236"/>
 		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -7281,6 +7537,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Dennou Ehon - Kyouryuu no Sekai</description>
 		<year>1990</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="serial" value="HMB-133"/>
 		<info name="alt_title" value="電脳絵本 恐竜の世界" />
 		<info name="release" value="199004xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7331,6 +7588,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kyouiku &amp; FM Towns Vol. 3</description>
 		<year>1992?</year>
 		<publisher>電脳商会 (Dennou Shoukai)</publisher>
+		<info name="serial" value="HMC-526"/>
 		<info name="alt_title" value="教育＆ＦＭ　ＴＯＷＮＳ　ＶＯＬ．３" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -7370,6 +7628,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Legend of Kyrandia</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="SC-93002"/>
 		<info name="alt_title" value="レジェンド・オブ・キランディア" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7479,6 +7738,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kyrandia II - The Hand of Fate</description>
 		<year>1995</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMG-130"/>
 		<info name="alt_title" value="キランディア2 運命の手" />
 		<info name="release" value="199510xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7499,6 +7759,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Kyuukyoku Tiger</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-246"/>
 		<info name="alt_title" value="究極タイガー" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7520,6 +7781,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ku²++</description>
 		<year>1993</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
+		<info name="serial" value="HME-243"/>
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -7540,8 +7802,9 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="lands of lore.cue" size="74" crc="95020903" sha1="994125d8e7d1be1ebe0728e1bdb4258f648ef50a"/>
 		-->
 		<description>Lands of Lore - The Throne of Chaos</description>
-		<year>1993</year>
+		<year>1995</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMF-201"/>
 		<info name="alt_title" value="ランズ オブ ロア" />
 		<info name="release" value="199501xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7729,6 +7992,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Last Armageddon CD Special</description>
 		<year>1989</year>
 		<publisher>ブレイングレイ (Brain Grey)</publisher>
+		<info name="serial" value="HMA-207"/>
 		<info name="alt_title" value="ラスト・ハルマゲドン CDスペシャル" />
 		<info name="release" value="198907xx" />
 		<part name="cdrom1" interface="fmt_cdrom">
@@ -7768,6 +8032,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Last Survivor</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-167"/>
 		<info name="alt_title" value="ラストサバイバー" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7826,6 +8091,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Leading Company</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-104 / KN10241030"/>
 		<info name="alt_title" value="リーディングカンパニー" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7853,6 +8119,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lemmings</description>
 		<year>1992</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HMD-106"/>
 		<info name="alt_title" value="レミングス" />
 		<info name="release" value="199204xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -7874,6 +8141,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lemmings 2 - The Tribes</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-258"/>
 		<info name="alt_title" value="レミングス2 ザ・トライブス" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7895,6 +8163,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lesser Mern</description>
 		<year>1992</year>
 		<publisher>パンサーソフトウェア (Panther Software)</publisher>
+		<info name="serial" value="HMD-181 / MTC-1019"/>
 		<info name="alt_title" value="レッサーメルン" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7939,6 +8208,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Libido7</description>
 		<year>1994</year>
 		<publisher>リビドー (Libido)</publisher>
+		<info name="serial" value="MTC-1093"/>
 		<info name="alt_title" value="リビドー７" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7962,6 +8232,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Life &amp; Death</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMC-193"/>
 		<info name="alt_title" value="ライフ＆デス" />
 		<info name="release" value="199201xx" />
 		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
@@ -7983,6 +8254,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Life &amp; Death II - The Brain</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMD-177"/>
 		<info name="alt_title" value="ライフ＆デスII" />
 		<info name="release" value="199211xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8073,6 +8345,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Loom</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-111-1 / HMC-111-2 / A2760080 / TSC090"/>
 		<info name="release" value="199104xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
@@ -8099,6 +8372,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Libble Rabble</description>
 		<year>1994</year>
 		<publisher>電波新聞社 (Dempa Shinbunsha)</publisher>
+		<info name="serial" value="DP-3301216"/>
 		<info name="alt_title" value="リブルラブル" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8119,6 +8393,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lord of the Rings, Vol. I</description>
 		<year>1992</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMD-113"/>
 		<info name="alt_title" value="指輪物語 第一巻 旅の仲間" />
 		<info name="release" value="199203xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8140,6 +8415,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>J. R. R. Tolkien's The Lord of the Rings, Vol. II - The Two Towers</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HME-130"/>
 		<info name="alt_title" value="指輪物語 第二巻 二つの塔" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8167,6 +8443,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-125"/>
 		<info name="alt_title" value="ルパン三世-香港の魔手 「復讐は迷宮の果てに」" />
 		<info name="release" value="199006xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8193,6 +8470,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Legends of Valour - Gouyuu no Densetsu</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-259"/>
 		<info name="alt_title" value="レジェンド・オブ・バロア ～豪勇の伝説～" />
 		<info name="release" value="199403xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8213,6 +8491,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mad Paradox</description>
 		<year>1994</year>
 		<publisher>クィーンソフト (Queensoft)</publisher>
+		<info name="serial" value="HMF-107"/>
 		<info name="alt_title" value="マッドパラドックス" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8288,12 +8567,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mahjong de Pon!</description>
 		<year>1994</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="2TD-3013"/>
 		<info name="alt_title" value="麻雀でPON！" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mahjong de pon! (japan)" sha1="a6332b3d1f893621f25f035b538cb14a6e5d946e" />
+				<disk name="mahjong de pon (japan)" sha1="a6332b3d1f893621f25f035b538cb14a6e5d946e" />
 			</diskarea>
 		</part>
 	</software>
@@ -8327,6 +8607,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mahjong Bishoujoden Ripple</description>
 		<year>1995</year>
 		<publisher>フォーサイト (Foresight)</publisher>
+		<info name="serial" value="FSCR-001"/>
 		<info name="alt_title" value="麻雀美少女伝リップル" />
 		<info name="release" value="199502xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8346,6 +8627,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mahou Daisakusen</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMF-182"/>
 		<info name="alt_title" value="魔法大作戦" />
 		<info name="release" value="199502xx" />
 		<info name="usage" value="Requires 3 MB RAM"/>
@@ -8388,6 +8670,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Many Colors</description>
 		<year>1993</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="serial" value="HMD-225A"/>
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8430,6 +8713,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Marble Madness</description>
 		<year>1991</year>
 		<publisher>ホームデータ (Home Data)</publisher>
+		<info name="serial" value="HMC-124 / HD91406"/>
 		<info name="alt_title" value="マーブルマッドネス" />
 		<info name="release" value="199106xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8449,6 +8733,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Marine Philt</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HME-132"/>
 		<info name="alt_title" value="マリンフィルト" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8481,19 +8766,49 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="mbomber">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Muscle Bomber.mdf" size="579201696" crc="2383cfb2" sha1="1da7b2822c496bd727dfa1d4c67a266f5719d01e"/>
-		<rom name="Muscle Bomber.mds" size="3038" crc="403bad3d" sha1="7abc6f7ca827e6c87ee1b48e162fa1ba9b6f0524"/>
+		Origin: redump.org
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 01).bin" size="29576400" crc="2cd9aca2" sha1="847518006253f270fb7825638d48558f5dca1a00"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 02).bin" size="3904320" crc="814ec9ee" sha1="56f81d416fafcaa9780abc0a245dae1e903b524d"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 03).bin" size="7408800" crc="3a321d7f" sha1="e7453454b2a52a6d2a83fd40c375171b043cf694"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 04).bin" size="1364160" crc="6cbed03a" sha1="aca6469b7fcad554a5a4e0b56d5b4995de2221f3"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 05).bin" size="12164544" crc="0ff408ec" sha1="996980cb0a90e73d0fb4b774c7bd4a00684f5675"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 06).bin" size="12178656" crc="b54fd6d5" sha1="b94c368cf299cee73995c645fa7a78178b741eba"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 07).bin" size="12176304" crc="a3832499" sha1="fa6ce52c683bbc78b184ce1eafeba7add988d793"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 08).bin" size="12166896" crc="f848b512" sha1="7e6bee2cd1f4a03bb2da5de7e0cd5efa475e0959"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 09).bin" size="12206880" crc="7c8d5989" sha1="d91bebc2b70820f5469683a0cf8f7ec9aa1f2504"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 10).bin" size="12171600" crc="c7737beb" sha1="f6242f0a90f7172a73ba8f82e25c37989acc32d1"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 11).bin" size="12171600" crc="f2677702" sha1="a7b21ee1ac0e68c462f24565fb02bbb55ef3e913"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 12).bin" size="12171600" crc="17c004fb" sha1="3a57f0b77f4865ee44961e0e51413780ba129ab7"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 13).bin" size="12164544" crc="e89a63a4" sha1="feee1b930bed88a04dbd61e57b9c56f6f9bbeac7"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 14).bin" size="12166896" crc="3560aef1" sha1="a55ad3e98f4e605b949d2b4ca630dbbbfbbfc437"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 15).bin" size="36867600" crc="9d49e813" sha1="832eac30662590562a844a646a94d05724024dda"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 16).bin" size="36855840" crc="b3118605" sha1="bf718aef78f7e0805ae9beee8c1d565af8f2030f"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 17).bin" size="36867600" crc="b45d20e6" sha1="5b944c30e2758c9f69764e75247c2683b412217b"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 18).bin" size="36867600" crc="33193c10" sha1="7b4f033e97a71dcc7d66a02bab4370dd0dda856c"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 19).bin" size="36860544" crc="38c38aa4" sha1="f908f911534f89a94baa9399485b56dac0b52bd7"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 20).bin" size="36862896" crc="35e5a6b1" sha1="cb74b568202e0db80026520d623c62626f226711"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 21).bin" size="36860544" crc="8ebd9ac9" sha1="2018666bd1f60d3fd0d16d2a989d30badf82674a"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 22).bin" size="36862896" crc="42031012" sha1="3df7411e8d8953d4b1c04ff87799e1dce7963ce8"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 23).bin" size="36867600" crc="05969e02" sha1="4d6cdfd5d5d74cb8fe3799e1f5ee14a81eafcbd8"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 24).bin" size="1164240" crc="9f9a6e56" sha1="e6b6e46207a5fb19acf6487fb04277acb3a44aef"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 25).bin" size="10325280" crc="778db1ef" sha1="de20ac9ed5cc21d2f48652b0579be4f8e26a57be"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 26).bin" size="1246560" crc="c5a7e8dd" sha1="0d6b618307c7b7c2a85f18c978118880734fef52"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 27).bin" size="1505280" crc="4605bf4e" sha1="37eedfef26f92ea41c367824dbd7cd6cd75a078e"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 28).bin" size="10395840" crc="376d9d49" sha1="cbebfae73a227084de8e14bf7e8ce8f50d0ae991"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 29).bin" size="15452640" crc="08f4127a" sha1="cb78f5df9253f3884a9cb5e0976d0686fe2f225d"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan) (Track 30).bin" size="20984544" crc="5a147859" sha1="7d4f485c2c1f558d69838e0b13a1024cb1c48c8d"/>
+		<rom name="Muscle Bomber - The Body Explosion (Japan).cue" size="4092" crc="e33fa896" sha1="79bd4f5e2d85bd5adf60b5b8e5c1af42470af264"/>
 		-->
 		<description>Muscle Bomber - The Body Explosion</description>
 		<year>1993</year>
 		<publisher>カプコン (Capcom)</publisher>
+		<info name="serial" value="HME-227"/>
 		<info name="alt_title" value="マッスルボマー" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="muscle bomber" sha1="c10e04ed66acd02d9e383e948625091bb8c37cd9" />
+				<disk name="muscle bomber - the body explosion (japan)" sha1="18a0b9b11880cac45b6cc4e212a5004ede512628" />
 			</diskarea>
 		</part>
 	</software>
@@ -8515,6 +8830,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Microcosm (HMD-215A)</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-215A / A2760410 / TSC340"/>
 		<info name="alt_title" value="マイクロコズム" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8542,6 +8858,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Microcosm (HMD-215)</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-215 / A2760410 / TSC340"/>
 		<info name="alt_title" value="マイクロコズム" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8563,6 +8880,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mega Lo Mania</description>
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HME-119"/>
 		<info name="alt_title" value="メガロマニア" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8607,6 +8925,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Metal Eye</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HME-161"/>
 		<info name="alt_title" value="メタルアイ" />
 		<info name="release" value="199307xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8619,21 +8938,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="metaley2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Metal Eye 2.ccd" size="767" crc="3c5874e0" sha1="2c8d455408f231205240a5e6e36e89650017f655"/>
-		<rom name="Metal Eye 2.cue" size="75" crc="41f36759" sha1="4f767b382824be18d5a72ba98ace5ae70431a27e"/>
-		<rom name="Metal Eye 2.img" size="20815200" crc="cdca503f" sha1="e854c199591397594f6726c636d4f1cd5035014a"/>
-		<rom name="Metal Eye 2.sub" size="849600" crc="33bd68f0" sha1="3f88891c58b28e15968d8e5ca8638b9fd66665db"/>
+		Origin: redump.org
+		<rom name="Metal Eye 2 (Japan).bin" size="20815200" crc="cdca503f" sha1="e854c199591397594f6726c636d4f1cd5035014a"/>
+		<rom name="Metal Eye 2 (Japan).cue" size="85" crc="322a732b" sha1="78fcac3f449f29384bbe2f1850625264da68f813"/>
 		-->
 		<description>Metal Eye 2</description>
 		<year>1994</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMF-177"/>
 		<info name="alt_title" value="メタルアイ2" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="metal eye 2" sha1="a657dea0277866d0dee8af92f987985464e5f83d" />
+				<disk name="metal eye 2 (japan)" sha1="2f2a25fb6d4fd20d2e9fc436e10db09f21cc5ec7" />
 			</diskarea>
 		</part>
 	</software>
@@ -8650,6 +8968,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>My Fair Lady CAN II. Elementary</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-184 / T-2036-009"/>
 		<info name="release" value="199009xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8708,31 +9027,12 @@ User/save disks that can be created from the game itself are not included.
 		<description>My Fair Lady CAN III. Intermediate</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-208"/>
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="my fair lady can iii. intermediate (japan)" sha1="eacdc75dad22a3308268fb022a6091c67fc90fd1" />
-			</diskarea>
-		</part>
-	</software>
-
-	<software name="mugenhoy">
-		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Mugen Houyou.ccd" size="2290" crc="efb9c6dd" sha1="dfd3d76b44371623ae396bab962493ca44e64b8e"/>
-		<rom name="Mugen Houyou.cue" size="388" crc="d0dee7b7" sha1="13234af65455d3dfa24183d4b70fb8520abe8a7b"/>
-		<rom name="Mugen Houyou.img" size="470750448" crc="6858f768" sha1="6e46253314b6f06cd4d744a524a90ca388ad3cb3"/>
-		<rom name="Mugen Houyou.sub" size="19214304" crc="00b20527" sha1="ea060ccabe3e87313c22304f9b5d2380e096cd3e"/>
-		-->
-		<description>Mugen Houyou</description>
-		<year>1995</year>
-		<publisher>アリスソフト (AliceSoft)</publisher>
-		<info name="alt_title" value="夢幻泡影" />
-		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
-		<part name="cdrom" interface="fmt_cdrom">
-			<diskarea name="cdrom">
-				<disk name="mugen houyou" sha1="19d89c9f5c41fc1c77bc3a27220aeb9da39f484a" />
 			</diskarea>
 		</part>
 	</software>
@@ -8748,6 +9048,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mirage</description>
 		<year>1992</year>
 		<publisher>ディスカバリー (Discovery)</publisher>
+		<info name="serial" value="HMD-169"/>
 		<info name="alt_title" value="ミラージュ" />
 		<info name="release" value="199201xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8769,6 +9070,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mirrors</description>
 		<year>1992</year>
 		<publisher>Apros</publisher>
+		<info name="serial" value="HMC-176"/>
 		<info name="alt_title" value="ミラーズ" />
 		<info name="release" value="199206xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8808,6 +9110,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Misty - Meitantei Toujou</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-202"/>
 		<info name="alt_title" value="Ｍｉｓｔｙ 名探偵登場" />
 		<info name="release" value="198906xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8826,6 +9129,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic III - Isles of Terra</description>
 		<year>1992</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMD-160"/>
 		<info name="alt_title" value="マイト＆マジックIII" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8845,6 +9149,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic - Clouds of Xeen</description>
 		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HME-190"/>
 		<info name="alt_title" value="クラウズ・オブ・ジーン" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8864,6 +9169,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Might and Magic - Darkside of Xeen</description>
 		<year>1994</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMF-140"/>
 		<info name="alt_title" value="ダークサイド・オブ・ジーン" />
 		<info name="release" value="199405xx" />
 		<info name="usage" value="Requires 3 MB RAM"/>
@@ -8886,6 +9192,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Megamorph</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-174"/>
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -8913,47 +9220,44 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="monkey">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Secret of Monkey Island.mdf" size="553740048" crc="f5901779" sha1="b6453e8c6624a41389a1941a393eaf7742906005"/>
-		<rom name="The Secret of Monkey Island.mds" size="3312" crc="0bd969f2" sha1="4f29b87406dc5cb0698d5123edbe608625d1fe91"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="the secret of monkey island.cue" size="4074" crc="9751447a" sha1="d5d52e89cc5d20d11721fa0c5a0bbceecc242cb3"/>
-		<rom name="track01.bin" size="13495776" crc="067d4a9a" sha1="d7b5582f04f79aeab286df02fa06c9f5a7981d9f"/>
-		<rom name="track02.bin" size="41896176" crc="419291a4" sha1="4cce47f993acd0bfd0cea168ed989cf9a2b3f0d6"/>
-		<rom name="track03.bin" size="22402800" crc="89f2e0ad" sha1="1e2c0a1a321986e55f6282794c1e7b6d80ddfd7a"/>
-		<rom name="track04.bin" size="22755600" crc="752196f9" sha1="7e82a1910b08ddf1b5c0b3325d8e06fb3d7e20c7"/>
-		<rom name="track05.bin" size="20815200" crc="f33b5656" sha1="f27c5a53e468696e1658da537a1aff58216ca408"/>
-		<rom name="track06.bin" size="23108400" crc="64b02737" sha1="e514e3c7f4547119c41192572570c2e1ceca2e9f"/>
-		<rom name="track07.bin" size="2646000" crc="05c4f5c4" sha1="48c1e95cd90857e5c10247ea3ad276f5310f8b4c"/>
-		<rom name="track08.bin" size="12877200" crc="97432d66" sha1="6b56183c301a0fde1ed3ae74e40c0b1d6fa66e80"/>
-		<rom name="track09.bin" size="25048800" crc="b2050100" sha1="24bd814b99e1925c1a24a19bff6dfe0b12c527bc"/>
-		<rom name="track10.bin" size="22226400" crc="7145d83d" sha1="21cbaefc9bebb35baecfd6d06877c78dd5d16d79"/>
-		<rom name="track11.bin" size="17110800" crc="63f56d77" sha1="cfe91cf082a9df067318ab2e3d48d4ce7f3e1e61"/>
-		<rom name="track12.bin" size="24696000" crc="99b5957f" sha1="7d7934c2bf267c1405b2d54e4317516db6859b9b"/>
-		<rom name="track13.bin" size="22226400" crc="8748e4f9" sha1="5c4de86268fad933daf1c9fafbb24ce65e72cbf8"/>
-		<rom name="track14.bin" size="3528000" crc="af8df960" sha1="09aaca7a91a9b3e4063b1d8bccf519f4dfda65cf"/>
-		<rom name="track15.bin" size="28224000" crc="23e3c5ec" sha1="ab998f8a3fe6ab1b5075ffa264419bd3b4e04faf"/>
-		<rom name="track16.bin" size="26989200" crc="c3f6278b" sha1="1be6d8a012a84253308d5e3568f5c1de0ade8257"/>
-		<rom name="track17.bin" size="39513600" crc="841372eb" sha1="ba13a1d3b6d087e3a9f83735a90604e5f47a7ef8"/>
-		<rom name="track18.bin" size="29282400" crc="495c7b2f" sha1="89b610209cd7414d46b2eae08bb3cee02fab03b6"/>
-		<rom name="track19.bin" size="28224000" crc="b9282170" sha1="60df43ca91b950fe3ece9261139469942fcde15b"/>
-		<rom name="track20.bin" size="3880800" crc="e4656fc7" sha1="0817db28d20e68681c887d13fc3938b8fd7d0d6a"/>
-		<rom name="track21.bin" size="4410000" crc="e26288f1" sha1="63540efd6e1b6b4cb5dbab936379ea9ba63b39d6"/>
-		<rom name="track22.bin" size="24343200" crc="066a23df" sha1="ce6a0e2994bd9b6aaec2dfb24c0bca8fdb0cf09f"/>
-		<rom name="track23.bin" size="25930800" crc="0eebbccb" sha1="3b4712780e2c020985a97c90cfb56a7ef4ae6254"/>
-		<rom name="track24.bin" size="24696000" crc="7d527f06" sha1="d55efbaf89a004de1611dfac0b31dfbf4c81b0da"/>
-		<rom name="track25.bin" size="22050000" crc="bc030f08" sha1="c1a1ed3ca80dcff6c0e7ce9a2d60b1ed68f21706"/>
+		Origin: redump.org
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 01).bin" size="13495776" crc="067d4a9a" sha1="d7b5582f04f79aeab286df02fa06c9f5a7981d9f"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 02).bin" size="41896176" crc="bd08bf07" sha1="0b2a817a300e40da8387730905e71d8e77bdbf04"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 03).bin" size="22402800" crc="861fd587" sha1="384e202e60c192f8ae3786858ecbc2713fe93653"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 04).bin" size="22755600" crc="bebe0194" sha1="2a9a19715b6428ec1bad02edf7aa32c789f1af3e"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 05).bin" size="20815200" crc="05409552" sha1="32ae64dc7403bd5791137f8d3c27cd13ebfa1c52"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 06).bin" size="23108400" crc="60081557" sha1="ecbdf7fb8b40b616d4d607e84ef603f1fad4dc78"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 07).bin" size="2646000" crc="dfd74737" sha1="3f153408abb0167a2f1527029dcf8debc15bfa72"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 08).bin" size="12877200" crc="5a8088be" sha1="1202ca702c9d69ae7939f4eb6367ff4a6af8053b"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 09).bin" size="25048800" crc="4b93c20d" sha1="226e21111250b8d6dd72c8ce62e0adb4a0c5c51b"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 10).bin" size="22226400" crc="e7e1b26c" sha1="87fb3ecec152ba78bbb004526ced78e8dd91f3c1"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 11).bin" size="17110800" crc="fb0681df" sha1="15eb8c35bb70003a5f0efda2870b8b432b9c4014"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 12).bin" size="24696000" crc="aafb06ba" sha1="9eb5012395f85a3afdb59b673ff06e7e09ebedd1"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 13).bin" size="22226400" crc="0d67ffeb" sha1="92a0da278dc1d7c093218242974da43e78db9e49"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 14).bin" size="3528000" crc="6d2e8866" sha1="9c03d42ed0474ecdf1b15b85b79279a3754f6688"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 15).bin" size="28224000" crc="a70d76ac" sha1="68ef73396b524a9c2c8e1421350810f09fdc1463"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 16).bin" size="26989200" crc="73efd5e9" sha1="73dd8605c3b6c24a783c3949cf0107f764276c52"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 17).bin" size="39513600" crc="39c1f79e" sha1="97c8dca62e0b6fad9c442266ff8780d84ead3785"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 18).bin" size="29282400" crc="4ee37b16" sha1="e9faee2c9a81558320b7cc48239e6ba6a779ff92"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 19).bin" size="28224000" crc="e2eea527" sha1="1c74774c01a9e14729df031a88d3d494b48c4bbd"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 20).bin" size="3880800" crc="fc98f353" sha1="f0636e7d8790202624cf55c0e33efae1a98123c3"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 21).bin" size="4410000" crc="65e3ba80" sha1="11f00b140be9b5b104c35511c20b81ef139e9ede"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 22).bin" size="24343200" crc="bd736a2e" sha1="17dfcd0cd85117461897ecf52b5b9de77a02e3ed"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 23).bin" size="25930800" crc="5d6ae0e8" sha1="c7e1e94918e23a3b90f3b9aa0144ca5c45ce749e"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 24).bin" size="24696000" crc="ad7b0845" sha1="96c1f112d3f9530d199e5a90a3a0c09596ba82cf"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja) (Track 25).bin" size="22050000" crc="7743d03f" sha1="f46b49e5850f3abcf3d2e95da977e7c4cf6c47cb"/>
+		<rom name="Secret of Monkey Island, The (Japan) (En,Ja).cue" size="3480" crc="6c432bf2" sha1="14837f809a3ebdf5afad68aaf86877e8666aa6e3"/>
 		-->
 		<description>The Secret of Monkey Island</description>
 		<year>1992</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMD-155 / F-5505"/>
 		<info name="alt_title" value="モンキーアイランド" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the secret of monkey island" sha1="06ed4efdb149fbee70474bc9a4fd0002b9a6a31e" />
+				<disk name="secret of monkey island, the (japan) (en,ja)" sha1="aae1f4c6b33fbca3727415ce467b142f7e2cb0ee" />
 			</diskarea>
 		</part>
 	</software>
@@ -8971,6 +9275,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Monkey Island 2 - LeChuck's Revenge</description>
 		<year>1994</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HME-253 / F-5514"/>
 		<info name="alt_title" value="モンキーアイランド２ ～ル・チャックの逆襲～" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -8992,6 +9297,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Moonlight-chan Rinshan</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-129"/>
 		<info name="alt_title" value="Ｍゥーンライトちゃんリンしゃん" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9037,6 +9343,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken</description>
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT 2004 / DWFT 2005"/>
 		<info name="alt_title" value="Ms.DETECTIVE ファイル#1 「石見銀山殺人事件」" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9048,6 +9355,29 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom2" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (disc 2)" sha1="8a4034b01081630e80033b777951c876f41ebc34" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="msdet1m" cloneof="msdet1" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 1).bin" size="473692800" crc="94b7e859" sha1="7f44d047146dfd282abf05dc92e5b9db2eb582ff"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 2).bin" size="57240624" crc="e46efbbc" sha1="b0bda4091b22c7eda443b102d1c2f1271c87567a"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 3).bin" size="5992896" crc="7d0d6658" sha1="f36b48802dd13cfb4c27058455c21915ed395db0"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 4).bin" size="50208144" crc="f10a619d" sha1="8ca2d99e7095fda0c6c1c77fc3c9552657b4da5a"/>
+		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty).cue" size="658" crc="ee907f5a" sha1="53693155a8abb8b3ef7152b6f21cca87bd6b99a5"/>
+		-->
+		<description>Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken (FM Towns Marty version)</description>
+		<year>1992</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFS3009"/>
+		<info name="alt_title" value="Ms.DETECTIVE ファイル#1 「石見銀山殺人事件」" />
+		<info name="release" value="199209xx" />
+		<part name="cdrom1" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (fm towns marty)" sha1="fff0bea9c41f0fca097db68988596abcc5787ce9" />
 			</diskarea>
 		</part>
 	</software>
@@ -9064,6 +9394,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ms. Detective File #2 - Sugata-naki Irainin</description>
 		<year>1993</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWDC 3015"/>
 		<info name="alt_title" value="Ms.DETECTIVE ファイル#2 「姿なき依頼人」" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9089,10 +9420,31 @@ User/save disks that can be created from the game itself are not included.
 		<description>Megaspectre</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-153 / A2760450 / TSC350"/>
 		<info name="release" value="199306xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="megaspectre (japan)" sha1="bf94612efacd913bc7f825c18fcb36750aa26b04" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="mugenhoy">
+		<!--
+		Origin: Neo Kobe Collection
+		<rom name="Mugen Houyou.ccd" size="2290" crc="efb9c6dd" sha1="dfd3d76b44371623ae396bab962493ca44e64b8e"/>
+		<rom name="Mugen Houyou.cue" size="388" crc="d0dee7b7" sha1="13234af65455d3dfa24183d4b70fb8520abe8a7b"/>
+		<rom name="Mugen Houyou.img" size="470750448" crc="6858f768" sha1="6e46253314b6f06cd4d744a524a90ca388ad3cb3"/>
+		<rom name="Mugen Houyou.sub" size="19214304" crc="00b20527" sha1="ea060ccabe3e87313c22304f9b5d2380e096cd3e"/>
+		-->
+		<description>Mugen Houyou</description>
+		<year>1995</year>
+		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="alt_title" value="夢幻泡影" />
+		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="mugen houyou" sha1="19d89c9f5c41fc1c77bc3a27220aeb9da39f484a" />
 			</diskarea>
 		</part>
 	</software>
@@ -9108,6 +9460,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mujintou Monogatari</description>
 		<year>1995</year>
 		<publisher>ケイエスエス (KSS)</publisher>
+		<info name="serial" value="JSGF60028"/>
 		<info name="alt_title" value="無人島物語" />
 		<info name="release" value="199509xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9130,6 +9483,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Murder Club DX</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMD-121 / MTC-1009"/>
 		<info name="alt_title" value="マーダークラブＤＸ" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9162,6 +9516,41 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="musicmac">
 		<!--
+		Origin: redump.org
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 01).bin" size="52567200" crc="f4e44e65" sha1="79d3e242aac915637267f1c0e1b3bc1037ac3032"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 02).bin" size="27518400" crc="0728a186" sha1="ea1a2a33b54837df49c5b23307408958bcfe9c8b"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 03).bin" size="21168000" crc="30691ae4" sha1="d224910f9b05a0475ded118c25f44c2048d00ac4"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 04).bin" size="17110800" crc="cdcb95ad" sha1="810393549963564dc0a1ba7ad22e8fdac0aef3da"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 05).bin" size="22755600" crc="e4387f22" sha1="f56564b05c12b694410d7fdd0a82430b8d997f19"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 06).bin" size="37220400" crc="61a26ae6" sha1="20cfe71a83f1b4daf3b82b85503f777bffa5263d"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 07).bin" size="26460000" crc="50f57586" sha1="a3e2675cbd5e7bf64c585cf046dab1c0396d92e5"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 08).bin" size="34045200" crc="5ef5b4f1" sha1="05cd9dfbc797325b5de1b84f3154d4b71cbb78f4"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 09).bin" size="52038000" crc="1a97a31e" sha1="c770582d09aaa6fc6bde9cd19ffff5ebc3dc7209"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 10).bin" size="27342000" crc="55fb3b38" sha1="71b3db56052bdd4b9f5718cd674d6fae6ea43eb5"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 11).bin" size="25754400" crc="0cb8a125" sha1="d2811421de63fc47a85b66a72d62ad08b061f4bc"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 12).bin" size="22050000" crc="cab89c60" sha1="f59de120d616769bd2799c87fbc48524a376e8e4"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 13).bin" size="23637600" crc="8ad15df7" sha1="547b517c93217fbe7dd5c76899d291868e534a2e"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 14).bin" size="29458800" crc="4f2054f9" sha1="239cfcaa565bd3faceebc5ba008d6540a138efc4"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 15).bin" size="27694800" crc="f4aa2d34" sha1="64a229736b949731e341a9dc0991f01b73e02af8"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 16).bin" size="24519600" crc="490b16de" sha1="a936e866a01358d3ab40dff435102494727d696f"/>
+		<rom name="Ed Bogas' Music Machine (Japan) (Track 17).bin" size="25930800" crc="48781333" sha1="f7e36da669e45fc7c7c685f9ec7c39c1cd9691ff"/>
+		<rom name="Ed Bogas' Music Machine (Japan).cue" size="2124" crc="307120e8" sha1="a27f3f0891aee7940854ae94f49d169e2664ff1d"/>
+		-->
+		<description>Ed Bogas' Music Machine</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-144 / A2760440 / TSC-360"/>
+		<info name="release" value="199311xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="ed bogas' music machine (japan)" sha1="292f1dd1aabf5d59339dd2940b71afcf75806ada" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="musicmaclt">
+		<!--
 		Origin: P2P
 		<rom name="Image.cdm" size="3347" crc="a049d27c" sha1="74cbee93729fdd87d3eddba95d2f3f3d42b4ea04"/>
 		<rom name="Image.cue" size="627" crc="472c64bb" sha1="3ac1a131481a0fbad19d36b6a2fd86248fdbb543"/>
@@ -9171,6 +9560,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Mr. Ed Bogas' Music Machine Lite</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-914"/>
 		<info name="release" value="19931126" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9191,6 +9581,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Musium Towns</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HME-167"/>
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9211,11 +9602,12 @@ User/save disks that can be created from the game itself are not included.
 		<description>My Eyes!</description>
 		<year>1992</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="serial" value="HMD-200"/>
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="my eyes!" sha1="a1093fcd4bbddcd90b3faa0617d5a895c214e3c4" />
+				<disk name="my eyes" sha1="a1093fcd4bbddcd90b3faa0617d5a895c214e3c4" />
 			</diskarea>
 		</part>
 	</software>
@@ -9269,6 +9661,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Fushigi no Umi no Nadia - The Secret of Blue Water</description>
 		<year>1993</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="serial" value="HMD-156-1 / HMD-156-2 / HMD-156-3 / GTX-010 / GTX-011 / GTX-012"/>
 		<info name="alt_title" value="ふしぎの海のナディア" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9303,6 +9696,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Necronomicon</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMF-168"/>
 		<info name="alt_title" value="ネクロノミコン" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9315,19 +9709,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="3dgolfha">
 		<!--
-		Origin: Private dump (r09)
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 1).bin" size="10235904" crc="3737fb6f" sha1="938a1e5f7af506bdbf40620ad75f6bc411e2efff"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 2).bin" size="121993536" crc="0fa88600" sha1="73cb9fcb7f00fc31f3ec6b2f07ef978521da19fa"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 3).bin" size="7754544" crc="734d3a67" sha1="74e5be92e562284827b8aa9258681bb392ff6510"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 4).bin" size="21057456" crc="d9d8b7e7" sha1="1bd9233e6d24d165d3ce2991794cdf542f9c9b6f"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 5).bin" size="25589760" crc="c1cccc35" sha1="d20dd4e4d5b2db0586f8b71bba59108cb444228b"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 6).bin" size="14986944" crc="4d61c786" sha1="b8f92f54d5e064fcb0ea268dfa6f86ba742629da"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan) (track 7).bin" size="123663456" crc="de8371bb" sha1="e68e91cbb6bd5a08d54090207f1a38885b58ee74"/>
-		<rom name="new 3d golf simulation - harukanaru augusta (japan).cue" size="997" crc="4cbe5466" sha1="e23e22ef3b4029ede40b48958cf23f1301014ea7"/>
+		Origin: redump.org
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 1).bin" size="10235904" crc="3737fb6f" sha1="938a1e5f7af506bdbf40620ad75f6bc411e2efff"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 2).bin" size="121993536" crc="0fa88600" sha1="73cb9fcb7f00fc31f3ec6b2f07ef978521da19fa"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 3).bin" size="7754544" crc="734d3a67" sha1="74e5be92e562284827b8aa9258681bb392ff6510"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 4).bin" size="21057456" crc="d9d8b7e7" sha1="1bd9233e6d24d165d3ce2991794cdf542f9c9b6f"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 5).bin" size="25589760" crc="c1cccc35" sha1="d20dd4e4d5b2db0586f8b71bba59108cb444228b"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 6).bin" size="14986944" crc="4d61c786" sha1="b8f92f54d5e064fcb0ea268dfa6f86ba742629da"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc) (Track 7).bin" size="123663456" crc="de8371bb" sha1="e68e91cbb6bd5a08d54090207f1a38885b58ee74"/>
+		<rom name="Harukanaru Augusta (Japan) (Course Disc).cue" size="920" crc="f6478a04" sha1="13fa1106069252b79011673287e261feee5c04c6"/>
 		-->
 		<description>New 3D Golf Simulation - Harukanaru Augusta</description>
 		<year>1990</year>
 		<publisher>ティーアンドイーソフト (T&amp;E Soft)</publisher>
+		<info name="serial" value="HMB-105"/>
 		<info name="alt_title" value="遙かなるオーガスタ" />
 		<info name="release" value="199001xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9419,10 +9814,11 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="NHK Eigo de Asobo Vol. 1 (Japan) (Track 69).bin" size="4762800" crc="d886d260" sha1="51dcf2dc4c1975f9f2954210a55dcaa1a80e3b45"/>
 		<rom name="NHK Eigo de Asobo Vol. 1 (Japan).cue" size="8745" crc="209eca07" sha1="cd71c0fca0490ee2df8d1f2da27a75c6fa970b87"/>
 		-->
-		<description>NHK Eigo de Asobo Vol. 1</description>
+		<description>NHK Eigo de Asobo Vol. 1 - Daitanken! Hotel Galaxy</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="alt_title" value="ＮＨＫ英語であそぼ 1" />
+		<info name="serial" value="HME-162 / A2760460"/>
+		<info name="alt_title" value="ＮＨＫ英語であそぼ 1 ～大たんけん！ホテル・ギャラクシ～" />
 		<info name="release" value="199307xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9504,6 +9900,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>NHK Eigo de Asobo Vol. 2</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-206 / A2760461"/>
 		<info name="alt_title" value="ＮＨＫ英語であそぼ 2" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9588,12 +9985,79 @@ User/save disks that can be created from the game itself are not included.
 		<description>New Horizon CD Learning System II - English Course 1</description>
 		<year>1993</year>
 		<publisher>東京書籍 (Tokyo Shoseki)</publisher>
+		<info name="serial" value="HMD-186 / MTC-1004"/>
 		<info name="alt_title" value="NEW HORIZON CD ラーニングシステム II 1年" />
 		<info name="release" value="199305xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="new horizon cd learning system ii - english course 1 (japan)" sha1="b75d8ca2fcbe6cf85059c608a117af5ad6316c39" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="nhorz2e1m">
+		<!--
+		Origin: redump.org
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 01).bin" size="10231200" crc="d63bcafe" sha1="43d9dc1d884e6030af2cedcefd8539dddfeaa19a"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 02).bin" size="5755344" crc="34acdef2" sha1="a44dd1cb06905687dba1662c0ff4d4dce1c15490"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 03).bin" size="8932896" crc="d79fe8e0" sha1="7008a7db7e5d0d943121b213d57a49bded6a1efd"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 04).bin" size="8448384" crc="191d50b8" sha1="76333f15638cacb3aa8e407ee8c51aace7d60ae1"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 05).bin" size="15024576" crc="49e62daf" sha1="248889fa5b22d41007bf65e65aa0464d2b0a8bea"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 06).bin" size="14182560" crc="7d21221d" sha1="c6ab088c2c176fd3cfa229e90e76a719c3dcdbed"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 07).bin" size="16010064" crc="eb87e73a" sha1="e503ba1e99c7023ee3881c5c7e08e038f92d9bda"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 08).bin" size="11407200" crc="78e7a2f1" sha1="837dc763d1cd76097ee1ca39dc7d83813cc5d331"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 09).bin" size="9897216" crc="fd52e707" sha1="d424c210db2f64379b53ec540e6c62ea1f424fa8"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 10).bin" size="16057104" crc="777578f8" sha1="372f6ff46af7388a2ae04cf0564fd6177fea0282"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 11).bin" size="10544016" crc="b91d1c67" sha1="fa26ffd9860876da5fb304bea74a2ee818681b0a"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 12).bin" size="12482064" crc="c2678071" sha1="e7940c03b695a437348396b2cd2c5c1d316fcfac"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 13).bin" size="15429120" crc="d7515ed8" sha1="11afc5de187441f4d05bcb1e551a25084e7e9b65"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 14).bin" size="5546016" crc="aef9de69" sha1="e370d6150e8ab12c1b280e2a6ed4810eeaf6bdf4"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 15).bin" size="17298960" crc="b37468d1" sha1="ab94e3687e56a210018b15ac8d1216fc690c1fde"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 16).bin" size="21384384" crc="1d22aa14" sha1="5f2411b197b3b76f60e69bc254d75d750766c7cb"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 17).bin" size="14801136" crc="3f58bbfc" sha1="7e23ca3fe55aab967a2a7a3fa9e713ab1c72d1bf"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 18).bin" size="6303360" crc="af41c24c" sha1="14f0d6123d4e85331a6d7009c9e0b78e5836c80a"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 19).bin" size="5590704" crc="2e2b93ad" sha1="d958a3e255bf64002acea964a0a413c19b6add6c"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 20).bin" size="14394240" crc="505569ab" sha1="74927ce3ef5eec22afc6aeeef8a946e706ef3ef7"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 21).bin" size="13065360" crc="72967f86" sha1="496bff6cbbe38651fba34b984b1b04541e453fec"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 22).bin" size="19345200" crc="39f34d16" sha1="617631c534c96ac46f0934678746f3307826091e"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 23).bin" size="6463296" crc="55ec916d" sha1="0affd0ef404b793a6ceb7f5c80201116cbe9679a"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 24).bin" size="9008160" crc="0b2819b7" sha1="e48da562f8593ecd244a959ef6db97d8cab9b83f"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 25).bin" size="12305664" crc="388c08d6" sha1="716475d8a632764be7ef32123088844af8170b85"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 26).bin" size="14518896" crc="61229e63" sha1="905f6bef121575b5e989607aa6224f1689ead54d"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 27).bin" size="12482064" crc="f804fe57" sha1="34c3597e7bf32792e49e8ae34fc5a75aee8044cd"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 28).bin" size="13307616" crc="116b10b5" sha1="17e7b650800cd03ddfadd6d505e2dc9a9d8c93a3"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 29).bin" size="3386880" crc="4601cb20" sha1="6ffbf208b1bc979577f51c38ba95076b78d66c59"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 30).bin" size="1168944" crc="98a60a42" sha1="98506f4d8d08c90112a5cc0ebb38b3ade68feb78"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 31).bin" size="15264480" crc="02b734b7" sha1="9fc9533d22be21c1c0198825fb9afb905472bd20"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 32).bin" size="7032480" crc="5c54495d" sha1="1660bd6f637a7b02ada37e3b5afb3dec78ec19e3"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 33).bin" size="11061456" crc="fba05f49" sha1="14f41aba00207c0c4278764f6f21405cead9a520"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 34).bin" size="17468304" crc="d11a50b3" sha1="d1570dda3a16c5f761cc65626bb3930f0b6eede2"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 35).bin" size="7662816" crc="48195e04" sha1="900ae32e9274b02bb1bb3e9d1b68fed6309dfe91"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 36).bin" size="15292704" crc="026c9c27" sha1="d78e4a91b6c10df274c1965cb1c8839270694b05"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 37).bin" size="14330736" crc="cb3e78ec" sha1="5f5810cf603f4ab1a8eaebc876fc309bcd5218bf"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 38).bin" size="14829360" crc="7a0f63b9" sha1="a0c351ef8899938e7c776d37c8487129c0ed3e28"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 39).bin" size="2940000" crc="89a13457" sha1="a528780e2025de6c246582fa9cb92b6184817f76"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 40).bin" size="21367920" crc="d039262d" sha1="cdbfc3f633d1ef10b2ded4407e23aaa694eb3ae2"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 41).bin" size="12423264" crc="2b5115f0" sha1="8f4be24b7a6ab76dfc9e9906268477fe1141d14d"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 42).bin" size="10943856" crc="80fcb8ab" sha1="fdf4bc9da74b828ddb761a3928209e351034f841"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 43).bin" size="13469904" crc="8b4dacfa" sha1="159ac48b684a15c902a0da171ec771c842db7d97"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 44).bin" size="3234000" crc="890b0d30" sha1="06a4d63ed6e4c2ec353f0185ad56ad10e7d1e7eb"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 45).bin" size="21085680" crc="21070b7e" sha1="7182828502da28eb5e3be7379f2b1b298ff0862e"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 46).bin" size="11331936" crc="0f39f7f8" sha1="901619459972754477b3c46ce1c165a1b0794b42"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty) (Track 47).bin" size="27605424" crc="b60a5475" sha1="b44339316b76ef8c7d4291deda1d446b777c8fef"/>
+		<rom name="New Horizon English Course 1 - CD Learning System II (Japan) (FM Towns Marty).cue" size="7054" crc="71f68e4f" sha1="4b1d48b54572d8231d9918f86b534c2f67769efc"/>
+		-->
+		<description>New Horizon CD Learning System II - English Course 1 (FM Towns Marty version)</description>
+		<year>1993</year>
+		<publisher>東京書籍 (Tokyo Shoseki)</publisher>
+		<info name="serial" value="HME-174"/>
+		<info name="alt_title" value="NEW HORIZON CD ラーニングシステム II 1年" />
+		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="new horizon english course 1 - cd learning system ii (japan) (fm towns marty)" sha1="ca1e3f72ad1d40e27ff48f135587396e4a55272f" />
 			</diskarea>
 		</part>
 	</software>
@@ -9607,6 +10071,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon Mukashibanashi</description>
 		<year>1990</year>
 		<publisher>ぎょうせい (Gyousei)</publisher>
+		<info name="serial" value="HMB-199"/>
 		<info name="alt_title" value="日本昔ばなし" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9628,6 +10093,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon no Rekishi - Kizoku-hen</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-163 / T2017-006"/>
 		<info name="alt_title" value="日本の歴史 貴族編" />
 		<info name="release" value="199009xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9640,21 +10106,92 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="nihonrko">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Nihon no Rekishi - Kodai-hen.ccd" size="14611" crc="868db9c6" sha1="b9fd8385688d722ddc942f800815757a2a317b8a"/>
-		<rom name="Nihon no Rekishi - Kodai-hen.cue" size="2964" crc="42810f29" sha1="a92a00bb9609be5da3f24b0d2be771c046591623"/>
-		<rom name="Nihon no Rekishi - Kodai-hen.img" size="632718576" crc="245c0277" sha1="ac4857a0985acda75b732a3590a2278d8628f0fb"/>
-		<rom name="Nihon no Rekishi - Kodai-hen.sub" size="25825248" crc="4d377848" sha1="1f4cb424de7625b41d865c395a7ec6882cf2f984"/>
+		Origin: redump.org
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 01).bin" size="158407200" crc="cbf680ee" sha1="34efd1df22465a3c2fe9db511120b5d9dd6cc464"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 02).bin" size="6308064" crc="a5fa4d97" sha1="7ac09c40b2431bd364ec10841ec338f3ac3959d5"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 03).bin" size="7161840" crc="78d05fda" sha1="abe86e6c806b9493b22b56c16dd7cb038aa28e8b"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 04).bin" size="8196720" crc="78d89e57" sha1="9905c04b63d193095d94d273d36e0fc1a36a47a9"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 05).bin" size="9520896" crc="4b93dc16" sha1="3073ccd1e8272fdf79ffed30bab220144339663f"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 06).bin" size="5750640" crc="99b30083" sha1="3a5127c9a35dec41b08748bd3c4f470518408799"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 07).bin" size="10325280" crc="5ff4d69a" sha1="fb91bf3a5140c65561f0802e86e3c6ed93d722d4"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 08).bin" size="7373520" crc="4ddd0f84" sha1="44913d9f946cc690fbcdc293dd81cfb1a14864b0"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 09).bin" size="8130864" crc="2ccb28a3" sha1="1afbc4d9fe36b26854b70b69a853da0e74cf3ac1"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 10).bin" size="4664016" crc="aff6de91" sha1="a88432a9b1365aa845835af6292ae46453f48cdf"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 11).bin" size="2486064" crc="fdab001a" sha1="5af7e8cc0e1fdab35edfce6d46239b4975017ecf"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 12).bin" size="5357856" crc="681dac36" sha1="70940b2fd5d8fa38d888f95ced4553ba1fec2634"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 13).bin" size="6115200" crc="112d10df" sha1="593775474654f9df51c8a46c3676c5c2c67a969f"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 14).bin" size="4574640" crc="08b5923b" sha1="3baa2f080b84361d22d2fde017a9382dfff3cef1"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 15).bin" size="6202224" crc="b125e2a4" sha1="6459741e957b7e61f38c49e1b39dc398d3f61b0d"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 16).bin" size="6463296" crc="3acd0821" sha1="1cb33bb925957b87e98430b8546f068894b3dc4d"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 17).bin" size="10819200" crc="4b3f7a2e" sha1="4f908ef6c5b21e5a17145c8313eabc5706e038bb"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 18).bin" size="4374720" crc="1806615a" sha1="f086ca1891ff175cdfb785ec8622729165c4b45f"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 19).bin" size="4026624" crc="4513e5ee" sha1="3f670443ed53bbcfd013b49837287d2338949f70"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 20).bin" size="4170096" crc="2e27ff5c" sha1="e5ad8f19fad2eefcf1d5f1be5bdc624964ce56c7"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 21).bin" size="7926240" crc="cc9c7bbf" sha1="1a71e2889e9fb915d72df01ab32439ee7116500a"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 22).bin" size="4786320" crc="ffa085d9" sha1="240d1034d9f43c3c94625ebcd611b33ba8e172fa"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 23).bin" size="5296704" crc="76dd489b" sha1="fbc5b5a0d3fda2703da08c704f1008c9193588f8"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 24).bin" size="10191216" crc="72841793" sha1="30cd7fb73d1ddc09ba4d42a165db1519b2c6c647"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 25).bin" size="14340144" crc="1ab6ca97" sha1="8e928a96b39fbc92358fb0863f51d7a2d35aa6b6"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 26).bin" size="4680480" crc="5379bc78" sha1="878c1174a4e6ae2332c10ab241ee36ffa493322d"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 27).bin" size="11520096" crc="189fdffa" sha1="c26a91c2e8dbabafa29b72c01ecfe7d21bf282e1"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 28).bin" size="6044640" crc="1f6e1a35" sha1="4364b22c3e675c791b86ef36ea3be04fd12f56d3"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 29).bin" size="7531104" crc="dc2d8803" sha1="0dacd50e17f0be773ff1189bd4f92ee9dc8d9979"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 30).bin" size="4028976" crc="9457f6bb" sha1="c156a80440794641c341d4cec354197cc5542dc0"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 31).bin" size="5755344" crc="66f94a67" sha1="1ac7655c895792fb96642225abb07ec8e7ba5731"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 32).bin" size="6197520" crc="f18072b4" sha1="a6fcf76541acabe3927617737297ef5f431f8d0e"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 33).bin" size="10148880" crc="fd6ed44a" sha1="6670c5307c88dd5bc83381d0a6429e836d79dbd0"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 34).bin" size="7538160" crc="ed7d09cf" sha1="2b5d940d58da6019a1420c033cb1e4797c5c7af5"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 35).bin" size="4527600" crc="c0c88c73" sha1="688985b6a03322026c5583363360b7b94b9942f6"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 36).bin" size="4334736" crc="caecf2ff" sha1="205530748ea3881c78fb8f0052d39456f740f5b7"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 37).bin" size="6338640" crc="7d72141a" sha1="3faf0e1b3bd9be37d1d91afe77dd695620b79522"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 38).bin" size="4661664" crc="f63309df" sha1="77e6873a2c6fd87e716e1fe281b58f07c396ece4"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 39).bin" size="4393536" crc="78e20dd3" sha1="5bfd7091480ddebe6888f74d20eb9e1dda4db948"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 40).bin" size="10407600" crc="61673a45" sha1="23d6a04f2edb1791ef868f2a87a9c94ffde2ad37"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 41).bin" size="10113600" crc="7ba02663" sha1="eb5d672d0ca95ac88465b453d922b651971aee4d"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 42).bin" size="6009360" crc="203148b9" sha1="b881bf7cf98cab09d0d6447123cbdf51ba750854"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 43).bin" size="5209680" crc="f5af0207" sha1="2617b4f8e2fd40f2c0388b844197823239d091d1"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 44).bin" size="8119104" crc="50650dd9" sha1="590414a7c5932ab472d08c225229efbf5ca21292"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 45).bin" size="4327680" crc="c7b99208" sha1="9435bd47476582d346639afb47623b4e7746ed96"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 46).bin" size="4899216" crc="76cc692f" sha1="584a207ecdf1e64e484eb121046061931bd26a09"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 47).bin" size="7213584" crc="901c892a" sha1="c6b393c02d1d3ac1a2dd19fcfe6d0373b7aaf589"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 48).bin" size="8549520" crc="372c07e4" sha1="351ebc73ce1b1e403d58332da2fb98ee7eda4174"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 49).bin" size="5574240" crc="8f5bc72f" sha1="0ab303c26f4dc6763fd780261bf30f8d8b93e828"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 50).bin" size="5851776" crc="b829892e" sha1="71fc4a917f8b39212e8190a6931d0393bfdc1f5b"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 51).bin" size="13194720" crc="140e3b0c" sha1="075da5fe417825639a8397a181fd6e00dc8d3c69"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 52).bin" size="5625984" crc="8da4869a" sha1="25bc8f3ead37d822e39f074669097054cf1ac232"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 53).bin" size="4076016" crc="bd617197" sha1="4579e3868cd4deca8cb3ba07abdd667121fdeb84"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 54).bin" size="9012864" crc="e7ed8a54" sha1="84e5b6eade68fd5b610587e9d6832bb5012669d6"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 55).bin" size="5515440" crc="78c0e678" sha1="6177eb1ba83fbc49fe586ecc75398b3f542f8ec3"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 56).bin" size="4504080" crc="67901075" sha1="5fad65292d069744a0c0efa9038081419a941813"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 57).bin" size="7592256" crc="cb88cbea" sha1="c12754070e979d339891dfef5b7463459964672c"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 58).bin" size="7683984" crc="e34453c2" sha1="b6a875b29caa513ff09d86f890333b3cacbe93bd"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 59).bin" size="6432720" crc="7002fe4a" sha1="765c8b9a12eb79f23c5271bbac9786013f0c0a0f"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 60).bin" size="6769056" crc="c7699300" sha1="934a3d21651251d0c0256f30cd36a938619e7896"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 61).bin" size="7507584" crc="aefe68a6" sha1="0dd9466a1821a450d24e45950da76e37a954220c"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 62).bin" size="4252416" crc="a7023751" sha1="ea0a985d89bcaf57f933dde48d3ff162a3fbab17"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 63).bin" size="9659664" crc="f65ae363" sha1="a9f12d23772fef249c17919a997bd165d123b15c"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 64).bin" size="8090880" crc="d6b91706" sha1="4c99f5a6bffe58aef7095c9945c1f442fb5c10ff"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 65).bin" size="2594256" crc="2aec29bf" sha1="292e6e03c0e124e553fe83f7acc8902e2834385a"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 66).bin" size="2968224" crc="3d506540" sha1="ec9b9580a7077bcf8cf40e6936999be28938c4e1"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 67).bin" size="4845120" crc="9716f713" sha1="ec5df519c7af3f109f4e7b055767a2027ea2e129"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 68).bin" size="4410000" crc="e83f7c3c" sha1="f9799672f91d67af00943e032baa22f3d4867092"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 69).bin" size="4504080" crc="5946a927" sha1="28268347790cfe9daf7944d091b7b167df2c3139"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 70).bin" size="4809840" crc="859e9da1" sha1="6e4309e24f3f0d0aca28b1a4b8662e1f897ffe67"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 71).bin" size="5710656" crc="8f55de14" sha1="9ff50a17911b86a67c286fa71648ae2a507c2a65"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 72).bin" size="5002704" crc="9f9bb1b3" sha1="831e2ec5c17d274381e33e819a1846b7196177c6"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan) (Track 73).bin" size="11009712" crc="49d37230" sha1="6e29e7a54e7df9b2458a396235f05615fe01ca9d"/>
+		<rom name="Nihon no Rekishi - Kodai-hen - Nihon Tanjou (Japan).cue" size="9030" crc="75c7321c" sha1="778875ac2a965fb7c6d152a866639530835cb30e"/>
 		-->
 		<description>Nihon no Rekishi - Kodai-hen</description>
 		<year>1990</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-127 / T2016-005"/>
 		<info name="alt_title" value="日本の歴史 古代編" />
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nihon no rekishi - kodai-hen" sha1="994b5f62b4c1ff2cd439948f12c52fa6d63cb8dc" />
+				<disk name="nihon no rekishi - kodai-hen - nihon tanjou (japan)" sha1="b0753ac0f059edea3f159533a80061e7158058e4" />
 			</diskarea>
 		</part>
 	</software>
@@ -9670,6 +10207,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nihon no Yachou</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-117"/>
 		<info name="alt_title" value="日本の野鳥" />
 		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9689,6 +10227,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Niko²</description>
 		<year>1991</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HMC-185 / CD-W16-TO"/>
 		<info name="alt_title" value="ニコニコ" />
 		<info name="release" value="199111xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9711,6 +10250,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ningyou Tsukai</description>
 		<year>1993</year>
 		<publisher>フォレスト (Forest)</publisher>
+		<info name="serial" value="HME-212"/>
 		<info name="alt_title" value="人形使い" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9732,12 +10272,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Bushou Fuuunroku</description>
 		<year>1991</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMC-134"/>
 		<info name="alt_title" value="信長の野望 武将風雲録" />
 		<info name="release" value="199107xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
-			<dataarea name="flop" size="1261568">
+			<dataarea name="flop" size="1281968">
 				<rom name="nobubus.d88" size="1281968" crc="6ac325e5" sha1="c12389c6a34ed87155ab4db4831479f608e47d59" offset="000000" />
 			</dataarea>
 		</part>
@@ -9759,6 +10300,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Haouden</description>
 		<year>1993</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HME-114"/>
 		<info name="alt_title" value="信長の野望 覇王伝" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9792,6 +10334,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Sengoku Gun'yuuden</description>
 		<year>1989</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMA-258 / FWKN14001"/>
 		<info name="alt_title" value="信長の野望 戦国群雄伝" />
 		<info name="release" value="198912xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9811,6 +10354,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nobunaga no Yabou - Tenshouki</description>
 		<year>1995</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMG-107"/>
 		<info name="alt_title" value="信長の野望 天翔記" />
 		<info name="release" value="199503xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9851,6 +10395,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Nova - Miirareta Shitai</description>
 		<year>1993</year>
 		<publisher>Cat's Pro.</publisher>
+		<info name="serial" value="HME-182 / PAND 002"/>
 		<info name="alt_title" value="ノ・ヴァ～魅入られた肢体" />
 		<info name="release" value="199307xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9893,6 +10438,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Hyper Oku no Hosomichi</description>
 		<year>1991</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-197"/>
 		<info name="alt_title" value="ハイパー奥の細道" />
 		<info name="release" value="199103xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9912,6 +10458,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Okumanchouja II</description>
 		<year>1991</year>
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
+		<info name="serial" value="HMC-135"/>
 		<info name="alt_title" value="億万長者II" />
 		<info name="release" value="199107xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9938,6 +10485,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Operation Wolf</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-126"/>
 		<info name="alt_title" value="オペレーション・ウルフ" />
 		<info name="release" value="199004xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9960,6 +10508,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oshare Club</description>
 		<year>1991</year>
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMB-204"/>
 		<info name="alt_title" value="おしゃれ倶楽部" />
 		<info name="release" value="199103xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -9981,6 +10530,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oshare Cooking</description>
 		<year>1989</year>
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMA-267"/>
 		<info name="alt_title" value="おしゃれクッキング" />
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10026,6 +10576,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oshare Cooking II</description>
 		<year>1990</year>
 		<publisher>ミサワホーム総合研究所 (Misawa Home Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMA-267B"/>
 		<info name="alt_title" value="おしゃれクッキングII" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10046,6 +10597,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ougon no Rashinban - Shouyomaru San Francisco Kouro Satsujin Jiken</description>
 		<year>1991</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMC-114"/>
 		<info name="alt_title" value="黄金の羅針盤 翔洋丸桑港航路殺人事件" />
 		<info name="release" value="199104xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10140,6 +10692,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Para Para Paradise</description>
 		<year>1997</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="FST-002 / ACD-8394 / ACD-8395 / ACD-8396"/>
 		<info name="alt_title" value="ぱらＰＡＲＡ　パラダイス" />
 		<info name="usage" value="Requires a 486 CPU, 8 MB RAM and a hard disk. The box indicates the FM Towns II MA as the minimum supported model."/>
 		<part name="cdrom1" interface="fmt_cdrom">
@@ -10173,6 +10726,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Panzer Division - Kikou Shidan</description>
 		<year>1990</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMB-219"/>
 		<info name="alt_title" value="機甲師団" />
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10192,6 +10746,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pegasus (Rev C)</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A600"/>
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10209,6 +10764,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pegasus (Rev A)</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276A600"/>
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -10228,6 +10784,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yuka Watanabe &amp; Tomo Kawai - Pleasure</description>
 		<year>1994</year>
 		<publisher>ジャニス (Janis)</publisher>
+		<info name="serial" value="HMF-109"/>
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10276,6 +10833,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Planet's Edge</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-172"/>
 		<info name="alt_title" value="プラネッツ・エッジ" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10297,6 +10855,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Princess Maker 2</description>
 		<year>1994</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="serial" value="HMF-116"/>
 		<info name="alt_title" value="プリンセスメーカー２" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10339,6 +10898,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Populous &amp; The Promised Lands</description>
 		<year>1990</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HMB-177"/>
 		<info name="alt_title" value="ポピュラス" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10366,6 +10926,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Power Dolls</description>
 		<year>1994</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="serial" value="HMF-151"/>
 		<info name="alt_title" value="パワードール" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10399,6 +10960,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Power Dolls 2</description>
 		<year>1995</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="serial" value="HMF-152"/>
 		<info name="alt_title" value="パワードール2" />
 		<info name="release" value="199511xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10420,6 +10982,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Powermonger</description>
 		<year>1992</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="MTC-1003"/>
 		<info name="alt_title" value="パワーモンガー" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10453,6 +11016,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Prince of Persia</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
+		<info name="serial" value="HMD-123"/>
 		<info name="alt_title" value="プリンス・オブ・ペルシャ" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10471,6 +11035,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Prince of Persia 2 - The Shadow and the Flame</description>
 		<year>1994</year>
 		<publisher>インタープログ (Interprog)</publisher>
+		<info name="serial" value="HMF-124"/>
 		<info name="alt_title" value="プリンス・オブ・ペルシャ2 ザ・シャドウ アンド ザ・フレーム" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10492,6 +11057,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pro Student G</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HME-171"/>
 		<info name="alt_title" value="ぷろすちゅーでんとG" />
 		<info name="release" value="199307xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -10516,6 +11082,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Professional Mahjong Goku</description>
 		<year>1989</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="Y627"/>
 		<info name="alt_title" value="プロフェッショナル麻雀悟空" />
 		<info name="release" value="198904xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10537,6 +11104,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Provvidenza - Legenda la Spada di Alfa</description>
 		<year>1991</year>
 		<publisher>Sofcom</publisher>
+		<info name="serial" value="HMC-147"/>
 		<info name="alt_title" value="プロビデンツァ Legenda la Spada di Alfa" />
 		<info name="release" value="199109xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10594,6 +11162,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 2 - Memories</description>
 		<year>1989</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-209"/>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.2　メモリーズ" />
 		<info name="release" value="198910xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10620,6 +11189,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 3 - Aya</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-141"/>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.3　アヤ" />
 		<info name="release" value="199006xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10646,6 +11216,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 4 - Orgel</description>
 		<year>1991</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMC-106"/>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.4　オルゴール" />
 		<info name="release" value="199104xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10678,6 +11249,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Vol. 5 - Nightmare</description>
 		<year>1991</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMC-177"/>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.5　ナイトメア" />
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10709,6 +11281,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Final - Solitude Joukan</description>
 		<year>1992</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT2007"/>
 		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ・ファイナル　「ソリチュード（上巻）」" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10737,6 +11310,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Psychic Detective Series Final - Solitude Gekan</description>
 		<year>1993</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT3008"/>
 		<info name="alt_title" value="サイキック・ディテクティヴシリーズ・ファイナル　「ソリチュード（下巻）」" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10788,6 +11362,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Pu-Li-Ru-La</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-186"/>
 		<info name="alt_title" value="プリルラ" />
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10807,6 +11382,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tom Snyder's Puppy Love 2</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-234"/>
 		<info name="alt_title" value="Tom Snyder's パピーラブ２" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10843,6 +11419,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Puyo Puyo</description>
 		<year>1994</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="CRI-015"/>
 		<info name="alt_title" value="ぷよぷよ" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10861,6 +11438,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Puzznic</description>
 		<year>1990</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMB-166"/>
 		<info name="alt_title" value="パズニック" />
 		<info name="release" value="199007xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10881,6 +11459,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>RAC Rally</description>
 		<year>1995</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMF-200"/>
 		<info name="release" value="199501xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -10907,6 +11486,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Raiden Densetsu / Raiden Trad</description>
 		<year>1991</year>
 		<publisher>KID</publisher>
+		<info name="serial" value="HMC-179"/>
 		<info name="alt_title" value="雷電伝説" />
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -10979,6 +11559,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Railroad Tycoon</description>
 		<year>1993</year>
 		<publisher>マイクロプローズジャパン (MicroProse Japan)</publisher>
+		<info name="serial" value="HME-245"/>
 		<info name="alt_title" value="レイルロードタイクーン" />
 		<info name="release" value="199312xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -11009,6 +11590,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance III - Leazas Kanraku</description>
 		<year>1992</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HMD-115 / ALS-0001"/>
 		<info name="alt_title" value="Rance3 リーザス陥落" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11054,6 +11636,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rance IV - Kyoudan no Isan</description>
 		<year>1994</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="ALS-1006"/>
 		<info name="alt_title" value="Rance4 ～教団の遺産～" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11123,6 +11706,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ravenloft - Aku no Keshin</description>
 		<year>1995</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-203"/>
 		<info name="alt_title" value="Ｒａｖｅｎｌｏｆｔ ～悪の化身～" />
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11144,6 +11728,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rayxanber</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-113"/>
 		<info name="alt_title" value="ライザンバー" />
 		<info name="release" value="199004xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11169,6 +11754,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rainbow Islands Extra</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMD-110"/>
 		<info name="alt_title" value="レインボーアイランド EXTRA" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11190,6 +11776,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Regional Power II</description>
 		<year>1992</year>
 		<publisher>コスモス・コンピュータ (Cosmos Computer)</publisher>
+		<info name="serial" value="HMD-161"/>
 		<info name="alt_title" value="レジオナルパワー2" />
 		<info name="release" value="199209xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11215,6 +11802,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rejection - Den-no Senshi</description>
 		<year>1992</year>
 		<publisher>シュールド・ウェーブ (Sur De Wave)</publisher>
+		<info name="serial" value="HMD-197"/>
 		<info name="alt_title" value="電脳少女" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11262,7 +11850,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ring out!!" sha1="2b50d05b278824e36a1b2fdf500a5ec4c9daeb3b" />
+				<disk name="ring out" sha1="2b50d05b278824e36a1b2fdf500a5ec4c9daeb3b" />
 			</diskarea>
 		</part>
 	</software>
@@ -11297,6 +11885,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Rocket Ranger</description>
 		<year>1990</year>
 		<publisher>ポニーキャニオン (Pony Canyon)</publisher>
+		<info name="serial" value="HMB-116"/>
 		<info name="release" value="199005xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -11317,6 +11906,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ryuutouden</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-213"/>
 		<info name="alt_title" value="龍闘伝" />
 		<info name="release" value="199005xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11359,6 +11949,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sangokushi II</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMB-159"/>
 		<info name="alt_title" value="三国志II" />
 		<info name="release" value="199006xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11404,11 +11995,37 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sangokushi III</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-131"/>
 		<info name="alt_title" value="三国志Ⅲ" />
 		<info name="release" value="199206xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sangokushi iii with soundware (japan)" sha1="a9110f89450f9504435b53bb923ac1829bbcf4ee" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="sargon5">
+		<!--
+		Origin: redump.org
+		<rom name="Sargon V - World Class Chess (Japan) (Track 1).bin" size="10231200" crc="7cf8d1d6" sha1="10734f1fb7a813b36fc4d43ab9b7a861153b9cd1"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 2).bin" size="19227600" crc="8065aeb4" sha1="26fce6b3e078deaec35aa702ad5b6f1e59793e5f"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 3).bin" size="20991600" crc="95fe1f11" sha1="f741776065f17a987b1b6cc8d0d1cf22683cf6f7"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 4).bin" size="11642400" crc="93f22469" sha1="d9a61aa68c6b9e22b3f1368406cc93f3b88c1fd5"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 5).bin" size="10407600" crc="5d0ef261" sha1="e668231a555b21020d720562483a64d2b386a565"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 6).bin" size="4586400" crc="1654c536" sha1="91c8059b37d82839983ce30787c85475f729ca12"/>
+		<rom name="Sargon V - World Class Chess (Japan) (Track 7).bin" size="1058400" crc="dada7c1d" sha1="0b4704f788c9e43ed0cf78863b53884b47f3b045"/>
+		<rom name="Sargon V - World Class Chess (Japan).cue" size="915" crc="501d2686" sha1="4d885397ba49cd8daefb91bfe2fc1b9dbe5c37e6"/>
+		-->
+		<description>Sargon V - World Class Chess</description>
+		<year>1992</year>
+		<publisher>ジーエーエム (GAM)</publisher>
+		<info name="serial" value="HMD-191 / MTC-1024"/>
+		<info name="alt_title" value="サルゴンⅤ" />
+		<info name="release" value="199211xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="sargon v - world class chess (japan)" sha1="22df62eee419429358db4c9a4e4b3f187e9571a1" />
 			</diskarea>
 		</part>
 	</software>
@@ -11443,6 +12060,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sayaka &amp; Miho</description>
 		<year>1994</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMF-179"/>
 		<info name="alt_title" value="沙也香＆美穂" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11463,6 +12081,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Scavenger 4 Demo Disc</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-918"/>
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -11480,9 +12099,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Scavenger 4.img" size="528847200" crc="177b3405" sha1="5738450c2f212634341c4d540c5350ec1c60f35a"/>
 		<rom name="Scavenger 4.sub" size="21585600" crc="e8c0f2a6" sha1="b6a7f3f5d155f80d813fad9228f3be2eebdb0227"/>
 		-->
-		<description>Scavenger 4 (1993-12-16)</description>
+		<description>Scavenger 4 (HME-217A)</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-217A / A2760510 / TSC390"/>
 		<info name="alt_title" value="スカベンジャー４" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11499,9 +12119,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Scavenger 4 (Japan).bin" size="528844848" crc="e4962f69" sha1="082ab4b5b471bc9f8b9a890b8d8fbdf0aece8f0d"/>
 		<rom name="Scavenger 4 (Japan).cue" size="108" crc="3c19efb7" sha1="d37833c44a86d1512d5def2683c3a08995d5bab2"/>
 		-->
-		<description>Scavenger 4 (1993-11-11)</description>
+		<description>Scavenger 4 (HME-217)</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-217 / A2760510 / TSC390"/>
 		<info name="alt_title" value="スカベンジャー４" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11550,6 +12171,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Schwarzschild</description>
 		<year>1991</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="serial" value="HMC-171"/>
 		<info name="alt_title" value="シュヴァルツシルト" />
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11585,6 +12207,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Schwarzschild IV - The Cradle End</description>
 		<year>1993</year>
 		<publisher>工画堂 (Kogado)</publisher>
+		<info name="serial" value="HME-223"/>
 		<info name="alt_title" value="シュヴァルツシルト4 THE CRADLE END" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11604,6 +12227,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Secre Volume I - Naoko Iijima</description>
 		<year>1993</year>
 		<publisher>グラムス (Glams)</publisher>
+		<info name="serial" value="HME-168"/>
 		<info name="alt_title" value="Secre VOLUME I 飯島直子" />
 		<info name="release" value="199308xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11625,6 +12249,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Secre Volume 2 - Mai Oikawa</description>
 		<year>1993</year>
 		<publisher>グラムス (Glams)</publisher>
+		<info name="serial" value="HME-180"/>
 		<info name="alt_title" value="Secre VOLUME 2 及川麻衣" />
 		<info name="release" value="19930819" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11652,6 +12277,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sekigahara</description>
 		<year>1992</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMD-128"/>
 		<info name="alt_title" value="関ヶ原" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11673,6 +12299,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shamhat - The Holy Circlet</description>
 		<year>1993</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT 3012"/>
 		<info name="alt_title" value="シャムハト　－Ｔｈｅ　Ｈｏｌｙ　Ｃｉｒｃｌｅｔ－" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11705,6 +12332,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shanghai</description>
 		<year>1990</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMB-192"/>
 		<info name="alt_title" value="上海" />
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11724,6 +12352,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shangrlia 2</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HME-220"/>
 		<info name="alt_title" value="シャングリラ2" />
 		<info name="release" value="199410xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11743,6 +12372,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sherlock Holmes - Consulting Detective</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-127 / A2760120 / TSC160"/>
 		<info name="alt_title" value="シャーロックホームズの探偵講座" />
 		<info name="release" value="199106xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11764,6 +12394,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shinc</description>
 		<year>1993</year>
 		<publisher>リビドー (Libido)</publisher>
+		<info name="serial" value="HME-131"/>
 		<info name="alt_title" value="シンク" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11808,12 +12439,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shinjuku Labyrinth</description>
 		<year>1994</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
+		<info name="serial" value="FMSC0030"/>
 		<info name="alt_title" value="新宿ラビリンス" />
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Master Disk" />
-			<dataarea name="flop" size="1261568">
+			<dataarea name="flop" size="3583660">
 				<rom name="shinjuku labyrinth (master disk).mfm" size="3583660" crc="78b7c26c" sha1="778befacd1534dc22edffccaebb2957823e488e7" offset="000000" />
 			</dataarea>
 		</part>
@@ -11838,6 +12470,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shooting Towns</description>
 		<year>1990</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="serial" value="HMB-118"/>
 		<info name="alt_title" value="シューティングTOWNS" />
 		<info name="release" value="199003xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -11858,6 +12491,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shounen Magazine History</description>
 		<year>1992</year>
 		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HMD-151"/>
 		<info name="alt_title" value="少年マガジンヒストリー" />
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11877,6 +12511,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimAnt</description>
 		<year>1993</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HME-104 / MTC-1033"/>
 		<info name="alt_title" value="シムアント" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11931,6 +12566,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimCity (1990-03-05)</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-121 / A27600A0 / TSC060"/>
 		<info name="alt_title" value="シムシティ" />
 		<info name="release" value="199003xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11954,6 +12590,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimCity 2000</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-191"/>
 		<info name="alt_title" value="シムシティ2000" />
 		<info name="release" value="199412xx" />
 		<info name="usage" value="Requires 3 MB RAM"/>
@@ -11975,6 +12612,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimEarth</description>
 		<year>1991</year>
 		<publisher>イマジニア (Imagineer)</publisher>
+		<info name="serial" value="HMC-141"/>
 		<info name="alt_title" value="シムアース" />
 		<info name="release" value="199109xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -11996,6 +12634,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>SimFarm</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-170"/>
 		<info name="alt_title" value="シムファーム" />
 		<info name="release" value="199409xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12075,6 +12714,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Silent Möbius</description>
 		<year>1991</year>
 		<publisher>ガイナックス (Gainax)</publisher>
+		<info name="serial" value="HMC-143"/>
 		<info name="alt_title" value="サイレントメビウス" />
 		<info name="release" value="199109xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12099,6 +12739,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Sotsugyou '93 - Graduation</description>
 		<year>1993</year>
 		<publisher>JHV</publisher>
+		<info name="serial" value="JH-002"/>
 		<info name="alt_title" value="卒業 '９３" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12153,6 +12794,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Space Museum</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="A2760480"/>
 		<info name="alt_title" value="スペースミュージアム" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12213,6 +12855,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Splatterhouse</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMD-146"/>
 		<info name="alt_title" value="スプラッターハウス" />
 		<info name="release" value="199206xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12250,6 +12893,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Odyssey &amp; Dennou Planetarium</description>
 		<year>1989</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="serial" value="HMA-237"/>
 		<info name="alt_title" value="スーパー・オデッセイ＆電脳プラネタリウム" />
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12290,6 +12934,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Software Contest Nyuusen Sakuhinshuu 1 (HMC-139B)</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-139B"/>
 		<info name="alt_title" value="ソフトウェアコンテスト入選作品集 1" />
 		<info name="release" value="199201xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -12329,6 +12974,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Software Contest Nyuusen Sakuhinshuu 1 (HMC-139)</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-139"/>
 		<info name="alt_title" value="ソフトウェアコンテスト入選作品集 1" />
 		<info name="release" value="199110xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -12357,6 +13003,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Software Contest Nyuusen Sakuhinshuu 2</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-189"/>
 		<info name="alt_title" value="ソフトウェアコンテスト入選作品集 2" />
 		<info name="release" value="199301xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12376,6 +13023,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Software Contest Nyuusen Sakuhinshuu 3</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-200"/>
 		<info name="alt_title" value="ソフトウェアコンテスト入選作品集 3" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12395,6 +13043,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Soko-ban Perfect</description>
 		<year>1990</year>
 		<publisher>シンキングラビット (Thinking Rabbit)</publisher>
+		<info name="serial" value="HMB-145"/>
 		<info name="alt_title" value="倉庫番パーフェクト" />
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12422,6 +13071,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shadow of the Beast - Mashou no Okite</description>
 		<year>1991</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMC-157 / F-5503"/>
 		<info name="alt_title" value="シャドー・オブ・ザ・ビースト 魔性の掟" />
 		<info name="release" value="199109xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12455,6 +13105,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Shadow of the Beast II - Juushin no Jubaku</description>
 		<year>1993</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMD-184 / F-5508"/>
 		<info name="alt_title" value="シャドー・オブ・ザ・ビースト2 獣神の呪縛" />
 		<info name="release" value="199306xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12500,6 +13151,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PII &amp; PIII</description>
 		<year>1992</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMD-126"/>
 		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12519,6 +13171,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PII &amp; PIII +</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-111"/>
 		<info name="alt_title" value="スーパーリアル麻雀PII＆PIII＋" />
 		<info name="release" value="199303xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12550,6 +13203,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Real Mahjong PIV</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-138"/>
 		<info name="alt_title" value="スーパーリアル麻雀PIV" />
 		<info name="release" value="199405xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12569,6 +13223,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Space Rogue</description>
 		<year>1990</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="serial" value="HMB-180"/>
 		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12592,6 +13247,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Space Rogue (no disc check)</description>
 		<year>1990</year>
 		<publisher>ウェーブトレイン (Wave Train)</publisher>
+		<info name="serial" value="HMB-180"/>
 		<info name="alt_title" value="スペースローグ" />
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12658,6 +13314,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Street Fighter II - The New Challengers</description>
 		<year>1994</year>
 		<publisher>カプコン (Capcom)</publisher>
+		<info name="serial" value="HMF-162"/>
 		<info name="alt_title" value="スーパーストリートファイターII" />
 		<info name="release" value="199410xx" />
 		<info name="usage" value="Requires 4 MB RAM"/>
@@ -12718,6 +13375,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Shanghai - Dragon's Eye</description>
 		<year>1991</year>
 		<publisher>HOT・B</publisher>
+		<info name="serial" value="HMC-181"/>
 		<info name="alt_title" value="スーパー上海ドラゴンズアイ" />
 		<info name="release" value="199111xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12767,6 +13425,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Super Shooting Towns</description>
 		<year>1991</year>
 		<publisher>アモルファス (Amorphous)</publisher>
+		<info name="serial" value="HMC-191"/>
 		<info name="alt_title" value="スーパーシューティングTOWNS" />
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12814,6 +13473,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Oto to E no Deru Eigo Jisho No. 1 - Start with Words</description>
 		<year>1989</year>
 		<publisher>ソフメディア (SofMedia)</publisher>
+		<info name="serial" value="HMA-217"/>
 		<info name="alt_title" value="音と絵の出る英語辞書　Ｎｏ．１　「Ｓｔａｒｔ　ｗｉｔｈ　Ｗｏｒｄｓ」" />
 		<info name="release" value="198908xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -12834,6 +13494,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Strike Commander</description>
 		<year>1994</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="EFT-7010 / HMDC-1915"/>
 		<info name="alt_title" value="ストライク・コマンダー" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
@@ -12876,6 +13537,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Stronghold - Koutei no Yousai</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-133"/>
 		<info name="alt_title" value="ストロングホールド ～皇帝の要塞～" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12896,6 +13558,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Suikoden - Tenmei no Chikai</description>
 		<year>1990</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMB-108"/>
 		<info name="alt_title" value="水滸伝・天命の誓い" />
 		<info name="release" value="199002xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -12914,6 +13577,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Suzaku</description>
 		<year>1992</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HMD-178 / MTC-1023"/>
 		<info name="alt_title" value="スザク" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12943,6 +13607,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Syndicate</description>
 		<year>1994</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMF-163"/>
 		<info name="alt_title" value="シンジケート" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -12992,12 +13657,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taiken Shiyou! Marty Channel</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-917"/>
 		<info name="alt_title" value="体験しよう！マーティチャンネル" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="taiken shiyou! marty channel (japan)" sha1="d1577643f6bdf903c22877f7de6c450c5bed8730" />
+				<disk name="taiken shiyou marty channel (japan)" sha1="d1577643f6bdf903c22877f7de6c450c5bed8730" />
 			</diskarea>
 		</part>
 	</software>
@@ -13013,6 +13679,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Taikou Risshiden</description>
 		<year>1992</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-130"/>
 		<info name="alt_title" value="太閤立志伝" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13047,12 +13714,13 @@ User/save disks that can be created from the game itself are not included.
 		<description>Takamizawa Kyousuke - Nekketsu!! Kyouiku Kenshuu</description>
 		<year>1995</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="serial" value="ZYX-0002"/>
 		<info name="alt_title" value="高見沢恭介 熱血！！教育研修" />
 		<info name="release" value="199501xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="takamizawa kyousuke nekketsu!! kyouiku kenshuu (japan)" sha1="c221b1b63f145650bff7f050cc7040d5cb794887" />
+				<disk name="takamizawa kyousuke nekketsu kyouiku kenshuu (japan)" sha1="c221b1b63f145650bff7f050cc7040d5cb794887" />
 			</diskarea>
 		</part>
 	</software>
@@ -13068,6 +13736,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tanjou - Debut</description>
 		<year>1994</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWDC4027"/>
 		<info name="alt_title" value="誕生 ～Ｄｅｂｕｔ～" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13103,6 +13772,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tatsujin Ou</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-112"/>
 		<info name="alt_title" value="達人王" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13128,6 +13798,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TDF - Terrestrial Defense Force</description>
 		<year>1990</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMB-185"/>
 		<info name="release" value="199009xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13160,6 +13831,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Teitoku no Ketsudan II</description>
 		<year>1994</year>
 		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMF-145 / KN10521040"/>
 		<info name="alt_title" value="提督の決断II" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13184,6 +13856,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Teito Taisen</description>
 		<year>1989</year>
 		<publisher>超音速 (Super Sonic)</publisher>
+		<info name="serial" value="HMA-249"/>
 		<info name="alt_title" value="帝都大戦" />
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13205,6 +13878,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tenka Gomen</description>
 		<year>1994</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMF-160 / MTC-1084"/>
 		<info name="alt_title" value="天下御免" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13232,6 +13906,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Date - Kore de Kanojo wa Boku no Mono!</description>
 		<year>1990</year>
 		<publisher>JAMP</publisher>
+		<info name="serial" value="HMB-123"/>
 		<info name="alt_title" value="ザ・デート これで彼女はぼくのもの！" />
 		<info name="release" value="199002xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13280,6 +13955,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Titan</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-238 / A2760030 / TSC030"/>
 		<info name="alt_title" value="タイタン" />
 		<info name="release" value="198911xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13298,6 +13974,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The New Zealand Story (HMA-213A)</description>
 		<year>1989</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMA-213A"/>
 		<info name="alt_title" value="ニュージーランドストーリー" />
 		<info name="release" value="198908xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13316,6 +13993,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The New Zealand Story (HMA-213)</description>
 		<year>1989</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMA-213"/>
 		<info name="alt_title" value="ニュージーランドストーリー" />
 		<info name="release" value="198908xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13337,6 +14015,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tokio - Tokyo-to Dai-24-ku</description>
 		<year>1992</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMD-207 / MTC-1030"/>
 		<info name="alt_title" value="トキオ 東京都第24区" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13415,6 +14094,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Queen of Duellist (HME-166A)</description>
 		<year>1993</year>
 		<publisher>アグミックス (Agumix)</publisher>
+		<info name="serial" value="HME-166A"/>
 		<info name="alt_title" value="クイーン・オブ・デュエリスト" />
 		<info name="release" value="199306xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13435,6 +14115,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Queen of Duellist (HME-166)</description>
 		<year>1993</year>
 		<publisher>アグミックス (Agumix)</publisher>
+		<info name="serial" value="HME-166"/>
 		<info name="alt_title" value="クイーン・オブ・デュエリスト" />
 		<info name="release" value="199306xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13534,6 +14215,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Turbo Out Run</description>
 		<year>1989</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HMA-225 / T2013-911"/>
 		<info name="alt_title" value="ターボアウトラン" />
 		<info name="release" value="198912xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13600,6 +14282,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns Magazine Vol. 2</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276F020 / HMF-917"/>
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires 2 MB RAM to boot, some demos require more"/>
 		<part name="cdrom1" interface="fmt_cdrom">
@@ -13624,6 +14307,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TownsFullcolor V2.1 L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D071"/>
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<info name="release" value="199412xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -13642,6 +14326,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TownsPAINT V1.1 L10</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D010"/>
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -13652,17 +14337,18 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="tpaint20">
 		<!--
-		Origin: Private dump (r09)
-		<rom name="townspaint.bin" size="39337200" crc="a384a685" sha1="d1ba91cffb50916c04d2cce54b5622a0181df451"/>
-		<rom name="townspaint.cue" size="99" crc="1805e758" sha1="542e6bc81f6321e8981eff94f55c3dc644ef769f"/>
+		Origin: redump.org
+		<rom name="Towns Paint V1.1L20 (Japan).bin" size="39337200" crc="a384a685" sha1="d1ba91cffb50916c04d2cce54b5622a0181df451"/>
+		<rom name="Towns Paint V1.1L20 (Japan).cue" size="116" crc="25536585" sha1="fe860c609baae4c5f148ecc49f541ae3f0e6739b"/>
 		-->
 		<description>TownsPAINT V1.1 L20</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D010"/>
 		<info name="release" value="199411xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="townspaint" sha1="ac943aca97da28d24c07ed0c7118b15bc237befb" />
+				<disk name="towns paint v1.1l20 (japan)" sha1="ac943aca97da28d24c07ed0c7118b15bc237befb" />
 			</diskarea>
 		</part>
 	</software>
@@ -13676,6 +14362,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>TownsSOUND V1.1 L20</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D020"/>
 		<info name="release" value="199004xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -13694,6 +14381,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Towns VNet V1.1 L20</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276B500"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns vnet v1.1 l20 (japan)" sha1="65c17682530c9a705d72588b75fe57d8e73b364b" />
@@ -13712,6 +14400,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Trigger</description>
 		<year>1994</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="serial" value="HMF-176"/>
 		<info name="alt_title" value="トリガー" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13747,6 +14436,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Tunnels and Trolls - Khazan no Senshi-tachi</description>
 		<year>1990</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="HMB-196"/>
 		<info name="alt_title" value="トンネルズ・アンド・トロールズ カザンの戦士たち" />
 		<info name="release" value="199011xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13766,6 +14456,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima IV - Quest of the Avatar</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-200"/>
 		<info name="alt_title" value="ウルティマIV Quest of the Avatar" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13787,6 +14478,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima V - Warriors of Destiny</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-112"/>
 		<info name="alt_title" value="ウルティマV Warriors of Destiny" />
 		<info name="release" value="199208xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13808,6 +14500,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima VI - The False Prophet</description>
 		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-170"/>
 		<info name="alt_title" value="ウルティマVI 偽りの予言者" />
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13829,6 +14522,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima Trilogy I-II-III</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-176 / A27600B0 / TSC110"/>
 		<info name="alt_title" value="ウルティマトリロジー Ⅰ・Ⅱ・Ⅲ" />
 		<info name="release" value="199010xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13850,6 +14544,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima Underworld - The Stygian Abyss</description>
 		<year>1993</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HME-249 / EFT-7007"/>
 		<info name="alt_title" value="ウルティマアンダーワールド" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM. Insert a floppy disk in drive 1 before booting the game."/>
@@ -13869,6 +14564,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Ultima Underworld II - Labyrinth of Worlds</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="EFT-7016"/>
 		<info name="alt_title" value="ウルティマアンダーワールド2" />
 		<info name="release" value="199502xx" />
 		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
@@ -13940,6 +14636,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vain Dream</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="serial" value="HME-122"/>
 		<info name="alt_title" value="ヴェインドリーム" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -13981,6 +14678,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vain Dream II</description>
 		<year>1993</year>
 		<publisher>グローディア (Glodia)</publisher>
+		<info name="serial" value="GRD-006"/>
 		<info name="alt_title" value="ヴェインドリームII" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14008,6 +14706,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Vastness - Kuukyo no Ikenie-tachi</description>
 		<year>1993</year>
 		<publisher>CD Bros.</publisher>
+		<info name="serial" value="HMF-132"/>
 		<info name="alt_title" value="ヴアーストニス 空虚の生贄達" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14031,6 +14730,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Veil of Darkness</description>
 		<year>1994</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMF-166"/>
 		<info name="alt_title" value="ヴェイル オブ ダークネス ～呪われた予言～" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14051,6 +14751,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Video Koubou V1.4 L10</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D053"/>
 		<info name="alt_title" value="ビデオ工房 V1.4 L10" />
 		<info name="release" value="199511xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -14069,6 +14770,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Video Koubou V1.3 L10</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D052"/>
 		<info name="alt_title" value="ビデオ工房 V1.3 L10" />
 		<info name="release" value="199402xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -14114,6 +14816,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Viewpoint</description>
 		<year>1993</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HME-229"/>
 		<info name="alt_title" value="ビューポイント" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14135,6 +14838,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Viper V6 Turbo RS</description>
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
+		<info name="serial" value="HMG-112"/>
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -14155,6 +14859,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Viper V10 Turbo RS</description>
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
+		<info name="serial" value="HMG-127"/>
 		<info name="release" value="199507xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -14181,6 +14886,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Virtuacall</description>
 		<year>1995</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMG-113 / IDES-031"/>
 		<info name="alt_title" value="バーチャコール" />
 		<info name="release" value="199503xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14223,6 +14929,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Virtuacall 2</description>
 		<year>1995</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="IDES-048"/>
 		<info name="alt_title" value="バーチャコール" />
 		<info name="release" value="199512xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14263,6 +14970,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>The Visitor</description>
 		<year>1989</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-220"/>
 		<info name="alt_title" value="ビジター 訪問者" />
 		<info name="release" value="198909xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -14281,6 +14989,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Volfied</description>
 		<year>1991</year>
 		<publisher>ビング (Ving)</publisher>
+		<info name="serial" value="HMC-174"/>
 		<info name="alt_title" value="ヴォルフィード" />
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14302,6 +15011,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wakoku Seiha Den</description>
 		<year>1994</year>
 		<publisher>Mic</publisher>
+		<info name="serial" value="HMF-111"/>
 		<info name="alt_title" value="倭国制覇伝" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14402,6 +15112,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-166 / A2760340 / TSC220"/>
 		<info name="alt_title" value="ウイングコマンダー" />
 		<info name="release" value="199212xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14422,6 +15133,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander - Secret Missions</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-135"/>
 		<info name="alt_title" value="ウィング・コマンダー シークレット・ミッション" />
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires HDD installation"/>
@@ -14442,6 +15154,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wing Commander II and Special Operations</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
+		<info name="serial" value="HMG-129"/>
 		<info name="alt_title" value="ウィング・コマンダーII" />
 		<info name="release" value="199507xx" />
 		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
@@ -14478,6 +15191,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wizardry V - Heart of the Maelstrom</description>
 		<year>1990</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMB-224"/>
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -14504,6 +15218,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wizardry VI - Bane of the Cosmic Forge</description>
 		<year>1991</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMC-187"/>
 		<info name="release" value="199112xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
@@ -14529,6 +15244,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wizardry VII - Crusaders of the Dark Savant</description>
 		<year>1994</year>
 		<publisher>アスキー (ASCII)</publisher>
+		<info name="serial" value="HMF-143"/>
 		<info name="release" value="199409xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
@@ -14553,6 +15269,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Wrestle Angels 3 - Mezasu wa Saikyou Dantai!</description>
 		<year>1994</year>
 		<publisher>グレイト (Great)</publisher>
+		<info name="serial" value="GRT-940805"/>
 		<info name="alt_title" value="レッスル エンジェルス 3 目指すは最強団体！" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14607,6 +15324,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Where in the World is Carmen Sandiego?</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-117"/>
 		<info name="alt_title" value="カルメン・サンディエゴを探せ! -世界編-" />
 		<info name="release" value="199304xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14628,6 +15346,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Words Worth</description>
 		<year>1993</year>
 		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HME-197"/>
 		<info name="alt_title" value="ワーズ・ワース" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14649,6 +15368,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Xak II - Rising of the Redmoon</description>
 		<year>1991</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="serial" value="HMC-125"/>
 		<info name="alt_title" value="サークII ライジング・オブ・ザ・レッドムーン" />
 		<info name="release" value="199107xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14779,6 +15499,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yami no Ketsuzoku Special - The Predestined Homicides</description>
 		<year>1991</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="serial" value="HMB-234"/>
 		<info name="alt_title" value="闇の血族 スペシャル" />
 		<info name="release" value="199106xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14804,6 +15525,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Youjuu Senki - A.D. 2048</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-235 / MTC-1066"/>
 		<info name="alt_title" value="妖獣戦記 -A.D.2048-" />
 		<info name="release" value="199311xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14848,6 +15570,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Yumimi Mix</description>
 		<year>1993</year>
 		<publisher>CRI</publisher>
+		<info name="serial" value="HME-145 / T2069-312"/>
 		<info name="alt_title" value="ゆみみみっくす" />
 		<info name="release" value="199312xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14893,6 +15616,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Z's Triphony DigitalCraft Towns</description>
 		<year>1990</year>
 		<publisher>ツァイト (Zeit)</publisher>
+		<info name="serial" value="HMB-212A"/>
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -14936,6 +15660,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zan II - Towns Special</description>
 		<year>1992</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HMD-120"/>
 		<info name="alt_title" value="斬2タウンズスペシャル" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14964,6 +15689,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zan III - Ten'un Ware ni Ari</description>
 		<year>1994</year>
 		<publisher>日本テレネット (Nihon Telenet)</publisher>
+		<info name="serial" value="HMF-103"/>
 		<info name="alt_title" value="斬III　～天運我にあり～" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -15061,6 +15787,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zoku Dungeon Master - Chaos no Gyakushuu</description>
 		<year>1990</year>
 		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMB-216 / F-5502"/>
 		<info name="alt_title" value="続ダンジョン・マスター カオスの逆襲" />
 		<info name="release" value="199012xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -15080,6 +15807,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Zoku Youjuu Senki - Suna no Mokushiroku</description>
 		<year>1994</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="2TD-3010"/>
 		<info name="alt_title" value="続妖獣戦記 ―砂塵の黙示録―" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>


### PR DESCRIPTION
- Added known serial numbers for all entries.

- Re-classified some of my old dumps as being from Redump, since I submitted them anyway.

- Added floppy dump for Angel and promoted to working.

- New dumps from redump.org (working):

Ed Bogas' Music Machine
HomeStudio V1.2L10
Kid Pix Jr.
New Horizon CD Learning System II - English Course 1 (FM Towns Marty version)
Sargon V - World Class Chess

- New dumps from redump.org (not working):

Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken (FM Towns Marty version)

- Replaced entries with dumps from redump.org:

A Ressha de Ikou III
Appare CD Vol. 1 - Hiryuu no Maki
ElFish Lite
Muscle Bomber - The Body Explosion
Metal Eye 2
Nihon no Rekishi - Kodai-hen
The Secret of Monkey Island

- Reordered some entries