### PR TITLE
Add new option -speaker_report <n> to help devs tune volume

### DIFF
--- a/src/devices/machine/netlist.cpp
+++ b/src/devices/machine/netlist.cpp
@@ -882,12 +882,12 @@ void netlist_mame_stream_output_device::process(netlist::netlist_time_ext tim, n
 	}
 
 	/* ignore spikes */
-	if (plib::abs(val) < 32767.0)
+	if (plib::abs(val) < 32767.0*256.0)
 		m_cur = val;
 	else if (val > 0.0)
-		m_cur = 32767.0;
+		m_cur = 32767.0*256.0;
 	else
-		m_cur = -32767.0;
+		m_cur = -32767.0*256.0;
 
 }
 

--- a/src/devices/machine/netlist.cpp
+++ b/src/devices/machine/netlist.cpp
@@ -881,7 +881,9 @@ void netlist_mame_stream_output_device::process(netlist::netlist_time_ext tim, n
 		m_buffer.push_back(static_cast<stream_sample_t>(m_cur));
 	}
 
-	/* ignore spikes */
+	// clamp to avoid spikes, but not too hard, as downstream processing, volume
+	// controls, etc may bring values above 32767 back down in range; some clamping
+	// is still useful, however, as the mixing is done with integral values
 	if (plib::abs(val) < 32767.0*256.0)
 		m_cur = val;
 	else if (val > 0.0)

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -137,7 +137,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SAMPLERATE ";sr(1000-1000000)",             "48000",     OPTION_INTEGER,    "set sound output sample rate" },
 	{ OPTION_SAMPLES,                                    "1",         OPTION_BOOLEAN,    "enable the use of external samples if available" },
 	{ OPTION_VOLUME ";vol",                              "0",         OPTION_INTEGER,    "sound volume in decibels (-32 min, 0 max)" },
-	{ OPTION_SPEAKER_REPORT,                             "0",         OPTION_INTEGER,    "print report of speaker ouput maxima (0=none, or 1-3 for more detail)" },
+	{ OPTION_SPEAKER_REPORT,                             "0",         OPTION_INTEGER,    "print report of speaker ouput maxima (0=none, or 1-4 for more detail)" },
 
 	// input options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE INPUT OPTIONS" },

--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -137,6 +137,7 @@ const options_entry emu_options::s_option_entries[] =
 	{ OPTION_SAMPLERATE ";sr(1000-1000000)",             "48000",     OPTION_INTEGER,    "set sound output sample rate" },
 	{ OPTION_SAMPLES,                                    "1",         OPTION_BOOLEAN,    "enable the use of external samples if available" },
 	{ OPTION_VOLUME ";vol",                              "0",         OPTION_INTEGER,    "sound volume in decibels (-32 min, 0 max)" },
+	{ OPTION_SPEAKER_REPORT,                             "0",         OPTION_INTEGER,    "print report of speaker ouput maxima (0=none, or 1-3 for more detail)" },
 
 	// input options
 	{ nullptr,                                           nullptr,     OPTION_HEADER,     "CORE INPUT OPTIONS" },

--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -118,6 +118,7 @@
 #define OPTION_SAMPLERATE           "samplerate"
 #define OPTION_SAMPLES              "samples"
 #define OPTION_VOLUME               "volume"
+#define OPTION_SPEAKER_REPORT       "speaker_report"
 
 // core input options
 #define OPTION_COIN_LOCKOUT         "coin_lockout"
@@ -397,6 +398,7 @@ public:
 	int sample_rate() const { return int_value(OPTION_SAMPLERATE); }
 	bool samples() const { return bool_value(OPTION_SAMPLES); }
 	int volume() const { return int_value(OPTION_VOLUME); }
+	int speaker_report() const { return int_value(OPTION_SPEAKER_REPORT); }
 
 	// core input options
 	bool coin_lockout() const { return bool_value(OPTION_COIN_LOCKOUT); }

--- a/src/emu/speaker.cpp
+++ b/src/emu/speaker.cpp
@@ -9,6 +9,7 @@
 ***************************************************************************/
 
 #include "emu.h"
+#include "emuopts.h"
 #include "speaker.h"
 
 
@@ -36,11 +37,8 @@ speaker_device::speaker_device(const machine_config &mconfig, const char *tag, d
 	, m_x(0.0)
 	, m_y(0.0)
 	, m_z(0.0)
-#if SPEAKER_TRACK_MAX_SAMPLE
-	, m_max_sample(0)
-	, m_clipped_samples(0)
-	, m_total_samples(0)
-#endif
+	, m_current_max(0)
+	, m_samples_this_bucket(0)
 {
 }
 
@@ -51,11 +49,6 @@ speaker_device::speaker_device(const machine_config &mconfig, const char *tag, d
 
 speaker_device::~speaker_device()
 {
-#if SPEAKER_TRACK_MAX_SAMPLE
-	// log the maximum sample values for all speakers
-	if (m_max_sample > 0)
-		osd_printf_verbose("Speaker \"%s\" - max = %d (gain *= %f) - %d%% samples clipped\n", tag(), m_max_sample, 32767.0 / (m_max_sample ? m_max_sample : 1), (int)((double)m_clipped_samples * 100.0 / m_total_samples));
-#endif
 }
 
 
@@ -84,24 +77,21 @@ void speaker_device::mix(s32 *leftmix, s32 *rightmix, int &samples_this_update, 
 	}
 	assert(samples_this_update == numsamples);
 
-#if SPEAKER_TRACK_MAX_SAMPLE
-	// debug version: keep track of the maximum sample
-	// ignore the first 100k or so samples to avoid biasing in favor
-	// of initial sound glitches
-	if (m_total_samples < 100000)
-		m_total_samples += samples_this_update;
-	else
+	// track maximum sample value for each 0.1s bucket
+	if (machine().options().speaker_report() != 0)
+	{
+		u32 samples_per_bucket = m_mixer_stream->sample_rate() / BUCKETS_PER_SECOND;
 		for (int sample = 0; sample < samples_this_update; sample++)
 		{
-			if (stream_buf[sample] > m_max_sample)
-				m_max_sample = stream_buf[sample];
-			else if (-stream_buf[sample] > m_max_sample)
-				m_max_sample = -stream_buf[sample];
-			if (stream_buf[sample] > 32767 || stream_buf[sample] < -32768)
-				m_clipped_samples++;
-			m_total_samples++;
+			m_current_max = std::max(m_current_max, abs(stream_buf[sample]));
+			if (++m_samples_this_bucket >= samples_per_bucket)
+			{
+				m_max_sample.push_back(m_current_max);
+				m_current_max = 0;
+				m_samples_this_bucket = 0;
+			}
 		}
-#endif
+	}
 
 	// mix if sound is enabled
 	if (!suppress)
@@ -135,3 +125,48 @@ void speaker_device::device_start()
 {
 	// dummy save to make device.c happy
 }
+
+
+//-------------------------------------------------
+//  device_stop - cleanup and report
+//-------------------------------------------------
+
+void speaker_device::device_stop()
+{
+	// level 1: just report if there was any clipping
+	// level 2: report the overall maximum, even if no clipping
+	// level 3: print a detailed list of all the times there was clipping
+	// level 4: print a detailed list of every bucket
+	int report = machine().options().speaker_report();
+	if (report != 0)
+	{
+		m_max_sample.push_back(m_current_max);
+
+		// determine overall maximum and number of clipped buckets
+		s32 overallmax = 0;
+		u32 clipped = 0;
+		for (auto &curmax : m_max_sample)
+		{
+			overallmax = std::max(overallmax, curmax);
+			if (curmax > 32767)
+				clipped++;
+		}
+
+		// levels 1 and 2 just get a summary
+		if (clipped != 0 || report == 2 || report == 4)
+			osd_printf_info("Speaker \"%s\" - max = %d (gain *= %.3f) - clipped in %d/%d (%d%%) buckets\n", tag(), overallmax, 32767.0 / (overallmax ? overallmax : 1), clipped, m_max_sample.size(), clipped * 100 / m_max_sample.size());
+
+		// levels 3 and 4 get a full dump
+		if (report >= 3)
+		{
+			double t = 0;
+			for (auto &curmax : m_max_sample)
+			{
+				if (curmax > 32767 || report == 4)
+					osd_printf_info("   t=%5.1f  max=%6d\n", t, curmax);
+				t += 1.0 / double(BUCKETS_PER_SECOND);
+			}
+		}
+	}
+}
+

--- a/src/emu/speaker.h
+++ b/src/emu/speaker.h
@@ -26,15 +26,6 @@
 #pragma once
 
 
-#ifndef SPEAKER_TRACK_MAX_SAMPLE
-#ifdef MAME_DEBUG
-#define SPEAKER_TRACK_MAX_SAMPLE (1)
-#else
-#define SPEAKER_TRACK_MAX_SAMPLE (0)
-#endif
-#endif
-
-
 //**************************************************************************
 //  GLOBAL VARIABLES
 //**************************************************************************
@@ -83,6 +74,7 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override ATTR_COLD;
+	virtual void device_stop() override ATTR_COLD;
 
 	// inline configuration state
 	double              m_x;
@@ -90,11 +82,10 @@ protected:
 	double              m_z;
 
 	// internal state
-#if SPEAKER_TRACK_MAX_SAMPLE
-	s32                 m_max_sample;           // largest sample value we've seen
-	s32                 m_clipped_samples;      // total number of clipped samples
-	s32                 m_total_samples;        // total number of samples
-#endif
+	static constexpr int BUCKETS_PER_SECOND = 10;
+	std::vector<s32> 	m_max_sample;
+	s32					m_current_max;
+	u32					m_samples_this_bucket;
 };
 
 


### PR DESCRIPTION
Added a new option -speaker_report <n> which enables an end-of-session report from each speaker on the maximum sample value seen and whether there was any clipping. n=0 (default) means no report. n=1 prints a summary only if there was clipping, and n=2 prints the summary regardless. n=3 prints a list of clipped maxima over time, and n=4 prints the entire list of maxima across the whole session.