### PR TITLE
audio input support

### DIFF
--- a/src/emu/audioin.cpp
+++ b/src/emu/audioin.cpp
@@ -1,0 +1,94 @@
+// ============================================================================
+// audioin.cpp
+// host os sound input device such as microphone, line in or virtual audio cable.
+//
+// BSD3, jariseon 2020
+// based on speaker and device_mixer_interface by Aaron Giles
+// ============================================================================
+
+#include "emu.h"
+#include "audioin.h"
+#include "osdepend.h"
+
+
+DEFINE_DEVICE_TYPE(AUDIOIN, audioin_device, "audioin", "AudioInput")
+#define MAX_NSAMPLES 48000  // todo: how to get max buffersize ?
+
+
+// ===-------------------------------------------------------------------------
+// constructor
+// ===-------------------------------------------------------------------------
+
+audioin_device::audioin_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, AUDIOIN, tag, owner, clock)
+	, device_sound_interface(mconfig, *this)
+	, m_input_stream(nullptr)
+{
+	m_audioin = new s16[MAX_NSAMPLES * 2]; // interleaved stereo
+}
+
+
+// ===-------------------------------------------------------------------------
+// destructor
+// ===-------------------------------------------------------------------------
+
+audioin_device::~audioin_device()
+{
+  delete [] m_audioin;
+}
+
+
+// ===-------------------------------------------------------------------------
+// perform startup prior to the device startup
+// ===-------------------------------------------------------------------------
+
+void audioin_device::interface_pre_start()
+{
+  device_sound_interface::interface_pre_start();
+  m_input_stream = stream_alloc(0, 2, device().machine().sample_rate());
+}
+
+// ===-------------------------------------------------------------------------
+// device startup
+// ===-------------------------------------------------------------------------
+
+void audioin_device::device_start()
+{
+}
+
+// ===-------------------------------------------------------------------------
+// update stream sample rate after loading a save state
+// ===-------------------------------------------------------------------------
+
+void audioin_device::interface_post_load()
+{
+  if (m_input_stream)
+    m_input_stream->set_sample_rate(device().machine().sample_rate());
+  device_sound_interface::interface_post_load();
+}
+
+
+// ===-------------------------------------------------------------------------
+// capture audio input from osd
+// ===-------------------------------------------------------------------------
+
+void audioin_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int nsamples)
+{
+  if (m_input_stream == nullptr || nsamples < 0)
+    return;
+  
+  memset(outputs[0], 0, nsamples * sizeof(s16));
+  memset(outputs[1], 0, nsamples * sizeof(s16));
+  
+  // unsure if it is cool to access the osd layer directly from device level
+  // seems a logical place for this though
+  int N = std::min(nsamples, MAX_NSAMPLES);
+  device().machine().osd().capture_audio_stream(m_audioin, nsamples);
+
+  // de-interleave
+  s16* p = m_audioin;
+  for (int n = 0; n < N; n++) {
+    outputs[0][n] = *p++;
+    outputs[1][n] = *p++;
+  }
+}

--- a/src/emu/audioin.h
+++ b/src/emu/audioin.h
@@ -1,0 +1,44 @@
+// ============================================================================
+// audioin.h
+// host os sound input device such as microphone, line in or virtual audio cable.
+//
+// BSD3, jariseon 2020
+// based on speaker and device_mixer_interface by Aaron Giles
+// ============================================================================
+
+#ifndef MAME_EMU_AUDIOIN_H
+#define MAME_EMU_AUDIOIN_H
+
+#pragma once
+
+DECLARE_DEVICE_TYPE(AUDIOIN, audioin_device)
+
+class audioin_device : public device_t, public device_sound_interface
+{
+public:
+	// construction/destruction
+	audioin_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
+	virtual ~audioin_device();
+
+protected:
+	// device-level overrides
+	virtual void device_start() override ATTR_COLD;
+  
+  // optional operation overrides
+  virtual void interface_pre_start() override;
+  virtual void interface_post_load() override;
+
+  // sound interface overrides
+  virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) override;
+
+  // internal state
+  sound_stream * m_input_stream;
+  s16* m_audioin;
+};
+
+
+// device iterator
+typedef device_type_iterator<audioin_device> audioin_device_iterator;
+
+
+#endif // MAME_EMU_AUDIOIN_H

--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -542,6 +542,23 @@ void osd_common_t::update_audio_stream(const int16_t *buffer, int samples_this_f
 
 
 //-------------------------------------------------
+//  capture_audio_stream - capture input stereo audio
+//  stream
+//-------------------------------------------------
+
+void osd_common_t::capture_audio_stream(const int16_t *buffer, int samples_this_frame)
+{
+  //
+  // This method is called for each audiograph render quantum when there's
+  // an AUDIOIN device attached to the graph. platform implementation fills
+  // 'buffer' with 'samples_this_frame' number of samples, interleaved in stereo
+  // L-R order.
+  //
+  m_sound->capture_audio_stream(m_machine->video().throttled(), buffer, samples_this_frame);
+}
+
+
+//-------------------------------------------------
 //  set_mastervolume - set the system volume
 //-------------------------------------------------
 

--- a/src/osd/modules/lib/osdobj_common.h
+++ b/src/osd/modules/lib/osdobj_common.h
@@ -200,6 +200,7 @@ public:
 
 	// audio overridables
 	virtual void update_audio_stream(const int16_t *buffer, int samples_this_frame) override;
+  virtual void capture_audio_stream(const int16_t *buffer, int samples_this_frame) override;
 	virtual void set_mastervolume(int attenuation) override;
 	virtual bool no_sound() override;
 

--- a/src/osd/modules/sound/TPCircularBuffer.c
+++ b/src/osd/modules/sound/TPCircularBuffer.c
@@ -1,0 +1,149 @@
+//
+//  TPCircularBuffer.c
+//  Circular/Ring buffer implementation
+//
+//  https://github.com/michaeltyson/TPCircularBuffer
+//
+//  Created by Michael Tyson on 10/12/2011.
+//
+//  Copyright (C) 2012-2013 A Tasty Pixel
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#include "TPCircularBuffer.h"
+#include <mach/mach.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define reportResult(result,operation) (_reportResult((result),(operation),strrchr(__FILE__, '/')+1,__LINE__))
+static inline bool _reportResult(kern_return_t result, const char *operation, const char* file, int line) {
+    if ( result != ERR_SUCCESS ) {
+        printf("%s:%d: %s: %s\n", file, line, operation, mach_error_string(result));
+        return false;
+    }
+    return true;
+}
+
+bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t structSize) {
+	
+    assert(length > 0);
+	
+    if ( structSize != sizeof(TPCircularBuffer) ) {
+        fprintf(stderr, "TPCircularBuffer: Header version mismatch. Check for old versions of TPCircularBuffer in your project\n");
+        abort();
+    }
+	
+    // Keep trying until we get our buffer, needed to handle race conditions
+    int retries = 3;
+    while ( true ) {
+
+        buffer->length = (uint32_t)round_page(length);    // We need whole page sizes
+
+        // Temporarily allocate twice the length, so we have the contiguous address space to
+        // support a second instance of the buffer directly after
+        vm_address_t bufferAddress;
+        kern_return_t result = vm_allocate(mach_task_self(),
+                                           &bufferAddress,
+                                           buffer->length * 2,
+                                           VM_FLAGS_ANYWHERE); // allocate anywhere it'll fit
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Buffer allocation");
+                return false;
+            }
+            // Try again if we fail
+            continue;
+        }
+			
+        // Now replace the second half of the allocation with a virtual copy of the first half. Deallocate the second half...
+        result = vm_deallocate(mach_task_self(),
+                               bufferAddress + buffer->length,
+                               buffer->length);
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Buffer deallocation");
+                return false;
+            }
+            // If this fails somehow, deallocate the whole region and try again
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+			
+        // Re-map the buffer to the address space immediately after the buffer
+        vm_address_t virtualAddress = bufferAddress + buffer->length;
+        vm_prot_t cur_prot, max_prot;
+        result = vm_remap(mach_task_self(),
+                          &virtualAddress,   // mirror target
+                          buffer->length,    // size of mirror
+                          0,                 // auto alignment
+                          0,                 // force remapping to virtualAddress
+                          mach_task_self(),  // same task
+                          bufferAddress,     // mirror source
+                          0,                 // MAP READ-WRITE, NOT COPY
+                          &cur_prot,         // unused protection struct
+                          &max_prot,         // unused protection struct
+                          VM_INHERIT_DEFAULT);
+        if ( result != ERR_SUCCESS ) {
+            if ( retries-- == 0 ) {
+                reportResult(result, "Remap buffer memory");
+                return false;
+            }
+            // If this remap failed, we hit a race condition, so deallocate and try again
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+			
+        if ( virtualAddress != bufferAddress+buffer->length ) {
+            // If the memory is not contiguous, clean up both allocated buffers and try again
+            if ( retries-- == 0 ) {
+                printf("Couldn't map buffer memory to end of buffer\n");
+                return false;
+            }
+
+            vm_deallocate(mach_task_self(), virtualAddress, buffer->length);
+            vm_deallocate(mach_task_self(), bufferAddress, buffer->length);
+            continue;
+        }
+			
+        buffer->buffer = (void*)bufferAddress;
+        buffer->fillCount = 0;
+        buffer->head = buffer->tail = 0;
+        buffer->atomic = true;
+			
+        return true;
+    }
+    return false;
+}
+
+void TPCircularBufferCleanup(TPCircularBuffer *buffer) {
+    vm_deallocate(mach_task_self(), (vm_address_t)buffer->buffer, buffer->length * 2);
+    memset(buffer, 0, sizeof(TPCircularBuffer));
+}
+
+void TPCircularBufferClear(TPCircularBuffer *buffer) {
+    uint32_t fillCount;
+    if ( TPCircularBufferTail(buffer, &fillCount) ) {
+        TPCircularBufferConsume(buffer, fillCount);
+    }
+}
+
+void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic) {
+    buffer->atomic = atomic;
+}

--- a/src/osd/modules/sound/TPCircularBuffer.h
+++ b/src/osd/modules/sound/TPCircularBuffer.h
@@ -1,0 +1,243 @@
+//
+//  TPCircularBuffer.h
+//  Circular/Ring buffer implementation
+//
+//  https://github.com/michaeltyson/TPCircularBuffer
+//
+//  Created by Michael Tyson on 10/12/2011.
+//
+//
+//  This implementation makes use of a virtual memory mapping technique that inserts a virtual copy
+//  of the buffer memory directly after the buffer's end, negating the need for any buffer wrap-around
+//  logic. Clients can simply use the returned memory address as if it were contiguous space.
+//
+//  The implementation is thread-safe in the case of a single producer and single consumer.
+//
+//  Virtual memory technique originally proposed by Philip Howard (http://vrb.slashusr.org/), and
+//  adapted to Darwin by Kurt Revis (http://www.snoize.com,
+//  http://www.snoize.com/Code/PlayBufferedSoundFile.tar.gz)
+//
+//
+//  Copyright (C) 2012-2013 A Tasty Pixel
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//
+
+#ifndef TPCircularBuffer_h
+#define TPCircularBuffer_h
+
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef __cplusplus
+    extern "C++" {
+        #include <atomic>
+        typedef std::atomic_int atomicInt;
+        #define atomicFetchAdd(a,b) std::atomic_fetch_add(a,b)
+    }
+#else
+    #include <stdatomic.h>
+    typedef atomic_int atomicInt;
+    #define atomicFetchAdd(a,b) atomic_fetch_add(a,b)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	
+typedef struct {
+    void             *buffer;
+    uint32_t           length;
+    uint32_t           tail;
+    uint32_t           head;
+    volatile atomicInt fillCount;
+    bool              atomic;
+} TPCircularBuffer;
+
+/*!
+ * Initialise buffer
+ *
+ *  Note that the length is advisory only: Because of the way the
+ *  memory mirroring technique works, the true buffer length will
+ *  be multiples of the device page size (e.g. 4096 bytes)
+ *
+ *  If you intend to use the AudioBufferList utilities, you should
+ *  always allocate a bit more space than you need for pure audio
+ *  data, so there's room for the metadata. How much extra is required
+ *  depends on how many AudioBufferList structures are used, which is
+ *  a function of how many audio frames each buffer holds. A good rule
+ *  of thumb is to add 15%, or at least another 2048 bytes or so.
+ *
+ * @param buffer Circular buffer
+ * @param length Length of buffer
+ */
+#define TPCircularBufferInit(buffer, length) \
+    _TPCircularBufferInit(buffer, length, sizeof(*buffer))
+bool _TPCircularBufferInit(TPCircularBuffer *buffer, uint32_t length, size_t structSize);
+
+/*!
+ * Cleanup buffer
+ *
+ *  Releases buffer resources.
+ */
+void  TPCircularBufferCleanup(TPCircularBuffer *buffer);
+
+/*!
+ * Clear buffer
+ *
+ *  Resets buffer to original, empty state.
+ *
+ *  This is safe for use by consumer while producer is accessing
+ *  buffer.
+ */
+void  TPCircularBufferClear(TPCircularBuffer *buffer);
+	
+/*!
+ * Set the atomicity
+ *
+ *  If you set the atomiticy to false using this method, the buffer will
+ *  not use atomic operations. This can be used to give the compiler a little
+ *  more optimisation opportunities when the buffer is only used on one thread.
+ *
+ *  Important note: Only set this to false if you know what you're doing!
+ *
+ *  The default value is true (the buffer will use atomic operations)
+ *
+ * @param buffer Circular buffer
+ * @param atomic Whether the buffer is atomic (default true)
+ */
+void  TPCircularBufferSetAtomic(TPCircularBuffer *buffer, bool atomic);
+
+// Reading (consuming)
+
+/*!
+ * Access end of buffer
+ *
+ *  This gives you a pointer to the end of the buffer, ready
+ *  for reading, and the number of available bytes to read.
+ *
+ * @param buffer Circular buffer
+ * @param availableBytes On output, the number of bytes ready for reading
+ * @return Pointer to the first bytes ready for reading, or NULL if buffer is empty
+ */
+static __inline__ __attribute__((always_inline)) void* TPCircularBufferTail(TPCircularBuffer *buffer, uint32_t* availableBytes) {
+    *availableBytes = buffer->fillCount;
+    if ( *availableBytes == 0 ) return NULL;
+    return (void*)((char*)buffer->buffer + buffer->tail);
+}
+
+/*!
+ * Consume bytes in buffer
+ *
+ *  This frees up the just-read bytes, ready for writing again.
+ *
+ * @param buffer Circular buffer
+ * @param amount Number of bytes to consume
+ */
+static __inline__ __attribute__((always_inline)) void TPCircularBufferConsume(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->tail = (buffer->tail + amount) % buffer->length;
+    if ( buffer->atomic ) {
+        atomicFetchAdd(&buffer->fillCount, -(int)amount);
+    } else {
+        buffer->fillCount -= amount;
+    }
+    assert(buffer->fillCount >= 0);
+}
+
+/*!
+ * Access front of buffer
+ *
+ *  This gives you a pointer to the front of the buffer, ready
+ *  for writing, and the number of available bytes to write.
+ *
+ * @param buffer Circular buffer
+ * @param availableBytes On output, the number of bytes ready for writing
+ * @return Pointer to the first bytes ready for writing, or NULL if buffer is full
+ */
+static __inline__ __attribute__((always_inline)) void* TPCircularBufferHead(TPCircularBuffer *buffer, uint32_t* availableBytes) {
+    *availableBytes = (buffer->length - buffer->fillCount);
+    if ( *availableBytes == 0 ) return NULL;
+    return (void*)((char*)buffer->buffer + buffer->head);
+}
+	
+// Writing (producing)
+
+/*!
+ * Produce bytes in buffer
+ *
+ *  This marks the given section of the buffer ready for reading.
+ *
+ * @param buffer Circular buffer
+ * @param amount Number of bytes to produce
+ */
+static __inline__ __attribute__((always_inline)) void TPCircularBufferProduce(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->head = (buffer->head + amount) % buffer->length;
+    if ( buffer->atomic ) {
+        atomicFetchAdd(&buffer->fillCount, (int)amount);
+    } else {
+        buffer->fillCount += amount;
+    }
+    assert(buffer->fillCount <= buffer->length);
+}
+
+/*!
+ * Helper routine to copy bytes to buffer
+ *
+ *  This copies the given bytes to the buffer, and marks them ready for reading.
+ *
+ * @param buffer Circular buffer
+ * @param src Source buffer
+ * @param len Number of bytes in source buffer
+ * @return true if bytes copied, false if there was insufficient space
+ */
+static __inline__ __attribute__((always_inline)) bool TPCircularBufferProduceBytes(TPCircularBuffer *buffer, const void* src, uint32_t len) {
+    uint32_t space;
+    void *ptr = TPCircularBufferHead(buffer, &space);
+    if ( space < len ) return false;
+    memcpy(ptr, src, len);
+    TPCircularBufferProduce(buffer, len);
+    return true;
+}
+
+/*!
+ * Deprecated method
+ */
+static __inline__ __attribute__((always_inline)) __deprecated_msg("use TPCircularBufferSetAtomic(false) and TPCircularBufferConsume instead")
+void TPCircularBufferConsumeNoBarrier(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->tail = (buffer->tail + amount) % buffer->length;
+    buffer->fillCount -= amount;
+    assert(buffer->fillCount >= 0);
+}
+
+/*!
+ * Deprecated method
+ */
+static __inline__ __attribute__((always_inline)) __deprecated_msg("use TPCircularBufferSetAtomic(false) and TPCircularBufferProduce instead")
+void TPCircularBufferProduceNoBarrier(TPCircularBuffer *buffer, uint32_t amount) {
+    buffer->head = (buffer->head + amount) % buffer->length;
+    buffer->fillCount += amount;
+    assert(buffer->fillCount <= buffer->length);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/osd/modules/sound/sound_module.h
+++ b/src/osd/modules/sound/sound_module.h
@@ -26,7 +26,14 @@ public:
 
 	virtual void update_audio_stream(bool is_throttled, const int16_t *buffer, int samples_this_frame) = 0;
 	virtual void set_mastervolume(int attenuation) = 0;
-
+	
+  // todo: should really be pure virtual and implemented for all platforms
+  virtual void capture_audio_stream(bool is_throttled, const int16_t *buffer, int samples_this_frame)
+  {
+    if (buffer)
+      memset((void*)buffer, 0, samples_this_frame * sizeof(int16_t));
+  }
+	
 	int sample_rate() const { return m_sample_rate; }
 
 	int m_sample_rate;

--- a/src/osd/osdepend.h
+++ b/src/osd/osdepend.h
@@ -73,6 +73,7 @@ public:
 
 	// audio overridables
 	virtual void update_audio_stream(const int16_t *buffer, int samples_this_frame) = 0;
+  virtual void capture_audio_stream(const int16_t *buffer, int samples_this_frame) = 0;
 	virtual void set_mastervolume(int attenuation) = 0;
 	virtual bool no_sound() = 0;
 


### PR DESCRIPTION
seems to work fine in Mojave, tested using microphone and virtual audio cables.

this PR is probably not ready for prime time yet, but as suggested in the forums, i submitted it here for feedback. i can either hand it over to more experienced mame devs, or try to work it further given some suggestions on best practices.

current limitations:
- platform implementation is for coreaudio only
- binds to default audio input device
- dependency to a 3rd party ring buffer (TPCircularBuffer.c, good one though)

usage in a driver:
```
#include "emu.h"
#include "audioin.h"
#include "speaker.h"

class x_state : public driver_device
{
public:
  x_state (...) : driver_device(...), m_audioIn(*this, "audioin") {}
  void x (machine_config &config)
  {
    AUDIOIN(config, m_audioIn); // stereo
    SPEAKER(config, "lspeaker").front_left();
    SPEAKER(config, "rspeaker").front_right();

    // beware of feedback if routing mic to the speakers !!!
    m_audioIn->add_route(0, "lspeaker", 1.0);
    m_audioIn->add_route(1, "rspeaker", 1.0);    
  }
private:
  required_device<audioin_device> m_audioIn;
}
```
