### PR TITLE
Relax the crc requirement when loading comments.

### DIFF
--- a/src/emu/debug/debugcpu.h
+++ b/src/emu/debug/debugcpu.h
@@ -408,6 +408,9 @@ private:
 	public:
 		dasm_comment(offs_t address, u32 crc, const char *text, rgb_t color);
 
+		// relaxed comparison for comments
+		bool operator < (const dasm_comment& rhs) const { return (m_address < rhs.m_address); }
+
 		std::string  m_text;        // Stores comment text & color for a given address & crc32
 		rgb_t        m_color;
 	};


### PR DESCRIPTION
This allows external tools to create comment files without the need to track the disassembler format.