### PR TITLE
os9 dsk: add 8 inch, 16 sector, single density formats

### DIFF
--- a/src/lib/formats/os9_dsk.cpp
+++ b/src/lib/formats/os9_dsk.cpp
@@ -412,27 +412,35 @@ const os9_format::format os9_format::formats[] = {
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
 		2000, 15, 77, 2, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
 	},
-	{ // 38 497.75K 8 inch double density (single density track 0)
+	{ // 38 308K 8 inch single density
+		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
+		2000, 16, 77, 1, 256, {}, -1, {0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15}, 35, 12, 12
+	},
+	{ // 39 616K 8 inch single density
+		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
+		2000, 16, 77, 2, 256, {}, -1, {0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15}, 35, 12, 12
+	},
+	{ // 40 497.75K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
 		1000, 26, 77, 1, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
 	},
-	{ // 39 500.5K 8 inch double density
+	{ // 41 500.5K 8 inch double density
 		floppy_image::FF_8, floppy_image::SSDD, floppy_image::MFM,
 		1000, 26, 77, 1, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
 	},
-	{ // 40 995.5K 8 inch double density (single density track 0)
+	{ // 42 995.5K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
 		1000, 26, 77, 2, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
 	},
-	{ // 41 1001K 8 inch double density
+	{ // 43 1001K 8 inch double density
 		floppy_image::FF_8, floppy_image::DSDD, floppy_image::MFM,
 		1000, 26, 77, 2, 256, {}, -1, {0, 19, 12, 5, 24, 17, 10, 3, 22, 15, 8, 1, 20, 13, 6, 25, 18, 11, 4, 23, 16, 9, 2, 21, 14, 7}, 80, 22, 24
 	},
-	{ // 42 1440K 3 1/2 inch high density (single density track 0)
+	{ // 44 1440K 3 1/2 inch high density (single density track 0)
 		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
 		1000, 36, 80, 2, 256, {}, -1, {0, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12, 1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11}, 80, 22, 24
 	},
-	{ // 43 1440K 3 1/2 inch high density.
+	{ // 45 1440K 3 1/2 inch high density.
 		floppy_image::FF_35,  floppy_image::DSHD, floppy_image::MFM,
 		1000, 36, 80, 2, 256, {}, -1, {0, 25, 14, 3, 28, 17, 6, 31, 20, 9, 34, 23, 12, 1, 26, 15, 4, 29, 18, 7, 32, 21, 10, 35, 24, 13, 2, 27, 16, 5, 30, 19, 8, 33, 22, 11}, 80, 22, 24
 	},
@@ -545,23 +553,27 @@ const os9_format::format os9_format::formats_track0[] = {
 	},
 	{ // 37 577.5K 8 inch single density
 	},
-	{ // 38 497.75K 8 inch double density (single density track 0)
+	{ // 38 308K 8 inch single density
+	},
+	{ // 39 616K 8 inch single density
+	},
+	{ // 40 497.75K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
 		2000, 15, 77, 1, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
 	},
-	{ // 39 500.5K 8 inch double density
+	{ // 41 500.5K 8 inch double density
 	},
-	{ // 40 995.5K 8 inch double density (single density track 0)
+	{ // 42 995.5K 8 inch double density (single density track 0)
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
 		2000, 15, 77, 2, 256, {}, -1, {0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13}, 40, 12, 12
 	},
-	{ // 41 1001K 8 inch double density
+	{ // 43 1001K 8 inch double density
 	},
-	{ // 42 1440K 3 1/2 inch high density (single density track 0)
+	{ // 44 1440K 3 1/2 inch high density (single density track 0)
 		floppy_image::FF_35,  floppy_image::DSSD, floppy_image::FM,
 		2000, 18, 80, 2, 256, {}, -1, {0, 5, 10, 15, 2, 7, 12, 17, 4, 9, 14, 1, 6, 11, 16, 3, 8, 13}, 40, 12, 12
 	},
-	{ // 43 1440K 3 1/2 inch high density.
+	{ // 45 1440K 3 1/2 inch high density.
 	},
 	{}
 };


### PR DESCRIPTION
These formats were by OS9 L1 on the Motorola EXORciser.