### PR TITLE
Define IMGUI_DISABLE_OBSOLETE_FUNCTIONS consistently

### DIFF
--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1395,6 +1395,7 @@ end
 		"__STDC_FORMAT_MACROS",
 		"__STDC_CONSTANT_MACROS",
 		"BGFX_CONFIG_MAX_FRAME_BUFFERS=128",
+		"IMGUI_DISABLE_OBSOLETE_FUNCTIONS",
 	}
 
 	if _OPTIONS["targetos"]=="linux" or _OPTIONS["targetos"]=="netbsd" or _OPTIONS["targetos"]=="openbsd" then


### PR DESCRIPTION
IMGUI_DISABLE_OBSOLETE_FUNCTIONS was defined in osd/modules.lua but not
in 3rdparty.lua. As a result, two different variants of struct ImGuiIO
were being defined, causing a C++ One Definition Rule violation