### PR TITLE
Use gcc broken friend workaround also with clang8

### DIFF
--- a/src/emu/devcb.h
+++ b/src/emu/devcb.h
@@ -29,11 +29,17 @@
 //  DETECT PROBLEMATIC COMPILERS
 //**************************************************************************
 
-#if defined(__GNUC__) || defined(__clang_major__)
-#if (__GNUC__ >= 8) || (__clang_major__ == 8)
+#if defined(__GNUC__)
+#if (__GNUC__ >= 8)
 #define MAME_DEVCB_GNUC_BROKEN_FRIEND 1
-#endif // (__GNUC__ >= 8) || (__clang_major__ == 8)
-#endif // defined(__GNUC__) || defined(__clang_major__)
+#endif // (__GNUC__ >= 8)
+#endif // defined(__GNUC__)
+
+#if defined(__clang__)
+#if (__clang_major__ == 8)
+#define MAME_DEVCB_GNUC_BROKEN_FRIEND 1
+#endif // (__clang_major__ == 8)
+#endif // defined(__clang__)
 
 //**************************************************************************
 //  DELEGATE TYPES

--- a/src/emu/devcb.h
+++ b/src/emu/devcb.h
@@ -29,13 +29,11 @@
 //  DETECT PROBLEMATIC COMPILERS
 //**************************************************************************
 
-#if defined(__GNUC__) && !defined(__clang__)
-#if __GNUC__ >= 8
+#if defined(__GNUC__) || defined(__clang_major__)
+#if (__GNUC__ >= 8) || (__clang_major__ == 8)
 #define MAME_DEVCB_GNUC_BROKEN_FRIEND 1
-#endif // __GNUC__ >= 8
-#endif // defined(__GNUC__) && !defined(__clang__)
-
-
+#endif // (__GNUC__ >= 8) || (__clang_major__ == 8)
+#endif // defined(__GNUC__) || defined(__clang_major__)
 
 //**************************************************************************
 //  DELEGATE TYPES

--- a/src/emu/devcb.h
+++ b/src/emu/devcb.h
@@ -29,10 +29,10 @@
 //  DETECT PROBLEMATIC COMPILERS
 //**************************************************************************
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #if (__GNUC__ >= 8)
 #define MAME_DEVCB_GNUC_BROKEN_FRIEND 1
-#endif // (__GNUC__ >= 8)
+#endif // (__GNUC__ >= 8) && !defined(__clang__)
 #endif // defined(__GNUC__)
 
 #if defined(__clang__)


### PR DESCRIPTION
"Fix"
```
In file included from ../../../../../src/emu/emu.h:103:
/Users/buildbot/buildbot/osx/libretro-mame/build/projects/retro/mame/gmake-osx-clang/../../../../../src/emu/devcb.h:1102:12: error: 'consume' is a protected member of 'devcb_write<unsigned char, '\xFF'>::builder_base'
                { m_sink.consume(); }
                         ^
```
full build log: http://paste.libretro.com/215612

Feedback welcome about best way to implement the compiler check.
