### PR TITLE
pcp8718 / pcp8728 work, including unsp2.0 fixes [David Haywood]

### DIFF
--- a/src/devices/cpu/unsp/unsp_extended.cpp
+++ b/src/devices/cpu/unsp/unsp_extended.cpp
@@ -64,14 +64,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 
 			if (size == 0) size = 8;
 
-			while (size>0)
+			while (size--)
 			{
 				push(m_core->m_r[((rx--)&7) + 8], &m_core->m_r[rb]);
-				size--;
 			}
-
-			// FF80 CA20     Extended group) push r13, r10 to [sp]
-
 			return;
 		}
 		else
@@ -82,14 +78,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 
 			if (size == 0) size = 8;
 
-			while (size>0)
+			while (size--)
 			{
 				m_core->m_r[((++rx)&7) + 8] = pop(&m_core->m_r[rb]);
-				size--;
 			}
-
-			// FF80 4220   (Extended group) pop r10, r13 from [sp]
-
 			return;
 		}
 		return;

--- a/src/devices/cpu/unsp/unsp_extended.cpp
+++ b/src/devices/cpu/unsp/unsp_extended.cpp
@@ -64,17 +64,10 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 
 			if (size == 0) size = 8;
 
-			if ((rx - (size - 1)) >= 0)
+			while (size>0)
 			{
-				while (size--)
-				{
-					push(m_core->m_r[(rx--) + 8], &m_core->m_r[rb]);
-				}
-			}
-			else
-			{
-				logerror("(Ext) push <BAD>\n");
-				unimplemented_opcode(op, ximm);
+				push(m_core->m_r[((rx++)&7) + 8], &m_core->m_r[rb]);
+				size--;
 			}
 
 			return;
@@ -85,24 +78,13 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 			uint8_t size = (ximm & 0x7000) >> 12;
 			uint8_t rx = (ximm & 0x0e00) >> 9;
 
-
 			if (size == 0) size = 8;
 
-			if ((rx - (size - 1)) >= 0)
+			while (size>0)
 			{
-				int realrx = 7 - rx;
-
-				while (size--)
-				{
-					m_core->m_r[(realrx++) + 8] = pop(&m_core->m_r[rb]);
-				}
+				m_core->m_r[((--rx)&7) + 8] = pop(&m_core->m_r[rb]);
+				size--;
 			}
-			else
-			{
-				logerror("(Ext) pop <BAD>\n");
-				unimplemented_opcode(op, ximm);
-			}
-
 
 			return;
 		}

--- a/src/devices/cpu/unsp/unsp_extended.cpp
+++ b/src/devices/cpu/unsp/unsp_extended.cpp
@@ -66,9 +66,11 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 
 			while (size>0)
 			{
-				push(m_core->m_r[((rx++)&7) + 8], &m_core->m_r[rb]);
+				push(m_core->m_r[((rx--)&7) + 8], &m_core->m_r[rb]);
 				size--;
 			}
+
+			// FF80 CA20     Extended group) push r13, r10 to [sp]
 
 			return;
 		}
@@ -82,9 +84,11 @@ void unsp_20_device::execute_extended_group(uint16_t op)
 
 			while (size>0)
 			{
-				m_core->m_r[((--rx)&7) + 8] = pop(&m_core->m_r[rb]);
+				m_core->m_r[((++rx)&7) + 8] = pop(&m_core->m_r[rb]);
 				size--;
 			}
+
+			// FF80 4220   (Extended group) pop r10, r13 from [sp]
 
 			return;
 		}

--- a/src/devices/cpu/unsp/unsp_other.cpp
+++ b/src/devices/cpu/unsp/unsp_other.cpp
@@ -350,7 +350,7 @@ bool unsp_device::do_basic_alu_ops(const uint16_t &op0, uint32_t &lres, uint16_t
 		return false;
 
 	default:
-		fatalerror("UNSP: illegal ALU optype %02x at %04x\n", op0, UNSP_LPC);
+		logerror("UNSP: illegal ALU optype %02x at %04x\n", op0, UNSP_LPC);
 		return false;
 	}
 

--- a/src/devices/cpu/unsp/unsp_other.cpp
+++ b/src/devices/cpu/unsp/unsp_other.cpp
@@ -350,6 +350,8 @@ bool unsp_device::do_basic_alu_ops(const uint16_t &op0, uint32_t &lres, uint16_t
 		return false;
 
 	default:
+		// pcp87xx 'Elevator Action' explicitly jumps into the middle of an earlier opcode (off-by-one error in the code)
+		// It looks like the illegal op should have no meaningful effect so just log rather than fatalerroring
 		logerror("UNSP: illegal ALU optype %02x at %04x\n", op0, UNSP_LPC);
 		return false;
 	}

--- a/src/devices/cpu/unsp/unspdasm_extended.cpp
+++ b/src/devices/cpu/unsp/unspdasm_extended.cpp
@@ -133,15 +133,15 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 			uint8_t rx   = (ximm & 0x0e00) >> 9;
 
 			if (size == 0) size = 8;
-			size -= 1;
 
-			if ((rx-size) >= 0)
-				util::stream_format(stream, "(Extended group) push %s, %s to [%s]",
-					   extregs[rx-size],
-					   extregs[rx],
-					   (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
-			else
-				util::stream_format(stream, "(Extended group) push <BAD>");
+			int start = rx; // r13
+			int end = (start-(size-1))&7; // r10
+
+			util::stream_format(stream, "(Extended group) push %s, %s to [%s]",
+					extregs[start],
+					extregs[end],
+					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+
 		}
 		else
 		{
@@ -150,15 +150,14 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 			uint8_t rx   = (ximm & 0x0e00) >> 9;
 
 			if (size == 0) size = 8;
-			size -= 1;
 
-			if ((rx-size) >= 0)
-				util::stream_format(stream, "(Extended group) pop %s, %s from [%s]",
-					   extregs[7-rx],
-					   extregs[7-(rx-size)],
-					   (rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
-			else
-				util::stream_format(stream, "(Extended group) pop <BAD>");
+			int start = (rx + 1)&7;
+			int end = (start+(size-1))&7;
+
+			util::stream_format(stream, "(Extended group) pop %s, %s from [%s]",
+					extregs[start],
+					extregs[end],
+					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 		}
 		return UNSP_DASM_OK;
 	}

--- a/src/devices/cpu/unsp/unspdasm_extended.cpp
+++ b/src/devices/cpu/unsp/unspdasm_extended.cpp
@@ -142,13 +142,16 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 					extregs[end],
 					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
 
+			// FF80 CA20     Extended group) push r13, r10 to [sp]
+
+
 		}
 		else
 		{
 			uint8_t rb =   (ximm & 0x000f) >> 0;
 			uint8_t size = (ximm & 0x7000) >> 12;
 			uint8_t rx   = (ximm & 0x0e00) >> 9;
-
+			
 			if (size == 0) size = 8;
 
 			int start = (rx + 1)&7;
@@ -158,6 +161,9 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 					extregs[start],
 					extregs[end],
 					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
+
+			// FF80 4220   (Extended group) pop r10, r13 from [sp]
+
 		}
 		return UNSP_DASM_OK;
 	}

--- a/src/devices/cpu/unsp/unspdasm_extended.cpp
+++ b/src/devices/cpu/unsp/unspdasm_extended.cpp
@@ -134,17 +134,13 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 
 			if (size == 0) size = 8;
 
-			int start = rx; // r13
-			int end = (start-(size-1))&7; // r10
+			int start = rx;
+			int end = (start-(size-1))&7;
 
 			util::stream_format(stream, "(Extended group) push %s, %s to [%s]",
 					extregs[start],
 					extregs[end],
 					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
-
-			// FF80 CA20     Extended group) push r13, r10 to [sp]
-
-
 		}
 		else
 		{
@@ -161,9 +157,6 @@ offs_t unsp_20_disassembler::disassemble_extended_group(std::ostream& stream, of
 					extregs[start],
 					extregs[end],
 					(rb & 0x8) ? extregs[rb & 0x7] : regs[rb & 0x7]);
-
-			// FF80 4220   (Extended group) pop r10, r13 from [sp]
-
 		}
 		return UNSP_DASM_OK;
 	}

--- a/src/mame/drivers/generalplus_gpl_unknown.cpp
+++ b/src/mame/drivers/generalplus_gpl_unknown.cpp
@@ -139,6 +139,9 @@ private:
 	uint16_t unk_7860_r();
 	uint16_t unk_780f_r();
 
+	void unk_7860_w(uint16_t data);
+	uint16_t m_7860;
+
 	void unk_7868_w(uint16_t data);
 	uint16_t unk_7868_r();
 	uint16_t m_7868;
@@ -351,7 +354,20 @@ uint16_t pcp8718_state::unk_7abf_r()
 
 uint16_t pcp8718_state::unk_7860_r()
 {
-	return (machine().rand() & 0x0008) | (m_io_p2->read() & 0xfff7);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: unk_7860_r (IO port)\n", machine().describe_context());
+
+	uint16_t ret = (m_io_p2->read() & 0xfff7);
+
+	if ((m_7860 & 0x20))
+		ret |= 0x08;
+
+	return ret;
+}
+
+void pcp8718_state::unk_7860_w(uint16_t data)
+{
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: unk_7860_w %04x (IO port)\n", machine().describe_context(), data);
+	m_7860 = data;
 }
 
 
@@ -718,7 +734,7 @@ uint16_t pcp8718_state::system_dma_params_channel0_r(offs_t offset)
 
 uint16_t pcp8718_state::unk_7870_r()
 {
-	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: unk_7870_r (IO port)\n", machine().describe_context());
+	logerror("%06x: unk_7870_r (IO port)\n", machine().describe_context());
 	return m_io_p2->read();
 }
 
@@ -746,15 +762,13 @@ void pcp8718_state::map(address_map &map)
 	map(0x00780f, 0x00780f).r(FUNC(pcp8718_state::unk_780f_r));
 
 
-	map(0x007860, 0x007860).r(FUNC(pcp8718_state::unk_7860_r)).nopw();
+	map(0x007860, 0x007860).rw(FUNC(pcp8718_state::unk_7860_r),FUNC(pcp8718_state::unk_7860_w));
+	map(0x007862, 0x007862).nopw();
 	map(0x007863, 0x007863).nopw();
 
-	map(0x007870, 0x007870).r(FUNC(pcp8718_state::unk_7870_r)); // I/O
-
-	map(0x007862, 0x007862).nopw();
-
-
 	map(0x007868, 0x007868).rw(FUNC(pcp8718_state::unk_7868_r), FUNC(pcp8718_state::unk_7868_w));
+
+	map(0x007870, 0x007870).r(FUNC(pcp8718_state::unk_7870_r)); // I/O
 
 	map(0x007940, 0x007940).w(FUNC(pcp8718_state::spi_control_w));
 	// 7941 SPI Transmit Status

--- a/src/mame/drivers/generalplus_gpl_unknown.cpp
+++ b/src/mame/drivers/generalplus_gpl_unknown.cpp
@@ -949,41 +949,64 @@ uint16_t pcp8718_state::ramcall_287a_logger_r()
 			}
 			else if ((command) == 0x04)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set add value)\n", command, param);
 				// used with down
 				if (param == 0x03)
 					m_addval = 4;
 				else if (param == 0x00)
 					m_addval = 0;
+
+				// used if you try to scroll up or left past 0 and the value becomes too large (a negative number)
+				// actually writes 0x314 split into 2 commands, so the 2nd write to 0x04 with param then instead 0b/16 sequence of writes instead of 26/0c adds to the high byte?
+				if (param == 0x14)
+					m_addval = 0x314;
+
 			}
 			else if ((command) == 0x05)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set subtract value)\n", command, param);
+
+				// used if you try to scroll down past the and the value becomes too large
+				// actually writes 0x313 split into 2 commands, so the 2nd write to 0x05 with param then instead 0b/16 sequence of writes instead of 26/0c subtracts from the high byte?
+				if (param == 0x13)
+					m_addval = -0x314; // why 314, it writes 313
+
+			}
+			else if ((command) == 0x10)
+			{
+				// this is followed by 0x1b, written if you try to move right off last entry
+				m_stored_gamenum = 0x00;
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x (reset value)\n", command);
 			}
 			else if (command == 0x26)
 			{
-				// used in direction handlers
+				// used in direction handlers after writing the first command
 				m_stored_gamenum += m_addval;
 				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
-				// command 0x0c is called after 26
 			}
 			else if (command == 0x30)
 			{
 				// used with right
 				m_addval = 1;
 				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				// 26/0c called after this, then another fixed command value, then 0b/16
+				// unlike commands 04/05 there's no parameter byte written here, must be derived from the command? 
 			}
 			else if (command == 0x37)
 			{
 				// used with left
 				m_addval = -1;
 				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				// 26/0c called after this, then another fixed command value, then 0b/16
+				// unlike commands 04/05 there's no parameter byte written here, must be derived from the command? 
 			}
 			else if (command == 0x39)
 			{
 				// used with up
 				m_addval = -4;
 				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				// 26/0c called after this, then another fixed command value, then 0b/16
+				// unlike commands 04/05 there's no parameter byte written here, must be derived from the command? 
 			}
 			else
 			{

--- a/src/mame/drivers/generalplus_gpl_unknown.cpp
+++ b/src/mame/drivers/generalplus_gpl_unknown.cpp
@@ -79,6 +79,12 @@ the first piece of code copied appears to attempt to checksum the internal BIOS!
 #include "screen.h"
 #include "speaker.h"
 
+#define LOG_GPL_UNKNOWN            (1U << 1)
+#define LOG_ALL             ( LOG_GPL_UNKNOWN )
+
+#define VERBOSE             (0)
+#include "logmacro.h"
+
 
 class pcp8718_state : public driver_device
 {
@@ -213,6 +219,8 @@ private:
 	uint16_t unk_7870_r();
 	required_ioport m_io_p1;
 	required_ioport m_io_p2;
+
+	int m_gamehack;
 };
 
 uint32_t pcp8718_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
@@ -250,9 +258,7 @@ uint32_t pcp8718_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 
 
 
-void pcp8718_state::machine_start()
-{
-}
+
 
 static INPUT_PORTS_START( pcp8718 )
 	PORT_START("IN0")
@@ -358,7 +364,7 @@ uint16_t pcp8718_state::unk_780f_r()
 
 uint16_t pcp8718_state::spi_misc_control_r()
 {
-	//logerror("%06x: spi_misc_control_r\n", machine().describe_context());
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: spi_misc_control_r\n", machine().describe_context());
 	return 0x0000;
 }
 
@@ -368,13 +374,13 @@ uint16_t pcp8718_state::spi_rx_fifo_r()
 	if (m_spistate == SPI_STATE_READING_FAST)
 		return spi_rx_fast();
 
-	//logerror("%06x: spi_rx_fifo_r\n", machine().describe_context());
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: spi_rx_fifo_r\n", machine().describe_context());
 	return spi_rx();
 }
 
 void pcp8718_state::spi_process_tx_data(uint8_t data)
 {
-	//logerror("transmitting %02x\n", data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"transmitting %02x\n", data);
 
 	switch (m_spistate)
 	{
@@ -382,18 +388,18 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	{
 		if (data == 0x03)
 		{
-			logerror("set to read mode (need address) %02x\n", data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"set to read mode (need address) %02x\n", data);
 			m_spistate = SPI_STATE_WAITING_HIGH_ADDR;
 		}
 		else if (data == 0x0b)
 		{
-			logerror("set to fast read mode (need address) %02x\n", data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"set to fast read mode (need address) %02x\n", data);
 			m_spistate = SPI_STATE_WAITING_HIGH_ADDR_FAST;
 			//machine().debug_break();
 		}
 		else
 		{
-			logerror("invalid state request %02x\n", data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"invalid state request %02x\n", data);
 		}
 		break;
 	}
@@ -401,7 +407,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_HIGH_ADDR:
 	{
 		m_spiaddress = (m_spiaddress & 0xff00ffff) | data << 16;
-	//	logerror("set to high address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to high address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_WAITING_MID_ADDR;
 		break;
 	}
@@ -409,7 +415,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_MID_ADDR:
 	{
 		m_spiaddress = (m_spiaddress & 0xffff00ff) | data << 8;
-	//	logerror("set to mid address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to mid address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_WAITING_LOW_ADDR;
 		break;
 	}
@@ -417,7 +423,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_LOW_ADDR:
 	{
 		m_spiaddress = (m_spiaddress & 0xffffff00) | data;
-		logerror("set to low address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to low address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_READING;
 		break;
 	}
@@ -425,7 +431,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_READING:
 	{
 		// writes when in read mode clock in data?
-	//	logerror("write while in read mode (clock data?)\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"write while in read mode (clock data?)\n", data, m_spiaddress);
 		break;
 	}
 
@@ -445,7 +451,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_HIGH_ADDR_FAST:
 	{
 		m_spiaddress = (m_spiaddress & 0xff00ffff) | data << 16;
-		logerror("set to high address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to high address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_WAITING_MID_ADDR_FAST;
 		break;
 	}
@@ -453,7 +459,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_MID_ADDR_FAST:
 	{
 		m_spiaddress = (m_spiaddress & 0xffff00ff) | data << 8;
-		logerror("set to mid address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to mid address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_WAITING_LOW_ADDR_FAST;
 		break;
 	}
@@ -461,7 +467,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_WAITING_LOW_ADDR_FAST:
 	{
 		m_spiaddress = (m_spiaddress & 0xffffff00) | data;
-		logerror("set to low address %02x address is now %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"set to low address %02x address is now %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_WAITING_LOW_ADDR_FAST_DUMMY;
 
 		break;
@@ -469,7 +475,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 
 	case SPI_STATE_WAITING_LOW_ADDR_FAST_DUMMY:
 	{
-		logerror("dummy write %08x\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"dummy write %08x\n", data, m_spiaddress);
 		m_spistate = SPI_STATE_READING_FAST;
 		break;
 	}
@@ -477,7 +483,7 @@ void pcp8718_state::spi_process_tx_data(uint8_t data)
 	case SPI_STATE_READING_FAST:
 	{
 		// writes when in read mode clock in data?
-	//	logerror("write while in read mode (clock data?)\n", data, m_spiaddress);
+		LOGMASKED(LOG_GPL_UNKNOWN,"write while in read mode (clock data?)\n", data, m_spiaddress);
 		break;
 	}
 
@@ -499,14 +505,14 @@ uint8_t pcp8718_state::spi_process_rx()
 		//	if (dat == 0x4e)
 		//		dat = 0x5e;
 
-		//logerror("reading SPI %02x from SPI Address %08x (adjusted word offset %08x)\n", dat, m_spiaddress, (m_spiaddress/2)+0x20000);
+		LOGMASKED(LOG_GPL_UNKNOWN,"reading SPI %02x from SPI Address %08x (adjusted word offset %08x)\n", dat, m_spiaddress, (m_spiaddress/2)+0x20000);
 		m_spiaddress++;
 		return dat;
 	}
 
 	default:
 	{
-		logerror("reading FIFO in unknown state\n");
+		LOGMASKED(LOG_GPL_UNKNOWN,"reading FIFO in unknown state\n");
 		return 0x00;
 	}
 	}
@@ -543,7 +549,7 @@ uint8_t pcp8718_state::spi_rx_fast()
 void pcp8718_state::spi_tx_fifo_w(uint16_t data)
 {
 	data &= 0x00ff;
-	//logerror("%06x: spi_tx_fifo_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: spi_tx_fifo_w %04x\n", machine().describe_context(), data);
 
 	spi_process_tx_data(data);
 }
@@ -552,7 +558,7 @@ void pcp8718_state::spi_tx_fifo_w(uint16_t data)
 // it's accessed after each large data transfer, probably to reset the SPI into 'ready for command' state?
 void pcp8718_state::unk_7868_w(uint16_t data)
 {
-	//logerror("%06x: unk_7868_w %04x (Port B + SPI reset?)\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: unk_7868_w %04x (Port B + SPI reset?)\n", machine().describe_context(), data);
 
 	for (int i = 0; i < 4; i++)
 		m_rx_fifo[i] = 0xff;
@@ -568,7 +574,7 @@ uint16_t pcp8718_state::unk_7868_r()
 
 void pcp8718_state::bankswitch_707e_w(uint16_t data)
 {
-	logerror("%06x: bankswitch_707e_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: bankswitch_707e_w %04x\n", machine().describe_context(), data);
 	m_707e_bank = data;
 }
 
@@ -580,7 +586,7 @@ uint16_t pcp8718_state::bankswitch_707e_r()
 
 void pcp8718_state::bankswitch_703a_w(uint16_t data)
 {
-	logerror("%06x: bankswitch_703a_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: bankswitch_703a_w %04x\n", machine().describe_context(), data);
 	m_703a_bank = data;
 }
 
@@ -633,7 +639,7 @@ void pcp8718_state::system_dma_params_channel0_w(offs_t offset, uint16_t data)
 	{
 		case 0:
 		{
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Mode)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Mode)\n", machine().describe_context(), offset, data);
 
 #if 1
 
@@ -642,20 +648,32 @@ void pcp8718_state::system_dma_params_channel0_w(offs_t offset, uint16_t data)
 			uint32_t dest = m_dmaregs[2] | (m_dmaregs[5] << 16) ;
 			uint32_t length = m_dmaregs[3] | (m_dmaregs[6] << 16);
 
-			if ((mode != 0x0200) && (mode != 0x4009))
+			if ((mode != 0x0200) && (mode != 0x4009) && (mode != 0x6009))
 				fatalerror("unknown dma mode write %04x\n", data);
 
-			if (mode == 0x4009)
+			if ((mode == 0x4009) || (mode == 0x6009))
 			{
 				address_space& mem = m_maincpu->space(AS_PROGRAM);
 
-				// source and dest are swapped compared to gpl16250 hookup? probably mode?
 				for (int i = 0; i < length; i++)
 				{
 					uint16_t dat = mem.read_word(source);
-					mem.write_word(dest, dat);
 
-					dest++;
+					if (mode & 0x2000)
+					{
+						// Racing Car and Elevator Action need this logic, the code in gpl16250 should probably be like this
+						// but currently gets used in non-increment mode
+						mem.write_word(dest, dat & 0xff);
+						dest++;
+						mem.write_word(dest, dat >> 8);
+						dest++;
+					}
+					else
+					{
+						mem.write_word(dest, dat);
+						dest++;
+					}
+
 					source++;
 				}
 			}
@@ -663,50 +681,50 @@ void pcp8718_state::system_dma_params_channel0_w(offs_t offset, uint16_t data)
 			break;
 		}
 		case 1:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Source Low)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Source Low)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 2:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Dest Low)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Dest Low)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 3:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Length Low)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Length Low)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 4:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Source High)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Source High)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 5:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Dest High)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Dest High)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 6:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA Length High)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA Length High)\n", machine().describe_context(), offset, data);
 			break;
 
 		case 7:
-			logerror("%06x: system_dma_params_channel0_w %01x %04x (DMA unknown)\n", machine().describe_context(), offset, data);
+			LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_w %01x %04x (DMA unknown)\n", machine().describe_context(), offset, data);
 			break;
 	}
 }
 
 uint16_t pcp8718_state::system_dma_params_channel0_r(offs_t offset)
 {
-	logerror("%06x: system_dma_params_channel0_r %01x\n", machine().describe_context(), offset);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: system_dma_params_channel0_r %01x\n", machine().describe_context(), offset);
 	return m_dmaregs[offset];
 }
 
 uint16_t pcp8718_state::unk_7870_r()
 {
-	logerror("%06x: unk_7870_r (IO port)\n", machine().describe_context());
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: unk_7870_r (IO port)\n", machine().describe_context());
 	return m_io_p2->read();
 }
 
 void pcp8718_state::spi_control_w(uint16_t data)
 {
-	logerror("%06x: spi_control_w %04x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: spi_control_w %04x\n", machine().describe_context(), data);
 }
 
 void pcp8718_state::map(address_map &map)
@@ -728,7 +746,8 @@ void pcp8718_state::map(address_map &map)
 	map(0x00780f, 0x00780f).r(FUNC(pcp8718_state::unk_780f_r));
 
 
-	map(0x007860, 0x007860).r(FUNC(pcp8718_state::unk_7860_r));
+	map(0x007860, 0x007860).r(FUNC(pcp8718_state::unk_7860_r)).nopw();
+	map(0x007863, 0x007863).nopw();
 
 	map(0x007870, 0x007870).r(FUNC(pcp8718_state::unk_7870_r)); // I/O
 
@@ -747,7 +766,6 @@ void pcp8718_state::map(address_map &map)
 	map(0x007a80, 0x007a87).rw(FUNC(pcp8718_state::system_dma_params_channel0_r), FUNC(pcp8718_state::system_dma_params_channel0_w));
 
 	map(0x007abf, 0x007abf).r(FUNC(pcp8718_state::unk_7abf_r));
-
 
 	// there are calls to 0x0f000 (internal ROM?)
 	map(0x00f000, 0x00ffff).rom().region("maincpu", 0x00000);
@@ -787,7 +805,7 @@ void pcp8718_state::lcd_command_w(uint16_t data)
 void pcp8718_state::lcd_w(uint16_t data)
 {
 	data &= 0xff; // definitely looks like 8-bit port as 16-bit values are shifted and rewritten
-	logerror("%06x: lcd_w %02x\n", machine().describe_context(), data);
+	LOGMASKED(LOG_GPL_UNKNOWN,"%06x: lcd_w %02x\n", machine().describe_context(), data);
 
 	if ((m_lcdstate == LCD_STATE_PROCESSING_COMMAND) && (m_lastlcdcommand == 0x22))
 	{
@@ -826,7 +844,7 @@ uint16_t pcp8718_state::simulate_f000_r(offs_t offset)
 					uint16_t data3 = m_spirom[((source - 0x20000) * 2) + 4] | (m_spirom[((source - 0x20000) * 2) + 5] << 8);
 					uint16_t data4 = m_spirom[((source - 0x20000) * 2) + 6] | (m_spirom[((source - 0x20000) * 2) + 7] << 8);
 
-					logerror("call to 0xf000 - copying 4 words from %08x to 04/05/06/07\n", source); // some code only uses 04, but other code copies pointers and expects results in 04 and 05
+					LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf000 - copying 4 words from %08x to 04/05/06/07\n", source); // some code only uses 04, but other code copies pointers and expects results in 04 and 05
 
 					mem.write_word(0x0004, data);
 					mem.write_word(0x0005, data2);
@@ -839,17 +857,17 @@ uint16_t pcp8718_state::simulate_f000_r(offs_t offset)
 			}
 			else if (realpc == 0xf58f)
 			{
-			//	logerror("call to 0xf58f - unknown function\n");
+				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf58f - unknown function\n");
 				return m_mainrom[offset];
 			}
 			else if (realpc == 0xfb26) // done with a call, and also a pc =
 			{
-			//	logerror("call to 0xfb26 - unknown function\n");
+				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xfb26 - unknown function\n");
 				return m_mainrom[offset];
 			}
 			else if (realpc == 0xf56f) // done with a pc =
 			{
-			//	logerror("call to 0xf56f - unknown function\n");
+				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf56f - unknown function\n");
 				return m_mainrom[offset];
 			}
 			else
@@ -860,7 +878,7 @@ uint16_t pcp8718_state::simulate_f000_r(offs_t offset)
 		}
 		else
 		{
-		//	logerror("simulate_f000_r reading BIOS area (for checksum?) %04x\n", offset);
+			LOGMASKED(LOG_GPL_UNKNOWN,"simulate_f000_r reading BIOS area (for checksum?) %04x\n", offset);
 			return m_mainrom[offset];
 		}
 	}
@@ -871,7 +889,7 @@ uint16_t pcp8718_state::ramcall_2060_logger_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x2060 in RAM (set SPI to read mode, set address, do dummy FIFO reads)\n");
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x2060 in RAM (set SPI to read mode, set address, do dummy FIFO reads)\n");
 	}
 	return m_mainram[0x2060];
 }
@@ -880,7 +898,7 @@ uint16_t pcp8718_state::ramcall_2189_logger_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x2189 in RAM (unknown)\n");
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x2189 in RAM (unknown)\n");
 	}
 	return m_mainram[0x2189];
 }
@@ -891,19 +909,17 @@ uint16_t pcp8718_state::ramcall_2829_logger_r()
 	// this in turn calls 28f7 but has restore logic too
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x2829 in RAM (load+call function from SPI address %08x)\n", (m_mainram[0x1e] << 16) | m_mainram[0x1d]);
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x2829 in RAM (load+call function from SPI address %08x)\n", (m_mainram[0x1e] << 16) | m_mainram[0x1d]);
 	}
 	return m_mainram[0x2829];
 }
-
-
 
 
 uint16_t pcp8718_state::ramcall_287a_logger_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x287a in RAM (unknown)\n");
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (unknown)\n");
 	}
 	return m_mainram[0x287a];
 }
@@ -913,7 +929,7 @@ uint16_t pcp8718_state::ramcall_28f7_logger_r()
 	if (!machine().side_effects_disabled())
 	{
 		// no  restore logic?
-	//	logerror("call to 0x28f7 in RAM (load+GO TO function from SPI address %08x)\n", (m_mainram[0x1e] << 16) | m_mainram[0x1d]);
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x28f7 in RAM (load+GO TO function from SPI address %08x)\n", (m_mainram[0x1e] << 16) | m_mainram[0x1d]);
 	}
 	return m_mainram[0x28f7];
 }
@@ -922,7 +938,7 @@ uint16_t pcp8718_state::ramcall_2079_logger_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x2079 in RAM (maybe drawing related?)\n"); // called in the 'dummy' loop that doesn't actually draw? and other places? as well as after the actual draw command below in the real loop
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x2079 in RAM (maybe drawing related?)\n"); // called in the 'dummy' loop that doesn't actually draw? and other places? as well as after the actual draw command below in the real loop
 	}
 	return m_mainram[0x2079];
 }
@@ -931,26 +947,18 @@ uint16_t pcp8718_state::ramcall_2434_logger_r()
 {
 	if (!machine().side_effects_disabled())
 	{
-	//	logerror("call to 0x2434 in RAM (drawing related?)\n"); // [1d] as the tile / sprite number, [1e] as xpos, [1f] as ypos, [20] as 0. [21] as ff in some title drawing calls
+		LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x2434 in RAM (drawing related?)\n"); // [1d] as the tile / sprite number, [1e] as xpos, [1f] as ypos, [20] as 0. [21] as ff in some title drawing calls
 	}
 	return m_mainram[0x2434];
 }
 
-
+void pcp8718_state::machine_start()
+{
+	m_gamehack = 0x0;
+}
 
 void pcp8718_state::machine_reset()
 {
-	// this looks like it might actually be part of the IRQ handler (increase counter at 00 at the very start) rather than where we should end up after startup
-	// it also looks like (from the pc = 2xxx opcodes) that maybe this code should be being executed in RAM as those don't give correct offsets in the data segment.
-	//m_maincpu->set_state_int(UNSP_PC, 0x4000);
-	//m_maincpu->set_state_int(UNSP_SR, 0x0000);
-
-	//uint16_t* ROM = (uint16_t*)memregion("maincpu")->base();
-	//ROM[0x0000] = 0x9a90; // retf from internal ROM call to 0xf000 (unknown purpose)
-
-	// there doesn't appear to be any code to set the SP, so it must be done by the internal ROM
-	//m_maincpu->set_state_int(UNSP_SP, 0x5fff);
-
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0xf000, 0xffff, read16sm_delegate(*this, FUNC(pcp8718_state::simulate_f000_r)));
 
 	m_maincpu->space(AS_PROGRAM).install_read_handler(0x2060, 0x2060, read16smo_delegate(*this, FUNC(pcp8718_state::ramcall_2060_logger_r)));
@@ -970,13 +978,18 @@ void pcp8718_state::machine_reset()
 	m_spistate = SPI_STATE_READY;
 	m_spiaddress = 0;
 
-	for (int i = 0; i < 0x20000; i++)
+	for (int i = 0; i < 320*240*2; i++)
 		m_displaybuffer[i] = i&0xff;
 
 	m_lcdaddr = 0;
 
 	m_lcdstate = LCD_STATE_READY;
 	m_lastlcdcommand = 0;
+
+	// hack the first game in the menu to allow for easier testing until we figure out why the menu isn't working
+	m_gamehack %= 0x65;
+	m_gamehack++;
+	m_spirom[0x16000] = m_gamehack;
 }
 
 

--- a/src/mame/drivers/generalplus_gpl_unknown.cpp
+++ b/src/mame/drivers/generalplus_gpl_unknown.cpp
@@ -79,10 +79,13 @@ the first piece of code copied appears to attempt to checksum the internal BIOS!
 #include "screen.h"
 #include "speaker.h"
 
-#define LOG_GPL_UNKNOWN            (1U << 1)
-#define LOG_ALL             ( LOG_GPL_UNKNOWN )
 
+#define LOG_GPL_UNKNOWN            (1U << 1)
+#define LOG_GPL_UNKNOWN_SELECT_SIM (1U << 2)
+
+#define LOG_ALL             (LOG_GPL_UNKNOWN | LOG_GPL_UNKNOWN_SELECT_SIM)
 #define VERBOSE             (0)
+
 #include "logmacro.h"
 
 
@@ -927,26 +930,26 @@ uint16_t pcp8718_state::ramcall_287a_logger_r()
 			if ((command) == 0x00)  // request result  low
 			{
 				m_maincpu->set_state_int(UNSP_R1, m_stored_gamenum & 0xff);
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x (request result low)\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x (request result low)\n", command);
 			}
 			else if ((command) == 0x01) // request result  high
 			{
 				m_maincpu->set_state_int(UNSP_R1, (m_stored_gamenum>>8) & 0xff);
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x (request result high)\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x (request result high)\n", command);
 			}
 			else if ((command) == 0x02)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x %02x (set data low)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set data low)\n", command, param);
 				m_stored_gamenum = (m_stored_gamenum & 0xff00) | (m_mainram[0x1e] & 0x00ff);
 			}
 			else if ((command) == 0x03)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x %02x (set data high)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set data high)\n", command, param);
 				m_stored_gamenum = (m_stored_gamenum & 0x00ff) | ((m_mainram[0x1e] & 0x00ff) << 8);
 			}
 			else if ((command) == 0x04)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
 				// used with down
 				if (param == 0x03)
 					m_addval = 4;
@@ -955,36 +958,36 @@ uint16_t pcp8718_state::ramcall_287a_logger_r()
 			}
 			else if ((command) == 0x05)
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x %02x (set unknown)\n", command, param);
 			}
 			else if (command == 0x26)
 			{
 				// used in direction handlers
 				m_stored_gamenum += m_addval;
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
 				// command 0x0c is called after 26
 			}
 			else if (command == 0x30)
 			{
 				// used with right
 				m_addval = 1;
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
 			}
 			else if (command == 0x37)
 			{
 				// used with left
 				m_addval = -1;
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
 			}
 			else if (command == 0x39)
 			{
 				// used with up
 				m_addval = -4;
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
 			}
 			else
 			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
+				LOGMASKED(LOG_GPL_UNKNOWN_SELECT_SIM,"call to 0x287a in RAM (transmit / receive) %02x\n", command);
 			}
 
 			// hack retf

--- a/src/mame/drivers/generalplus_gpl_unknown.cpp
+++ b/src/mame/drivers/generalplus_gpl_unknown.cpp
@@ -868,56 +868,12 @@ uint16_t pcp8718_state::simulate_f000_r(offs_t offset)
 
 		if ((offset + 0xf000) == (realpc))
 		{
-#if 0
-			// still simulate this as it uses 'fast read' mode which doesn't work in the SPI handler at the moment
-			if (realpc == 0xf000)
-			{
-				address_space& mem = m_maincpu->space(AS_PROGRAM);
-
-				uint32_t source = (mem.read_word(0x001e) << 16) | mem.read_word(0x001d);
-
-				if (source >= 0x20000)
-				{
-					uint16_t data = m_spirom[((source - 0x20000) * 2) + 0] | (m_spirom[((source - 0x20000) * 2) + 1] << 8);
-					uint16_t data2 = m_spirom[((source - 0x20000) * 2) + 2] | (m_spirom[((source - 0x20000) * 2) + 3] << 8);
-					uint16_t data3 = m_spirom[((source - 0x20000) * 2) + 4] | (m_spirom[((source - 0x20000) * 2) + 5] << 8);
-					uint16_t data4 = m_spirom[((source - 0x20000) * 2) + 6] | (m_spirom[((source - 0x20000) * 2) + 7] << 8);
-
-					LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf000 - copying 4 words from %08x to 04/05/06/07\n", source); // some code only uses 04, but other code copies pointers and expects results in 04 and 05
-
-					mem.write_word(0x0004, data);
-					mem.write_word(0x0005, data2);
-					mem.write_word(0x0006, data3);
-					mem.write_word(0x0007, data4);
-
-				}
-
-				return 0x9a90; // retf
-			}
-			else if (realpc == 0xf58f)
-			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf58f - unknown function\n");
-				return m_mainrom[offset];
-			}
-			else if (realpc == 0xfb26) // done with a call, and also a pc =
-			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xfb26 - unknown function\n");
-				return m_mainrom[offset];
-			}
-			else if (realpc == 0xf56f) // done with a pc =
-			{
-				LOGMASKED(LOG_GPL_UNKNOWN,"call to 0xf56f - unknown function\n");
-				return m_mainrom[offset];
-			}
-			else
-			{
-				return m_mainrom[offset];
-			}
-#endif
+			//LOGMASKED(LOG_GPL_UNKNOWN,"simulate_f000_r reading BIOS area (for BIOS call?) %04x\n", offset);
+			return m_mainrom[offset];
 		}
 		else
 		{
-			LOGMASKED(LOG_GPL_UNKNOWN,"simulate_f000_r reading BIOS area (for checksum?) %04x\n", offset);
+			//LOGMASKED(LOG_GPL_UNKNOWN,"simulate_f000_r reading BIOS area (for checksum?) %04x\n", offset);
 			return m_mainrom[offset];
 		}
 	}
@@ -1092,7 +1048,7 @@ void pcp8718_state::machine_reset()
 	m_spiaddress = 0;
 
 	for (int i = 0; i < 320*240*2; i++)
-		m_displaybuffer[i] = i&0xff;
+		m_displaybuffer[i] = 0x00;
 
 	m_lcdaddr = 0;
 


### PR DESCRIPTION
- fixed extended push/pop for unsp2.0 devices
- identified alt use of dma mode by pcp8718/8728
- allow some illegal opcodes in unsp to be treated as NOP because buggy code in pcp8718/8728 explicitly attempts to execute them