### PR TITLE
CoCo: Changed driver coco3dw1 to have a default on becker port.

### DIFF
--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -173,6 +173,13 @@ INPUT_PORTS_START( coco_beckerport )
 	PORT_CONFSETTING(    0x01, DEF_STR( On ))
 INPUT_PORTS_END
 
+INPUT_PORTS_START( coco_beckerport_dw )
+	PORT_START(BECKERPORT_TAG)
+	PORT_CONFNAME( 0x01, 0x01, "Becker Port" )
+	PORT_CONFSETTING(    0x00, DEF_STR( Off ))
+	PORT_CONFSETTING(    0x01, DEF_STR( On ))
+INPUT_PORTS_END
+
 //-------------------------------------------------
 //  INPUT_PORTS( coco_rtc )
 //-------------------------------------------------

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -229,6 +229,16 @@ static INPUT_PORTS_START( coco3 )
 	PORT_INCLUDE( coco_beckerport )
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( coco3dw )
+	PORT_INCLUDE( coco3_keyboard )
+	PORT_INCLUDE( coco3_joystick )
+	PORT_INCLUDE( coco_analog_control )
+	PORT_INCLUDE( coco_rat_mouse )
+	PORT_INCLUDE( coco_lightgun )
+	PORT_INCLUDE( coco_rtc )
+	PORT_INCLUDE( coco_beckerport_dw )
+INPUT_PORTS_END
+
 static DEVICE_INPUT_DEFAULTS_START( printer )
 	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_600 )
 	DEVICE_INPUT_DEFAULTS( "RS232_STARTBITS", 0xff, RS232_STARTBITS_1 )
@@ -386,4 +396,4 @@ ROM_END
 COMP( 1986, coco3,    coco, 0, coco3,    coco3, coco3_state, empty_init, "Tandy Radio Shack", "Color Computer 3 (NTSC)",          0 )
 COMP( 1986, coco3p,   coco, 0, coco3p,   coco3, coco3_state, empty_init, "Tandy Radio Shack", "Color Computer 3 (PAL)",           0 )
 COMP( 19??, coco3h,   coco, 0, coco3h,   coco3, coco3_state, empty_init, "Tandy Radio Shack", "Color Computer 3 (NTSC; HD6309)",  MACHINE_UNOFFICIAL )
-COMP( 19??, coco3dw1, coco, 0, coco3dw1, coco3, coco3_state, empty_init, "Tandy Radio Shack", "Color Computer 3 (NTSC; HDB-DOS)", MACHINE_UNOFFICIAL )
+COMP( 19??, coco3dw1, coco, 0, coco3dw1, coco3dw, coco3_state, empty_init, "Tandy Radio Shack", "Color Computer 3 (NTSC; HDB-DOS)", MACHINE_UNOFFICIAL )

--- a/src/mame/includes/coco.h
+++ b/src/mame/includes/coco.h
@@ -34,6 +34,7 @@ INPUT_PORTS_EXTERN( coco_analog_control );
 INPUT_PORTS_EXTERN( coco_joystick );
 INPUT_PORTS_EXTERN( coco_rtc );
 INPUT_PORTS_EXTERN( coco_beckerport );
+INPUT_PORTS_EXTERN( coco_beckerport_dw );
 
 void coco_cart(device_slot_interface &device);
 


### PR DESCRIPTION
CoCo: Modified coco3dw1 to have becker port turned on by default.