### PR TITLE
Fix non-x86 build and try to make sure it does not break silently again

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,8 +23,8 @@ install:
   - set MSYSTEM=MINGW64
 
 build_script:
-  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=0 vs2019 -j3"
-  - msbuild "build\projects\windows\mametiny\vs2019\mametiny.sln" /m /p:ContinueOnError=false /p:StopOnFirstFailure=true /property:Configuration=Debug /property:Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=ci PTR64=1 TOOLS=1 OPTIMIZE=0 vs2019 -j3"
+  - msbuild "build\projects\windows\mameci\vs2019\mameci.sln" /m /p:ContinueOnError=false /p:StopOnFirstFailure=true /property:Configuration=Debug /property:Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 for:
   -
     matrix:
@@ -43,16 +43,16 @@ for:
       - taskkill /f /fi "MODULES eq msys-2.0.dll"
       - bash -lc "pacman -Syu --noconfirm"
     build_script:
-      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=tiny PTR64=1 TOOLS=1 OPTIMIZE=3 IGNORE_GIT=1 -j3"
+      - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER && export MINGW64=/mingw64 && make SUBTARGET=ci PTR64=1 TOOLS=1 OPTIMIZE=3 IGNORE_GIT=1 -j3"
     test_script:
-      - \projects\mame\mametiny64.exe -validate
+      - \projects\mame\mameci64.exe -validate
     after_test:
-      - 7z a mametiny64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z %APPVEYOR_BUILD_FOLDER%\*.exe %APPVEYOR_BUILD_FOLDER%\artwork %APPVEYOR_BUILD_FOLDER%\bgfx %APPVEYOR_BUILD_FOLDER%\ctrlr %APPVEYOR_BUILD_FOLDER%\docs %APPVEYOR_BUILD_FOLDER%\hash %APPVEYOR_BUILD_FOLDER%\hlsl %APPVEYOR_BUILD_FOLDER%\ini %APPVEYOR_BUILD_FOLDER%\language %APPVEYOR_BUILD_FOLDER%\nl_examples %APPVEYOR_BUILD_FOLDER%\plugins %APPVEYOR_BUILD_FOLDER%\roms %APPVEYOR_BUILD_FOLDER%\samples
-      - appveyor PushArtifact mametiny64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z
+      - 7z a mameci64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z %APPVEYOR_BUILD_FOLDER%\*.exe %APPVEYOR_BUILD_FOLDER%\artwork %APPVEYOR_BUILD_FOLDER%\bgfx %APPVEYOR_BUILD_FOLDER%\ctrlr %APPVEYOR_BUILD_FOLDER%\docs %APPVEYOR_BUILD_FOLDER%\hash %APPVEYOR_BUILD_FOLDER%\hlsl %APPVEYOR_BUILD_FOLDER%\ini %APPVEYOR_BUILD_FOLDER%\language %APPVEYOR_BUILD_FOLDER%\nl_examples %APPVEYOR_BUILD_FOLDER%\plugins %APPVEYOR_BUILD_FOLDER%\roms %APPVEYOR_BUILD_FOLDER%\samples
+      - appveyor PushArtifact mameci64-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z
 
 test_script:
-  - \projects\mame\mametiny64d.exe -validate
+  - \projects\mame\mameci64d.exe -validate
 
 after_test:
-  - 7z a mametiny64d-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z %APPVEYOR_BUILD_FOLDER%\*.exe %APPVEYOR_BUILD_FOLDER%\artwork %APPVEYOR_BUILD_FOLDER%\bgfx %APPVEYOR_BUILD_FOLDER%\ctrlr %APPVEYOR_BUILD_FOLDER%\docs %APPVEYOR_BUILD_FOLDER%\hash %APPVEYOR_BUILD_FOLDER%\hlsl %APPVEYOR_BUILD_FOLDER%\ini %APPVEYOR_BUILD_FOLDER%\language %APPVEYOR_BUILD_FOLDER%\nl_examples %APPVEYOR_BUILD_FOLDER%\plugins %APPVEYOR_BUILD_FOLDER%\roms %APPVEYOR_BUILD_FOLDER%\samples
-  - appveyor PushArtifact mametiny64d-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z
+  - 7z a mameci64d-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z %APPVEYOR_BUILD_FOLDER%\*.exe %APPVEYOR_BUILD_FOLDER%\artwork %APPVEYOR_BUILD_FOLDER%\bgfx %APPVEYOR_BUILD_FOLDER%\ctrlr %APPVEYOR_BUILD_FOLDER%\docs %APPVEYOR_BUILD_FOLDER%\hash %APPVEYOR_BUILD_FOLDER%\hlsl %APPVEYOR_BUILD_FOLDER%\ini %APPVEYOR_BUILD_FOLDER%\language %APPVEYOR_BUILD_FOLDER%\nl_examples %APPVEYOR_BUILD_FOLDER%\plugins %APPVEYOR_BUILD_FOLDER%\roms %APPVEYOR_BUILD_FOLDER%\samples
+  - appveyor PushArtifact mameci64d-appveyor-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT%-%APPVEYOR_BUILD_NUMBER%.7z

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,19 @@ jobs:
     - os: osx
       osx_image: xcode11.6
       compiler: clang
-      env: SUBTARGET=tiny   MAME=mametiny64
+      env: SUBTARGET=ci   MAME=mameci64
     - os: linux
       arch: amd64
       compiler: gcc
-      env: SUBTARGET=tiny   MAME=mametiny64
+      env: SUBTARGET=ci   MAME=mameci64
     - os: linux
       arch: arm64
       compiler: gcc
-      env: SUBTARGET=tiny   MAME=mametiny
+      env: SUBTARGET=ci   MAME=mameci
     - os: linux
       arch: s390x
       compiler: gcc
-      env: SUBTARGET=tiny   MAME=mametiny64
+      env: SUBTARGET=ci   MAME=mameci64
 script:
   - if [ $TRAVIS_OS_NAME == 'linux' ]; then
     if [ $CC == 'clang' ]; then

--- a/scripts/src/cpu.lua
+++ b/scripts/src/cpu.lua
@@ -39,12 +39,16 @@ if (CPU_INCLUDE_DRC) then
 		MAME_DIR .. "src/devices/cpu/uml.h",
 		MAME_DIR .. "src/devices/cpu/x86log.cpp",
 		MAME_DIR .. "src/devices/cpu/x86log.h",
-		MAME_DIR .. "src/devices/cpu/drcbex86.cpp",
-		MAME_DIR .. "src/devices/cpu/drcbex86.h",
-		MAME_DIR .. "src/devices/cpu/drcbex64.cpp",
-		MAME_DIR .. "src/devices/cpu/drcbex64.h",
 		MAME_DIR .. "src/devices/cpu/drcumlsh.h",
 	}
+	if not _OPTIONS["FORCE_DRC_C_BACKEND"] then
+		files {
+			MAME_DIR .. "src/devices/cpu/drcbex64.cpp",
+			MAME_DIR .. "src/devices/cpu/drcbex64.h",
+			MAME_DIR .. "src/devices/cpu/drcbex86.cpp",
+			MAME_DIR .. "src/devices/cpu/drcbex86.h",
+		}
+	end
 end
 
 --------------------------------------------------

--- a/scripts/target/mame/ci.lua
+++ b/scripts/target/mame/ci.lua
@@ -1,0 +1,188 @@
+-- license:BSD-3-Clause
+-- copyright-holders:MAMEdev Team
+
+---------------------------------------------------------------------------
+--
+--   ci.lua
+--
+--   Small driver-specific example makefile for use in CI
+--   Use make SUBTARGET=ci to build
+--
+---------------------------------------------------------------------------
+
+
+--------------------------------------------------
+-- Specify all the CPU cores necessary for the
+-- drivers referenced in ci.lst.
+--------------------------------------------------
+
+CPUS["Z80"] = true
+CPUS["M6502"] = true
+CPUS["MCS48"] = true
+CPUS["MCS51"] = true
+CPUS["M6800"] = true
+CPUS["M6805"] = true
+CPUS["M6809"] = true
+CPUS["M680X0"] = true
+CPUS["TMS9900"] = true
+CPUS["COP400"] = true
+CPUS["MIPS3"] = true
+CPUS["ADSP21XX"] = true
+CPUS["FR"] = true
+
+--------------------------------------------------
+-- Specify all the sound cores necessary for the
+-- drivers referenced in ci.lst.
+--------------------------------------------------
+
+SOUNDS["SAMPLES"] = true
+SOUNDS["DAC"] = true
+SOUNDS["DISCRETE"] = true
+SOUNDS["AY8910"] = true
+SOUNDS["YM2151"] = true
+SOUNDS["ASTROCADE"] = true
+SOUNDS["TMS5220"] = true
+SOUNDS["OKIM6295"] = true
+SOUNDS["HC55516"] = true
+SOUNDS["YM3812"] = true
+SOUNDS["CEM3394"] = true
+SOUNDS["VOTRAX"] = true
+SOUNDS["VOLT_REG"] = true
+SOUNDS["DMADAC"] = true
+SOUNDS["CDDA"] = true
+
+--------------------------------------------------
+-- specify available video cores
+--------------------------------------------------
+
+VIDEOS["PS2GIF"] = true
+VIDEOS["PS2GS"] = true
+
+--------------------------------------------------
+-- specify available machine cores
+--------------------------------------------------
+
+MACHINES["6821PIA"] = true
+MACHINES["ADC0808"] = true
+MACHINES["TTL74148"] = true
+MACHINES["TTL74153"] = true
+MACHINES["TTL74157"] = true
+MACHINES["TTL7474"] = true
+MACHINES["TTL74259"] = true
+MACHINES["RIOT6532"] = true
+MACHINES["PIT8253"] = true
+MACHINES["Z80CTC"] = true
+MACHINES["Z80PIO"] = true
+MACHINES["68681"] = true
+MACHINES["BANKDEV"] = true
+MACHINES["GEN_LATCH"] = true
+MACHINES["INPUT_MERGER"] = true
+MACHINES["OUTPUT_LATCH"] = true
+MACHINES["TICKET"] = true
+MACHINES["WATCHDOG"] = true
+MACHINES["Z80DAISY"] = true
+MACHINES["NETLIST"] = true
+MACHINES["IDECTRL"] = true
+MACHINES["PS2INTC"] = true
+
+--------------------------------------------------
+-- specify available bus cores
+--------------------------------------------------
+
+BUSES["CENTRONICS"] = true
+BUSES["ATA"] = true
+
+--------------------------------------------------
+-- This is the list of files that are necessary
+-- for building all of the drivers referenced
+-- in ci.lst
+--------------------------------------------------
+
+function createProjects_mame_ci(_target, _subtarget)
+	project ("mame_ci")
+	targetsubdir(_target .."_" .. _subtarget)
+	kind (LIBTYPE)
+	uuid (os.uuid("drv-mame-ci"))
+	addprojectflags()
+	precompiledheaders_novs()
+
+	includedirs {
+		MAME_DIR .. "src/osd",
+		MAME_DIR .. "src/emu",
+		MAME_DIR .. "src/devices",
+		MAME_DIR .. "src/mame",
+		MAME_DIR .. "src/lib",
+		MAME_DIR .. "src/lib/util",
+		MAME_DIR .. "3rdparty",
+		GEN_DIR  .. "mame/layout",
+	}
+
+files{
+	MAME_DIR .. "src/mame/audio/nl_carpolo.h",
+	MAME_DIR .. "src/mame/audio/nl_carpolo.cpp",
+	MAME_DIR .. "src/mame/drivers/carpolo.cpp",
+	MAME_DIR .. "src/mame/includes/carpolo.h",
+	MAME_DIR .. "src/mame/machine/carpolo.cpp",
+	MAME_DIR .. "src/mame/video/carpolo.cpp",
+	MAME_DIR .. "src/mame/drivers/circus.cpp",
+	MAME_DIR .. "src/mame/includes/circus.h",
+	MAME_DIR .. "src/mame/audio/circus.cpp",
+	MAME_DIR .. "src/mame/video/circus.cpp",
+	MAME_DIR .. "src/mame/drivers/exidy.cpp",
+	MAME_DIR .. "src/mame/includes/exidy.h",
+	MAME_DIR .. "src/mame/audio/exidy.cpp",
+	MAME_DIR .. "src/mame/audio/exidy.h",
+	MAME_DIR .. "src/mame/video/exidy.cpp",
+	MAME_DIR .. "src/mame/audio/exidy440.cpp",
+	MAME_DIR .. "src/mame/audio/exidy440.h",
+	MAME_DIR .. "src/mame/drivers/starfire.cpp",
+	MAME_DIR .. "src/mame/audio/nl_fireone.h",
+	MAME_DIR .. "src/mame/audio/nl_fireone.cpp",
+	MAME_DIR .. "src/mame/includes/starfire.h",
+	MAME_DIR .. "src/mame/video/starfire.cpp",
+	MAME_DIR .. "src/mame/drivers/vertigo.cpp",
+	MAME_DIR .. "src/mame/includes/vertigo.h",
+	MAME_DIR .. "src/mame/machine/vertigo.cpp",
+	MAME_DIR .. "src/mame/video/vertigo.cpp",
+	MAME_DIR .. "src/mame/drivers/victory.cpp",
+	MAME_DIR .. "src/mame/includes/victory.h",
+	MAME_DIR .. "src/mame/video/victory.cpp",
+	MAME_DIR .. "src/mame/audio/targ.cpp",
+	MAME_DIR .. "src/mame/drivers/astrocde.cpp",
+	MAME_DIR .. "src/mame/includes/astrocde.h",
+	MAME_DIR .. "src/mame/video/astrocde.cpp",
+	MAME_DIR .. "src/mame/drivers/gridlee.cpp",
+	MAME_DIR .. "src/mame/includes/gridlee.h",
+	MAME_DIR .. "src/mame/audio/gridlee.cpp",
+	MAME_DIR .. "src/mame/video/gridlee.cpp",
+	MAME_DIR .. "src/mame/drivers/williams.cpp",
+	MAME_DIR .. "src/mame/includes/williams.h",
+	MAME_DIR .. "src/mame/machine/williams.cpp",
+	MAME_DIR .. "src/mame/audio/williams.cpp",
+	MAME_DIR .. "src/mame/audio/williams.h",
+	MAME_DIR .. "src/mame/video/williams.cpp",
+	MAME_DIR .. "src/mame/drivers/gaelco.cpp",
+	MAME_DIR .. "src/mame/includes/gaelco.h",
+	MAME_DIR .. "src/mame/video/gaelco.cpp",
+	MAME_DIR .. "src/mame/machine/gaelcrpt.cpp",
+	MAME_DIR .. "src/mame/drivers/wrally.cpp",
+	MAME_DIR .. "src/mame/includes/wrally.h",
+	MAME_DIR .. "src/mame/machine/wrally.cpp",
+	MAME_DIR .. "src/mame/video/wrally.cpp",
+	MAME_DIR .. "src/mame/video/gaelco_wrally_sprites.cpp",
+	MAME_DIR .. "src/mame/video/gaelco_wrally_sprites.h",
+	MAME_DIR .. "src/mame/machine/gaelco_ds5002fp.cpp",
+	MAME_DIR .. "src/mame/machine/gaelco_ds5002fp.h",
+	MAME_DIR .. "src/mame/drivers/looping.cpp",
+	MAME_DIR .. "src/mame/drivers/supertnk.cpp",
+	MAME_DIR .. "src/mame/drivers/kinst.cpp",
+	MAME_DIR .. "src/mame/audio/dcs.cpp",
+	MAME_DIR .. "src/mame/audio/dcs.h",
+}
+end
+
+function linkProjects_mame_ci(_target, _subtarget)
+	links {
+		"mame_ci",
+	}
+end

--- a/src/devices/cpu/drcuml.cpp
+++ b/src/devices/cpu/drcuml.cpp
@@ -36,8 +36,10 @@
 
 #include "emuopts.h"
 #include "drcbec.h"
+#ifdef NATIVE_DRC
 #include "drcbex86.h"
 #include "drcbex64.h"
+#endif
 
 #include <fstream>
 

--- a/src/mame/ci.lst
+++ b/src/mame/ci.lst
@@ -1,0 +1,41 @@
+// license:BSD-3-Clause
+// copyright-holders:Aaron Giles
+/******************************************************************************
+
+    ci.lst
+
+    List of all enabled drivers in the system. This file is parsed by
+    makelist.exe, sorted, and output as C code describing the drivers.
+
+******************************************************************************/
+
+robby           // (c) 1981 Bally Midway
+gridlee         // [1983 Videa] prototype - no copyright notice
+alienar         // (c) 1985 Duncan Brown
+
+carpolo         // (c) 1977 Exidy
+sidetrac        // (c) 1979 Exidy
+targ            // (c) 1980 Exidy
+spectar         // (c) 1980 Exidy
+teetert         // (c) 1982 Exidy
+hardhat         // (c) 1982
+fax             // (c) 1983
+fax2            // (c) 1983
+circus          // (c) 1977 Exidy
+robotbwl        // (c) 197? Exidy
+crash           // (c) 1979 Exidy
+ripcord         // (c) 1979 Exidy
+starfire        // (c) 1979 Exidy
+starfirea       // (c) 1979 Exidy
+fireone         // (c) 1979 Exidy
+starfir2        // (c) 1979 Exidy
+victory         // (c) 1982
+victorba        // (c) 1982
+topgunnr        // (c) 1986
+
+looping         // (c) 1982 Video Games GMBH
+supertnk        // (c) 1981 VIDEO GAMES GmbH, W.-GERMANY
+
+wrally          // (c) 1993 - Ref 930705
+
+kinst           // (c) 1994 Rare


### PR DESCRIPTION
As mentioned in #7037 and #7039, non-x86 build is broken which went unnoticed because the tiny build used for CI currently does not use DRC capable CPU cores.
The approach suggested here does build but I do not know whether it is correct. Thank you for reviewing.