### PR TITLE
This fixes the ability for one to use UI Paste with the Default Serial Terminal

### DIFF
--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -539,6 +539,34 @@ bool ioport_condition::eval() const
 	return true;
 }
 
+//-------------------------------------------------
+//  evalzero - evaluate zero condition
+//-------------------------------------------------
+
+bool ioport_condition::evalzero() const
+{
+	// always condition is always true
+	if (m_condition == ALWAYS)
+		return true;
+
+	// Read the zero condition
+	// This is used as a workaround, so that users who are parsing the
+	// the ioport structure at init time can get at least one valid set
+	// of values, even when PORT_CONDITION() is being used
+
+	ioport_value condvalue = 0;
+	switch (m_condition)
+	{
+		case ALWAYS:            return true;
+		case EQUALS:            return ((condvalue & m_mask) == m_value);
+		case NOTEQUALS:         return ((condvalue & m_mask) != m_value);
+		case GREATERTHAN:       return ((condvalue & m_mask) > m_value);
+		case NOTGREATERTHAN:    return ((condvalue & m_mask) <= m_value);
+		case LESSTHAN:          return ((condvalue & m_mask) < m_value);
+		case NOTLESSTHAN:       return ((condvalue & m_mask) >= m_value);
+	}
+	return true;
+}
 
 //-------------------------------------------------
 //  initialize - create the live state

--- a/src/emu/ioport.h
+++ b/src/emu/ioport.h
@@ -903,6 +903,7 @@ public:
 	// operators
 	bool operator==(const ioport_condition &rhs) const { return (m_mask == rhs.m_mask && m_value == rhs.m_value && m_condition == rhs.m_condition && strcmp(m_tag, rhs.m_tag) == 0); }
 	bool eval() const;
+	bool evalzero() const;
 	bool none() const { return (m_condition == ALWAYS); }
 
 	// configuration

--- a/src/emu/natkeyboard.cpp
+++ b/src/emu/natkeyboard.cpp
@@ -631,7 +631,7 @@ void natural_keyboard::build_codes(ioport_manager &manager)
 	{
 		for (ioport_field &field : port.second->fields())
 		{
-			if (field.type() == IPT_KEYBOARD)
+			if ((field.type() == IPT_KEYBOARD) && (field.condition().evalzero()))
 			{
 				// iterate over all shift states
 				for (unsigned curshift = 0; curshift < SHIFT_STATES; ++curshift)


### PR DESCRIPTION
Without this fix, 8 characters @^&():" and backslash cannot be pasted from the UI
Workaround for issue with natural_keyboard device and PORT_CONDITION()

A better fix would be for the natural keyboard device to respond to ioport changes at runtime