### PR TITLE
gal3.cpp, namcos21*.cpp: Fix c140 input clock source related to on-chip XTALs

### DIFF
--- a/src/mame/drivers/gal3.cpp
+++ b/src/mame/drivers/gal3.cpp
@@ -599,7 +599,7 @@ void gal3_state::gal3(machine_config &config)
 	rs_cpu.set_addrmap(AS_PROGRAM, &gal3_state::rs_cpu_map);
 	rs_cpu.set_vblank_int("lscreen", FUNC(gal3_state::irq5_line_hold));  /// programmable via 148 IC
 
-	m68000_device &sound_cpu(M68000(config, "sound_cpu", 12000000)); // ??
+	m68000_device &sound_cpu(M68000(config, "sound_cpu", 49152000/4)); // ??
 	sound_cpu.set_addrmap(AS_PROGRAM, &gal3_state::sound_cpu_map);
 
 	m68000_device &psn_b1_cpu(M68000(config, "psn_b1_cpu", 12000000)); // ??
@@ -679,12 +679,12 @@ void gal3_state::gal3(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	C140(config, m_c140_16g, 8000000/374);
+	C140(config, m_c140_16g, 49152000/2304);
 	//m_c140_16g->set_addrmap(0, &gal3_state::c140_16g_map);    //to be verified
 	m_c140_16g->add_route(0, "lspeaker", 0.50);
 	m_c140_16g->add_route(1, "rspeaker", 0.50);
 
-	C140(config, m_c140_16a, 8000000/374);
+	C140(config, m_c140_16a, 49152000/2304);
 	//m_c140_16a->set_addrmap(0, &gal3_state::c140_16a_map);    //to be verified
 	m_c140_16a->add_route(0, "lspeaker", 0.50);
 	m_c140_16a->add_route(1, "rspeaker", 0.50);

--- a/src/mame/drivers/gal3.cpp
+++ b/src/mame/drivers/gal3.cpp
@@ -679,6 +679,7 @@ void gal3_state::gal3(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
+	// TODO: Total 5 of C140s in sound board, verified from gal3zlgr PCB - gal3 uses same board?
 	C140(config, m_c140_16g, 49152000/2304);
 	//m_c140_16g->set_addrmap(0, &gal3_state::c140_16g_map);    //to be verified
 	m_c140_16g->add_route(0, "lspeaker", 0.50);

--- a/src/mame/drivers/namcos21.cpp
+++ b/src/mame/drivers/namcos21.cpp
@@ -907,7 +907,7 @@ void namcos21_state::winrun(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	C140(config, m_c140, 8000000/374);
+	C140(config, m_c140, 49.152_MHz_XTAL / 2304);
 	m_c140->set_addrmap(0, &namcos21_state::c140_map);
 	m_c140->int1_callback().set_inputline(m_audiocpu, M6809_FIRQ_LINE);
 	m_c140->add_route(0, "lspeaker", 0.50);

--- a/src/mame/drivers/namcos21_c67.cpp
+++ b/src/mame/drivers/namcos21_c67.cpp
@@ -838,7 +838,7 @@ void namcos21_c67_state::namcos21(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	C140(config, m_c140, 8000000/374);
+	C140(config, m_c140, 49.152_MHz_XTAL / 2304);
 	m_c140->set_addrmap(0, &namcos21_c67_state::c140_map);
 	m_c140->int1_callback().set_inputline(m_audiocpu, M6809_FIRQ_LINE);
 	m_c140->add_route(0, "lspeaker", 0.50);

--- a/src/mame/drivers/namcos21_de.cpp
+++ b/src/mame/drivers/namcos21_de.cpp
@@ -204,7 +204,7 @@ void namco_de_pcbstack_device::device_add_mconfig(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	C140(config, m_c140, 8000000/374);
+	C140(config, m_c140, 49.152_MHz_XTAL / 2304);
 	m_c140->set_addrmap(0, &namco_de_pcbstack_device::c140_map);
 	m_c140->int1_callback().set_inputline(m_audiocpu, M6809_FIRQ_LINE);
 	m_c140->add_route(0, "lspeaker", 0.50);


### PR DESCRIPTION
8MHz XTAL isn't exists in these hardwares, so 21.39KHz is wrong.