### PR TITLE
vtvideo.cpp: Implement pixel stretching of characters.

### DIFF
--- a/src/mame/video/vtvideo.cpp
+++ b/src/mame/video/vtvideo.cpp
@@ -630,6 +630,53 @@ void vt100_video_device::display_char(bitmap_ind16 &bitmap, uint8_t code, int x,
 			if (m_columns == 80)
 				bitmap.pix16(y_preset, x_preset + 9) = bit;
 		}
+
+		/* The DEC terminals use a single ROM bitmap font and
+		 * dot-stretching to synthesize multiple variants that are not
+		 * just nearest neighbor resampled. The result is the same
+		 * as one would get by fake-bolding; the already doubled raster image;
+		 * by rendering twice with 1px horizontal offset.
+		 *
+		 * For details see: https://vt100.net/dec/vt220/glyphs
+		 */
+		int prev_bit = back_intensity;
+		int bits_width = 21;
+		if (!double_width)
+		{
+			if (m_columns == 80)
+				bits_width = 11;
+			else
+				bits_width = 10;
+		}
+		for (int b = 0; b < bits_width; b++)
+		{
+			if (double_width)
+			{ 
+		  		if (bitmap.pix16(y_preset, DOUBLE_x_preset + b) == fg_intensity)
+		  		{
+			  		prev_bit = fg_intensity;
+		  		}
+		  		else
+		  		{
+			  		if (prev_bit == fg_intensity)
+						bitmap.pix16(y_preset, DOUBLE_x_preset + b) = fg_intensity;
+			  		prev_bit = back_intensity;
+		  		}
+			}
+			else
+			{
+		  		if (bitmap.pix16(y_preset, x_preset + b) == fg_intensity)
+		  		{
+			  		prev_bit = fg_intensity;
+		  		}
+		  		else
+		  		{
+			  		if (prev_bit == fg_intensity)
+						bitmap.pix16(y_preset, x_preset + b) = fg_intensity;
+			  		prev_bit = back_intensity;
+		  		}
+			}
+		}
 	} // for (scan_line)
 
 }


### PR DESCRIPTION
This fills in 1px gaps in 80column wide mode, details which are lost
unless the line-mode is double-wide. This reintroduces functionality
lost in commit d0fa593c1ea1ad.