### PR TITLE
mc6843: add a delay reading the CRC

### DIFF
--- a/src/devices/machine/mc6843.h
+++ b/src/devices/machine/mc6843.h
@@ -75,6 +75,7 @@ private:
 	uint32_t m_data_idx;    /* current read/write position in data */
 	uint32_t m_data_id;     /* chrd_id for sector write */
 	uint8_t  m_index_pulse;
+	uint8_t  m_crc_wait;
 
 	/* trigger delayed actions (bottom halves) */
 	emu_timer* m_timer_cont;
@@ -88,6 +89,7 @@ private:
 	int address_search_read(chrn_id* id);
 	void finish_RCR();
 	void cont_SR();
+	void finish_SR();
 	void cont_SW();
 
 };


### PR DESCRIPTION
Code using programmed I/O may read the last byte of a sector and then
expect to have some time to store that to memory before receiving an
interrupt on the completion of the command. The interrupt was
occurring on the last read and the last byte was being lost by some
drivers. This change adds a delay after reading the last byte, roughly
the time needed to read the 16 bit CRC, before the end of a read
command is processed.

Avoid side effects when these are disabled.

Tested on an EXORset emulator.