### PR TITLE
Fix CoCo cartridge loading for less than 16k carts.

### DIFF
--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -450,7 +450,7 @@ image_init_result cococart_slot_device::call_load()
 
 		while (read_length < cart_length)
 		{
-			offs_t len = std::min(read_length, m_cart->get_cart_size() - read_length);
+			offs_t len = std::min(read_length, cart_length - read_length);
 			memcpy(base + read_length, base, len);
 			read_length += len;
 		}


### PR DESCRIPTION
The previous code would get into an infinite loop if the user tried to load a ROM cartridge smaller than or equal to 16k. That's because m_cart->get_cart_size() is 16384:

len = min(16384, 16384-16384)
len = 0
