### PR TITLE
nes.xml, famicom_flop.xml, msx1_cart.xml: minor metadata fixes

### DIFF
--- a/hash/famicom_flop.xml
+++ b/hash/famicom_flop.xml
@@ -1366,7 +1366,7 @@ Re-releases (probably the same as the original release, but listed while waiting
 
 	<software name="meikyujd">
 		<description>Meikyuu Jiin Dababa</description>
-		<year>1986</year>
+		<year>1987</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="KDS-MIK"/>
 		<info name="release" value="19870529"/>

--- a/hash/msx1_cart.xml
+++ b/hash/msx1_cart.xml
@@ -5312,7 +5312,7 @@ kept for now until finding out what those bytes affect...
 		</part>
 	</software>
 
-	<software name="gw126a">
+	<software name="gw126a" cloneof="gw126">
 		<description>Game World - 126 Games (Kor, Hacked?)</description>
 		<year>19??</year>
 		<publisher>Zemina</publisher>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -25010,7 +25010,7 @@ license:CC0
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="JF-28"/>
 		<info name="release" value="19900629"/>
-		<info name="alt_title" value="燃えろ!! 柔道うぉり・ーず"/>
+		<info name="alt_title" value="燃えろ!! 柔道うおりあ〜ず"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="jf17" />
 			<feature name="pcb" value="JALECO-JF-17" />
@@ -75764,7 +75764,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="sf3_9">
+	<software name="sf3_9" cloneof="sf3">
 		<description>Street Fighter III (Asia, 9 characters)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>


### PR DESCRIPTION
moejudo alt_title typo is fixed and also made to match box orthography, otherwise changes are self explanatory.