### PR TITLE
chdman: generate IDNT from template and add a few more templates

### DIFF
--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1823,6 +1823,7 @@ static void do_create_hd(parameters_map &params)
 
 	// process template
 	auto template_str = params.find(OPTION_TEMPLATE);
+	std::string template_idnt_str;
 	if (template_str != params.end())
 	{
 		uint32_t id = parse_number(template_str->second->c_str());
@@ -1834,8 +1835,12 @@ static void do_create_hd(parameters_map &params)
 		heads = s_hd_templates[id].heads;
 		sectors = s_hd_templates[id].sectors;
 		sector_size = s_hd_templates[id].sector_size;
+		std::string manuf_str(s_hd_templates[id].manufacturer);
+		std::transform(manuf_str.begin(), manuf_str.end(), manuf_str.begin(), ::toupper);
+		template_idnt_str = string_format("%-8s%-16s%4s", manuf_str.substr(0, 6), s_hd_templates[id].model, "1.00");
 
 		printf("Template:     %s %s\n", s_hd_templates[id].manufacturer, s_hd_templates[id].model);
+		printf("Identifier:   %s\n", template_idnt_str.c_str());
 	}
 
 	// extract geometry from the parent if we have one
@@ -1908,6 +1913,12 @@ static void do_create_hd(parameters_map &params)
 		{
 			err = chd->write_metadata(HARD_DISK_IDENT_METADATA_TAG, 0, identdata);
 			if (err != CHDERR_NONE)
+				report_error(1, "Error adding hard disk metadata: %s", chd_file::error_string(err));
+		}
+		else if (!template_idnt_str.empty())
+		{
+		  err = chd->write_metadata(HARD_DISK_IDENT_METADATA_TAG, 0, template_idnt_str);
+		  if (err != CHDERR_NONE)
 				report_error(1, "Error adding hard disk metadata: %s", chd_file::error_string(err));
 		}
 

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -108,6 +108,7 @@ const int MODE_GDI = 2;
 #define OPTION_NUMPROCESSORS "numprocessors"
 #define OPTION_SIZE "size"
 #define OPTION_TEMPLATE "template"
+#define OPTION_GENIDENT "genident"
 
 
 //**************************************************************************
@@ -156,7 +157,7 @@ struct command_description
 	const char *name;
 	void (*handler)(parameters_map &);
 	const char *description;
-	const char *valid_options[16];
+	const char *valid_options[17];
 };
 
 
@@ -597,6 +598,7 @@ static const option_description s_options[] =
 	{ OPTION_VERBOSE,               "v",    false, ": output additional information" },
 	{ OPTION_SIZE,                  "s",    true, ": <bytes>: size of the output file" },
 	{ OPTION_TEMPLATE,              "tp",   true, ": <id>: use hard disk template (see listtemplates)" },
+	{ OPTION_GENIDENT,              "gi",   false, ": populate IDENT with generated string from template data" },
 };
 
 
@@ -651,7 +653,8 @@ static const command_description s_commands[] =
 			OPTION_CHS,
 			OPTION_SIZE,
 			OPTION_SECTOR_SIZE,
-			OPTION_NUMPROCESSORS
+			OPTION_NUMPROCESSORS,
+			OPTION_GENIDENT
 		}
 	},
 
@@ -1843,12 +1846,17 @@ static void do_create_hd(parameters_map &params)
 		heads = s_hd_templates[id].heads;
 		sectors = s_hd_templates[id].sectors;
 		sector_size = s_hd_templates[id].sector_size;
-		std::string manuf_str(s_hd_templates[id].manufacturer);
-		std::transform(manuf_str.begin(), manuf_str.end(), manuf_str.begin(), ::toupper);
-		template_idnt_str = string_format("%-8s%-16s%4s", manuf_str.substr(0, 6), s_hd_templates[id].model, "1.00");
 
 		printf("Template:     %s %s\n", s_hd_templates[id].manufacturer, s_hd_templates[id].model);
-		printf("Identifier:   %s\n", template_idnt_str.c_str());
+
+		auto genident_bool = params.find(OPTION_GENIDENT);
+		if (genident_bool != params.end())
+		{
+			std::string manuf_str(s_hd_templates[id].manufacturer);
+			std::transform(manuf_str.begin(), manuf_str.end(), manuf_str.begin(), ::toupper);
+			template_idnt_str = string_format("%-8s%-16s%4s", manuf_str.substr(0, 6), s_hd_templates[id].model, "1.00");
+			printf("Identifier:   %s\n", template_idnt_str.c_str());
+		}
 	}
 
 	// extract geometry from the parent if we have one

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -784,11 +784,19 @@ static const command_description s_commands[] =
 // hard disk templates
 static const hd_template s_hd_templates[] =
 {
-	{ "Conner", "CFA170A", 332, 16, 63, 512 }, // 163 MB
-	{ "Rodime", "R0201",   321,  2, 16, 512 }, //   5 MB
-	{ "Rodime", "R0202",   321,  4, 16, 512 }, //  10 MB
-	{ "Rodime", "R0203",   321,  6, 16, 512 }, //  15 MB
-	{ "Rodime", "R0204",   321,  8, 16, 512 }, //  20 MB
+	{ "Conner",     "CFA170A",    332, 16, 63, 512 }, //  163 MB
+	{ "Rodime",     "R0201",      321,  2, 16, 512 }, //    5 MB
+	{ "Rodime",     "R0202",      321,  4, 16, 512 }, //   10 MB
+	{ "Rodime",     "R0203",      321,  6, 16, 512 }, //   15 MB
+	{ "Rodime",     "R0204",      321,  8, 16, 512 }, //   20 MB
+	{ "Seagate",    "ST-213",     615,  2, 17, 512 }, //   10 MB
+	{ "Seagate",    "ST-225",     615,  4, 17, 512 }, //   20 MB
+	{ "Seagate",    "ST-251",     820,  6, 17, 512 }, //   40 MB
+	{ "Seagate",    "ST-3600N",  1877,  7, 76, 512 }, //  525 MB
+	{ "Maxtor",     "LXT-213S",  1314,  7, 53, 512 }, //  200 MB
+	{ "Maxtor",     "LXT-340S",  1574,  7, 70, 512 }, //  340 MB
+	{ "Maxtor",     "MXT-540SL", 2466,  7, 87, 512 }, //  540 MB
+	{ "Micropolis", "1528",      2094, 15, 83, 512 }, // 1342 MB
 };
 
 
@@ -1917,8 +1925,8 @@ static void do_create_hd(parameters_map &params)
 		}
 		else if (!template_idnt_str.empty())
 		{
-		  err = chd->write_metadata(HARD_DISK_IDENT_METADATA_TAG, 0, template_idnt_str);
-		  if (err != CHDERR_NONE)
+			err = chd->write_metadata(HARD_DISK_IDENT_METADATA_TAG, 0, template_idnt_str);
+			if (err != CHDERR_NONE)
 				report_error(1, "Error adding hard disk metadata: %s", chd_file::error_string(err));
 		}
 


### PR DESCRIPTION
Programmatically generate a stub IDNT when building a chd hard drive from a template. The version is always hardcoded to "1.00", mostly because I've never seen anything else in the wild. Also extend the template list with a few more entries while at it.