### PR TITLE
exorterm: more realistic layout screen aspect ratio.

### DIFF
--- a/src/emu/layout/exorterm155.lay
+++ b/src/emu/layout/exorterm155.lay
@@ -42,38 +42,38 @@ LEDs for the Motorola EXORterm 155
 
 	<view name="Keyboard LEDs">
 		<bezel name="auto_lf_txt" element="AUTO_LF">
-			<bounds left="0" right="70" top="296" bottom="304" />
+			<bounds left="0" right="70" top="520" bottom="528" />
 		</bezel>
 		<bezel name="auto_lf_led" element="red_led">
-			<bounds left="31" right="39" top="308" bottom="316" />
+			<bounds left="31" right="39" top="532" bottom="540" />
 		</bezel>
 
 		<bezel name="online_txt" element="ON_LINE">
-			<bounds left="70" right="140" top="296" bottom="304" />
+			<bounds left="70" right="140" top="520" bottom="528" />
 		</bezel>
 		<bezel name="online_led" element="red_led">
-			<bounds left="101" right="109" top="308" bottom="316" />
+			<bounds left="101" right="109" top="532" bottom="540" />
 		</bezel>
 
 		<bezel name="page_mode_txt" element="PAGE_MODE">
-			<bounds left="140" right="210" top="296" bottom="304" />
+			<bounds left="140" right="210" top="520" bottom="528" />
 		</bezel>
 		<bezel name="page_mode_led" element="red_led">
-			<bounds left="171" right="179" top="308" bottom="316" />
+			<bounds left="171" right="179" top="532" bottom="540" />
 		</bezel>
 
 		<bezel name="insert_char_txt" element="INS_CHAR">
-			<bounds left="281" right="351" top="296" bottom="304" />
+			<bounds left="281" right="351" top="520" bottom="528" />
 		</bezel>
 		<bezel name="insert_char_led" element="red_led">
-			<bounds left="312" right="320" top="308" bottom="316" />
+			<bounds left="312" right="320" top="532" bottom="540" />
 		</bezel>
 
 		<bezel element="background">
-			<bounds left="0" top="316" right="720" bottom="320" />
+			<bounds left="0" top="540" right="720" bottom="544" />
 		</bezel>
 		<screen index="0">
-			<bounds x="0" y="0" width="720" height="288" />
+			<bounds x="0" y="0" width="720" height="512" />
 		</screen>
 	</view>
 


### PR DESCRIPTION
This change adjusts the aspect ratio to bring it close to that in the
photo of the screen in the manual. The monitor has a 4:3 aspect
ratio. The character area resolution is 720x288 pixels and the prior
1:1 dot ratio was far from realistic.