### PR TITLE
vsmile: Simple controller LED visualization support

### DIFF
--- a/src/mame/drivers/vsmile.cpp
+++ b/src/mame/drivers/vsmile.cpp
@@ -13,6 +13,8 @@
 #include "softlist.h"
 #include "speaker.h"
 
+#include "vsmile.lh"
+
 #define VERBOSE (1)
 #include "logmacro.h"
 
@@ -57,6 +59,11 @@ void vsmile_state::machine_start()
 {
 	vsmile_base_state::machine_start();
 
+	m_redled.resolve();
+	m_yellowled.resolve();
+	m_blueled.resolve();
+	m_greenled.resolve();
+
 	save_item(NAME(m_ctrl_rts));
 	save_item(NAME(m_ctrl_select));
 }
@@ -85,6 +92,25 @@ void vsmile_state::uart_rx(uint8_t data)
 	//printf("Ctrl Rx: %02x\n", data);
 	m_ctrl[0]->data_w(data);
 	m_ctrl[1]->data_w(data);
+
+	//TODO: should be moved to pad code somehow
+	if ((data & 0xF0) == 0x60)
+	{
+		if (m_ctrl_select[0])
+		{
+			m_redled[0] = BIT(data, 3);
+			m_yellowled[0] = BIT(data, 2);
+			m_blueled[0] = BIT(data, 1);
+			m_greenled[0] = BIT(data, 0);
+		}
+		if (m_ctrl_select[1])
+		{
+			m_redled[1] = BIT(data, 3);
+			m_yellowled[1] = BIT(data, 2);
+			m_blueled[1] = BIT(data, 1);
+			m_greenled[1] = BIT(data, 0);
+		}
+	}
 }
 
 uint16_t vsmile_state::portb_r()
@@ -245,6 +271,8 @@ static void vsmile_cart(device_slot_interface &device)
 
 void vsmile_base_state::vsmile_base(machine_config &config)
 {
+	config.set_default_layout(layout_vsmile);
+
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_refresh_hz(60);
 	m_screen->set_size(320, 262);

--- a/src/mame/includes/vsmile.h
+++ b/src/mame/includes/vsmile.h
@@ -68,6 +68,10 @@ public:
 		: vsmile_base_state(mconfig, type, tag)
 		, m_ctrl(*this, "ctrl%u", 1U)
 		, m_dsw_region(*this, "REGION")
+		, m_redled(*this, "redled%u", 1U)
+		, m_yellowled(*this, "yellowled%u", 1U)
+		, m_blueled(*this, "blueled%u", 1U)
+		, m_greenled(*this, "greenled%u", 1U)
 	{ }
 
 	void vsmile(machine_config &config);
@@ -109,6 +113,11 @@ private:
 
 	required_device_array<vsmile_ctrl_port_device, 2> m_ctrl;
 	required_ioport m_dsw_region;
+
+	output_finder<2> m_redled;
+	output_finder<2> m_yellowled;
+	output_finder<2> m_blueled;
+	output_finder<2> m_greenled;
 
 	bool m_ctrl_rts[2];
 	bool m_ctrl_select[2];

--- a/src/mame/layout/vsmile.lay
+++ b/src/mame/layout/vsmile.lay
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!--
+license:CC0
+-->
+<mamelayout version="2">
+	<element name="redled" defstate="0">
+		<disk state="1">
+			<color red="0.75" green="0.0" blue="0.0" />
+		</disk>
+		<disk state="0">
+			<color red="0.20" green="0.0" blue="0.0" />
+		</disk>
+	</element>
+	<element name="yellowled" defstate="0">
+		<disk state="1">
+			<color red="0.75" green="0.75" blue="0.0" />
+		</disk>
+		<disk state="0">
+			<color red="0.20" green="0.20" blue="0.0" />
+		</disk>
+	</element>
+	<element name="blueled" defstate="0">
+		<disk state="1">
+			<color red="0" green="0.0" blue="0.75" />
+		</disk>
+		<disk state="0">
+			<color red="0.0" green="0.0" blue="0.20" />
+		</disk>
+	</element>
+	<element name="greenled" defstate="0">
+		<disk state="1">
+			<color red="0.0" green="0.75" blue="0.0" />
+		</disk>
+		<disk state="0">
+			<color red="0.0" green="0.20" blue="0.0" />
+		</disk>
+	</element>
+	<view name="Screen Only">
+		<screen index="0">
+			<bounds x="0" y="0" width="320" height="240" />
+		</screen>
+	</view>
+	<view name="Screen with Controller LEDs">
+		<screen index="0">
+			<bounds x="0" y="0" width="320" height="240" />
+		</screen>
+		<bezel name="redled1" element="redled">
+			<bounds x="5" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="yellowled1" element="yellowled">
+			<bounds x="20" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="blueled1" element="blueled">
+			<bounds x="35" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="greenled1" element="greenled">
+			<bounds x="50" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="redled2" element="redled">
+			<bounds x="260" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="yellowled2" element="yellowled">
+			<bounds x="275" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="blueled2" element="blueled">
+			<bounds x="290" y="245" width="10" height="10" />
+		</bezel>
+		<bezel name="greenled2" element="greenled">
+			<bounds x="305" y="245" width="10" height="10" />
+		</bezel>
+	</view>
+</mamelayout>


### PR DESCRIPTION
This PR adds support for visualizing the LEDs in the V.Smile controllers using an opt-in custom layout.
The exact design of the layout could of course be discussed and improved on.