### PR TITLE
Change aspect ratio for Konami Twinkle to 16:9

### DIFF
--- a/src/mame/drivers/twinkle.cpp
+++ b/src/mame/drivers/twinkle.cpp
@@ -1090,7 +1090,9 @@ void twinkle_state::twinkle(machine_config &config)
 	/* video hardware */
 	CXD8561Q(config, "gpu", XTAL(53'693'175), 0x200000, subdevice<psxcpu_device>("maincpu")).set_screen("screen");
 
-	SCREEN(config, "screen", SCREEN_TYPE_RASTER);
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	//all twinkle cabinets use anamorphic widescreen displays
+	screen.set_physical_aspect(16, 9);
 
 	/* sound hardware */
 	SPEAKER(config, "speakerleft").front_left();

--- a/src/mame/layout/bmiidx.lay
+++ b/src/mame/layout/bmiidx.lay
@@ -55,13 +55,13 @@ license:CC0
 
 	<element name="led">
 		<led16seg>
-			<color red="0" green="0.6" blue="1.0" />
+			<color red="1.0" green="0.1" blue="0.15" />
 		</led16seg>
 	</element>
 
 	<view name="Lamps">
 		<screen index="0">
-			<bounds left="0" top="0" right="320" bottom="240"/>
+			<bounds left="0" top="0" right="426" bottom="240"/>
 		</screen>
 
 		<bezel name="1p" element="1p"><bounds x="0" y="240" width="48" height="16"/></bezel>
@@ -69,20 +69,20 @@ license:CC0
 		<bezel name="effect" element="effect"><bounds x="0" y="272" width="48" height="16"/></bezel>
 		<bezel name="vefx" element="vefx"><bounds x="0" y="288" width="48" height="16"/></bezel>
 
-		<bezel name="credit" element="credit"><bounds x="48" y="240" width="48" height="16"/></bezel>
-		<bezel name="neonlamp" element="neonlamp"><bounds x="48" y="256" width="48" height="16"/></bezel>
-		<bezel name="unknown1" element="neonlamp"><bounds x="48" y="272" width="48" height="16"/></bezel>
-		<bezel name="unknown2" element="neonlamp"><bounds x="48" y="288" width="48" height="16"/></bezel>
+		<bezel name="credit" element="credit"><bounds x="64" y="240" width="48" height="16"/></bezel>
+		<bezel name="neonlamp" element="neonlamp"><bounds x="64" y="256" width="48" height="16"/></bezel>
+		<bezel name="unknown1" element="neonlamp"><bounds x="64" y="272" width="48" height="16"/></bezel>
+		<bezel name="unknown2" element="neonlamp"><bounds x="64" y="288" width="48" height="16"/></bezel>
 
-		<bezel name="spotlight0" element="spotlight0"><bounds x="96" y="240" width="48" height="16"/></bezel>
-		<bezel name="spotlight1" element="spotlight1"><bounds x="96" y="256" width="48" height="16"/></bezel>
-		<bezel name="spotlight2" element="spotlight2"><bounds x="96" y="272" width="48" height="16"/></bezel>
-		<bezel name="spotlight3" element="spotlight3"><bounds x="96" y="288" width="48" height="16"/></bezel>
+		<bezel name="spotlight0" element="spotlight0"><bounds x="128" y="240" width="48" height="16"/></bezel>
+		<bezel name="spotlight1" element="spotlight1"><bounds x="128" y="256" width="48" height="16"/></bezel>
+		<bezel name="spotlight2" element="spotlight2"><bounds x="128" y="272" width="48" height="16"/></bezel>
+		<bezel name="spotlight3" element="spotlight3"><bounds x="128" y="288" width="48" height="16"/></bezel>
 
-		<bezel name="spotlight4" element="spotlight4"><bounds x="144" y="240" width="48" height="16"/></bezel>
-		<bezel name="spotlight5" element="spotlight5"><bounds x="144" y="256" width="48" height="16"/></bezel>
-		<bezel name="spotlight6" element="spotlight6"><bounds x="144" y="272" width="48" height="16"/></bezel>
-		<bezel name="spotlight7" element="spotlight7"><bounds x="144" y="288" width="48" height="16"/></bezel>
+		<bezel name="spotlight4" element="spotlight4"><bounds x="192" y="240" width="48" height="16"/></bezel>
+		<bezel name="spotlight5" element="spotlight5"><bounds x="192" y="256" width="48" height="16"/></bezel>
+		<bezel name="spotlight6" element="spotlight6"><bounds x="192" y="272" width="48" height="16"/></bezel>
+		<bezel name="spotlight7" element="spotlight7"><bounds x="192" y="288" width="48" height="16"/></bezel>
 
 		<bezel name="led0" element="led" state="0">
 			<bounds x="0" y="304" width="32" height="64"/>
@@ -117,38 +117,38 @@ license:CC0
 		<bezel name="key1-3" element="key1-3"><bounds x="0" y="400" width="48" height="16"/></bezel>
 		<bezel name="key1-4" element="key1-4"><bounds x="0" y="416" width="48" height="16"/></bezel>
 
-		<bezel name="key1-5" element="key1-5"><bounds x="48" y="368" width="48" height="16"/></bezel>
-		<bezel name="key1-6" element="key1-6"><bounds x="48" y="384" width="48" height="16"/></bezel>
-		<bezel name="key1-7" element="key1-7"><bounds x="48" y="400" width="48" height="16"/></bezel>
-		<bezel name="key2-1" element="key2-1"><bounds x="48" y="416" width="48" height="16"/></bezel>
+		<bezel name="key1-5" element="key1-5"><bounds x="64" y="368" width="48" height="16"/></bezel>
+		<bezel name="key1-6" element="key1-6"><bounds x="64" y="384" width="48" height="16"/></bezel>
+		<bezel name="key1-7" element="key1-7"><bounds x="64" y="400" width="48" height="16"/></bezel>
+		<bezel name="key2-1" element="key2-1"><bounds x="64" y="416" width="48" height="16"/></bezel>
 
-		<bezel name="key2-2" element="key2-2"><bounds x="96" y="368" width="48" height="16"/></bezel>
-		<bezel name="key2-3" element="key2-3"><bounds x="96" y="384" width="48" height="16"/></bezel>
-		<bezel name="key2-4" element="key2-4"><bounds x="96" y="400" width="48" height="16"/></bezel>
-		<bezel name="key2-5" element="key2-5"><bounds x="96" y="416" width="48" height="16"/></bezel>
+		<bezel name="key2-2" element="key2-2"><bounds x="128" y="368" width="48" height="16"/></bezel>
+		<bezel name="key2-3" element="key2-3"><bounds x="128" y="384" width="48" height="16"/></bezel>
+		<bezel name="key2-4" element="key2-4"><bounds x="128" y="400" width="48" height="16"/></bezel>
+		<bezel name="key2-5" element="key2-5"><bounds x="128" y="416" width="48" height="16"/></bezel>
 
-		<bezel name="key2-6" element="key2-6"><bounds x="144" y="368" width="48" height="16"/></bezel>
-		<bezel name="key2-7" element="key2-7"><bounds x="144" y="384" width="48" height="16"/></bezel>
-		<bezel name="unknown3" element="unknown3"><bounds x="144" y="400" width="48" height="16"/></bezel>
-		<bezel name="unknown4" element="unknown4"><bounds x="144" y="416" width="48" height="16"/></bezel>
+		<bezel name="key2-6" element="key2-6"><bounds x="192" y="368" width="48" height="16"/></bezel>
+		<bezel name="key2-7" element="key2-7"><bounds x="192" y="384" width="48" height="16"/></bezel>
+		<bezel name="unknown3" element="unknown3"><bounds x="192" y="400" width="48" height="16"/></bezel>
+		<bezel name="unknown4" element="unknown4"><bounds x="192" y="416" width="48" height="16"/></bezel>
 
 		<bezel name="main_led0" element="main_led0"><bounds x="0" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led1" element="main_led1"><bounds x="24" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led2" element="main_led2"><bounds x="48" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led3" element="main_led3"><bounds x="72" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led4" element="main_led4"><bounds x="96" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led5" element="main_led5"><bounds x="120" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led6" element="main_led6"><bounds x="144" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led7" element="main_led7"><bounds x="168" y="432" width="24" height="16"/></bezel>
-		<bezel name="main_led8" element="main_led8"><bounds x="192" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led1" element="main_led1"><bounds x="32" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led2" element="main_led2"><bounds x="64" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led3" element="main_led3"><bounds x="96" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led4" element="main_led4"><bounds x="128" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led5" element="main_led5"><bounds x="160" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led6" element="main_led6"><bounds x="192" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led7" element="main_led7"><bounds x="224" y="432" width="24" height="16"/></bezel>
+		<bezel name="main_led8" element="main_led8"><bounds x="256" y="432" width="24" height="16"/></bezel>
 
 		<bezel name="spu_led0" element="spu_led0"><bounds x="0" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led1" element="spu_led1"><bounds x="24" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led2" element="spu_led2"><bounds x="48" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led3" element="spu_led3"><bounds x="72" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led4" element="spu_led4"><bounds x="96" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led5" element="spu_led5"><bounds x="120" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led6" element="spu_led6"><bounds x="144" y="448" width="24" height="16"/></bezel>
-		<bezel name="spu_led7" element="spu_led7"><bounds x="168" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led1" element="spu_led1"><bounds x="32" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led2" element="spu_led2"><bounds x="64" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led3" element="spu_led3"><bounds x="96" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led4" element="spu_led4"><bounds x="128" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led5" element="spu_led5"><bounds x="160" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led6" element="spu_led6"><bounds x="192" y="448" width="24" height="16"/></bezel>
+		<bezel name="spu_led7" element="spu_led7"><bounds x="224" y="448" width="24" height="16"/></bezel>
 	</view>
 </mamelayout>


### PR DESCRIPTION
All games running on the Twinkle hardware shipped with anamorphic 16:9 widescreen monitors. In 4:3, most graphics appear squashed horizontally. (beatmania IIDX continued to use anamorphic widescreen after switching to PC hardware with 9th style.)

This also updates the Lamps layout to display the screen in 16:9 and changes the color of the 16-segment display to "LED red" to match the 16-segment displays that were used on the machines.