### PR TITLE
indy_indigo2: fix include ordering

### DIFF
--- a/src/mame/drivers/indy_indigo2.cpp
+++ b/src/mame/drivers/indy_indigo2.cpp
@@ -76,10 +76,9 @@
 
 #include "emupal.h"
 #include "screen.h"
+#include "softlist.h"
 
 #include "logmacro.h"
-
-#include "softlist.h"
 
 class ip24_state : public driver_device
 {


### PR DESCRIPTION
Move `softlist.h` include before `logmacro.h` per @cuavas comment on https://github.com/mamedev/mame/pull/6601