### PR TITLE
Debugger - add `-debuglog` option to log debug console output to file

### DIFF
--- a/src/emu/debug/debugcon.h
+++ b/src/emu/debug/debugcon.h
@@ -118,6 +118,9 @@ private:
 	CMDERR internal_execute_command(bool execute, int params, char **param);
 	CMDERR internal_parse_command(const std::string &original_command, bool execute);
 
+	void print_core(const char *text);                   // core text output
+	void print_core_wrap(const char *text, int wrapcol); // core text output
+
 	struct debug_command
 	{
 		debug_command(const char *_command, u32 _flags, int _ref, int _minparams, int _maxparams, std::function<void(int, const std::vector<std::string> &)> _handler);
@@ -140,6 +143,7 @@ private:
 	std::forward_list<debug_command> m_commandlist;
 
 	std::unique_ptr<std::istream> m_source_file;        // script source file
+	std::unique_ptr<emu_file> m_logfile;                // logfile for debug console output
 };
 
 #endif // MAME_EMU_DEBUG_DEBUGCON_H

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -176,6 +176,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_DEBUG ";d",                                 "0",         OPTION_BOOLEAN,    "enable/disable debugger" },
 	{ OPTION_UPDATEINPAUSE,                              "0",         OPTION_BOOLEAN,    "keep calling video updates while in pause" },
 	{ OPTION_DEBUGSCRIPT,                                nullptr,     OPTION_STRING,     "script for debugger" },
+	{ OPTION_DEBUGLOG,                                   "0",         OPTION_BOOLEAN,    "write debug console output to debug.log" },
 
 	// comm options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE COMM OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -154,6 +154,7 @@
 #define OPTION_OSLOG                "oslog"
 #define OPTION_UPDATEINPAUSE        "update_in_pause"
 #define OPTION_DEBUGSCRIPT          "debugscript"
+#define OPTION_DEBUGLOG             "debuglog"
 
 // core misc options
 #define OPTION_DRC                  "drc"
@@ -430,6 +431,7 @@ public:
 	bool oslog() const { return bool_value(OPTION_OSLOG); }
 	const char *debug_script() const { return value(OPTION_DEBUGSCRIPT); }
 	bool update_in_pause() const { return bool_value(OPTION_UPDATEINPAUSE); }
+	bool debuglog() const { return bool_value(OPTION_DEBUGLOG); }
 
 	// core misc options
 	bool drc() const { return bool_value(OPTION_DRC); }

--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -314,10 +314,18 @@ int running_machine::run(bool quiet)
 			m_logfile = std::make_unique<emu_file>(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 			osd_file::error filerr = m_logfile->open("error.log");
 			if (filerr != osd_file::error::NONE)
-				throw emu_fatalerror("running_machine::run: unable to open log file");
+				throw emu_fatalerror("running_machine::run: unable to open error.log file");
 
 			using namespace std::placeholders;
 			add_logerror_callback(std::bind(&running_machine::logfile_callback, this, _1));
+		}
+
+		if (options().debug() && options().debuglog())
+		{
+			m_debuglogfile = std::make_unique<emu_file>(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
+			osd_file::error filerr = m_debuglogfile->open("debug.log");
+			if (filerr != osd_file::error::NONE)
+				throw emu_fatalerror("running_machine::run: unable to open debug.log file");
 		}
 
 		// then finish setting up our local machine

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -264,6 +264,10 @@ private:
 public:
 	// debugger-related information
 	u32                     debug_flags;        // the current debug flags
+	bool debug_enabled() { return (debug_flags & DEBUG_FLAG_ENABLED) != 0; }
+
+	// used by debug_console to take ownership of the debug.log file
+	std::unique_ptr<emu_file> steal_debuglogfile() { return std::move(m_debuglogfile); }
 
 private:
 	class side_effects_disabler {
@@ -346,7 +350,8 @@ private:
 	time_t                  m_base_time;            // real time at initial emulation time
 	std::string             m_basename;             // basename used for game-related paths
 	int                     m_sample_rate;          // the digital audio sample rate
-	std::unique_ptr<emu_file>  m_logfile;              // pointer to the active log file
+	std::unique_ptr<emu_file>  m_logfile;           // pointer to the active error.log file
+	std::unique_ptr<emu_file>  m_debuglogfile;      // pointer to the active debug.log file
 
 	// load/save management
 	enum class saveload_schedule


### PR DESCRIPTION
When this option is specified, all console output is echoed to a log
file.

Some caveats/limitations:

- The file-open process was copied from -log, so it has the same limits
  - Filename is hard-coded (debug.log)
  - File is overwritten if it exists
  - File is opened during emulation initialization
    - Thus, the file is cleared if you invoke the "Hard Reset"
      debugger command
  - Probably some other details I don't know about

- Logging works as such: When a string is appended to the scrollback
  buffer, it is also written to the log file.

  Some commands forcibly wrap their output (e.g. `help` to 80 columns.)
  Because this wrapping is done inside the scrollback buffer, the text
  written to the file is not wrapped.

  This can be seen with `help execution`.