### PR TITLE
hp86: fixed a bug in key auto-repeat function

### DIFF
--- a/src/mame/drivers/hp80.cpp
+++ b/src/mame/drivers/hp80.cpp
@@ -487,10 +487,9 @@ READ8_MEMBER(hp80_base_state::keycod_r)
 
 WRITE8_MEMBER(hp80_base_state::keycod_w)
 {
-	if (m_has_int_keyb) {
+	if (m_kb_raw_readout) {
 		m_kb_keycode = data;
-	}
-	if (data == 1) {
+	} else if (data == 1) {
 		unsigned irq = get_kb_irq();
 		irq_w(irq , false);
 		m_kb_enable = true;


### PR DESCRIPTION
I've just fixed a bug in HP86 emulation that prevented correct key auto-repeat with non-English keyboard layouts.
Thanks.
--F.Ulivi
