### PR TITLE
(nw) (destdrby) Rom Image Corrections/Fixups:

### DIFF
--- a/src/mame/drivers/chicago.cpp
+++ b/src/mame/drivers/chicago.cpp
@@ -115,19 +115,21 @@ void chicago_state::chicago(machine_config &config)
 
  ***************************************************************************/
 
+// Demolition Derby is licensed from Exidy, PROMs are identical to Exidy Destruction Derby
+// However, the PCBs and layouts are different, so there is a seperate driver here
 
 ROM_START( dmodrbcc )
 	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASE00 )
 
 	ROM_REGION( 0x0400, "roms", ROMREGION_ERASE00 )
-	ROM_LOAD( "cdi.b2",     0x0000, 0x0200, CRC(9c727712) SHA1(0d5da25fda57da873da0c066d3472c076c18b853) )
-	ROM_LOAD( "cdi.b8",     0x0000, 0x0200, CRC(840653fa) SHA1(b71d35af4bb4a6f98acfa9161c0f3e8165440d16) )
-	ROM_LOAD( "cdi.c8",     0x0000, 0x0200, CRC(79ebcfa1) SHA1(5267a38b76f58a9add928d1241803792b35f65c0) )
-	ROM_LOAD( "cdi.d8",     0x0000, 0x0200, CRC(afcfe339) SHA1(34912eb50fe162743fa2a7433a1e8634050fb514) )
-	ROM_LOAD( "cdi.e8",     0x0000, 0x0200, CRC(7b7bf492) SHA1(6d48ae1963c6f867a461d15e657df8196fdeaf20) )
-	ROM_LOAD( "cdi.h3",     0x0000, 0x0200, CRC(66f25de0) SHA1(1984c3f9a4f5c01b1db784cec7279307aa9a851b) )
-	ROM_LOAD( "cdi.h6",     0x0000, 0x0200, CRC(9c727712) SHA1(0d5da25fda57da873da0c066d3472c076c18b853) )
-	ROM_LOAD( "cdi.n1",     0x0000, 0x0200, CRC(66f25de0) SHA1(1984c3f9a4f5c01b1db784cec7279307aa9a851b) )
+	ROM_LOAD( "cdi.b2",     0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "cdi.b8",     0x0000, 0x0100, CRC(9f65c1df) SHA1(e367cc418b34005198f9b958592573986d37274a) )
+	ROM_LOAD( "cdi.c8",     0x0000, 0x0100, CRC(5e27fc7c) SHA1(bae31e7f0ff7a5ebfe4a12fc537249ee24a4cf4b) )
+	ROM_LOAD( "cdi.d8",     0x0000, 0x0100, CRC(93dc096c) SHA1(b89a478ef731024eb24a79f9e82a5ef779e8e3d0) )
+	ROM_LOAD( "cdi.e8",     0x0000, 0x0100, CRC(ddbb0cc7) SHA1(6f169566cb09c78090cec2e375013c0eb2656890) )
+	ROM_LOAD( "cdi.h3",     0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
+	ROM_LOAD( "cdi.h6",     0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "cdi.n1",     0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
 
 	ROM_LOAD( "cdi.c13",    0x0000, 0x0020, CRC(f304a1fb) SHA1(0f029274bb99723ebcc271d761e1500ca50b2738) )
 	ROM_LOAD( "cdi.c14",    0x0000, 0x0020, CRC(f8dbd779) SHA1(55bdaf9eb1ba6185e20512c4874ebb625861508e) )

--- a/src/mame/drivers/exidyttl.cpp
+++ b/src/mame/drivers/exidyttl.cpp
@@ -7,7 +7,7 @@ Exidy discrete hardware games
  Alley Rally (1976/10) (AR-1A)
  Attack (1977/02)
  Death Race (1976/04)
- Destruction Derby (1976/01)
+ Destruction Derby (1976/01) (DD-2A)
  Hockey / Tennis (Thumper Bumper?) (1974/03)
  Score (1977/07)
  Spiders From Space (1976)
@@ -53,6 +53,7 @@ public:
 
 	void attack(machine_config &config);
 	void deathrac(machine_config &config);
+	void destdrby(machine_config &config);
 
 private:
 	// devices
@@ -110,7 +111,7 @@ void exidyttl_state::attack(machine_config &config)
 	m_video->set_threshold(0.30);
 }
 
-void exidyttl_state::deathrac(machine_config &config)
+void exidyttl_state::destdrby(machine_config &config)
 {
 	/* basic machine hardware */
 	NETLIST_CPU(config, m_maincpu, netlist::config::DEFAULT_CLOCK()).set_source(netlist_attack);
@@ -125,6 +126,10 @@ void exidyttl_state::deathrac(machine_config &config)
 	m_video->set_threshold(0.30);
 }
 
+void exidyttl_state::deathrac(machine_config& config)
+{
+	destdrby(config);
+}
 
 /***************************************************************************
 
@@ -157,6 +162,58 @@ ROM_START( attckexd2 )  //  These are likely an overdump, but we are waiting for
 	ROM_LOAD( "attack__set2.k6",     0x0000, 0x0200, CRC(ba5115b3) SHA1(1679b07e8a9376789c9cf15fe16e97003e9267be) )
 ROM_END
 
+/***********
+
+ Exidy Destruction Derby 1976
+
+ Drawing Name
+ ------------
+ 82S123-34.E7 32x8    Right Drone
+ 82S129-91.J10    256x4
+
+ 82S123-34.R7 32x8    Left Drone
+ 82S129-91.V10    256x4
+
+ 82S129-92.V5     P1 (left car)
+ 82S123-35.T7
+
+ 82S129-92.J5     P2 (right car)
+ 82S123-35.G7
+
+ 82S129-93.M11        Image Generation
+ 82S129-94.L11
+ 82S129-95.K11
+ 82S129-96.J11
+
+ 82S123-33.P14        Score & Timer
+
+ 82S123-31.A11        Timing / Sync
+ 82S123-32.C12
+
+***********/
+
+
+ROM_START( destdrby )
+	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASE00 )
+	 
+	ROM_REGION( 0x0400, "roms", ROMREGION_ERASE00)
+	ROM_LOAD( "82s123-31.a11", 0x0000, 0x0020, CRC(f304a1fb) SHA1(0f029274bb99723ebcc271d761e1500ca50b2738) )
+	ROM_LOAD( "82s123-32.c12", 0x0000, 0x0020, CRC(f8dbd779) SHA1(55bdaf9eb1ba6185e20512c4874ebb625861508e) )
+	ROM_LOAD( "82s123-33.p14", 0x0000, 0x0020, CRC(2e83bf80) SHA1(02fcc1e879c06759a21ef4f004fe7aa790814112) )
+	ROM_LOAD( "82s123-34.e7",  0x0000, 0x0020, CRC(e9af4217) SHA1(813e126b1263e13f1684d700c5c4bec34d063b38) )
+	ROM_LOAD( "82s123-35.g7",  0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
+	ROM_LOAD( "82s123-34.r7",  0x0000, 0x0020, CRC(e9af4217) SHA1(813e126b1263e13f1684d700c5c4bec34d063b38) )
+	ROM_LOAD( "82s123-35.t7",  0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
+
+	ROM_LOAD( "82s129-91.j10", 0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "82s129-91.v10", 0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "82s129-92.j5",  0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
+	ROM_LOAD( "82s129-92.v5",  0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
+	ROM_LOAD( "82s129-93.m11", 0x0000, 0x0100, CRC(9f65c1df) SHA1(e367cc418b34005198f9b958592573986d37274a) )
+	ROM_LOAD( "82s129-94.l11", 0x0000, 0x0100, CRC(5e27fc7c) SHA1(bae31e7f0ff7a5ebfe4a12fc537249ee24a4cf4b) )
+	ROM_LOAD( "82s129-95.k11", 0x0000, 0x0100, CRC(93dc096c) SHA1(b89a478ef731024eb24a79f9e82a5ef779e8e3d0) )
+	ROM_LOAD( "82s129-96.j11", 0x0000, 0x0100, CRC(ddbb0cc7) SHA1(6f169566cb09c78090cec2e375013c0eb2656890) )
+ROM_END
 
 /***********
 
@@ -193,46 +250,29 @@ ROM_START( deathrac )
 	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASE00 )
 
 	ROM_REGION( 0x0400, "roms", ROMREGION_ERASE00 )
-	ROM_LOAD( "6301-100.j11",   0x0000, 0x0100, CRC(d751bd57) SHA1(a6208af40661bf3cd50363d2ece38cd3b9f6a7a0) )
-	ROM_LOAD( "6301-91.j10",    0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
-	ROM_LOAD( "6301-91.v10",    0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
-	ROM_LOAD( "6301-92.j5",     0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
-	ROM_LOAD( "6301-92.v5",     0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
-	ROM_LOAD( "6301-97.m11",    0x0000, 0x0100, CRC(2b02444f) SHA1(e1fc01f7271109515438542a223efc0042f794a5) )
-	ROM_LOAD( "6301-98.l11",    0x0000, 0x0100, CRC(0bdaf1eb) SHA1(67976e73bfdc4d42a520212d020dd52d51667674) )
-	ROM_LOAD( "6301-99.k11",    0x0000, 0x0100, CRC(34763c8f) SHA1(2012ace666e8b82a89a0c15511ee80173d9700bc) )
+	ROM_LOAD( "6331-31.a11", 0x0000, 0x0020, CRC(f304a1fb) SHA1(0f029274bb99723ebcc271d761e1500ca50b2738) )
+	ROM_LOAD( "6331-32.c12", 0x0000, 0x0020, CRC(f8dbd779) SHA1(55bdaf9eb1ba6185e20512c4874ebb625861508e) )
+	ROM_LOAD( "6331-33.p14", 0x0000, 0x0020, CRC(2e83bf80) SHA1(02fcc1e879c06759a21ef4f004fe7aa790814112) )
+	// Note: Image for 36 has all zeros in the second half, which is unused.  
+	// Other roms in this series (34,35) all have duplicate content in the second half
+	ROM_LOAD( "6331-36.e7",  0x0000, 0x0020, CRC(bb743b79) SHA1(8eb73782bcea7dbba7b75db32307e562248691bb) )
+	ROM_LOAD( "6331-35.g7",  0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
+	ROM_LOAD( "6331-36.r7",  0x0000, 0x0020, CRC(bb743b79) SHA1(8eb73782bcea7dbba7b75db32307e562248691bb) )
+	ROM_LOAD( "6331-35.t7",  0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
 
-	ROM_LOAD( "6331-31.a11",    0x0000, 0x0020, CRC(f304a1fb) SHA1(0f029274bb99723ebcc271d761e1500ca50b2738) )
-	ROM_LOAD( "6331-32.c12",    0x0000, 0x0020, CRC(f8dbd779) SHA1(55bdaf9eb1ba6185e20512c4874ebb625861508e) )
-	ROM_LOAD( "6331-33.p14",    0x0000, 0x0020, CRC(2e83bf80) SHA1(02fcc1e879c06759a21ef4f004fe7aa790814112) )
-	ROM_LOAD( "6331-36.e7",     0x0000, 0x0020, CRC(1358c8d5) SHA1(2fa1041f30f3a6775393714a65c416738b06b330) )
-	ROM_LOAD( "6331-36.g7",     0x0000, 0x0020, CRC(15e00a2a) SHA1(cd43d227a34e5444ed9d8a4acf5497df9c789c73) )
-	ROM_LOAD( "6331-36.r7",     0x0000, 0x0020, CRC(1358c8d5) SHA1(2fa1041f30f3a6775393714a65c416738b06b330) )
-	ROM_LOAD( "6331-36.t7",     0x0000, 0x0020, CRC(15e00a2a) SHA1(cd43d227a34e5444ed9d8a4acf5497df9c789c73) )
+	ROM_LOAD( "6301-91.j10",  0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "6301-91.v10",  0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
+	ROM_LOAD( "6301-92.j5",   0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
+	ROM_LOAD( "6301-92.v5",   0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
+	ROM_LOAD( "6301-97.m11",  0x0000, 0x0100, CRC(2b02444f) SHA1(e1fc01f7271109515438542a223efc0042f794a5) )
+	ROM_LOAD( "6301-98.l11",  0x0000, 0x0100, CRC(0bdaf1eb) SHA1(67976e73bfdc4d42a520212d020dd52d51667674) )
+	ROM_LOAD( "6301-99.k11",  0x0000, 0x0100, CRC(34763c8f) SHA1(2012ace666e8b82a89a0c15511ee80173d9700bc) )
+	ROM_LOAD( "6301-100.j11", 0x0000, 0x0100, CRC(d751bd57) SHA1(a6208af40661bf3cd50363d2ece38cd3b9f6a7a0) )
 ROM_END
 
-ROM_START( rhunting )
-	ROM_REGION( 0x10000, "maincpu", ROMREGION_ERASE00 )
-
-	ROM_REGION( 0x0400, "roms", ROMREGION_ERASE00 )
-	ROM_LOAD( "6301-1.j11",     0x0000, 0x0100, CRC(d751bd57) SHA1(a6208af40661bf3cd50363d2ece38cd3b9f6a7a0) )
-	ROM_LOAD( "93427.j10",      0x0000, 0x0100, CRC(c3823f0b) SHA1(42fe8c1e0f54b3f968a630dd564a8941410c5d86) )
-	ROM_LOAD( "6301-1.v5",      0x0000, 0x0100, CRC(82d7d25f) SHA1(d4b3a6655f91647545d493c2ff996daa66df0395) )
-	ROM_LOAD( "6301-1.m11",     0x0000, 0x0100, CRC(2b02444f) SHA1(e1fc01f7271109515438542a223efc0042f794a5) )
-	ROM_LOAD( "6301-1.l11",     0x0000, 0x0100, CRC(0bdaf1eb) SHA1(67976e73bfdc4d42a520212d020dd52d51667674) )
-	ROM_LOAD( "6301-1.k11",     0x0000, 0x0100, CRC(34763c8f) SHA1(2012ace666e8b82a89a0c15511ee80173d9700bc) )
-
-	ROM_LOAD( "6331-1.a11",     0x0000, 0x0020, CRC(f304a1fb) SHA1(0f029274bb99723ebcc271d761e1500ca50b2738) )
-	ROM_LOAD( "6331-1.c12",     0x0000, 0x0020, CRC(f8dbd779) SHA1(55bdaf9eb1ba6185e20512c4874ebb625861508e) )
-	ROM_LOAD( "6331-1.p14",     0x0000, 0x0020, CRC(2e83bf80) SHA1(02fcc1e879c06759a21ef4f004fe7aa790814112) )
-	ROM_LOAD( "6331-1.e7",      0x0000, 0x0020, CRC(bb743b79) SHA1(8eb73782bcea7dbba7b75db32307e562248691bb) )
-	ROM_LOAD( "6331-1.g7",      0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
-	ROM_LOAD( "6331-1.r7",      0x0000, 0x0020, CRC(bb743b79) SHA1(8eb73782bcea7dbba7b75db32307e562248691bb) )
-	ROM_LOAD( "6331-1.t7",      0x0000, 0x0020, CRC(5ed8cdd2) SHA1(d193d819ad634c43d648ce49073799b4df6dfd2f) )
-ROM_END
-
-
-GAME( 1977, attckexd,  0,        attack,   0, exidyttl_state, empty_init, ROT0, "Exidy", "Attack (set 1) [TTL]", MACHINE_IS_SKELETON )
-GAME( 1977, attckexd2, attckexd, attack,   0, exidyttl_state, empty_init, ROT0, "Exidy", "Attack (set 2) [TTL]", MACHINE_IS_SKELETON )
-GAME( 1976, deathrac,  0,        deathrac, 0, exidyttl_state, empty_init, ROT0, "Exidy", "Death Race [TTL]",     MACHINE_IS_SKELETON )
+#define rom_rhunting rom_deathrac
+GAME( 1977, attckexd,  0,        attack,   0, exidyttl_state, empty_init, ROT0, "Exidy", "Attack (set 1) [TTL]",    MACHINE_IS_SKELETON )
+GAME( 1977, attckexd2, attckexd, attack,   0, exidyttl_state, empty_init, ROT0, "Exidy", "Attack (set 2) [TTL]",    MACHINE_IS_SKELETON )
+GAME( 1976, deathrac,  0,        deathrac, 0, exidyttl_state, empty_init, ROT0, "Exidy", "Death Race [TTL]",        MACHINE_IS_SKELETON )
+GAME( 1976, destdrby,  0,        destdrby, 0, exidyttl_state, empty_init, ROT0, "Exidy", "Destruction Derby [TTL]", MACHINE_IS_SKELETON)
 GAME( 1976, rhunting,  deathrac, deathrac, 0, exidyttl_state, empty_init, ROT0, "bootleg", "Robot Hunting (bootleg of Death Race) [TTL]",MACHINE_IS_SKELETON )


### PR DESCRIPTION
Various prom image issues were fixed

dmodrbcc:
All 512 byte roms were set to length 256 (incorrect length)
Some upper bits in nibble-wide roms were not set to default zero

destdrby ("new" driver):
Added newly dumped roms from exidy PCB, images now match fixed images from dmodrbcc (expected)
Added new skeleton driver in exidyttl.cpp.
    (Redundant with dmodrbcc in chicago.cpp, but it is a different PCB layout and different company)

deathrac:
Images 36 and 35 were corrupt, fixed with correct images from bootleg rhunting
Added note about format of image 36

rhunting:
Images now match death race 100%
Driver now uses deathrac rom images