### PR TITLE
rs232 serial printer: initialize the data output high.

### DIFF
--- a/src/devices/bus/rs232/printer.cpp
+++ b/src/devices/bus/rs232/printer.cpp
@@ -52,7 +52,7 @@ WRITE_LINE_MEMBER(serial_printer_device::update_serial)
 	set_rcv_rate(rxbaud);
 
 	// TODO: make this configurable
-	output_rxd(0);
+	output_rxd(1);
 	output_dcd(0);
 	output_dsr(0);
 	output_cts(0);


### PR DESCRIPTION
High is the restful state for RS232. The low level could cause
continual breaks to be received by an attached device and this could
cause problems for some drives.