### PR TITLE
Remove colon as a path seperator in the core

### DIFF
--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -195,7 +195,7 @@ void device_image_interface::set_image_filename(const std::string &filename)
 	auto iter = std::find_if(
 		m_image_name.rbegin(),
 		m_image_name.rend(),
-		[](char c) { return (c == '\\') || (c == '/') || (c == ':'); });
+		[](char c) { return (c == '\\') || (c == '/'); });
 
 	if (iter != m_image_name.rend())
 		m_basename.assign(iter.base(), m_image_name.end());


### PR DESCRIPTION
I don't believe MAME compiles on any platform where the colon is a path seperator.
So removing this solves a problem when viewing file names in the UI File Manager.
![Screen Shot 2020-05-03 at 2 17 40 PM](https://user-images.githubusercontent.com/3808/80926268-0db12c00-8d4b-11ea-9242-fa80bcddb968.png)
