### PR TITLE
fmtowns: changes to 15-bit layer/sprite drawing, fixes niko2

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -11638,8 +11638,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Wrong colors and other graphical glitches -->
-	<software name="niko2" supported="partial">
+	<software name="niko2">
 		<!--
 		Origin: redump.org
 		<rom name="Niko^2 (Japan).bin" size="10231200" crc="a0d255b9" sha1="16924ba91862c909730502cadec7eefb94150521"/>

--- a/src/mame/video/fmtowns.cpp
+++ b/src/mame/video/fmtowns.cpp
@@ -830,7 +830,7 @@ void towns_state::render_sprite_4(uint32_t poffset, uint32_t coffset, uint16_t x
 
 			voffset = 0;
 			pixel = (m_towns_txtvram[poffset] & 0xf0) >> 4;
-			col = m_towns_txtvram[coffset+(pixel*2)] | (m_towns_txtvram[coffset+(pixel*2)+1] << 8);
+			col = (m_towns_txtvram[coffset+(pixel*2)] | (m_towns_txtvram[coffset+(pixel*2)+1] << 8)) & 0x7fff;
 			if (rotation)
 			{
 				voffset += linesize * (xpos & 0x1ff);  // scanline size in bytes * y pos
@@ -861,7 +861,7 @@ void towns_state::render_sprite_4(uint32_t poffset, uint32_t coffset, uint16_t x
 						voffset-=2;
 
 				pixel = m_towns_txtvram[poffset] & 0x0f;
-				col = m_towns_txtvram[coffset+(pixel*2)] | (m_towns_txtvram[coffset+(pixel*2)+1] << 8);
+				col = (m_towns_txtvram[coffset+(pixel*2)] | (m_towns_txtvram[coffset+(pixel*2)+1] << 8)) & 0x7fff;
 				if(voffset < 0x20000 && xpos < width && ypos < height && pixel != 0 && voffset > linesize)
 				{
 					m_towns_gfxvram[0x40000+voffset+vbase+1] = (col & 0xff00) >> 8;
@@ -1126,7 +1126,7 @@ void towns_state::towns_crtc_draw_scan_layer_hicolour(bitmap_rgb32 &bitmap,const
 			curoff = ((off & 0x7fff8) >> 1) | (off & 3);
 		}
 		colour = (m_towns_gfxvram[curoff+(offpage*0x40000)+1] << 8) | m_towns_gfxvram[curoff+(offpage*0x40000)];
-		if(colour < 0x8000)
+		if(!(m_video.towns_video_reg[0] & 0x10) || (m_video.towns_video_reg[1] & 0x01) != layer || colour < 0x8000)
 		{
 			for (pixel = 0; pixel < hzoom; pixel++)
 				bitmap.pix32(scanline, x+pixel) =


### PR DESCRIPTION
This update slightly changes the behavior of layer and sprite drawing in 15-bit mode:

- Sprite color values are masked to their 15 least significant bits before they are rendered to VRAM.

- Pixels on the bottom layer (or in single-layer mode) are always drawn, even if the transparency bit is set to 1.

This is presumably the actual behavior of the hardware, since the menus and UI elements in Niko² (which are sprites on the top layer) all have bit 15 set to 1 and they would be transparent otherwise, and the Wolfteam logo screen (which is a bitmap drawn on a single layer) has some parts with bit 15 set that are very clearly meant to be visible.

This fixes the missing colors, menus and UI elements in Niko², so the game is playable now. Also fixes a regression in Hatchake Ayayo 1-2-3 with missing dialogue text. So far I haven't found anything else that abuses the video hardware in this way.

Before:
![0024](https://user-images.githubusercontent.com/13178957/92313483-73007c80-efcc-11ea-9995-47d20be3fd87.png)

After:
![0030](https://user-images.githubusercontent.com/13178957/92313487-78f65d80-efcc-11ea-9b77-f5997ad1e846.png)
