### PR TITLE
ibm5150: add XENIX Development System

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -6857,6 +6857,79 @@ has been replaced with an all-zero block. -->
 		</part>
 	</software>
 
+	<software name="xenixdev213">
+		<description>SCO XENIX System V Development System version 2.1.3</description>
+		<year>1986</year>
+		<publisher>SCO</publisher>
+		<!-- Origin: archive.org -->
+		<part name="flop1" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D1"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D1.img" size="368640" crc="aebb993e" sha1="a82b134e6a16c824dc203ddc63b3093070778aeb"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D2"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D2.img" size="368640" crc="1b27d622" sha1="fe29ce2833d7e7731c166ce58edb4bb965a1db10"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D3"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D3.img" size="368640" crc="7e2bac6c" sha1="7c8c09a2accd866c4bbe2b1f0b900d1d8d5e1beb"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D4"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D4.img" size="368640" crc="6a20dc53" sha1="1b29be4c8be12f330b758ce288381bb7311dcb09"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D5"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D5.img" size="368640" crc="e4766e89" sha1="f7dbd8b572b20451ca1d9607711d6f8cca2394e9"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D6"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D6.img" size="368640" crc="e8962a7e" sha1="8dbcf2b2d3c849de88a9db5d817bffbcb3d074e0"/>
+			</dataarea>
+		</part>
+			<part name="flop7" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D7"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D7.img" size="368640" crc="5e734955" sha1="e925c894c0674a83185d1d2f4dcfa3834fc8aa2d"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D8"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D8.img" size="368640" crc="6601c6a5" sha1="dde9189542007afca40cc752bfe0f500362e2594"/>
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D9"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D9.img" size="368640" crc="d07dbd2c" sha1="1941e45a0a3d861222a0ada0e945a8ac69f18074"/>
+			</dataarea>
+		</part>
+			<part name="flop10" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D10"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D10.img" size="368640" crc="25d07207" sha1="ef25823026141ccf3d5c12a0f64e5bca7703e65a"/>
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_5_25">
+			<feature name="part_id" value="Development System volume D11"/>
+			<dataarea name="flop" size="368640">
+				<rom name="D11.img" size="368640" crc="84d74eb0" sha1="bd17a850b990e846b35bd38671cd9a6f76e33106"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Driver disks -->
 
 	<software name="amouse7">


### PR DESCRIPTION
Source: https://archive.org/download/msxenix/apps/sco-xenixdev-2.1.3.zip

The manual is also available at https://archive.org/details/xenix-release-notes-2