### PR TITLE
gameboy.xml, famicom_flop.xml, nes.xml: more metadata corrections

### DIFF
--- a/hash/famicom_flop.xml
+++ b/hash/famicom_flop.xml
@@ -527,7 +527,7 @@ Re-releases (probably the same as the original release, but listed while waiting
 
 	<software name="dkong">
 		<description>Donkey Kong (Disk Writer)</description>
-		<year>1987</year>
+		<year>1988</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="FMC-DKD"/>
 		<info name="release" value="19880408"/>
@@ -1005,7 +1005,7 @@ Re-releases (probably the same as the original release, but listed while waiting
 <!-- Save Disk Error -->
 	<software name="haokun" supported="no">
 		<description>Hao-kun no Fushigi na Tabi</description>
-		<year>1986</year>
+		<year>1987</year>
 		<publisher>Square</publisher>
 		<info name="serial" value="SQF-HFT"/>
 		<info name="release" value="19870501"/>
@@ -1128,7 +1128,7 @@ Re-releases (probably the same as the original release, but listed while waiting
 
 	<software name="kickchal">
 		<description>Kick Challenger Air Foot - Yasai no Kuni no Ashi Senshi</description>
-		<year>1988</year>
+		<year>1987</year>
 		<publisher>VAP</publisher>
 		<info name="serial" value="VAP-AFT"/>
 		<info name="release" value="19871120"/>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -17239,7 +17239,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pocketmj" cloneof="pokeyell">
+	<software name="pocketmj">
 		<description>Pocket Mahjong (Japan)</description>
 		<year>1997</year>
 		<publisher>Bottom Up</publisher>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -39045,7 +39045,7 @@ license:CC0
 
 	<software name="ttoonadv">
 		<description>Tiny Toon Adventures (Euro)</description>
-		<year>1993</year>
+		<year>1992</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="NES-NI (NOE/SCN)"/>
 		<info name="release" value="19921022"/>
@@ -46949,7 +46949,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>Natsume</publisher>
 		<info name="serial" value="NAT-JL"/>
 		<info name="release" value="19900810"/>
-		<info name="alt_title" value=""/>
+		<info name="alt_title" value="闇の仕事人KAGE"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
@@ -47610,7 +47610,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>Namcot</publisher>
 		<info name="serial" value="NAM-FMT-7800"/>
 		<info name="release" value="19900406"/>
-		<info name="alt_title" value=""/>
+		<info name="alt_title" value="女神転生Ⅱ デジタルデビル物語"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="namcot_163" />
 			<feature name="pcb" value="NAMCOT-163" />
@@ -49876,7 +49876,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>Capcom</publisher>
 		<info name="serial" value=""/>
 		<info name="release" value="19861224"/>
-		<info name="alt_title" value=""/>
+		<info name="alt_title" value="闘いの挽歌"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="uxrom" />
 			<feature name="pcb" value="NES-UNROM" />


### PR DESCRIPTION
gameboy.xml's pocket mahjong was listed as a clone of pokemon yellow which explains an earlier mistake where a jp version of pokemon yellow was not listed as a clone. pocketmj is clearly a different game.