### PR TITLE
nscsi/cd: handle eject command for SGI drives

### DIFF
--- a/src/devices/bus/nscsi/cd.cpp
+++ b/src/devices/bus/nscsi/cd.cpp
@@ -604,13 +604,23 @@ enum sgi_scsi_command_e : uint8_t {
 	 * in the kernel runs, if there are SCSI problems.
 	 */
 	SGI_HD2CDROM = 0xc9,
+	/*
+	 * IRIX 5.3 sends this command when it wants to eject the drive
+	 */
+	SGI_EJECT = 0xc4,
 };
 
 void nscsi_cdrom_sgi_device::scsi_command()
 {
 	switch (scsi_cmdbuf[0]) {
 	case SGI_HD2CDROM:
-		LOG("command SGI_HD2CDROM");
+		LOG("command SGI_HD2CDROM\n");
+		// No need to do anything (yet). Just acknowledge the command.
+		scsi_status_complete(SS_GOOD);
+		break;
+
+	case SGI_EJECT:
+		LOG("command SGI_EJECT\n");
 		// No need to do anything (yet). Just acknowledge the command.
 		scsi_status_complete(SS_GOOD);
 		break;
@@ -625,6 +635,9 @@ bool nscsi_cdrom_sgi_device::scsi_command_done(uint8_t command, uint8_t length)
 {
 	switch (command) {
 	case SGI_HD2CDROM:
+		return length == 10;
+
+	case SGI_EJECT:
 		return length == 10;
 
 	default:


### PR DESCRIPTION
On `indy_4610` running IRIX 5.3, the `eject` command (or selecting the same operation in the UI, e.g. in the cdrom icon context menu) causes an immediate abort due to
```
[:scsibus:6:cdrom] Unhandled command ? (1): c4
```
Adding a stub handler for the command allows the system to work properly. Moreover, it is now possible to switch CD media on a running system without having to resort to messy workarounds: just switch the media MAME's file manager and run `eject` to make IRIX reload it.