### PR TITLE
Switch appveyor GCC build to -O3 (issue #6804)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,7 @@ for:
       - bash -lc "pacman -Syu --noconfirm"
       - bash -lc "pacman -Syu --noconfirm"
     build_script:
-      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=1 IGNORE_GIT=1 -j3"
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=3 IGNORE_GIT=1 -j3"
     test_script:
       - \projects\mame\mametiny64.exe -validate
     after_test:


### PR DESCRIPTION
GCC build on windows appears to be broken on optimisation levels below -O3. O3 build has finished within approximately 50 minutes which means that it at least has a chance of succeeding. Once gcc or mame is fixed to build with -O1, this change can be reverted. While not ideal, it would unbreak the CI until a proper fix is in place.