### PR TITLE
mc6852 - implement more functionality, add byte interface.

### DIFF
--- a/src/devices/machine/mc6852.h
+++ b/src/devices/machine/mc6852.h
@@ -64,6 +64,11 @@ public:
 	DECLARE_READ_LINE_MEMBER( sm_dtr_r ) { return m_sm_dtr; }
 	DECLARE_READ_LINE_MEMBER( tuf_r ) { return m_tuf; }
 
+	// These are to allow integration of this driver with code
+	// controlling floppy disks.
+	void receive_byte(uint8_t data);
+	uint8_t get_tx_byte(int *tuf);
+
 protected:
 	// device-level overrides
 	virtual void device_start() override;
@@ -148,6 +153,7 @@ private:
 	int m_dcd;              // data carrier detect
 	int m_sm_dtr;           // sync match/data terminal ready
 	int m_tuf;              // transmitter underflow
+	int m_in_sync;
 };
 
 


### PR DESCRIPTION
This adds functionality needed to support a Motorola m68sfdc floppy disk controller emulator. It adds byte sized functions for sending and receiving data as these are a practical size for the FDC emulation. It should not regress any existing functionality and does not touch the serial interface which appears to be only a skeleton. Various issues TODO are noted. It has been tested on a m68sfdc emulator running EXORciser firmware.