### PR TITLE
rescap.h: Credit the actual authors (nw)

### DIFF
--- a/src/devices/machine/rescap.h
+++ b/src/devices/machine/rescap.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Aaron Giles
+// copyright-holders:Juergen Buchmueller, Derrick Renaud, Curt Coder
 #ifndef MAME_MACHINE_RESCAP_H
 #define MAME_MACHINE_RESCAP_H
 


### PR DESCRIPTION
The exact authorship of a few of these definitions isn't quite clear, though @aaronsgiles had nothing to do with them as far as I can tell. I'm not sure how much credit other developers are willing to take for these, though, so I'll invite comments before merging.