### PR TITLE
legionj : Fixed wrong atract demo display

### DIFF
--- a/src/mame/drivers/armedf.cpp
+++ b/src/mame/drivers/armedf.cpp
@@ -409,6 +409,13 @@ void armedf_state::irq_lv2_ack_w(u16 data)
 	m_maincpu->set_input_line(2, CLEAR_LINE);
 }
 
+void armedf_state::irq_lv2_ack_legion_w(u16 data)
+{
+	if (m_nb1414m4 != nullptr)
+		m_nb1414m4->vblank_trigger();
+	m_maincpu->set_input_line(2, CLEAR_LINE);
+	m_legion_reg_7c00e = data;
+}
 
 /*************************************
  *
@@ -516,7 +523,6 @@ void armedf_state::legion_common_map(address_map &map)
 	map(0x07c004, 0x07c005).w(FUNC(armedf_state::bg_scrolly_w));
 	map(0x07c00b, 0x07c00b).w(FUNC(armedf_state::sound_command_w));
 	map(0x07c00c, 0x07c00d).nopw();        /* Watchdog ? cycle 0000 -> 0100 -> 0200 back to 0000 */
-	map(0x07c00e, 0x07c00f).w(FUNC(armedf_state::irq_lv2_ack_w));
 }
 
 void armedf_state::legion_map(address_map &map)
@@ -525,6 +531,7 @@ void armedf_state::legion_map(address_map &map)
 
 	map(0x068000, 0x069fff).rw(FUNC(armedf_state::text_videoram_r), FUNC(armedf_state::text_videoram_w)).umask16(0x00ff).share("text_videoram");
 	map(0x07c000, 0x07c001).w(FUNC(armedf_state::terraf_io_w));
+	map(0x07c00e, 0x07c00f).w(FUNC(armedf_state::irq_lv2_ack_legion_w));
 }
 
 void armedf_state::legionjb_fg_scroll_w(offs_t offset, u8 data)
@@ -543,6 +550,7 @@ void armedf_state::legionjb_map(address_map &map)
 	map(0x040000, 0x04003f).w(FUNC(armedf_state::legionjb_fg_scroll_w)).umask16(0x00ff);
 	map(0x068000, 0x069fff).rw(FUNC(armedf_state::text_videoram_r), FUNC(armedf_state::text_videoram_w)).umask16(0x00ff).share("text_videoram");
 	map(0x07c000, 0x07c001).w(FUNC(armedf_state::armedf_io_w));
+	map(0x07c00e, 0x07c00f).w(FUNC(armedf_state::irq_lv2_ack_w));
 }
 
 void armedf_state::legionjb2_map(address_map &map)
@@ -552,6 +560,7 @@ void armedf_state::legionjb2_map(address_map &map)
 	map(0x000000, 0x00003f).w(FUNC(armedf_state::legionjb_fg_scroll_w)).umask16(0x00ff);
 	map(0x068000, 0x069fff).rw(FUNC(armedf_state::text_videoram_r), FUNC(armedf_state::text_videoram_w)).umask16(0x00ff).share("text_videoram");
 	map(0x07c000, 0x07c001).w(FUNC(armedf_state::armedf_io_w));
+	map(0x07c00e, 0x07c00f).w(FUNC(armedf_state::irq_lv2_ack_w));
 	//also writes to 7c0010 / 70c020 / 70c030. These could possibly be the scroll registers on this bootleg and the writes to 000000 - 00003f could just be leftovers.
 }
 
@@ -1085,6 +1094,7 @@ void armedf_state::machine_reset()
 	m_fg_scrolly = 0;
 	m_bg_scrollx = 0;
 	m_bg_scrolly = 0;
+	m_legion_reg_7c00e = 0;
 }
 
 void armedf_state::video_config(machine_config &config, int hchar_start, int vstart, int vend)
@@ -1911,6 +1921,8 @@ void armedf_state::init_legion()
 #endif
 
 	m_scroll_type = 2;
+
+	save_item(NAME(m_legion_reg_7c00e));
 }
 
 void armedf_state::init_legionjb()
@@ -1923,14 +1935,14 @@ void armedf_state::init_legionjb()
 	/* No need to patch the checksum routine (see notes) ! */
 #endif
 
-	m_scroll_type = 2;
+	m_scroll_type = 3;
 
 	save_item(NAME(m_legion_cmd));
 }
 
 void armedf_state::init_cclimbr2()
 {
-	m_scroll_type = 3;
+	m_scroll_type = 4;
 }
 
 /*************************************

--- a/src/mame/includes/armedf.h
+++ b/src/mame/includes/armedf.h
@@ -86,6 +86,7 @@ protected:
 	int   m_sprite_offy;
 	int   m_old_mcu_mode;
 	int   m_waiting_msb;
+	int   m_legion_reg_7c00e;	// legion and legionj only
 
 	// read/write handlers
 	void terraf_io_w(offs_t offset, u16 data, u16 mem_mask);
@@ -95,6 +96,7 @@ protected:
 	u8 soundlatch_clear_r();
 	void irq_lv1_ack_w(u16 data);
 	void irq_lv2_ack_w(u16 data);
+	void irq_lv2_ack_legion_w(u16 data);
 
 	// video handlers
 	void legionjb_fg_scroll_w(offs_t offset, u8 data);

--- a/src/mame/video/armedf.cpp
+++ b/src/mame/video/armedf.cpp
@@ -114,13 +114,13 @@ TILE_GET_INFO_MEMBER(armedf_state::get_bg_tile_info)
 
 VIDEO_START_MEMBER(armedf_state,terraf)
 {
-	m_sprite_offy = (m_scroll_type & 2 ) ? 0 : 128;  /* legion, legiono, crazy climber 2 */
+	m_sprite_offy = (m_scroll_type == 2 || m_scroll_type == 3 || m_scroll_type == 4) ? 0 : 128;  /* legion, legion bootlegs, crazy climber 2 */
 
 	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(armedf_state::get_bg_tile_info)), TILEMAP_SCAN_COLS, 16, 16, 64, 32);
 	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(armedf_state::get_fg_tile_info)), TILEMAP_SCAN_COLS, 16, 16, 64, 32);
 
 	m_tx_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(armedf_state::get_nb1414m4_tx_tile_info)),
-			(m_scroll_type == 2) ? tilemap_mapper_delegate(*this, FUNC(armedf_state::armedf_scan_type3)) : tilemap_mapper_delegate(*this, FUNC(armedf_state::armedf_scan_type2)), 8, 8, 64, 32);
+			(m_scroll_type == 2 || m_scroll_type == 3) ? tilemap_mapper_delegate(*this, FUNC(armedf_state::armedf_scan_type3)) : tilemap_mapper_delegate(*this, FUNC(armedf_state::armedf_scan_type2)), 8, 8, 64, 32);
 
 	m_bg_tilemap->set_transparent_pen(0xf);
 	m_fg_tilemap->set_transparent_pen(0xf);
@@ -132,7 +132,7 @@ VIDEO_START_MEMBER(armedf_state,terraf)
 
 VIDEO_START_MEMBER(armedf_state,armedf)
 {
-	m_sprite_offy = (m_scroll_type & 2 ) ? 0 : 128;  /* legion, legiono, crazy climber 2 */
+	m_sprite_offy = (m_scroll_type == 2 || m_scroll_type == 3 || m_scroll_type == 4) ? 0 : 128;  /* legion, legion bootlegs, crazy climber 2 */
 
 	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(armedf_state::get_bg_tile_info)), TILEMAP_SCAN_COLS, 16, 16, 64, 32);
 	m_fg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(armedf_state::get_fg_tile_info)), TILEMAP_SCAN_COLS, 16, 16, 64, 32);
@@ -363,7 +363,8 @@ u32 armedf_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 	{
 		case 0: /* terra force, kozure ookami */
 		case 2: /* legion */
-		case 3: /* crazy climber 2 */
+		case 3: /* legion bootlegs */
+		case 4: /* crazy climber 2 */
 			m_fg_tilemap->set_scrollx(0, (m_fg_scrollx & 0x3ff));
 			m_fg_tilemap->set_scrolly(0, (m_fg_scrolly & 0x3ff));
 			break;
@@ -378,10 +379,20 @@ u32 armedf_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, con
 	screen.priority().fill(0, cliprect);
 	bitmap.fill(0xff, cliprect);
 
-	m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1), 1);
-	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 1);
-	m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
-	m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0), 4);
+	if (m_scroll_type == 2) /* legion */
+	{
+		if ((m_legion_reg_7c00e & 0x30) == 0x30) m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1), 1);
+		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 1);
+		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
+		if ((m_legion_reg_7c00e & 0x30) == 0x00) m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0), 4);
+	}
+	else
+	{
+		m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(1), 1);
+		m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 1);
+		m_fg_tilemap->draw(screen, bitmap, cliprect, 0, 2);
+		m_tx_tilemap->draw(screen, bitmap, cliprect, TILEMAP_DRAW_CATEGORY(0), 4);
+	}
 
 	if (sprite_enable)
 		draw_sprites(bitmap, cliprect, screen.priority());


### PR DESCRIPTION
Fix for [Testers-07655:  legionj: The attract demo is displayed incorrectly.](https://mametesters.org/view.php?id=7655)
This fix is based on information from the developer of Finalburn Neo, as written in Tester's comments.
Add support for text layer enable bits, which only legion and legionj have.