### PR TITLE
Update hd6309.ops

### DIFF
--- a/src/devices/cpu/m6809/hd6309.ops
+++ b/src/devices/cpu/m6809/hd6309.ops
@@ -50,7 +50,6 @@ MAIN:
 		case 0x1E:								%EXG;			return;
 		case 0x1F:								%TFR;			return;
 
-		case 0x20:				set_cond(true);			%BRANCH;	return;
 		case 0x21:				set_cond(false);		%BRANCH;	return;
 		case 0x22:				set_cond(cond_hi());	%BRANCH;	return;
 		case 0x23:				set_cond(!cond_hi());	%BRANCH;	return;


### PR DESCRIPTION
$1020 is an illegal opcode on the 6309. On the 6809 it is a rarely used form of LBRA. I tested on a real 6309 and $1020 vectors to Illegal.