### PR TITLE
Add Monkey King 3B SoC skeleton and RS-70 system

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -4016,6 +4016,7 @@ files {
 	MAME_DIR .. "src/mame/drivers/actions_atj2279b.cpp",
 	MAME_DIR .. "src/mame/drivers/pubint_storyreader.cpp",
 	MAME_DIR .. "src/mame/drivers/magiceyes_pollux_vr3520f.cpp",
+	MAME_DIR .. "src/mame/drivers/monkey_king_3b.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "ultimachine")

--- a/src/mame/drivers/monkey_king_3b.cpp
+++ b/src/mame/drivers/monkey_king_3b.cpp
@@ -25,16 +25,35 @@ The typical configuration of the Monkey King SoCs (other than the
 3.6) is with 8/16MB of SDRAM, NOR flash for the firmware and
 built-in games, and a SD card for additional games.
 
-The RS-70 is notable for having a debug UART on the USB port 
+The RS-70 is notable for having a debug UART on the USB port
 (serial TX on D+, 115200). It prints the following messages on boot:
 
 	EXEC: Executing 'boot' with 0 args (ZLib ON)...
 	EXEC: Loading 'boot' at 0x18000000...
-	EXEC: Loaded 372272 bytes of 2097152 available.	
+	EXEC: Loaded 372272 bytes of 2097152 available.
 
 This is different from the serial output that this emulation model
 currently produces. Perhaps one of the unimplemented IO is causing
-it to go into some kind of 
+it to go into some kind of debug mode. The log output produced by
+this machine is:
+
+	Modes:0x00000000
+	PUT: Setting joystick to mode 0x0, timer to 250us
+
+	******************************************************
+	 MK FIRMWARE INFORMATION
+	 Mode:       0xB4
+	 Build Time: May  8 2019 14:09:21
+	 CPU Clock:  240MHz
+	 TFS Start:  0x8070000
+	 Video Buf:  0x6000000
+	 Stack Top:  0x3001EE8
+	 IWRAM Size: 32kB
+	 EVRAM Size: 16384kB
+	 Heap Size:  6144kB at 0x18200000
+	 Video Mode: 0
+	 Video Size: 1280x720x16bpp
+	******************************************************
 
 There are other strings in the ROM that imply there may be more serial
 debug possibilities.
@@ -132,7 +151,7 @@ void mk3b_soc_state::mk3b_soc(machine_config &config)
 {
 	// type unknown (should actually have VFP?)
 	// debug output suggests 240MHz clock
-	ARM920T(config, m_maincpu, 240000000); 
+	ARM920T(config, m_maincpu, 240000000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &mk3b_soc_state::map);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
@@ -163,6 +182,8 @@ void mk3b_soc_state::io4_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 uint32_t mk3b_soc_state::io7_r(offs_t offset, uint32_t mem_mask)
 {
 	switch (offset) {
+		case 0x21: // video size
+			return (1280 << 16) | (720);
 		default:
 			logerror("%s: IO 0x07 read 0x%04X\n", machine().describe_context(), offset);
 			return 0x00;

--- a/src/mame/drivers/monkey_king_3b.cpp
+++ b/src/mame/drivers/monkey_king_3b.cpp
@@ -1,0 +1,141 @@
+// license:BSD-3-Clause
+// copyright-holders:David Shah
+
+/*
+
+Monkey King SoCs (currently only 3B is supported)
+
+Presumably-custom ARM-based system-on-chips by Digital Media Cartridge (DMC).
+Intended to run NES and Genesis emulators, primarily for ATgames systems.
+
+Sometimes abbreviated MK. It is a successor of the Titan SoC used in previous
+emulation based ATgames systems.
+
+Monkey King and Monkey 2: Presumed custom. Used in some ATgames/Blaze
+Genesis systems and the Atari Flashback Portable.
+
+Monkey King 3 and Monkey King 3B: Presumed custom. Used in the ATgames
+BLAST system and the RS-70 648-in-1 "PS1 form factor" clone. Supports
+HDMI output.
+
+Monkey King 3.6: not a custom part but a rebranded RK3036, usually
+running a cut-down Android based OS. Used in newer ATgames systems.
+
+The typical configuration of the Monkey King SoCs (other than the
+3.6) is with 8/16MB of SDRAM, NOR flash for the firmware and
+built-in games, and a SD card for additional games.
+
+The RS-70 is notable for having a debug UART on the USB port 
+(serial TX on D+, 115200). It prints the following messages on boot:
+
+	EXEC: Executing 'boot' with 0 args (ZLib ON)...
+	EXEC: Loading 'boot' at 0x18000000...
+	EXEC: Loaded 372272 bytes of 2097152 available.	
+
+There are other strings in the ROM that imply there may be more serial
+debug possibilities.
+
+TODO:
+	implement everything
+	add dumps of more Monkey King systems
+*/
+
+#include "emu.h"
+#include "cpu/arm7/arm7.h"
+#include "cpu/arm7/arm7core.h"
+#include "emupal.h"
+#include "screen.h"
+
+class mk3b_soc_state : public driver_device
+{
+public:
+	mk3b_soc_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag),
+		m_iram3(*this, "iram3"),
+		m_iram7(*this, "iram7"),
+		m_sdram(*this, "sdram"),
+		m_maincpu(*this, "maincpu")
+	{ }
+
+	void mk3b_soc(machine_config &config);
+
+	void init_rs70();
+
+private:
+	required_shared_ptr<uint32_t> m_iram3, m_iram7;
+	required_shared_ptr<uint32_t> m_sdram;
+	required_device<cpu_device> m_maincpu;
+
+	virtual void machine_reset() override;
+	virtual void video_start() override;
+	uint32_t screen_update_mk3b_soc(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void map(address_map &map);
+};
+
+
+void mk3b_soc_state::map(address_map &map)
+{
+	// 64MB external NOR flash
+	// We assume that the lower 32MB is mirrored to 0x00000000
+	// solely so the vectors end up in the right place. This may
+	// well not be correct.
+	map(0x08000000, 0x0BFFFFFF).rom().share("norflash");
+	map(0x00000000, 0x01FFFFFF).rom().share("norflash");
+	// unknown amount and configuration of internal RAM
+	map(0x03000000, 0x0300FFFF).ram().share("iram3");
+	map(0x07000000, 0x0700FFFF).ram().share("iram7");
+	// 16MB of external SDRAM
+	map(0x18000000, 0x18FFFFFF).ram().share("sdram");
+}
+
+static INPUT_PORTS_START( mk3b_soc )
+
+INPUT_PORTS_END
+
+void mk3b_soc_state::video_start()
+{
+}
+
+void mk3b_soc_state::machine_reset()
+{
+}
+
+uint32_t mk3b_soc_state::screen_update_mk3b_soc(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+void mk3b_soc_state::mk3b_soc(machine_config &config)
+{
+	/* basic machine hardware */
+	ARM920T(config, m_maincpu, 200000000); // type + clock unknown
+	m_maincpu->set_addrmap(AS_PROGRAM, &mk3b_soc_state::map);
+
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	screen.set_refresh_hz(60);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500) /* not accurate */);
+	screen.set_size(1280, 720);
+	screen.set_visarea(0, 1280-1, 0, 720-1);
+	screen.set_screen_update(FUNC(mk3b_soc_state::screen_update_mk3b_soc));
+
+}
+
+void mk3b_soc_state::init_rs70()
+{
+	// Uppermost address bit seems to be inverted
+	uint8_t *ROM = memregion("maincpu")->base();
+	int size = memregion("maincpu")->bytes();
+
+	for (int i = 0; i < (size / 2); i++)
+	{
+		std::swap(ROM[i], ROM[i + (size / 2)]);
+	}
+}
+
+
+ROM_START( rs70_748in1 )
+	ROM_REGION(0x04000000, "maincpu", 0)
+	ROM_LOAD("s29gl512p.bin", 0x000000, 0x04000000, CRC(cb452bd7) SHA1(0b19a13a3d0b829725c10d64d7ff852ff5202ed0) )
+ROM_END
+
+CONS( 2019, rs70_748in1,  0,        0, mk3b_soc, mk3b_soc, mk3b_soc_state, init_rs70, "<unknown>", "RS-70 748-in-1",      MACHINE_IS_SKELETON )

--- a/src/mame/drivers/monkey_king_3b.cpp
+++ b/src/mame/drivers/monkey_king_3b.cpp
@@ -244,9 +244,9 @@ void mk3b_soc_state::init_rs70()
 }
 
 
-ROM_START( rs70_748in1 )
+ROM_START( rs70_648 )
 	ROM_REGION(0x04000000, "norflash", 0)
 	ROM_LOAD("s29gl512p.bin", 0x000000, 0x04000000, CRC(cb452bd7) SHA1(0b19a13a3d0b829725c10d64d7ff852ff5202ed0) )
 ROM_END
 
-CONS( 2019, rs70_748in1,  0,        0, mk3b_soc, mk3b_soc, mk3b_soc_state, init_rs70, "<unknown>", "RS-70 748-in-1",      MACHINE_IS_SKELETON )
+CONS( 2019, rs70_648,  0,        0, mk3b_soc, mk3b_soc, mk3b_soc_state, init_rs70, "<unknown>", "RS-70 648-in-1",      MACHINE_IS_SKELETON )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -23149,7 +23149,7 @@ monacogp                        // (c) 1980 Sega
 monacogpa                       // (c) 1980 Sega
 
 @source:monkey_king_3b.cpp
-rs70_748in1                     //
+rs70_648                        //
 
 @source:monon_color.cpp
 mononcol                        // (c) 2011 M&D

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -23148,6 +23148,9 @@ momokoe                         // (c) 1986 Jaleco (English text)
 monacogp                        // (c) 1980 Sega
 monacogpa                       // (c) 1980 Sega
 
+@source:monkey_king_3b.cpp
+rs70_748in1                     //
+
 @source:monon_color.cpp
 mononcol                        // (c) 2011 M&D
 

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -587,6 +587,7 @@ mmd2.cpp
 mod8.cpp
 modellot.cpp
 molecular.cpp
+monkey_king_3b.cpp
 monon_color.cpp
 monty.cpp
 mpc3000.cpp


### PR DESCRIPTION
The Monkey King 3B is an emulation-oriented ARM-based SoC by Digital Media Cartridge, a company closely associated with AtGames. The Monkey King family is a successor to their Titan ARM-based SoCs.

The RS-70 is one of the systems using it, with 648 NES and Genesis games on NOR flash in a PS1-esque casing and HDMI output.

This is just the beginnings of the core, all it does so far is print the following debug messages before hanging, but at least that means the memory mapping is vaguely right:

```
Modes:0x00000000
PUT: Setting joystick to mode 0x0, timer to 250us

******************************************************
 MK FIRMWARE INFORMATION
 Mode:       0xB4
 Build Time: May  8 2019 14:09:21
 CPU Clock:  240MHz
 TFS Start:  0x8070000
 Video Buf:  0x6000000
 Stack Top:  0x3001EE8
 IWRAM Size: 32kB
 EVRAM Size: 16384kB
 Heap Size:  6144kB at 0x18200000
 Video Mode: 0
 Video Size: 1280x720x16bpp
******************************************************
```

I can't guarantee that I will be able to finish this given the uncertainties involved, but hopefully this starting point is useful, and I would appreciate feedback on the code style. 