### PR TITLE
mdos dsk: fix the cells size and gaps, make clear its Motorola MDOS

### DIFF
--- a/src/lib/formats/mdos_dsk.h
+++ b/src/lib/formats/mdos_dsk.h
@@ -1,7 +1,7 @@
 // license:BSD-3-Clause
 // copyright-holders:68bit
 /*
- * mdos_dsk.h
+ * mdos_dsk.h  -  Motorola MDOS compatible disk images
  */
 #ifndef MAME_FORMATS_MDOS_DSK_H
 #define MAME_FORMATS_MDOS_DSK_H


### PR DESCRIPTION
Some more scrutiny made it clear that the cells size was wrong, and the gaps then needed some correction too. It was working, the PLL adjusted the bit clock, but it was off. Updated the comments to make it clear that this is the Motorola MDOS format, as requested. FYI EXORterm 155 and EXORciser emulators are being developed and reading, writing and formatting this disc format is working - trying to finish them off and clean them up.