### PR TITLE
Fix redundancy in pacman-key --verify call

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ for:
       - set MSYSTEM=MINGW64
       - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
       - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
-      - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+      - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
       - bash -lc "pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
       - bash -lc "pacman -Syu --noconfirm"
       - taskkill /f /fi "MODULES eq msys-2.0.dll"


### PR DESCRIPTION
Appveyor VS2017 image only ships with pacman 5.1.3 as of now. In that version pacman-key --verify only takes one argument, the signature.