### PR TITLE
some small GPL16250 tweaks / hacks so that tkmag220 and lazertag show more (nw)

### DIFF
--- a/src/devices/machine/generalplus_gpl16250soc.cpp
+++ b/src/devices/machine/generalplus_gpl16250soc.cpp
@@ -148,7 +148,7 @@ void sunplus_gcm394_base_device::trigger_systemm_dma(address_space &space, int c
 	else if ((mode & 0x50) == 0x10)
 		destdelta = -1;
 
-	LOGMASKED(LOG_GCM394_SYSDMA, "%s:possible DMA operation (7abf) with params mode:%04x source:%08x (word offset) dest:%08x (word offset) length:%08x (words) while csbank is %02x\n", machine().describe_context().c_str(), mode, source, dest, length, m_membankswitch_7810 );
+	LOGMASKED(LOG_GCM394_SYSDMA, "%s:possible DMA operation with params mode:%04x source:%08x (word offset) dest:%08x (word offset) length:%08x (words) while csbank is %02x\n", machine().describe_context().c_str(), mode, source, dest, length, m_membankswitch_7810 );
 
 	// wrlshunt transfers ROM to RAM, all RAM write addresses have 0x800000 in the destination set
 
@@ -560,11 +560,33 @@ READ16_MEMBER(sunplus_gcm394_base_device::unkarea_78d8_r)
 
 // **************************************** 793x uknown region stubs *************************************************
 
-READ16_MEMBER(sunplus_gcm394_base_device::unkarea_7934_r) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_r\n", machine().describe_context()); return 0x0000; }
-WRITE16_MEMBER(sunplus_gcm394_base_device::unkarea_7934_w) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_w %04x\n", machine().describe_context(), data); m_7934 = data; }
+READ16_MEMBER(sunplus_gcm394_base_device::unkarea_7904_r)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7904_r\n", machine().describe_context());
+	return machine().rand(); // lazertag waits on a bit, status flag for something?
+
+}
+
+READ16_MEMBER(sunplus_gcm394_base_device::unkarea_7934_r)
+{
+	// does this return data written, or is it a status flag?
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_r\n", machine().describe_context());
+	return m_7934;
+}
+
+WRITE16_MEMBER(sunplus_gcm394_base_device::unkarea_7934_w)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7934_w %04x\n", machine().describe_context(), data);
+	m_7934 = data;
+}
 
 // value of 7935 is read then written in irq6, nothing happens unless bit 0x0100 was set, which could be some kind of irq source being acked?
-READ16_MEMBER(sunplus_gcm394_base_device::unkarea_7935_r) { LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7935_r\n", machine().describe_context()); return m_7935; }
+READ16_MEMBER(sunplus_gcm394_base_device::unkarea_7935_r)
+{
+	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7935_r\n", machine().describe_context());
+	return m_7935;
+}
+
 WRITE16_MEMBER(sunplus_gcm394_base_device::unkarea_7935_w)
 {
 	LOGMASKED(LOG_GCM394, "%s:sunplus_gcm394_base_device::unkarea_7935_w %04x\n", machine().describe_context(), data);
@@ -835,6 +857,8 @@ void sunplus_gcm394_base_device::base_internal_map(address_map &map)
 	// ######################################################################################################################################################################################
 	// 793x - misc?
 	// ######################################################################################################################################################################################
+
+	map(0x007904, 0x007904).r(FUNC(sunplus_gcm394_base_device::unkarea_7904_r)); // lazertag after a while
 
 	// possible rtc?
 	map(0x007934, 0x007934).rw(FUNC(sunplus_gcm394_base_device::unkarea_7934_r), FUNC(sunplus_gcm394_base_device::unkarea_7934_w));

--- a/src/devices/machine/generalplus_gpl16250soc.h
+++ b/src/devices/machine/generalplus_gpl16250soc.h
@@ -75,6 +75,8 @@ public:
 
 	void set_paldisplaybank_high_hack(int pal_displaybank_high) { m_spg_video->set_paldisplaybank_high(pal_displaybank_high); }
 	void set_alt_tile_addressing_hack(int alt_tile_addressing) { m_spg_video->set_alt_tile_addressing(alt_tile_addressing); }
+	void set_pal_sprites_hack(int pal_sprites) { m_spg_video->set_pal_sprites(pal_sprites); }
+
 	void set_romtype(int romtype) { m_romtype = romtype; }
 
 protected:
@@ -290,6 +292,8 @@ private:
 	DECLARE_READ16_MEMBER(unkarea_78d8_r);
 
 	DECLARE_WRITE16_MEMBER(unkarea_78f0_w);
+
+	DECLARE_READ16_MEMBER(unkarea_7904_r);
 
 	DECLARE_READ16_MEMBER(unkarea_7934_r);
 	DECLARE_WRITE16_MEMBER(unkarea_7934_w);

--- a/src/devices/machine/generalplus_gpl16250soc_video.h
+++ b/src/devices/machine/generalplus_gpl16250soc_video.h
@@ -32,6 +32,7 @@ public:
 
 	void set_paldisplaybank_high(int pal_displaybank_high) { m_pal_displaybank_high = pal_displaybank_high; }
 	void set_alt_tile_addressing(int alt_tile_addressing) { m_alt_tile_addressing = alt_tile_addressing; }
+	void set_pal_sprites(int pal_sprites) { m_pal_sprites = pal_sprites; }
 
 	DECLARE_READ16_MEMBER(tmap0_regs_r);
 	DECLARE_WRITE16_MEMBER(tmap0_regs_w);
@@ -269,6 +270,7 @@ protected:
 	void decodegfx(const char* tag);
 
 	int m_pal_displaybank_high;
+	int m_pal_sprites;
 	int m_alt_tile_addressing;
 };
 

--- a/src/mame/drivers/generalplus_gpl16250.cpp
+++ b/src/mame/drivers/generalplus_gpl16250.cpp
@@ -61,6 +61,10 @@
     jak_hmhsm : uses the standard JAKKS code (on first screen - Hold Up, Hold A, Release Up, Down)
                 the High School Musical part has its own test mode which tests a different part of the ROM, use the same code but after selecting the game from menu
 
+
+	--- the individual CS spaces could (and probably should?) be done with a bunch of extra memory spaces rather than the cs0_r / cs0_w etc. but that would mean yet
+	    another trip through the memory system for almost everything and at ~100Mhz that is slow.
+
 */
 
 #include "emu.h"
@@ -159,14 +163,7 @@ void gcm394_game_state::base(machine_config &config)
 }
 
 
-void tkmag220_game_state::tkmag220(machine_config &config)
-{
-	gcm394_game_state::base(config);
 
-	m_maincpu->porta_in().set_ioport("IN0");
-	m_maincpu->portb_in().set_ioport("IN1");
-	m_maincpu->portc_in().set_ioport("IN2");
-}
 
 void gcm394_game_state::machine_start()
 {

--- a/src/mame/drivers/generalplus_gpl16250_rom.cpp
+++ b/src/mame/drivers/generalplus_gpl16250_rom.cpp
@@ -415,6 +415,33 @@ ROM_END
 
 
 
+void tkmag220_game_state::tkmag220(machine_config &config)
+{
+	gcm394_game_state::base(config);
+
+	m_maincpu->porta_in().set_ioport("IN0");
+	m_maincpu->portb_in().set_ioport("IN1");
+	m_maincpu->portc_in().set_ioport("IN2");
+}
+
+READ16_MEMBER(tkmag220_game_state::cs0_r)
+{
+	// [:] installing cs0 handler start_address 00000000 end_address 007fffff
+	return m_romregion[(offset & 0x07fffff) + m_upperbase];
+}
+
+
+void tkmag220_game_state::machine_reset()
+{
+	// as with the Family Sport multi-game versions on spg2xx hardware, there are actually 8 programs in here, externally banked
+	// each of those programs is 16MBytes, so is either going to have the upper half banked externally like the older hardware types, os possibly using the CS registers on this hardware type
+	m_upperbase = 0 * (0x1000000 / 2);
+	gcm394_game_state::machine_reset();
+
+	m_maincpu->set_paldisplaybank_high_hack(0);
+	m_maincpu->set_pal_sprites_hack(0x000);
+}
+
 
 // the JAKKS ones of these seem to be known as 'Generalplus GPAC500' hardware?
 CONS(2009, smartfp,   0,       0, base, smartfp,  gcm394_game_state, empty_init, "Fisher-Price", "Fun 2 Learn Smart Fit Park (UK)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/drivers/generalplus_gpl16250_romram.cpp
+++ b/src/mame/drivers/generalplus_gpl16250_romram.cpp
@@ -314,6 +314,11 @@ void jak_s500_game_state::machine_reset()
 }
 
 
+void lazertag_game_state::machine_reset()
+{
+	jak_s500_game_state::machine_reset();
+	m_maincpu->set_pal_sprites_hack(0x800);
+}
 
 
 
@@ -485,7 +490,7 @@ which is also found in the Wireless Air 60 ROM.
 // also sold as "Pac-Man Connect & Play 35th Anniversary" (same ROM?)
 CONS(2012, paccon, 0, 0, paccon, paccon, jak_s500_game_state, init_wrlshunt, "Bandai", "Pac-Man Connect & Play (Feb 14 2012 10:46:23)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
-CONS(2008, lazertag, 0, 0, wrlshunt, jak_s500, jak_s500_game_state, init_wrlshunt, "Tiger Electronics", "Lazer Tag Video Game Module", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
+CONS(2008, lazertag, 0, 0, wrlshunt, jak_s500, lazertag_game_state, init_wrlshunt, "Tiger Electronics", "Lazer Tag Video Game Module", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 
 CONS(2009, jak_s500, 0, 0, wrlshunt, jak_s500, jak_s500_game_state, init_wrlshunt, "JAKKS Pacific Inc / HotGen Ltd",          "SpongeBob SquarePants Bikini Bottom 500 (JAKKS Pacific TV Motion Game)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)
 CONS(2009, jak_smwm, 0, 0, wrlshunt, jak_s500, jak_s500_game_state, init_wrlshunt, "JAKKS Pacific Inc / HotGen Ltd",          "Spider-Man Web Master (JAKKS Pacific TV Motion Game)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND)

--- a/src/mame/includes/generalplus_gpl16250.h
+++ b/src/mame/includes/generalplus_gpl16250.h
@@ -86,6 +86,8 @@ public:
 
 protected:
 
+	virtual void machine_reset() override;
+
 	/*
 	virtual DECLARE_READ16_MEMBER(porta_r) override
 	{
@@ -103,11 +105,10 @@ protected:
 	*/
 
 private:
+	int m_upperbase;
 
-	virtual DECLARE_READ16_MEMBER(cs0_r) override
-	{
-		return m_romregion[offset & 0x3ffffff];
-	}
+	virtual DECLARE_READ16_MEMBER(cs0_r) override;
+
 };
 
 

--- a/src/mame/includes/generalplus_gpl16250_romram.h
+++ b/src/mame/includes/generalplus_gpl16250_romram.h
@@ -69,6 +69,23 @@ protected:
 private:
 };
 
+class lazertag_game_state : public jak_s500_game_state
+{
+public:
+	lazertag_game_state(const machine_config& mconfig, device_type type, const char* tag) :
+		jak_s500_game_state(mconfig, type, tag)
+	{
+	}
+
+protected:
+	//virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+};
+
+
+
 
 #endif // MAME_INCLUDES_GENERALPLUS_GPL16250_ROMRAM_H
 


### PR DESCRIPTION
tkmag220 will fairly quickly show a rom test screen where the check fails (not surprising, ROM is banked etc. and might need some swapping applied) (nw)

lazertag, after a long time unthrottled, will show a single screen of sprites, there are palettes uploaded for something else before that, but like many of these it never seems to populate tile ram (nw)