### PR TITLE
saa1099.cpp: Fix output, frequency behavior, Add notes

### DIFF
--- a/src/devices/bus/isa/gblaster.cpp
+++ b/src/devices/bus/isa/gblaster.cpp
@@ -72,12 +72,12 @@ void isa8_gblaster_device::device_add_mconfig(machine_config &config)
 {
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
-	SAA1099(config, m_saa1099_1, 7159090);
-	m_saa1099_1->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
-	m_saa1099_1->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
-	SAA1099(config, m_saa1099_2, 7159090);
-	m_saa1099_2->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
-	m_saa1099_2->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
+	SAA1099(config, m_saa1099_1, XTAL(14'318'181) / 2); // or CMS-301, from OSC pin in ISA bus
+	m_saa1099_1->add_route(0, "lspeaker", 0.50);
+	m_saa1099_1->add_route(1, "rspeaker", 0.50);
+	SAA1099(config, m_saa1099_2, XTAL(14'318'181) / 2); // or CMS-301, from OSC pin in ISA bus
+	m_saa1099_2->add_route(0, "lspeaker", 0.50);
+	m_saa1099_2->add_route(1, "rspeaker", 0.50);
 }
 
 //**************************************************************************

--- a/src/devices/bus/isa/sblaster.cpp
+++ b/src/devices/bus/isa/sblaster.cpp
@@ -1171,13 +1171,13 @@ void isa8_sblaster1_0_device::device_add_mconfig(machine_config &config)
 	m_ym3812->add_route(ALL_OUTPUTS, "lspeaker", 3.0);
 	m_ym3812->add_route(ALL_OUTPUTS, "rspeaker", 3.0);
 
-	SAA1099(config, m_saa1099_1, 7159090);
-	m_saa1099_1->add_route(ALL_OUTPUTS, "lspeaker", 0.5);
-	m_saa1099_1->add_route(ALL_OUTPUTS, "rspeaker", 0.5);
+	SAA1099(config, m_saa1099_1, XTAL(14'318'181) / 2); // or CMS-301, from OSC pin in ISA bus
+	m_saa1099_1->add_route(0, "lspeaker", 0.5);
+	m_saa1099_1->add_route(1, "rspeaker", 0.5);
 
-	SAA1099(config, m_saa1099_2, 7159090);
-	m_saa1099_2->add_route(ALL_OUTPUTS, "lspeaker", 0.5);
-	m_saa1099_2->add_route(ALL_OUTPUTS, "rspeaker", 0.5);
+	SAA1099(config, m_saa1099_2, XTAL(14'318'181) / 2); // or CMS-301, from OSC pin in ISA bus
+	m_saa1099_2->add_route(0, "lspeaker", 0.5);
+	m_saa1099_2->add_route(1, "rspeaker", 0.5);
 }
 
 void isa8_sblaster1_5_device::device_add_mconfig(machine_config &config)

--- a/src/devices/sound/saa1099.h
+++ b/src/devices/sound/saa1099.h
@@ -47,22 +47,19 @@ private:
 		u8 envelope[2];             // envelope (0x00..0x0f or 0x10 == off)
 
 		/* vars to simulate the square wave */
-		double counter = 0.0;
-		double freq = 0.0;
+		inline u32 freq() const { return (511 - frequency) << (8 - octave); } // clock / ((511 - frequency) * 2^(8 - octave))
+		int counter = 0;
 		u8 level = 0;
 	};
 
 	struct saa1099_noise
 	{
-		saa1099_noise() { (void)pad; }
+		saa1099_noise() { }
 
 		/* vars to simulate the noise generator output */
-		double counter = 0.0;
-		double freq = 0.0;
+		int counter = 0;
+		int freq = 0;
 		u32 level = 0xffffffffU;    // noise polynomial shifter
-
-	private:
-		u32 pad; // pad out structure to multiple of sizeof(double)
 	};
 
 	void envelope_w(int ch);
@@ -80,7 +77,6 @@ private:
 	u8 m_selected_reg;              // selected register
 	saa1099_channel m_channels[6];  // channels
 	saa1099_noise m_noise[2];       // noise generators
-	double m_sample_rate;
 };
 
 DECLARE_DEVICE_TYPE(SAA1099, saa1099_device)

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -3935,12 +3935,12 @@ void vgmplay_state::vgmplay(machine_config &config)
 	m_vsu_vue[1]->add_route(1, m_mixer, 1.0, AUTO_ALLOC_INPUT, 1);
 
 	SAA1099(config, m_saa1099[0], 0);
-	m_saa1099[0]->add_route(ALL_OUTPUTS, m_mixer, 0.5, AUTO_ALLOC_INPUT, 0);
-	m_saa1099[0]->add_route(ALL_OUTPUTS, m_mixer, 0.5, AUTO_ALLOC_INPUT, 1);
+	m_saa1099[0]->add_route(0, m_mixer, 1.0, AUTO_ALLOC_INPUT, 0);
+	m_saa1099[0]->add_route(1, m_mixer, 1.0, AUTO_ALLOC_INPUT, 1);
 
 	SAA1099(config, m_saa1099[1], 0);
-	m_saa1099[1]->add_route(ALL_OUTPUTS, m_mixer, 0.5, AUTO_ALLOC_INPUT, 0);
-	m_saa1099[1]->add_route(ALL_OUTPUTS, m_mixer, 0.5, AUTO_ALLOC_INPUT, 1);
+	m_saa1099[1]->add_route(0, m_mixer, 1.0, AUTO_ALLOC_INPUT, 0);
+	m_saa1099[1]->add_route(1, m_mixer, 1.0, AUTO_ALLOC_INPUT, 1);
 
 	ES5503(config, m_es5503[0], 0);
 	m_es5503[0]->set_channels(2);
@@ -3956,12 +3956,14 @@ void vgmplay_state::vgmplay(machine_config &config)
 
 	ES5505(config, m_es5505[0], 0);
 	// TODO m_es5505[0]->set_addrmap(0, &vgmplay_state::es5505_map<0>);
+	// TODO m_es5505[0]->set_addrmap(1, &vgmplay_state::es5505_map<0>);
 	m_es5505[0]->set_channels(1);
 	m_es5505[0]->add_route(0, m_mixer, 0.5, AUTO_ALLOC_INPUT, 0);
 	m_es5505[0]->add_route(1, m_mixer, 0.5, AUTO_ALLOC_INPUT, 1);
 
 	ES5505(config, m_es5505[1], 0);
 	// TODO m_es5505[1]->set_addrmap(0, &vgmplay_state::es5505_map<1>);
+	// TODO m_es5505[1]->set_addrmap(1, &vgmplay_state::es5505_map<1>);
 	m_es5505[1]->set_channels(1);
 	m_es5505[1]->add_route(0, m_mixer, 0.5, AUTO_ALLOC_INPUT, 0);
 	m_es5505[1]->add_route(1, m_mixer, 0.5, AUTO_ALLOC_INPUT, 1);


### PR DESCRIPTION
Fix noise frequency closer to real hardware, Reduce unnecessary, unused values, Reduce duplicates, macros
gblaster.cpp, sblaster.cpp: Fix output, clock inputs, verified from real hardware
vgmplay.cpp: Support SAA1099 stereo output, reference: pinout, datasheet