### PR TITLE
Add support for WAV tape files to VG5000µ and fix timings.

### DIFF
--- a/src/lib/formats/vg5k_cas.cpp
+++ b/src/lib/formats/vg5k_cas.cpp
@@ -234,4 +234,5 @@ static const struct CassetteFormat vg5k_k7_format =
 
 CASSETTE_FORMATLIST_START(vg5k_cassette_formats)
 	CASSETTE_FORMAT(vg5k_k7_format)
+    CASSETTE_FORMAT(wavfile_format)
 CASSETTE_FORMATLIST_END


### PR DESCRIPTION
Add wavfile support for reading/writing tapes, for more accuracy. The currently supported K7 file type misses timing data.

VG5000µ adds a wait cycle after the second T state of the M1 cycle of the Z80. Because it was not emulated, the timings were off, especially in the sensible cassette read/write routines.

With wavfile support added and timings fixed, the emulation can now read/write cassette at 1200 and 2400 bauds.

Still keeping the MACHINE_NOT_WORKING flag, as real hardware tests need to be complete.