### PR TITLE
Enable option to generate symbols in Release as well as Debug under V…

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -505,6 +505,11 @@ configuration { "Release", "vs20*" }
 		"NoEditAndContinue",
 		"NoIncrementalLink",
 	}
+	if _OPTIONS["SYMBOLS"] then
+		flags {
+			"Symbols",
+		}
+	end
 
 configuration { "vsllvm" }
 	buildoptions {


### PR DESCRIPTION
…isual Studio.  (This is important because debugging Debug builds is too slow)