### PR TITLE
fix HFE disk write

### DIFF
--- a/src/lib/formats/hxchfe_dsk.cpp
+++ b/src/lib/formats/hxchfe_dsk.cpp
@@ -615,7 +615,6 @@ void hfe_format::generate_hfe_bitstream_from_track(int cyl, int head, int& sampl
 		// Start of track? Use next entry.
 		if (edge==0)
 		{
-			cur_pos = 0;
 			edge = tbuf[++cur_entry] & floppy_image::TIME_MASK;
 		}
 
@@ -671,10 +670,6 @@ void hfe_format::generate_hfe_bitstream_from_track(int cyl, int head, int& sampl
 		}
 
 		cur_pos = next;
-		if(cur_pos >= 200000000) {
-			cur_pos -= 200000000;
-			cur_entry = 0;
-		}
 
 		bit = (bit << 1) & 0xff;
 		if (bit == 0)


### PR DESCRIPTION
this fixes https://mametesters.org/view.php?id=7526

`src/lib/formats/hxchfe_dsk.cpp` reproducibly creates a SEGV when writing HFE files. This is caused by an endless loop in `hfe_format::generate_hfe_bitstream_from_track`, writing beyond end-of-array at https://github.com/mamedev/mame/blob/140ba5147df230751a87a62374eba8880f5d3dbe/src/lib/formats/hxchfe_dsk.cpp#L683

The endless loop is caused by re-setting `cur_pos` at two occasions and re-setting the loop variable.

This fix drops the reset of `cur_pos` resulting in a successful write of a mixed-density (track0 sd, others dd) HFE image.