### PR TITLE
ibm5170_hdd: new software list

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -5762,16 +5762,19 @@ has been replaced with an all-zero block. -->
 		<publisher>Microsoft</publisher>
 		<info name="version" value="5.00" />
 		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 - Setup" />
 			<dataarea name="flop" size="737280">
 				<rom name="disk01_35.img" size="737280" crc="a34dc98f" sha1="791e291a16a7ce3b3ffb536b1c27dfe8e620338e"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="737280">
 				<rom name="disk02_35.img" size="737280" crc="332cb5b4" sha1="0e1f4f63d68d02b5224a69e73ee9b7a3e630a1bb"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="737280">
 				<rom name="disk03_35.img" size="737280" crc="758c9037" sha1="53ba701accbf58db3b43188f4b4769a6a8008e05"/>
 			</dataarea>

--- a/hash/ibm5170.xml
+++ b/hash/ibm5170.xml
@@ -2392,31 +2392,43 @@ license:CC0
 		<publisher>IBM</publisher>
 		<info name="version" value="7.0, Revision 1" />
 		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_number" value="04L9090" />
+			<feature name="part_id" value="Set-up Diskette 1" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk01.img" size="1474560" crc="69909031" sha1="1fa1e65320ad3a5287746aca9c40fb9671f9cdc6"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_number" value="04L9091" />
+			<feature name="part_id" value="Diskette 2" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk02.img" size="1474560" crc="553d1cae" sha1="75fd11da9b6567fd362c432c81accccd22e7d4ae"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_number" value="04L9092" />
+			<feature name="part_id" value="Diskette 3" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk03.img" size="1474560" crc="49e9fa80" sha1="77704444d8afd756840bd7484c5d727b3eb8b555"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_number" value="04L9093" />
+			<feature name="part_id" value="Diskette 4" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk04.img" size="1474560" crc="b38cd931" sha1="14b4b23bef5cf60a8151ac95f62b91bfd9a6f1ca"/>
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_number" value="04L9094" />
+			<feature name="part_id" value="Diskette 5" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk05.img" size="1474560" crc="5cfbfef6" sha1="5de6e9c19ccf270edecfaefaceffb3259be90565"/>
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_number" value="04L9095" />
+			<feature name="part_id" value="Diskette 6" />
 			<dataarea name="flop" size = "1474560">
 				<rom name="disk06.img" size="1474560" crc="8f37413c" sha1="ac9a0208ef5019b68ff8879a80a6e1efa29fcc4c"/>
 			</dataarea>
@@ -2892,21 +2904,25 @@ license:CC0
 		<publisher>Microsoft</publisher>
 		<info name="version" value="6.22" />
 		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 - Setup" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk1.img" size="1474560" crc="adbd36fe" sha1="3fb0df208670ea5fafae451661017391a381bc9d"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk2.img" size="1474560" crc="417eb8b3" sha1="63e670bb166995a7a1124c8f2b540355eed3bbd8"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk3.img" size="1474560" crc="6a158e98" sha1="b8493fc000f405ba7a1a89503178482328616e01"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Supplemental" />
 			<dataarea name="flop" size="1474560">
 				<rom name="supplemental.img" size="1474560" crc="136b4fae" sha1="c397f4825337204ee49467bd7a598d77bc2fe19f"/>
 			</dataarea>
@@ -4221,28 +4237,38 @@ license:CC0
 		<publisher>Microsoft</publisher>
 
 		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk1.img" size="1474560" crc="e6e8ce2c" sha1="ce1b1a436f03d05eae556587ea0554eba7df2e04"/>
+			  <!-- not original, has WinImage header -->
+				<rom name="disk1.img" size="1474560" crc="e6e8ce2c" sha1="ce1b1a436f03d05eae556587ea0554eba7df2e04" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk2.img" size="1474560" crc="43998fd9" sha1="8780c96ef206a7acfa4f539298e1f98856b5542d"/>
+			  <!-- not original, has WinImage header -->
+				<rom name="disk2.img" size="1474560" crc="43998fd9" sha1="8780c96ef206a7acfa4f539298e1f98856b5542d" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk3.img" size="1474560" crc="f02f5e0b" sha1="6d70edaf0645b7ea112f7cb95e39cd0d1d7dbe2a"/>
+			  <!-- not original, has WinImage header -->
+				<rom name="disk3.img" size="1474560" crc="f02f5e0b" sha1="6d70edaf0645b7ea112f7cb95e39cd0d1d7dbe2a" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk4.img" size="1474560" crc="b7763596" sha1="df5afa986a66fc7646cb554af25acb20ebb95a05"/>
+			  <!-- not original, has WinImage header -->
+				<rom name="disk4.img" size="1474560" crc="b7763596" sha1="df5afa986a66fc7646cb554af25acb20ebb95a05" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk5.img" size="1474560" crc="6279f86e" sha1="f0378635d49816c28a42a2b8dd0ef0aa59bd585f"/>
+			  <!-- not original, has WinImage header -->
+				<rom name="disk5.img" size="1474560" crc="6279f86e" sha1="f0378635d49816c28a42a2b8dd0ef0aa59bd585f" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4719,41 +4745,49 @@ license:CC0
 		<year>1993</year>
 		<publisher>Microsoft</publisher>
 		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk01.img" size="1474560" crc="385b3bbb" sha1="cf4c0a86129fefbc944c52db44631c988b8a60f6"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk02.img" size="1474560" crc="ae1a4150" sha1="06a8b2e119ec316a17767ffa62aa54450b42d960"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk03.img" size="1474560" crc="059fc210" sha1="b47e7a780560fc0a93b6d2d12651d8d0fb4ed6c8"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk04.img" size="1474560" crc="dcd1ebdf" sha1="b76c7db60e49d78690fc54496e6301162591b641"/>
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk05.img" size="1474560" crc="9ab6f9bb" sha1="b4a9adac4a13f3d12883a37a71730537bec106f4"/>
 			</dataarea>
 		</part>
 		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk06.img" size="1474560" crc="b0164e96" sha1="f6d15cb13cde71200932d713d6c0dd16321fc772"/>
 			</dataarea>
 		</part>
 		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 7" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk07.img" size="1474560" crc="023c0551" sha1="39c9412c5385e7b79f35860f12e6711e9d072445"/>
 			</dataarea>
 		</part>
 		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 8" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk08.img" size="1474560" crc="9e485583" sha1="b4ff44d26186f5b6e6775f72b1d7a27102e34b62"/>
 			</dataarea>

--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0
+-->
+<softwarelist name="ibm5170_hdd" description="IBM PC/AT hard disk images">
+	<!--
+	Unless otherwise specified, all images are based on default installs of the
+	corresponding ibm5150 or ibm5170 sets. BIOS should be able to autodetect the
+	hard drive, if not set it up as Type 47 with C/H/S of 1015/16/63.
+	-->
+
+	<software name="msdos5">
+		<description>MS-DOS (Version 5.00)</description>
+		<year>1991</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="msdos5" sha1="2c585ce9193b5420bfe4f6fca591226bf69a8664" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="msdos622">
+		<description>MS-DOS (Version 6.22)</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="msdos622" sha1="ceaa0a963ae2b301c8d799e3f7c733f13eebe8bc" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pcdos2k">
+		<description>IBM PC DOS 2000</description>
+		<year>1998</year>
+		<publisher>IBM</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="pcdos2k" sha1="96addad58a341c5ac005bbec700e7e52e2ae091f" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="win30">
+		<description>Microsoft Windows Version 3.0</description>
+		<year>1990</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="win30" sha1="64c7099b65b6561c8e346d240796bf4c00d381ab" writeable="yes" />
+			</diskarea>
+		</part>
+	</software>
+
+</softwarelist>

--- a/src/mame/drivers/atpci.cpp
+++ b/src/mame/drivers/atpci.cpp
@@ -103,6 +103,7 @@ void at586_state::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "at_hdd_list").set_original("ibm5170_hdd");
 	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 

--- a/src/mame/drivers/ct486.cpp
+++ b/src/mame/drivers/ct486.cpp
@@ -188,6 +188,7 @@ void ct486_state::ct486(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "at_hdd_list").set_original("ibm5170_hdd");
 	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 

--- a/src/mame/drivers/ps2.cpp
+++ b/src/mame/drivers/ps2.cpp
@@ -44,6 +44,7 @@ void ps2_state::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "at_hdd_list").set_original("ibm5170_hdd");
 	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 

--- a/src/mame/machine/at.cpp
+++ b/src/mame/machine/at.cpp
@@ -52,6 +52,7 @@ void at_mb_device::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
 	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
 	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "at_hdd_list").set_original("ibm5170_hdd");
 	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 


### PR DESCRIPTION
Also add a few missing labels, and tag `win30` as a bad dump due to the WinImage header.