### PR TITLE
Fix for Issue #6712

### DIFF
--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -1421,7 +1421,7 @@ void rom_load_manager::process_region_list()
 -------------------------------------------------*/
 
 rom_load_manager::rom_load_manager(running_machine &machine)
-	: m_machine(machine), m_biosmismatch(false)
+	: m_machine(machine)
 {
 	// figure out which BIOS we are using
 	std::map<std::string, std::string> card_bios;

--- a/src/emu/romload.cpp
+++ b/src/emu/romload.cpp
@@ -359,7 +359,8 @@ void rom_load_manager::determine_bios_rom(device_t &device, const char *specbios
 	// default is applied by the device at config complete time
 	if (specbios && *specbios && core_stricmp(specbios, "default"))
 	{
-		bool found(false);
+		bool found_system_bios = false;
+		bool found_a_bios = false;
 		for (const rom_entry &rom : device.rom_region_vector())
 		{
 			if (ROMENTRY_ISSYSTEM_BIOS(&rom))
@@ -367,12 +368,13 @@ void rom_load_manager::determine_bios_rom(device_t &device, const char *specbios
 				char const *const biosname = ROM_GETNAME(&rom);
 				int const bios_flags = ROM_GETBIOSFLAGS(&rom);
 				char bios_number[20];
+				found_a_bios = true;
 
 				// Allow '-bios n' to still be used
 				sprintf(bios_number, "%d", bios_flags - 1);
 				if (!core_stricmp(bios_number, specbios) || !core_stricmp(biosname, specbios))
 				{
-					found = true;
+					found_system_bios = true;
 					device.set_system_bios(bios_flags);
 					break;
 				}
@@ -380,10 +382,13 @@ void rom_load_manager::determine_bios_rom(device_t &device, const char *specbios
 		}
 
 		// if we got neither an empty string nor 'default' then warn the user
-		if (!found)
+		if (!found_system_bios)
 		{
-			m_errorstring.append(util::string_format("%s: invalid BIOS \"%s\", reverting to default\n", device.tag(), specbios));
-			m_warnings++;
+			if (found_a_bios)
+				m_errorstring.append(util::string_format("%s: invalid BIOS \"%s\", reverting to default\n", device.tag(), specbios));
+			else
+				m_errorstring.append(util::string_format("%s: invalid BIOS \"%s\", no BIOS required\n", device.tag(), specbios));
+			m_biosmismatch = true;
 		}
 	}
 
@@ -1416,7 +1421,7 @@ void rom_load_manager::process_region_list()
 -------------------------------------------------*/
 
 rom_load_manager::rom_load_manager(running_machine &machine)
-	: m_machine(machine)
+	: m_machine(machine), m_biosmismatch(false)
 {
 	// figure out which BIOS we are using
 	std::map<std::string, std::string> card_bios;

--- a/src/emu/romload.h
+++ b/src/emu/romload.h
@@ -413,6 +413,9 @@ public:
 	/* return the number of BAD_DUMP/NO_DUMP warnings we generated */
 	int knownbad() const { return m_knownbad; }
 
+	/* return true if the bios option doesn't match this driver */
+	bool biosmismatch() const { return m_biosmismatch; }
+
 	/* ----- disk handling ----- */
 
 	/* return a pointer to the CHD file associated with the given region */
@@ -458,6 +461,7 @@ private:
 	int                 m_warnings;           // warning count during processing
 	int                 m_knownbad;           // BAD_DUMP/NO_DUMP count during processing
 	int                 m_errors;             // error count during processing
+	int					m_biosmismatch;		  // BIOS option doesn't match this driver
 
 	int                 m_romsloaded;         // current ROMs loaded count
 	int                 m_romstotal;          // total number of ROMs to read

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -54,6 +54,7 @@ mame_machine_manager::mame_machine_manager(emu_options &options,osd_interface &o
 	m_lua(global_alloc(lua_engine)),
 	m_new_driver_pending(nullptr),
 	m_firstrun(true),
+	m_firstgame(true),
 	m_autoboot_timer(nullptr)
 {
 }
@@ -209,8 +210,6 @@ int mame_machine_manager::execute()
 {
 	bool started_empty = false;
 
-	bool firstgame = true;
-
 	// loop across multiple hard resets
 	bool exit_pending = false;
 	int error = EMU_ERR_NONE;
@@ -224,11 +223,9 @@ int mame_machine_manager::execute()
 		if (system == nullptr)
 		{
 			system = &GAME_NAME(___empty);
-			if (firstgame)
+			if (m_firstgame)
 				started_empty = true;
 		}
-
-		firstgame = false;
 
 		// parse any INI files as the first thing
 		if (m_options.read_config())
@@ -260,6 +257,7 @@ int mame_machine_manager::execute()
 		// run the machine
 		error = machine.run(is_empty);
 		m_firstrun = false;
+		m_firstgame = false;
 
 		// check the state of the machine
 		if (m_new_driver_pending)
@@ -320,7 +318,7 @@ void mame_machine_manager::ui_initialize(running_machine& machine)
 	m_ui->initialize(machine);
 
 	// display the startup screens
-	m_ui->display_startup_screens(m_firstrun);
+	m_ui->display_startup_screens(m_firstrun, m_firstgame);
 }
 
 void mame_machine_manager::before_load_settings(running_machine& machine)

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -248,6 +248,7 @@ int mame_machine_manager::execute()
 			valid.set_verbose(false);
 			valid.check_shared_source(*system);
 		}
+
 		// create the machine configuration
 		machine_config config(*system, m_options);
 
@@ -272,6 +273,8 @@ int mame_machine_manager::execute()
 			if (machine.exit_pending())
 			{
 				m_options.set_system_name("");
+				// In this case, we are going back to the __empty driver
+				// so we need to clear this here
 				m_options.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);
 			}
 		}

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -271,12 +271,7 @@ int mame_machine_manager::execute()
 		else
 		{
 			if (machine.exit_pending())
-			{
 				m_options.set_system_name("");
-				// In this case, we are going back to the __empty driver
-				// so we need to clear this here
-				m_options.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);
-			}
 		}
 
 		if (machine.exit_pending() && (!started_empty || is_empty))

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -248,7 +248,6 @@ int mame_machine_manager::execute()
 			valid.set_verbose(false);
 			valid.check_shared_source(*system);
 		}
-
 		// create the machine configuration
 		machine_config config(*system, m_options);
 
@@ -271,7 +270,10 @@ int mame_machine_manager::execute()
 		else
 		{
 			if (machine.exit_pending())
+			{
 				m_options.set_system_name("");
+				m_options.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);
+			}
 		}
 
 		if (machine.exit_pending() && (!started_empty || is_empty))

--- a/src/frontend/mame/mame.h
+++ b/src/frontend/mame/mame.h
@@ -75,7 +75,8 @@ private:
 	lua_engine *            m_lua;
 
 	const game_driver *     m_new_driver_pending;   // pointer to the next pending driver
-	bool                    m_firstrun;
+	bool                    m_firstrun;				// true if first run of a new driver
+	bool                    m_firstgame;			// true if this is the first driver being run
 
 	static mame_machine_manager* m_manager;
 	emu_timer               *m_autoboot_timer;      // autoboot timer

--- a/src/frontend/mame/ui/info.cpp
+++ b/src/frontend/mame/ui/info.cpp
@@ -180,12 +180,13 @@ machine_info::machine_info(running_machine &machine)
 //  text to the given buffer
 //-------------------------------------------------
 
-std::string machine_info::warnings_string() const
+std::string machine_info::warnings_string(bool first_time) const
 {
 	std::ostringstream buf;
 
-	// add a warning if any ROMs were loaded with warnings
-	if (m_machine.rom_load().warnings() > 0)
+	// Warn if bios mismatch and this is the first launch, or
+	// if any ROMs were loaded with warnings
+	if ((first_time && m_machine.rom_load().biosmismatch()) || (m_machine.rom_load().warnings() > 0))
 		buf << _("One or more ROMs/CHDs for this machine are incorrect. The machine may not run correctly.\n");
 
 	if (!m_machine.rom_load().software_load_warnings_message().empty())

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -74,7 +74,7 @@ public:
 	machine_info(running_machine &machine);
 
 	// text generators
-	std::string warnings_string(bool first_time) const;
+	std::string warnings_string(bool first_game) const;
 	std::string game_info_string() const;
 	std::string get_screen_desc(screen_device &screen) const;
 

--- a/src/frontend/mame/ui/info.h
+++ b/src/frontend/mame/ui/info.h
@@ -74,7 +74,7 @@ public:
 	machine_info(running_machine &machine);
 
 	// text generators
-	std::string warnings_string() const;
+	std::string warnings_string(bool first_time) const;
 	std::string game_info_string() const;
 	std::string get_screen_desc(screen_device &screen) const;
 

--- a/src/frontend/mame/ui/selmenu.cpp
+++ b/src/frontend/mame/ui/selmenu.cpp
@@ -572,11 +572,8 @@ void menu_select_launch::launch_system(mame_ui_manager &mui, game_driver const &
 		reselect_last::set_driver(driver);
 	}
 
-	// Overwrite any old BIOS every time we launch
 	if (bios)
 		moptions.set_value(OPTION_BIOS, *bios, OPTION_PRIORITY_CMDLINE);
-	else
-		moptions.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);		
 
 	mame_machine_manager::instance()->schedule_new_driver(driver);
 	mui.machine().schedule_hard_reset();

--- a/src/frontend/mame/ui/selmenu.cpp
+++ b/src/frontend/mame/ui/selmenu.cpp
@@ -572,8 +572,11 @@ void menu_select_launch::launch_system(mame_ui_manager &mui, game_driver const &
 		reselect_last::set_driver(driver);
 	}
 
+	// Overwrite any old BIOS every time we launch
 	if (bios)
 		moptions.set_value(OPTION_BIOS, *bios, OPTION_PRIORITY_CMDLINE);
+	else
+		moptions.set_value(OPTION_BIOS, "", OPTION_PRIORITY_CMDLINE);		
 
 	mame_machine_manager::instance()->schedule_new_driver(driver);
 	mui.machine().schedule_hard_reset();

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -298,7 +298,7 @@ static void output_joined_collection(const TColl &collection, TEmitMemberFunc em
 //  various startup screens
 //-------------------------------------------------
 
-void mame_ui_manager::display_startup_screens(bool first_time)
+void mame_ui_manager::display_startup_screens(bool first_time, bool first_game)
 {
 	const int maxstate = 3;
 	int str = machine().options().seconds_to_run();
@@ -330,7 +330,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 		{
 		case 0:
 			if (show_warnings)
-				messagebox_text = machine_info().warnings_string(first_time);
+				messagebox_text = machine_info().warnings_string(first_game);
 			if (!messagebox_text.empty())
 			{
 				set_handler(ui_callback_type::MODAL, std::bind(&mame_ui_manager::handler_messagebox_anykey, this, _1));

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -330,7 +330,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 		{
 		case 0:
 			if (show_warnings)
-				messagebox_text = machine_info().warnings_string();
+				messagebox_text = machine_info().warnings_string(first_time);
 			if (!messagebox_text.empty())
 			{
 				set_handler(ui_callback_type::MODAL, std::bind(&mame_ui_manager::handler_messagebox_anykey, this, _1));

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -192,7 +192,7 @@ public:
 
 	void set_handler(ui_callback_type callback_type, const std::function<uint32_t (render_container &)> &&callback);
 
-	void display_startup_screens(bool first_time);
+	void display_startup_screens(bool first_time, bool first_game);
 	virtual void set_startup_text(const char *text, bool force) override;
 	void update_and_render(render_container &container);
 	render_font *get_font();


### PR DESCRIPTION
The UI re-uses emu_options, but doesn't clear out the default bios choice from a previous driver selection.  I would have fixed this by modifying launch_system() to set the bios option to "" even if the bios argument is nullptr.  However, when launching the UI itself via the empty driver, launch_system() is not used and there is still a warning.  So instead, I reset it when the game name is reset, so there is never an invalid choice.
This does make me wonder if there are any other params that need re-initializing when a new driver is launched, though