### PR TITLE
Debugger: add `condump` command to export console buffer to a log file

### DIFF
--- a/src/emu/debug/debugcon.h
+++ b/src/emu/debug/debugcon.h
@@ -117,6 +117,7 @@ private:
 	void exit();
 
 	void execute_help_custom(int ref, const std::vector<std::string> &params);
+	void execute_condump(int ref, const std::vector<std::string>& params);
 
 	void trim_parameter(char **paramptr, bool keep_quotes);
 	CMDERR internal_execute_command(bool execute, int params, char **param);

--- a/src/emu/debug/textbuf.cpp
+++ b/src/emu/debug/textbuf.cpp
@@ -311,3 +311,66 @@ const char *text_buffer_get_seqnum_line(text_buffer *text, u32 seqnum)
 		return nullptr;
 	return &text->buffer[text->lineoffs[(text->linestart + index) % text->linesize]];
 }
+
+text_buffer_lines text_buffer_get_lines(text_buffer* text)
+{
+	return text_buffer_lines(*text);
+}
+
+/*---------------------------------------------------------------------
+	text_buffer_lines::text_buffer_line_iterator::operator*
+	Gets the line that the iterator currently points to.
+-----------------------------------------------------------------------*/
+
+text_buffer_line text_buffer_lines::text_buffer_line_iterator::operator*() const
+{
+	const char* line = &m_buffer.buffer[m_buffer.lineoffs[m_lineptr]];
+
+	auto next_lineptr = m_lineptr + 1;
+	if (next_lineptr == m_buffer.linesize)
+		next_lineptr = 0;
+
+	const char* nextline = &m_buffer.buffer[m_buffer.lineoffs[next_lineptr]];
+	
+	/* -1 for the '\0' at the end of line */
+
+	ptrdiff_t difference = (nextline - line) - 1;
+
+	if (difference < 0)
+		difference += m_buffer.bufsize;
+
+	return text_buffer_line{ line, (size_t)difference };
+}
+
+/*---------------------------------------------------------------------
+	text_buffer_lines::text_buffer_line_iterator::operator++
+	Moves to the next line.
+-----------------------------------------------------------------------*/
+
+text_buffer_lines::text_buffer_line_iterator& text_buffer_lines::text_buffer_line_iterator::operator++()
+{
+	if (++m_lineptr == m_buffer.linesize)
+		m_lineptr = 0;
+
+	return *this;
+}
+
+/*------------------------------------------------------
+	text_buffer_lines::begin()
+	Returns an iterator that points to the first line.
+--------------------------------------------------------*/
+
+text_buffer_lines::iterator text_buffer_lines::begin() const
+{
+	return text_buffer_line_iterator(m_buffer, m_buffer.linestart);
+}
+
+/*-----------------------------------------------------------
+	text_buffer_lines::begin()
+	Returns an iterator that points just past the last line.
+-------------------------------------------------------------*/
+
+text_buffer_lines::iterator text_buffer_lines::end() const
+{
+	return text_buffer_line_iterator(m_buffer, m_buffer.lineend);
+}

--- a/src/emu/debug/textbuf.h
+++ b/src/emu/debug/textbuf.h
@@ -19,7 +19,52 @@
 
 struct text_buffer;
 
+struct text_buffer_line
+{
+    const char *text;
+    size_t length;
+};
 
+/* helper class that makes it possible to iterate over the lines of a text_buffer */
+class text_buffer_lines
+{
+private:
+    text_buffer& m_buffer;
+
+public:
+    text_buffer_lines(text_buffer& buffer) : m_buffer(buffer) { }
+
+    class text_buffer_line_iterator
+    {
+        text_buffer& m_buffer;
+        s32 m_lineptr;
+    public:
+        text_buffer_line_iterator(text_buffer& buffer, s32 lineptr) :
+            m_buffer(buffer),
+            m_lineptr(lineptr)
+        {
+        }
+
+        /* technically this isn't a valid forward iterator, because
+         * operator * doesn't return a reference
+         */
+        text_buffer_line operator *() const;
+        text_buffer_line_iterator& operator ++(); 
+
+        bool operator != (const text_buffer_line_iterator& rhs)
+        {
+            return m_lineptr != rhs.m_lineptr;
+        }
+        /* according to C++ spec, only != is needed; == is present for completeness. */
+        bool operator == (const text_buffer_line_iterator& rhs) { return !(operator !=(rhs)); }
+    };
+
+    typedef text_buffer_line_iterator iterator;
+    typedef text_buffer_line_iterator const iterator_const;
+
+    iterator begin() const;
+    iterator end() const;
+};
 
 /***************************************************************************
     FUNCTION PROTOTYPES
@@ -52,5 +97,7 @@ u32 text_buffer_line_index_to_seqnum(text_buffer *text, u32 index);
 /* get a sequenced line from the text buffer */
 const char *text_buffer_get_seqnum_line(text_buffer *text, u32 seqnum);
 
+/* get an iterable container of the lines in the buffer */
+text_buffer_lines text_buffer_get_lines(text_buffer* text);
 
 #endif  /* MAME_EMU_DEBUG_TEXTBUF_H */


### PR DESCRIPTION
This is another debugger enhancement -- it allows you to export the
current contents of the debug console window to a file.

The filename parsing is based on the `trace` command, and as such,
supports both the "{game}" placeholder, and the ">>" prefix for
appending instead of overwriting.