### PR TITLE
pc98_cd.xml: 15 new dumps, 11 replacements

### DIFF
--- a/hash/pc98_cd.xml
+++ b/hash/pc98_cd.xml
@@ -873,20 +873,34 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="branmar2">
 		<!--
-		Origin: Unknown
-		<rom name="GAME.BIN" size="479222352" crc="b96fad3a" sha1="76d673cd9fdcf7479f484e2e5b92fcde3d6c6e41"/>
-		<rom name="GAME.CUE" size="173" crc="75049f00" sha1="008c1c2053e71aa20f6818fbe4f9eeb6705ef7a6"/>
+		Origin: redump.org
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 1).bin" size="371159712" crc="df2701fe" sha1="ecc0d8153e5b476e1692a33e61f0cea18c8a7cce"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 2).bin" size="54495840" crc="d6fea193" sha1="26dfee2e39be02968294b0fa2c304dd69bde4bc5"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc) (Track 3).bin" size="53919600" crc="932ba984" sha1="8b143a0c7f1f44038c71a84df064e98c87a9dde9"/>
+		<rom name="Branmarker 2 (Japan) (Game Disc).cue" size="337" crc="049ba1fe" sha1="1c65dbd4898a0c483ee92e87cc2d9d0fa81996b7"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 1).bin" size="482889120" crc="ae31a549" sha1="9f4ca18f2ba133534dd7a150e248398fe9cf5151"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 2).bin" size="209972448" crc="dca6cf1c" sha1="d2125cf9cdd51d66f6af23dc9d8a3c16c2b5000d"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc) (Track 3).bin" size="33464256" crc="115ae1b1" sha1="fd3ed992993023660b1aedae0b1659e6efa80ee5"/>
+		<rom name="Branmarker 2 (Japan) (Extra Disc).cue" size="340" crc="b9c8fbc2" sha1="715fa4406d6ede1cdfbd02f7aac0fa3a6e4205ba"/>
 		-->
 		<description>Branmarker 2</description>
 		<year>1995</year>
 		<publisher>ディー・オー (D.O.)</publisher>
 		<info name="alt_title" value="ブランマーカー２" />
 		<info name="release" value="19951014" />
-		<part name="cdrom" interface="cdrom">
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="Game Disc" />
 			<diskarea name="cdrom">
-				<disk name="branmarker 2" sha1="15f0320726f83a341a7f01e3268945b143c66873" />
+				<disk name="branmarker 2 (japan) (game disc)" sha1="242b3fd57b45e08f29fba516257821ad7f132152" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Extra Disc" />
+			<diskarea name="cdrom">
+				<disk name="branmarker 2 (japan) (extra disc)" sha1="755865e904bf3ee527c629a45cea052f7bb10f5b" />
 			</diskarea>
 		</part>
 	</software>
@@ -1021,6 +1035,55 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="brandish vt (japan)" sha1="0aa4a61ad74f93d78fc331ddefb91e67c79e9bc8" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- After installing the system files, it fails to boot with "CD-ROM ドライブが見つかりません" (CD-ROM drive not found) -->
+	<software name="chiemi" supported="no">
+		<!--
+		Origin: redump.org / wiggy2k
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 01).bin" size="31399200" crc="286527ae" sha1="546c782bf12f9d2d64c92204e3b53f19a12fd1c5"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 02).bin" size="23816352" crc="42619143" sha1="c1482839c418c8705e8ae73d3533c0ba7f98f7b0"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 03).bin" size="6174000" crc="0c91acac" sha1="d028c88815a1f0e9d2e70fb634f14101f490ab9d"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 04).bin" size="30870000" crc="5ce57017" sha1="443f512b65730a5d13bb26ceeda63300fb253e27"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 05).bin" size="30870000" crc="699eb0f1" sha1="948e6ece37165d1d336b5eb2260806912ec34dea"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 06).bin" size="40748400" crc="fdc102e0" sha1="49337a0b4fbd61c5c9400e12d93ccf891347ec1f"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 07).bin" size="27871200" crc="ff7de08d" sha1="1ba07789c6e3e2c84743d8bf0dca8a3c5965f281"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 08).bin" size="41101200" crc="06834f32" sha1="5235cc6c9bd04ebee2a5e0bde3b7f6b248bd407c"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 09).bin" size="27165600" crc="a3a89ad6" sha1="e10bf13c3384e6d8368b8446688e333319b4c4df"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 10).bin" size="35103600" crc="3d165d3c" sha1="b02ee7af8cfc74e8e2fc4ad725b3c599ec40bc31"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 11).bin" size="5821200" crc="d0740da8" sha1="70ca1a6786677463c7b942aecb37af8c05be79ef"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 12).bin" size="2469600" crc="6bc3a822" sha1="7f13602935ce28335ad806b08cc0be81680887c9"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 13).bin" size="1058400" crc="e0e9caeb" sha1="707eb37890638680247262bb36c3f5099af64992"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 14).bin" size="32810400" crc="be6b8c6c" sha1="7739e705be4a7e772b5b14bfb3c5624ba28cf06b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 15).bin" size="31222800" crc="b58e2405" sha1="92c5a72d96f1f696f148e9923213cdd38b40ab81"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 16).bin" size="41277600" crc="ad6f2bf8" sha1="96d13571993b309204023af5f8b19ffd3177710c"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 17).bin" size="11642400" crc="dfa70b75" sha1="1e17c3307196ec0ef838cf7db46243c27c0c199d"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 18).bin" size="53802000" crc="da940b3d" sha1="cf9cd5b7dc4fa3421416ea66f1ef32cf8ac024fb"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 19).bin" size="30693600" crc="e292d51b" sha1="f52e8faf3ea2468f78cac37cbe7008d4c5e0bdb2"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 20).bin" size="1058400" crc="682b5602" sha1="5ac3ddcefe255704586ea634bc8a2078d10d81bb"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 21).bin" size="1587600" crc="3ac9ae1f" sha1="3616c0a7cc1ec336dc0d7fd40c7bb5c4d0a2f353"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 22).bin" size="1587600" crc="8f3f9ef8" sha1="c65ce38405157ed671253f3478d63e1c651a1d0b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 23).bin" size="22932000" crc="6ef7fe0d" sha1="123112b8f2c7ae0fa7e1a84d7aecdfa5daa0330b"/>
+		<rom name="Chiemi &amp; Naomi (Japan) (Track 24).bin" size="1940400" crc="500763cd" sha1="b0abbabe9b29f9e626a89e30e3c8cbe7baba1f01"/>
+		<rom name="Chiemi &amp; Naomi (Japan).cue" size="2813" crc="5e8b2677" sha1="7f07cbe86e4eee8e3d9f2a4b5dc82f5f0deee491"/>
+		-->
+		<description>Chiemi &amp; Naomi</description>
+		<year>1993</year>
+		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="serial" value="HME-244"/>
+		<info name="alt_title" value="稚恵美＆奈緒美" />
+		<info name="release" value="199312xx" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="1261568">
+				<rom name="chiemi-and-naomi.hdm" size="1261568" crc="7b3706d4" sha1="a63be0d0426e54291586f8d246c4fab58630026d" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="chiemi &amp; naomi (japan)" sha1="dcdb4cccbce006739a1d48959fc7514441b2240c" />
 			</diskarea>
 		</part>
 	</software>
@@ -1504,6 +1567,48 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- Black screen on boot -->
+	<software name="dorse93" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="DOR SE (Special Edition) '93 (Japan) (Track 1).bin" size="317167200" crc="e4cc8ac3" sha1="e8e32b1a959f69b4bdd0fef124d72ce2e64c747d"/>
+		<rom name="DOR SE (Special Edition) '93 (Japan) (Track 2).bin" size="35630448" crc="99da051e" sha1="15151aa198c8e2c6c528ff9be2ebd262344678a5"/>
+		<rom name="DOR SE (Special Edition) '93 (Japan) (Track 3).bin" size="36164352" crc="825418a8" sha1="d58a5a9afdd409b428f794c129f39ec3d0627b43"/>
+		<rom name="DOR SE (Special Edition) '93 (Japan).cue" size="395" crc="b921381c" sha1="777da9a56c83b06f9c75eedd12433bf9105a0fb9"/>
+		-->
+		<description>DOR Special Edition '93</description>
+		<year>1993</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-255 / 2TD-3004"/>
+		<info name="release" value="199312xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="dor se (special edition) '93 (japan)" sha1="effc100b0dc1850e840390a8ae52b7b5e80af821" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="dorse93a" cloneof="dorse93" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="DOR - Special Edition &apos;93 (Japan) (Alt) (Track 1).bin" size="310421664" crc="752f9bdd" sha1="ae19d158d5cc4c094d216b593ff383bd7ee33abb"/>
+		<rom name="DOR - Special Edition &apos;93 (Japan) (Alt) (Track 2).bin" size="35630448" crc="b8116f60" sha1="1ad59d2a1d591251b9b68093b572b4c253eb2017"/>
+		<rom name="DOR - Special Edition &apos;93 (Japan) (Alt) (Track 3).bin" size="35635152" crc="5a9d095a" sha1="d93ba61f4cb4b841ba2a93256182ef71452b0501"/>
+		<rom name="DOR - Special Edition &apos;93 (Japan) (Alt).cue" size="404" crc="0f4aee39" sha1="c95f294d8607b877a4fe6d4e8723acd728747d14"/>
+		-->
+		<description>DOR Special Edition '93 (alt)</description>
+		<year>1993</year>
+		<publisher>ディー・オー (D.O.)</publisher>
+		<info name="serial" value="HME-255"/>
+		<info name="release" value="199312xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="dor special edition '93 (alt)" sha1="7c8ed53fc332b99eebdeb81933184b85b424a1ac" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="dstat_09">
 		<!--
 		Origin: redump.org
@@ -1665,19 +1770,23 @@ license:CC0
 	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="eimmy">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Eimmy to Yobanaide.ccd" size="1536" crc="5a957719" sha1="b674f4c5d249abd3f0b90bf82991f1128ba05ab9"/>
-		<rom name="Eimmy to Yobanaide.cue" size="238" crc="dcae031f" sha1="d27f55850c97b3761b09bb043f87c4a6ec89da2d"/>
-		<rom name="Eimmy to Yobanaide.img" size="549742368" crc="1585640a" sha1="7f98c92bb3917cf2d87d325ddc4c1ce36b5a6484"/>
-		<rom name="Eimmy to Yobanaide.sub" size="22438464" crc="03ea8525" sha1="3cbd86397d59300f0ae4d977436a12cdcad742e1"/>
+		Origin: redump.org
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 1).bin" size="385579824" crc="99869352" sha1="429f8879aff4809064f08bf893f5a1d7329ba7bf"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 2).bin" size="51459408" crc="b447fa0d" sha1="d45f8d372e0f3d78ca08fdcdf78a367582ca267c"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 3).bin" size="51167760" crc="bc870a2f" sha1="439d9c4c619bdbbf87676bb9a4b4645ef7161dcf"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 4).bin" size="29665776" crc="4bffe326" sha1="ca1f5c4389fe6ca748a558ffe94a4bb85e1c077d"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan) (Track 5).bin" size="31869600" crc="707adf40" sha1="f512336d7b8758af78cb5b08504590834c78038e"/>
+		<rom name="Eimmy to Yobanaide - Please Don't Call Me Eimmy (Japan).cue" size="658" crc="608ac853" sha1="4083d7bf509ff71735613ef4f634a92d42d7c52b"/>
 		-->
 		<description>Eimmy to Yobanaide</description>
 		<year>1995</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
+		<info name="serial" value="CSW-0003"/>
+		<info name="alt_title" value="エイミーと呼ばないでっ" />
 		<info name="release" value="199508xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="eimmy to yobanaide" sha1="4c321b593322b94cf84a68ad1021d0cf3b24b1c4" />
+				<disk name="eimmy to yobanaide - please don't call me eimmy (japan)" sha1="15ba4ebd4f932f9b3406e40b439172a7680222f7" />
 			</diskarea>
 		</part>
 	</software>
@@ -1847,6 +1956,24 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="f117mlti" sha1="c46bbe48c829b98d7ee806b4b242a8fd80af20f8"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="f15se3">
+		<!--
+		Origin redump.org
+		<rom name="F-15 Strike Eagle III (Japan).bin" size="12141024" crc="e603b6f5" sha1="991b5a9b05c9fa7424e7474bad544aeb43ace86e"/>
+		<rom name="F-15 Strike Eagle III (Japan).cue" size="118" crc="427a1e8c" sha1="7cac9565d86c47b4d73e93a8ff8762d7499d8b89"/>
+		-->
+		<description>F15 Strike Eagle III</description>
+		<year>1995</year>
+		<publisher>スペクトラムホロバイトジャパン (Spectrum HoloByte Japan)</publisher>
+		<info name="alt_title" value="Ｆ－１５ ストライクイーグル３" />
+		<info name="release" value="19951006" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="f-15 strike eagle iii (japan)" sha1="9b830e4c843f50c09480976a577638200ebe5f5b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2293,6 +2420,26 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<software name="if2">
+		<!--
+		Origin: redump.org
+		<rom name="if 2 - Invitations from Fantastic Stories (Japan).bin" size="20815200" crc="2b674736" sha1="cfc887aa25a66dc5bccd35153989d0a7590a9755"/>
+		<rom name="if 2 - Invitations from Fantastic Stories (Japan).cue" size="138" crc="5a455327" sha1="92f01383275dd88e6aff59373b52b6aa87dc3ca5"/>
+		-->
+		<description>if 2 - Invitations from Fantastic Stories</description>
+		<year>1993</year>
+		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="HMF-228 / 2TD-3003"/>
+		<info name="alt_title" value="イフ2" />
+		<info name="release" value="19931119" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="if 2 - invitations from fantastic stories (japan)" sha1="aab5838de5a0e92d8a887e075f913aed0acdf18d" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="inhearth">
 		<!--
 		Origin unknown
@@ -2398,6 +2545,31 @@ license:CC0
 	</software>
 
 	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- Only the top 2 lines show up on screen, the rest is empty -->
+	<software name="knjland3" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Kanji Land 3-nen (Japan) (Track 1).bin" size="32539920" crc="c8b3bd9a" sha1="22735456fc350697845450cd95c63a3119c939bd"/>
+		<rom name="Kanji Land 3-nen (Japan) (Track 2).bin" size="19488672" crc="6290a60f" sha1="6cb0f3e4679ac4bed0df6bad19cbc55e4c20125b"/>
+		<rom name="Kanji Land 3-nen (Japan) (Track 3).bin" size="32544624" crc="9e0b3bbe" sha1="b11572cc05568e5c5800f43f4f1d46f901d8ebd2"/>
+		<rom name="Kanji Land 3-nen (Japan) (Track 4).bin" size="34661424" crc="7917756f" sha1="b039d7a236e92084995a9cea64c63dae7375e9e9"/>
+		<rom name="Kanji Land 3-nen (Japan) (Track 5).bin" size="40306224" crc="ef038840" sha1="1fd7250bff7578f0e39a12efe13c5fd7525195b6"/>
+		<rom name="Kanji Land 3-nen (Japan).cue" size="595" crc="ade9085c" sha1="3a32a76c1568b8c2efed6006d28019c1db0aff83"/>
+		-->
+		<description>Kanji Land 3-nen</description>
+		<year>1995</year>
+		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
+		<info name="serial" value="OSL-010A"/>
+		<info name="alt_title" value="漢字ランド３年" />
+		<info name="release" value="199507xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="kanji land 3-nen (japan)" sha1="fb7b3684231bde65a285fe528b6c42f0be6f74cd" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="kokoraku">
 		<!--
 		Origin: Neo Kobe Collection
@@ -2456,18 +2628,37 @@ license:CC0
 
 	<software name="kyrandia">
 		<!--
-		Origin: Neo Kobe Collection
-		CCD converted to CUE with GNU ccd2cue
-		<rom name="The Legend of Kyrandia.ccd" size="4894" crc="3a8bbbfb" sha1="132f7535d204a731423b497729d3b7e01f35eefd"/>
-		<rom name="The Legend of Kyrandia.cue" size="917" crc="126b517a" sha1="50280ae669798e6e37f82a9621e8a2b2341832ba"/>
-		<rom name="The Legend of Kyrandia.img" size="561895152" crc="8f8bb29e" sha1="15d73a824957614af96bac3467c37f576a50390f"/>
-		<rom name="The Legend of Kyrandia.sub" size="22934496" crc="0638eedb" sha1="76d14925a9f668100d2e55f610b56cacf6fbb292"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Legend of Kyrandia, The (Japan) (Track 01).bin" size="9403296" crc="22887101" sha1="310f10bc63da750541b513913990708daf57e14f"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 02).bin" size="29752800" crc="25626629" sha1="174ff1838863decc1d0d85aa96e4a25cc051f7ac"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 03).bin" size="28129920" crc="9118b9ea" sha1="eda13c04ef5fd2e540f2b313c3ede040dc039511"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 04).bin" size="20991600" crc="e947027f" sha1="c6daed40f17f86b33515126e1dd693d663c4abc5"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 05).bin" size="17146080" crc="f72d5f33" sha1="29e574677f57f994d2379d7d3694b9aff24deff8"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 06).bin" size="25013520" crc="1fa1be1e" sha1="a5a3d4c17bd68a57861f4686d24e02d95a74eaf1"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 07).bin" size="18340896" crc="39ec5b66" sha1="670f639a9ef064c9673d818a8ba3753ed4aec2fb"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 08).bin" size="21266784" crc="26bc5a4b" sha1="007241398eb076c30830f9ce3ca019c457f269ad"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 09).bin" size="34720224" crc="7de82006" sha1="71a7f245dc1f6b78aa5f78bba1ac4d906ff12855"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 10).bin" size="28607376" crc="1d50f9dc" sha1="be14acaa770940026a2f395acb3652be8e071bbb"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 11).bin" size="31575600" crc="2ced7636" sha1="b5859fa5105992ec149bf591169c0cf253196724"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 12).bin" size="15424416" crc="98c26745" sha1="ddf835c2034de1e0c1180b0cfa3161a2623d756d"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 13).bin" size="21960624" crc="3992269a" sha1="c874ca23da50011a23db06c8c25fdaca1ae0e2aa"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 14).bin" size="78415680" crc="cdd6d402" sha1="c6f583afdd17a59133a2112075551322bdbe883d"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 15).bin" size="27612480" crc="e3cba596" sha1="1c93a3785b583db57094c179928d2b2add2cd788"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 16).bin" size="45593520" crc="4a57c679" sha1="bb29d4153db1864b6aca7f583256f1993c94b4c0"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 17).bin" size="12430320" crc="523cd6db" sha1="6a24ffe7b532fa3c6b7fe8e27129ab179701bba7"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 18).bin" size="8624784" crc="dc9d19ca" sha1="cb6ba4f6a592b769e13bb8950da6c47be6bac9fd"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 19).bin" size="10614576" crc="8a1bfb3f" sha1="3cb83119ea14bb7220da4a15e12c20f264b23852"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 20).bin" size="14229600" crc="fd2fc7cc" sha1="efdf399475a4e1fd330e5bf0c627d82a781942f7"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 21).bin" size="12136320" crc="973875fa" sha1="5e887dd49336fab522991343ee68b999fa7fc690"/>
+		<rom name="Legend of Kyrandia, The (Japan) (Track 22).bin" size="49904736" crc="f4fc1800" sha1="3e14d6e4d3143f51dd4b20b29617748bf669ea48"/>
+		<rom name="Legend of Kyrandia, The (Japan).cue" size="2294" crc="b9a1dd2b" sha1="922a29b2a73047b58abb17fccb945e7a9188cf60"/>
 		-->
 		<description>The Legend of Kyrandia</description>
-		<year>1994</year>
+		<year>1993</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
-		<info name="alt_title" value="レジェンド　オブ　キランディア" />
-		<info name="release" value="19940215" />
+		<info name="serial" value="SC-93002"/>
+		<info name="alt_title" value="レジェンド・オブ・キランディア" />
+		<info name="release" value="199310xx" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="1261568">
 				<rom name="the legend of kyrandia (cd install disk).hdm" size="1261568" crc="005afba9" sha1="b60c579d34363f947bfb187401aa53eafe4d299a" offset="000000" />
@@ -2475,7 +2666,72 @@ license:CC0
 		</part>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="the legend of kyrandia" sha1="c1e8ad3237cc405e134ccebb7466f356d6280871" />
+				<disk name="legend of kyrandia, the (japan)" sha1="c5b8ccb2a80a2053c0cb1ae0b0546ba5a0fe6677" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Hangs after the title screen. Could be related to the bad sectors on the floppy disk. -->
+	<software name="kyrandia2" supported="no">
+		<!--
+		Origin: redump.org (CD) / KailoKyra (floppy)
+		<rom name="Kyrandia II - The Hand of Fate (Japan).bin" size="19535712" crc="189dec4f" sha1="55091fb0dd63855eb527753a46737142e17b7ae6"/>
+		<rom name="Kyrandia II - The Hand of Fate (Japan).cue" size="127" crc="ee8bf244" sha1="55f2b4c6a2faadb71269fc36d490d9289dba60ec"/>
+		-->
+		<description>Kyrandia II - The Hand of Fate</description>
+		<year>1995</year>
+		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="serial" value="SC-95002"/>
+		<info name="alt_title" value="ザ・ハンド・オブ・フェイト キランディア２" />
+		<info name="release" value="19951014" />
+		<part name="flop1" interface="floppy_5_25">
+			<!-- Several bad sectors, needs a redump -->
+			<dataarea name="flop" size="1261568">
+				<rom name="kyrandia ii pc-9821.hdm" size="1261568" crc="67ad11ea" sha1="c1f9f4ab622cd04d8954b921750acda1650ffac5" offset="000000" status="baddump" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="kyrandia ii - the hand of fate (japan)" sha1="88ec7b26f9acd111150a46b1460e466d9bbb28aa" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- Fails with "can't find the CD-ROM drive" error -->
+	<software name="lemoncc" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Lemon Cocktail Collection (Japan) (Track 01).bin" size="31399200" crc="ed3b3b75" sha1="941364b602e9c0fe9c0682ba342a052de6d4ea03"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 02).bin" size="30164400" crc="6d056e4e" sha1="f08fd5b36730246fa9346858839bb756c640cdde"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 03).bin" size="46746000" crc="1eea2fc5" sha1="27dd006784be1902f58bb88fb726909da6aca250"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 04).bin" size="43747200" crc="eb597d0a" sha1="ab76557a1ca57953592edb9987098cf3364a8098"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 05).bin" size="30340800" crc="4cf5eb6d" sha1="27fdcc111fd63b6844724fabbd94018ff64a957d"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 06).bin" size="37926000" crc="b6356045" sha1="6d35c9872ad7da946a1d06917a030fc7f8809309"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 07).bin" size="38808000" crc="d17604fd" sha1="8f208d1779c1b0e2a4e6238dcf44d73a4dd3baf0"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 08).bin" size="39513600" crc="9fd04581" sha1="e7a09ba8dd070fa4ecd34b6cc309a0a4cf948dfb"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 09).bin" size="33868800" crc="5af50c83" sha1="19672e4e73b0ef9e438b90ffa1a634db7e5e5cb4"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 10).bin" size="30870000" crc="9e43d498" sha1="8d3067f23310b4731a690b4270e46bdfa3c125fe"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 11).bin" size="32457600" crc="00f3d2c0" sha1="f43426a61850877f614895f478ac2dc214d03f29"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 12).bin" size="29282400" crc="3285f41e" sha1="904cf11e4326521897434cf85e4524676405bb21"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 13).bin" size="7408800" crc="dc332186" sha1="e529334b5c58665c70e91d316f0849eb694ba65a"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 14).bin" size="31046400" crc="7a5933cd" sha1="12a5d3b61da4d32c84c23435e79cd7f727215489"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 15).bin" size="32457600" crc="2f2b4fcd" sha1="d67fd767a926fb0874745857ad0f1906945cc1b1"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 16).bin" size="40924800" crc="37f417b1" sha1="25bae598fe25ccd19fd839985c22dc14a80225af"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 17).bin" size="28576800" crc="de0575a8" sha1="a010aedd53a02cdac4930e19e872140382a06748"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 18).bin" size="17463600" crc="1ed23af9" sha1="7628aace5c65598355d2f64f55f243e9892190f2"/>
+		<rom name="Lemon Cocktail Collection (Japan) (Track 19).bin" size="26107200" crc="89b3a0d3" sha1="4e6dd9a07d655aacad7a2461407ee2ba16b2dc0f"/>
+		<rom name="Lemon Cocktail Collection (Japan).cue" size="2414" crc="bf6e3f6a" sha1="8c903aa24570e9ea4c9aa6b722504eb7a29b0d73"/>
+		-->
+		<description>Lemon Cocktail Collection</description>
+		<year>1993</year>
+		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
+		<info name="alt_title" value="レモン・カクテル・コレクション" />
+		<info name="serial" value="HME-101"/>
+		<info name="release" value="199303xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="lemon cocktail collection (japan)" sha1="a17512ebc210b781310d79a35cf8da325ed1374a" />
 			</diskarea>
 		</part>
 	</software>
@@ -2486,12 +2742,10 @@ license:CC0
 	-->
 	<software name="lesserm" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		CCD converted to CUE with GNU ccd2cue
-		<rom name="Lesser Mern Special Director's Edition.ccd" size="957" crc="189d87e2" sha1="0d829c0ca27ab24a1404ce8932219a52a2519a0a"/>
-		<rom name="Lesser Mern Special Director's Edition.cue" size="138" crc="815d6da0" sha1="f8cf64b84815ec089c8ab9f3bdcee99c76a3bdab"/>
-		<rom name="Lesser Mern Special Director's Edition.img" size="298544064" crc="6df3f1b5" sha1="54232495cf7288d21d20d62a6cbea74c6e64660a"/>
-		<rom name="Lesser Mern Special Director's Edition.sub" size="12185472" crc="734bf105" sha1="4a0f9eda741adaaff00021574fa096e4f7a7c75b"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Lesser Mern - Special Director's Edition (Japan) (Track 1).bin" size="9530304" crc="5b0f4a83" sha1="f5410af0b1177f62c7f22bb2ba6a572a93528582"/>
+		<rom name="Lesser Mern - Special Director's Edition (Japan) (Track 2).bin" size="289013760" crc="56060d44" sha1="2b5c901351bd829de702605fff82c862b96543d8"/>
+		<rom name="Lesser Mern - Special Director's Edition (Japan).cue" size="289" crc="cfe05e75" sha1="43d95b291c3a40d1a87914e18c90bf13b7629e9a"/>
 		-->
 		<description>Lesser Mern - Special Director's Edition</description>
 		<year>1992</year>
@@ -2511,7 +2765,7 @@ license:CC0
 		</part>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="lesser mern special director's edition" sha1="238538d0118a18ce8237f681bf0de70b73af887d" />
+				<disk name="lesser mern - special director's edition (japan)" sha1="9ecf32d0dfe54a3781e822e30ac40ab971ba03b2" />
 			</diskarea>
 		</part>
 	</software>
@@ -2548,6 +2802,37 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="golf links 386 pro (japan)" sha1="c0eb847d7168e6209482b19a270bd81d40383137" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- Missing a floppy disk? -->
+	<software name="lipsadv3" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 01).bin" size="52567200" crc="7462e0c3" sha1="48900be15c74d4099e25710dcd5e6f26123c1d7f"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 02).bin" size="43923600" crc="12c3a386" sha1="853c797694005ab58666f5c21e2fa0f461c9fc5d"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 03).bin" size="32281200" crc="7fe731f3" sha1="c831ad5520e846d0d2f7145e6358b092ae80ff2f"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 04).bin" size="19404000" crc="0caf8555" sha1="be705a4209922d7253771c9042a9a055b7f46b69"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 05).bin" size="28224000" crc="cb3c404d" sha1="cd06c6312a80fed619c8f1a0d37de35239654a37"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 06).bin" size="33692400" crc="e6832e70" sha1="41424966a28305fbae01f69ad499942a3b145249"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 07).bin" size="27871200" crc="82d18093" sha1="87850e07f580fd8d0c03b712824a91990bc35be4"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 08).bin" size="34574400" crc="ba15484d" sha1="afbfa37d18570433b4786823622eb31caff106c7"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 09).bin" size="46040400" crc="09bcb43a" sha1="9611971fdbf918086742f169b53f860e03be299c"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 10).bin" size="46393200" crc="f2b00612" sha1="d1cd805d5ec73615cc22683f2687c6d67b023f88"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 11).bin" size="33516000" crc="f6b1128f" sha1="c22c7c63a7c0b42f10350581a937b12312aebe3b"/>
+		<rom name="Lip 3 - Lipstick Adventure 3 (Japan).cue" size="1423" crc="583e7d8b" sha1="68abb3c69843d9a1297c90a04f0613d98962d691"/>
+		-->
+		<description>Lip 3 - Lipstick Adventure 3</description>
+		<year>1993</year>
+		<publisher>フェアリーテール (Fairytale)</publisher>
+		<info name="alt_title" value="LIP3 リップスティック・アドベンチャー３" />
+		<info name="serial" value="HME-221"/>
+		<info name="release" value="199305xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="lip 3 - lipstick adventure 3 (japan)" sha1="c0507c340b55c1fa08a8080e0fc3d53d271f6a1e" />
 			</diskarea>
 		</part>
 	</software>
@@ -2692,6 +2977,25 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<software name="manadoko2">
+		<!--
+		Origin: redump.org
+		<rom name="Manami no Doko made Iku no 2 - Return of the Kuro Pack (Japan).bin" size="12376224" crc="81fd5145" sha1="8f2ceebf79dc77fa29a788ec05ede101d6045de4"/>
+		<rom name="Manami no Doko made Iku no 2 - Return of the Kuro Pack (Japan).cue" size="151" crc="7351f4ca" sha1="3914f29f9afd579a56aecb42c478f9b170bded64"/>
+		-->
+		<description>Manami no Doko made Iku no? 2 - Return of the Kuro Pack</description>
+		<year>1995</year>
+		<publisher>ウエンディマガジン (Wendy Magazine)</publisher>
+		<info name="alt_title" value="まなみのどこまでイクの? 2 リターン オブ THE 黒パック" />
+		<info name="release" value="199505xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="manami no doko made iku no 2 - return of the kuro pack (japan)" sha1="026662a39cda929bcc4b33110b0192f92f09d398" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- MAME crashes with "Incorrect layout on track 77 head 0" error -->
 	<software name="manpsy" supported="no">
 		<!--
@@ -2739,22 +3043,56 @@ license:CC0
 	</software>
 
 	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
-	<!-- Parts of the voiced dialogue get cut off, probably due to the lack of proper pregaps in the audio tracks -->
+	<!-- Hangs shortly after starting -->
+	<software name="mirage2" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand (Japan).bin" size="18726624" crc="94f9dfb8" sha1="f60333837f42ca928f677bc5da1f6b0966d2eacf"/>
+		<rom name="Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand (Japan).cue" size="127" crc="0053d83b" sha1="9799d748643ce4a6bf634ca3acf2ca359fe5de6a"/>
+		-->
+		<description>Mirage 2 - Torry, Neat &amp; Roan Fairladies in MagicLand</description>
+		<year>1994</year>
+		<publisher>ディスカバリー (Discovery)</publisher>
+		<info name="serial" value="2TD-3018"/>
+		<info name="alt_title" value="ミラージュ２ トリー×ニート×ローンの大冒険" />
+		<info name="release" value="199412xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="mirage 2 - torry, neat &amp; roan fairladies in magicLand (japan)" sha1="22c46e6409b2ffa8423691d12340b189f2e24358" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="mjdepon">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Mahjong de Pon!.ccd" size="3410" crc="2c6f9c3a" sha1="345140cdfe2dced80d7dccee798cea13ee8d7a58"/>
-		<rom name="Mahjong de Pon!.cue" size="631" crc="96651093" sha1="609f56161fd6e17522e3200a1207319bcce7b478"/>
-		<rom name="Mahjong de Pon!.img" size="247331616" crc="b973c373" sha1="f29afc379f24e00b5d0719ef962feabb6ec97187"/>
-		<rom name="Mahjong de Pon!.sub" size="10095168" crc="7c68bfd2" sha1="0bfab2bf3cd775663dbc33133aea2d043fb74a7f"/>
+		Origin: redump.org
+		<rom name="Mahjong de Pon! (Japan) (Track 01).bin" size="16421664" crc="cbdf74ed" sha1="74ae179088e5e549f487bc844b5220ccd5666ca0"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 02).bin" size="21520800" crc="2badd8fc" sha1="0b8066a8d74e446f15a97bc97b9b05eed5c390ba"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 03).bin" size="34927200" crc="c2621921" sha1="be4518ca76b4a093ba9f27d4b35ca4d5049971f9"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 04).bin" size="10936800" crc="0474ca45" sha1="79ea76bd1e0dade9aa2018b4ef73bd8d02969a0f"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 05).bin" size="26989200" crc="163bb41c" sha1="4492c1e8a1c66dc9ffca81bfc1719af973c7870d"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 06).bin" size="10584000" crc="bfaadfeb" sha1="420bef04eb402323ed2a46db452917042d7dfed6"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 07).bin" size="26283600" crc="a936f2a4" sha1="9014257e17d4d9fa2130c80ac7a97f2070d870f5"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 08).bin" size="10407600" crc="78201ff5" sha1="29e1cec86732b525f59f9ac30371de5c395b32b7"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 09).bin" size="26460000" crc="937abcb7" sha1="f8a84bb330695ed4e16a46bec6f040282a55de0b"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 10).bin" size="8290800" crc="daee42b7" sha1="bab67ba1394672afa227940e1380735c0c0e0ba4"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 11).bin" size="8467200" crc="968aaf37" sha1="a3964b2474c9f4fe8ede0159b878c8b1c4d8e13d"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 12).bin" size="8467200" crc="5bbe7d16" sha1="5810b129215010e42334c23787c0c0ad1583c406"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 13).bin" size="11642400" crc="96958c55" sha1="16ee2cdee03dfb96608868284276cf8fca97434f"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 14).bin" size="11818800" crc="8ed5bad8" sha1="16e9b001142de022776165749b5141592f175c91"/>
+		<rom name="Mahjong de Pon! (Japan) (Track 15).bin" size="14114352" crc="1a6683a7" sha1="b1ed8c28b8656ce463cf6ef5eaade83dd7ff627b"/>
+		<rom name="Mahjong de Pon! (Japan).cue" size="1775" crc="e6451e66" sha1="1b1096501add7f3c4cfe4a0316644fa9e02c343d"/>
 		-->
 		<description>Mahjong de Pon!</description>
 		<year>1994</year>
 		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="2TD-3013"/>
+		<info name="alt_title" value="麻雀でPON！" />
 		<info name="release" value="199404xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="mahjong de pon" sha1="58c4ae95a830294baa1a448c328d53c1d0a6002b" />
+				<disk name="mahjong de pon (japan)" sha1="a6332b3d1f893621f25f035b538cb14a6e5d946e" />
 			</diskarea>
 		</part>
 	</software>
@@ -3073,6 +3411,26 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<software name="phobos">
+		<!--
+		Origin: redump.org
+		<rom name="Phobos (Japan).bin" size="109074000" crc="7d8a4ad6" sha1="04848bc5e17007c4422dab14934eef29dd50accc"/>
+		<rom name="Phobos (Japan).cue" size="80" crc="d4091963" sha1="b6ee8af14fbd01ad236d5523acb554ddd6141542"/>
+		-->
+		<description>Phobos</description>
+		<year>1995</year>
+		<publisher>姫屋ソフト (Himeya Soft)</publisher>
+		<info name="alt_title" value="フォボス" />
+		<info name="serial" value="HMS-0002"/>
+		<info name="release" value="199508xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="phobos (japan)" sha1="3ef091b02523c332e6c423b02618022a01b8a46b" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="photogen">
 		<!--
 		Origin: redump.org
@@ -3219,6 +3577,47 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="probb96" sha1="eed3db3977df444b4f5fb8d66211f6728059babc" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<!-- Does an earlier PC-98-only release exist, like it does for the FM Towns? -->
+	<software name="prostudgr">
+		<!--
+		Origin: redump.org
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 01).bin" size="17578848" crc="1c135323" sha1="5ac9502fb8403ae6758bfb1987b307551c4aa64a"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 02).bin" size="39690000" crc="b90fdc51" sha1="1116aeaa041c448af34b50bf5a950ab2128094b6"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 03).bin" size="37044000" crc="5cf5891b" sha1="c9c5e3788cd0ca592ae48c99571504299faea51c"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 04).bin" size="34221600" crc="48d69882" sha1="5f0ef4164da83f9e6df3984101f2dc9e152924cd"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 05).bin" size="34927200" crc="8fab8c62" sha1="806a9e5ffe9a44a24a0b06f0daa1f4f2388b5ffa"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 06).bin" size="35280000" crc="d2c122fc" sha1="522fdc34d23fd590ea6104f03e3713cc2f17eaed"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 07).bin" size="38455200" crc="a406d437" sha1="d2ebee07144e231056a7f9322504c341b5492a66"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 08).bin" size="40219200" crc="b07efecc" sha1="4acc0e2854a467c4372232f0e75ef052dc254932"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 09).bin" size="40572000" crc="06cc5fa2" sha1="17413d5c3022bd3d9c0948475ac2f3bb60a34077"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 10).bin" size="42336000" crc="7e370915" sha1="bf8795c013c170c38439ebdf6aa99a96df97fe01"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 11).bin" size="36338400" crc="467afaa9" sha1="92dc0fad6abd5f96f8f140d6e18b4c4aa1c120ed"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 12).bin" size="35103600" crc="403e89ae" sha1="984441b0dca2bf82cb26ced130403b0be44aeb14"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 13).bin" size="38102400" crc="d328b087" sha1="302ef11c3a573abe7074ad8037fa5aef19cd6979"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 14).bin" size="36514800" crc="88a78af9" sha1="1fdf76aaf88357e0abd39931ecff4e60b5636ea3"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 15).bin" size="36162000" crc="0b6aefcc" sha1="d03e2ab593f0a3f4947141092d28d19b99e0473b"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 16).bin" size="37220400" crc="80292d1e" sha1="fb913d4512db6e1b54eb4b9f1dae3736f74f8f31"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 17).bin" size="7761600" crc="dd48a75c" sha1="c19375235bd173043baefa837f5c542eaf41d7d2"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 18).bin" size="9878400" crc="11683d0d" sha1="abd580333025a8abbb65a108d57f2bf71196153b"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 19).bin" size="9349200" crc="e419c606" sha1="fd3d6047d07cd4d0fddd22ec468068f4cc145944"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 20).bin" size="8996400" crc="3bc95efd" sha1="cbe9f1be6fd040c05b8837af4beaf2f201a34ba5"/>
+		<rom name="Pro Student G (Japan) (Rerelease) (Track 21).bin" size="9878400" crc="cbd9495f" sha1="916d94dfe84edc954d6a1a6b40051ba534bef120"/>
+		<rom name="Pro Student G (Japan) (Rerelease).cue" size="2670" crc="b270fa34" sha1="87898b38c2fe1ed83a633444408d4b1a69b4bb05"/>
+		-->
+		<description>Pro Student G (ALS-0010)</description>
+		<year>1994</year>
+		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="ALS-0010"/>
+		<info name="alt_title" value="ぷろすちゅーでんとG" />
+		<info name="release" value="199407xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="pro student g (japan) (rerelease)" sha1="11bc5195ccaf557fe17a349eb8284c78e08e29ac" />
 			</diskarea>
 		</part>
 	</software>
@@ -3720,11 +4119,9 @@ license:CC0
 
 	<software name="saintdia">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="844" crc="51d2e30a" sha1="e080d6fbd0d2c181fd303e2a89d997d65158809f"/>
-		<rom name="Image.cue" size="71" crc="b496048a" sha1="8590392ca153b7559d50bef2f83defc45e315624"/>
-		<rom name="Image.img" size="17835216" crc="7942b16b" sha1="607c6633b8c4b62e9e34fc3a5b7a9456dc08c466"/>
-		<rom name="Image.sub" size="727968" crc="3ee737d5" sha1="93f010ad0dd73881df678910b46af696fd906005"/>
+		Origin: redump.org
+		<rom name="Saint Diary - Kiyoka-chan no Nikki (Japan).bin" size="17835216" crc="7942b16b" sha1="607c6633b8c4b62e9e34fc3a5b7a9456dc08c466"/>
+		<rom name="Saint Diary - Kiyoka-chan no Nikki (Japan).cue" size="108" crc="effe090b" sha1="91224feb75754c839b40fa2d7fbb8de5f70440a7"/>
 		-->
 		<description>Saint Diary - Kiyoka-chan no Nikki</description>
 		<year>1996</year>
@@ -3733,7 +4130,7 @@ license:CC0
 		<info name="release" value="19951129" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="saintdia" sha1="6739b5d1454abfbf0bda6a6cc82f2b7e5b19af66" />
+				<disk name="saint diary - kiyoka-chan no nikki (japan)" sha1="832e546c489a29c3986c8a7022a3de43b229ea1f" />
 			</diskarea>
 		</part>
 	</software>
@@ -4135,19 +4532,34 @@ license:CC0
 	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="takamiza">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu.ccd" size="3627" crc="523d5414" sha1="38a3d547c0c351e201fb2faa2f4fe05080d81b01"/>
-		<rom name="Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu.cue" size="703" crc="81f0c8ab" sha1="f0bc997d4643da5ebb15341f67981507587eac16"/>
-		<rom name="Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu.img" size="445943904" crc="0f83a769" sha1="b417cc433d6946ea6939e4f80b722bccb038318f"/>
-		<rom name="Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu.sub" size="18201792" crc="1412cb19" sha1="28071814e73145f6e9ca4eb16a1704fb00ab6109"/>
+		Origin: redump.org
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 01).bin" size="20102544" crc="832bed19" sha1="9c4cbe6becd6fea4132272fa248f5d56e89e81b4"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 02).bin" size="28823760" crc="ce63facb" sha1="0b1149d646b2ba1e3ddd964e4bfd9e12afc12760"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 03).bin" size="20156640" crc="59930c20" sha1="57021c3c3a78563781ecf821c934370266b9713d"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 04).bin" size="20749344" crc="f9a3b0a8" sha1="05aa07e7975d94f2f0ad0f6a7f3df9d33626aafe"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 05).bin" size="46541376" crc="9f8329c1" sha1="00ba11f3a71eb06685f9fbe413dd77505cf8b711"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 06).bin" size="40588464" crc="6ddef2fc" sha1="24c461e4e7c7dded805b9780ab5eb8b6acd5adcd"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 07).bin" size="21494928" crc="2fc2ce13" sha1="f3bcc2e4b334789d1c8f5ace580115053fc0ca32"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 08).bin" size="31192224" crc="02f0f767" sha1="e6ce9baeed1c64af659f9052c69884e2fb86c1bf"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 09).bin" size="33306672" crc="ffe687f0" sha1="43e3a8b72bac68047d102001744556d0becd67cf"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 10).bin" size="22635648" crc="0e457432" sha1="89b6dc8e48f1b3fe92e78bd62a8a9999d7a4363a"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 11).bin" size="29409408" crc="47470780" sha1="347b4990229d0ff3488f2cc983d3131670abc982"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 12).bin" size="13041840" crc="b48c1cfb" sha1="10b08a89fd05f3259f1cc943c0ba9fbfc0a280d8"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 13).bin" size="24639552" crc="ed3cf802" sha1="6273117073394d97c89951f78ee870136083e5f1"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 14).bin" size="26561136" crc="d54c846a" sha1="a98602c43700d3760a449ab7b86acb72043acd07"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 15).bin" size="41479872" crc="2bb60608" sha1="0bcc4687750a3c97c3dec466d7f1969ed54dae40"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan) (Track 16).bin" size="25220496" crc="d33f8f34" sha1="4b689062806241de217dab4f2894847c28d9db26"/>
+		<rom name="Takamizawa Kyousuke Nekketsu!! Kyouiku Kenshuu (Japan).cue" size="2044" crc="6d9055b2" sha1="9e9161f54a5f3fdc832a1ef17d12fae82740c3a7"/>
 		-->
-		<description>Takamizawa Kyosuke - Nekketsu!! Kyouiku Kenshuu</description>
+		<description>Takamizawa Kyousuke - Nekketsu!! Kyouiku Kenshuu</description>
 		<year>1995</year>
 		<publisher>ジックス (ZyX)</publisher>
+		<info name="serial" value="ZYX-0002"/>
+		<info name="alt_title" value="高見沢恭介 熱血！！教育研修" />
 		<info name="release" value="199501xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="takamizawa kyosuke - nekketsu kyouiku kenshuu" sha1="ce13831f3094f9ab53c392480ece497c9b3c7997" />
+				<disk name="takamizawa kyousuke nekketsu kyouiku kenshuu (japan)" sha1="c221b1b63f145650bff7f050cc7040d5cb794887" />
 			</diskarea>
 		</part>
 	</software>
@@ -4336,12 +4748,9 @@ license:CC0
 
 	<software name="tunedhrt">
 		<!--
-		Origin: Neo Kobe Collection
-		CCD converted to CUE with GNU ccd2cue
-		<rom name="Tuned Heart.ccd" size="769" crc="dbe8ffa6" sha1="cee4b22d9ee44f5a6991066a7b2029e60e2b119d"/>
-		<rom name="Tuned Heart.cue" size="73" crc="b24bd492" sha1="e80940cadc9e028df3a76dc1113404cf644dc3e3"/>
-		<rom name="Tuned Heart.img" size="99155616" crc="99bd1f7a" sha1="751a1d740446cf2d591acca5888eb1ea4b0fb186"/>
-		<rom name="Tuned Heart.sub" size="4047168" crc="51cb456d" sha1="da7807fe854d60225e06d01ae9abe548c4499a77"/>
+		Origin: redump.org
+		<rom name="Tuned Heart (Japan).bin" size="99155616" crc="99bd1f7a" sha1="751a1d740446cf2d591acca5888eb1ea4b0fb186"/>
+		<rom name="Tuned Heart (Japan).cue" size="85" crc="c701d867" sha1="a6f8f522d934240520f0b57865af7328688e1708"/>
 		-->
 		<description>Tuned Heart</description>
 		<year>1996</year>
@@ -4351,7 +4760,7 @@ license:CC0
 		<info name="usage" value="Requires serial number printed on registration card"/>
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="tuned heart" sha1="8022484f60e7afe9c348b7f1a979766968c9400f" />
+				<disk name="tuned heart (japan)" sha1="8022484f60e7afe9c348b7f1a979766968c9400f" />
 			</diskarea>
 		</part>
 	</software>
@@ -4378,19 +4787,23 @@ license:CC0
 	<!-- Hangs at the text / voice selection screen -->
 	<software name="vastness" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Vastness.ccd" size="1525" crc="41bb06da" sha1="764c09836fc45e09f6efe47ed2b9da4c49a97e7f"/>
-		<rom name="Vastness.cue" size="228" crc="e8656a96" sha1="193c31c0fa10f79dd7c2601bf42bb764edb2d353"/>
-		<rom name="Vastness.img" size="463666224" crc="ff249f28" sha1="21c024c9f4bc2fcfaadf84072e094998facad4a7"/>
-		<rom name="Vastness.sub" size="18925152" crc="1f3a4a5d" sha1="7d26e94d29997ae4c1f204a143194c9a08c74860"/>
+		Origin: redump.org
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 1).bin" size="10231200" crc="ca6a503d" sha1="688f246987699717d7a3caa49914c34e5c2637ec"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 2).bin" size="5731824" crc="65e978bf" sha1="3bbb11f1180f0985225e774a6664badeb11fbd51"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 3).bin" size="232466976" crc="befe530a" sha1="99717ae81e6b5dc9b7f09bfdd7ed14f541f90428"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 4).bin" size="123978624" crc="dbd4fc08" sha1="af28b6e43f566c5d07d9af67826cbec7a379c4c7"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan) (Track 5).bin" size="91257600" crc="2ce807e4" sha1="8a25b2ddd808f4403a854e3d9db0f92464ca3052"/>
+		<rom name="Vastness - Kuukyo no Ikenie-tachi (Japan).cue" size="657" crc="aad2990f" sha1="4e750c468bccb248fab521e20a4d55a422b5490d"/>
 		-->
 		<description>Vastness - Kuukyo no Ikenie-tachi</description>
-		<year>1994</year>
+		<year>1995</year>
 		<publisher>CD Bros.</publisher>
-		<info name="release" value="19940422" />
+		<info name="serial" value="HMF-132 / CB-001"/>
+		<info name="alt_title" value="ヴアーストニス 空虚の生贄達" />
+		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="vastness" sha1="12d1fbe66e92cd580616814077eebb402d4e0332" />
+				<disk name="vastness - kuukyo no ikenie-tachi (japan)" sha1="bd8b85316d31bbe6efc543ef9c5fbf2e3a7b02d7" />
 			</diskarea>
 		</part>
 	</software>
@@ -4537,22 +4950,61 @@ license:CC0
 	</software>
 
 	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
+	<software name="yeshg">
+		<!--
+		Origin: redump.org
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 01).bin" size="265220928" crc="cc93d1fe" sha1="a8225d3549ba99aeb0696503ad8ba382c744e8a7"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 02).bin" size="31681440" crc="f1895c66" sha1="fa365fdf0aab278c77c5a1ad7d01ed73588e37e5"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 03).bin" size="29153040" crc="66458fe7" sha1="9ea60b9228171cdfe8b3d43927274e53fc0998fa"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 04).bin" size="24108000" crc="a7c1d463" sha1="3f41bc0e27ba089c0d58af4acd3f0b8e5fb1b404"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 05).bin" size="24681888" crc="ee1b1cc0" sha1="becd261a5ccf758371850832f0535b33ac3c3d8b"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 06).bin" size="32022480" crc="41224dae" sha1="5d183e42b301f3090e1ebc3a6ef099b5df68c1e6"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 07).bin" size="32676336" crc="9a87018a" sha1="240ab5985db6a447767e9dddee40e9653dc7aa5c"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 08).bin" size="35028336" crc="6316956e" sha1="f06cdd56c093157afff51d782c0a4b83ccefae5c"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 09).bin" size="43956528" crc="9b5a41eb" sha1="f8c83a2f3af2630c7d75ace7ff82f4296a1c9ca7"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 10).bin" size="28515648" crc="21095ba9" sha1="04cc52a6102666dd991c6affa4df84a40a572fb1"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan) (Track 11).bin" size="24919440" crc="8b9f2552" sha1="6872b88379d3688ad68fad2e3e7cfde836df70e9"/>
+		<rom name="YES! HG - Erotic Voice Version (Japan).cue" size="1238" crc="1f9dbaf4" sha1="f75cf01ff1292bbd61d71ac749e896cce1283b99"/>
+		-->
+		<description>YES! HG - Erotic Voice Version</description>
+		<year>1995</year>
+		<publisher>姫屋ソフト (Himeya Soft)</publisher>
+		<info name="release" value="199512xx" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="yes hg - erotic voice version (japan)" sha1="1973d5e32f50ada90f093203de09c87b51af489d" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="yojusen2">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="3205" crc="ca4446d3" sha1="8028e2647ef572de3dcf27ce5332f7ca00530a42"/>
-		<rom name="Image.cue" size="586" crc="b6b20ac9" sha1="b8bc72b8d909546d1078b1921ec04f526e746e3a"/>
-		<rom name="Image.img" size="649808208" crc="16f70c96" sha1="29b587dbcdaae2d471b7c13c1ce5c5825bc86eaf"/>
-		<rom name="Image.sub" size="26522784" crc="af8cb6ad" sha1="f77df38b35d73e8bc3e20033a8878af0e9c03ea8"/>
+		Origin: redump.org
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 01).bin" size="245104272" crc="eaf647b7" sha1="cd8ad09cfbd77af4bdc14c87cf3a40f95d5693e0"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 02).bin" size="27421968" crc="01ffa5b8" sha1="fb6f409029df70a25b91cf63fddd15f22f57618f"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 03).bin" size="21304416" crc="a8a49409" sha1="6a4fa97b448e00e7a0f3aca1c8b1b8fbf8fb3d70"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 04).bin" size="29240064" crc="8e56a2d5" sha1="00eca09b1c442e4ca6047511650974b5b22e3aa8"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 05).bin" size="31634400" crc="547bec0d" sha1="5167d5ee996ed8db4094c73e8b240ff38a978e7f"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 06).bin" size="41877360" crc="1b56f87a" sha1="00343ee6bb85f4af0f55cfc554324383d14647bc"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 07).bin" size="37817808" crc="e0009c74" sha1="1f49b162cf913429530d007483246f7ff27b3e05"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 08).bin" size="30418416" crc="d2031484" sha1="83190a6ec4773b857ec8f8c45eb32e24906f5821"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 09).bin" size="29000160" crc="77290d48" sha1="11587e4fef756f033a9507c9a89fee8d4336e137"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 10).bin" size="41778576" crc="b1ed8767" sha1="53f36fe9ca460f980a66502856b46eaab48d612a"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 11).bin" size="40562592" crc="6090e013" sha1="021fd651bb35cb76b71e5ca90dfa8df3ea2a8b27"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 12).bin" size="43001616" crc="5d47a747" sha1="55a4b0925d0a52c24248fe864c0892dcf8df2d6a"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan) (Track 13).bin" size="30646560" crc="1241e2db" sha1="c189de3cb6bf93d1b90159499cd35611faeb9f0e"/>
+		<rom name="Youjuu Senki 2 - Reimei no Senshi-tachi (Japan).cue" size="1575" crc="ebb77713" sha1="881d04c4e6938dd301f3acfdf9139f2a56a9e000"/>
 		-->
-		<description>Youjuu Senki 2 - Reimei no Senshi</description>
+		<description>Youjuu Senki 2 - Reimei no Senshi-tachi</description>
 		<year>1993</year>
 		<publisher>ディー・オー (D.O.)</publisher>
-		<info name="alt_title" value="妖獣戦記2 黎明の戦士" />
+		<info name="serial" value="DCD-0011"/>
+		<info name="alt_title" value="妖獣戦記2 黎明の戦士たち" />
 		<info name="release" value="199402xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="yojusen2" sha1="219f6731e9960291832df99d43ee52ab5d62bc52" />
+				<disk name="youjuu senki 2 - reimei no senshi-tachi (japan)" sha1="365c5e7983cc3aa59a97992035c6ddf76a86ab6e" />
 			</diskarea>
 		</part>
 	</software>
@@ -4633,6 +5085,35 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="yuurou">
+		<!--
+		Origin: redump.org
+		<rom name="Yuurou - Transient Sands (Japan) (Track 01).bin" size="9692592" crc="d9ba2d44" sha1="5bd16e87e901cd6465bea1147f994385e781a220"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 02).bin" size="24646608" crc="6ed9d4a8" sha1="b81ed5b12134e6dca61fb1ae504fa162c5bb1e00"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 03).bin" size="27748896" crc="9d201cd9" sha1="0d84ec092a04d2606ccb050cf752bd9fad0771f9"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 04).bin" size="30778272" crc="2eff4221" sha1="33c58519ff49462640a5cc1550741ebdd23f5216"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 05).bin" size="34186320" crc="3ff623d6" sha1="e03f0cd19c42854db1b5bef4d5bbb6ff0655ca47"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 06).bin" size="29402352" crc="c602ab34" sha1="4b88fd808d4374566a52f5600596d50838d56a71"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 07).bin" size="25307520" crc="754ccd21" sha1="a74ff68fa263a864224faab3f2b479d7bffdf287"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 08).bin" size="37594368" crc="914c956e" sha1="381c612b6e6ed93f5ceed0e8e862268ef9a73bdb"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 09).bin" size="22473360" crc="cce1174e" sha1="a3db27b848d7f28878b54f9e749ab2d7d527a6da"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 10).bin" size="40101600" crc="81be03c8" sha1="0c298381596f3db6d29cf85dcfa086417190a441"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 11).bin" size="60286464" crc="973707d0" sha1="b5759889837273dd41c986da8abbcc10305ecf7c"/>
+		<rom name="Yuurou - Transient Sands (Japan) (Track 12).bin" size="31728480" crc="aff2af6a" sha1="d0fc0074588d5b8d3b33d70c107abf0df0efc2de"/>
+		<rom name="Yuurou - Transient Sands (Japan).cue" size="1506" crc="58b35d82" sha1="4fcc41af9c7c63a9383c167af03e8bd90a2eaae9"/>
+		-->
+		<description>Yuurou - Transient Sands</description>
+		<year>1996</year>
+		<publisher>ハーベスト (Hervest)</publisher>
+		<info name="alt_title" value="憂楼 　－Ｔｒａｎｓｉｅｎｔ　Ｓａｎｄｓ－" />
+		<info name="release" value="19960802" />
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="yuurou - transient sands (japan)" sha1="07d11d70d7f06321a3695a75edf3d9b617e980b2" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="zaimeta">
 		<!--
 		Origin: Unknown
@@ -4671,19 +5152,32 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- PC-98x1 / FM Towns hybrid, also included in fmtowns_cd.xml -->
 	<software name="zenith">
 		<!--
-		 Origin: peter_j (Super Lonely Terminal)
-		 <rom name="zenith_cd.bin" size="634910640" crc="5810c93d" sha1="79c092a48ae49ae81414631eee6678fef1603931"/>
-		 <rom name="zenith_cd.cue" size="547" crc="4f1d0d78" sha1="7e5f0ad7f3e3b43ad52a628de191cc789e6ff51f"/>
-		 -->
+		Origin: redump.org
+		<rom name="Animation Zenith (Japan) (Track 01).bin" size="42253680" crc="57313645" sha1="db347eeb7b89001e4c4823b9e9ab99183a042558"/>
+		<rom name="Animation Zenith (Japan) (Track 02).bin" size="71893584" crc="0c118374" sha1="6dea000ab14066e3eecef5a37f96af19e53c6e19"/>
+		<rom name="Animation Zenith (Japan) (Track 03).bin" size="67761120" crc="e26102e4" sha1="373fc9d93256b126c88f72816626c9a63fbc7db7"/>
+		<rom name="Animation Zenith (Japan) (Track 04).bin" size="66528672" crc="8d800702" sha1="9c133dc99ec8ed72c2a5194a1665385a33915b53"/>
+		<rom name="Animation Zenith (Japan) (Track 05).bin" size="69177024" crc="08b90269" sha1="2d0150bb0b3f124e67ff77159535bcc706cd5f00"/>
+		<rom name="Animation Zenith (Japan) (Track 06).bin" size="78493296" crc="f835785a" sha1="28be5e63f35aa9037c1e5aaabaa67d62a04abb97"/>
+		<rom name="Animation Zenith (Japan) (Track 07).bin" size="77653632" crc="dffc1548" sha1="b43d67a4dbbfcb295ab66b0f8c7efbdd0edb328a"/>
+		<rom name="Animation Zenith (Japan) (Track 08).bin" size="39610032" crc="1b36ee9f" sha1="642cf720f6c302e443f13b6416b84b4cdf5e0bf3"/>
+		<rom name="Animation Zenith (Japan) (Track 09).bin" size="27981744" crc="e81f8d36" sha1="1f15ba82a16fc749fea01fce95613e50d5f115b6"/>
+		<rom name="Animation Zenith (Japan) (Track 10).bin" size="26140128" crc="61430506" sha1="8f7c96d14614904f4060b4d63d6167270010a468"/>
+		<rom name="Animation Zenith (Japan) (Track 11).bin" size="23870448" crc="86a01836" sha1="c56edc34a923f3d22d16df8ca555f86dedc35d1d"/>
+		<rom name="Animation Zenith (Japan) (Track 12).bin" size="43900080" crc="0e891e7d" sha1="aef3c7caa61e937c05253e3873c5da2af2c9d848"/>
+		<rom name="Animation Zenith (Japan).cue" size="1180" crc="00ecc2e4" sha1="a7398fd40a67d4c494b3030992241852c92183b9"/>
+		-->
 		<description>Zenith - Full Animation Adventure Series #1</description>
-		<year>1994</year>
+		<year>1995</year>
 		<publisher>姫屋ソフト (Himeya Soft)</publisher>
 		<info name="alt_title" value="ゼニス" />
+		<info name="release" value="199502xx" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
-				<disk name="zenith_cd" sha1="3288b12f463e0df371804ff0db38546a452217f0"/>
+				<disk name="animation zenith (japan)" sha1="c99f1b2db763f5e0eaf48cb5726351a81d2fd916" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
- New dumps from redump.org (working):

Chiemi & Naomi
F15 Strike Eagle III
if 2 - Invitations from Fantastic Stories
Manami no Doko made Iku no? 2 - Return of the Kuro Pack
Phobos
Pro Student G (ALS-0010)
YES! HG - Erotic Voice Version
Yuurou - Transient Sands

- New dumps from redump.org (not working):

DOR Special Edition '93
DOR Special Edition '93 (alt)
Kanji Land 3-nen
Kyrandia II - The Hand of Fate
Lemon Cocktail Collection
Lip 3 - Lipstick Adventure 3
Mirage 2 - Torry, Neat & Roan Fairladies in MagicLand

- Replaced entries with dumps from redump.org:

Branmarker 2
Eimmy to Yobanaide
Lesser Mern - Special Director's Edition
Mahjong de Pon!
Saint Diary - Kiyoka-chan no Nikki
Takamizawa Kyousuke - Nekketsu!! Kyouiku Kenshuu
The Legend of Kyrandia
Tuned Heart
Vastness - Kuukyo no Ikenie-tachi
Youjuu Senki 2 - Reimei no Senshi-tachi
Zenith - Full Animation Adventure Series #1

Most of these discs are hybrid (they work on both PC-98x1 and FM Towns), so their CHDs are exactly the same as in fmtowns_cd.xml.