### PR TITLE
Support Colecovision Megacart.

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -909,6 +909,8 @@ if (BUSES["COLECO_CART"]~=null) then
 	files {
 		MAME_DIR .. "src/devices/bus/coleco/cartridge/exp.cpp",
 		MAME_DIR .. "src/devices/bus/coleco/cartridge/exp.h",
+		MAME_DIR .. "src/devices/bus/coleco/cartridge/megacart.cpp",
+		MAME_DIR .. "src/devices/bus/coleco/cartridge/megacart.h",
 		MAME_DIR .. "src/devices/bus/coleco/cartridge/std.cpp",
 		MAME_DIR .. "src/devices/bus/coleco/cartridge/std.h",
 		MAME_DIR .. "src/devices/bus/coleco/cartridge/xin1.h",

--- a/src/devices/bus/coleco/cartridge/exp.cpp
+++ b/src/devices/bus/coleco/cartridge/exp.cpp
@@ -86,13 +86,10 @@ image_init_result colecovision_cartridge_slot_device::call_load()
 		if (!loaded_through_softlist())
 		{
 			fread(m_card->m_rom, size);
-			m_megacart_bankcount = size >> 14;
-			m_megacart_activebank = 0;
 		}
 		else
 		{
 			// TODO 8000/a000/c000/e000
-			m_megacart_bankcount = 0;
 			memcpy(m_card->m_rom, get_software_region("rom"), size);
 		}
 	}
@@ -112,6 +109,12 @@ std::string colecovision_cartridge_slot_device::get_default_card_software(get_de
 		uint32_t length = hook.image_file()->size();
 		if (length == 0x100000 || length == 0x200000)
 			return software_get_default_slot("xin1");
+
+		if (length > 0x8000)
+		{
+			// Assume roms longer than 32K are megacarts.
+			return software_get_default_slot("megacart");
+		}
 	}
 	return software_get_default_slot("standard");
 }
@@ -121,47 +124,28 @@ std::string colecovision_cartridge_slot_device::get_default_card_software(get_de
 //  bd_r - cartridge data read
 //-------------------------------------------------
 
+
 uint8_t colecovision_cartridge_slot_device::bd_r(offs_t offset, uint8_t data, int _8000, int _a000, int _c000, int _e000)
 {
-	// offset zero is the start of cartridge space, 0x8000 in CPU space.
 	if (m_card)
-	{
-		if (m_megacart_bankcount > 2)
-		{
-			if (offset >= 0x7FC0)
-			{
-				// Reads within the final 64 bytes select which megacart bank is active.
-				m_megacart_activebank = offset & (m_megacart_bankcount - 1);
-			}
-
-			if (offset >= 0x4000)
-			{
-				// The offset is within the active megacart bank
-				offset = (m_megacart_activebank << 14) + (offset - 0x4000);
-			}
-			else
-			{
-				// The offset is within the last bank.
-				offset = (m_megacart_bankcount << 14) + (offset - 0x4000);
-			}
-		}
-		data = m_card->bd_r(offset, data, _8000, _a000, _c000, _e000);
-	}
+		data = m_card->bd_r(offset , data, _8000, _a000, _c000, _e000);
 
 	return data;
-}
+	}
 
 
 //-------------------------------------------------
 //  SLOT_INTERFACE( colecovision_cartridges )
 //-------------------------------------------------
 
+#include "megacart.h"
 #include "std.h"
 #include "xin1.h"
 
 void colecovision_cartridges(device_slot_interface &device)
 {
 	// the following need ROMs from the software list
+	device.option_add_internal("megacart", COLECOVISION_MEGACART);
 	device.option_add_internal("standard", COLECOVISION_STANDARD);
 	device.option_add_internal("xin1", COLECOVISION_XIN1);
 }

--- a/src/devices/bus/coleco/cartridge/exp.h
+++ b/src/devices/bus/coleco/cartridge/exp.h
@@ -89,9 +89,6 @@ protected:
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_colecovision_cartridge_interface *m_card;
-
-	size_t m_megacart_bankcount;
-	size_t m_megacart_activebank;
 };
 
 

--- a/src/devices/bus/coleco/cartridge/exp.h
+++ b/src/devices/bus/coleco/cartridge/exp.h
@@ -89,6 +89,9 @@ protected:
 	virtual std::string get_default_card_software(get_default_card_software_hook &hook) const override;
 
 	device_colecovision_cartridge_interface *m_card;
+
+	size_t m_megacart_bankcount;
+	size_t m_megacart_activebank;
 };
 
 

--- a/src/devices/bus/coleco/cartridge/megacart.cpp
+++ b/src/devices/bus/coleco/cartridge/megacart.cpp
@@ -1,0 +1,93 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark/Space Inc.
+/**********************************************************************
+
+    ColecoVision MegaCart emulation
+
+**********************************************************************/
+
+#include "emu.h"
+#include "megacart.h"
+
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(COLECOVISION_MEGACART, colecovision_megacart_cartridge_device, "colecovision_megacart", "ColecoVision MegaCart")
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  colecovision_megacart_cartridge_device - constructor
+//-------------------------------------------------
+
+colecovision_megacart_cartridge_device::colecovision_megacart_cartridge_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, COLECOVISION_MEGACART, tag, owner, clock),
+	device_colecovision_cartridge_interface(mconfig, *this),
+	m_bankcount(0),
+	m_activebank(0)
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void colecovision_megacart_cartridge_device::device_start()
+{
+}
+
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void colecovision_megacart_cartridge_device::device_reset()
+{
+	m_bankcount = m_rom_size >> 14;
+	m_activebank = 0;
+}
+
+
+//-------------------------------------------------
+//  read - cartridge data read
+//-------------------------------------------------
+
+uint8_t colecovision_megacart_cartridge_device::bd_r(offs_t offset, uint8_t data, int _8000, int _a000, int _c000, int _e000)
+{
+	if (!_8000 || !_a000 || !_c000 || !_e000)
+	{
+		if (m_bankcount > 2)
+		{
+			// offset as passed to us is a delta from address 0x8000.
+
+			if (offset >= 0x7FC0)
+			{
+				// Reads within the final 64 bytes select which megacart bank is active.
+				m_activebank = offset & (m_bankcount - 1);
+			}
+
+			if (offset >= 0x4000)
+			{
+				// The offset is within the active megacart bank.
+				offset = (m_activebank << 14) + (offset - 0x4000);
+			}
+			else
+			{
+				// The offset is within the last bank.
+				offset = (m_bankcount << 14) + (offset - 0x4000);
+			}
+		}
+
+		data = m_rom[offset];
+	}
+
+	return data;
+}

--- a/src/devices/bus/coleco/cartridge/megacart.h
+++ b/src/devices/bus/coleco/cartridge/megacart.h
@@ -1,0 +1,49 @@
+// license:BSD-3-Clause
+// copyright-holders:Mark/Space Inc.
+/**********************************************************************
+
+    ColecoVision MegaCart emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_COLECO_MEGACART_H
+#define MAME_BUS_COLECO_MEGACART_H
+
+#pragma once
+
+#include "exp.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> colecovision_megacart_cartridge_device
+
+class colecovision_megacart_cartridge_device : public device_t,
+												public device_colecovision_cartridge_interface
+{
+public:
+	// construction/destruction
+	colecovision_megacart_cartridge_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device_t overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// device_colecovision_cartridge_interface overrides
+	virtual uint8_t bd_r(offs_t offset, uint8_t data, int _8000, int _a000, int _c000, int _e000) override;
+
+private:
+	size_t m_bankcount;
+	size_t m_activebank;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(COLECOVISION_MEGACART, colecovision_megacart_cartridge_device)
+
+
+#endif // MAME_BUS_COLECO_MEGACART_H


### PR DESCRIPTION
Assume that a rom file that is more than 32K in size is a megacart
and that it should be bankswitched using Megacart protocol.