### PR TITLE
ics2115.h: Add imperfect_features related to incorrect/unverified interrupt, interpolation, ramping

### DIFF
--- a/src/devices/sound/ics2115.h
+++ b/src/devices/sound/ics2115.h
@@ -15,6 +15,8 @@
 class ics2115_device : public device_t, public device_sound_interface
 {
 public:
+	static constexpr feature_type imperfect_features() { return feature::SOUND; } // Incorrect/Unverified interrupt, interpolation
+
 	// construction/destruction
 	ics2115_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 

--- a/src/devices/sound/ics2115.h
+++ b/src/devices/sound/ics2115.h
@@ -15,7 +15,8 @@
 class ics2115_device : public device_t, public device_sound_interface
 {
 public:
-	static constexpr feature_type imperfect_features() { return feature::SOUND; } // Incorrect/Unverified interrupt, interpolation
+	static constexpr feature_type imperfect_features() { return feature::SOUND; } // Incorrect/Unverified interrupt, interpolation;
+	// current ramping behavior is seems like incorrect?
 
 	// construction/destruction
 	ics2115_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);


### PR DESCRIPTION
Interpolation issue is most noticeable in cave PGM hardware game musics