### PR TITLE
Move sprite delaying behavior into screen_vblank for some drivers

### DIFF
--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -342,6 +342,7 @@ const double XTAL::known_xtals[] = {
 	 28'375'160, /* 28.37516_MHz_XTAL      Amiga PAL systems */
 	 28'475'000, /* 28.475_MHz_XTAL        CoCo 3 PAL */
 	 28'480'000, /* 28.48_MHz_XTAL         Chromatics CGC-7900 */
+	 28'636'000, /* 28.636_MHz_XTAL        Super Kaneko Nova System */
 	 28'636'363, /* 28.636363_MHz_XTAL     Later Leland games and Atari GT, Amiga NTSC, Raiden2 h/w (8x NTSC subcarrier)*/
 	 28'640'000, /* 28.64_MHz_XTAL         Fukki FG-1c AI AM-2 PCB */
 	 28'700'000, /* 28.7_MHz_XTAL          - */
@@ -367,6 +368,7 @@ const double XTAL::known_xtals[] = {
 	 33'264'000, /* 33.264_MHz_XTAL        Hazeltine 1500 terminal */
 	 33'330'000, /* 33.33_MHz_XTAL         Sharp X68000 XVI */
 	 33'333'000, /* 33.333_MHz_XTAL        Sega Model 3 CPU board, Vegas */
+	 33'333'333, /* 33.333333_MHz_XTAL     Super Kaneko Nova System Sound clock (2x) */
 	 33'833'000, /* 33.833_MHz_XTAL        - */
 	 33'868'800, /* 33.8688_MHz_XTAL       Usually used to drive 90's Yamaha OPL/FM chips with /2 divider */
 	 34'000'000, /* 34_MHz_XTAL            Gaelco PCBs */

--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -368,7 +368,7 @@ const double XTAL::known_xtals[] = {
 	 33'264'000, /* 33.264_MHz_XTAL        Hazeltine 1500 terminal */
 	 33'330'000, /* 33.33_MHz_XTAL         Sharp X68000 XVI */
 	 33'333'000, /* 33.333_MHz_XTAL        Sega Model 3 CPU board, Vegas */
-	 33'333'333, /* 33.333333_MHz_XTAL     Super Kaneko Nova System Sound clock (2x) */
+	 33'333'333, /* 33.333333_MHz_XTAL     Super Kaneko Nova System Sound clock with /2 divider */
 	 33'833'000, /* 33.833_MHz_XTAL        - */
 	 33'868'800, /* 33.8688_MHz_XTAL       Usually used to drive 90's Yamaha OPL/FM chips with /2 divider */
 	 34'000'000, /* 34_MHz_XTAL            Gaelco PCBs */

--- a/src/mame/drivers/gaiden.cpp
+++ b/src/mame/drivers/gaiden.cpp
@@ -807,7 +807,7 @@ void gaiden_state::raiga(machine_config &config)
 	MCFG_VIDEO_START_OVERRIDE(gaiden_state,raiga)
 
 	m_screen->set_screen_update(FUNC(gaiden_state::screen_update_raiga));
-	m_screen->screen_vblank().set("spriteram", FUNC(buffered_spriteram16_device::vblank_copy_rising));
+	m_screen->screen_vblank().set(FUNC(gaiden_state::screen_vblank_raiga));
 }
 
 void gaiden_state::drgnbowl(machine_config &config)

--- a/src/mame/drivers/suprnova.cpp
+++ b/src/mame/drivers/suprnova.cpp
@@ -800,7 +800,7 @@ void skns_state::skns(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	ymz280b_device &ymz(YMZ280B(config, "ymz", 33333333 / 2));
+	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(33'333'333) / 2));
 	ymz.add_route(0, "lspeaker", 1.0);
 	ymz.add_route(1, "rspeaker", 1.0);
 }

--- a/src/mame/drivers/suprnova.cpp
+++ b/src/mame/drivers/suprnova.cpp
@@ -154,7 +154,6 @@ NEP-16
 #include "machine/nvram.h"
 #include "sound/ymz280b.h"
 
-#include "screen.h"
 #include "speaker.h"
 
 
@@ -751,45 +750,20 @@ void skns_state::skns_map(address_map &map)
 
 /***** GFX DECODE *****/
 
-static const gfx_layout skns_tilemap_layout =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	8,
-	{ 0, 1, 2, 3, 4, 5, 6, 7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8,
-		8*8, 9*8, 10*8, 11*8, 12*8, 13*8, 14*8, 15*8 },
-	{ 0*128, 1*128, 2*128, 3*128, 4*128, 5*128, 6*128, 7*128,
-		8*128, 9*128, 10*128, 11*128, 12*128, 13*128, 14*128, 15*128 },
-	16*16*8
-};
-
-static const gfx_layout skns_4bpptilemap_layout =
-{
-	16,16,
-	RGN_FRAC(1,1),
-	4,
-	{ 0, 1, 2, 3  },
-	{ 1*4, 0*4, 3*4, 2*4, 5*4, 4*4, 7*4, 6*4,
-		9*4, 8*4, 11*4, 10*4, 13*4, 12*4, 15*4, 14*4 },
-	{ 0*64, 1*64, 2*64, 3*64, 4*64, 5*64, 6*64, 7*64,
-		8*64, 9*64, 10*64, 11*64, 12*64, 13*64, 14*64, 15*64 },
-	16*16*4
-};
-
 static GFXDECODE_START( skns_bg )
 	/* "spritegen" is sprites, RLE encoded */
-	GFXDECODE_ENTRY( "gfx2", 0, skns_tilemap_layout, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx3", 0, skns_tilemap_layout, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx2", 0, skns_4bpptilemap_layout, 0x000, 128 )
-	GFXDECODE_ENTRY( "gfx3", 0, skns_4bpptilemap_layout, 0x000, 128 )
+	GFXDECODE_ENTRY( "gfx2", 0, gfx_16x16x8_raw, 0x000, 128 )
+	GFXDECODE_ENTRY( "gfx3", 0, gfx_16x16x8_raw, 0x000, 128 )
+	GFXDECODE_ENTRY( "gfx2", 0, gfx_16x16x4_packed_lsb, 0x000, 128 )
+	GFXDECODE_ENTRY( "gfx3", 0, gfx_16x16x4_packed_lsb, 0x000, 128 )
 GFXDECODE_END
 
 /***** MACHINE DRIVER *****/
 
+// XTALs : 28.636MHz, 33.3333MHz, 21.504MHz
 void skns_state::skns(machine_config &config)
 {
-	SH2(config, m_maincpu, 28638000);
+	SH2(config, m_maincpu, XTAL(28'636'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &skns_state::skns_map);
 
 	TIMER(config, "scantimer").configure_scanline(FUNC(skns_state::irq), "screen", 0, 1);
@@ -805,22 +779,22 @@ void skns_state::skns(machine_config &config)
 	int11_timer.configure_periodic(FUNC(skns_state::interrupt_callback), attotime::from_msec(8));
 	int11_timer.config_param(11);
 	timer_device &int9_timer(TIMER(config, "int9_timer"));
-	int9_timer.configure_periodic(FUNC(skns_state::interrupt_callback), attotime::from_hz(28638000/1824));
+	int9_timer.configure_periodic(FUNC(skns_state::interrupt_callback), attotime::from_hz(XTAL(28'636'000)/1824));
 	int9_timer.config_param(9);
 
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_video_attributes(VIDEO_ALWAYS_UPDATE);
-	screen.set_refresh_hz(59.5971); // measured by Guru
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0));
-	screen.set_size(340,262);
-	screen.set_visarea(0,319,0,239);
-	screen.set_screen_update(FUNC(skns_state::screen_update));
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_video_attributes(VIDEO_ALWAYS_UPDATE);
+	m_screen->set_refresh_hz(59.5971); // measured by Guru
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0));
+	m_screen->set_size(340,262);
+	m_screen->set_visarea(0,319,0,239);
+	m_screen->set_screen_update(FUNC(skns_state::screen_update));
+	m_screen->screen_vblank().set(FUNC(skns_state::screen_vblank));
 
 	PALETTE(config, m_palette).set_entries(32768);
 	GFXDECODE(config, m_gfxdecode, m_palette, skns_bg);
 
 	SKNS_SPRITE(config, m_spritegen, 0);
-
 
 	/* sound hardware */
 	SPEAKER(config, "lspeaker").front_left();

--- a/src/mame/drivers/tecmo16.cpp
+++ b/src/mame/drivers/tecmo16.cpp
@@ -352,7 +352,7 @@ void tecmo16_state::fstarfrc(machine_config &config)
 	m_screen->set_visarea(0*8, 32*8-1, 2*8, 30*8-1);
 	m_screen->set_screen_update(FUNC(tecmo16_state::screen_update));
 	m_screen->screen_vblank().set_inputline(m_maincpu, INPUT_LINE_IRQ5);
-	m_screen->screen_vblank().append(m_spriteram, FUNC(buffered_spriteram16_device::vblank_copy_rising));
+	m_screen->screen_vblank().append(FUNC(tecmo16_state::screen_vblank));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_tecmo16);
 	PALETTE(config, m_palette, palette_device::BLACK).set_format(palette_device::xBGR_444, 4096);

--- a/src/mame/includes/gaiden.h
+++ b/src/mame/includes/gaiden.h
@@ -134,7 +134,7 @@ private:
 	DECLARE_VIDEO_START(gaiden);
 	DECLARE_VIDEO_START(drgnbowl);
 	DECLARE_VIDEO_START(raiga);
-	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank_raiga);
 	uint32_t screen_update_gaiden(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_raiga(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_drgnbowl(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/includes/suprnova.h
+++ b/src/mame/includes/suprnova.h
@@ -11,6 +11,7 @@
 #include "machine/timer.h"
 
 #include "emupal.h"
+#include "screen.h"
 #include "tilemap.h"
 
 
@@ -23,6 +24,7 @@ public:
 		m_spritegen(*this, "spritegen"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_palette(*this, "palette"),
+		m_screen(*this, "screen"),
 		m_spriteram(*this,"spriteram"),
 		m_spc_regs(*this, "spc_regs"),
 		m_v3_regs(*this, "v3_regs"),
@@ -86,6 +88,7 @@ private:
 	required_device<sknsspr_device> m_spritegen;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<palette_device> m_palette;
+	required_device<screen_device> m_screen;
 
 	required_shared_ptr<uint32_t> m_spriteram;
 	required_shared_ptr<uint32_t> m_spc_regs;
@@ -173,6 +176,8 @@ private:
 	TILE_GET_INFO_MEMBER(get_tilemap_A_tile_info);
 	TILE_GET_INFO_MEMBER(get_tilemap_B_tile_info);
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
+
 	TIMER_DEVICE_CALLBACK_MEMBER(interrupt_callback);
 	TIMER_DEVICE_CALLBACK_MEMBER(irq);
 	void draw_roz(bitmap_ind16 &bitmap, bitmap_ind8& bitmapflags, const rectangle &cliprect, tilemap_t *tmap, uint32_t startx, uint32_t starty, int incxx, int incxy, int incyx, int incyy, int wraparound, int columnscroll, uint32_t* scrollram);

--- a/src/mame/includes/tecmo16.h
+++ b/src/mame/includes/tecmo16.h
@@ -90,6 +90,7 @@ private:
 	DECLARE_VIDEO_START(riot);
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
 
 	void save_state();
 

--- a/src/mame/video/gaiden.cpp
+++ b/src/mame/video/gaiden.cpp
@@ -326,9 +326,6 @@ uint32_t gaiden_state::screen_update_raiga(screen_device &screen, bitmap_rgb32 &
 
 	m_mixer->mix_bitmaps(screen, bitmap, cliprect, *m_palette, &m_tile_bitmap_bg, &m_tile_bitmap_fg, &m_tile_bitmap_tx, &m_sprite_bitmap);
 
-	// raiga sprite has 2 frame lags
-	m_sprite_bitmap.fill(0, cliprect);
-	m_sprgen->gaiden_draw_sprites(screen, m_gfxdecode->gfx(3), cliprect, m_spriteram->buffer(), m_sprite_sizey, flip_screen() ? -m_spr_offset_y : m_spr_offset_y, flip_screen(), m_sprite_bitmap);
 	return 0;
 }
 
@@ -341,4 +338,17 @@ uint32_t gaiden_state::screen_update_drgnbowl(screen_device &screen, bitmap_ind1
 	m_text_layer->draw(screen, bitmap, cliprect, 0, 4);
 	drgnbowl_draw_sprites(screen, bitmap, cliprect);
 	return 0;
+}
+
+WRITE_LINE_MEMBER(gaiden_state::screen_vblank_raiga)
+{
+	if (state)
+	{
+		const rectangle visarea = m_screen->visible_area();
+		// raiga sprite has 2 frame lags
+		m_sprite_bitmap.fill(0, visarea);
+		m_sprgen->gaiden_draw_sprites(*m_screen, m_gfxdecode->gfx(3), visarea, m_spriteram->buffer(), m_sprite_sizey, flip_screen() ? -m_spr_offset_y : m_spr_offset_y, flip_screen(), m_sprite_bitmap);
+
+		m_spriteram->copy();
+	}
 }

--- a/src/mame/video/suprnova.cpp
+++ b/src/mame/video/suprnova.cpp
@@ -507,7 +507,7 @@ uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 					uint16_t pendata  = src[x]&0x7fff;
 					uint16_t pendata2 = src2[x]&0x7fff;
 					uint16_t bgpendata;
-					uint16_t pendata3 = src3[x]&0x3fff;
+					uint16_t pendata3 = m_alt_enable_sprites ? src3[x]&0x3fff : 0;
 
 					uint32_t coldat;
 
@@ -621,8 +621,13 @@ uint32_t skns_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, 
 		}
 	}
 
-	if (m_alt_enable_sprites)
-		m_spritegen->skns_draw_sprites(m_sprite_bitmap, cliprect, m_spriteram, m_spriteram.bytes(), m_spc_regs ); // TODO : not all 0x4000 of the sprite RAM area can be displayed on real hardware
-
 	return 0;
+}
+
+WRITE_LINE_MEMBER(skns_state::screen_vblank)
+{
+	if (state)
+	{
+		m_spritegen->skns_draw_sprites(m_sprite_bitmap, m_screen->visible_area(), m_spriteram, m_spriteram.bytes(), m_spc_regs); // TODO: not all 0x4000 of the sprite RAM area can be displayed on real hardware
+	}
 }

--- a/src/mame/video/tecmo16.cpp
+++ b/src/mame/video/tecmo16.cpp
@@ -231,10 +231,19 @@ uint32_t tecmo16_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 
 	m_mixer->mix_bitmaps(screen, bitmap, cliprect, *m_palette, &m_tile_bitmap_bg, &m_tile_bitmap_fg, &m_tile_bitmap_tx, &m_sprite_bitmap);
 
-	// 2 frame sprite lags
-	m_sprite_bitmap.fill(0, cliprect);
-	if (m_game_is_riot)  m_sprgen->gaiden_draw_sprites(screen, m_gfxdecode->gfx(2), cliprect, m_spriteram->buffer(), 0, 0, flip_screen(),  m_sprite_bitmap);
-	else m_sprgen->gaiden_draw_sprites(screen, m_gfxdecode->gfx(2), cliprect, m_spriteram->buffer(), 2, 0, flip_screen(),  m_sprite_bitmap);
-
 	return 0;
+}
+
+WRITE_LINE_MEMBER(tecmo16_state::screen_vblank)
+{
+	if (state)
+	{
+		const rectangle visarea = m_screen->visible_area();
+		// 2 frame sprite lags
+		m_sprite_bitmap.fill(0, visarea);
+		if (m_game_is_riot)  m_sprgen->gaiden_draw_sprites(*m_screen, m_gfxdecode->gfx(2), visarea, m_spriteram->buffer(), 0, 0, flip_screen(),  m_sprite_bitmap);
+		else m_sprgen->gaiden_draw_sprites(*m_screen, m_gfxdecode->gfx(2), visarea, m_spriteram->buffer(), 2, 0, flip_screen(),  m_sprite_bitmap);
+
+		m_spriteram->copy();
+	}
 }


### PR DESCRIPTION
gaiden.cpp, tecmo16.cpp, suprnova.cpp: Move delayed sprite drawing function into screen_vblank
suprnova.cpp: Use generic gfx layout, Fix CPU clock related to XTAL, Use device for screen