### PR TITLE
wd177x dsk: be permissive of some missing sectors in later tracks

### DIFF
--- a/src/lib/formats/wd177x_dsk.cpp
+++ b/src/lib/formats/wd177x_dsk.cpp
@@ -460,7 +460,12 @@ void wd177x_format::check_compatibility(floppy_image *image, std::vector<int> &c
 						}
 						ns++;
 					}
-				if(ns != tf.sector_count)
+
+				if(ns > tf.sector_count)
+					goto fail;
+
+				// Be permissive of some missing sectors in later tracks
+				if(ns < tf.sector_count && track < 2)
 					goto fail;
 			}
 		}


### PR DESCRIPTION
A single missing sector was causing it to give up on an images, as incompatible. Being a little more permissive here helps working
with some old recovered disk images with some lost sectors.

It had once looked at only the first track to assess compatibility, but that was changed to look at all tracks to deal with variations on the first track and variations on different sides, but that was probably a little to restrictive.