### PR TITLE
Add new option beam_dot_size

### DIFF
--- a/src/devices/video/vector.cpp
+++ b/src/devices/video/vector.cpp
@@ -54,12 +54,14 @@
 float vector_options::s_flicker = 0.0f;
 float vector_options::s_beam_width_min = 0.0f;
 float vector_options::s_beam_width_max = 0.0f;
+float vector_options::s_beam_dot_size = 0.0f;
 float vector_options::s_beam_intensity_weight = 0.0f;
 
 void vector_options::init(emu_options& options)
 {
 	s_beam_width_min = options.beam_width_min();
 	s_beam_width_max = options.beam_width_max();
+	s_beam_dot_size = options.beam_dot_size();
 	s_beam_intensity_weight = options.beam_intensity_weight();
 	s_flicker = options.flicker();
 }
@@ -175,6 +177,10 @@ uint32_t vector_device::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 
 		// normalize width
 		beam_width *= 1.0f / (float)VECTOR_WIDTH_DENOM;
+
+		// apply point scale for points
+		if (lastx == curpoint->x && lasty == curpoint->y)
+			beam_width *= vector_options::s_beam_dot_size;
 
 		coords.x0 = ((float)lastx - xoffs) * xscale;
 		coords.y0 = ((float)lasty - yoffs) * yscale;

--- a/src/devices/video/vector.h
+++ b/src/devices/video/vector.h
@@ -16,6 +16,7 @@ public:
 	static float s_flicker;
 	static float s_beam_width_min;
 	static float s_beam_width_max;
+	static float s_beam_dot_size;
 	static float s_beam_intensity_weight;
 
 protected:

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -129,6 +129,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE VECTOR OPTIONS" },
 	{ OPTION_BEAM_WIDTH_MIN,                             "1.0",       OPTION_FLOAT,      "set vector beam width minimum" },
 	{ OPTION_BEAM_WIDTH_MAX,                             "1.0",       OPTION_FLOAT,      "set vector beam width maximum" },
+	{ OPTION_BEAM_DOT_SIZE,                              "1.0",       OPTION_FLOAT,      "set vector beam size for dots" },
 	{ OPTION_BEAM_INTENSITY_WEIGHT,                      "0",         OPTION_FLOAT,      "set vector beam intensity weight " },
 	{ OPTION_FLICKER,                                    "0",         OPTION_FLOAT,      "set vector flicker effect" },
 

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -111,6 +111,7 @@
 // core vector options
 #define OPTION_BEAM_WIDTH_MIN       "beam_width_min"
 #define OPTION_BEAM_WIDTH_MAX       "beam_width_max"
+#define OPTION_BEAM_DOT_SIZE        "beam_dot_size"
 #define OPTION_BEAM_INTENSITY_WEIGHT   "beam_intensity_weight"
 #define OPTION_FLICKER              "flicker"
 
@@ -390,6 +391,7 @@ public:
 	// core vector options
 	float beam_width_min() const { return float_value(OPTION_BEAM_WIDTH_MIN); }
 	float beam_width_max() const { return float_value(OPTION_BEAM_WIDTH_MAX); }
+	float beam_dot_size() const { return float_value(OPTION_BEAM_DOT_SIZE); }
 	float beam_intensity_weight() const { return float_value(OPTION_BEAM_INTENSITY_WEIGHT); }
 	float flicker() const { return float_value(OPTION_FLICKER); }
 

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -1477,6 +1477,7 @@ std::vector<ui::menu_item> mame_ui_manager::slider_init(running_machine &machine
 			m_sliders.push_back(slider_alloc(SLIDER_ID_FLICKER + slider_index, _("Vector Flicker"), 0, 0, 1000, 10, nullptr));
 			m_sliders.push_back(slider_alloc(SLIDER_ID_BEAM_WIDTH_MIN + slider_index, _("Beam Width Minimum"), 100, 100, 1000, 1, nullptr));
 			m_sliders.push_back(slider_alloc(SLIDER_ID_BEAM_WIDTH_MAX + slider_index, _("Beam Width Maximum"), 100, 100, 1000, 1, nullptr));
+			m_sliders.push_back(slider_alloc(SLIDER_ID_BEAM_DOT_SIZE + slider_index, _("Beam Dot Size"), 100, 100, 1000, 1, nullptr));
 			m_sliders.push_back(slider_alloc(SLIDER_ID_BEAM_INTENSITY + slider_index, _("Beam Intensity Weight"), -1000, 0, 1000, 10, nullptr));
 			slider_index++;
 			break;
@@ -1560,6 +1561,8 @@ int32_t mame_ui_manager::slider_changed(running_machine &machine, void *arg, int
 			return slider_beam_width_min(machine, arg, id, str, newval);
 	else if (id >= SLIDER_ID_BEAM_WIDTH_MAX && id <= SLIDER_ID_BEAM_WIDTH_MAX_LAST)
 			return slider_beam_width_max(machine, arg, id, str, newval);
+	else if (id >= SLIDER_ID_BEAM_DOT_SIZE && id <= SLIDER_ID_BEAM_DOT_SIZE_LAST)
+			return slider_beam_dot_size(machine, arg, id, str, newval);
 	else if (id >= SLIDER_ID_BEAM_INTENSITY && id <= SLIDER_ID_BEAM_INTENSITY_LAST)
 			return slider_beam_intensity_weight(machine, arg, id, str, newval);
 #ifdef MAME_DEBUG
@@ -1955,6 +1958,21 @@ int32_t mame_ui_manager::slider_beam_width_max(running_machine &machine, void *a
 	if (str != nullptr)
 		*str = string_format(_("%1$1.2f"), vector_options::s_beam_width_max);
 	return floor(vector_options::s_beam_width_max * 100.0f + 0.5f);
+}
+
+
+//-------------------------------------------------
+//  slider_beam_dot_size - beam dot size slider
+//  callback
+//-------------------------------------------------
+
+int32_t mame_ui_manager::slider_beam_dot_size(running_machine &machine, void *arg, int id, std::string *str, int32_t newval)
+{
+	if (newval != SLIDER_NOCHANGE)
+		vector_options::s_beam_dot_size = std::max((float)newval * 0.01f, 0.1f);
+	if (str != nullptr)
+		*str = string_format(_("%1$1.2f"), vector_options::s_beam_dot_size);
+	return floor(vector_options::s_beam_dot_size * 100.0f + 0.5f);
 }
 
 

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -91,6 +91,8 @@ enum
 	SLIDER_ID_BEAM_WIDTH_MAX_LAST   = SLIDER_ID_BEAM_WIDTH_MAX + SLIDER_SCREEN_SPACING,
 	SLIDER_ID_BEAM_INTENSITY,
 	SLIDER_ID_BEAM_INTENSITY_LAST   = SLIDER_ID_BEAM_INTENSITY + SLIDER_SCREEN_SPACING,
+	SLIDER_ID_BEAM_DOT_SIZE,
+	SLIDER_ID_BEAM_DOT_SIZE_LAST    = SLIDER_ID_BEAM_DOT_SIZE + SLIDER_SCREEN_SPACING,
 	SLIDER_ID_CROSSHAIR_SCALE,
 	SLIDER_ID_CROSSHAIR_SCALE_LAST  = SLIDER_ID_CROSSHAIR_SCALE + SLIDER_INPUT_SPACING,
 	SLIDER_ID_CROSSHAIR_OFFSET,
@@ -320,6 +322,7 @@ private:
 	int32_t slider_flicker(running_machine &machine, void *arg, int id, std::string *str, int32_t newval);
 	int32_t slider_beam_width_min(running_machine &machine, void *arg, int id, std::string *str, int32_t newval);
 	int32_t slider_beam_width_max(running_machine &machine, void *arg, int id, std::string *str, int32_t newval);
+	int32_t slider_beam_dot_size(running_machine &machine, void *arg, int id, std::string *str, int32_t newval);
 	int32_t slider_beam_intensity_weight(running_machine &machine, void *arg, int id, std::string *str, int32_t newval);
 	std::string slider_get_screen_desc(screen_device &screen);
 	#ifdef MAME_DEBUG


### PR DESCRIPTION
Add new option beam_dot_size that controls the rendered size of 'dots' in vector games. [Aaron Giles]