### PR TITLE
gameking: added crude DAC to give sound

### DIFF
--- a/src/devices/cpu/m6502/st2204.cpp
+++ b/src/devices/cpu/m6502/st2204.cpp
@@ -289,7 +289,7 @@ TIMER_CALLBACK_MEMBER(st2204_device::dac_interrupt)
 void st2204_device::update_dac_timer()
 {
 	// TODO: this should be calculated from registers! (all gameking games set the same values?)
-	m_dactimer->adjust(attotime::from_hz(8000));
+	m_dactimer->adjust(attotime::from_hz(6000000/128/6));
 }
 
 void st2204_device::timer_start_from_tclk(int t)

--- a/src/devices/cpu/m6502/st2204.h
+++ b/src/devices/cpu/m6502/st2204.h
@@ -13,6 +13,9 @@
 #pragma once
 
 #include "st2xxx.h"
+#include "sound/dac.h"
+#include "sound/volt_reg.h"
+#include "speaker.h"
 
 class st2204_device : public st2xxx_device
 {
@@ -32,6 +35,7 @@ public:
 
 protected:
 	st2204_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, address_map_constructor int_map);
+	virtual void device_add_mconfig(machine_config &config) override;
 
 	virtual void device_start() override;
 	virtual void device_reset() override;
@@ -75,6 +79,7 @@ private:
 
 	TIMER_CALLBACK_MEMBER(t0_interrupt);
 	TIMER_CALLBACK_MEMBER(t1_interrupt);
+	TIMER_CALLBACK_MEMBER(dac_interrupt);
 	void timer_start_from_tclk(int t);
 	void t1_start_from_oscx();
 	u8 t0m_r();
@@ -110,11 +115,15 @@ private:
 	u8 m_tcntr[2];
 	u8 m_tload[2];
 	emu_timer *m_timer[2];
+	emu_timer *m_dactimer;
 	u16 m_psg[2];
 	u8 m_psgc;
 	u16 m_dms;
 	u16 m_dmd;
 	u8 m_dcnth;
+
+	void update_dac_timer();
+	required_device<dac_8bit_r2r_twos_complement_device> m_dac;
 };
 
 class st2202_device : public st2204_device


### PR DESCRIPTION
this is just using a hardcoded frequency on the timer, I couldn't get the calculations to give the correct value, all games seem to use the same values so this is enough to give sound in gameking and gameking3

@ajrhacker feel free to reject if you have something better, I was just fed up of running these in silence, it can certainly be tweaked / improved / made to use the proper written value.