### PR TITLE
mdos dsk: support legacy floppy images, add XDOS support

### DIFF
--- a/src/lib/formats/mdos_dsk.cpp
+++ b/src/lib/formats/mdos_dsk.cpp
@@ -3,17 +3,18 @@
 /*
  * mdos_dsk.c  -  Motorola MDOS compatible disk images
  *
- * The format is largely IBM 3740 compatible, with 77 tracks, and 26 sectors
- * per track, and a sector size of 128 bytes. Single sided disks were initially
- * supported and later software supported double sided disk with 52 sectors per
- * cylinder. The sectors are numbered from one, and the sectors indexes on the
+ * The format is largely IBM 3740 compatible with a sector size of 128
+ * bytes. The sectors are numbered from one, and the sectors indexes on the
  * second side continue from the first side rather than starting again at
- * one.
+ * one. The address mark 'head' field is filled with zero irrespective of the
+ * disk head and the software ignores this field when read.
  *
- * The disk drives run at 360rpm, and the bit clock frequency at 500kHz.  This
- * gives 6 revs per second, and 500000 / 6 = 83333 cells per track. MAME uses
- * disk rotation position units of 1/200000000 of a turn and the cells size in
- * this unit is 200000000 / (500000 / 6) = 2400.
+ * The 8 inch disk format has 77 tracks, and 26 sectors per track, and 52
+ * sectors per cylinder for double sided disks. The disk drives run at 360rpm
+ * or 6 revs per second and the bit clock frequency is 500kHz which gives
+ * 500000 / 6 = 83333 cells per track. MAME uses disk rotation position units
+ * of 1/200000000 of a turn and the cell size in this unit is 200000000 /
+ * (500000 / 6) = 2400.
  *
  * The M68SFDC2 user guide details the format gaps. "The Post-Index Gap is
  * defined as the 32 bytes between Index Address Mark and the ID Address Mark
@@ -44,14 +45,350 @@
  * 209 bytes, but this now extends to the start of the track to the index
  * marker.
  *
- * TODO The MDOS 3 FORMAT command writes a zero in the address mark 'head'
- * field irrespective of the disk head and the software ignores this field when
- * read.
+ * The XDOS format disk is largely compatible with MDOS, adding 5.25 inch disk
+ * formats. The XDOS4 format command also numbers sectors indexes starting at
+ * 1 and continuing on the second side for double sided disk, and also writes
+ * a zero in the address mark 'head' field irrespective of the disk head. The
+ * interleave for the 5.25 inch disk format is 2. The 5.25 inch disk drives
+ * run at 300rpm or 5 revs per second and the bit clock is 250kHz which gives
+ * 250000 / 5 = 50000 cells per track. MAME uses disk rotation position units
+ * of 1/200000000 of a turn and the cell size in this unit is 200000000 /
+ * (250000 / 5) = 4000. The disk format is:
+ *
+ * 80 x 0xff,
+ * For each sector (16):
+ *   6 x 0x00, 0xF57E, 4 x data, 2 x CRC,
+ *   12 x 0xff,
+ *   6 x 0x00, 0xF56F, 128 x data, 2 x CRC,
+ *   27 x FF
+ *
+ * giving a total of 3104 bytes and at 16 cells per byte gives 49664 cells.
  */
 
 #include "mdos_dsk.h"
+#include "formats/basicdsk.h"
 #include "formats/imageutl.h"
 
+
+static bool check_ascii(uint8_t *str, size_t len, const char* name)
+{
+	LOG_FORMATS(" %s: \"", name);
+	for (int i = 0; i < len; i++) {
+		uint8_t ch = str[i];
+		if (ch == 0) {
+			LOG_FORMATS("\\0");
+		} else if (ch < 0x20 || ch > 0x7f) {
+			return 0;
+		} else {
+			LOG_FORMATS("%c", ch);
+		}
+	}
+	LOG_FORMATS("\"\n");
+	return 1;
+}
+
+static int parse_date_field(uint8_t *str)
+{
+	uint8_t high = str[0];
+	uint8_t low = str[1];
+
+	if (high < 0x30 || high > 0x39 || low < 0x30 || low > 0x39)
+		return -1;
+
+	return (high - 0x30) * 10 + (low - 0x30);
+}
+
+struct disk_id_sector
+{
+	uint8_t id[8];
+	uint8_t version[2];
+	uint8_t revision[2];
+	uint8_t date[6];
+	uint8_t username[20];
+	uint8_t rib_addr[20];
+	uint8_t unused[70];
+};
+
+// The 'unused' area is not necessarily zero filled and is ignored in the
+// identification of a MDOS format image.
+//
+// XDOS stores a table of the usable sectors in the id sector, see the table
+// below. The total number of usable sectors is the total rounded double to
+// the nearest multiple of four - allocation is in multiples of four sector
+// clusters.
+//
+// 0x70    disks 0-3 single sided sectors per cylinder
+// 0x71,2  disks 0-3 single sided total usable sectors
+// 0x73    disks 0-3 double sided sectors per cylinder
+// 0x74,5  disks 0-3 double sided total usable sectors
+// 0x76    disks 4-7 single sided sectors per cylinder
+// 0x77,8  disks 4-7 single sided total usable sectors
+// 0x79    disks 4-7 double sided sectors per cylinder
+// 0x7a,b  disks 4-7 double sided total usable sectors
+//
+static int check_id_sector(struct disk_id_sector *info, uint64_t size)
+{
+	// Expect an ASCII id, version, revision, and 'user name' strings.
+	if (!check_ascii(info->id, sizeof(info->id), "id"))
+		return 0;
+
+	if (!check_ascii(info->version, sizeof(info->version), "version"))
+		return 0;
+
+	if (!check_ascii(info->revision, sizeof(info->revision), "revision"))
+		return 0;
+
+	if (!check_ascii(info->date, sizeof(info->date), "date"))
+		return 0;
+
+	if (!check_ascii(info->username, sizeof(info->username), "username"))
+		return 0;
+
+	// The date should be the numeric day, month and year.
+	// Permit the day and month to be in either order.
+	int day_month1 = parse_date_field(info->date);
+	int day_month2 = parse_date_field(info->date + 2);
+	int year = parse_date_field(info->date + 4);
+
+	LOG_FORMATS(" day/month %d, day/month %d, year %d\n", day_month1, day_month2, year);
+	if (day_month1 < 1 || day_month1 > 32 ||
+		day_month2 < 1 || day_month2 > 32 ||
+		(day_month1 > 12 && day_month2 > 12) ||
+		year < 0)
+	{
+		return 0;
+	}
+
+	// The RIB address seems to be a sequence of 16 bit cluster numbers,
+	// ending in a zero word. The maximum size appears to be 20 bytes, or
+	// 10 words. The area beyond the zero word is not always zero filled,
+	// and is ignored here. Check that it is consistent with this.
+	for (int i = 0; i < 10; i++) {
+		uint8_t high = info->rib_addr[i * 2];
+		uint8_t low = info->rib_addr[i * 2 + 1];
+		uint16_t cluster = (high << 8) | low;
+
+		if (cluster == 0)
+			break;
+
+		// The lowest value cluster here appears to be 6, just after
+		// the director sectors.
+		if (cluster < 6) {
+			LOG_FORMATS(" id sector rib address %d unexpectedly low\n", cluster);
+			return 0;
+		}
+
+		if (cluster * 4 * 128 + 4 * 128 > size) {
+			LOG_FORMATS(" id sector rib address %d beyond disk extent\n", cluster);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static int check_alloc_tables(uint8_t cluster_allocation[128], uint8_t cluster_available[128], uint64_t size)
+{
+	// Check that the cluster allocation table and the cluster available
+	// table are consistent with the disk size, that no clusters beyond
+	// the extent of the disk are free or available.
+
+	for (int cluster = 0; cluster < 128 * 8; cluster++) {
+		if (cluster * 4 * 128 + 4 * 128 > size) {
+			// This cluster does not fit within the disk size, so
+			// should be marked as not free and not available.
+			uint8_t mask = 1 << (7 - (cluster & 7));
+			uint8_t offset = cluster >> 3;
+			if ((cluster_allocation[offset] & mask) == 0) {
+				LOG_FORMATS("  unexpected free cluster %d beyond disk extent\n", cluster);
+				return 0;
+			}
+			if ((cluster_available[offset] & mask) == 0) {
+				LOG_FORMATS("  unexpected available cluster %d beyond disk extent\n", cluster);
+				return 0;
+			}
+		}
+	}
+
+	return 1;
+}
+
+
+static floperr_t mdos_dsk_readheader(floppy_image_legacy *floppy, struct basicdsk_geometry *geometry)
+{
+	struct disk_id_sector info;
+	uint64_t size;
+
+	size = floppy_image_size(floppy);
+
+	if (size < 3 * 128 || size % 128 != 0)
+		return FLOPPY_ERROR_INVALIDIMAGE;
+
+	floppy_image_read(floppy, &info, 0, sizeof(info));
+
+	if (!check_id_sector(&info, size))
+		return FLOPPY_ERROR_INVALIDIMAGE;
+
+	uint8_t cluster_allocation[128], cluster_available[128];
+	floppy_image_read(floppy, &cluster_allocation, 1 * 128, sizeof(cluster_allocation));
+	floppy_image_read(floppy, &cluster_available, 2 * 128, sizeof(cluster_available));
+
+	if (!check_alloc_tables(cluster_allocation, cluster_available, size))
+		return FLOPPY_ERROR_INVALIDIMAGE;
+
+	memset(geometry, 0, sizeof(*geometry));
+	geometry->first_sector_id = 1;
+	geometry->sector_length = 128;
+
+	if (size == 81920)
+	{
+		geometry->tracks = 40;
+		geometry->sectors = 16;
+		geometry->heads = 1;
+	}
+	else if (size == 2 * 81920)
+	{
+		geometry->tracks = 40;
+		geometry->sectors = 16;
+		geometry->heads = 2;
+	}
+	else if (size == 256256)
+	{
+		geometry->tracks = 77;
+		geometry->sectors = 26;
+		geometry->heads = 1;
+	}
+	else if (size == 2 * 256256)
+	{
+		geometry->tracks = 77;
+		geometry->sectors = 26;
+		geometry->heads = 2;
+	}
+	else
+	{
+		return FLOPPY_ERROR_INVALIDIMAGE;
+	}
+
+	return FLOPPY_ERROR_SUCCESS;
+}
+
+static floperr_t mdos_dsk_post_format(floppy_image_legacy *floppy, util::option_resolution *params)
+{
+	int heads, tracks, sectors, total_sectors;
+	struct disk_id_sector info;
+	time_t t;
+	struct tm *ltime;
+	floperr_t err;
+
+	heads   = params->lookup_int(PARAM_HEADS);
+	tracks  = params->lookup_int(PARAM_TRACKS);
+	sectors = params->lookup_int(PARAM_SECTORS);
+	total_sectors = heads * tracks * sectors;
+
+	if (total_sectors < 3)
+		return FLOPPY_ERROR_INVALIDIMAGE;
+
+	memset(&info, 0, sizeof(info));
+
+	memset(info.id, 0x20, sizeof(info.id));
+	info.id[0] = 'M';
+	info.id[1] = 'D';
+	info.id[2] = 'O';
+	info.id[3] = 'S';
+
+	memset(info.version, 0x20, sizeof(info.version));
+	info.version[1] = '2';
+
+	memset(info.revision, '0', sizeof(info.revision));
+
+	time(&t);
+	ltime = localtime(&t);
+	info.date[0] = (ltime->tm_mon + 1) / 10 + '0';
+	info.date[1] = (ltime->tm_mon + 1) % 10 + '0';
+	info.date[2] = ltime->tm_mday / 10 + '0';
+	info.date[3] = ltime->tm_mday % 10 + '0';
+	info.date[4] = (ltime->tm_year % 100) / 10 + '0';
+	info.date[5] = ltime->tm_year % 10 + '0';
+
+	memset(info.username, 0x20, sizeof(info.username));
+
+	err = floppy_write_sector(floppy, 0, 0, 1, 0, &info, 128, 0);
+	if (err)
+		return err;
+
+	uint8_t alloc[128];
+	memset(alloc, 0xff, sizeof(alloc));
+
+	for (int cluster = 0; cluster < 128 * 8; cluster++) {
+		uint8_t mask = 1 << (7 - (cluster & 7));
+		uint8_t offset = cluster >> 3;
+		uint8_t bit = (cluster * 4 + 4 > total_sectors) ? mask : 0;
+		alloc[offset] |= bit;
+	}
+
+	err = floppy_write_sector(floppy, 0, 0, 2, 0, alloc, 128, 0);
+	if (err)
+		return err;
+
+	err = floppy_write_sector(floppy, 0, 0, 3, 0, alloc, 128, 0);
+	if (err)
+		return err;
+
+	return FLOPPY_ERROR_SUCCESS;
+}
+
+
+
+static FLOPPY_IDENTIFY(mdos_dsk_identify)
+{
+	struct basicdsk_geometry geometry;
+	*vote = mdos_dsk_readheader(floppy, &geometry) ? 0 : 100;
+	return FLOPPY_ERROR_SUCCESS;
+}
+
+
+
+static FLOPPY_CONSTRUCT(mdos_dsk_construct)
+{
+	floperr_t err;
+	struct basicdsk_geometry geometry;
+
+	if (params)
+	{
+		/* create */
+		memset(&geometry, 0, sizeof(geometry));
+		geometry.heads              = params->lookup_int(PARAM_HEADS);
+		geometry.tracks             = params->lookup_int(PARAM_TRACKS);
+		geometry.sectors            = params->lookup_int(PARAM_SECTORS);
+		geometry.first_sector_id    = params->lookup_int(PARAM_FIRST_SECTOR_ID);
+		geometry.sector_length      = params->lookup_int(PARAM_SECTOR_LENGTH);
+	}
+	else
+	{
+		/* open */
+		err = mdos_dsk_readheader(floppy, &geometry);
+		if (err)
+			return err;
+	}
+
+	/* actually construct the image */
+	err = basicdsk_construct(floppy, &geometry);
+	floppy_callbacks(floppy)->post_format = mdos_dsk_post_format;
+
+	return err;
+}
+
+LEGACY_FLOPPY_OPTIONS_START( mdos )
+	LEGACY_FLOPPY_OPTION( mdos_dsk, "dsk", "Motorola MDOS disk image", mdos_dsk_identify,  mdos_dsk_construct, nullptr,
+		HEADS([1]-2)
+		TRACKS([40]-255)
+		SECTORS(1-[16]-255)
+		SECTOR_LENGTH([128])
+		FIRST_SECTOR_ID([1]))
+	LEGACY_FLOPPY_OPTION( imd, "imd", "IMD floppy disk image",  imd_dsk_identify, imd_dsk_construct, nullptr, nullptr) \
+LEGACY_FLOPPY_OPTIONS_END0
+
+/* ----------------------------------------------------------------------- */
 
 mdos_format::mdos_format() : wd177x_format(formats)
 {
@@ -81,125 +418,30 @@ int mdos_format::identify(io_generic *io, uint32_t form_factor)
 	return 0;
 }
 
-bool mdos_format::check_ascii(uint8_t *str, size_t len, const char* name)
-{
-	LOG_FORMATS(" %s: \"", name);
-	for (int i = 0; i < len; i++) {
-		uint8_t ch = str[i];
-		if (ch == 0) {
-			LOG_FORMATS("\\0");
-		} else if (ch < 0x20 || ch > 0x7f) {
-			return 0;
-		} else {
-			LOG_FORMATS("%c", ch);
-		}
-	}
-	LOG_FORMATS("\"\n");
-	return 1;
-}
-
-int mdos_format::parse_date_field(uint8_t *str)
-{
-	uint8_t high = str[0];
-	uint8_t low = str[1];
-
-	if (high < 0x30 || high > 0x39 || low < 0x30 || low > 0x39)
-		return -1;
-
-	return (high - 0x30) * 10 + (low - 0x30);
-}
-
 int mdos_format::find_size(io_generic *io, uint32_t form_factor)
 {
+	struct disk_id_sector info;
 	uint64_t size = io_generic_size(io);
+
+	if (size < 3 * 128 || size % 128 != 0)
+		return -1;
 
 	// Look at the disk id sector.
 	io_generic_read(io, &info, 0, sizeof(struct disk_id_sector));
 
-	LOG_FORMATS("MDOS floppy dsk: size %d bytes, %d total sectors, %d remaining bytes, expected form factor %x\n", (uint32_t)size, (uint32_t)size / 128, (uint32_t)size % 128, form_factor);
-
-	// The 'unused' area is not necessarily zero filled and is ignoded
-	// in the identification of a MDOS format image.
-
-	// Expect an ASCII id, version, revision, and 'user name' strings.
-	if (!check_ascii(info.id, sizeof(info.id), "id"))
+	if (!check_id_sector(&info, size))
 		return -1;
-
-	if (!check_ascii(info.version, sizeof(info.version), "version"))
-		return -1;
-
-	if (!check_ascii(info.revision, sizeof(info.revision), "revision"))
-		return -1;
-
-	if (!check_ascii(info.date, sizeof(info.date), "date"))
-		return -1;
-
-	if (!check_ascii(info.username, sizeof(info.username), "username"))
-		return -1;
-
-	// The date should be the numeric day, month and year.
-	int month = parse_date_field(info.date);
-	int day = parse_date_field(info.date + 2);
-	int year = parse_date_field(info.date + 4);
-
-	LOG_FORMATS(" day %d, month %d, year %d\n", day, month, year);
-	if (day < 1 || day > 32 || month < 1 || month > 12 || year < 0)
-		return -1;
-
-	// The RIB address seems to be a sequence of 16 bit cluster numbers,
-	// ending in a zero word. The maximum size appears to be 20 bytes, or
-	// 10 words. The area beyond the zero word is not always zero filled,
-	// and is ignored here. Check that it is consistent with this.
-	for (int i = 0; i < 10; i++) {
-		uint8_t high = info.rib_addr[i * 2];
-		uint8_t low = info.rib_addr[i * 2 + 1];
-		uint16_t cluster = (high << 8) | low;
-
-		if (cluster == 0)
-			break;
-
-		// The lowest value cluster here appears to be 92, just after
-		// the director sectors.
-		if (cluster < 92) {
-			LOG_FORMATS(" id sector rib address %d unexpectedly low\n", cluster);
-			return -1;
-		}
-
-		if (cluster * 4 * 128 + 4 * 128 > size) {
-			LOG_FORMATS(" id sector rib address %d beyond disk extent\n", cluster);
-			return -1;
-		}
-	}
-
-	// Check that the cluster allocation table and the cluster available
-	// table are consistent with the disk size, that no clusters beyond
-	// the extent of the disk are free or available.
 
 	uint8_t cluster_allocation[128], cluster_available[128];
 	io_generic_read(io, &cluster_allocation, 1 * 128, sizeof(cluster_allocation));
 	io_generic_read(io, &cluster_available, 2 * 128, sizeof(cluster_available));
 
-	for (int cluster = 0; cluster < sizeof(cluster_allocation) * 8; cluster++) {
-		if (cluster * 4 * 128 + 4 * 128 > size) {
-			// This cluster does not fit within the disk size, so
-			// should be marked as not free and not available.
-			uint8_t mask = 1 << (7 - (cluster & 7));
-			uint8_t offset = cluster >> 3;
-			if ((cluster_allocation[offset] & mask) == 0) {
-				LOG_FORMATS("  unexpected free cluster %d beyond disk extent\n", cluster);
-				return -1;
-			}
-			if ((cluster_available[offset] & mask) == 0) {
-				LOG_FORMATS("  unexpected available cluster %d beyond disk extent\n", cluster);
-				return -1;
-			}
-		}
-	}
+	if (!check_alloc_tables(cluster_allocation, cluster_available, size))
+		return -1;
 
 	for (int i=0; formats[i].form_factor; i++) {
 		const format &f = formats[i];
-		LOG_FORMATS(" checking format %d with form factor %02x, %d sectors, %d heads\n",
-				i, f.form_factor, f.sector_count, f.head_count);
+
 		if (form_factor != floppy_image::FF_UNKNOWN && form_factor != f.form_factor)
 			continue;
 
@@ -211,11 +453,9 @@ int mdos_format::find_size(io_generic *io, uint32_t form_factor)
 			}
 		}
 
-		LOG_FORMATS(" image size %u\n", format_size);
 		if (format_size != size)
 			continue;
 
-		LOG_FORMATS("MDOS matching format index %d\n", i);
 		return i;
 	}
 	return -1;
@@ -260,11 +500,19 @@ const wd177x_format::format &mdos_format::get_track_format(const format &f, int 
 }
 
 const mdos_format::format mdos_format::formats[] = {
-	{ // 55 250.25K 8 inch single sided single density
+	{ // 80K 5 1/4 inch single sided single density
+		floppy_image::FF_525, floppy_image::SSSD, floppy_image::FM,
+		4000, 16, 40, 1, 128, {}, -1, {1,9,2,10,3,11,4,12,5,13,6,14,7,15,8,16}, 80, 12, 27
+	},
+	{ // 80K 5 1/4 inch double sided single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 16, 40, 2, 128, {}, -1, {1,9,2,10,3,11,4,12,5,13,6,14,7,15,8,16}, 80, 12, 27
+	},
+	{ // 250.25K 8 inch single sided single density
 		floppy_image::FF_8, floppy_image::SSSD, floppy_image::FM,
 		2400, 26, 77, 1, 128, {}, 1, {}, 32-6, 17-6, 33-6
 	},
-	{ // 57 500.5K 8 inch double sided single density
+	{ // 500.5K 8 inch double sided single density
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
 		2400, 26, 77, 2, 128, {}, 1, {}, 32-6, 17-6, 33-6
 	},
@@ -272,9 +520,15 @@ const mdos_format::format mdos_format::formats[] = {
 };
 
 const mdos_format::format mdos_format::formats_head1[] = {
-	{ // 55 250.25K 8 inch single sided single density
+	{
 	},
-	{ // 57 500.5K 8 inch double sided single density
+	{ // 80K 5 1/4 inch double sided single density
+		floppy_image::FF_525, floppy_image::DSSD, floppy_image::FM,
+		4000, 16, 40, 2, 128, {}, -1, {17,25,18,26,19,27,20,28,21,29,22,30,23,31,24,32}, 80, 12, 27
+	},
+	{ // 250.25K 8 inch single sided single density
+	},
+	{ // 500.5K 8 inch double sided single density
 		floppy_image::FF_8, floppy_image::DSSD, floppy_image::FM,
 		2400, 26, 77, 2, 128, {}, 27, {}, 32-6, 17-6, 33-6
 	},

--- a/src/lib/formats/mdos_dsk.h
+++ b/src/lib/formats/mdos_dsk.h
@@ -11,6 +11,8 @@
 #include "flopimg.h"
 #include "wd177x_dsk.h"
 
+LEGACY_FLOPPY_OPTIONS_EXTERN(mdos);
+
 class mdos_format : public wd177x_format
 {
 public:
@@ -24,20 +26,8 @@ public:
 	virtual const wd177x_format::format &get_track_format(const format &f, int head, int track) override;
 
 private:
-	struct disk_id_sector
-	{
-		uint8_t id[8];
-		uint8_t version[2];
-		uint8_t revision[2];
-		uint8_t date[6];
-		uint8_t username[20];
-		uint8_t rib_addr[20];
-		uint8_t unused[70];
-	} info;
 	static const format formats[];
 	static const format formats_head1[];
-	bool check_ascii(uint8_t *, size_t len, const char* name);
-	int parse_date_field(uint8_t *str);
 };
 
 extern const floppy_format_type FLOPPY_MDOS_FORMAT;


### PR DESCRIPTION
Add legacy floppy image support which is currently required for the
mc6843 FDC emulator and used by the EXORset which run XDOS a variant
of MDOS.

Add support for 5.25 inch XDOS floppy drive formats as used by the
EXORset.

Make some of the identity tests more permissive to work with observer
disks. The date day and month are reversed on some disks, and the boot
rib cluster is lower.