### PR TITLE
Drop MASK from taputil.sh

### DIFF
--- a/src/osd/sdl/taputil.sh
+++ b/src/osd/sdl/taputil.sh
@@ -22,9 +22,9 @@ ip tuntap del dev $TAP mode tap
 exit
 fi
 
-if [ "$#" != "5" ]
+if [ "$#" != "4" ]
 then
-echo "usage: mess-tap [-c] [-d] USER EMUADDR HOSTADDR MASK"
+echo "usage: mess-tap [-c] [-d] USER EMUADDR HOSTADDR"
 echo "-c        create interface"
 echo "-d        delete interface"
 echo "USER      user to own interface, required to delete"


### PR DESCRIPTION
I found this while doing the Uthernet work.  The taputil.sh script mentions a "MASK" command line arg and treats it as mandatory but then doesn't actually make any use of it.  So, I dropped it from my copy and the team may be interested in picking that up.

If there's interest in me adding some scripting to perform the iptables commands for performing IP masquerading, I'm happy to do that, too.  Alternatively, it's something that could be added to documentation.