### PR TITLE
Pass FORCE_C_DRC_BACKEND=1 on ppc architectures

### DIFF
--- a/makefile
+++ b/makefile
@@ -392,6 +392,13 @@ ifndef NOASM
 endif
 endif
 
+# ppc has inline assembly support but no DRC
+ifeq ($(findstring ppc,$(UNAME)),ppc)
+ifndef FORCE_DRC_C_BACKEND
+	FORCE_DRC_C_BACKEND := 1
+endif
+endif
+
 # Autodetect BIGENDIAN
 # MacOSX
 ifndef BIGENDIAN


### PR DESCRIPTION
PowerPC architecture is special in a way that it has some inline assembly
code but no DRC support. As a result, NOASM=1 was never configured.
In contrast to the old DRC, asmjit only compiles on the architectures it
supports. FORCE_C_DRC_BACKEND=1 needs to be passed to the makefile or
the compilation will fail.

CI target does compile on travis but fails to validate. Full compilation is likely going to fail due to #3157 but with this PR there is one issue fewer.