### PR TITLE
Widescreen layouts

### DIFF
--- a/src/mame/layout/spyhunt.lay
+++ b/src/mame/layout/spyhunt.lay
@@ -153,6 +153,114 @@ license:CC0
 		</bezel>
 	</view>
 
+	<view name="Lamps + Widescreen Shifter-R">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="5" y="641" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="72" y="641" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="172" y="641" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="295" y="641" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="390" y="641" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="496" y="574" width="32" height="64" />
+			<color alpha="0.65" />
+		</bezel>
+	</view>
+
+	<view name="Lamps + Widescreen Shifter-L">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="5" y="641" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="72" y="641" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="172" y="641" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="295" y="641" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="390" y="641" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="-48" y="574" width="32" height="64" />
+			<color alpha="0.65" />
+		</bezel>
+	</view>
+
+	<view name="Widescreen Lamps and Shifter-R">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="494" y="430" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="493" y="455" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="494" y="480" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="492" y="505" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="494" y="530" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="496" y="574" width="32" height="64" />
+			<color alpha="0.65" />
+		</bezel>
+	</view>
+
+	<view name="Widescreen Lamps and Shifter-L">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="-70" y="430" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="-69" y="455" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="-95" y="480" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="-102" y="505" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="-100" y="530" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="-48" y="574" width="32" height="64" />
+			<color alpha="0.65" />
+		</bezel>
+	</view>
+
 	<view name="Lamps">
 		<screen index="0">
 			<bounds x="0" y="0" width="480" height="640" />

--- a/src/mame/layout/spyhunt.lay
+++ b/src/mame/layout/spyhunt.lay
@@ -261,6 +261,60 @@ license:CC0
 		</bezel>
 	</view>
 
+	<view name="Vertical Widescreen Lamps + Shifter-R">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="5" y="641" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="72" y="641" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="172" y="641" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="295" y="641" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="390" y="641" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="446" y="667" width="32" height="64" />
+			<color alpha="0.6" />
+		</bezel>
+	</view>
+
+	<view name="Vertical Widescreen Lamps + Shifter-L">
+		<screen index="0">
+			<bounds x="0" y="0" width="480" height="640" />
+		</screen>
+
+		<bezel name="lamp1" element="lamp_miss">
+			<bounds x="5" y="641" width="60" height="25" />
+		</bezel>
+		<bezel name="lamp0" element="lamp_oil">
+			<bounds x="72" y="641" width="59" height="25" />
+		</bezel>
+		<bezel name="lamp2" element="lamp_van">
+			<bounds x="172" y="641" width="85" height="25" />
+		</bezel>
+		<bezel name="lamp3" element="lamp_smoke">
+			<bounds x="295" y="641" width="93" height="25" />
+		</bezel>
+		<bezel name="lamp4" element="lamp_gun">
+			<bounds x="390" y="641" width="90" height="25" />
+		</bezel>
+
+		<bezel element="shifter" inputtag="ssio:IP0" inputmask="0x10">
+			<bounds x="2" y="667" width="32" height="64" />
+			<color alpha="0.6" />
+		</bezel>
+	</view>
+
 	<view name="Lamps">
 		<screen index="0">
 			<bounds x="0" y="0" width="480" height="640" />


### PR DESCRIPTION
This adds several optional layouts for Spy Hunter for use of modern widescreen displays.
Included are the following:
- Shifter off the game screen on the left or right
- Shifter and lamps off the game screen on the left or right. This is not 100% accurate to the original display but allows for a larger game screen.
- Vertically oriented layouts with the shifter below the lamps on the left or right side. This is designed for a widescreen monitor rotated 90 degrees to the left or right.