### PR TITLE
gaplus : Fixed displaying of starfield

### DIFF
--- a/src/mame/includes/gaplus.h
+++ b/src/mame/includes/gaplus.h
@@ -109,6 +109,7 @@ protected:
 	tilemap_t *m_bg_tilemap;
 	uint8_t m_starfield_control[4];
 	int m_total_stars;
+	int m_starfield_framecount;
 	struct star m_stars[MAX_STARS];
 	uint8_t m_main_irq_mask;
 	uint8_t m_sub_irq_mask;

--- a/src/mame/video/gaplus.cpp
+++ b/src/mame/video/gaplus.cpp
@@ -133,9 +133,9 @@ void gaplus_base_state::starfield_init()
 	/* precalculate the star background */
 	/* this comes from the Galaxian hardware, Gaplus is probably different */
 
-	for (int y = 0; y < height - STARFIELD_CLIPPING_X * 2; y++)
+	for (int y = 0; y < height; y++)
 	{
-		for (int x = width - 1; x >= 0; x--)
+		for (int x = width - (STARFIELD_CLIPPING_X * 2) - 1; x >= 0; x--)
 		{
 			generator <<= 1;
 			const int bit1 = (~generator >> 17) & 1;
@@ -163,8 +163,8 @@ void gaplus_base_state::starfield_init()
 
 				if (color && m_total_stars < MAX_STARS)
 				{
-					m_stars[m_total_stars].x = x;
-					m_stars[m_total_stars].y = y + STARFIELD_CLIPPING_X;
+					m_stars[m_total_stars].x = x + STARFIELD_CLIPPING_X;
+					m_stars[m_total_stars].y = y;
 					m_stars[m_total_stars].col = color_base + color;
 					m_stars[m_total_stars].set = set++;
 

--- a/src/mame/video/gaplus.cpp
+++ b/src/mame/video/gaplus.cpp
@@ -114,9 +114,10 @@ TILE_GET_INFO_MEMBER(gaplus_base_state::get_tile_info)
 ***************************************************************************/
 
 /* starfield speed constants (bigger = faster) */
-#define SPEED_1 0.5f
-#define SPEED_2 1.0f
-#define SPEED_3 2.0f
+#define SPEED_1 1.0f
+#define SPEED_2 2.0f
+#define SPEED_3 3.0f
+#define STARFIELD_CLIPPING_X 16
 
 void gaplus_base_state::starfield_init()
 {
@@ -127,13 +128,14 @@ void gaplus_base_state::starfield_init()
 	const int height = m_screen->height();
 
 	m_total_stars = 0;
+	m_starfield_framecount = 0;
 
 	/* precalculate the star background */
 	/* this comes from the Galaxian hardware, Gaplus is probably different */
 
 	for (int y = 0; y < height; y++)
 	{
-		for (int x = width * 2 - 1; x >= 0; x--)
+		for (int x = width - 1; x >= 0; x--)
 		{
 			generator <<= 1;
 			const int bit1 = (~generator >> 17) & 1;
@@ -143,12 +145,27 @@ void gaplus_base_state::starfield_init()
 
 			if (BIT(~generator, 16) && (generator & 0xff) == 0xff)
 			{
-				const int color = ~(generator >> 8) & 0x3f;
+				const int color = (~(generator >> 8)) % 7 + 1;
+				int color_base = 0;
+				/* A guess based on comparison with PCB video output */
+				switch (set)
+				{
+				case 0:
+					color_base = 0x250;
+					break;
+				case 1:
+					color_base = 0x230;
+					break;
+				case 2:
+					color_base = 0x210;
+					break;
+				}
+
 				if (color && m_total_stars < MAX_STARS)
 				{
 					m_stars[m_total_stars].x = x;
 					m_stars[m_total_stars].y = y;
-					m_stars[m_total_stars].col = color;
+					m_stars[m_total_stars].col = color_base + color;
 					m_stars[m_total_stars].set = set++;
 
 					if (set == 3)
@@ -178,6 +195,7 @@ void gaplus_base_state::video_start()
 	starfield_init();
 
 	save_item(NAME(m_starfield_control));
+	save_item(NAME(m_starfield_framecount));
 
 	for (int i = 0; i < MAX_STARS; i++)
 	{
@@ -228,6 +246,13 @@ void gaplus_base_state::starfield_render(bitmap_ind16 &bitmap)
 	{
 		int x = m_stars[i].x;
 		int y = m_stars[i].y;
+
+		/* Some stars in the second tier will flash erratically while changing their movements. */
+		if (m_stars[i].set == 1 && m_starfield_control[2] != 0x85 && i % 2 == 0)
+		{
+			int bit = BIT(m_starfield_framecount + i, 3) ? 1 : 2;
+			if (BIT(m_starfield_framecount + i, bit)) { continue; }
+		}
 
 		if (x >= 0 && x < width && y >= 0 && y < height)
 		{
@@ -319,6 +344,8 @@ WRITE_LINE_MEMBER(gaplus_base_state::screen_vblank)/* update starfields */
 		int width = m_screen->width();
 		int height = m_screen->height();
 
+		m_starfield_framecount ++;
+
 		/* check if we're running */
 		if ( ( m_starfield_control[0] & 1 ) == 0 )
 			return;
@@ -330,21 +357,17 @@ WRITE_LINE_MEMBER(gaplus_base_state::screen_vblank)/* update starfields */
 					/* stand still */
 				break;
 
+				case 0x85:
 				case 0x86:
 					/* scroll down (speed 1) */
 					stars[i].x += SPEED_1;
 				break;
 
-				case 0x85:
+				case 0x06:
 					/* scroll down (speed 2) */
 					stars[i].x += SPEED_2;
 				break;
-
-				case 0x06:
-					/* scroll down (speed 3) */
-					stars[i].x += SPEED_3;
-				break;
-
+				
 				case 0x80:
 					/* scroll up (speed 1) */
 					stars[i].x -= SPEED_1;
@@ -362,21 +385,21 @@ WRITE_LINE_MEMBER(gaplus_base_state::screen_vblank)/* update starfields */
 
 				case 0x9f:
 					/* scroll left (speed 2) */
-					stars[i].y += SPEED_2;
+					stars[i].y += SPEED_3;
 				break;
 
 				case 0xaf:
-					/* scroll left (speed 1) */
-					stars[i].y += SPEED_1;
+					/* scroll right (speed 1) */
+					stars[i].y -= SPEED_3;
 				break;
 			}
 
 			/* wrap */
-			if ( stars[i].x < 0 )
-				stars[i].x = ( float )( width*2 ) + stars[i].x;
+			if ( stars[i].x < STARFIELD_CLIPPING_X )
+				stars[i].x = ( float )( width-STARFIELD_CLIPPING_X*2) + stars[i].x;
 
-			if ( stars[i].x >= ( float )( width*2 ) )
-				stars[i].x -= ( float )( width*2 );
+			if ( stars[i].x >= ( float )( width-STARFIELD_CLIPPING_X) )
+				stars[i].x -= ( float )( width-STARFIELD_CLIPPING_X*2);
 
 			if ( stars[i].y < 0 )
 				stars[i].y = ( float )( height ) + stars[i].y;

--- a/src/mame/video/gaplus.cpp
+++ b/src/mame/video/gaplus.cpp
@@ -133,7 +133,7 @@ void gaplus_base_state::starfield_init()
 	/* precalculate the star background */
 	/* this comes from the Galaxian hardware, Gaplus is probably different */
 
-	for (int y = 0; y < height; y++)
+	for (int y = 0; y < height - STARFIELD_CLIPPING_X * 2; y++)
 	{
 		for (int x = width - 1; x >= 0; x--)
 		{
@@ -164,7 +164,7 @@ void gaplus_base_state::starfield_init()
 				if (color && m_total_stars < MAX_STARS)
 				{
 					m_stars[m_total_stars].x = x;
-					m_stars[m_total_stars].y = y;
+					m_stars[m_total_stars].y = y + STARFIELD_CLIPPING_X;
 					m_stars[m_total_stars].col = color_base + color;
 					m_stars[m_total_stars].set = set++;
 


### PR DESCRIPTION
- Fixed scrolling speed and direction ([Testers-00434](https://mametesters.org/view.php?id=434))
- Added top and bottom clipping ([Testers-07663](https://mametesters.org/view.php?id=7663))
- Modified to use sprite color instead of text color with refer to the PCB
- Added blinking when the movement of the star changes

Reference Video:
https://www.youtube.com/watch?v=vrmZAUJYXnI
https://www.youtube.com/watch?v=_1x5Oid3uPg