### PR TITLE
imagetek_i4100.cpp: Partially fix flip screen

### DIFF
--- a/src/devices/video/imagetek_i4100.h
+++ b/src/devices/video/imagetek_i4100.h
@@ -32,8 +32,24 @@ public:
 
 	void map(address_map &map);
 
-	void set_tmap_xoffsets(int x1, int x2, int x3) { m_tilemap_scrolldx[0] = x1; m_tilemap_scrolldx[1] = x2; m_tilemap_scrolldx[2] = x3; }
-	void set_tmap_yoffsets(int y1, int y2, int y3) { m_tilemap_scrolldy[0] = y1; m_tilemap_scrolldy[1] = y2; m_tilemap_scrolldy[2] = y3; }
+	void set_tmap_flip_xoffsets(int x1, int x2, int x3) { m_tilemap_flip_scrolldx[0] = x1; m_tilemap_flip_scrolldx[1] = x2; m_tilemap_flip_scrolldx[2] = x3; }
+	void set_tmap_flip_yoffsets(int y1, int y2, int y3) { m_tilemap_flip_scrolldy[0] = y1; m_tilemap_flip_scrolldy[1] = y2; m_tilemap_flip_scrolldy[2] = y3; }
+	void set_tmap_xoffsets(int x1, int x2, int x3)
+	{
+		m_tilemap_scrolldx[0] = x1;
+		m_tilemap_scrolldx[1] = x2;
+		m_tilemap_scrolldx[2] = x3;
+		// default flip xoffset
+		set_tmap_flip_xoffsets(-x1, -x2, -x3);
+	}
+	void set_tmap_yoffsets(int y1, int y2, int y3)
+	{
+		m_tilemap_scrolldy[0] = y1;
+		m_tilemap_scrolldy[1] = y2;
+		m_tilemap_scrolldy[2] = y3;
+		// default flip yoffset
+		set_tmap_flip_yoffsets(-y1, -y2, -y3);
+	}
 
 	auto blit_irq_cb() { return m_blit_irq_cb.bind(); }
 	void set_spriteram_buffered(bool buffer) { m_spriteram_buffered = buffer; }
@@ -97,6 +113,8 @@ protected:
 	const bool m_support_8bpp, m_support_16x16;
 	int  m_tilemap_scrolldx[3];
 	int  m_tilemap_scrolldy[3];
+	int  m_tilemap_flip_scrolldx[3];
+	int  m_tilemap_flip_scrolldy[3];
 	bool m_spriteram_buffered;
 
 	void blt_write(const int tmap, const offs_t offs, const u16 data, const u16 mask);

--- a/src/mame/drivers/hyprduel.cpp
+++ b/src/mame/drivers/hyprduel.cpp
@@ -436,6 +436,7 @@ void hyprduel_state::i4220_config(machine_config &config)
 {
 	I4220(config, m_vdp, XTAL(26'666'000));
 	m_vdp->blit_irq_cb().set(FUNC(hyprduel_state::vdp_blit_end_w));
+	m_vdp->set_spriteram_buffered(true); // sprites are 1 frame delayed
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_video_attributes(VIDEO_UPDATE_SCANLINE);

--- a/src/mame/drivers/metro.cpp
+++ b/src/mame/drivers/metro.cpp
@@ -3606,8 +3606,10 @@ void metro_state::vmetal(machine_config &config)
 
 	m_screen->screen_vblank().set(FUNC(metro_state::vblank_irq));
 
-	m_vdp2->set_tmap_xoffsets(-16,-16,-16);
-	m_vdp2->set_tmap_yoffsets(-16,-16,-16);
+	m_vdp2->set_tmap_xoffsets(0,0,0);
+	m_vdp2->set_tmap_yoffsets(0,0,0);
+	m_vdp2->set_tmap_flip_xoffsets(16,16,16);
+	m_vdp2->set_tmap_flip_yoffsets(16,16,16);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
Sprite position when zoomed, Tilemap offsets, glitches in hyprduel
hyprduel.cpp: Fix sprite delay
metro.cpp: Fix flipped tilemap offset for vmetal