### PR TITLE
ibm5150 - New working software list additions

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -11734,10 +11734,22 @@ has been replaced with an all-zero block. -->
 		</part>
 	</software>
 
-	<software name="ppersia35a" cloneof="ppersia">
+	<software name="ppersia35c" cloneof="ppersia">
 		<description>Prince of Persia (3.5", v1.1)</description>
 		<year>1990</year>
 		<publisher>Brøderbund Software</publisher>
+		<info name="version" value="V1.1" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size = "737280">
+				<rom name="Prince of Persia (v1.1) [Broderbund] [1990] [3.5DD] [Disk 1 of 1].img" size="737280" crc="151bbd64" sha1="6340b76af36796e41432cf15f85b26c882229a34"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ppersia35a" cloneof="ppersia">
+		<description>Prince of Persia (3.5", v1.1, Hit Squad release)</description>
+		<year>1992</year>
+		<publisher>Hit Squad</publisher>
 		<info name="version" value="V1.1" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size = "737280">
@@ -11776,7 +11788,7 @@ has been replaced with an all-zero block. -->
 	</software>
 
 	<software name="ppersia35fr" cloneof="ppersia">
-		<description>Prince of Persia (3.5", v1.0, French)</description>
+		<description>Prince of Persia (3.5", v1.0, France)</description>
 		<year>1990</year>
 		<publisher>Brøderbund Software</publisher>
 		<info name="version" value="V1.0" />
@@ -13207,6 +13219,19 @@ has been replaced with an all-zero block. -->
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size = "304146">
 				<rom name="wizzard.imd" size="304146" crc="05215c36" sha1="05b0fb2dd5ceae97fde46a071da06393e4803cd8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wolfpack">
+		<description>Wolfpack (USA)</description>
+		<year>1990</year>
+		<publisher>Brøderbund</publisher>
+		<info name="developer" value="Novalogic" />
+		<info name="version" value="1.10" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size = "737280">
+				<rom name="Wolfpack [Broderbund] [1990] [3.5DD] [Disk 1 of 1].img" size="737280" crc="09fd3cb5" sha1="3b51892af5c41303ce50e34d64cb85f464dbccd8"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Added: Prince of Persia (3.5", v1.1), Wolfpack (USA)
Renamed [ppersia35a]: Prince of Persia (3.5", v1.1) --> Prince of Persia (3.5", v1.1, Hit Squad release)
Renamed [ppersia35fr]: Prince of Persia (3.5", v1.0, French) --> Prince of Persia (3.5", v1.0, France)