### PR TITLE
Docs updates

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1036,7 +1036,7 @@ Core Search Path Options
     The default is ``.`` (that is, in the current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -homepath c:\mame\lua
 
@@ -1051,7 +1051,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -rompath c:\mame\roms;c:\roms\another
 
@@ -1066,7 +1066,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -hashpath c:\mame\hash;c:\roms\softlists
 
@@ -1081,7 +1081,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -samplepath c:\mame\samples;c:\roms\samples
 
@@ -1096,7 +1096,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -artpath c:\mame\artwork;c:\emu\shared-artwork
 
@@ -1111,7 +1111,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -ctrlrpath c:\mame\ctrlr;c:\emu\controllers
 
@@ -1140,7 +1140,7 @@ Core Search Path Options
     directory ``ini`` in the current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -inipath c:\users\thisuser\documents\mameini
 
@@ -1155,7 +1155,7 @@ Core Search Path Options
     The default is ``.`` (that is, search in the current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -fontpath c:\mame\;c:\emu\artwork\mamefonts
 
@@ -1170,7 +1170,7 @@ Core Search Path Options
     current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -cheatpath c:\mame\cheat;c:\emu\cheats
 
@@ -1185,7 +1185,7 @@ Core Search Path Options
     current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -crosshairpath c:\mame\crsshair;c:\emu\artwork\crosshairs
 
@@ -1199,7 +1199,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -pluginspath c:\mame\plugins;c:\emu\lua
 
@@ -1214,7 +1214,7 @@ Core Search Path Options
     current working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -languagepath c:\mame\language;c:\emu\mame-languages
 
@@ -1228,7 +1228,7 @@ Core Search Path Options
     working directory).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -swpath c:\mame\software;c:\emu\mydisks
 
@@ -1251,7 +1251,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -cfg_directory c:\mame\cfg
 
@@ -1269,7 +1269,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -nvram_directory c:\mame\nvram
 
@@ -1286,7 +1286,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -input_directory c:\mame\inp
 
@@ -1303,7 +1303,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -state_directory c:\mame\sta
 
@@ -1319,7 +1319,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -snapshot_directory c:\mame\snap
 
@@ -1338,7 +1338,7 @@ Core Output Directory Options
     automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -diff_directory c:\mame\diff
 
@@ -1355,7 +1355,7 @@ Core Output Directory Options
     created automatically.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -comment_directory c:\mame\comments
 
@@ -1380,7 +1380,7 @@ Core State/Playback Options
     command.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -norewind
 
@@ -1395,7 +1395,7 @@ Core State/Playback Options
     clamped to 0.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -rewind_capacity 30
 
@@ -1407,7 +1407,7 @@ Core State/Playback Options
     in the specified <slot> to be loaded.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -state 1
 
@@ -1423,7 +1423,7 @@ Core State/Playback Options
     The default is OFF (**-noautosave**).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 -autosave
 
@@ -1438,7 +1438,7 @@ Core State/Playback Options
     The default is ``NULL`` (no playback).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -playback worldrecord
 
@@ -1458,7 +1458,7 @@ Core State/Playback Options
     The default is OFF (**-noexit_after_playback**).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -playback worldrecord -exit_after_playback
 
@@ -1473,7 +1473,7 @@ Core State/Playback Options
     The default is ``NULL`` (no recording).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -record worldrecord
 
@@ -1494,7 +1494,7 @@ Core State/Playback Options
     By default, no timecode file is saved.
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -record worldrecord -record_timecode
 
@@ -1511,7 +1511,7 @@ Core State/Playback Options
     The default is ``NULL`` (no recording).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -mngwrite pacman-video
 
@@ -1531,7 +1531,7 @@ Core State/Playback Options
     The default is ``NULL`` (no recording).
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -playback worldrecord -exit_after_playback -aviwrite worldrecord
 
@@ -1547,7 +1547,7 @@ Core State/Playback Options
 .. _mame-commandline-snapname:
 
     Example:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 pacman -wavewrite pacsounds
 
@@ -1572,21 +1572,21 @@ Core State/Playback Options
     with the media switch you want to use.
 
     Example 1:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 robby -snapname foo\%g%i
 
         Snapshots will be saved as ``snaps\foo\robby0000.png``, ``snaps\foo\robby0001.png`` and so on.
 
     Example 2:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 nes -cart robby -snapname %g\%d_cart
 
         Snapshots will be saved as ``snaps\nes\robby.png``.
 
     Example 3:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 c64 -flop1 robby -snapname %g\%d_flop1/%i
 
@@ -1671,19 +1671,19 @@ Core State/Playback Options
     ``[media]`` with the media switch you want to use.
 
     Example 1:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 robby -statename foo\%g
             All save states will be stored inside sta\foo\robby\
 
     Example 2:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 nes -cart robby -statename %g/%d_cart
             All save states will be stored inside sta\nes\robby\
 
     Example 3:
-        .. code-block::
+        .. code-block:: bash
 
             mame64 c64 -flop1 robby -statename %g/%d_flop1
             All save states will be stored inside sta\c64\robby\
@@ -2180,6 +2180,7 @@ Core Video Options
     The default is OFF (**-nosyncrefresh**).
 
 .. _mame-commandline-prescale:
+
     Example:
         .. code-block:: bash
 
@@ -2890,7 +2891,7 @@ Core Sound Options
 
     The default is ``1``.
 
-    | For PortAudio, see :ref:`mame-commandline-pa-latency`.
+    | For PortAudio, see the section on :ref:`-pa_latency <mame-commandline-pa-latency>`.
     | XAudio2 calculates audio_latency as 10ms steps.
     | DSound calculates audio_latency as 10ms steps.
     | CoreAudio calculates audio_latency as 25ms steps.
@@ -3743,6 +3744,7 @@ Core Misc Options
     The default is (**-noui_mouse**).
 
 .. _mame-commandline-language:
+
     Example:
         .. code-block:: bash
 

--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -1387,6 +1387,19 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="ido_5_2">
+		<description>IRIS Development Option 5.2</description>
+		<year>1994</year> <!-- 03/94 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0129-004"/>
+			<!-- Origin: private dump -->
+			<diskarea name="cdrom">
+				<disk name="iris_development_option_5_2" sha1="b011702ba853d744e047dcf28091a75a06fcf972" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="ido_5_3">
 		<description>IRIS Development Option 5.3</description>
 		<year>1994</year> <!-- 11/94 -->
@@ -1409,6 +1422,19 @@ license:CC0
 			<!-- Origin: jrra.zone -->
 			<diskarea name="cdrom">
 				<disk name="iris_development_option_6_2" sha1="eabaa5238a3515f1c71d693efc2781b4d1675cf9" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="f77_4_0_1">
+		<description>FORTRAN 77 Compiler 4.0.1</description>
+		<year>1994</year> <!-- 03/94 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0132-005"/>
+			<!-- Origin: private dump -->
+			<diskarea name="cdrom">
+				<disk name="fortran_77_compiler_4_0_1" sha1="1d214d44deb8d68833e334628e333a54f7ce7c04" />
 			</diskarea>
 		</part>
 	</software>
@@ -1842,6 +1868,32 @@ license:CC0
 			<!-- Origin: private dump -->
 			<diskarea name="cdrom">
 				<disk name="supportfolio_irix_5_3_6_3_and_6_4_patches_4_97" sha1="b33cc43486fe375d126b8e39178f69072b0310d3" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="sadvantage_11_93">
+		<description>Support Advantage Int'l 11/93</description>
+		<year>1993</year> <!-- 11/93 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-4015-001"/>
+			<diskarea name="cdrom">
+				<!-- Origin: private dump -->
+				<disk name="support_advantage_intl_11_93.chd" sha1="36324701f84531b965046a17ed7aebfa4e8bf7ca" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="sadvantage_3_94">
+		<description>Support Advantage Int'l 3/94</description>
+		<year>1994</year> <!-- 3/94 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-4015-002"/>
+			<diskarea name="cdrom">
+				<!-- Origin: private dump -->
+				<disk name="support_advantage_intl_3_94.chd" sha1="3079331e1f47f6d9537d1a1dcda9c00ad3a6b0af" />
 			</diskarea>
 		</part>
 	</software>
@@ -2377,6 +2429,19 @@ license:CC0
 			<!-- Origin: private dump -->
 			<diskarea name="cdrom">
 				<disk name="irix_5_2_for_indy_r4600sc_xz_and_presenter" sha1="5f81496d2291e80d8d0bd5b0c470725fc6214ab4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="irix_5_2_patches">
+		<description>IRIX 5.2 Patches</description>
+		<year>1994</year> <!-- 06/94 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0290-001"/>
+			<!-- Origin: private dump -->
+			<diskarea name="cdrom">
+				<disk name="irix_5_2_patches" sha1="fb7e6b45f0cc96d40f9e2634882345f4846bfb60" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
RTD/Sphinx is now more strict about code blocks, busting HTML generation somewhat. Additionally manfiles weren't being compiled due to compilation choking on lack of blank lines at two points-- but only for manfile compilation. HTML was fine with that.