### PR TITLE
fmtowns_cd.xml: 26 new dumps, 24 replacements

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -54,7 +54,6 @@ Butoukai no Yoru                                              Fujitsu           
 ByHAND V1.1                                                   Fujitsu                           1992/1     CD
 ByHAND V2.1                                                   Fujitsu                           1993/3     CD
 ByHAND V3.1                                                   Fujitsu                           1994/3     CD
-CAL Towns 3                                                   Birdy Soft                        1993/7     CD
 California X Party: Joshi Daisei Himitsu Club                 HOP                               1994/9     SET(CD+FD)
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
@@ -71,7 +70,6 @@ CD Eigo Gakushuu System 2-nen Kairyuudou: Sunshine            Uchida Youkou     
 CD Eigo Gakushuu System 2-nen Sanseidou: New Crown            Uchida Youkou                     1991/4     SET(CD+FD)
 CD-ROM-ban Katei Igaku Daizenka                               Houken                            1992/10    SET(CD+FD)
 CDWord                                                        Sanshusha                         1989/3     SET(CD+FD)
-Chiemi & Naomi                                                Fairytale (Red Zone)              1993/12    CD
 Chiisana Ensouka                                              Fujitsu Social Science Laboratory 1993/9     CD
 Chikyuu no Himitsu (Kankyou Kyouiku Kyouzai)                  Fujitsu                           1994/7     CD
 Chinmoku no Kantai                                            GAM                               1992/4     SET(CD+FD)
@@ -166,7 +164,6 @@ Eigo de Eigo ni Tsuyoku Naru 6                                Infortech         
 Eigo de Eigo ni Tsuyoku Naru 7                                Infortech                         1990/4     CD
 Eigo de Eigo ni Tsuyoku Naru 8                                Infortech                         1990/4     CD
 Eigo de Eigo ni Tsuyoku Naru 9                                Infortech                         1990/4     CD
-Eikan wa Kimi ni 2: Koukou Yakyuu Zenkoku Taikai              Artdink                           1991/8     CD
 Eikan wa Kimi ni 3: Koukou Yakyuu Zenkoku Taikai              Artdink                           1993/8     SET(CD+FD)
 Ei-wa-doku-ro Denki Jutsugo Daijiten                          Ohmsha                            1990/4     CD
 Emit Vol. 3: Watashi ni Sayonara wo                           Koei                              1994/9     SET(CD+FD)
@@ -275,7 +272,6 @@ Hyper Drill Series Shougakkou Shakai 4-nen                    Uchida Youkou     
 Hyper Drill Series Shougakkou Shakai 5-nen                    Uchida Youkou                     1994/4     CD
 Hyper Drill Series Shougakkou Shakai 6-nen                    Uchida Youkou                     1994/8     CD
 Hyper DX                                                      Datt Japan                        1989/10    SET(CD+FD)
-Hyper Fetishism                                               Extend                            1993/12    CD
 Hyper Ikuji Guide: Babubabu Tenshi                            Dennou Shoukai                    1996/4     CD
 Hyper Koto no Tabi: Kyoto                                     Nanken Koubou                     1993/2     CD
 Hyper Land: Doubutsu no Sekai                                 Datt Japan                        1993/3     CD
@@ -297,7 +293,6 @@ If 3                                                          Active            
 Igo Doujou Shodan Kaigan! Kyuu kara Dan e no Chousen          Fujitsu OA                        1991/5     CD
 Igo Doujou Yaburi: Menkyo Kaiden!! Mezase 7-kyuu              Fujitsu OA                        1990/10    CD
 Igo Nyuumon Doujou                                            GAM                               1991/6     CD
-Illust Hyakka: Yamashita Hideki no Ikiiki Cut-shuu            CSK Research Institute (CRI)      1990/8     CD
 Image Art System                                              Raison                            1990/6     CD
 Image Art System Pro                                          Raison                            1990/8     CD
 Image Power                                                   Raison                            1990/3     CD
@@ -316,7 +311,6 @@ JAF Drive Guide (Ver. 2)                                      JAF Shuppansha    
 Jinmon Yuugi                                                  Fairytale (Red Zone)              1995/8     SET(CD+FD)
 Jintaizu System Skeleton                                      Medical System                    1995/8     CD
 Joshikousei Shoujo Densetsu                                   Byakuya Shobou                    1994/4     CD
-Jouhou Club                                                   Fujitsu Social Science Laboratory 1989/11    CD
 Jouhou Gijutsu Yougo Shuu CD-ROM                              Fujitsu                           1991/12    CD
 JYB                                                           Cocktail Soft                     1993/4     CD
 Kadokawa Ruigo Shin Jiten CD-ROM                              Fujitsu                           1989/12    CD
@@ -370,9 +364,7 @@ Lua                                                           Interheart        
 M Talk                                                        Fujitsu Office Kiki               1993/6     CD
 Mahjong Gensoukyoku 2                                         Active                            1993/9     CD
 Mahjong Gensoukyoku III                                       Active                            1995/11    CD
-Mahjong Musashi                                               Cosmos Computer                   1989/10    CD
 Manami no Dokomade Iku no?                                    Wendy Magazine                    1995/5     CD
-Manami no Dokomade Iku no? 2: Return of the Kuro Pack         Wendy Magazine                    1995/5     CD
 Manami: Ai to Koukan no Hibi                                  Fairytale (Red Zone)              1995/10    SET(CD+FD)
 Many Colors 2                                                 Amorphous                         1995/6     CD
 Manyoushuu                                                    Uchida Youkou                     1993/2     CD
@@ -496,7 +488,6 @@ Present                                                       Orange House      
 Primary Health Care System                                    Raison                            1990/9     CD
 Princess Danger                                               Janis                             1996/4     CD
 Private Slave                                                 Raccoon                           1993/8     SET(CD+FD)
-Pro Student G Renkaban                                        Alice Soft                        1995/4     CD
 Psychic Detective Series Vol. 1: Invitation: Kage kara no Shoutaijou (Remake)   Data West                         1993/11    SET(CD+FD)
 Psychic Detective Series Vol. 2: Memories (Remake)            Data West                         1994/4     SET(CD+FD)
 Psychic Detective Series Vol. 3: Aya (Remake)                 Data West                         1994/7     SET(CD+FD)
@@ -648,7 +639,6 @@ Towns System Software V2.1 L20                                Fujitsu           
 Towns System Software V2.1 L30                                Fujitsu                           ?          CD
 Towns System Software V2.1 L31                                Fujitsu                           ?          CD
 Towns System Software V2.1 L40                                Fujitsu                           ?          CD
-Towns Telop                                                   Lambda System                     1989/5     SET(CD+FD)
 TownsFullcolor V1.1                                           Fujitsu                           1993/3     CD
 TownsGraph V1.1                                               Fujitsu                           1993/4     CD
 TownsGraph V2.1                                               Fujitsu                           1994/10    CD
@@ -681,8 +671,6 @@ Video Koubou V1.2                                             Fujitsu           
 VIP Ball                                                      CSK Research Institute (CRI)      1991/8     CD
 VIP Tone                                                      CSK Research Institute (CRI)      1991/9     CD
 VIPER GTS                                                     Sogna                             1995/11    CD
-VIPER V12                                                     Sogna                             1995/12    CD
-VIPER V8 Turbo RS                                             Sogna                             1995/6     CD
 * Virtuacall 2                                                Fairytale                         1995/12    SET(CD+FD)
 Virtual Tours V1.0                                            Fujitsu                           1995/1     SET(CD+FD)
 Watashi no Tsukue                                             GAM                               1994/9     SET(CD+FD)
@@ -702,7 +690,6 @@ Yacht & Cruiser System                                        Raison            
 Yasashii Chuugokugo                                           SofMedia                          1990/12    CD
 Yawahada Bishoujo                                             Illusion                          1995/3     CD
 Yellows                                                       Digital Rogue                     1994/12    CD
-Yes! HG                                                       Himeya Soft                       1995/12    CD
 Yoshioka Mayumi: Last Nude                                    Janis                             1993/12    CD
 Youki de Cool na LA Towns                                     Media Art                         1990/12    CD
 Yumeutsutsu                                                   Megami                            1992/5     CD
@@ -1253,11 +1240,36 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="4dtennis">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="4D Tennis.ccd" size="5869" crc="6287f51f" sha1="49c79b3496465cf35eb46c8f2d4e4bb7d13baf00"/>
-		<rom name="4D Tennis.cue" size="1145" crc="c0bb25ae" sha1="de404e98b76891fcaf5070f526e290d945d13365"/>
-		<rom name="4D Tennis.img" size="79031904" crc="6107a3ea" sha1="a53b7bb8b30ade50d9d076d080adb62059ecdf42"/>
-		<rom name="4D Tennis.sub" size="3225792" crc="1239c112" sha1="434cfbd5edc000dc2c6432bf4a5697b5d9e75109"/>
+		Origin: redump.org
+		<rom name="4D Tennis (Japan) (Track 01).bin" size="10231200" crc="0aa6ed1a" sha1="1b4aab3b82894befdaf97508ed26eb2eb156575c"/>
+		<rom name="4D Tennis (Japan) (Track 02).bin" size="11247264" crc="a2a7f636" sha1="3313531a6ff3e6e5d0a002dc2ff02c37a7547a66"/>
+		<rom name="4D Tennis (Japan) (Track 03).bin" size="26601120" crc="2881bace" sha1="d2d6b82c3b2d2c39b5f5edd8095c2dc53374beb1"/>
+		<rom name="4D Tennis (Japan) (Track 04).bin" size="1241856" crc="e65a82c8" sha1="ebc8386bc02c452bbf14bc654b02bf517a2579f1"/>
+		<rom name="4D Tennis (Japan) (Track 05).bin" size="1234800" crc="4a2b1b54" sha1="b5def19b86b2083ce7f2b6090130ae84d26e4eac"/>
+		<rom name="4D Tennis (Japan) (Track 06).bin" size="1239504" crc="06b46b49" sha1="1579aa2277c92ac74ce00382a07ecc20abcc2a35"/>
+		<rom name="4D Tennis (Japan) (Track 07).bin" size="1234800" crc="5838c7d3" sha1="52178e886ec50a4fbac501b614e84d9146d7a2aa"/>
+		<rom name="4D Tennis (Japan) (Track 08).bin" size="1234800" crc="0888376c" sha1="54a2d5552ddacf15458ec751850130a6a1111e24"/>
+		<rom name="4D Tennis (Japan) (Track 09).bin" size="1183056" crc="e6a700af" sha1="756cc051e236b0983cea4b06dafd9a2cf7007941"/>
+		<rom name="4D Tennis (Japan) (Track 10).bin" size="1234800" crc="f919abd6" sha1="5eb5afb696a451dc03491ca493a839179f585db5"/>
+		<rom name="4D Tennis (Japan) (Track 11).bin" size="1180704" crc="0a9bcd0f" sha1="046bd796b7a91b5b520e0dde48cc263ce72f9bfa"/>
+		<rom name="4D Tennis (Japan) (Track 12).bin" size="1241856" crc="264cf2af" sha1="918c04ff59e9fccb5a7be296064089dc906cd780"/>
+		<rom name="4D Tennis (Japan) (Track 13).bin" size="1234800" crc="37bb36a8" sha1="f46caf76b1d6654d93022b8cec4a980ce36a0d47"/>
+		<rom name="4D Tennis (Japan) (Track 14).bin" size="1239504" crc="ba13030b" sha1="c12c76eb68c8669be944bb498f7cb960bc39fc57"/>
+		<rom name="4D Tennis (Japan) (Track 15).bin" size="1234800" crc="bcf35808" sha1="9360f6a6b42db6f770cb7b53f4186f4fabeb7d4b"/>
+		<rom name="4D Tennis (Japan) (Track 16).bin" size="1234800" crc="a86cec98" sha1="032f0c80c270433a981df48531fb0ebcb3b38f7d"/>
+		<rom name="4D Tennis (Japan) (Track 17).bin" size="1241856" crc="03007776" sha1="dd8a8a9b952e016da00dce60bfa0dab35db35aae"/>
+		<rom name="4D Tennis (Japan) (Track 18).bin" size="1234800" crc="134b657b" sha1="a4742803af5992f7fc6952be7f327e96bb488516"/>
+		<rom name="4D Tennis (Japan) (Track 19).bin" size="1239504" crc="aa360a34" sha1="1b395b0cabf3a8064538734ced14d2aae7d86415"/>
+		<rom name="4D Tennis (Japan) (Track 20).bin" size="1187760" crc="ee8beabb" sha1="35eeb2337c41c46ba05200b49243b504e91666f9"/>
+		<rom name="4D Tennis (Japan) (Track 21).bin" size="1241856" crc="7e96e3d8" sha1="38317f4e2574c367778872bcc9ed39966287dde8"/>
+		<rom name="4D Tennis (Japan) (Track 22).bin" size="1234800" crc="312fee49" sha1="234ede1a2e6e825bfa14c4181399d3e2942bbdde"/>
+		<rom name="4D Tennis (Japan) (Track 23).bin" size="1239504" crc="f737d3af" sha1="e29fda2240ee89232ddbd3666176d4091f7da1ba"/>
+		<rom name="4D Tennis (Japan) (Track 24).bin" size="1234800" crc="be087de3" sha1="1e8611e875a8a211ba1d865fc8e353e3fa0041d5"/>
+		<rom name="4D Tennis (Japan) (Track 25).bin" size="1234800" crc="89fa78e7" sha1="c98ca7fb446a3a0c7b3d17bb55665187038cecfd"/>
+		<rom name="4D Tennis (Japan) (Track 26).bin" size="1241856" crc="59f63f6b" sha1="99ef56684f1af8dae0914cea18e7fa2f6c8c994e"/>
+		<rom name="4D Tennis (Japan) (Track 27).bin" size="1234800" crc="7f7d8afc" sha1="2f2f137c6486306328e8543c5d6ee5b59ca3f1e6"/>
+		<rom name="4D Tennis (Japan) (Track 28).bin" size="1415904" crc="d091faf7" sha1="4e50905a6015b889cf6a93e76fca53667fdc6a2a"/>
+		<rom name="4D Tennis (Japan).cue" size="3118" crc="8945fc99" sha1="1843e657d09f76b10ce8f9326778b878c4619992"/>
 		-->
 		<description>4D Tennis</description>
 		<year>1993</year>
@@ -1268,7 +1280,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="4d tennis" sha1="5ee1a3342469e87bc0f1d613982a92bc8ab5c5bb" />
+				<disk name="4d tennis (japan)" sha1="1ddcaee84631b1f5ace7dd60d8b4c7415ed4d789" />
 			</diskarea>
 		</part>
 	</software>
@@ -2303,11 +2315,25 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="arabesq">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Arabesque.ccd" size="3266" crc="4bf6d3b1" sha1="611ac34cbd65fcbc4cee3fc2c9681b1e602e7c6b"/>
-		<rom name="Arabesque.cue" size="1115" crc="9c89fc40" sha1="e98b9b24baa65eeddae1fbb2905ecd7554bd8e4a"/>
-		<rom name="Arabesque.img" size="584413200" crc="b9abe5c0" sha1="3f7494d07e9ef8493e801932e3ae39f334b43824"/>
-		<rom name="Arabesque.sub" size="23853600" crc="01f20a90" sha1="c244dedc2946a534932aed7d886fb3f56ab38c9f"/>
+		Origin: redump.org
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 01).bin" size="20815200" crc="d0dde34d" sha1="72d5c9e6e578a2e0faf63ca7088d7673f050b145"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 02).bin" size="44805600" crc="54efca78" sha1="2cd283b0445590468c92cca1a0888e38c22d6bd1"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 03).bin" size="43041600" crc="6e8cb4cf" sha1="10310413729403cba1393978d80f354039d1b68b"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 04).bin" size="42688800" crc="e769f894" sha1="b29db1472b297d0f5bff1a4da30377ede9413406"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 05).bin" size="40924800" crc="198d69d0" sha1="5bbeed797686229cc9280d68389c4c80325c2e78"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 06).bin" size="41806800" crc="f7e84a8e" sha1="515b961b154925eedcb5dde0452b9079860d9598"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 07).bin" size="42688800" crc="4cba1c3c" sha1="bddd6ce21bb9ae0b2234d67870f1b27deda34687"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 08).bin" size="40924800" crc="1cd8b7d6" sha1="019f380205c433b031fd52e3fcb017a0d83b447c"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 09).bin" size="44629200" crc="ad1fe0d5" sha1="fe77dc55b1340bfcba41ab87877508a2f9dc21dd"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 10).bin" size="40924800" crc="09ecdada" sha1="1be708b134482bf68354cec47826cce5f405cfea"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 11).bin" size="43570800" crc="786b2389" sha1="ee423d23209f3370d040bfbef59632e691c13202"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 12).bin" size="42512400" crc="106d3c3f" sha1="0cc9c4c7d07ea0a43581af02f633c4afb8b32690"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 13).bin" size="46393200" crc="cae41412" sha1="6edc0485993043390a91e5c94c5ced1e0e4fcaa2"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 14).bin" size="2293200" crc="3c56dfd3" sha1="b0f9277f443643c2389e03f4e5c5c406e658e020"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 15).bin" size="1587600" crc="e4b02e95" sha1="78c36b55cc5d6f72a3e16f83ecf89ec7bd628feb"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 16).bin" size="2293200" crc="4c22c63a" sha1="be32733bd034d57502dae57c32fb76bbb0cd41fd"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan) (Track 17).bin" size="42512400" crc="966a7b42" sha1="7a3b90590b4b5bcfe4ba1ab6f06da26b6a13e58f"/>
+		<rom name="Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari (Japan).cue" size="2617" crc="02f4118f" sha1="cca26382434d5123921b62bb958cf4983dfaad83"/>
 		-->
 		<description>Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari</description>
 		<year>1994</year>
@@ -2318,7 +2344,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="arabesque" sha1="5869c0c1d2eee0f551722a7d08d7feef6be53868" />
+				<disk name="arabesque - shoujo-tachi no orinasu ai no monogatari (japan)" sha1="c9474eff1c7e6d5078bb2b8ce6df8b176075bd3d" />
 			</diskarea>
 		</part>
 	</software>
@@ -2387,11 +2413,14 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="atlas">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Atlas.ccd" size="1536" crc="7baa5573" sha1="30db8d77f0a80e951185804b12be324f112eacf8"/>
-		<rom name="The Atlas.cue" size="7587" crc="f14077fc" sha1="dc949e3d6fe998d047417b1778b4cefd88cfa240"/>
-		<rom name="The Atlas.img" size="707540400" crc="85ae7606" sha1="26437d18b6220e8db8f246671f191cf0241bd556"/>
-		<rom name="The Atlas.sub" size="28879200" crc="d5787c1f" sha1="b7d236402ba5b766f203718feb196619a7637f8c"/>
+		Origin: redump.org
+		<rom name="Atlas, The (Japan) (Track 1).bin" size="10231200" crc="47f34c41" sha1="606ad06ef515cebc3d74849d7aa44d0ac063e9fa"/>
+		<rom name="Atlas, The (Japan) (Track 2).bin" size="160112400" crc="b18ee89c" sha1="1cd17e23e75044e99006481a66e363e55e96e698"/>
+		<rom name="Atlas, The (Japan) (Track 3).bin" size="159524400" crc="e7b3f8e3" sha1="5d539d831f57379c1f3d35351b5a01abd3b9669c"/>
+		<rom name="Atlas, The (Japan) (Track 4).bin" size="159759600" crc="93c02683" sha1="1cbe667afa7699bb51a0c8d54bc81787a68946c0"/>
+		<rom name="Atlas, The (Japan) (Track 5).bin" size="159642000" crc="28354b4c" sha1="cc809754ff84a354de283b7bc22e6335fd3457e6"/>
+		<rom name="Atlas, The (Japan) (Track 6).bin" size="58270800" crc="6f7d7035" sha1="3096be48c7241abdc4d2dbf6410547ec4185f1fd"/>
+		<rom name="Atlas, The (Japan).cue" size="7830" crc="86b2b9b9" sha1="7626223f525ee46e5df396a3b6a4816bf95f8b40"/>
 		-->
 		<description>The Atlas</description>
 		<year>1991</year>
@@ -2402,7 +2431,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the atlas" sha1="31378695a7eb7fe953e51463829468f214f2a2f4" />
+				<disk name="atlas, the (japan)" sha1="576d2ac0f7af32ef5b8bffb5d7e1b1378263c9fc" />
 			</diskarea>
 		</part>
 	</software>
@@ -2485,11 +2514,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="ayumi">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Ayumi-chan Monogatari.ccd" size="751" crc="07695447" sha1="ab5e786148d9271297215724891d159f82ebfbf4"/>
-		<rom name="Ayumi-chan Monogatari.cue" size="103" crc="97e8d9b5" sha1="7b862c32e6509decbf691fce5db0a7de8cc34c46"/>
-		<rom name="Ayumi-chan Monogatari.img" size="67737600" crc="fbddbc97" sha1="5eff9ba669a7ff75572b70654a83d001baa7f012"/>
-		<rom name="Ayumi-chan Monogatari.sub" size="2764800" crc="76b91a7c" sha1="1a7b8b6d3342d3732f85e3284492418fad91e482"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Ayumi-chan Monogatari (Japan).bin" size="67737600" crc="fbddbc97" sha1="5eff9ba669a7ff75572b70654a83d001baa7f012"/>
+		<rom name="Ayumi-chan Monogatari (Japan).cue" size="95" crc="8cc50273" sha1="f40912f1b7aa1d9371a0c62db0379c6c4e6183a4"/>
 		-->
 		<description>Ayumi-chan Monogatari</description>
 		<year>1993</year>
@@ -2498,14 +2525,13 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Boot Disk?" />
 			<dataarea name="flop" size="1261568">
 				<rom name="ayumi-chan monogatari.hdm" size="1261568" crc="9bf209ba" sha1="cc2be00834492b0ccf5b25a1b0a5ceb810a2e330" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ayumi-chan monogatari" sha1="b4adc7cb1f2f74f8beea76afb930d053addea67e" />
+				<disk name="ayumi-chan monogatari (japan)" sha1="d2fe72822ec0e7fbf5d4b0b8ce30b8ad79fed459" />
 			</diskarea>
 		</part>
 	</software>
@@ -3079,11 +3105,10 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="cal">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Cal Towns.ccd" size="953" crc="d6cfe9dd" sha1="e4938344d6242ec8efb79fe5307c55445c7668e9"/>
-		<rom name="Cal Towns.cue" size="112" crc="33ae2e5e" sha1="0672f7eec1748d724095b7d4512b2a94cd9c29ec"/>
-		<rom name="Cal Towns.img" size="59976000" crc="28cf5f0f" sha1="2cf85b59d3a2f5d28fd0267f998389570ef00107"/>
-		<rom name="Cal Towns.sub" size="2448000" crc="764fd5c3" sha1="580edbcef27d5935b83583209ad480d09dc7e52a"/>
+		Origin: redump.org
+		<rom name="CAL - Towns (Japan) (Track 1).bin" size="20815200" crc="3f16c619" sha1="3a1854fce04ba70f778754fff21973366e6b246b"/>
+		<rom name="CAL - Towns (Japan) (Track 2).bin" size="39160800" crc="8593c96b" sha1="4d8b2553c3e41dbf55a0beebd1a2ab286930b5f2"/>
+		<rom name="CAL - Towns (Japan).cue" size="231" crc="17fb6eb8" sha1="fd7c3e1bd38e1e69b99927e275dfaa8622e53877"/>
 		-->
 		<description>Cal Towns</description>
 		<year>1992</year>
@@ -3093,7 +3118,28 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cal towns" sha1="ab905889b8a3edfd7cdfe51c728d017f257e34f7" />
+				<disk name="cal - towns (japan)" sha1="26747efe7dc470bd04af3872c257a670991498e7" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="cal3">
+		<!--
+		Origin: redump.org
+		<rom name="CAL III - Kanketsu-hen (Japan) (Track 1).bin" size="20815200" crc="e7a4625b" sha1="5573990abfbd401f7dc0e6891df05fb661d0204e"/>
+		<rom name="CAL III - Kanketsu-hen (Japan) (Track 2).bin" size="132311760" crc="bfabb97c" sha1="f65dea1be7ce6d5102e2ca19fbe43026b9cac1c7"/>
+		<rom name="CAL III - Kanketsu-hen (Japan).cue" size="253" crc="58fc56bd" sha1="af62c3ec2f8f9c0db1674b8d02b99f01e265012f"/>
+		-->
+		<description>Cal III - Kanketsu-hen</description>
+		<year>1993</year>
+		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="alt_title" value="キャルⅢ　完結編" />
+		<info name="serial" value="HME-243"/>
+		<info name="release" value="199307xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="cal iii - kanketsu-hen (japan)" sha1="7adce4023f809277ce4309b8f285159b921589ba" />
 			</diskarea>
 		</part>
 	</software>
@@ -3345,6 +3391,53 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="chiemi">
+		<!--
+		Origin: redump.org / wiggy2k
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 01).bin" size="31399200" crc="286527ae" sha1="546c782bf12f9d2d64c92204e3b53f19a12fd1c5"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 02).bin" size="23816352" crc="42619143" sha1="c1482839c418c8705e8ae73d3533c0ba7f98f7b0"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 03).bin" size="6174000" crc="0c91acac" sha1="d028c88815a1f0e9d2e70fb634f14101f490ab9d"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 04).bin" size="30870000" crc="5ce57017" sha1="443f512b65730a5d13bb26ceeda63300fb253e27"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 05).bin" size="30870000" crc="699eb0f1" sha1="948e6ece37165d1d336b5eb2260806912ec34dea"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 06).bin" size="40748400" crc="fdc102e0" sha1="49337a0b4fbd61c5c9400e12d93ccf891347ec1f"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 07).bin" size="27871200" crc="ff7de08d" sha1="1ba07789c6e3e2c84743d8bf0dca8a3c5965f281"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 08).bin" size="41101200" crc="06834f32" sha1="5235cc6c9bd04ebee2a5e0bde3b7f6b248bd407c"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 09).bin" size="27165600" crc="a3a89ad6" sha1="e10bf13c3384e6d8368b8446688e333319b4c4df"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 10).bin" size="35103600" crc="3d165d3c" sha1="b02ee7af8cfc74e8e2fc4ad725b3c599ec40bc31"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 11).bin" size="5821200" crc="d0740da8" sha1="70ca1a6786677463c7b942aecb37af8c05be79ef"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 12).bin" size="2469600" crc="6bc3a822" sha1="7f13602935ce28335ad806b08cc0be81680887c9"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 13).bin" size="1058400" crc="e0e9caeb" sha1="707eb37890638680247262bb36c3f5099af64992"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 14).bin" size="32810400" crc="be6b8c6c" sha1="7739e705be4a7e772b5b14bfb3c5624ba28cf06b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 15).bin" size="31222800" crc="b58e2405" sha1="92c5a72d96f1f696f148e9923213cdd38b40ab81"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 16).bin" size="41277600" crc="ad6f2bf8" sha1="96d13571993b309204023af5f8b19ffd3177710c"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 17).bin" size="11642400" crc="dfa70b75" sha1="1e17c3307196ec0ef838cf7db46243c27c0c199d"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 18).bin" size="53802000" crc="da940b3d" sha1="cf9cd5b7dc4fa3421416ea66f1ef32cf8ac024fb"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 19).bin" size="30693600" crc="e292d51b" sha1="f52e8faf3ea2468f78cac37cbe7008d4c5e0bdb2"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 20).bin" size="1058400" crc="682b5602" sha1="5ac3ddcefe255704586ea634bc8a2078d10d81bb"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 21).bin" size="1587600" crc="3ac9ae1f" sha1="3616c0a7cc1ec336dc0d7fd40c7bb5c4d0a2f353"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 22).bin" size="1587600" crc="8f3f9ef8" sha1="c65ce38405157ed671253f3478d63e1c651a1d0b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 23).bin" size="22932000" crc="6ef7fe0d" sha1="123112b8f2c7ae0fa7e1a84d7aecdfa5daa0330b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 24).bin" size="1940400" crc="500763cd" sha1="b0abbabe9b29f9e626a89e30e3c8cbe7baba1f01"/>
+		<rom name="Chiemi &amp; Naomi (Japan).cue" size="2813" crc="5e8b2677" sha1="7f07cbe86e4eee8e3d9f2a4b5dc82f5f0deee491"/>
+		-->
+		<description>Chiemi &amp; Naomi</description>
+		<year>1993</year>
+		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HME-244"/>
+		<info name="alt_title" value="稚恵美＆奈緒美" />
+		<info name="release" value="199312xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="chiemi-and-naomi.hdm" size="1261568" crc="7b3706d4" sha1="a63be0d0426e54291586f8d246c4fab58630026d" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="chiemi &amp; naomi (japan)" sha1="dcdb4cccbce006739a1d48959fc7514441b2240c" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="chuumon">
 		<!--
 		Origin: P2P
@@ -3499,11 +3592,26 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="cm2itsuk">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Custom Mate 2 &amp; Itsuka dokoka de.ccd" size="4020" crc="eb37b9d9" sha1="47395b77c3fe7de2ac325e0c2463f560351be37b"/>
-		<rom name="Custom Mate 2 &amp; Itsuka dokoka de.cue" size="768" crc="a8faa951" sha1="c05a7f2e2d3ddda885bc16800787698ce1eba23b"/>
-		<rom name="Custom Mate 2 &amp; Itsuka dokoka de.img" size="477531264" crc="c7830bbe" sha1="8f95cbec78826c280d82bf2347d53bada974df74"/>
-		<rom name="Custom Mate 2 &amp; Itsuka dokoka de.sub" size="19491072" crc="c171c2e3" sha1="74b537a43e564d6df407b9fd43c1ddbda5603a05"/>
+		Origin: redump.org / wiggy2k
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 01).bin" size="20610576" crc="4dec490b" sha1="731ce1099139ceeeb7201e347cd2792a3f409271"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 02).bin" size="36164352" crc="35c40c78" sha1="1022d98e43b9422603685d9665d860b2d77225b5"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 03).bin" size="31229856" crc="fa3c547c" sha1="0469a8d015ea76a51520747de46f3d5b99c77819"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 04).bin" size="44807952" crc="8063e979" sha1="59fa6182a0948342d564a0b281910c5575618edd"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 05).bin" size="43984752" crc="0c7f6474" sha1="737a5181a8e9cc71ae5d91375cbe07535f2ebcce"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 06).bin" size="11854080" crc="cb2c5b63" sha1="7f615ff8f440efd0ce549927f3fd1625a08c9c13"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 07).bin" size="51776928" crc="5679504f" sha1="84322a5530cb46a984e4914ca922c1466aa80fe1"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 08).bin" size="20304816" crc="54ca92dc" sha1="a567c043ee848d7322c3c0d021ac44fd03f4f357"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 09).bin" size="1441776" crc="df089697" sha1="f07a880ea3edc9d32788c65d9581d456c88105ce"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 10).bin" size="22050000" crc="a49b06e6" sha1="67091896e0df33ec8bfe02ba635f146ced7c54e6"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 11).bin" size="19669776" crc="7c3d1017" sha1="807886c66e1c737e988a8881a23309cc2071071f"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 12).bin" size="31871952" crc="83e9162a" sha1="477bc0738881fc0a6ab102d3a08467e1a1159403"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 13).bin" size="45109008" crc="d9544545" sha1="571a8d0382919adb37033525e4f4a094591688af"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 14).bin" size="34753152" crc="1455518c" sha1="c999f4716a8c546e0a8f8d5b35c317225cf3f50d"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 15).bin" size="14116704" crc="24d440b0" sha1="24e76717849a5b606a241cc11778e32b17bf98a2"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 16).bin" size="1413552" crc="e51fb3a7" sha1="c7815d34e45463aba518ba94b9a1edfbaddc42ff"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 17).bin" size="23051952" crc="77db2c6d" sha1="93761f9872059472667cb4a092ce20927dcbac8f"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan) (Track 18).bin" size="23320080" crc="cc6cdbe8" sha1="d209ef89f1ecac14725e9d0aada727dd67ee6564"/>
+		<rom name="Custom Mate 2 + Itsuka Dokoka de (Japan).cue" size="2435" crc="21bfdf02" sha1="8a80a7fc4e635cc56322e318231a23461b2ca54e"/>
 		-->
 		<description>Custom Mate 2 &amp; Itsuka dokoka de</description>
 		<year>1995</year>
@@ -3512,14 +3620,13 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199508xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Save Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="custom mate 2 &amp; itsuka dokoka de (save disk).hdm" size="1261568" crc="aead04fb" sha1="70197de9a7a138209b7e726063b5bca8f6534575" offset="000000" />
+				<rom name="custommate2.hdm" size="1261568" crc="7ea7f95a" sha1="23be34e523e56b51934b0428f4afeeda1243cdca" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="custom mate 2 &amp; itsuka dokoka de" sha1="c7671fa372beae381bb95728ac85793fd0a0ccc7" />
+				<disk name="custom mate 2 + itsuka dokoka de (japan)" sha1="99441d82ee2cd9f5f8e45e2a6fc7168646f98413" />
 			</diskarea>
 		</part>
 	</software>
@@ -4609,6 +4716,109 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="eikanwa2">
+		<!--
+		Origin: redump.org
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 01).bin" size="15170400" crc="4c27211b" sha1="9ef5515bb9af19f0042aab1518fa813751f2a372"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 02).bin" size="1234800" crc="6d7c8c62" sha1="65647ca31ffaeb3d35a3c651d69f48672f451d2d"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 03).bin" size="969024" crc="48e072cb" sha1="050481aefd3e63e039a7c78a99e76a8a5c2260ec"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 04).bin" size="924336" crc="9c81bfc6" sha1="b231da6ee51756c5760a808535fa82a8e51034b8"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 05).bin" size="964320" crc="0969ba5e" sha1="71871e81bf1a95d3967cde45242fb5b9d9478769"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 06).bin" size="893760" crc="1b4d06b3" sha1="a11c9ae781f1ff0838c28139f8d50c75ba3c909a"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 07).bin" size="910224" crc="5d7d0c1e" sha1="0d901f698ba8967884b74753e6ffcac3f975dc8e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 08).bin" size="959616" crc="f9e6dcae" sha1="0072c600205849821bca888a9e64e737d7bc147c"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 09).bin" size="945504" crc="e816b39e" sha1="f59550fe23bba3e3d63ad8bbc66cee882b9c1b9b"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 10).bin" size="952560" crc="a8bccb2f" sha1="36414944eef3d1e185a09221a248d7132c9cfa4f"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 11).bin" size="987840" crc="1649c336" sha1="e8489d86b2415eb889667ec4e9596dfca851bb77"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 12).bin" size="1093680" crc="2aa362e0" sha1="491451f9dd0bca17ec626b1f627e3c11a2a29ed7"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 13).bin" size="900816" crc="d9794b7a" sha1="dad6ee4355daba08887222e86327b4511883346e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 14).bin" size="992544" crc="847d301f" sha1="08b1cfc67ee7ac53b604d76417e6e8658f91ea6f"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 15).bin" size="1100736" crc="01eea6cf" sha1="3e16789f7037613e2a5fada4dd806b1a7eb6869e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 16).bin" size="898464" crc="b1365102" sha1="396cf5a89909e79fe6b7c1ea6093564b05e9d3ec"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 17).bin" size="1152480" crc="59e18eca" sha1="c9b5d59b24cd2372a30d4d5a72ec608c7aa77cab"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 18).bin" size="865536" crc="6d352f4f" sha1="733111c696e1fc1833f6b1e5f1ec73f757771a58"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 19).bin" size="1246560" crc="cf7df391" sha1="be21df9ecc429646c5ebd18d948bfd69a0a8eed9"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 20).bin" size="1274784" crc="d2250e09" sha1="e430ab9c2921e2eeb42b177a13979b087b88e7e8"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 21).bin" size="1300656" crc="08f2a072" sha1="797f153354eaf418ac3cb17775dd8f4b5e867635"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 22).bin" size="1176000" crc="6e16e4b8" sha1="72844509c814c94336373816d6e176d3352330b9"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 23).bin" size="1133664" crc="ab81e57b" sha1="ea601b9fe82f17a37b7ae6258832067932ea5500"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 24).bin" size="865536" crc="0698833b" sha1="fa857311eefc437a73297a3a6958ef957b71e366"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 25).bin" size="969024" crc="9dee6092" sha1="db7453a010447f99b5bb500807739c3fe1e03dd9"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 26).bin" size="924336" crc="676af92c" sha1="8fb10b5485073ebc696bf4f84a76154b9dc30522"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 27).bin" size="1027824" crc="d18ddcc0" sha1="88add9cd498ef945b2244fdb9e63406ebf724d30"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 28).bin" size="987840" crc="6ea76406" sha1="eae902412d4e131d298b2fc7b606dde2c4b49c57"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 29).bin" size="917280" crc="8e2f0337" sha1="f73730dc4ab89bf9665445fa5f3948714e33317d"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 30).bin" size="787920" crc="066b7be4" sha1="4a975b62b2da563f2c1f7f7e660c25a61a0a84ba"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 31).bin" size="846720" crc="d31b95d1" sha1="3431508ddf62a6ee131c138f8daed5f45e621371"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 32).bin" size="924336" crc="0f3fed91" sha1="8b66da51f70d5182fc89a4fb832867997c44517e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 33).bin" size="823200" crc="ebf225f4" sha1="c245f34bf502632c5b7551bc2f3ff75e1840b158"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 34).bin" size="823200" crc="fbd4caa9" sha1="0f62179a95ec1975b180a84e8588473e68e257ee"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 35).bin" size="804384" crc="fec0ca14" sha1="5bef9aa3ea7881771bf3ec042b1af2e571351009"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 36).bin" size="870240" crc="4edd4f0d" sha1="a8a361cdb99ff6786d2f2824968599e7897762ce"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 37).bin" size="776160" crc="47c085ce" sha1="e386bd54e858aecd0760c2094454bd7d21e561cc"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 38).bin" size="818496" crc="eb264ce2" sha1="b66c204a30d77ff2b28f1979c06ba9bf3916bae6"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 39).bin" size="858480" crc="42388508" sha1="b7da9e5f0000e8729c02e4334b3f73258466691e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 40).bin" size="811440" crc="ebd6b718" sha1="52847b6c5802dd0d49a094c5d80727cdfb1f9f0a"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 41).bin" size="870240" crc="5152bd4f" sha1="1b3e8dc79258502492ece206120bfb0a2ffdc324"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 42).bin" size="1305360" crc="0c4bfe00" sha1="50f27ad41df10b06f83db2633671da190eb9560f"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 43).bin" size="1380624" crc="0728a9d9" sha1="1f1ab3be6a84f83529face6040dd854c5e1bd44f"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 44).bin" size="1387680" crc="3b338b3b" sha1="37f2c78cd90b7683b162b19cc37eb429134674d2"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 45).bin" size="1371216" crc="3ae0a37b" sha1="d9515592b796c0e83bd6fc2a890b501c06cd634a"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 46).bin" size="1580544" crc="6b598d20" sha1="398a00a91cfc79a8df8e269b29bb2c6d945ba5e3"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 47).bin" size="1375920" crc="5678c6ac" sha1="a664688d97107583391536a48ff23b12a01b1b43"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 48).bin" size="1317120" crc="1401baf4" sha1="750f74a3ba08e23a25f768bc726a3ea13541bf19"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 49).bin" size="858480" crc="c84e4926" sha1="e473e71154c90004dbf99083ef9a84213b8671d4"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 50).bin" size="1030176" crc="544073c5" sha1="2873ccf38192970913b25d09fd06b4343b40b40c"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 51).bin" size="1023120" crc="df38a9c1" sha1="991505e9bc067eba78b5904b5bb183482d000a63"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 52).bin" size="1121904" crc="c53248f7" sha1="7e185de323013f0459ef6302be03277a3bd1f35b"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 53).bin" size="994896" crc="902e0caf" sha1="fa51e8260ea9749d3a9d425bde794ff5b8dc9c70"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 54).bin" size="1027824" crc="0948d34d" sha1="7a7f493d5c042dff42c34dbb290e2fbd41b6be62"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 55).bin" size="1046640" crc="af5d5b30" sha1="1baa3975c85af66821d6e409c5cf64f59a95da1e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 56).bin" size="964320" crc="c53e9ff9" sha1="78531da490bfe4f9e9a0b7d5674f53f66ccea01f"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 57).bin" size="940800" crc="501135b9" sha1="ca62d2a99a3fa38da7878b6aaab81412725a1a41"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 58).bin" size="971376" crc="f0184f54" sha1="f69bed9f700e321ebc55b53e14b79b25df09d030"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 59).bin" size="834960" crc="908e3909" sha1="d7ec3414589706c3538637759923c2d1433a34df"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 60).bin" size="910224" crc="10351b92" sha1="927acb8df2fe87871880ef179564607b83263467"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 61).bin" size="877296" crc="1be12e72" sha1="f0d686c3635487d8e79cba1a0afdd495f7728616"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 62).bin" size="1027824" crc="ff7c3419" sha1="7262b70951d5c06b15377435865991c708594bc8"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 63).bin" size="971376" crc="eb86c921" sha1="e3907feceee90a7c2aef0c609bfd77877e5b7508"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 64).bin" size="874944" crc="b5422667" sha1="a7ac6d0c231ec92366815901f50b452d573b9e34"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 65).bin" size="858480" crc="92fd68e9" sha1="758374028fed4b8255ff713f69fdf0fac2f1ae09"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 66).bin" size="1077216" crc="2641d441" sha1="2390e0256695944ca111e4ae06fe8ed54ea7f5b7"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 67).bin" size="1034880" crc="2bf9d242" sha1="666be2d3ae95b6cf8ce5fdd7c3ab262f1a4a956a"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 68).bin" size="1016064" crc="64d1f66c" sha1="e1d342d1a90d9813a570bc1f2662fa60bac6fe5c"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 69).bin" size="1006656" crc="b11468e3" sha1="a77fa028a44fec052bab5568d28db9cd70b74ddb"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 70).bin" size="905520" crc="bd4d5e28" sha1="b9c1fe3a123fd185110ed81628176651b762f926"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 71).bin" size="910224" crc="3b918d5a" sha1="30eea5e93de46b80faf59286b9ab6a6ea454e0bd"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 72).bin" size="983136" crc="71504c24" sha1="13e19b878d05acaa1b029699b0927cc8b2e79d02"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 73).bin" size="976080" crc="3fae2553" sha1="80e0f0eaaf1c34737e55ee60293c5b580e8b5bc5"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 74).bin" size="1086624" crc="65b37dd4" sha1="f6a6ee866301f410da6dfd9c4d6c08b91800b39e"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 75).bin" size="870240" crc="a7a474c1" sha1="bcbdc7525def350019ef56a26aada1cb16f733cb"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 76).bin" size="917280" crc="abd16e63" sha1="0fc858a994685bb82f87f216ac221cdb5c27f4f9"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 77).bin" size="952560" crc="4d815b28" sha1="e02390b9c17eeb94a71e40d3e38c03bd040061e1"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 78).bin" size="1006656" crc="51411ed8" sha1="a0c05a599998cc12cb93583c6c491881430888cd"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 79).bin" size="1121904" crc="80eb7089" sha1="4567576c9780b9344907858927e032fd011bd2c5"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 80).bin" size="1081920" crc="00fbf7d9" sha1="ba6eed86b843ed47c6ace8570b174b058268c538"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 81).bin" size="707952" crc="2b65a541" sha1="ce478d5ca1fa75f81c65010e1ab2c1c884eeebff"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 82).bin" size="1879248" crc="9be86d25" sha1="0f6778b8e08cbcb7a942abcd5604f10cf4b87ff8"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 83).bin" size="1011360" crc="43933954" sha1="20d59c5c5f0279236d405710a0988b14ff672251"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A) (Track 84).bin" size="705600" crc="47930701" sha1="186c826d96d1c495e68454d2b978a008660e6bc8"/>
+		<rom name="Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai (Japan) (Rev A).cue" size="11559" crc="c99722d6" sha1="e6dea6fb475966b0acad96bfb93d2fe438bb8126"/>
+		-->
+		<description>Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai</description>
+		<year>1991</year>
+		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="HMC-144A"/>
+		<info name="alt_title" value="栄冠は君に2 高校野球全国大会" />
+		<info name="release" value="199108xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="eikan wa kimi ni 2 - koukou yakyuu zenkoku taikai (japan) (rev a)" sha1="401f46c7f782b07f8668b64cb49a6e17340da534" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="eimmy">
 		<!--
 		Origin: redump.org
@@ -5291,6 +5501,98 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="fmtappc">
+		<!--
+		Origin: redump.org
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 01).bin" size="15530256" crc="52d70dcf" sha1="b0e1be696a0c8ac9eff53c3deb257d1f2e0050b0"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 02).bin" size="11795280" crc="91ca7078" sha1="3897df329d788a7645eb4bd0470da1cc7184a738"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 03).bin" size="14676480" crc="551b385d" sha1="cbfffe21b173e8ad745c8d900ac61dbbda868565"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 04).bin" size="11611824" crc="89c3f5aa" sha1="774d97b815315d361080fd0f4afb79082069b069"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 05).bin" size="6475056" crc="dbfb4209" sha1="3c9ee47b65b0574843116569e64955c8ef391220"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 06).bin" size="14281344" crc="e3c1b1e9" sha1="ff298a60c6510824d84c8531dc5853d740231b79"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 07).bin" size="9085776" crc="5c1e5640" sha1="ac77e27ba0cae179d697047016cd66f32feb0733"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 08).bin" size="7397040" crc="dc349201" sha1="f58ab81b913f3e99bae8234c00d33a11cc25a607"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 09).bin" size="4520544" crc="de298a86" sha1="9935e1f8ba22b7a760e26ab7e1d61325e9f110de"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 10).bin" size="6686736" crc="186ac46c" sha1="9e09cc82e1a22ce3b87a1531fbed0ffc8dc62a45"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 11).bin" size="5555424" crc="3e6b9143" sha1="dfbffd1cdca803042193e69263c44450ea6430d1"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 12).bin" size="13759200" crc="39f80329" sha1="487a5aec9b84cc81954d656b20b90e68164f22d5"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 13).bin" size="5875296" crc="7b95564e" sha1="ba6aaa226dbbb6fb7444785c10ec0fe31d322dd7"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 14).bin" size="7883904" crc="87abec76" sha1="11bf007d5f93c855f1eb5bf51cffffb5fd25858c"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 15).bin" size="6832560" crc="aafdb4a9" sha1="f921350ea1f5d0b4ab8a650326e815d5ded3313b"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 16).bin" size="5369616" crc="9d41de95" sha1="a8c5536bdf4123e1d5bb0442287d54530569c462"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 17).bin" size="7554624" crc="f34ac613" sha1="c706373067d90a07cd28f5a4fc8f18b2858ff42d"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 18).bin" size="7968576" crc="626b0189" sha1="37ace62c153a7a39d0b4caa2ab23a44e4443bbb5"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 19).bin" size="9925440" crc="e5a6831a" sha1="b2524e63dd49361a6dcbeb9f06778abab14f3761"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 20).bin" size="8707104" crc="52b2cfbd" sha1="a0e0d4174112132917645d683d59993f2aecc17f"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 21).bin" size="5339040" crc="6acf3956" sha1="a5bbe2833989d024c87e7cd5a67781a426fe5b58"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 22).bin" size="5433120" crc="06866fab" sha1="7d29ae9c74e8f2a38c32480e270b5a45d1a6165a"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 23).bin" size="12237456" crc="9e59fcec" sha1="8659392e97f0decb1b59c71c6f3d675022ff5953"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 24).bin" size="7437024" crc="2ce72622" sha1="05b13ac41177b33ce444ee5cffd4c0dea62f5c0d"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 25).bin" size="4915680" crc="c4c936f1" sha1="88d363a78ce1c0a6a342ad02ae5d9319204189ed"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 26).bin" size="5515440" crc="5cc0e731" sha1="6c65d9d7b24700c1e5bf8c9ddeac0110da2ddfd0"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 27).bin" size="12566736" crc="b670082d" sha1="6fbd7648022733af27edda78068c493baa47ccc7"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 28).bin" size="5578944" crc="19e43fde" sha1="7e979c1cd3e612efc9e3c50ef982374fac0107c8"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 29).bin" size="6157536" crc="d39a2578" sha1="e362f29f3ad1b128cf15da2eda43ab60d21df49e"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 30).bin" size="7013664" crc="bb6570a7" sha1="2736ab486adf032000253e9cf902e0cacd50edf4"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 31).bin" size="5134416" crc="0cb7bdf1" sha1="dc08ba573bfab75b93510f2ecd47543edf69c9da"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 32).bin" size="7655760" crc="44e472b7" sha1="798e3059631b6f4d12cfe9c3928facd3532ea297"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 33).bin" size="11195520" crc="c603ec65" sha1="875fbe4a8abbd9f77f8b938a60f01ac2012b0d0b"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 34).bin" size="6213984" crc="3063af33" sha1="ca452a70a4d2de33220343a3e97bae1dcb95656c"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 35).bin" size="5703600" crc="951aa5b8" sha1="cfe2196dc462434aee47918cc6a9e684982cdf79"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 36).bin" size="4475856" crc="b4705502" sha1="041a6bad485af5a3fb7c0ad43a3769c6e6991264"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 37).bin" size="11324880" crc="161f08dc" sha1="04ce4b1db5f5d2aa577e2e9c25c27db698fac31a"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 38).bin" size="5738880" crc="256b1e0b" sha1="9975a308311711f93b10fcd77f50f4d623765a9f"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 39).bin" size="5480160" crc="74875fd6" sha1="5a4bd6d50efb412ce6f12e874d8a7aafaa680560"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 40).bin" size="5868240" crc="f6024905" sha1="f9751e730561594445395ec4e021a5d895f84c7b"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 41).bin" size="5186160" crc="60fd7298" sha1="849886710ecaa6c2083b3b4ea726c8fc12cbdef2"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 42).bin" size="5597760" crc="848345e9" sha1="0582d9c3194cd8b0d850488b3adc0b2c84107257"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 43).bin" size="5473104" crc="1a1fc415" sha1="4452082d53ecb7dfcaaae1860926e705766c63a6"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 44).bin" size="5675376" crc="f553e9bb" sha1="2e2c8be9636ac0aaacf2ad3a2a6e6bee8842d1a0"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 45).bin" size="5837664" crc="7c2f7403" sha1="2d384189ab7d4968e8868be2a4c2e530769d114c"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 46).bin" size="5451936" crc="94ebbc96" sha1="7027c2b8db4f50cac3d6ca5bd755025bf18a8852"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 47).bin" size="6373920" crc="97ed91a2" sha1="dc5d2977b8212662d99d9359a9b3b56847f8f112"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 48).bin" size="5061504" crc="5f61d8d4" sha1="aec035bab19c0c43de1bf2953b6de283467a3f7a"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 49).bin" size="5209680" crc="bf307f54" sha1="4c0472373b5186438a63b3029b535d78ed3de844"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 50).bin" size="5221440" crc="5abe8324" sha1="4bfa5e2315b3c70225a327e6d3792123803a3496"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 51).bin" size="5451936" crc="f5f64a2b" sha1="b655b85a9642e57fc8ec887ab2fa1894135fb93a"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 52).bin" size="6256320" crc="f87cf05a" sha1="72804a863f852dddd72458fb602711875f12336d"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 53).bin" size="5496624" crc="f0fb93e8" sha1="71bb20856fc9b619a8ab77bd9cf4ee66647f2ad9"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 54).bin" size="4809840" crc="705cb5ea" sha1="36a6e2b5fc709db29e49fde476c269a3c3ba35aa"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 55).bin" size="5303760" crc="cbc358e2" sha1="0f74520024d34286aa358903e406d745e9bbcfbc"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 56).bin" size="5240256" crc="35c2aab1" sha1="aa0933e84200d537075079f0b472acdda311763f"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 57).bin" size="5155584" crc="bb17d662" sha1="4d8f76f7fa4f7f956246b4980ed31e5d6cd18c46"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 58).bin" size="5675376" crc="15c5c33e" sha1="cbb75746b57a296ce8fc8ab51f8320b1d4034858"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 59).bin" size="8914080" crc="799ffdb7" sha1="083622cdb8b378ea0fdd027a05757e4f185f9c27"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 60).bin" size="5832960" crc="402204cc" sha1="cd80eaafe94407eada670a69dded64033f0928c2"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 61).bin" size="5762400" crc="6615ec8f" sha1="e4f3aa5e36d3bfc7f17f7db6cd27981480feb17c"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 62).bin" size="6437424" crc="8d7dd7a3" sha1="9afc5234442fbafdb3ce7b7bf6ab915c8e742f7e"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 63).bin" size="5209680" crc="4f611843" sha1="6857a83007540356b818398209e010676b45e8be"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 64).bin" size="4903920" crc="965e8912" sha1="fe7f075d754eb3f573fa3bd6e7b9df03d1344624"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 65).bin" size="5757696" crc="6eb2f02c" sha1="4e3a17734f41c31f9461516b54953d1264333abd"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 66).bin" size="5767104" crc="f4df1ad6" sha1="7929bdeb41c17b797afff1fd7ed30562611f36f5"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 67).bin" size="5374320" crc="abd4d752" sha1="f7be6016137328c5589bdfb1d8b30ad415de430b"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 68).bin" size="5903520" crc="5841a86c" sha1="b5eb4e1e49a192e1d48bc09a9e2cb40fc1d9db4f"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 69).bin" size="4934496" crc="8df58a0b" sha1="59a271b9e6b764f2d0253f40d26eff1d862d781a"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 70).bin" size="5562480" crc="bb0b4d09" sha1="f239bbf2835b839241dd7669e6feb1833f4e88c6"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 71).bin" size="4445280" crc="b15e2048" sha1="621e319be114bee8df009f95e8863f8bf15190a0"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 72).bin" size="5362560" crc="b1f3a777" sha1="b34507b57c8cb20ab36f027f4db66ea6403f29c6"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 73).bin" size="8130864" crc="7f96d8c5" sha1="0eb47882ddee19551cb3960d5b18557c1b4fba22"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 74).bin" size="4809840" crc="0ae6ce5d" sha1="1a201450c74d218e3995014eeb315376b69d5387"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan) (Track 75).bin" size="6174000" crc="0ec56263" sha1="2d2447ec6ddba3d744d60d09b91d3c2989e87b8f"/>
+		<rom name="FM Towns Application Catalog CD-ROM - Original Soft-hen (Japan).cue" size="11832" crc="73362051" sha1="0b00afdb9b2f28fe92a8965e9bb5a73b79143bd4"/>
+		-->
+		<description>FM Towns Application Catalog CD-ROM - Original Soft-hen</description>
+		<year>1989</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMA-904"/>
+		<info name="alt_title" value="ＦＭ　ＴＯＷＮＳ　アプリケーション・カタログＣＤ‐ＲＯＭ　オリジナル・ソフト編" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fm towns application catalog cd-rom - original soft-hen (japan)" sha1="071d7090c1295d610cd9518bd547ab07f6c73ff5" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Seems to be a coverdisc for Oh!FM magazine, would be nice to have more info -->
 	<software name="fmthcdd1">
 		<!--
@@ -5829,17 +6131,17 @@ User/save disks that can be created from the game itself are not included.
 	<software name="g5">
 		<!--
 		Origin: redump.org
-		<rom name="G5 (Japan) (Track 1).bin" size="27875904" crc="5c1f8806" sha1="6bdb36d9a38c50615d9cffca9456e0b49dd9ff78"/>
-		<rom name="G5 (Japan) (Track 2).bin" size="36145536" crc="ce0cb02c" sha1="9176e536a1e8ba977f9a05455f159dadd726af6b"/>
-		<rom name="G5 (Japan) (Track 3).bin" size="156972480" crc="4362731b" sha1="1b9bc817f9cd9450db048989aa0dca0ef06205c8"/>
-		<rom name="G5 (Japan) (Track 4).bin" size="41759760" crc="27534dbf" sha1="1cf94204f04a3f06d8bfd4319e409d1df2716779"/>
-		<rom name="G5 (Japan) (Track 5).bin" size="63685104" crc="4f819e54" sha1="b6c7c708d9f5e935ecbc024c894b95d2482a68d3"/>
-		<rom name="G5 (Japan) (Track 6).bin" size="39901680" crc="fc0d37bd" sha1="19bd225c4f54630cab6cf1018bf9182bbd077a07"/>
-		<rom name="G5 (Japan) (Track 7).bin" size="41277600" crc="8d676919" sha1="edea880a03554aced8b180d44ddf75c251ebdf95"/>
-		<rom name="G5 (Japan) (Track 8).bin" size="164976336" crc="ec9f23a9" sha1="fc7dbf3d7c6194221038581cd439caac5b9261a9"/>
-		<rom name="G5 (Japan).cue" size="814" crc="1568c89d" sha1="290eb5d5299379a25240bef8b3fa43dc4beee7c0"/>
+		<rom name="G5 (Japan) (Rev A) (Track 1).bin" size="27875904" crc="5c1f8806" sha1="6bdb36d9a38c50615d9cffca9456e0b49dd9ff78"/>
+		<rom name="G5 (Japan) (Rev A) (Track 2).bin" size="36145536" crc="ce0cb02c" sha1="9176e536a1e8ba977f9a05455f159dadd726af6b"/>
+		<rom name="G5 (Japan) (Rev A) (Track 3).bin" size="156972480" crc="4362731b" sha1="1b9bc817f9cd9450db048989aa0dca0ef06205c8"/>
+		<rom name="G5 (Japan) (Rev A) (Track 4).bin" size="41759760" crc="27534dbf" sha1="1cf94204f04a3f06d8bfd4319e409d1df2716779"/>
+		<rom name="G5 (Japan) (Rev A) (Track 5).bin" size="63685104" crc="4f819e54" sha1="b6c7c708d9f5e935ecbc024c894b95d2482a68d3"/>
+		<rom name="G5 (Japan) (Rev A) (Track 6).bin" size="39901680" crc="fc0d37bd" sha1="19bd225c4f54630cab6cf1018bf9182bbd077a07"/>
+		<rom name="G5 (Japan) (Rev A) (Track 7).bin" size="41277600" crc="8d676919" sha1="edea880a03554aced8b180d44ddf75c251ebdf95"/>
+		<rom name="G5 (Japan) (Rev A) (Track 8).bin" size="164976336" crc="ec9f23a9" sha1="fc7dbf3d7c6194221038581cd439caac5b9261a9"/>
+		<rom name="G5 (Japan) (Rev A).cue" size="878" crc="38f47687" sha1="07a91d1bedfcf68eb823e892fbc3aba492b6a216"/>
 		-->
-		<description>G5</description>
+		<description>G5 (HMA-206A)</description>
 		<year>1989</year>
 		<publisher>エー・エム・アール (AMR)</publisher>
 		<info name="serial" value="HMA-206A"/>
@@ -5848,7 +6150,39 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="g5 (japan)" sha1="3038fd11e7c7f58b17ef96fb9c872f4c7924915a" />
+				<disk name="g5 (japan) (rev a)" sha1="3038fd11e7c7f58b17ef96fb9c872f4c7924915a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="g5o" cloneof="g5">
+		<!--
+		Origin: redump.org
+		<rom name="G5 (Japan) (Track 1).bin" size="27875904" crc="9e2e9d03" sha1="0b1cfd7cf34ede3beadc4d33603ca8b0e40f6287"/>
+		<rom name="G5 (Japan) (Track 2).bin" size="36150240" crc="2522d5ab" sha1="2c636f310ba9c77efbd5f443e414bf5a8781df06"/>
+		<rom name="G5 (Japan) (Track 3).bin" size="156972480" crc="3dd235b8" sha1="6455c0bca59d35880a46baf3bdf6819105357cd7"/>
+		<rom name="G5 (Japan) (Track 4).bin" size="41759760" crc="97a9806a" sha1="fc5c72858293442d88154cc0387b71a4645b744d"/>
+		<rom name="G5 (Japan) (Track 5).bin" size="63687456" crc="f6aa8415" sha1="580cfa3720bbb96780da93f87847d411eb666ebd"/>
+		<rom name="G5 (Japan) (Track 6).bin" size="39901680" crc="e8c40e4a" sha1="24e50e02cc9e1a5127f07ebad22efa72f5403455"/>
+		<rom name="G5 (Japan) (Track 7).bin" size="41277600" crc="66757946" sha1="0a391ba93651ed185e7cccb1363a0e469939e245"/>
+		<rom name="G5 (Japan) (Track 8).bin" size="164973984" crc="a1d16fe5" sha1="9670631e0201b4d7e3aa756fb33e89015aa4741a"/>
+		<rom name="G5 (Japan).cue" size="814" crc="48fec8f9" sha1="e0b9e5212acb70e90949dc5bc6621dd3e454cb0e"/>
+		-->
+		<description>G5 (HMA-206)</description>
+		<year>1989</year>
+		<publisher>エー・エム・アール (AMR)</publisher>
+		<info name="serial" value="HMA-206"/>
+		<info name="alt_title" value="ジーファイヴ" />
+		<info name="release" value="198907xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="g5.hdm" size="1261568" crc="be71541a" sha1="b6686763b1d4774a623c88bf86eee029224657c7" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="g5 (japan)" sha1="022cce796bb7879860ac6e7955a7de2763910bd2" />
 			</diskarea>
 		</part>
 	</software>
@@ -6605,6 +6939,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="hfetish">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Fetishism (Japan).bin" size="179575200" crc="baef4557" sha1="903b1e7103f30d7791512e4230e0363876585d19"/>
+		<rom name="Hyper Fetishism (Japan).cue" size="89" crc="78b12700" sha1="11ac4d0a5b2bc8e4be1398a47bc7531df46977ce"/>
+		-->
+		<description>Hyper Fetishism</description>
+		<year>1993</year>
+		<publisher>エクステンド (Extend)</publisher>
+		<info name="serial" value="HME-250"/>
+		<info name="alt_title" value="ハイパー・フェティシズム" />
+		<info name="release" value="199503xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper fetishism (japan)" sha1="40052a58a056709334273f5199dfae2bb11db116" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- These CDs are probably supposed to be self-bootable but they are missing the IPL sector. Marked as bad dumps until they are redumped. -->
 	<software name="highlt20">
 		<!--
@@ -7087,6 +7441,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="ilhyakka">
+		<!--
+		Origin: redump.org
+		<rom name="Illust Hyakka - Yamashita Hideki no Ikiiki Cut-shuu (Japan) (Rev A).bin" size="253663200" crc="672e5788" sha1="a53016373fb272b45fc1e96d367432676677ea9b"/>
+		<rom name="Illust Hyakka - Yamashita Hideki no Ikiiki Cut-shuu (Japan) (Rev A).cue" size="133" crc="0528e451" sha1="e6abc2c0f881acd48794d456670e328634482b84"/>
+		-->
+		<description>Illust Hyakka - Yamashita Hideki no Ikiiki Cut-shuu</description>
+		<year>1990</year>
+		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-160A"/>
+		<info name="alt_title" value="イラスト百科　～山下秀樹のいきいきカット集～" />
+		<info name="release" value="199008xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="illust hyakka - yamashita hideki no ikiiki cut-shuu (japan) (rev a)" sha1="b5927af960c7a80087ab24c96cd93f52fc7b340a" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="imgfight">
 		<!--
 		Origin: Neo Kobe Collection
@@ -7423,6 +7797,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="jankirou" sha1="b299d72db8a36c196f6795d450c9541244b1b208" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="jclub">
+		<!--
+		Origin: redump.org
+		<rom name="Jouhou Club - Card Processor Ver. 1.1 (Japan).bin" size="3716160" crc="8e291389" sha1="70e8f87c893567d86896865dd831c1960111a367"/>
+		<rom name="Jouhou Club - Card Processor Ver. 1.1 (Japan).cue" size="134" crc="9ae78bd1" sha1="1529bcd1cc5418c3f3d9cba9f73debb7bc7dfb58"/>
+		-->
+		<description>Jouhou Club - Card Processor Ver. 1.1</description>
+		<year>1989</year>
+		<publisher>富士通ソーシアルサイエンスラボラトリ (Fujitsu Social Science Laboratory)</publisher>
+		<info name="serial" value="HMA-214A"/>
+		<info name="alt_title" value="情報倶楽部" />
+		<info name="release" value="198911xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="jouhou club - card processor ver. 1.1 (japan)" sha1="84c7c26036a354c170f5fc9f638ebc52df02eeca" />
 			</diskarea>
 		</part>
 	</software>
@@ -9066,6 +9460,41 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="mjmusashi">
+		<!--
+		Origin: redump.org
+		<rom name="Mahjong Musashi (Japan) (Track 01).bin" size="2116800" crc="dce5d3e3" sha1="b59c50df396bcb355f547548bac83a12606a0d5b"/>
+		<rom name="Mahjong Musashi (Japan) (Track 02).bin" size="35103600" crc="e2bfa0a1" sha1="4f64e1ea6b9c3809e77bd769bc376af713bd8a9b"/>
+		<rom name="Mahjong Musashi (Japan) (Track 03).bin" size="35632800" crc="a310cf04" sha1="72ae2679d9c97c8191b898ae8bcd1e1cc37ad446"/>
+		<rom name="Mahjong Musashi (Japan) (Track 04).bin" size="41277600" crc="3cf5de10" sha1="75c345d1fe6ce2d47d4faf218564d6e2a1621e0b"/>
+		<rom name="Mahjong Musashi (Japan) (Track 05).bin" size="37044000" crc="4bb2d45c" sha1="c48d1122d24d6b9182e85fe6557e8c898ba59523"/>
+		<rom name="Mahjong Musashi (Japan) (Track 06).bin" size="26283600" crc="0cf5e1cf" sha1="44aeb1a5f18bcf2894e8b6e48ec5635afc0c8b3d"/>
+		<rom name="Mahjong Musashi (Japan) (Track 07).bin" size="21873600" crc="eec8a770" sha1="59420ec16f1d44a8902a3bf5f4845e832c16ba3e"/>
+		<rom name="Mahjong Musashi (Japan) (Track 08).bin" size="27636000" crc="abb0b64e" sha1="3912d6f930cffbd734cfeae5c79fbc51a936bd7b"/>
+		<rom name="Mahjong Musashi (Japan) (Track 09).bin" size="35338800" crc="c981b2f3" sha1="47f78eb5b765a6b8ad9b453ba276692821093725"/>
+		<rom name="Mahjong Musashi (Japan) (Track 10).bin" size="46746000" crc="2c51841e" sha1="875d01beb4db378a0d99b33901e4d6211fbbf4cf"/>
+		<rom name="Mahjong Musashi (Japan) (Track 11).bin" size="61916400" crc="a763b86b" sha1="c8483a5a4470dd18db87f1f8e72e71c52b192a75"/>
+		<rom name="Mahjong Musashi (Japan) (Track 12).bin" size="44100000" crc="27ebd76b" sha1="f1566b1f9a515bfdab25b3b2ad92056b727f30c5"/>
+		<rom name="Mahjong Musashi (Japan) (Track 13).bin" size="39690000" crc="677b0650" sha1="f5d0a550a3c16ea766a1dcc99d1289d104088b25"/>
+		<rom name="Mahjong Musashi (Japan) (Track 14).bin" size="37044000" crc="d5e0c6d4" sha1="c6767fffccd7992c5102fbed2aaa81ba29b28e05"/>
+		<rom name="Mahjong Musashi (Japan) (Track 15).bin" size="31752000" crc="c8330e9c" sha1="1ff83cbff57d5b0a6b6c734ac1cbb8f87673c397"/>
+		<rom name="Mahjong Musashi (Japan) (Track 16).bin" size="39337200" crc="4169578d" sha1="0794f8cd69858145de00fbd35fae9b9cbea347dc"/>
+		<rom name="Mahjong Musashi (Japan) (Track 17).bin" size="38278800" crc="505c076e" sha1="7d0f6906a7a2fb491c7b7e2ddbd809dec7393f55"/>
+		<rom name="Mahjong Musashi (Japan).cue" size="2011" crc="f990d3ec" sha1="a47ca93db234129c16ad23fe5eeacf73153d9aa0"/>
+		-->
+		<description>Mahjong Musashi</description>
+		<year>1989</year>
+		<publisher>コスモスコンピュータ (Cosmos Computer)</publisher>
+		<info name="serial" value="HMA-224"/>
+		<info name="alt_title" value="麻雀武蔵" />
+		<info name="release" value="198910xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="mahjong musashi (japan)" sha1="b283dc621d3ae7e4cb46b6a42648ff7b795355bf" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="mjripple">
 		<!--
 		Origin: redump.org
@@ -9102,6 +9531,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mahou daisakusen" sha1="534e04e71d29907098b0c0151b69de70ba37570e" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="manadoko2">
+		<!--
+		Origin: redump.org
+		<rom name="Manami no Doko made Iku no 2 - Return of the Kuro Pack (Japan).bin" size="12376224" crc="81fd5145" sha1="8f2ceebf79dc77fa29a788ec05ede101d6045de4"/>
+		<rom name="Manami no Doko made Iku no 2 - Return of the Kuro Pack (Japan).cue" size="151" crc="7351f4ca" sha1="3914f29f9afd579a56aecb42c478f9b170bded64"/>
+		-->
+		<description>Manami no Doko made Iku no? 2 - Return of the Kuro Pack</description>
+		<year>1995</year>
+		<publisher>ウエンディマガジン (Wendy Magazine)</publisher>
+		<info name="alt_title" value="まなみのどこまでイクの? 2 リターン オブ THE 黒パック" />
+		<info name="release" value="199505xx" />
+		<info name="usage" value="Requires 2 MB RAM and mouse on port 1"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="manami no doko made iku no 2 - return of the kuro pack (japan)" sha1="026662a39cda929bcc4b33110b0192f92f09d398" />
 			</diskarea>
 		</part>
 	</software>
@@ -11783,27 +12231,79 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="prostudg">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Pro Student G.ccd" size="3122" crc="432b8400" sha1="4924d961cfd32c8801b895a2ba38c24b07e75150"/>
-		<rom name="Pro Student G.cue" size="1055" crc="c2d44694" sha1="bb660cfa5764653f9241f038771f5c7ba98f5bf2"/>
-		<rom name="Pro Student G.img" size="602504784" crc="ea3e84ba" sha1="ea6bf35f3450cfb981f284bd9e2cd48ac4bc5345"/>
-		<rom name="Pro Student G.sub" size="24592032" crc="10d9ec13" sha1="1a8d47c6314b40e69aa6260cd0a60e837f18a19f"/>
+		Origin: redump.org / wiggy2k
+		<rom name="Pro Student G (Japan) (Track 01).bin" size="20286000" crc="67a54813" sha1="e2addb84d76ae60d3dd633a542c42e0147d97eff"/>
+		<rom name="Pro Student G (Japan) (Track 02).bin" size="54571104" crc="162e066d" sha1="6f6899b1aabe1d4ed44b32e1d31ab17112b7422a"/>
+		<rom name="Pro Student G (Japan) (Track 03).bin" size="52155600" crc="94f2606b" sha1="1c5ddf807d30040f3a75b17bcdd827933582c542"/>
+		<rom name="Pro Student G (Japan) (Track 04).bin" size="54408816" crc="bcc0c436" sha1="10ed1a515e6d7abe5d1d736a64448fd4ba41bf28"/>
+		<rom name="Pro Student G (Japan) (Track 05).bin" size="56459760" crc="aea89d20" sha1="cbb126d749bb288c34be7ee35ae1f6574f5080f6"/>
+		<rom name="Pro Student G (Japan) (Track 06).bin" size="54406464" crc="3633cb42" sha1="71d0c3d3492d91f9274529edaea9de0f7492ab5a"/>
+		<rom name="Pro Student G (Japan) (Track 07).bin" size="52491936" crc="346903b3" sha1="162cac12ead048ccee468e956edd3db6dd449728"/>
+		<rom name="Pro Student G (Japan) (Track 08).bin" size="54437040" crc="153c7795" sha1="770993b28de6a3882e8c33a762bcc4327d1f4cdd"/>
+		<rom name="Pro Student G (Japan) (Track 09).bin" size="54495840" crc="ac9cdad5" sha1="a352c23e8c8bee8b3d8eddfba379cfdd8a9079a6"/>
+		<rom name="Pro Student G (Japan) (Track 10).bin" size="54813360" crc="0c1747ce" sha1="4f3906500bd4cf59c14ba711588209a61b9bbe85"/>
+		<rom name="Pro Student G (Japan) (Track 11).bin" size="49337904" crc="b2d97770" sha1="22940f081f1c97174d92b93d1d7fd0afbb3869d1"/>
+		<rom name="Pro Student G (Japan) (Track 12).bin" size="7444080" crc="08bf76fe" sha1="04f4836ce9db4888f3079f1d7d8fc4dfe29c3bf3"/>
+		<rom name="Pro Student G (Japan) (Track 13).bin" size="9744336" crc="8c52e5e6" sha1="081eab9dad0758f954e5a0ab15b1a29d4f59043a"/>
+		<rom name="Pro Student G (Japan) (Track 14).bin" size="9137520" crc="730ef897" sha1="21f8e40623324ededf87fa75365927b1b6d7ff08"/>
+		<rom name="Pro Student G (Japan) (Track 15).bin" size="8761200" crc="fce73c9f" sha1="2d34703f83b64502d499102aa4d0c0d498a65d31"/>
+		<rom name="Pro Student G (Japan) (Track 16).bin" size="9553824" crc="90c2763c" sha1="5ffd6a802aaf276ccb8fe5fe1d4bb785b8d0e44a"/>
 		-->
-		<description>Pro Student G</description>
+		<description>Pro Student G (ALS-0004)</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
-		<info name="serial" value="HME-171"/>
+		<info name="serial" value="HME-171 / ALS-0004"/>
 		<info name="alt_title" value="ぷろすちゅーでんとG" />
 		<info name="release" value="199307xx" />
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Boot Disk" />
+			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="pro student g (boot disk).hdm" size="1261568" crc="a068feeb" sha1="fa5e5b185cc452e9fa252eac61eb6f8a133cc080" offset="000000" />
+				<rom name="pro-student-g.hdm" size="1261568" crc="b3786aa4" sha1="1b0f9cfcf93a15c7d063872877b1fcdeb6fd1d44" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pro student g" sha1="a7675c732045804fbaf292a191eb1967f98894a4" />
+				<disk name="pro student g (japan)" sha1="f4873e000d4070c1621bded2b33f785f7ff2de38" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Apparently the BAT file that launches the installer is incorrect? This needs to be investigated further -->
+	<software name="prostudgr" cloneof="prostudg" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 01).bin" size="17578848" crc="1c135323" sha1="5ac9502fb8403ae6758bfb1987b307551c4aa64a"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 02).bin" size="39690000" crc="b90fdc51" sha1="1116aeaa041c448af34b50bf5a950ab2128094b6"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 03).bin" size="37044000" crc="5cf5891b" sha1="c9c5e3788cd0ca592ae48c99571504299faea51c"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 04).bin" size="34221600" crc="48d69882" sha1="5f0ef4164da83f9e6df3984101f2dc9e152924cd"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 05).bin" size="34927200" crc="8fab8c62" sha1="806a9e5ffe9a44a24a0b06f0daa1f4f2388b5ffa"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 06).bin" size="35280000" crc="d2c122fc" sha1="522fdc34d23fd590ea6104f03e3713cc2f17eaed"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 07).bin" size="38455200" crc="a406d437" sha1="d2ebee07144e231056a7f9322504c341b5492a66"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 08).bin" size="40219200" crc="b07efecc" sha1="4acc0e2854a467c4372232f0e75ef052dc254932"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 09).bin" size="40572000" crc="06cc5fa2" sha1="17413d5c3022bd3d9c0948475ac2f3bb60a34077"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 10).bin" size="42336000" crc="7e370915" sha1="bf8795c013c170c38439ebdf6aa99a96df97fe01"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 11).bin" size="36338400" crc="467afaa9" sha1="92dc0fad6abd5f96f8f140d6e18b4c4aa1c120ed"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 12).bin" size="35103600" crc="403e89ae" sha1="984441b0dca2bf82cb26ced130403b0be44aeb14"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 13).bin" size="38102400" crc="d328b087" sha1="302ef11c3a573abe7074ad8037fa5aef19cd6979"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 14).bin" size="36514800" crc="88a78af9" sha1="1fdf76aaf88357e0abd39931ecff4e60b5636ea3"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 15).bin" size="36162000" crc="0b6aefcc" sha1="d03e2ab593f0a3f4947141092d28d19b99e0473b"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 16).bin" size="37220400" crc="80292d1e" sha1="fb913d4512db6e1b54eb4b9f1dae3736f74f8f31"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 17).bin" size="7761600" crc="dd48a75c" sha1="c19375235bd173043baefa837f5c542eaf41d7d2"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 18).bin" size="9878400" crc="11683d0d" sha1="abd580333025a8abbb65a108d57f2bf71196153b"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 19).bin" size="9349200" crc="e419c606" sha1="fd3d6047d07cd4d0fddd22ec468068f4cc145944"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 20).bin" size="8996400" crc="3bc95efd" sha1="cbe9f1be6fd040c05b8837af4beaf2f201a34ba5"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 21).bin" size="9878400" crc="cbd9495f" sha1="916d94dfe84edc954d6a1a6b40051ba534bef120"/>
+		<rom name="Pro Student G (Japan) (Rerelease).cue" size="2670" crc="b270fa34" sha1="87898b38c2fe1ed83a633444408d4b1a69b4bb05"/>
+		-->
+		<description>Pro Student G (ALS-0010)</description>
+		<year>1994</year>
+		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="ALS-0010"/>
+		<info name="alt_title" value="ぷろすちゅーでんとG" />
+		<info name="release" value="199407xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="pro student g (japan) (rerelease)" sha1="11bc5195ccaf557fe17a349eb8284c78e08e29ac" />
 			</diskarea>
 		</part>
 	</software>
@@ -14059,9 +14559,34 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="srogue">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Space Rogue.cue" size="2422" crc="505ed099" sha1="e7c51ba8a662bfb88c392cb1e71f051c80028533"/>
-		<rom name="Space Rogue.iso" size="341863200" crc="54c6360a" sha1="1eedb92c1c0668c5abe8d2a459f11263a48eb238"/>
+		Origin: redump.org
+		<rom name="Space Rogue (Japan) (Track 01).bin" size="9878400" crc="56c86b6d" sha1="95add72d920a13ca6036f7fc9812bf4bc6e800ad"/>
+		<rom name="Space Rogue (Japan) (Track 02).bin" size="13406400" crc="89868b75" sha1="8c205cea57ae2f8337c86950fd8453abe6e701cb"/>
+		<rom name="Space Rogue (Japan) (Track 03).bin" size="11995200" crc="db88f401" sha1="1cc63713b4a1630879e80d4a843fd7389c63e24b"/>
+		<rom name="Space Rogue (Japan) (Track 04).bin" size="7585200" crc="99620b1b" sha1="e291f44c67e182a883766c7936d2a52938d71645"/>
+		<rom name="Space Rogue (Japan) (Track 05).bin" size="16581600" crc="e83b1412" sha1="e8076df0bd2ff2bc44e56cb93bda7dffe6d66883"/>
+		<rom name="Space Rogue (Japan) (Track 06).bin" size="24872400" crc="50c479a0" sha1="da2e6eea1e35a249eeb60a717a4a31b38d782f92"/>
+		<rom name="Space Rogue (Japan) (Track 07).bin" size="15170400" crc="46e0640d" sha1="8a040eb5966f9c93f2c6074d346a975bfc9799eb"/>
+		<rom name="Space Rogue (Japan) (Track 08).bin" size="25048800" crc="55af8b95" sha1="c4906604e870ae29a648469c83bf54ee76ffd355"/>
+		<rom name="Space Rogue (Japan) (Track 09).bin" size="14817600" crc="23ae637e" sha1="be972c6c1aef6b438f2d8243b1f223e31debf41e"/>
+		<rom name="Space Rogue (Japan) (Track 10).bin" size="14994000" crc="cb47c7dd" sha1="414541ace28d71171ec56c5b9dde4bdad09ace10"/>
+		<rom name="Space Rogue (Japan) (Track 11).bin" size="15876000" crc="dfc7e4d1" sha1="b81c0a75b4f80ad2435dcccd6057108dbad3e9f0"/>
+		<rom name="Space Rogue (Japan) (Track 12).bin" size="7938000" crc="332f60ea" sha1="30562b4bea0241b80eab0b7a801091e0e1b2e4f5"/>
+		<rom name="Space Rogue (Japan) (Track 13).bin" size="17992800" crc="191d415b" sha1="4477001ff1a8fb34634e640f27d97958fd5ad99e"/>
+		<rom name="Space Rogue (Japan) (Track 14).bin" size="2469600" crc="702fe4ad" sha1="de0efe42fd2d986607470fef83ea726be050a900"/>
+		<rom name="Space Rogue (Japan) (Track 15).bin" size="3351600" crc="15eb0b29" sha1="e99eccb413d7c7e9264cdd7bcdde113ce4f17496"/>
+		<rom name="Space Rogue (Japan) (Track 16).bin" size="3528000" crc="8e064121" sha1="9bb3d005d63d79e17b5b661b933ebc0407feddc7"/>
+		<rom name="Space Rogue (Japan) (Track 17).bin" size="8996400" crc="4233b8ba" sha1="06aec2c8d257ea3ccb883a1421b14ebfcb088e27"/>
+		<rom name="Space Rogue (Japan) (Track 18).bin" size="7408800" crc="b6cfafea" sha1="52fb695acfb7a088eb45e3b28a785cb08f460af0"/>
+		<rom name="Space Rogue (Japan) (Track 19).bin" size="9702000" crc="c5198675" sha1="33dd8cb188d70dadbf01c23dae04d464d7ea36fb"/>
+		<rom name="Space Rogue (Japan) (Track 20).bin" size="14641200" crc="fddf0d42" sha1="466465dda4ee354675a8578cba63b1bdf59a872c"/>
+		<rom name="Space Rogue (Japan) (Track 21).bin" size="16405200" crc="783e207f" sha1="248eed086c9f4f1038277056214588b35bbcd384"/>
+		<rom name="Space Rogue (Japan) (Track 22).bin" size="16934400" crc="2736b86f" sha1="870195e8ec9b957e1ccd3fa4f3efe1baff2ec362"/>
+		<rom name="Space Rogue (Japan) (Track 23).bin" size="16405200" crc="62d260e6" sha1="96aa253b48bae7de4ec0679aedcf6b799cee6113"/>
+		<rom name="Space Rogue (Japan) (Track 24).bin" size="14112000" crc="82389fcd" sha1="c6db940354203608e4ff3c990d97693b4e4a91fb"/>
+		<rom name="Space Rogue (Japan) (Track 25).bin" size="17110800" crc="d6030688" sha1="1a6cbe275b626465b1d58015e782f24ea64d9045"/>
+		<rom name="Space Rogue (Japan) (Track 26).bin" size="14641200" crc="c2dbe1f1" sha1="d253134b2afdd5da652cf67fa018d8a21a909646"/>
+		<rom name="Space Rogue (Japan).cue" size="2923" crc="a7262191" sha1="9b3be2bbb9e59b4f46d95078166075ef503bcc0f"/>
 		-->
 		<description>Space Rogue</description>
 		<year>1990</year>
@@ -14072,7 +14597,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space rogue" sha1="f409d07391dfdff739241710df792ddd84531a85" />
+				<disk name="space rogue (japan)" sha1="029429a703b4f93905f0063038abf14004bb1ccd" />
 			</diskarea>
 		</part>
 	</software>
@@ -14081,7 +14606,7 @@ User/save disks that can be created from the game itself are not included.
 	This version seems to remove some kind of disc check (copy protection?).
 	Not sure when it was made or who made it.
 	-->
-	<software name="sroguend">
+	<software name="sroguend" cloneof="srogue">
 		<!--
 		Origin: Neo Kobe Collection
 		<rom name="Space Rogue (no disk check).cue" size="2438" crc="10b5891a" sha1="8456354802bb2dc2f2d01c11e9843d3e8d90849f"/>
@@ -14706,6 +15231,32 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="teito taisen (japan)" sha1="324eb4c855cf9b27ead9dc2f8706f8c0f23f06f4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Requires the FMT-411 Video Card, not currently emulated by MAME -->
+	<software name="telop" supported="no">
+		<!--
+		Origin: redump.org / wiggy2k
+		<rom name="Towns-Telop (Japan).bin" size="10231200" crc="a4790acd" sha1="401cb3b49f69680cd5fc3cbfc2b7f304e793587f"/>
+		<rom name="Towns-Telop (Japan).cue" size="85" crc="dbbe1098" sha1="d79a607758d3416a01e8d9a93438f5d35f8352f3"/>
+		-->
+		<description>Towns-Telop</description>
+		<year>1989</year>
+		<publisher>ラムダシステム (Lambda System)</publisher>
+		<info name="serial" value="DPS-69"/>
+		<info name="release" value="198905xx" />
+		<info name="usage" value="Requires the FMT-411 Video Card"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Towns-Telop System Programs" />
+			<dataarea name="flop" size="1261568">
+				<rom name="townstelopv100.hdm" size="1261568" crc="b7b525b2" sha1="43fbba547a73a85ee7dbca8777728b31c3a4de44" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="towns-telop (japan)" sha1="bfd73a565bd224798eec08e648a0fc6be5bfa41a" />
 			</diskarea>
 		</part>
 	</software>
@@ -15725,7 +16276,7 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Viper V6 Turbo RS.img" size="63151200" crc="307627bb" sha1="832dced51299a3f13ffc4532c76215f1b558c6d0"/>
 		<rom name="Viper V6 Turbo RS.sub" size="2577600" crc="b7dcf321" sha1="0993fbd9fcd53cffd0ca231f5180a9d233af319c"/>
 		-->
-		<description>Viper V6 Turbo RS</description>
+		<description>Viper-V6 Turbo RS</description>
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
 		<info name="serial" value="HMG-112"/>
@@ -15738,15 +16289,32 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="viperv8">
+		<!--
+		Origin: redump.org
+		<rom name="Viper-V8 Turbo RS (Japan).bin" size="48392400" crc="87d9a05c" sha1="cea620be746e1e86e1d1c06ec5ece8898144ae59"/>
+		<rom name="Viper-V8 Turbo RS (Japan).cue" size="91" crc="63d2d707" sha1="861e94a133304a61bdb5da4ecb8125195b2292d7"/>
+		-->
+		<description>Viper-V8 Turbo RS</description>
+		<year>1995</year>
+		<publisher>ソニア (Sogna)</publisher>
+		<info name="serial" value="HMG-121"/>
+		<info name="release" value="199506xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="viper-v8 turbo rs (japan)" sha1="f3348d252a15f7fa14439dedd4472eaf84cab96e" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="viperv10">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Viper V10 Turbo RS.ccd" size="782" crc="a5ba1d7c" sha1="6d16e338de23ff02145c648537558cfd50efd3a5"/>
-		<rom name="Viper V10 Turbo RS.cue" size="82" crc="3320346c" sha1="f93d377ee8aab8c26023a226b986552295cb14ed"/>
-		<rom name="Viper V10 Turbo RS.img" size="45911040" crc="b3d25f40" sha1="f6a2ace6e0c37402f2504fb4f4c2724db2b7dd4f"/>
-		<rom name="Viper V10 Turbo RS.sub" size="1873920" crc="5fe696ea" sha1="784729f33c6b2eabeed60dfdc6b3edbd64349d31"/>
+		Origin: redump.org
+		<rom name="Viper-V10 Turbo RS (Japan).bin" size="45911040" crc="f7232c71" sha1="7c988b0721f8e4d6cb95cef4bb81b56a3e7ee515"/>
+		<rom name="Viper-V10 Turbo RS (Japan).cue" size="92" crc="dd1128fd" sha1="9224cc239756d037b78c55f7c531fb4319cdb143"/>
 		-->
-		<description>Viper V10 Turbo RS</description>
+		<description>Viper-V10 Turbo RS</description>
 		<year>1995</year>
 		<publisher>ソニア (Sogna)</publisher>
 		<info name="serial" value="HMG-127"/>
@@ -15754,7 +16322,26 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="viper v10 turbo rs" sha1="0afcc96abbe300b9b0499948fede525dcf084ba0" />
+				<disk name="viper-v10 turbo rs (japan)" sha1="bc0b8f2a384442215fb251c124caa2fa5dec20ea" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="viperv12">
+		<!--
+		Origin: redump.org
+		<rom name="Viper-V12 RS (Japan).bin" size="77674800" crc="f1045710" sha1="e93415c638877e6592499623b2c7fc33364e36a3"/>
+		<rom name="Viper-V12 RS (Japan).cue" size="86" crc="848f6b70" sha1="0c491350006caf657746bd49a675aedbc32ec5d5"/>
+		-->
+		<description>Viper-V12 RS</description>
+		<year>1995</year>
+		<publisher>ソニア (Sogna)</publisher>
+		<info name="serial" value="HMG-141"/>
+		<info name="release" value="199512xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="viper-v12 rs (japan)" sha1="40973e9098c64c5e14c1c72df03487a0e82aad6e" />
 			</diskarea>
 		</part>
 	</software>
@@ -16402,6 +16989,34 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="yami no ketsuzoku special - the predestined homicides (japan)" sha1="04a091f1fbb3c1bc458bbbe3a4e000b6456bb93c" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="yeshg">
+		<!--
+		Origin: redump.org
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 01).bin" size="265220928" crc="cc93d1fe" sha1="a8225d3549ba99aeb0696503ad8ba382c744e8a7"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 02).bin" size="31681440" crc="f1895c66" sha1="fa365fdf0aab278c77c5a1ad7d01ed73588e37e5"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 03).bin" size="29153040" crc="66458fe7" sha1="9ea60b9228171cdfe8b3d43927274e53fc0998fa"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 04).bin" size="24108000" crc="a7c1d463" sha1="3f41bc0e27ba089c0d58af4acd3f0b8e5fb1b404"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 05).bin" size="24681888" crc="ee1b1cc0" sha1="becd261a5ccf758371850832f0535b33ac3c3d8b"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 06).bin" size="32022480" crc="41224dae" sha1="5d183e42b301f3090e1ebc3a6ef099b5df68c1e6"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 07).bin" size="32676336" crc="9a87018a" sha1="240ab5985db6a447767e9dddee40e9653dc7aa5c"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 08).bin" size="35028336" crc="6316956e" sha1="f06cdd56c093157afff51d782c0a4b83ccefae5c"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 09).bin" size="43956528" crc="9b5a41eb" sha1="f8c83a2f3af2630c7d75ace7ff82f4296a1c9ca7"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 10).bin" size="28515648" crc="21095ba9" sha1="04cc52a6102666dd991c6affa4df84a40a572fb1"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 11).bin" size="24919440" crc="8b9f2552" sha1="6872b88379d3688ad68fad2e3e7cfde836df70e9"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan).cue" size="1238" crc="1f9dbaf4" sha1="f75cf01ff1292bbd61d71ac749e896cce1283b99"/>
+		-->
+		<description>YES! HG - Erotic Voice Version</description>
+		<year>1995</year>
+		<publisher>姫屋ソフト (Himeya Soft)</publisher>
+		<info name="release" value="199512xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="yes hg - erotic voice version (japan)" sha1="1973d5e32f50ada90f093203de09c87b51af489d" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -31,7 +31,6 @@ Aesop World Dai-2-shuu (Denshi Ehon)                          Fujitsu           
 Airwave Adventure                                             Toshiba EMI                       1989/12    CD
 Aishuu to Netsujou no Chouwa                                  Fujitsu                           1995/4     CD
 Akiko Gold                                                    Fairytale (Red Zone)              1995/1     SET(CD+FD)
-Akiko Premium Version                                         Fairytale (Red Zone)              1993/3     CD
 Alice in Wonderland                                           DynEd Japan                       1993/3     SET(CD+FD)
 * Alice no Yakata 3 CD                                        Alice Soft                        1995/6     CD
 Amour Ver. 1.0                                                Kozu System                       1989/11    SET(CD+FD)
@@ -92,7 +91,6 @@ CRI Postman                                                   CSK Research Insti
 CRI StacCard                                                  CSK Research Institute (CRI)      1991/5     SET(CD+FD)
 Criss                                                         CSK Research Institute (CRI)      1989/7     CD
 C-Trace Towns                                                 Cast                              1989/6     CD
-Curse                                                         Queen Soft                        1995/2     CD
 Custom Mate & Denwa no Bell ga…                               Cocktail Soft                     1994/12    SET(CD+FD)
 Cutie Queen                                                   Crystal Eizou                     1995/2     CD
 Cybernoid Alpha                                               D.O.                              1996/4     CD
@@ -203,7 +201,6 @@ Fuzzy Kakeibo                                                 GAM               
 Fuzzy Kakeibo 3                                               GAM                               1995/11    CD
 Gakuen Bakuretsu Tenkousei!                                   ZyX                               1996/3     CD
 Gakuen Bomber                                                 Active                            1994/6     CD
-Gambler - Queen's Cup                                         Queen Soft                        1994/9     CD
 Game Nihonshi: Kakumeiji Oda Nobunaga                         Koei                              1996/3     SET(CD+FD)
 Game Nihonshi: Tenkabito Hideyoshi to Ieyasu                  Koei                              1996/6     SET(CD+FD)
 Garou Densetsu Special                                        Mahou (Nihon Home Data)           1996/9     SET(CD+FD)
@@ -221,7 +218,6 @@ Ginga Uchuu Odyssey 1                                         Fujitsu           
 Ginga Uchuu Odyssey 2                                         Fujitsu                           1992/4     CD
 Ginga Uchuu Odyssey 2                                         Fujitsu                           1991/3     CD
 Ginga Yuukyou Densetsu Tobakker                               Ponytail Soft                     1995/11    CD
-Gokuraku Mandala                                              Fairytale                         1994/2     CD
 Gomen ne Angel: Yokohama Monogatari                           JAST                              1992/1     ?
 Gram Cats 2                                                   Dot Kikaku                        ?          ?
 Grand Prix Densetsu                                           Soft Studio Wing                  1993/9     CD
@@ -311,7 +307,6 @@ Interactive Business English 3                                DynEd Japan       
 Interactive Business English 4                                DynEd Japan                       1992/7     SET(CD+FD)
 Interactive Business English 5                                DynEd Japan                       1992/7     SET(CD+FD)
 Interactive Business English 6                                DynEd Japan                       1992/7     SET(CD+FD)
-Iris-tei Sayokyoku                                            Agumix                            1992/11    CD
 Iwanami Bungakukan: Natsume Souseki                           Iwanami Shoten                    1994/2     CD
 Iwanami Denshi Nihon Sougou Nendo CD-ROM                      Fujitsu                           1993/10    CD
 J.League Professional Soccer 1994                             Victor Entertainment              1994/9     CD
@@ -363,7 +358,7 @@ Let's go 1-2                                                  DynEd Japan       
 Let's go 2-1                                                  DynEd Japan                       1995/7     SET(CD+FD)
 Let's go 2-2                                                  DynEd Japan                       1995/7     SET(CD+FD)
 Lettuce Cooking 2: Tanoshiku Tsukureru Obentou                SS Communications                 1990/8     SET(CD+FD)
-* Lipstick Adventure 3                                          Fairytale                         1993/5     CD
+* Lipstick Adventure 3                                        Fairytale                         1993/5     CD
 Little Big Adventure                                          Electronic Arts Victor            1995/12    CD
 LiveAnimation V1.1                                            Fujitsu                           1992/12    CD
 LiveAnimation V2.1                                            Fujitsu                           1994/5     CD
@@ -381,7 +376,6 @@ Manami no Dokomade Iku no? 2: Return of the Kuro Pack         Wendy Magazine    
 Manami: Ai to Koukan no Hibi                                  Fairytale (Red Zone)              1995/10    SET(CD+FD)
 Many Colors 2                                                 Amorphous                         1995/6     CD
 Manyoushuu                                                    Uchida Youkou                     1993/2     CD
-Marionette Mind                                               Studio Milk                       1994/3     CD
 Maruanki Eitango: Chuugaku 1-nensei                           CSK Research Institute (CRI)      1989/12    SET(CD+FD)
 Maruanki Eitango: Chuugaku 2-nensei                           CSK Research Institute (CRI)      1989/12    SET(CD+FD)
 Maruanki Eitango: Chuugaku 3-nensei                           CSK Research Institute (CRI)      1990/2     SET(CD+FD)
@@ -393,7 +387,6 @@ Mietarou V2.0                                                 Uchida Youkou     
 Migenerator V1.1                                              Fujitsu                           1992/7     SET(CD+FD)
 Mimi no Daibouken Hyper Land 2: Konchuu no Sekai              Datt Japan                        1995/2     SET(CD+FD)
 Minna de Sansuu 1-nen                                         Tokyo Shoseki                     1995/9     CD
-Mirage 2: Torry x Neat x Roan no Daibouken                    Discovery                         1994/12    CD
 Misato-san no Yume Nikki                                      Active                            1997/4     CD
 Mizube no Ninkimono                                           Fujitsu Social Science Laboratory 1994/7     CD
 Moeru Asoko no Paipai Yuugi                                   Illusion                          1993/12    CD
@@ -481,7 +474,6 @@ Nijiiro Denshoku Musume                                       ISC               
 * Nobunaga no Yabou: Tenshouki                                Koei                              1995/3     SET(CD+FD)
 Nooch: Abakareta Inbou                                        Bombee Bonbon                     1992/11    ?
 Nostalgia 1907                                                Sur de Wave                       1992/5     CD
-Noushuku Angel 120%                                           Cocktail Soft                     1995/4     SET(CD+FD)
 Noyama no Kensakuka                                           Fujitsu Social Science Laboratory 1995/3     CD
 O Hoshi Senjutsu Daireigen                                    Victor Entertainment              1990/2     CD
 Obaachan no Chiebukuro                                        Gyousei                           1991/11    CD
@@ -539,8 +531,8 @@ Sangokushi 4                                                  Koei              
 Sanseido Word Hunter Multi CD-ROM Jiten                       Fujitsu                           1991/10    CD
 Sayonara no Mukougawa                                         Foster                            1997/8     CD
 School Accessory Illust-hen V1.0                              Fujitsu                           1993/2     CD
-School Navi Nihon no Rekishi CD: Heian, Kamakura             Unitybell                         1995/8     CD
-School Navi Nihon no Rekishi CD: Kodai, Asuka-Nara           Unitybell                         1995/7     CD
+School Navi Nihon no Rekishi CD: Heian, Kamakura              Unitybell                         1995/8     CD
+School Navi Nihon no Rekishi CD: Kodai, Asuka-Nara            Unitybell                         1995/7     CD
 School Navi Nihon no Rekishi CD: Azuchi-Momoyama, Edo         Unitybell                         1995/9     CD
 School Navi Nihon no Rekishi CD: Meiji, Gendai                Unitybell                         1995/9     CD
 School-Ace Alpha HG Sensei-you                                Fujitsu                           1994/7     SET(CD+FD)
@@ -559,7 +551,6 @@ Sexy PK 2 World Cup Ban                                       Birdy Soft        
 Sexy PK World Cup Ban                                         Birdy Soft                        1995/6     CD
 Shadow of the Beast: Mashou no Okite (1991-10-11)             Victor Entertainment              1991/10?   CD
 Shakaika Database: Nihon no Bunka / Sangyou / Shizen          Nihon Kyouiku System              1991/12    CD
-Shamhat: The Holy Circlet (Marty-ban)                         Data West                         1993/4     SET(CD+FD)
 Shanghai: Banri no Choujou                                    Electronic Arts Victor            1995/9     CD
 Shijou Saikyou no Video Bible                                 System Sacom                      1989/12    CD
 Shiki wo Irodoru Nihon no Shouka: Aki-hen                     Toshiba EMI                       1991/10    CD
@@ -611,7 +602,6 @@ Tanoshii Sansuu Set 1-2-nen                                   Dainippon Tosho   
 Teata -vision- (V1.0-1.3)                                     Nanken Koubou                     1995/6     SET(CD+FD)
 Teitoku no Ketsudan                                           Koei                              1990/4     SET(CD+FD)
 Tender Light Vol. 1                                           Fujitsu                           1994/3     CD
-Tenjin Ranma                                                  Elf                               1992/5     SET(CD+FD)
 Tensai Kyuutei Ongaku no Kanade                               Fujitsu                           1992/12    CD
 Tensen Nyannyan                                               Ponytail Soft                     1994/9     CD
 Tenshi-tachi no Gogo 3: Bangai-hen Hanseiban                  JAST                              1993/3     ?
@@ -673,10 +663,9 @@ TownsVNET V1.1 (Reprint?)                                     Fujitsu           
 Towns-you Chuugakkou Gijutsu Kateika Kyouzai                  Uchida Youkou                     1994/3     CD
 Treeclub                                                      Fujitsu Parex                     1995/7     CD
 Trigger 2                                                     ZyX                               1995/9     CD
-True Heart                                                    Cocktail Soft                     1995/2     SET(CD+FD)
+* True Heart                                                  Cocktail Soft                     1995/2     SET(CD+FD)
 Tsubo Relaxation                                              Fujitsu Personal Computer Systems 1994/9     CD
 Twinkle Star                                                  Studio Twinkle                    1993/7     CD
-Two Shot Diary                                                Mink                              1994/10    CD
 Ujibushi no Chiiku Game                                       Nihon Keisoku Souchi              1994/4     CD
 Unmei no Tobira                                               Fujitsu                           1992/9     CD
 URM: 15 Wakusei ni Umarete                                    Japan Home Video (JHV)            1994/12    CD
@@ -687,8 +676,8 @@ Vanishing Point: Tenshi no Kieta Machi                        Tiara             
 Vector Moji Pattern 2                                         Fujitsu                           1992/12    IC
 Video Koubou V1.1                                             Fujitsu                           1992/6     SET(CD+FD)
 Video Koubou V1.2                                             Fujitsu                           1993/4     CD
-* Video Koubou V1.3                                             Fujitsu                           1994/2     CD
-* Video Koubou V1.4                                             Fujitsu                           1995/11    SET(CD+FD)
+* Video Koubou V1.3                                           Fujitsu                           1994/2     CD
+* Video Koubou V1.4                                           Fujitsu                           1995/11    SET(CD+FD)
 VIP Ball                                                      CSK Research Institute (CRI)      1991/8     CD
 VIP Tone                                                      CSK Research Institute (CRI)      1991/9     CD
 VIPER GTS                                                     Sogna                             1995/11    CD
@@ -1159,6 +1148,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="towns hyakunin isshu" sha1="ef05fdcfbcdd8e4777638eaa3b8e7bf1d3e13ba8" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="2shot">
+		<!--
+		Origin: redump.org
+		<rom name="Two Shot Diary (Japan).bin" size="126674016" crc="21f35608" sha1="d4fa738d07619eaced3e509b64a5d6b71ac62ac0"/>
+		<rom name="Two Shot Diary (Japan).cue" size="88" crc="a9278e47" sha1="43ed5b96a2a2a157ca7518495aa43d30d238a2d3"/>
+		-->
+		<description>Two Shot Diary</description>
+		<year>1994</year>
+		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="MTC-1116"/>
+		<info name="alt_title" value="ツー・ショット　Ｄｉａｒｙ" />
+		<info name="release" value="199410xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="two shot diary (japan)" sha1="c8fe6e8f1f6799e31ae7f5f93fb1d62098605b8b" />
 			</diskarea>
 		</part>
 	</software>
@@ -2001,13 +2010,56 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="akikoprm">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 1).bin" size="20815200" crc="c33b7c72" sha1="3ea2792cc94a1dcf76cae4f13b360c2ca39c5e0f"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 2).bin" size="55918800" crc="21e4a5a4" sha1="00d219297d4ed029ff384f864bd4fa70fdff6de4"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 3).bin" size="58741200" crc="986d52ac" sha1="26655aee034477fe252bd6a87a3d8432839fed83"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 4).bin" size="50626800" crc="c5244662" sha1="4c80f16077c88672d5b0c8eec2894b886c80e07e"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 5).bin" size="42159600" crc="7b7d6491" sha1="504f02113cd07a2374fd4173d18fc050740df4fd"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 6).bin" size="58388400" crc="562422e9" sha1="2943e7927d2c6e05c6a5bb98e9fd5e3e4aef9dc7"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 7).bin" size="40042800" crc="89fe15d8" sha1="c672babd51af7d9e4f30c6614ec715ea23333714"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 8).bin" size="37044000" crc="e395458d" sha1="e6908ae26c8628f466216275c3d8a64881901e1f"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan) (Track 9).bin" size="47628000" crc="316fd55f" sha1="6e0deccb28f3c325b8642df713b3fa63e9ca9712"/>
+		<rom name="Hyper Girl - Akiko - Premium Version (Japan).cue" size="1224" crc="564a7f99" sha1="d076e57aa73bb683832378130d344d894df47888"/>
+		-->
+		<description>Akiko - Premium Version</description>
+		<year>1993</year>
+		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HME-121"/>
+		<info name="alt_title" value="亜紀子 プレミアム・バージョン" />
+		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper girl - akiko - premium version (japan)" sha1="5869c0c1d2eee0f551722a7d08d7feef6be53868" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="alshark">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Alshark.ccd" size="4251" crc="c524a687" sha1="f7bfdc54de0930b263bb61bb1d313bdda14c7965"/>
-		<rom name="Alshark.cue" size="1100" crc="5eecf316" sha1="ab1d4bd49d9160fad9b9436f4b44494c03a0a845"/>
-		<rom name="Alshark.img" size="615636000" crc="a08e556c" sha1="685957bbf39071e56c23942792abb644f9083cce"/>
-		<rom name="Alshark.sub" size="25128000" crc="2d22213c" sha1="a556b64fec250576047b0cd376ce37c830ce7495"/>
+		Origin: redump.org
+		<rom name="Alshark (Japan) (Track 01).bin" size="20815200" crc="953bbbc2" sha1="08421ceb85585f2818c93e2550939824b90fea64"/>
+		<rom name="Alshark (Japan) (Track 02).bin" size="17816400" crc="b10ba3e4" sha1="f031dd8f27f477007b7276d3755c01171c79573a"/>
+		<rom name="Alshark (Japan) (Track 03).bin" size="19051200" crc="4c9a8815" sha1="be4cb00c8259a11f4d509f15aee637e75dd695da"/>
+		<rom name="Alshark (Japan) (Track 04).bin" size="13935600" crc="a31739ec" sha1="c9a88709222b9a29366fea9655a8347edd88a168"/>
+		<rom name="Alshark (Japan) (Track 05).bin" size="15170400" crc="0094f4f0" sha1="953cbd348d1c702c7a1b9354c863c4eb85491ada"/>
+		<rom name="Alshark (Japan) (Track 06).bin" size="37220400" crc="c962622c" sha1="ea5fa1ec47fbb96baafbc4730cba89440a593a0d"/>
+		<rom name="Alshark (Japan) (Track 07).bin" size="22755600" crc="ca5c0edd" sha1="f4b3e414f3e7d1eec0e10224004251133b568dc2"/>
+		<rom name="Alshark (Japan) (Track 08).bin" size="23284800" crc="ec56c826" sha1="502bf25af1a1b55b1b9db40b0eaa75219d8fe397"/>
+		<rom name="Alshark (Japan) (Track 09).bin" size="14112000" crc="0759d6d5" sha1="1f55abb8fa0876bfcd1006d18dde20dca7071cbc"/>
+		<rom name="Alshark (Japan) (Track 10).bin" size="20815200" crc="3bede9e6" sha1="e73055cfbf995703bb712263997b865f9b353998"/>
+		<rom name="Alshark (Japan) (Track 11).bin" size="16758000" crc="31ede800" sha1="4175c506d14d35a7247fdb7bb2d1f6cf7ad3ced0"/>
+		<rom name="Alshark (Japan) (Track 12).bin" size="17992800" crc="eeb9bec1" sha1="fd093564ce2d0c859c1ce670dc7dbe7862b07e7a"/>
+		<rom name="Alshark (Japan) (Track 13).bin" size="26460000" crc="63723a70" sha1="f6035435f37942f29c4b73c5b804e6e1fc708506"/>
+		<rom name="Alshark (Japan) (Track 14).bin" size="66150000" crc="fb49c3c8" sha1="6ab102606530ce5f1b763cda7a07cce1747dc3bb"/>
+		<rom name="Alshark (Japan) (Track 15).bin" size="31046400" crc="12343aab" sha1="f2694e26a690d3470ea142724df6f74ac973ba4b"/>
+		<rom name="Alshark (Japan) (Track 16).bin" size="60858000" crc="d6fe0d37" sha1="0ff527b39f8b7c4b4c3d05ce3b0389e0a4308de4"/>
+		<rom name="Alshark (Japan) (Track 17).bin" size="47628000" crc="ec6f4a41" sha1="cc67f4dace3951fb2d4c3c1de7ff9ea6cdd86665"/>
+		<rom name="Alshark (Japan) (Track 18).bin" size="143766000" crc="8c07e919" sha1="53d3e2d61af1f6b882d8ff8052ae939ff082f352"/>
+		<rom name="Alshark (Japan).cue" size="1985" crc="930f1e41" sha1="ff9e7eab7676130ca0880130ed8d058222a7ca29"/>
 		-->
 		<description>Alshark</description>
 		<year>1993</year>
@@ -2018,7 +2070,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alshark" sha1="ecbdc6dead64d45836037a341bfd49332c7f8e29" />
+				<disk name="alshark (japan)" sha1="99c36574a3826e2cbdece7271012314b425e090b" />
 			</diskarea>
 		</part>
 	</software>
@@ -2930,13 +2982,15 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="branmar2">
 		<!--
-		Origin: Neo Kobe Collection (Game Disc), DamienD / Tokugawa Corporate Forums (Extra Disc)
-		<rom name="Branmarker 2 (Game disc).ccd" size="1152" crc="5a5c5567" sha1="9201413c9a0109f0ebe03a99e35e01d18c9a09a5"/>
-		<rom name="Branmarker 2 (Game disc).cue" size="166" crc="760286da" sha1="961a4db20766d03f437819c33849c90370b9edf5"/>
-		<rom name="Branmarker 2 (Game disc).img" size="479575152" crc="8e722dbd" sha1="1bfa442a34d21ae2d37ca33d6a703a754e77cdb5"/>
-		<rom name="Branmarker 2 (Game disc).sub" size="19574496" crc="51b2a7ea" sha1="e527977f203bbe6f2b9ea25a617d450521e2bc2d"/>
-		<rom name="ブランマーカー2・エクストラディスク.img" size="726325824" crc="b9324800" sha1="295e3206778ab260c41478339cf8d4c3c981b980"/>
-		<rom name="ブランマーカー2・エクストラディスク.cue" size="206" crc="dc15aca7" sha1="9c4796da1de799894e9df7bd2a9985ffa370cc52"/>
+		Origin: redump.org
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 1).bin" size="371159712" crc="df2701fe" sha1="ecc0d8153e5b476e1692a33e61f0cea18c8a7cce"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 2).bin" size="54495840" crc="d6fea193" sha1="26dfee2e39be02968294b0fa2c304dd69bde4bc5"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 3).bin" size="53919600" crc="932ba984" sha1="8b143a0c7f1f44038c71a84df064e98c87a9dde9"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc).cue" size="337" crc="049ba1fe" sha1="1c65dbd4898a0c483ee92e87cc2d9d0fa81996b7"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 1).bin" size="482889120" crc="ae31a549" sha1="9f4ca18f2ba133534dd7a150e248398fe9cf5151"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 2).bin" size="209972448" crc="dca6cf1c" sha1="d2125cf9cdd51d66f6af23dc9d8a3c16c2b5000d"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 3).bin" size="33464256" crc="115ae1b1" sha1="fd3ed992993023660b1aedae0b1659e6efa80ee5"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc).cue" size="340" crc="b9c8fbc2" sha1="715fa4406d6ede1cdfbd02f7aac0fa3a6e4205ba"/>
 		-->
 		<description>Branmarker 2</description>
 		<year>1995</year>
@@ -2947,13 +3001,13 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom1" interface="fmt_cdrom">
 			<feature name="part_id" value="Game Disc" />
 			<diskarea name="cdrom">
-				<disk name="branmarker 2" sha1="b7a41a36bf83c293defa929dd8b2daea961cd3aa" />
+				<disk name="branmarker 2 (japan) (game disc)" sha1="242b3fd57b45e08f29fba516257821ad7f132152" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
 			<feature name="part_id" value="Extra Disc" />
 			<diskarea name="cdrom">
-				<disk name="branmarker 2 extra disc" sha1="8845dd975d20f8d9756b0c5d1859ef7bfd79b21d" />
+				<disk name="branmarker 2 (japan) (extra disc)" sha1="755865e904bf3ee527c629a45cea052f7bb10f5b" />
 			</diskarea>
 		</part>
 	</software>
@@ -3392,6 +3446,53 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="cubic sketch v1.1l10 (japan)" sha1="8add69fd06c252822725abe9da869be9e6a184bb" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="curse">
+		<!--
+		Origin: redump.org
+		<rom name="Curse (Japan) (Track 01).bin" size="10231200" crc="e6370e13" sha1="8fa9210d6616a0b3a9221005d971bbb6c74da711"/>
+		<rom name="Curse (Japan) (Track 02).bin" size="28224000" crc="4949670d" sha1="5d330a9c7580a61d9a49e912efc2cb07dbee58a1"/>
+		<rom name="Curse (Japan) (Track 03).bin" size="27165600" crc="1cdab61c" sha1="f58d139e740249df23a3fe94521ed912c8d7e75d"/>
+		<rom name="Curse (Japan) (Track 04).bin" size="23108400" crc="c5cf0269" sha1="1389aebcdf96f78af1189f2ca730acebe5c6d564"/>
+		<rom name="Curse (Japan) (Track 05).bin" size="21168000" crc="027befcc" sha1="67cd1ddfe296ab358346b90ef9e3bd7cd3a0018e"/>
+		<rom name="Curse (Japan) (Track 06).bin" size="26107200" crc="2e93ca3a" sha1="484a59c1f288013e61ae3960a09e5eb5efb04f34"/>
+		<rom name="Curse (Japan) (Track 07).bin" size="25754400" crc="6519ce69" sha1="65ad3f5cd51aa94672ff494fba231c72dd01c874"/>
+		<rom name="Curse (Japan) (Track 08).bin" size="25048800" crc="57a9e4ca" sha1="4a03d36ffb5e3351ffca2485de314f811fa280a4"/>
+		<rom name="Curse (Japan) (Track 09).bin" size="26283600" crc="80cffb30" sha1="7948b0908a6c42bdfb9c97cb6358ad5dba314fff"/>
+		<rom name="Curse (Japan) (Track 10).bin" size="27694800" crc="16ba096d" sha1="fa562d99b24738f12c27ff4a0a2816ac37bbc7fc"/>
+		<rom name="Curse (Japan) (Track 11).bin" size="26636400" crc="43bf708d" sha1="547a0165d2200bd3d6a0bb967868afde712f2637"/>
+		<rom name="Curse (Japan) (Track 12).bin" size="25578000" crc="a66b2005" sha1="859a08c57e167637dce780c6ee815c940b3e584a"/>
+		<rom name="Curse (Japan) (Track 13).bin" size="22402800" crc="a83319a7" sha1="c241360adec7d5da141cf2ffdd8639e6bcb0b1b3"/>
+		<rom name="Curse (Japan) (Track 14).bin" size="22402800" crc="3426d09e" sha1="929a3f509fb632bc514be49d911936cdf5a4398f"/>
+		<rom name="Curse (Japan) (Track 15).bin" size="23990400" crc="c31eb350" sha1="d17f47b6f60eee84ae43773bcaa0982e493f5abf"/>
+		<rom name="Curse (Japan) (Track 16).bin" size="22579200" crc="16c23989" sha1="a50b66c6d54301134ab03e4815a1dfc5c89040c5"/>
+		<rom name="Curse (Japan) (Track 17).bin" size="26989200" crc="6d62621c" sha1="9ac177c4d9f2c8ba52cb8de80b0008e9f9c01c0d"/>
+		<rom name="Curse (Japan) (Track 18).bin" size="32986800" crc="6536ac15" sha1="02e380c734b8f63caec17ecedd6fef2748f05348"/>
+		<rom name="Curse (Japan) (Track 19).bin" size="30340800" crc="9bb2b8f8" sha1="ba52dc197188f25755b121ec5ecd0d275abc5a4a"/>
+		<rom name="Curse (Japan) (Track 20).bin" size="22932000" crc="39d7ee94" sha1="9bb05221d39a8f55c9d53a35949401acff62e4ca"/>
+		<rom name="Curse (Japan) (Track 21).bin" size="24343200" crc="59c9bee5" sha1="0db9d3318e53047ed3d346f0c015e79760f4b2b5"/>
+		<rom name="Curse (Japan) (Track 22).bin" size="2293200" crc="fb230e1d" sha1="19daea731fdff4e3f16b1a40f9ba248d350245b7"/>
+		<rom name="Curse (Japan) (Track 23).bin" size="1411200" crc="3991bfc5" sha1="84199fb9d1ce782cead13a2f69f8369ff3e74990"/>
+		<rom name="Curse (Japan) (Track 24).bin" size="1764000" crc="61a64e88" sha1="34c097633538c8a3f19494f8617f423ba61f3110"/>
+		<rom name="Curse (Japan) (Track 25).bin" size="21873600" crc="03d4c3c6" sha1="3bd28c1557ff2b041d1e236ba8d47bb5dd4d355b"/>
+		<rom name="Curse (Japan) (Track 26).bin" size="25225200" crc="eb04c08b" sha1="4b694d1bbf2ede7f60ef16491e2fd217a6e32a44"/>
+		<rom name="Curse (Japan) (Track 27).bin" size="24166800" crc="8fe1c429" sha1="3cc022d049f02f56d2ddf6b7e7d93e76243e7b1a"/>
+		<rom name="Curse (Japan) (Track 28).bin" size="46040400" crc="85e4b6a3" sha1="8b955c7481187e03d55cffcc7f571ab3457c59eb"/>
+		<rom name="Curse (Japan).cue" size="3006" crc="09f8ab57" sha1="275c7fbd825f1ee6bfad1ee42c4d2b2d1a700967"/>
+		-->
+		<description>Curse</description>
+		<year>1995</year>
+		<publisher>クィーンソフト (Queen Soft)</publisher>
+		<info name="serial" value="HMG-102 / QCD9502"/>
+		<info name="alt_title" value="カース" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="curse (japan)" sha1="83e15d0ca514f344f4f059f289977b758f87e0a2" />
 			</diskarea>
 		</part>
 	</software>
@@ -4326,11 +4427,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="dknight4">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dragon Knight 4.ccd" size="767" crc="8bdfb40f" sha1="cb635633c22c5bc81e7f51006c7c319eceb316c3"/>
-		<rom name="Dragon Knight 4.cue" size="79" crc="896060d8" sha1="06a1ab4c07d51fd4ee67491a11fa0d0e1457461a"/>
-		<rom name="Dragon Knight 4.img" size="20815200" crc="4248f788" sha1="7a306ea8792d48b9ee1f952cf4246ea7e15b1e98"/>
-		<rom name="Dragon Knight 4.sub" size="849600" crc="4f418c0b" sha1="7017e03e20f31889be0af9456244aee7eaabd910"/>
+		Origin: redump.org
+		<rom name="Dragon Knight 4 (Japan).bin" size="20815200" crc="4248f788" sha1="7a306ea8792d48b9ee1f952cf4246ea7e15b1e98"/>
+		<rom name="Dragon Knight 4 (Japan).cue" size="89" crc="01711e23" sha1="0456e642e730a5fffdce67d4f66336e060f38567"/>
 		-->
 		<description>Dragon Knight 4</description>
 		<year>1994</year>
@@ -4341,7 +4440,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon knight 4" sha1="a8ed04efe5e90c18de6c1a76fc73d730670857dc" />
+				<disk name="dragon knight 4 (japan)" sha1="b430f8be0f739cb090a661f4663252e935bf63d1" />
 			</diskarea>
 		</part>
 	</software>
@@ -4512,21 +4611,24 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="eimmy">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Eimmy to Yobanaide.ccd" size="1536" crc="5a957719" sha1="b674f4c5d249abd3f0b90bf82991f1128ba05ab9"/>
-		<rom name="Eimmy to Yobanaide.cue" size="238" crc="dcae031f" sha1="d27f55850c97b3761b09bb043f87c4a6ec89da2d"/>
-		<rom name="Eimmy to Yobanaide.img" size="549742368" crc="1585640a" sha1="7f98c92bb3917cf2d87d325ddc4c1ce36b5a6484"/>
-		<rom name="Eimmy to Yobanaide.sub" size="22438464" crc="03ea8525" sha1="3cbd86397d59300f0ae4d977436a12cdcad742e1"/>
+		Origin: redump.org
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 1).bin" size="385579824" crc="99869352" sha1="429f8879aff4809064f08bf893f5a1d7329ba7bf"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 2).bin" size="51459408" crc="b447fa0d" sha1="d45f8d372e0f3d78ca08fdcdf78a367582ca267c"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 3).bin" size="51167760" crc="bc870a2f" sha1="439d9c4c619bdbbf87676bb9a4b4645ef7161dcf"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 4).bin" size="29665776" crc="4bffe326" sha1="ca1f5c4389fe6ca748a558ffe94a4bb85e1c077d"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 5).bin" size="31869600" crc="707adf40" sha1="f512336d7b8758af78cb5b08504590834c78038e"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan).cue" size="658" crc="608ac853" sha1="4083d7bf509ff71735613ef4f634a92d42d7c52b"/>
 		-->
 		<description>Eimmy to Yobanaide</description>
 		<year>1995</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="serial" value="CSW-0003"/>
 		<info name="alt_title" value="エイミーと呼ばないでっ" />
 		<info name="release" value="199508xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="eimmy to yobanaide" sha1="4c321b593322b94cf84a68ad1021d0cf3b24b1c4" />
+				<disk name="eimmy to yobanaide - please don't call me eimmy (japan)" sha1="15ba4ebd4f932f9b3406e40b439172a7680222f7" />
 			</diskarea>
 		</part>
 	</software>
@@ -4900,20 +5002,28 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="evolutn">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Evolution.ccd" size="2472" crc="e4211ac3" sha1="d75688f1352630aedb6e52e2261643d1dbb8d525"/>
-		<rom name="Evolution.cue" size="425" crc="260d9945" sha1="269452f29765f9215857e3c8662dc4fda535c6ad"/>
-		<rom name="Evolution.img" size="371474880" crc="cd5e4330" sha1="b53b98e9bc30de328a91399a96d70e2d5b978497"/>
-		<rom name="Evolution.sub" size="15162240" crc="b828ee66" sha1="e90bf9725a82c50c27e971ea806f81c94b744cc1"/>
+		Origin: redump.org
+		<rom name="Evolution (Japan) (Track 01).bin" size="2300256" crc="ac329687" sha1="660034dffe3a8344d96efecf13bddaf53cf196b3"/>
+		<rom name="Evolution (Japan) (Track 02).bin" size="6825504" crc="a096bac5" sha1="b55c58112697f7db85b17d6e105f39d0e82bdd35"/>
+		<rom name="Evolution (Japan) (Track 03).bin" size="54420576" crc="fa3feec7" sha1="1d4ca19b0fb07c8512cbf91143b5cd8922416b25"/>
+		<rom name="Evolution (Japan) (Track 04).bin" size="53296320" crc="e069fedf" sha1="d2ca96353de5fb47ce89ac73ee751697829fb3bd"/>
+		<rom name="Evolution (Japan) (Track 05).bin" size="53383344" crc="9dc58766" sha1="39d19b50646fb7cd25dff38b67acbcc8171ac291"/>
+		<rom name="Evolution (Japan) (Track 06).bin" size="53879616" crc="025244ec" sha1="edd8b772ff562c28d7a99b5216d2e0c728e5f0cf"/>
+		<rom name="Evolution (Japan) (Track 07).bin" size="53919600" crc="49e64b65" sha1="a6c607ce3bcc4787e26cd2f9a0fb11741e134ca1"/>
+		<rom name="Evolution (Japan) (Track 08).bin" size="54107760" crc="9c3c9e8f" sha1="b9e7d56ee9d096cf3a628822a466fad54ff9ff76"/>
+		<rom name="Evolution (Japan) (Track 09).bin" size="35108304" crc="36e8c284" sha1="cee2b86ac24088a3db5cc97eb150aad1714dc962"/>
+		<rom name="Evolution (Japan) (Track 10).bin" size="4233600" crc="253dea43" sha1="9339be17416f58210b6a28ff6ac05de2589a419c"/>
+		<rom name="Evolution (Japan).cue" size="1102" crc="8342d37b" sha1="61c794ddcb866aa9a7cd041eda0853174ad6e68a"/>
 		-->
 		<description>Evolution</description>
 		<year>1989</year>
 		<publisher>システムサコム (System Sacom)</publisher>
+		<info name="serial" value="DPS-70"/>
 		<info name="alt_title" value="エヴォリューション" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="evolution" sha1="93add8d48a5a0802cabc360b62c7cd39de7dabe2" />
+				<disk name="evolution (japan)" sha1="c518e330a3a9faccb4f1a7295d158361a5cf82f3" />
 			</diskarea>
 		</part>
 	</software>
@@ -6100,6 +6210,38 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="gokumand">
+		<!--
+		Origin: redump.org
+		<rom name="Gokuraku Mandala (Japan) (Track 01).bin" size="20815200" crc="067ea9ce" sha1="162bb2c4c46cdcc401e9d118792f4343184f1898"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 02).bin" size="49921200" crc="9301ace8" sha1="a004a60ba0067106c203ae8d7a99b3c4b41f0e2c"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 03).bin" size="49215600" crc="a79166a6" sha1="9b39107f2ec80431c30778a889cf05abacd94678"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 04).bin" size="55742400" crc="d1e86a69" sha1="b914de80829955dbad202fe26cd7f19f500fef4a"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 05).bin" size="47098800" crc="fb57f64a" sha1="104a1101804d961b71e0072bf0f3942290b6b67b"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 06).bin" size="47275200" crc="4c4993f1" sha1="bc43fa39c43d152f62c0efdd8100156a998f69f7"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 07).bin" size="54684000" crc="288e6e97" sha1="3b1b9fc9bc192adf4c852b7243d5e2654d14eb1e"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 08).bin" size="46569600" crc="973dccfd" sha1="8a5f53b401c293e8d252c8f03e5b3f1da655e12a"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 09).bin" size="49921200" crc="516b6a4a" sha1="fd0a7d8f6905374d455b0a843ae4fb3d85d13db4"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 10).bin" size="3704400" crc="477ffd1e" sha1="e5541250c7e86b694e69cad5a26b22506d679f3d"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 11).bin" size="7232400" crc="489f2069" sha1="3f74200f47b8e2c9ea3e491a3466ee423fe38b56"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 12).bin" size="1058400" crc="74965b12" sha1="7d139955173a7fc5ed1adde253f0b66c08e8a649"/>
+		<rom name="Gokuraku Mandala (Japan) (Track 13).bin" size="3175200" crc="e1921519" sha1="ed8c2f9397dbd88bbecf28b802eda6b28d4c8a74"/>
+		<rom name="Gokuraku Mandala (Japan).cue" size="1529" crc="c42ab548" sha1="6bd177e928c5ea9262f1df7948a8a7e205348bd3"/>
+		-->
+		<description>Gokuraku Mandala</description>
+		<year>1994</year>
+		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HMF-102"/>
+		<info name="alt_title" value="極楽まんだら" />
+		<info name="release" value="199402xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="gokuraku mandala (japan)" sha1="911f06db513d74c86c4e8b2baa10a9ac21663d56" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="grimmaka">
 		<!--
 		Origin: P2P
@@ -6201,11 +6343,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="gunblaze">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Gunblaze.ccd" size="3249" crc="d0f88b1a" sha1="7283b05fc15a7b1cf0d6f149ecfbb58e8149edda"/>
-		<rom name="Gunblaze.cue" size="584" crc="3c6ff80a" sha1="5df8151457900ffeadcd363aa8ba9ed18bc6def0"/>
-		<rom name="Gunblaze.img" size="654387552" crc="b14b4ec2" sha1="5df61a755df6e58b9939b878f933aadbde792cc0"/>
-		<rom name="Gunblaze.sub" size="26709696" crc="812809ef" sha1="732dfd7efe04f585b6a4a21a2457c097eaf59f41"/>
+		Origin: redump.org
+		<rom name="GunBlaze (Japan) (Track 01).bin" size="22169952" crc="ea4d18ce" sha1="1640bbaeb2e7d283ae426c95ba14f3d55d0170ff"/>
+		<rom name="GunBlaze (Japan) (Track 02).bin" size="47980800" crc="3d2555d0" sha1="db3d771ad9aa19c9ebaf66b7e3d92160d77f3ac1"/>
+		<rom name="GunBlaze (Japan) (Track 03).bin" size="19227600" crc="2f8678ab" sha1="ce48e775dfe653d8c664798946d039aaadc31c0f"/>
+		<rom name="GunBlaze (Japan) (Track 04).bin" size="39337200" crc="449e0cb6" sha1="716e36fc87c08d6a31c0c94424e42d2bb87e8f1e"/>
+		<rom name="GunBlaze (Japan) (Track 05).bin" size="28047600" crc="8a529a22" sha1="6abefc1f1d0caacdf1f5232263953a9774691b9b"/>
+		<rom name="GunBlaze (Japan) (Track 06).bin" size="68090400" crc="ee456e36" sha1="596f5b98eb48b28c72d97eba6dec3ca4ab2ef0e8"/>
+		<rom name="GunBlaze (Japan) (Track 07).bin" size="16934400" crc="40a4caad" sha1="2ff5c49121fb2e6b9e2a05e86946fd361af07776"/>
+		<rom name="GunBlaze (Japan) (Track 08).bin" size="22755600" crc="9af82a5e" sha1="1361a07ba97c4a18047cc911406dc042979c5453"/>
+		<rom name="GunBlaze (Japan) (Track 09).bin" size="53625600" crc="b2b91812" sha1="96b068f865a21d1b32ef93e6efc58fd5fc63d720"/>
+		<rom name="GunBlaze (Japan) (Track 10).bin" size="56800800" crc="a19f1695" sha1="90263879fa4c70ed56e54fd8e689384df8569a07"/>
+		<rom name="GunBlaze (Japan) (Track 11).bin" size="85906800" crc="1f8de6a0" sha1="c904fe37300cac2767c038d1cb0de71ff9c2c664"/>
+		<rom name="GunBlaze (Japan) (Track 12).bin" size="57859200" crc="91609f02" sha1="bd3882dcc1f47354a409b9598873ad78aef56832"/>
+		<rom name="GunBlaze (Japan) (Track 13).bin" size="89787600" crc="adb8eae8" sha1="e3932b57603992bc4a890d8348c255e477bfa9c0"/>
+		<rom name="GunBlaze (Japan) (Track 14).bin" size="45864000" crc="89666e12" sha1="66d6789e6393802369e4c0013a2e0d0683dcb17f"/>
+		<rom name="GunBlaze (Japan).cue" size="1536" crc="8f565d63" sha1="613ae9664c2e3955ca7720b843c49c1d7135799c"/>
 		-->
 		<description>Gunblaze</description>
 		<year>1994</year>
@@ -6215,7 +6368,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="gunblaze" sha1="2ef094206014ebbe9606e2eca117779e833bd1eb" />
+				<disk name="gunblaze (japan)" sha1="9f4631523057e4946484d23b3d5f28d1d65d16e6" />
 			</diskarea>
 		</part>
 	</software>
@@ -6894,11 +7047,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="igo2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Go II.ccd" size="768" crc="c0608f7b" sha1="1dcbb4856227905559ae70461907b529ac7bc74b"/>
-		<rom name="Go II.cue" size="69" crc="16a3bd2a" sha1="af36f49c218f4634d961f86ddbbc4196612249a8"/>
-		<rom name="Go II.img" size="3880800" crc="d32d5632" sha1="7aef1aa8570b38e7e85fe06bcfd835ddf8d985cd"/>
-		<rom name="Go II.sub" size="158400" crc="66b32aee" sha1="c3eb209b26f2794a74639760a4fffc9614aa9853"/>
+		Origin: redump.org
+		<rom name="Igo II (Japan) (Rev A).bin" size="3880800" crc="1dd0f59b" sha1="e1380283f529b6053fcc954e5273dc635f79fe16"/>
+		<rom name="Igo II (Japan) (Rev A).cue" size="111" crc="bfeeefba" sha1="d0161f5bca4bae641a6904128c2ee6196f89c23e"/>
 		-->
 		<description>Igo II</description>
 		<year>1989</year>
@@ -6907,7 +7058,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="囲碁II" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="go ii" sha1="74ad3665b97bf25ea91a7d7dd344de8bff845be0" />
+				<disk name="igo ii (japan) (rev a)" sha1="c8086e68ae61656c24034decab5c5044e02f50c6" />
 			</diskarea>
 		</part>
 	</software>
@@ -7117,6 +7268,36 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="injuu gakuen - la blue girl" sha1="5e9d0e7657f8834277ec7f2833fe3d3cc889b6e2" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="iris">
+		<!--
+		Origin: redump.org
+		<rom name="Iris-tei Serenade (Japan) (Track 01).bin" size="10231200" crc="07ac491a" sha1="d0e038d721c80a60b064aebf1bdab5a00d890aa5"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 02).bin" size="37961280" crc="1394ee31" sha1="44f912cf96fe67b94355ded99383cf0c15dc649e"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 03).bin" size="36103200" crc="e04f1024" sha1="10844dfb2780f3b096ed64bda881ba003de1696d"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 04).bin" size="40917744" crc="2dad7abf" sha1="4e9b301ea9de1935a9212bff21e155b2eb8d9867"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 05).bin" size="35992656" crc="7175d9e0" sha1="ad4252a86ee64e44fc25efd3ed0710742cff764c"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 06).bin" size="47021184" crc="179130ae" sha1="a35a8a16abe9086e196ee5bd9398b1ea14445a78"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 07).bin" size="47769120" crc="8ee147c8" sha1="d71a5ae23c04511efa7ac3dfcf87607f7b997752"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 08).bin" size="44177616" crc="33f62599" sha1="60d9b232925f2f68ef46fac17b1fff868efc45d5"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 09).bin" size="39478320" crc="93049efa" sha1="7a7192ffcfddb6fa7a7f74f080e571b3b1e60aff"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 10).bin" size="36326640" crc="d2f16a69" sha1="7fc00f22ff35ae65e73e756419871169186d8fd2"/>
+		<rom name="Iris-tei Serenade (Japan) (Track 11).bin" size="31039344" crc="06e2ac13" sha1="3458b148b561326885ed24e326682b4b965bb83f"/>
+		<rom name="Iris-tei Serenade (Japan).cue" size="1325" crc="a6f812d3" sha1="02859e1eeae9aea0a4bf57ef405a13b2ba9f26fb"/>
+		-->
+		<description>Iris-tei Serenade</description>
+		<year>1992</year>
+		<publisher>アグミックス (Agumix)</publisher>
+		<info name="serial" value="HMD-212 / MTC-1031"/>
+		<info name="alt_title" value="イーリス亭小夜曲" />
+		<info name="release" value="199211xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="iris-tei serenade (japan)" sha1="cb2c726ce594c8e56c47f8ce6c19ddbee96e62e6" />
 			</diskarea>
 		</part>
 	</software>
@@ -8411,11 +8592,10 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="lesserm">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Lesser Mern.ccd" size="956" crc="9fa79f85" sha1="e0dc612d75fc5cb9f84d61009d99658964e18f44"/>
-		<rom name="Lesser Mern.cue" size="114" crc="b94ab7d4" sha1="391c115b65f428082357911a4b0cd1d968378e58"/>
-		<rom name="Lesser Mern.img" size="309828960" crc="a9115225" sha1="76d5d8c7554fe9dbcd06674054c8969c34f00b26"/>
-		<rom name="Lesser Mern.sub" size="12646080" crc="bcf77f91" sha1="54f92b3ffd4367c9f8941a619add6228659b983a"/>
+		Origin: redump.org
+		<rom name="Lesser Mern (Japan) (Track 1).bin" size="20815200" crc="d87b1d37" sha1="668bcd1c70373ae9dae251f5778a2974bef7ef66"/>
+		<rom name="Lesser Mern (Japan) (Track 2).bin" size="289013760" crc="1df28c09" sha1="38d9ec06362917cb5e4d0a621fc67253033ae65e"/>
+		<rom name="Lesser Mern (Japan).cue" size="231" crc="72e54ef3" sha1="ae5961289300e8d0c8616d9058823ee7bbffeb62"/>
 		-->
 		<description>Lesser Mern</description>
 		<year>1992</year>
@@ -8426,7 +8606,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lesser mern" sha1="e9e9e42e26db1afbeb6f111d9ee4068fd09c3c3d" />
+				<disk name="lesser mern (japan)" sha1="cf4a79db0387994ce4e69cadf88c1dae76d17ad7" />
 			</diskarea>
 		</part>
 	</software>
@@ -8778,7 +8958,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Mad Paradox</description>
 		<year>1994</year>
-		<publisher>クィーンソフト (Queensoft)</publisher>
+		<publisher>クィーンソフト (Queen Soft)</publisher>
 		<info name="serial" value="HMF-107"/>
 		<info name="alt_title" value="マッドパラドックス" />
 		<info name="release" value="199402xx" />
@@ -8876,7 +9056,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Mahjong Hou Tei Rao Yui</description>
 		<year>1995</year>
-		<publisher>クィーンソフト (Queensoft)</publisher>
+		<publisher>クィーンソフト (Queen Soft)</publisher>
 		<info name="alt_title" value="麻雀河底撈魚" />
 		<info name="release" value="199508xx" />
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9032,6 +9212,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="marionetm">
+		<!--
+		Origin: redump.org
+		<rom name="Marionette Mind (Japan).bin" size="10231200" crc="89eb54af" sha1="330fed6c662d7b83ccd25d8e2fc242fd7db16802"/>
+		<rom name="Marionette Mind (Japan).cue" size="89" crc="a458ca9b" sha1="9cf92ae9a16a0f42205807f9b80ffb0a5aef827f"/>
+		-->
+		<description>Marionette Mind</description>
+		<year>1994</year>
+		<publisher>スタジオみるく (Studio Milk)</publisher>
+		<info name="serial" value="HME-251"/>
+		<info name="alt_title" value="マリオネット・マインド" />
+		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="marionette mind (japan)" sha1="060c3feab24d0212ffefe2b3338f9f78b98b5f34" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="manhole">
 		<!--
 		Origin: Neo Kobe Collection
@@ -9040,14 +9240,104 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="The Manhole.img" size="523672800" crc="33510cba" sha1="9ffc30557cc95464065c075c74583ef70f0be011"/>
 		<rom name="The Manhole.sub" size="21374400" crc="ec086392" sha1="01775a3b3ccb342a01bbe954626ab36f461fe053"/>
 		-->
-		<description>The Manhole</description>
+		<description>The Manhole (1990-09-06)</description>
+		<year>1990</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="マンホール" />
+		<info name="release" value="199009xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="the manhole" sha1="b469808157cd2aeff35c8c538c0a56c9dd41d064" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="manholeo" cloneof="manhole">
+		<!--
+		Origin: redump.org
+		<rom name="Manhole, The (Japan) (Track 01).bin" size="105487200" crc="ec45db33" sha1="f4954f1e6afe21e4b32858ddd4d671791e93e901"/>
+		<rom name="Manhole, The (Japan) (Track 02).bin" size="7338240" crc="c01cde84" sha1="ffcbc5f6c98eec23408ced136fa4cac447f77096"/>
+		<rom name="Manhole, The (Japan) (Track 03).bin" size="8455440" crc="59012515" sha1="659473f2cd8fb719c4083d4cef85e3c14367364e"/>
+		<rom name="Manhole, The (Japan) (Track 04).bin" size="12402096" crc="38976e6b" sha1="d281e47886fa85f18ff19a1b34810d253111cca7"/>
+		<rom name="Manhole, The (Japan) (Track 05).bin" size="13335840" crc="7ffe7e52" sha1="f7325da1ba4bbb9aa5c6c0f4da763b7a04169655"/>
+		<rom name="Manhole, The (Japan) (Track 06).bin" size="6879600" crc="bb38080c" sha1="e41ebbbb29bc9a9f2dac0de3103cfa528844166c"/>
+		<rom name="Manhole, The (Japan) (Track 07).bin" size="7625184" crc="9d199abe" sha1="afccc2e649cb778e541e1ca021f00fe3359ec813"/>
+		<rom name="Manhole, The (Japan) (Track 08).bin" size="9685536" crc="d6bdf47e" sha1="007974b483663f6295105aeffa7526ecf42996f5"/>
+		<rom name="Manhole, The (Japan) (Track 09).bin" size="10600464" crc="c2fd76db" sha1="c6cc5aef931501582cc2f6c61040ddeaab82f654"/>
+		<rom name="Manhole, The (Japan) (Track 10).bin" size="12484416" crc="8f024d56" sha1="7f94b60396ab44affcbb2620010b9b825e52823b"/>
+		<rom name="Manhole, The (Japan) (Track 11).bin" size="24025680" crc="f1a52185" sha1="65f4808c76c3e92ba390a0d1c93467489737d5bc"/>
+		<rom name="Manhole, The (Japan) (Track 12).bin" size="11313120" crc="178c48da" sha1="1989e2415fc508facb59f68906c14bb4de74a5dd"/>
+		<rom name="Manhole, The (Japan) (Track 13).bin" size="19749744" crc="5eb5b053" sha1="19404cab9b0c939e3280e8c5b2be25c0a3f39db5"/>
+		<rom name="Manhole, The (Japan) (Track 14).bin" size="8808240" crc="b5c5dab6" sha1="73f34caa248a05e1065925a60dd7493000ca3ac6"/>
+		<rom name="Manhole, The (Japan) (Track 15).bin" size="18470256" crc="7a54510a" sha1="139aec0a764ab3c927cd86b92183fbaf8733d8b1"/>
+		<rom name="Manhole, The (Japan) (Track 16).bin" size="13324080" crc="2e2cf4b6" sha1="2c78a96b134d7441454d581d5bc3891317ccdced"/>
+		<rom name="Manhole, The (Japan) (Track 17).bin" size="15534960" crc="db4d761a" sha1="748c279f463bc5e37878ebe3956b01eafca88a74"/>
+		<rom name="Manhole, The (Japan) (Track 18).bin" size="11501280" crc="a9e791c5" sha1="e4eb01295443500ad6446812078a05af6706f286"/>
+		<rom name="Manhole, The (Japan) (Track 19).bin" size="12470304" crc="c2a7de11" sha1="e9dba41a1076e59929097340fb0d4627aa7cbc41"/>
+		<rom name="Manhole, The (Japan) (Track 20).bin" size="10426416" crc="2c1da614" sha1="031fa08f30667a20a079a2ac0e9e75b364ed4c07"/>
+		<rom name="Manhole, The (Japan) (Track 21).bin" size="10224144" crc="e4f59ff8" sha1="600ea4907e15f8e5f52b473f4e5ba18189a0167d"/>
+		<rom name="Manhole, The (Japan) (Track 22).bin" size="11148480" crc="9eb125b4" sha1="a390b3f0db83ca96b0ad9a99700b6761173e974a"/>
+		<rom name="Manhole, The (Japan) (Track 23).bin" size="6933696" crc="d702ce59" sha1="9bc26f8167ddbee23bf526eeb92cd8e57a735eb0"/>
+		<rom name="Manhole, The (Japan) (Track 24).bin" size="5578944" crc="998f85c9" sha1="89b522a969d3cf0ab6ff2568e9bb3ab50ba7053f"/>
+		<rom name="Manhole, The (Japan) (Track 25).bin" size="3528000" crc="ee4c2c0b" sha1="1f72f42b85c2cec292c1eff95462289dfbe503dd"/>
+		<rom name="Manhole, The (Japan) (Track 26).bin" size="4362960" crc="07bf6202" sha1="0d0e0fe9d0caa8c58bc7274203a46e4a8be18885"/>
+		<rom name="Manhole, The (Japan) (Track 27).bin" size="665616" crc="59012a2c" sha1="4d678ff3ce5d8bfcfa8cde7f17ea5c220a40abf9"/>
+		<rom name="Manhole, The (Japan) (Track 28).bin" size="834960" crc="712eb475" sha1="d61306bf26a2115a56e027a3359f25c50498c775"/>
+		<rom name="Manhole, The (Japan) (Track 29).bin" size="780864" crc="32be2c43" sha1="a0c0a368069f386ada294454351be6e7fb5d19f8"/>
+		<rom name="Manhole, The (Japan) (Track 30).bin" size="776160" crc="07428177" sha1="5b6d37b0ed4e535f1833494fa69aee8502bd0ce3"/>
+		<rom name="Manhole, The (Japan) (Track 31).bin" size="912576" crc="95e00ebc" sha1="0ad87a944895eeab55e7d5b135ef22b8629f8212"/>
+		<rom name="Manhole, The (Japan) (Track 32).bin" size="1081920" crc="2f25ecd0" sha1="0f31d307e6dbee05cb294ebb768ded4492975884"/>
+		<rom name="Manhole, The (Japan) (Track 33).bin" size="910224" crc="7a6c358c" sha1="e16683d6ebb69ec7b2334c7887f30124f514cb40"/>
+		<rom name="Manhole, The (Japan) (Track 34).bin" size="929040" crc="b462278a" sha1="03d130d4ebb1808dcc2ab56f20d8957dfdd06cc9"/>
+		<rom name="Manhole, The (Japan) (Track 35).bin" size="818496" crc="8517e5e4" sha1="d5c9140adf331f790cc271f0181104171bd45fc6"/>
+		<rom name="Manhole, The (Japan) (Track 36).bin" size="2222640" crc="d2c61ad3" sha1="9f45e43d251071af627357dbcca5cca1b430dfe8"/>
+		<rom name="Manhole, The (Japan) (Track 37).bin" size="858480" crc="e7ef9c07" sha1="ac9b4a2dd5dcf9b1e49e1b1fa052e66d8e4ae297"/>
+		<rom name="Manhole, The (Japan) (Track 38).bin" size="764400" crc="f2f27f8e" sha1="ef420e2c6410d178aa379c44496b03d737941b50"/>
+		<rom name="Manhole, The (Japan) (Track 39).bin" size="639744" crc="cf1fa48b" sha1="b705d1c137248352ad3e80b414b2d15531172f25"/>
+		<rom name="Manhole, The (Japan) (Track 40).bin" size="1223040" crc="d8ee863e" sha1="2f009d94c3e7c827cc249a571028dde2f20c9644"/>
+		<rom name="Manhole, The (Japan) (Track 41).bin" size="1206576" crc="35385c80" sha1="2cf045ddf54b21e1993bb988ecda248eb281c0f5"/>
+		<rom name="Manhole, The (Japan) (Track 42).bin" size="851424" crc="ee5f361a" sha1="2d3ae2e3546190cae338f6e87ee9352d215ca4ec"/>
+		<rom name="Manhole, The (Japan) (Track 43).bin" size="917280" crc="a25d463f" sha1="72667adab078bc9ddf0b5e54b9d0dde241d32657"/>
+		<rom name="Manhole, The (Japan) (Track 44).bin" size="1105440" crc="5d20e995" sha1="487a2e60b669c35828719685ecdd761c4c518d11"/>
+		<rom name="Manhole, The (Japan) (Track 45).bin" size="1077216" crc="5499cc59" sha1="d87a8dd5f3d33741a000972b0e0382ef7e1798d9"/>
+		<rom name="Manhole, The (Japan) (Track 46).bin" size="2109744" crc="525dfb44" sha1="1d2c01980bf2d7dcc3f8e695a76629999c8f0109"/>
+		<rom name="Manhole, The (Japan) (Track 47).bin" size="700896" crc="3117de69" sha1="ec9c205b6cd5717ae3c5a937c680851bc8407659"/>
+		<rom name="Manhole, The (Japan) (Track 48).bin" size="1121904" crc="a9ae9622" sha1="1f7339b20d3d04a382bde67d36a5f73a0384e746"/>
+		<rom name="Manhole, The (Japan) (Track 49).bin" size="882000" crc="2d1cfc8f" sha1="5edb04fb8a79e59d8f8cacf771b8f1bc38a0a71e"/>
+		<rom name="Manhole, The (Japan) (Track 50).bin" size="764400" crc="61fdb406" sha1="58bcc3bdcbc26669397efe00399430ab9f360b93"/>
+		<rom name="Manhole, The (Japan) (Track 51).bin" size="2540160" crc="81fd2d52" sha1="0a113e2bf82f0bd75e7c0e99336129f5b621b359"/>
+		<rom name="Manhole, The (Japan) (Track 52).bin" size="1434720" crc="109b6fa1" sha1="e60d3bf8495bd726323e65afda2b90277d7dd025"/>
+		<rom name="Manhole, The (Japan) (Track 53).bin" size="1246560" crc="2e33753b" sha1="1cc0f9ce177dc0d0fbc0ff7806cbc3feab7532fa"/>
+		<rom name="Manhole, The (Japan) (Track 54).bin" size="736176" crc="286a981a" sha1="092ae238f716b6ade4db9aa5802d4144c21f1be7"/>
+		<rom name="Manhole, The (Japan) (Track 55).bin" size="917280" crc="abf1816f" sha1="0675f17340804d912b0d75102eaf8952ca8da72d"/>
+		<rom name="Manhole, The (Japan) (Track 56).bin" size="627984" crc="5ac69655" sha1="71176a5b33bffeb44f0097f2d552812b0ee52328"/>
+		<rom name="Manhole, The (Japan) (Track 57).bin" size="2493120" crc="cbe8ce7b" sha1="d748220ddf319116c2a33e9a7c75c684fcd6f2dc"/>
+		<rom name="Manhole, The (Japan) (Track 58).bin" size="1611120" crc="81ff85b2" sha1="f8de9bbed568745d3aaa7c2f3c26a6c13e571e4e"/>
+		<rom name="Manhole, The (Japan) (Track 59).bin" size="752640" crc="da78bea9" sha1="f5836bb6abda172a0eec4446f0f43392cff81410"/>
+		<rom name="Manhole, The (Japan) (Track 60).bin" size="693840" crc="251e5b2c" sha1="c3a33325a02d05072c8532d33a087f8290766f13"/>
+		<rom name="Manhole, The (Japan) (Track 61).bin" size="994896" crc="6431559e" sha1="4b7583da82fbb12fc79ffe591699758d24dc32d9"/>
+		<rom name="Manhole, The (Japan) (Track 62).bin" size="1486464" crc="8e2d13ab" sha1="12e3d3bc7653bcf7a93ab211161133c37581961e"/>
+		<rom name="Manhole, The (Japan) (Track 63).bin" size="1253616" crc="8f6e37ad" sha1="36c4c6d2696bc9c2453cdc5bf70b2b0d3b5a2f5d"/>
+		<rom name="Manhole, The (Japan) (Track 64).bin" size="811440" crc="f2b803cc" sha1="bcea665f5735d1846919f6d4e712190c4810a484"/>
+		<rom name="Manhole, The (Japan) (Track 65).bin" size="1251264" crc="ac8056c3" sha1="c2cd7337892514db2275f2748f85347e9d20a4dd"/>
+		<rom name="Manhole, The (Japan) (Track 66).bin" size="1046640" crc="27734d33" sha1="8e227fa5a895733f689d49bfc24e7d3bb5d4803a"/>
+		<rom name="Manhole, The (Japan) (Track 67).bin" size="1618176" crc="d94f4a04" sha1="dc8c3413fbffd8ce829dd94c118b2d50ae4edbef"/>
+		<rom name="Manhole, The (Japan) (Track 68).bin" size="72187584" crc="428281c7" sha1="500d5edd3d29167131ecee113fee68d5832a906c"/>
+		<rom name="Manhole, The (Japan) (Track 69).bin" size="14389536" crc="9f9476c3" sha1="a16229a211b343e3c6b7a7d5307a3e0399837bfb"/>
+		<rom name="Manhole, The (Japan) (Track 70).bin" size="2756544" crc="b8ae1a61" sha1="0d6488261fa1c9e90149d579ceb04946355beb41"/>
+		<rom name="Manhole, The (Japan) (Track 71).bin" size="3010560" crc="2117b7d8" sha1="e176efe36a46e6373cb5d353c0afac694185a3f0"/>
+		<rom name="Manhole, The (Japan) (Track 72).bin" size="2622480" crc="ada911e3" sha1="6ef2a9b43f349c6453cbfd9262abe19e1403142e"/>
+		<rom name="Manhole, The (Japan) (Track 73).bin" size="1340640" crc="ccb8f54c" sha1="eba98b1a87ab4f2cca530313294bd7a0b89f8227"/>
+		<rom name="Manhole, The (Japan).cue" size="8400" crc="446657cb" sha1="66f2603d5dc12d39f87a24f842378cb33a1f4042"/>
+		-->
+		<description>The Manhole (1990-08-01)</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="alt_title" value="マンホール" />
 		<info name="release" value="199008xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the manhole" sha1="b469808157cd2aeff35c8c538c0a56c9dd41d064" />
+				<disk name="manhole, the (japan)" sha1="314d7c0ddb900e9e8d6d104264cf95017d80f33d" />
 			</diskarea>
 		</part>
 	</software>
@@ -9343,6 +9633,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="mirage" sha1="b1536b6de52c10315b54a665a82cf83906c32f4a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="mirage2">
+		<!--
+		Origin: redump.org
+		<rom name="Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand (Japan).bin" size="18726624" crc="94f9dfb8" sha1="f60333837f42ca928f677bc5da1f6b0966d2eacf"/>
+		<rom name="Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand (Japan).cue" size="127" crc="0053d83b" sha1="9799d748643ce4a6bf634ca3acf2ca359fe5de6a"/>
+		-->
+		<description>Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand</description>
+		<year>1994</year>
+		<publisher>ディスカバリー (Discovery)</publisher>
+		<info name="serial" value="2TD-3018"/>
+		<info name="alt_title" value="ミラージュ２ トリー×ニート×ローンの大冒険" />
+		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="mirage 2 - torry, neat &amp; roan fairladies in magicLand (japan)" sha1="22c46e6409b2ffa8423691d12340b189f2e24358" />
 			</diskarea>
 		</part>
 	</software>
@@ -10774,6 +11084,46 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="nsangel">
+		<!--
+		Origin: redump.org
+		<rom name="Noushuku Angel 120% (Japan) (Track 01).bin" size="116071200" crc="13da9107" sha1="38a50b6a4d530ec9b157817ed5b0b28d1640f803"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 02).bin" size="46746000" crc="39981d2a" sha1="15be0d7ce0d732d843c834def8f2aad0d6aeae5d"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 03).bin" size="45334800" crc="6c24a035" sha1="3c119818b83f449dff5060bf5834aad762f99530"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 04).bin" size="45864000" crc="fec7747c" sha1="8475d21bde8654b7267f33419810d2c2c0833235"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 05).bin" size="46922400" crc="bdaeb016" sha1="d1dffc1545c6e25e18b0497a20112b4ddf738a4d"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 06).bin" size="46216800" crc="82ccaccb" sha1="3444a90b5aecec9cc53a420f54fc9dd0313056a0"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 07).bin" size="52390800" crc="b66bfe6d" sha1="339eeae795b6a7bcaa0adc8c0b7c6da50b58b2ad"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 08).bin" size="43218000" crc="c749c93c" sha1="fea2955d17f2ba326e47f6f7e0f1199aa4a5d17c"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 09).bin" size="46393200" crc="db27fc75" sha1="0904f12e43fc6082c3db0c83e33dc1056dd85131"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 10).bin" size="46216800" crc="7742b676" sha1="ee7e03ec2ad9d0cdb317142feff18eb850e38c4a"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 11).bin" size="53096400" crc="6bcc7382" sha1="63ddcd25e0d1659dc3dc0a697311cb3e78971a04"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 12).bin" size="42512400" crc="597afae5" sha1="c31f7efe149db4a49a8e351ef7b6355f94d0e5df"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 13).bin" size="5997600" crc="d66966f0" sha1="2f287e73882b9941ffbb7c1db43c97c7fd2c62ac"/>
+		<rom name="Noushuku Angel 120% (Japan) (Track 14).bin" size="5115600" crc="2d0b9103" sha1="fb8fa599858d8132626464cc9f2e40e90e4e6ce5"/>
+		<rom name="Noushuku Angel 120% (Japan).cue" size="1713" crc="a6d9a336" sha1="fcb6d755feed16a0339b36cdb5e4a58c8db2f102"/>
+		-->
+		<description>Noushuku Angel 120%</description>
+		<year>1995</year>
+		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HMG-118"/>
+		<info name="alt_title" value="濃縮エンジェル１２０％" />
+		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<!-- Floppy image created with the BSS tool included on the CD. Should match an image of the actual disk -->
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="nsangel_disk_a.hdm" size="1261568" crc="ba5a137b" sha1="b64d6bc1c303d281ff8ed9f81dbfbaa02ffde8a9" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="noushuku angel 120 (japan)" sha1="eae40afd0882c6dfbe127bd8b985e7c743443217" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="okitgear">
 		<!--
 		Origin: Neo Kobe Collection
@@ -11234,11 +11584,10 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="prinmak2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Princess Maker 2.ccd" size="908" crc="dba2d512" sha1="196e444bccbedee24a79da2d3c3e352217ebc7f4"/>
-		<rom name="Princess Maker 2.cue" size="162" crc="f1f3b81e" sha1="50cc03f0970cc60a8d78dda0e7d5235a68ff66ec"/>
-		<rom name="Princess Maker 2.img" size="621214944" crc="4540f9f0" sha1="304fad2201aa58a6528b152e12b97fd21dff4377"/>
-		<rom name="Princess Maker 2.sub" size="25355712" crc="4e54a2ff" sha1="53c6325736f83d4cb079b0ec32a6771e4df6a15d"/>
+		Origin: redump.org
+		<rom name="Princess Maker 2 (Japan) (Track 1).bin" size="84319200" crc="a56e88e3" sha1="8e6b892eb5406d97766cd0f05b7db2676b8e6c19"/>
+		<rom name="Princess Maker 2 (Japan) (Track 2).bin" size="536895744" crc="8eb99fd9" sha1="a068269a494234e8390115e405e395e5d601d71b"/>
+		<rom name="Princess Maker 2 (Japan).cue" size="218" crc="9d022bcf" sha1="66c4b27f7a08cd6deaf706eab8212d3952d3e035"/>
 		-->
 		<description>Princess Maker 2</description>
 		<year>1994</year>
@@ -11249,7 +11598,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="princess maker 2" sha1="a0ed8d1a394ccfc109c3afdc6fdc6fd6a095643d" />
+				<disk name="princess maker 2 (japan)" sha1="013247a78840c2a00f3a50aa1d19658586a16d49" />
 			</diskarea>
 		</part>
 	</software>
@@ -11834,6 +12183,47 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="queencup">
+		<!--
+		Origin: redump.org
+		<rom name="Gambler - Queen's Cup (Japan) (Track 01).bin" size="10231200" crc="7395f2e5" sha1="7ac8911da780869775a3b8d82c7f041fff946098"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 02).bin" size="28224000" crc="3730db43" sha1="6b0e0b33f36843477640d844c12ec09e4eb12887"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 03).bin" size="34574400" crc="d6303740" sha1="ba8b714e8fd34c3a6767f4018065ec8fb9c1520e"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 04).bin" size="9172800" crc="c44953b6" sha1="470d8a6a90ff3580b0260cf9da6f1e0b4ecef223"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 05).bin" size="9172800" crc="f4331595" sha1="18d912d3ca6a962598b887a682b65ebe93899a97"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 06).bin" size="33868800" crc="b343c990" sha1="46a924e512fc483fe63e9041a33e2abcec2c56b4"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 07).bin" size="30340800" crc="2698edaf" sha1="98b3f59b92f1453abe5eb7f972311df70f7cd92f"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 08).bin" size="31222800" crc="ea4e7ac0" sha1="0cb5702ad2c5c134fd93f05f6d780a8a33227787"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 09).bin" size="34045200" crc="826568b6" sha1="bc2d793d6e3adc4c1393287cc35b8fd43d9d9e94"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 10).bin" size="32457600" crc="3bdfe41e" sha1="ed52e4cc66f033ccf14407876022781143afd33b"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 11).bin" size="29635200" crc="8c5be8ce" sha1="8999d763265a5c0e5f06f023e707803b3584b49a"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 12).bin" size="31222800" crc="484535c6" sha1="40ec04af1e9f6cde3088b64d1940f591d09bf044"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 13).bin" size="31222800" crc="9911b750" sha1="a8850e6b1447108a3cc498b08a22acd74c98ad38"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 14).bin" size="28929600" crc="fbaa1181" sha1="4bd76a5f18ee7b913795ef39b3c489e0f6a7b903"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 15).bin" size="32281200" crc="18670d9e" sha1="56de59298958ba293053377f34a466cdfe9fbed2"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 16).bin" size="36162000" crc="620bbb71" sha1="be643dec236ccdb2aa4819bd541e23fe2f0b75db"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 17).bin" size="32634000" crc="1c0a3ff5" sha1="6006aa6104c8d3af94f87a2f7ae8d1afa5c889fb"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 18).bin" size="30693600" crc="bc99ffd8" sha1="921414d2f9cc5ba72994a89bf8c206eeff9e2656"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 19).bin" size="1411200" crc="cac4b12c" sha1="69c04a29b23c7a27e731fc1d4c7ebfaf12a6476c"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 20).bin" size="2469600" crc="11c8fa19" sha1="8b80db24c1fa2990c5bb8e4e9b0d165100c1aa6e"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 21).bin" size="1587600" crc="f8dc45df" sha1="edc4888cb260082cb23e3ce3a4bfa0ac90d624d3"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 22).bin" size="32281200" crc="ceb82122" sha1="a4c3ff3673ec0f09f68cd44e46fb572ed037cecf"/>
+		<rom name="Gambler - Queen's Cup (Japan) (Track 23).bin" size="1058400" crc="c2ff07f3" sha1="998857932ffe379a562106aa1cd9511f50938bc2"/>
+		<rom name="Gambler - Queen's Cup (Japan).cue" size="2834" crc="07681ae9" sha1="5d04f444a1f0761bf9ace90a441f9b2aca19a76d"/>
+		-->
+		<description>Gambler - Queen's Cup</description>
+		<year>1994</year>
+		<publisher>クィーンソフト (Queen Soft)</publisher>
+		<info name="serial" value="HMF-180 / QCD9409"/>
+		<info name="alt_title" value="ギャンブラー　－Ｑｕｅｅｎ’ｓ　Ｃｕｐ－" />
+		<info name="release" value="199409xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="gambler - queen's cup (japan)" sha1="6d12c2ce89e79c9fb8a78717c5771bffa3f632d2" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="racrally">
 		<!--
 		Origin: Neo Kobe Collection
@@ -12105,11 +12495,23 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="rayxanbr">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Rayxanber.ccd" size="3527" crc="7b3c29af" sha1="3077f1f119cfeb5e89262002bc6501fc5ea8c80c"/>
-		<rom name="Rayxanber.cue" size="670" crc="e0a2263d" sha1="153fc29eecde9cda783c5dc01b180b313a777d79"/>
-		<rom name="Rayxanber.img" size="417268320" crc="6cfe50cc" sha1="64843282a94d48fc2f185d9e5f2522ec145eef78"/>
-		<rom name="Rayxanber.sub" size="17031360" crc="c8fdc393" sha1="19257c49a93ba1ce34cdb32c42ae64f5427a9e7a"/>
+		Origin: redump.org
+		<rom name="Rayxanber (Japan) (Track 01).bin" size="8937600" crc="9699280b" sha1="5ba8bdf2a926c32942782aef738a8fbab282455b"/>
+		<rom name="Rayxanber (Japan) (Track 02).bin" size="54237120" crc="0c23a42f" sha1="08369036bca2b5fdc0e411321b6d3d60c860a959"/>
+		<rom name="Rayxanber (Japan) (Track 03).bin" size="27271440" crc="11b06bd6" sha1="1376993c3e871c6d0288079c11675014fdb80d23"/>
+		<rom name="Rayxanber (Japan) (Track 04).bin" size="28776720" crc="82abd0fb" sha1="77f1b5bcd491d0a8d8cf40cb5839f5c5039ac2d7"/>
+		<rom name="Rayxanber (Japan) (Track 05).bin" size="33222000" crc="ea5980cf" sha1="3652831c0a1e9fc15cee1d3dc0cedee4f5f4725a"/>
+		<rom name="Rayxanber (Japan) (Track 06).bin" size="40736640" crc="f3054da2" sha1="ff9d2869e9eec806fded9d1ec5a9c9b53d6fc09f"/>
+		<rom name="Rayxanber (Japan) (Track 07).bin" size="33457200" crc="5c45258c" sha1="f14c6628e86ea81e874128435fc7daf003f5b4f6"/>
+		<rom name="Rayxanber (Japan) (Track 08).bin" size="14394240" crc="d9f6ff7e" sha1="98242339c7eb2676b76dff50a43c86d4f223fa07"/>
+		<rom name="Rayxanber (Japan) (Track 09).bin" size="24284400" crc="66cf9ae2" sha1="fef17c2b46e0e6c86ec80e485075a9e19dbd3f55"/>
+		<rom name="Rayxanber (Japan) (Track 10).bin" size="45746400" crc="0917370b" sha1="c432f016544f5977df515edb52f5e912574642b4"/>
+		<rom name="Rayxanber (Japan) (Track 11).bin" size="30329040" crc="3f8a499e" sha1="684238be9fdc1389201eed2ea1b4f11691f506ec"/>
+		<rom name="Rayxanber (Japan) (Track 12).bin" size="21850080" crc="e1023d09" sha1="1201679e5efe4d8c5bc65d7157a9951fb005e443"/>
+		<rom name="Rayxanber (Japan) (Track 13).bin" size="43441440" crc="40cfcc18" sha1="a70c24d902c7d07937c79d45a560eabdaa3f8b4e"/>
+		<rom name="Rayxanber (Japan) (Track 14).bin" size="6350400" crc="24f467dc" sha1="a5f58e8736f972b703a5a05e406e8f47c38fe298"/>
+		<rom name="Rayxanber (Japan) (Track 15).bin" size="4240656" crc="b110050a" sha1="3ef64e567cab4d44b058fb21d07b6e3e7e7f7e3b"/>
+		<rom name="Rayxanber (Japan).cue" size="1685" crc="3f57cc4b" sha1="77d494307d8be79a6b19cb0010fb631d4f875825"/>
 		-->
 		<description>Rayxanber</description>
 		<year>1990</year>
@@ -12120,7 +12522,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rayxanber" sha1="5e7c36227d61be81f8a4cf4ef79889d12a72549c" />
+				<disk name="rayxanber (japan)" sha1="44c3f016aaa6365e05f5533adb82b56e2bf69ccf" />
 			</diskarea>
 		</part>
 	</software>
@@ -12695,6 +13097,35 @@ User/save disks that can be created from the game itself are not included.
 				<rom name="shamhat - the holy circlet (user disk).hdm" size="1261568" crc="77ae1f06" sha1="b95dae61c620f289d30378774afbd069658ef935" offset="000000" />
 			</dataarea>
 		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="shamhat - the holy circlet (japan)" sha1="538a5f793c970a3ad9732c9e30f75b5b68b7b8f0" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="shamhatm" cloneof="shamhat">
+		<!--
+		Origin: redump.org / wiggy2k
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 1).bin" size="260484000" crc="5c856e63" sha1="2751566dd6bb590dfb4c67e5e54d5c9535233d80"/>
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 2).bin" size="5997600" crc="97dfe1ae" sha1="1d9d1ff4e3ee96c9b14caa867d58fe7f58a693d4"/>
+		<rom name="Shamhat - The Holy Circlet (Japan) (Track 3).bin" size="54695760" crc="95e66371" sha1="ae10a3f5ce8fdc8a841aaaea5936dff6e576a2b1"/>
+		<rom name="Shamhat - The Holy Circlet (Japan).cue" size="366" crc="65b04438" sha1="a7bd44db41f64066975a485c166dada00468867c"/>
+		-->
+		<description>Shamhat - The Holy Circlet (FM Towns Marty version)</description>
+		<year>1993</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWFT 3012"/>
+		<info name="alt_title" value="シャムハト　－Ｔｈｅ　Ｈｏｌｙ　Ｃｉｒｃｌｅｔ－" />
+		<info name="release" value="199304xx" />
+		<info name="usage" value="Requires an FM Towns Marty. Won't run on any other models."/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="User Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="shamhat - the holy circlet (user disk) (marty version).hdm" size="1261568" crc="2acf7fea" sha1="4ad6670d633eaf158a24d5aa1fc9a3bcec0bbc0e" offset="000000" />
+			</dataarea>
+		</part>
+		<!-- Verified to use the same CD as the original version -->
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="shamhat - the holy circlet (japan)" sha1="538a5f793c970a3ad9732c9e30f75b5b68b7b8f0" />
@@ -14307,6 +14738,25 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="tenranma">
+		<!--
+		Origin: redump.org
+		<rom name="Tenshin Ranma (Japan).bin" size="10231200" crc="d886d832" sha1="106036b5b730478e6bc7626d12b40f07f0a60903"/>
+		<rom name="Tenshin Ranma (Japan).cue" size="110" crc="24157ac7" sha1="1e875712a4cf447e3bcd61ec355d87715d04cd8a"/>
+		-->
+		<description>Tenshin Ranma</description>
+		<year>1992</year>
+		<publisher>エルフ (Elf)</publisher>
+		<info name="serial" value="HMD-135"/>
+		<info name="alt_title" value="天神乱魔" />
+		<info name="release" value="199205xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="tenshin ranma (japan)" sha1="545427376d437155f46836bb043feb2d6e6f855f" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="date">
 		<!--
 		Origin: Neo Kobe Collection
@@ -14823,6 +15273,36 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="truheart" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="True Heart (Japan) (Track 01).bin" size="20815200" crc="b7b9c9d9" sha1="3f8f2ab8f60aa73692a0afc5b86dd4370269ff62"/>
+		<rom name="True Heart (Japan) (Track 02).bin" size="54507600" crc="6f4bf847" sha1="44eb881c45650f5f6e6dd4443627d9f588339949"/>
+		<rom name="True Heart (Japan) (Track 03).bin" size="44805600" crc="c5da9986" sha1="8d40fe2367cac3fd08e728fb0b46c36a45d478c3"/>
+		<rom name="True Heart (Japan) (Track 04).bin" size="44982000" crc="3aeb9577" sha1="1718cc5faa78bc2d44b09442e47610b560676a61"/>
+		<rom name="True Heart (Japan) (Track 05).bin" size="55213200" crc="01bf905b" sha1="39925a840f67b65c6de39ff718ab2c76fbac8978"/>
+		<rom name="True Heart (Japan) (Track 06).bin" size="55566000" crc="fe624ad5" sha1="3eae3e6e4d39f7712a4ef59302a465188ce98b48"/>
+		<rom name="True Heart (Japan) (Track 07).bin" size="49392000" crc="b774a425" sha1="52efa20fae3b8bf3c4ea2421a51a6965bfa69d2b"/>
+		<rom name="True Heart (Japan) (Track 08).bin" size="47275200" crc="2be5a75b" sha1="13291a097896e6e657bf4c43db9c5cc5ceed2509"/>
+		<rom name="True Heart (Japan) (Track 09).bin" size="41101200" crc="2afab07c" sha1="6b1a6ed9769f8146f67015035c5b492cd2a1ea56"/>
+		<rom name="True Heart (Japan) (Track 10).bin" size="58212000" crc="999b7bd5" sha1="bf2dbc36e68cf64723f621874d1987cf1c537f39"/>
+		<rom name="True Heart (Japan).cue" size="1135" crc="1baa7b0f" sha1="19ca4de8f59166a905296cb1bff2aa19376e9a48"/>
+		-->
+		<description>True Heart</description>
+		<year>1995</year>
+		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="serial" value="HMG-118"/>
+		<info name="alt_title" value="トゥルー・ハート" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="true heart (japan)" sha1="2d360a246a227c0531e586412f48f51b34eac771" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="tuntroll">
 		<!--
 		Origin: redump.org
@@ -15105,22 +15585,24 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="vastness">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Vastness.ccd" size="1525" crc="41bb06da" sha1="764c09836fc45e09f6efe47ed2b9da4c49a97e7f"/>
-		<rom name="Vastness.cue" size="228" crc="e8656a96" sha1="193c31c0fa10f79dd7c2601bf42bb764edb2d353"/>
-		<rom name="Vastness.img" size="463666224" crc="ff249f28" sha1="21c024c9f4bc2fcfaadf84072e094998facad4a7"/>
-		<rom name="Vastness.sub" size="18925152" crc="1f3a4a5d" sha1="7d26e94d29997ae4c1f204a143194c9a08c74860"/>
+		Origin: redump.org
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 1).bin" size="10231200" crc="ca6a503d" sha1="688f246987699717d7a3caa49914c34e5c2637ec"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 2).bin" size="5731824" crc="65e978bf" sha1="3bbb11f1180f0985225e774a6664badeb11fbd51"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 3).bin" size="232466976" crc="befe530a" sha1="99717ae81e6b5dc9b7f09bfdd7ed14f541f90428"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 4).bin" size="123978624" crc="dbd4fc08" sha1="af28b6e43f566c5d07d9af67826cbec7a379c4c7"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 5).bin" size="91257600" crc="2ce807e4" sha1="8a25b2ddd808f4403a854e3d9db0f92464ca3052"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan).cue" size="657" crc="aad2990f" sha1="4e750c468bccb248fab521e20a4d55a422b5490d"/>
 		-->
 		<description>Vastness - Kuukyo no Ikenie-tachi</description>
 		<year>1993</year>
 		<publisher>CD Bros.</publisher>
-		<info name="serial" value="HMF-132"/>
+		<info name="serial" value="HMF-132 / CB-001"/>
 		<info name="alt_title" value="ヴアーストニス 空虚の生贄達" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vastness" sha1="12d1fbe66e92cd580616814077eebb402d4e0332" />
+				<disk name="vastness - kuukyo no ikenie-tachi (japan)" sha1="bd8b85316d31bbe6efc543ef9c5fbf2e3a7b02d7" />
 			</diskarea>
 		</part>
 	</software>
@@ -15947,21 +16429,32 @@ User/save disks that can be created from the game itself are not included.
 	<!-- PC-98x1 / FM Towns hybrid, also included in pc98_cd.xml -->
 	<software name="yojusen2">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="3205" crc="ca4446d3" sha1="8028e2647ef572de3dcf27ce5332f7ca00530a42"/>
-		<rom name="Image.cue" size="586" crc="b6b20ac9" sha1="b8bc72b8d909546d1078b1921ec04f526e746e3a"/>
-		<rom name="Image.img" size="649808208" crc="16f70c96" sha1="29b587dbcdaae2d471b7c13c1ce5c5825bc86eaf"/>
-		<rom name="Image.sub" size="26522784" crc="af8cb6ad" sha1="f77df38b35d73e8bc3e20033a8878af0e9c03ea8"/>
+		Origin: redump.org
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 01).bin" size="245104272" crc="eaf647b7" sha1="cd8ad09cfbd77af4bdc14c87cf3a40f95d5693e0"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 02).bin" size="27421968" crc="01ffa5b8" sha1="fb6f409029df70a25b91cf63fddd15f22f57618f"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 03).bin" size="21304416" crc="a8a49409" sha1="6a4fa97b448e00e7a0f3aca1c8b1b8fbf8fb3d70"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 04).bin" size="29240064" crc="8e56a2d5" sha1="00eca09b1c442e4ca6047511650974b5b22e3aa8"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 05).bin" size="31634400" crc="547bec0d" sha1="5167d5ee996ed8db4094c73e8b240ff38a978e7f"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 06).bin" size="41877360" crc="1b56f87a" sha1="00343ee6bb85f4af0f55cfc554324383d14647bc"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 07).bin" size="37817808" crc="e0009c74" sha1="1f49b162cf913429530d007483246f7ff27b3e05"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 08).bin" size="30418416" crc="d2031484" sha1="83190a6ec4773b857ec8f8c45eb32e24906f5821"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 09).bin" size="29000160" crc="77290d48" sha1="11587e4fef756f033a9507c9a89fee8d4336e137"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 10).bin" size="41778576" crc="b1ed8767" sha1="53f36fe9ca460f980a66502856b46eaab48d612a"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 11).bin" size="40562592" crc="6090e013" sha1="021fd651bb35cb76b71e5ca90dfa8df3ea2a8b27"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 12).bin" size="43001616" crc="5d47a747" sha1="55a4b0925d0a52c24248fe864c0892dcf8df2d6a"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 13).bin" size="30646560" crc="1241e2db" sha1="c189de3cb6bf93d1b90159499cd35611faeb9f0e"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan).cue" size="1575" crc="ebb77713" sha1="881d04c4e6938dd301f3acfdf9139f2a56a9e000"/>
 		-->
 		<description>Youjuu Senki 2 - Reimei no Senshi-tachi</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="DCD-0011"/>
 		<info name="alt_title" value="妖獣戦記2 黎明の戦士たち" />
 		<info name="release" value="199402xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="yojusen2" sha1="219f6731e9960291832df99d43ee52ab5d62bc52" />
+				<disk name="youjuu senki 2 - reimei no senshi-tachi (japan)" sha1="365c5e7983cc3aa59a97992035c6ddf76a86ab6e" />
 			</diskarea>
 		</part>
 	</software>
@@ -16137,11 +16630,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="zenith">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Zenith.ccd" size="2872" crc="4426b6e6" sha1="7783bb8cd8cec3d812925d3edbdac4f6bd7dc625"/>
-		<rom name="Zenith.cue" size="502" crc="b24661ae" sha1="6873712a9eaf075f7f10d6d93c0632de4675f5df"/>
-		<rom name="Zenith.img" size="635263440" crc="59a86e0b" sha1="e30974c5d832961713cee73134e787fd880ad7fc"/>
-		<rom name="Zenith.sub" size="25929120" crc="751d0315" sha1="d4e2ec606815d6abd72a7a98606bc9a975f3ce58"/>
+		Origin: redump.org
+		<rom name="Animation Zenith (Japan) (Track 01).bin" size="42253680" crc="57313645" sha1="db347eeb7b89001e4c4823b9e9ab99183a042558"/>
+		<rom name="Animation Zenith (Japan) (Track 02).bin" size="71893584" crc="0c118374" sha1="6dea000ab14066e3eecef5a37f96af19e53c6e19"/>
+		<rom name="Animation Zenith (Japan) (Track 03).bin" size="67761120" crc="e26102e4" sha1="373fc9d93256b126c88f72816626c9a63fbc7db7"/>
+		<rom name="Animation Zenith (Japan) (Track 04).bin" size="66528672" crc="8d800702" sha1="9c133dc99ec8ed72c2a5194a1665385a33915b53"/>
+		<rom name="Animation Zenith (Japan) (Track 05).bin" size="69177024" crc="08b90269" sha1="2d0150bb0b3f124e67ff77159535bcc706cd5f00"/>
+		<rom name="Animation Zenith (Japan) (Track 06).bin" size="78493296" crc="f835785a" sha1="28be5e63f35aa9037c1e5aaabaa67d62a04abb97"/>
+		<rom name="Animation Zenith (Japan) (Track 07).bin" size="77653632" crc="dffc1548" sha1="b43d67a4dbbfcb295ab66b0f8c7efbdd0edb328a"/>
+		<rom name="Animation Zenith (Japan) (Track 08).bin" size="39610032" crc="1b36ee9f" sha1="642cf720f6c302e443f13b6416b84b4cdf5e0bf3"/>
+		<rom name="Animation Zenith (Japan) (Track 09).bin" size="27981744" crc="e81f8d36" sha1="1f15ba82a16fc749fea01fce95613e50d5f115b6"/>
+		<rom name="Animation Zenith (Japan) (Track 10).bin" size="26140128" crc="61430506" sha1="8f7c96d14614904f4060b4d63d6167270010a468"/>
+		<rom name="Animation Zenith (Japan) (Track 11).bin" size="23870448" crc="86a01836" sha1="c56edc34a923f3d22d16df8ca555f86dedc35d1d"/>
+		<rom name="Animation Zenith (Japan) (Track 12).bin" size="43900080" crc="0e891e7d" sha1="aef3c7caa61e937c05253e3873c5da2af2c9d848"/>
+		<rom name="Animation Zenith (Japan).cue" size="1180" crc="00ecc2e4" sha1="a7398fd40a67d4c494b3030992241852c92183b9"/>
 		-->
 		<description>Zenith</description>
 		<year>1995</year>
@@ -16151,7 +16653,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zenith" sha1="3709c5434e21c060895b0ee0d7921e7f2d0c4ca0" />
+				<disk name="animation zenith (japan)" sha1="c99f1b2db763f5e0eaf48cb5726351a81d2fd916" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -2033,7 +2033,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hyper girl - akiko - premium version (japan)" sha1="5869c0c1d2eee0f551722a7d08d7feef6be53868" />
+				<disk name="hyper girl - akiko - premium version (japan)" sha1="fa1b72c5b4a0ca23a32dd9f6004ea163d4578968" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
- New dumps from redump.org (working):

Akiko - Premium Version
Cal III - Kanketsu-hen
Chiemi & Naomi
Curse
Eikan wa Kimi ni 2 - Koukou Yakyuu Zenkoku Taikai
FM Towns Application Catalog CD-ROM - Original Soft-hen
G5 (HMA-206)
Gambler - Queen's Cup
Gokuraku Mandala
Hyper Fetishism
Illust Hyakka - Yamashita Hideki no Ikiiki Cut-shuu
Iris-tei Serenade
Jouhou Club - Card Processor Ver. 1.1
Mahjong Musashi
Manami no Doko made Iku no? 2 - Return of the Kuro Pack
Marionette Mind
Mirage 2 - Torry, Neat & Roan Fairladies in MagicLand
Noushuku Angel 120%
Shamhat - The Holy Circlet (FM Towns Marty version)
Tenshin Ranma
The Manhole (1990-08-01)
Two Shot Diary
Viper-V12 RS

- New dumps from redump.org (not working):

Pro Student G (ALS-0010)
Towns-Telop
True Heart

- Replaced entries with dumps from redump.org:

4D Tennis
Alshark
Arabesque - Shoujo-tachi no Orinasu Ai no Monogatari
Ayumi-chan Monogatari
Branmarker 2
Cal Towns
Custom Mate 2 & Itsuka dokoka de
Dragon Knight 4
Eimmy to Yobanaide
Evolution
Gunblaze
Igo II
Lesser Mern
Princess Maker 2
Pro Student G (ALS-0004)
Rayxanber
Space Rogue
The Atlas
Vastness - Kuukyo no Ikenie-tachi
Viper-V8 Turbo RS
Viper-V10 Turbo RS
Youjuu Senki 2 - Reimei no Senshi-tachi
YES! HG - Erotic Voice Version
Zenith