### PR TITLE
sgi_mips_hdd: add software list

### DIFF
--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -3,7 +3,7 @@
 <!--
 license:CC0
 -->
-<softwarelist name="sgi_mips" description="Sgi MIPS/IRIX software">
+<softwarelist name="sgi_mips" description="SGI MIPS/IRIX software">
 
 	<!-- Apps and utilities -->
 

--- a/hash/sgi_mips_hdd.xml
+++ b/hash/sgi_mips_hdd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0
+-->
+<softwarelist name="sgi_mips_hdd" description="Hard disk images for SGI MIPS">
+
+	<software name="irix_5_3">
+		<description>IRIX 5.3</description>
+		<year>1994</year>
+		<publisher>Silicon Graphics</publisher>
+		<!--
+		Requires a valid eaddr and high resolution mode. Before first boot, enter
+		the PROM command monitor and check printenv. If required settings are
+		missing, run
+			setenv -f eaddr 08:00:69:12:34:56
+		to set the Ethernet interface address, and
+			setenv -f monitor h
+		to enable high resolution mode (1280x1024), then power cycle.
+		-->
+		<part name="hdd" interface="scsi_hdd">
+			<diskarea name="harddriv">
+				<disk name="irix_5_3" sha1="22de8751b85fd5f5ff002657e0f475cce719ee52" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/mame/drivers/indy_indigo2.cpp
+++ b/src/mame/drivers/indy_indigo2.cpp
@@ -95,7 +95,6 @@ public:
 		, m_hpc3(*this, "hpc3")
 		, m_ioc2(*this, "ioc2")
 		, m_rtc(*this, "rtc")
-		, m_softlist(*this, "softlist")
 		, m_vino(*this, "vino")
 		, m_dmsd(*this, "dmsd")
 		, m_gio64(*this, "gio64")
@@ -145,7 +144,6 @@ protected:
 	required_device<hpc3_device> m_hpc3;
 	required_device<ioc2_device> m_ioc2;
 	required_device<ds1386_device> m_rtc;
-	required_device<software_list_device> m_softlist;
 	optional_device<vino_device> m_vino;
 	optional_device<saa7191_device> m_dmsd;
 	optional_device<gio64_device> m_gio64;
@@ -383,7 +381,8 @@ void ip24_state::ip24_base(machine_config &config)
 	SGI_HAL2(config, m_hal2);
 	EEPROM_93C56_16BIT(config, m_eeprom);
 
-	SOFTWARE_LIST(config, m_softlist).set_original("sgi_mips");
+	SOFTWARE_LIST(config, "sgi_mips").set_original("sgi_mips");
+	SOFTWARE_LIST(config, "sgi_mips_hdd").set_original("sgi_mips_hdd");
 }
 
 void ip24_state::ip24(machine_config &config)


### PR DESCRIPTION
Add a new software list to collect preinstalled hard disk images for SGI workstations.