### PR TITLE
plugins/autofire: don't save 2bytes cfg file (nw)

### DIFF
--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -74,16 +74,15 @@ function lib:save_settings(buttons)
 	elseif attr.mode ~= 'directory' then
 		return
 	end
-	local json = require('json')
-	local settings = serialize_settings(buttons)
-	local data = json.stringify(settings, {indent = true})
-	if string.len(data) <= 2 then
+	if #buttons == 0 then
 		os.remove(path .. get_settings_filename())
 		return
 	end
+	local json = require('json')
+	local settings = serialize_settings(buttons)
 	local file = io.open(path .. get_settings_filename(), 'w')
 	if file then
-		file:write(data)
+		file:write(json.stringify(settings, {indent = true}))
 		file:close()
 	end
 end

--- a/plugins/autofire/autofire_save.lua
+++ b/plugins/autofire/autofire_save.lua
@@ -76,9 +76,14 @@ function lib:save_settings(buttons)
 	end
 	local json = require('json')
 	local settings = serialize_settings(buttons)
+	local data = json.stringify(settings, {indent = true})
+	if string.len(data) <= 2 then
+		os.remove(path .. get_settings_filename())
+		return
+	end
 	local file = io.open(path .. get_settings_filename(), 'w')
 	if file then
-		file:write(json.stringify(settings, {indent = true}))
+		file:write(data)
 		file:close()
 	end
 end


### PR DESCRIPTION
Changed to determine if dictionary is empty