### PR TITLE
fmtowns_cd.xml: 13 new dumps, 16 replacements

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -43,7 +43,6 @@ Aska Word                                                     Algo              
 Band-kun                                                      Koei                              1991/1     SET(CD+FD)
 Battle                                                        GAM                               1992/10    CD
 Bell's Avenue Vol. 3                                          Wendy Magazine                    1995/4     CD
-Bible Master 2: Aglia no Jashin                               Glodia                            1995/1     SET(CD+FD)
 Bird Land no Komoriuta                                        Inter Limited Logic               1994/12    CD
 Birdy Soft Best Characters                                    Birdy Soft                        1995/4     CD
 Bohemia no Inori                                              Fujitsu                           1993/5     CD
@@ -99,7 +98,6 @@ Daijirin CD-ROM                                               Fujitsu           
 Daisenkai CD-ROM                                              Fujitsu                           1993/11    CD
 Debut Shimasu… 3                                              Ilis Plan                         1995/2     CD
 Demon City                                                    Cocktail Soft                     1994/3     CD
-Demonstration CD-ROM '90 Fuyu-gou                             Fujitsu                           1990/11    SET(CD+FD)
 Demonstration CD-ROM '90 Haru-gou                             Fujitsu                           1990/3     CD
 Demonstration CD-ROM '90 Natsu-gou                            Fujitsu                           1990/7     CD
 Demonstration CD-ROM '91 Fuyu-gou                             Fujitsu                           1991/11    CD×01
@@ -176,7 +174,6 @@ Euphony 2 / SCORE V1.1                                        Fujitsu           
 Eye of the Beholder 3                                         Ving                              1994/11    CD
 Fancy Illust: Hattori Yuki no Wakuwaku Cut-shuu               CSK Research Institute (CRI)      1990/3     CD
 F-BASIC Compiler V1.1                                         Fujitsu                           1990/12    CD
-F-BASIC386 Compiler V2.1                                      Fujitsu                           1994/9     CD
 FIRSTHAND ACCESS(Disc1)                                       DynEd Japan                       1994/11    SET(CD+FD)
 FIRSTHAND ACCESS(Disc2)                                       DynEd Japan                       1994/11    SET(CD+FD)
 FlexData Collection Vol. 1                                    Fujitsu                           1993/11    CD
@@ -210,10 +207,8 @@ Gendai Yougo no Kiso Chishiki (1992)                          Fujitsu           
 Gendai Yougo no Kiso Chishiki (1993)                          Fujitsu                           1993/9     CD
 Gendai Yougo no Kiso Chishiki (1994)                          Fujitsu                           1994/9     CD
 Ge-Ten 2                                                      Hokusho                           1993/?     ?
-Ginga Eiyuu Densetsu 2 DX+ Towns Special                      Bothtec Soft                      1992/5     CD
 Ginga Uchuu Odyssey 1                                         Fujitsu                           1991/3     CD
-Ginga Uchuu Odyssey 2                                         Fujitsu                           1992/4     CD
-Ginga Uchuu Odyssey 2                                         Fujitsu                           1991/3     CD
+Ginga Uchuu Odyssey 2 (Marty-compatible)                      Fujitsu                           1992/4     CD
 Ginga Yuukyou Densetsu Tobakker                               Ponytail Soft                     1995/11    CD
 Gomen ne Angel: Yokohama Monogatari                           JAST                              1992/1     ?
 Gram Cats 2                                                   Dot Kikaku                        ?          ?
@@ -249,7 +244,7 @@ Hirou                                                         Toshiba EMI       
 HomeSTUDIO V1.1                                               Fujitsu                           1992/12    SET(CD+FD)
 Hot de Art na Barcelona                                       Media Art                         1991/9     CD
 Hyoutan Shima Kouryaku-ki                                     Nihon Dennou Koubou               1994/?     ?
-Hyper Address Ver. 2.0                                        Datt Japan                        1991/4     SET(CD+FD)
+* Hyper Address Ver. 2.0                                      Datt Japan                        1991/4     SET(CD+FD)
 Hyper Aquarium Kaisui-hen                                     Inter Limited Logic               1992/4     CD
 Hyper Aquarium Tansui-hen                                     Inter Limited Logic               1992/1     CD
 Hyper Asobi Meijin                                            Corpus                            1989/11    SET(CD+FD)
@@ -371,7 +366,6 @@ Maruanki Eitango: Chuugaku 1-nensei                           CSK Research Insti
 Maruanki Eitango: Chuugaku 2-nensei                           CSK Research Institute (CRI)      1989/12    SET(CD+FD)
 Maruanki Eitango: Chuugaku 3-nensei                           CSK Research Institute (CRI)      1990/2     SET(CD+FD)
 Masuo per Masuo: Ikeda Masuo Hanga-shuu Kazadama Vol. 2       Fujitsu                           1994/7     CD
-Megamorph Demo                                                Fujitsu                           ?          CD
 Meisou Toshi                                                  Tiara                             1995/12    CD
 Microsoft Windows 95 (Upgrade Package)                        Fujitsu                           1996/6     CD
 Mietarou V2.0                                                 Uchida Youkou                     1992/12    SET(CD+FD)
@@ -481,8 +475,6 @@ Planet Harmony                                                Datt Japan        
 Pocky 1-2 & Ponyon                                            Ponytail Soft                     1994/6     CD
 Populous 2 Expert                                             Imagineer                         1993/2     CD
 Powers of Ten                                                 Datt Japan                        1995/10    CD
-Presence                                                      Orange House                      1992/12    ?
-Presence                                                      Sur de Wave                       1992/12    CD
 Present                                                       Orange House                      1991/6     ?
 Primary Health Care System                                    Raison                            1990/9     CD
 Princess Danger                                               Janis                             1996/4     CD
@@ -569,7 +561,6 @@ Speed Eiyou Check                                             Top Business Syste
 Speed Eiyou Check (?)                                         Top Business System               1992/4     SET(CD+FD)
 Star Wars: Rebel Assault                                      Victor Entertainment              1994/9     CD
 Steepia                                                       Fujitsu                           1993/6     CD
-Steepia Lite                                                  Fujitsu                           1993/3     CD
 Stingo Monogatari ST-1: Stingo to Gohoubi no Ki               Technos Yashima                   1995/1     CD
 Stingo Monogatari ST-2: Stingo no Atarashii Otomodachi        Technos Yashima                   1995/1     CD
 Stingo Monogatari ST-3: Stingo Umi ni Iku                     Technos Yashima                   1995/1     CD
@@ -651,7 +642,6 @@ TownsVNET V1.1                                                Fujitsu           
 TownsVNET V1.1 (Reprint?)                                     Fujitsu                           1992/1     CD
 Towns-you Chuugakkou Gijutsu Kateika Kyouzai                  Uchida Youkou                     1994/3     CD
 Treeclub                                                      Fujitsu Parex                     1995/7     CD
-Trigger 2                                                     ZyX                               1995/9     CD
 * True Heart                                                  Cocktail Soft                     1995/2     SET(CD+FD)
 Tsubo Relaxation                                              Fujitsu Personal Computer Systems 1994/9     CD
 Twinkle Star                                                  Studio Twinkle                    1993/7     CD
@@ -1572,21 +1562,39 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Runs too fast -->
 	<software name="abel" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Abel.ccd" size="4674" crc="d29bcd2e" sha1="1198a235c5463ca6ab1ef72bc89e2f307c9bc48f"/>
-		<rom name="Abel.cue" size="1219" crc="652022e2" sha1="ba92aea8595294a0ada64d1060bd1a6cd0186056"/>
-		<rom name="Abel.img" size="311764656" crc="c90bd8da" sha1="80e7940930b7c6330098e548a1cadd40bff29be9"/>
-		<rom name="Abel.sub" size="12725088" crc="63e70daa" sha1="373a0ebfe67c903c61d04fcbb69f21a1bfcfa450"/>
+		Origin: redump.org
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 01).bin" size="46282656" crc="2b409ed9" sha1="99a8bd827fcf1f073dd6e34c6428b5a4b19b84c3"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 02).bin" size="11289600" crc="3e3ce7a8" sha1="87963fc8093e7a83074b43d8b84d32c70b535c87"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 03).bin" size="31752000" crc="56e17ac8" sha1="0721e3e1fa3b9d3979e824e6b3a94b3991deece3"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 04).bin" size="4586400" crc="88935dbe" sha1="1d8d4c8ffbbd926c4d665ad40e872dd8f41621e4"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 05).bin" size="7585200" crc="c4d68f93" sha1="3a333a8d87accf20e027a6f6c57a7cfa7a5a5f3e"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 06).bin" size="9172800" crc="1481806f" sha1="c2ffe1f50789bcea98e41147e8ad0b99eda5679e"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 07).bin" size="10936800" crc="cf9298b9" sha1="eec100e9782a78df7600a6871cd1a7303ca5cb18"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 08).bin" size="10231200" crc="f69c2c19" sha1="c422e9637a7b4c202d4436268a60f92b3949a768"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 09).bin" size="6879600" crc="9ee49eaa" sha1="937f3ef1feb6c72e4a36f5663f7478dfefcbcf40"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 10).bin" size="2293200" crc="fb089e38" sha1="4505bb30740d82169111ee1aef99b324c758e7c5"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 11).bin" size="6174000" crc="62008e0b" sha1="f7d84dbf5ea882a575ca62d864914ba241cf78d5"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 12).bin" size="2293200" crc="76a56ce7" sha1="c9128ca1b117c0f1cbe5f6fd475328e8600d7ec9"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 13).bin" size="2998800" crc="f812cf79" sha1="d730e6f1088ae23a7f6569a488b2b88704b6efa3"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 14).bin" size="6879600" crc="e4742283" sha1="7a887867f72478efddc868516ba06d64ace201d5"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 15).bin" size="7938000" crc="f13f732b" sha1="d831b737c2d8c1c7fb507bb0bee2a348415895cf"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 16).bin" size="35103600" crc="43fd1637" sha1="bbf34e341fca45a4f52dd57ea75a90296bb10e48"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 17).bin" size="12524400" crc="3255ebfc" sha1="a9f2c39a6bd1f40c294fc961a028959bef6be4e4"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 18).bin" size="28753200" crc="edef3e00" sha1="75052b49405bcad1e615a80570b4f8aa39af4603"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 19).bin" size="28224000" crc="1c0c3134" sha1="41654c1e6c17d19801606a5935e94b30bc655c91"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan) (Track 20).bin" size="39866400" crc="18ca0163" sha1="63e767f2c7a3b6cd9c0beb154f5d7c380c9abefa"/>
+		<rom name="Abel - Shin Mokushiroku Taisen (Japan).cue" size="2642" crc="14c54499" sha1="a48b636c35f9fb5055de9f0a7a1c333147289122"/>
 		-->
 		<description>Abel - Shin Mokushiroku Taisen</description>
 		<year>1995</year>
 		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="serial" value="MTC-1137"/>
 		<info name="alt_title" value="ＡＢＥＬ 真・黙示録大戦" />
 		<info name="release" value="199511xx" />
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="abel" sha1="5fb92a84f3d1e7530b6dce9060f9814ec2fa6d2b" />
+				<disk name="abel - shin mokushiroku taisen (japan)" sha1="d4a49a59b582c870bb3ab843ffc3685c29efef86" />
 			</diskarea>
 		</part>
 	</software>
@@ -3074,11 +3082,42 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="bestplay">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Best Play Baseball.ccd" size="7024" crc="a7c14c1b" sha1="fa2f8745e64212605558ec88553cd3c4498f69cd"/>
-		<rom name="The Best Play Baseball.cue" size="1398" crc="0eccef35" sha1="28f5fc0b247679c38833d44ec2e02e95b2bd9b78"/>
-		<rom name="The Best Play Baseball.img" size="361443600" crc="5e3c3844" sha1="23e6cf7890b1fb294c1b77538578cbb4ab80e724"/>
-		<rom name="The Best Play Baseball.sub" size="14752800" crc="d901ca38" sha1="52e4e17b20893997070ce55a90cf7878013e1b05"/>
+		Origin: redump.org
+		<rom name="Best Play Baseball, The (Japan) (Track 01).bin" size="10231200" crc="91560cb7" sha1="243b93cc60d7a16b9ebcce5ea360ce092420c57e"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 02).bin" size="13759200" crc="afd66194" sha1="df5fa530bfe4b3f92b7891fd3bd306ac61c6a762"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 03).bin" size="12700800" crc="b4e68027" sha1="fcdf4f830e9ad9e2a7af28fa80f93f899adb0910"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 04).bin" size="13230000" crc="4461b313" sha1="cc1b226fceb7ac9f2f81f7b7902d766afcb1c07f"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 05).bin" size="14112000" crc="8d007657" sha1="5cf0122db802d7fb99f7cd32fd236aaca75756a3"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 06).bin" size="15170400" crc="8f706068" sha1="d0a2e2e3965fa32b199e15aed5c3c29d7fa33ec4"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 07).bin" size="12171600" crc="6a9b9e9f" sha1="b63635d8c561d352374a875da4bf00222d38884c"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 08).bin" size="2469600" crc="2bf0b244" sha1="00a48419cdde0baf3d208d29d315ca7a843c743a"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 09).bin" size="13759200" crc="d7433ce4" sha1="bd3fc3eac19834002a89ef9a204d73cbea6ca6ab"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 10).bin" size="11995200" crc="419b73a6" sha1="f922d6ada9220d5ae5eb4a2456b90b167bbd3738"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 11).bin" size="13759200" crc="2664ee50" sha1="0ad9e1f6b9162097494ca4bb8c55217749b83b82"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 12).bin" size="12877200" crc="5f0273c5" sha1="485ac92ba309bde04c03fb307dc02a1567f807dd"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 13).bin" size="12700800" crc="3a6751fa" sha1="28973b3b942aa09e70be634fd7f317bc804451ec"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 14).bin" size="12700800" crc="91ac360b" sha1="ed520d8dd619cc6a748a7d11e8e2ac3b265e11dd"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 15).bin" size="2469600" crc="48895b25" sha1="2997c35232aa3d48f0126644aa2eb42a4184623e"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 16).bin" size="3528000" crc="18eaf607" sha1="4a868b9813b6b58465a6109bd9bcfbd41726ed82"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 17).bin" size="11289600" crc="098a2787" sha1="6ba5653f1e86a4d66967aff15350a06b96013785"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 18).bin" size="1587600" crc="ed558a55" sha1="c574c0872fe5a4e4ae3ee76d4439508cd26f777a"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 19).bin" size="1411200" crc="fd67d8f6" sha1="022cadf01c41e7e9a5d578bfd71636f74a30ea1b"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 20).bin" size="5644800" crc="377c4763" sha1="2d85d471a804ab96650a5bd97b69a29c8ad89fda"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 21).bin" size="5115600" crc="69206535" sha1="8efb4c3ec86bc79d9526eba095e98e3a2aa21635"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 22).bin" size="5997600" crc="8546bc50" sha1="17a82a81f7e16b09c42b3d5402860facd1e8e8ce"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 23).bin" size="1234800" crc="3e69c0fc" sha1="0576f5d52a49b152619ba0797859edb0601950ef"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 24).bin" size="1058400" crc="77e0f748" sha1="a4b71b6cea2e62a1bb3ac50293f24f6bd73dd520"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 25).bin" size="705600" crc="4682a764" sha1="323dc66c4ba997e0ca0bd455fc5875fbb3c1ad5c"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 26).bin" size="16581600" crc="a419c0a9" sha1="34126c7e7f1af6510e67143c26c06fa8c8120e4b"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 27).bin" size="2998800" crc="661678cc" sha1="2ebdadc0acfec73b6bc02be08c10bf10191f0aad"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 28).bin" size="2998800" crc="b179d97d" sha1="1fbfdc4edc3fb3c8451f555b77a4efefd581c046"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 29).bin" size="32634000" crc="578b347f" sha1="a17b509ae24488a86da48ec3d05ebee0350ed5bf"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 30).bin" size="2998800" crc="f0695add" sha1="fd8e464ed6a31f73b79b43d391711127ab765e7b"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 31).bin" size="2998800" crc="0988d340" sha1="1ba6e3f7601dc4a001aae588a6f10b750b5f2715"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 32).bin" size="29635200" crc="c02b289f" sha1="7472b91df20972d685af1e8874fd43f618c68c22"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 33).bin" size="26283600" crc="ce4373f3" sha1="5179e20bd306cb1f03a2f469b061318de453fca3"/>
+		<rom name="Best Play Baseball, The (Japan) (Track 34).bin" size="32634000" crc="c4a57ff3" sha1="1b024b083d172e70f79ed1f97c37e53b0a0b98ae"/>
+		<rom name="Best Play Baseball, The (Japan).cue" size="4266" crc="e15e2c5b" sha1="016e0051dd5cb9202d3fef7532ad73ccbd046bc2"/>
 		-->
 		<description>The Best Play Baseball</description>
 		<year>1992</year>
@@ -3089,7 +3128,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the best play baseball" sha1="11bdce513c48010b272988525ae458ec60c743f6" />
+				<disk name="best play baseball, the (japan)" sha1="3edac55a3610917496413e93315180ff4a71e8de" />
 			</diskarea>
 		</part>
 	</software>
@@ -3795,22 +3834,20 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Hangs at name entry -->
 	<software name="cyberia" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Cyberia.ccd" size="772" crc="a4dc53ce" sha1="bf2f85696f9485834d782b6360a2824d9a2f30c3"/>
-		<rom name="Cyberia.cue" size="71" crc="5e540616" sha1="afc016200571e9e64cc5e5572d45a91e49275e4f"/>
-		<rom name="Cyberia.img" size="354987360" crc="b48e66ef" sha1="d5e3499d0e69e20a56b4ba4eb73e1215fa8daf93"/>
-		<rom name="Cyberia.sub" size="14489280" crc="94614ce5" sha1="ed6fe229ce847b5ffee463d0523cce7430934fac"/>
+		Origin: redump.org
+		<rom name="Cyberia (Japan).bin" size="354987360" crc="b48e66ef" sha1="d5e3499d0e69e20a56b4ba4eb73e1215fa8daf93"/>
+		<rom name="Cyberia (Japan).cue" size="81" crc="279db853" sha1="a263c8b34829f255be6e54f78f8722d32e482f98"/>
 		-->
 		<description>Cyberia</description>
 		<year>1995</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="serial" value="HMF-205"/>
+		<info name="serial" value="HMF-205 / A2760620 / TSC530"/>
 		<info name="alt_title" value="サイベリア" />
 		<info name="release" value="199505xx" />
 		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cyberia" sha1="9b6100154ebe61fe19e17b01a2f037310448a72a" />
+				<disk name="cyberia (japan)" sha1="27ae2fa1cec90c103e05e2ea7101cd828f630f1e" />
 			</diskarea>
 		</part>
 	</software>
@@ -4081,42 +4118,46 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="deadforc">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dead Force.ccd" size="769" crc="a25e1c7b" sha1="f3c2cfc0eb3cf2c238004c26a65f39556c8f259b"/>
-		<rom name="Dead Force.cue" size="74" crc="ddf34745" sha1="cae2f3f77b5b925990c3c7e1f621071a617ec727"/>
-		<rom name="Dead Force.img" size="5743584" crc="5056aeba" sha1="410f9ce5332deb402a803582e6a672b2615a454a"/>
-		<rom name="Dead Force.sub" size="234432" crc="c986024e" sha1="4b6e8f61900ac1daa7a6396537328204f721133e"/>
+		Origin: redump.org
+		<rom name="Shinseki Kouboushi - Dead Force (Japan).bin" size="5743584" crc="5056aeba" sha1="410f9ce5332deb402a803582e6a672b2615a454a"/>
+		<rom name="Shinseki Kouboushi - Dead Force (Japan).cue" size="128" crc="8a4ce91b" sha1="0fdb1378aaba7ca5e628e71839b512016c83428e"/>
 		-->
-		<description>Dead Force</description>
+		<description>Shinseiki Kouboushi - Dead Force</description>
 		<year>1995</year>
 		<publisher>風雅システム (Fuga System)</publisher>
-		<info name="alt_title" value="デッドフォース" />
+		<info name="alt_title" value="新世紀興亡史　デッド・フォース" />
 		<info name="release" value="199506xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dead force" sha1="737a16b6676808c759130ee78ecad3ca95a9d061" />
+				<disk name="shinseiki kouboushi - dead force (japan)" sha1="163b64c730ffb2c1c7d7d48b042e76cec1a4591a" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="deadbrn">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dead of the Brain.ccd" size="2272" crc="854e9efe" sha1="7d4be4e3ddd2810c532c88c623c5428e843550a7"/>
-		<rom name="Dead of the Brain.cue" size="393" crc="dabb161d" sha1="d39536bb98bdb79d68a5ba3cca1ec86326fd2957"/>
-		<rom name="Dead of the Brain.img" size="245901600" crc="c4da98d1" sha1="07bbe1a05e3cfaee9e6f0c4a6e3ba6d6ca9c19ff"/>
-		<rom name="Dead of the Brain.sub" size="10036800" crc="d62fbdc9" sha1="1718da7da07e68d650bd345b98deed7c0d919361"/>
+		Origin: redump.org
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 1).bin" size="10231200" crc="6b477157" sha1="0620e99ebe997d42a85a4e92626e75b92bbbb2e5"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 2).bin" size="23990400" crc="6bc542fe" sha1="75efa1b4da85db46f4054d18759c9173ec520df0"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 3).bin" size="41806800" crc="77581570" sha1="1e19a9638fba85a98716d556aee79ff4db903149"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 4).bin" size="31752000" crc="b6832839" sha1="87247491ca459a702237a8329d038e3722833d8f"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 5).bin" size="28047600" crc="46accecb" sha1="3866cd6328fc79c0468154c4d2534d35b0294b7a"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 6).bin" size="21697200" crc="38f29371" sha1="ad62526e42e3c44c90c7d45d68ba2dd8abb17b12"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 7).bin" size="22932000" crc="043fd42d" sha1="9255a7d1e2d3f4902c4c8e1c8955b299acd2abda"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 8).bin" size="48510000" crc="c6d161f7" sha1="bee884785db8e0f0f23b495f4e6b113042f1b911"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan) (Track 9).bin" size="16934400" crc="457b1412" sha1="482ea6f47e67d2c95d99af4a585e5fe9653a2267"/>
+		<rom name="Nightmare Collection - Dead of the Brain - Shiryou no Sakebi (Japan).cue" size="1440" crc="68454269" sha1="e97ae1c195c68a5bd59942138fada3dce73b0255"/>
 		-->
-		<description>Dead of the Brain</description>
+		<description>Dead of the Brain - Shiryou no Sakebi</description>
 		<year>1993</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
-		<info name="serial" value="HME-102"/>
-		<info name="alt_title" value="デッド・オブ・ザ・ブレイン" />
+		<info name="serial" value="HME-102 / IDES-004"/>
+		<info name="alt_title" value="デッド・オブ・ザ・ブレイン　死霊の叫び" />
 		<info name="release" value="199302xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dead of the brain" sha1="c8493803f60156504f69d8003624f4caf98831b6" />
+				<disk name="nightmare collection - dead of the brain - shiryou no sakebi (japan)" sha1="b1f04b77c641b343b74e82ceb9982aa5ed3726e5" />
 			</diskarea>
 		</part>
 	</software>
@@ -4193,6 +4234,38 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="de-ja ii (japan)" sha1="c87f65dc83d2201db10332bb46035fc41dc5bd3e" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="demo90f">
+		<!--
+		Origin: redump.org / wiggy2k
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 1).bin" size="11936400" crc="20b01635" sha1="932231a4ff9859c67e8d5047ad1f247f9192d79f"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 2).bin" size="27523104" crc="bac98b74" sha1="3889d773fc70a8bb527a7f9d24e1fb78742b69c9"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 3).bin" size="24072720" crc="b5bd2a96" sha1="f678c9b204008b2d1d9cdebb3a99ea3911e5c49a"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 4).bin" size="18470256" crc="8d4c9b7c" sha1="7625531f63928035452f5e6f6b497d7f98888e07"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 5).bin" size="24613680" crc="b0676441" sha1="af9c5e247f56a6fd89d2f9df5aa50202e364de1c"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 6).bin" size="21685440" crc="6c38f7a0" sha1="a04b1b7e23a71566b8024ad9a25dd44303c1888d"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan) (Track 7).bin" size="17404800" crc="b64dc05b" sha1="62c8bf8cea30969ad91a0488f7cf3a1b88411dde"/>
+		<rom name="FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns (Japan).cue" size="1144" crc="63c8e586" sha1="0ba06739ec59155646ca44b6cc98b7a9988ba60f"/>
+		-->
+		<description>FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns</description>
+		<year>1990</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-214"/>
+		<info name="alt_title" value="ＦＭ　ＴＯＷＮＳ　デモンストレーションＣＤ‐ＲＯＭ　’９０．冬" />
+		<info name="release" value="199011xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Floppy 0" />
+			<dataarea name="flop" size="1261568">
+				<rom name="fm towns demonstration cd-rom '90. fuyu - the galaxy of fm towns (japan) (floppy 0).hdm" size="1261568" crc="256383c4" sha1="1f65a0b58e04ad1c4eb7c5be4bf456defd734c0b" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fm towns demonstration cd-rom '90. fuyu - the galaxy of fm towns (japan)" sha1="439713d53fa02b815dfd4e15f0fbab8d1245d8a2" />
 			</diskarea>
 		</part>
 	</software>
@@ -4628,30 +4701,33 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="draghalf">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dragon Half.ccd" size="1399" crc="b056d56f" sha1="946db286305ced1214dba79376c67dcbec163147"/>
-		<rom name="Dragon Half.cue" size="372" crc="7d26b4f1" sha1="036bc530b7184909888ca1918b626b8d0b40242f"/>
-		<rom name="Dragon Half.img" size="178573248" crc="0b650cc5" sha1="8510c56fe191a6fae2f3bc79dd92fa321d8f7299"/>
-		<rom name="Dragon Half.sub" size="7288704" crc="35aa9ad6" sha1="4266a770d295948e10bf63b3bd0f79d746cece2b"/>
+		Origin: redump.org
+		<rom name="Dragon Half (Japan) (Track 1).bin" size="9102240" crc="ab4255e1" sha1="b1245cfd677d9f081bbc62b27ebd9586a75219ee"/>
+		<rom name="Dragon Half (Japan) (Track 2).bin" size="5404896" crc="f1a7b5b3" sha1="919e1c44dae3e006319ab75c0654d7a0741ab77d"/>
+		<rom name="Dragon Half (Japan) (Track 3).bin" size="13091232" crc="b80b78fa" sha1="d27e2d4af78448a6e2dfa95336de7e0eabc2c8ab"/>
+		<rom name="Dragon Half (Japan) (Track 4).bin" size="77164416" crc="25af41c3" sha1="81cb5ac8bdcae7d3cb226db2b1f234e76470f058"/>
+		<rom name="Dragon Half (Japan) (Track 5).bin" size="73810464" crc="656d8616" sha1="b0060120b84795301df0f8cf701e8e843e2ae356"/>
+		<rom name="Dragon Half (Japan).cue" size="570" crc="8f8b9ed8" sha1="3e8764e87c4daec53b37cb2fd3251a7efc9bbdc2"/>
 		-->
 		<description>Dragon Half</description>
 		<year>1994</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
+		<info name="serial" value="MTC-1086"/>
 		<info name="alt_title" value="ドラゴンハーフ" />
 		<info name="release" value="199404xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon half" sha1="390d5edd522faaeeda42237ced0856adbb0387ed" />
+				<disk name="dragon half (japan)" sha1="d772fa9f6b648b71a7db0261b1b131c70bf5a954" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="dknight3">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dragon Knight III.bin" size="12700800" crc="e0390649" sha1="8517065fd9dd2bb6a4bebdffad145626b085b6c1"/>
-		<rom name="Dragon Knight III.cue" size="83" crc="6a590cab" sha1="2bd3908ae81aaa5556d1817ef6dd60212a8b856e"/>
+		Origin: redump.org
+		<rom name="Dragon Knight III (Japan).bin" size="12700800" crc="e0390649" sha1="8517065fd9dd2bb6a4bebdffad145626b085b6c1"/>
+		<rom name="Dragon Knight III (Japan).cue" size="114" crc="ca9f00a9" sha1="38f92b3649572f09006641d7edc76629500df8f2"/>
 		-->
 		<description>Dragon Knight III</description>
 		<year>1992</year>
@@ -4662,7 +4738,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon knight iii" sha1="7f1d23ee707023d5058fda1c958c80fb45677489" />
+				<disk name="dragon knight iii (japan)" sha1="536e7ce3481098703e6544371f6bbaf060bd04b0" />
 			</diskarea>
 		</part>
 	</software>
@@ -5059,22 +5135,36 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="elmknigt">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Elm Knight.ccd" size="3285" crc="bd4bf3a0" sha1="3f0af5d3b0d9c8a0950fe62f9ca260d8c05473e6"/>
-		<rom name="Elm Knight.cue" size="1139" crc="da81c07b" sha1="9044bd3a0267720dccd03054a74d4f146a6ab275"/>
-		<rom name="Elm Knight.img" size="504504000" crc="585630e6" sha1="14220511daa03d2f06df2336d0559de7c1686fb7"/>
-		<rom name="Elm Knight.sub" size="20592000" crc="97e181cd" sha1="be2b903d21937d303462a0b42f42408acb89f942"/>
+		Origin: redump.org
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 01).bin" size="20815200" crc="b29982af" sha1="30116963214223e0d92797fd536dbbde5a6ffadc"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 02).bin" size="27871200" crc="d28d18b5" sha1="00fe2e1e9cf9cbd1d80592278ad18e946c57aa50"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 03).bin" size="29635200" crc="a1450d21" sha1="ffbe8d2bbfa53281c8753c61b9e3eb64ea370a5b"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 04).bin" size="28400400" crc="42b7e15c" sha1="9f180f474d152e008724da672e6729266325f467"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 05).bin" size="20638800" crc="e205f1dd" sha1="ddada4bc81da627a61b4d85a74e5d2375450f2fa"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 06).bin" size="33516000" crc="492e5f7e" sha1="656c3efe1673a2ddfea4569800254d0625322c50"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 07).bin" size="28400400" crc="27b746c5" sha1="66963c9a4843560f3a3617a15697fbd95275308a"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 08).bin" size="31752000" crc="81831841" sha1="e7cd43e5737deb54e3451461578cd0157975a27c"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 09).bin" size="34398000" crc="28eda659" sha1="1f25537dd63322dc9459c1adb2f0489605f01a5f"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 10).bin" size="40572000" crc="76120e0c" sha1="a6305e017ddeca6c0a0464c7ef31325fa03a09d1"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 11).bin" size="46393200" crc="6f2429a0" sha1="cf8f68fcb2e602a2e5227e112337dd878c8c6321"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 12).bin" size="23461200" crc="064992ce" sha1="4d1a0b51472415d36a69eb8f3a0042530cca6f58"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 13).bin" size="19933200" crc="49a45076" sha1="cbcb2a10ee56690c71d967b1380de8fefdba04cb"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 14).bin" size="23814000" crc="e38285f3" sha1="a2416b64a7fc533a5e1611b5b6ec9fdc7b12d81b"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 15).bin" size="27694800" crc="069dc5b7" sha1="499f40f63aa20b49cc064bf624ed82091c80f313"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 16).bin" size="24166800" crc="cc16db1e" sha1="0f0c3fd2815a67f359c5fa9dd816d3ca98de306b"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan) (Track 17).bin" size="43041600" crc="5e0f2566" sha1="4365360af2b1d6a0fd1a4e09d10dc6319b8d5500"/>
+		<rom name="Living Body Armor, A - Elm Knight (Japan).cue" size="2317" crc="4e2081b7" sha1="e395b035c6ae9aec348dea9f11b126a7fc43a7ca"/>
 		-->
 		<description>Elm Knight - A Living Body Armor</description>
 		<year>1992</year>
 		<publisher>マイクロキャビン (Micro Cabin)</publisher>
-		<info name="serial" value="HMD-198"/>
+		<info name="serial" value="HMD-198 / MTC-1027"/>
 		<info name="alt_title" value="エルムナイト" />
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="elm knight" sha1="98ff3cc7c954c1aa98b3c966d420bc72cb7fb423" />
+				<disk name="living body armor, a - elm knight (japan)" sha1="1de311fea7d4f173d5660c2530c585f05f83f6ef" />
 			</diskarea>
 		</part>
 	</software>
@@ -5645,6 +5735,36 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fbc1121" sha1="5ea72d3c25554a3bdcd64085ff4271cb5b0aac46" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="fbc2110">
+		<!--
+		 Origin: redump.org
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 01).bin" size="263894400" crc="99dd7303" sha1="c15a4e81a7bccb6daf6fee1caa1dcb888644668f"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 02).bin" size="41729184" crc="dfdf5c43" sha1="07c632f89506d3a543ea3fcbfa22a49bd43961ee"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 03).bin" size="15059856" crc="cb66c765" sha1="628f7b773a50a0b9b9011dc8602d8e12436da3fa"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 04).bin" size="24166800" crc="bd9213bc" sha1="006c5fcd90adff06b677b98017c4a69ef464b6de"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 05).bin" size="37330944" crc="5debd853" sha1="23d9e5395780a406cfe3e20210d553d1cf0f7064"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 06).bin" size="9085776" crc="5e39e97a" sha1="72c227ba97d353aefba2431ac8a93c3b4915bebd"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 07).bin" size="5491920" crc="5500d74a" sha1="7274dbf63d2db90579f79f1fadb8a6a7977ae76d"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 08).bin" size="5120304" crc="34a73d87" sha1="2a1cc41bf6b7f528efd77e38b539ea3f5e305780"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 09).bin" size="9478560" crc="547491a0" sha1="acaa5f1933d0cd48f9270520092110d13ae3a80b"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 10).bin" size="4793376" crc="e20371ea" sha1="55af96c06a9dad5c0d77caa8eb8705d3f90cb945"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 11).bin" size="16793280" crc="173b15bf" sha1="743c367f69136fb6e84c459dbce4d66cae7ca2ea"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 12).bin" size="34720224" crc="b51a094d" sha1="bd08476b38823cefc6aa5edcaa07c42ebc889fa5"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan) (Track 13).bin" size="20963376" crc="7cd41bcc" sha1="1d4334ea7e792d8186972bce90357a4a0055008d"/>
+		<rom name="F-BASIC386 Compiler V2.1L10 (Japan).cue" size="1695" crc="8057d590" sha1="cf0462eea9104661fdaff41f72ea5a3fbb92b18b"/>
+		 -->
+		<description>F-BASIC386 Compiler v2.1 L10</description>
+		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276C021"/>
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="f-basic386 compiler v2.1l10 (japan)" sha1="176537f88c83b2182b6e5f016a5c4b871f0cf1eb" />
 			</diskarea>
 		</part>
 	</software>
@@ -6627,6 +6747,40 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="ginga2dx">
+		<!--
+		Origin: redump.org
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 01).bin" size="10231200" crc="64b1247b" sha1="c3b35ca96ba954f3f220358d7a65ad999f8560c0"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 02).bin" size="50356320" crc="c0db5e43" sha1="a058b9ea87ce9debf51c4e4c5480320f32c57ac3"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 03).bin" size="31552080" crc="1775e87b" sha1="f5953d5233a687b69d54c436649a6cfc4be49dc1"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 04).bin" size="45080784" crc="d61b0803" sha1="10fd19d62e713d1fd21d81ca807f02cc4251c2ca"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 05).bin" size="33786480" crc="49539fee" sha1="c28eccf2927ad03a698b9b6991bc710aaf5b7478"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 06).bin" size="37349760" crc="7ec37ee2" sha1="17030d9247223f0d13fb9787448181d656542497"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 07).bin" size="24296160" crc="05a3331a" sha1="47a581936409b22a145a66153dd271df030ce270"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 08).bin" size="27553680" crc="d9051f98" sha1="e6b002a54758622015f7b7b3e0281b34a01d9689"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 09).bin" size="21450240" crc="7027f1c1" sha1="eff40189ed417a3d2522b89aba0c55c65aedb5a0"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 10).bin" size="27266736" crc="5deac1bb" sha1="68f2cc9cae0c8735fff41f8812d15a65d2c410db"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 11).bin" size="23548224" crc="43d921be" sha1="b13727aeeb8ae3353325dc506189199afaa292b8"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 12).bin" size="24997056" crc="bda08947" sha1="c7fac888cc908187f3b41e51f2b2e8055d690e27"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 13).bin" size="77286720" crc="6e66f966" sha1="d616cc77836602014473b781bca41f4bf7e7f62f"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 14).bin" size="42046704" crc="33e1ed49" sha1="1e522153b5acad7e27fa7abf03123d98c06637d1"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan) (Track 15).bin" size="1959216" crc="460945bc" sha1="beaeddb63fc5c944fa4811061b3ada14dca7f24f"/>
+		<rom name="Ginga Eiyuu Densetsu II DX+ Towns Special (Japan).cue" size="2142" crc="bbdaec3d" sha1="b81c8e74aba145d7677720e66323add12474e540"/>
+		-->
+		<description>Ginga Eiyuu Densetsu II DX+ Towns Special</description>
+		<year>1992</year>
+		<publisher>ボーステック (Bothtec)</publisher>
+		<info name="serial" value="HMD-136 / QR-9243"/>
+		<info name="alt_title" value="銀河英雄伝説ⅡＤＸ+　ＴＯＷＮＳスペシャル" />
+		<info name="release" value="199205xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="ginga eiyuu densetsu ii dx+ towns special (japan)" sha1="873fddaf81e034d22b502811d9b3c181fd436950" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="ginga3sp">
 		<!--
 		Origin: redump.org
@@ -6649,6 +6803,27 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ginga eiyuu densetsu iii sp (japan)" sha1="a490e0279fbb11f6e0b3d97e1cceb74c0cc09c09" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="gingaod2">
+		<!--
+		Origin: redump.org
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 2 - Choushinsei Bakuhatsu (Japan) (Track 1).bin" size="104958000" crc="0b9ed9c8" sha1="1074426139739a4f17670654f7f561c1d1fff1b4"/>
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 2 - Choushinsei Bakuhatsu (Japan) (Track 2).bin" size="486864000" crc="193500ab" sha1="c1bf3a8068acd6f9543c3a36f4b19be2d289986f"/>
+		<rom name="NHK Special - Ginga Uchuu Odyssey Vol. 2 - Choushinsei Bakuhatsu (Japan).cue" size="314" crc="783ac25f" sha1="5fe389e8c6fdb7c9e9b7cb0e0605f85563965925"/>
+		-->
+		<description>NHK Special - Ginga Uchuu Odyssey Vol. 2 - Choushinsei Bakuhatsu</description>
+		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="A2760151 / TSC240"/>
+		<info name="alt_title" value="ＮＨＫスペシャル　銀河宇宙オデッセイ②　「超新星爆発」" />
+		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nhk special - ginga uchuu odyssey vol. 2 - choushinsei bakuhatsu (japan)" sha1="d59248d8aea3611c11bf1be77ecb445f96425617" />
 			</diskarea>
 		</part>
 	</software>
@@ -7349,6 +7524,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="hypraddr2" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Address Ver. 2.0 (Japan) (Track 1).bin" size="31399200" crc="7135813e" sha1="939f5c57bd5b7ddd59cc5b834cf1538fd27e2ef5"/>
+		<rom name="Hyper Address Ver. 2.0 (Japan) (Track 2).bin" size="68541984" crc="1006c964" sha1="bfb743d513d7edd99146d635b3f583d8a1ad76dd"/>
+		<rom name="Hyper Address Ver. 2.0 (Japan) (Track 3).bin" size="24185616" crc="0bae0270" sha1="de67643ff528a277b6b68e1a90114318acc1644d"/>
+		<rom name="Hyper Address Ver. 2.0 (Japan).cue" size="354" crc="49bcf89f" sha1="c39c06e0370a6b436e1aa2afa9130f0e824abefe"/>
+		-->
+		<description>Hyper Address Ver. 2.0</description>
+		<year>1991</year>
+		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HMB-220"/>
+		<info name="release" value="199104xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper address ver. 2.0 (japan)" sha1="00755736bab60abc334487e29fd8317332482b21" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="hypchttv">
 		<!--
 		Origin: redump.org
@@ -7781,6 +7977,38 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="indiana jones and the last crusade (japan) (en,ja)" sha1="9ac388d3e0640d45cf2469a6fe4a872a45dcd8f2" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="indycrusd">
+		<!--
+		Origin: redump.org
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 01).bin" size="20822256" crc="2f7d8d6c" sha1="2ba068440d09626f48c119e3c5fc1584e544206b"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 02).bin" size="36688848" crc="27b4fff6" sha1="1ddbbf68d0e847f0542693d15a380f2ac1c00bd1"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 03).bin" size="12489120" crc="4203f415" sha1="9c16df4b80d3f448d7f90c2a77b44e4a687fe889"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 04).bin" size="20591760" crc="6c9a0625" sha1="15cb7fae3f4cd69608b6e4edd0f88e0c2f19f1bc"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 05).bin" size="26010768" crc="98901342" sha1="65ba134a91d42564aa1112e2d2bfc37be9b597c3"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 06).bin" size="21438480" crc="48786fc0" sha1="2c99c42fad07301e32124e1405f861a628806a19"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 07).bin" size="12606720" crc="0dd7f0ff" sha1="18a8d4d46cfe84bded5f27f04ebf67ec10329a24"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 08).bin" size="30608928" crc="eba506d7" sha1="5eda8e752bf39fb1f58270b680afea3499a2782b"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 09).bin" size="37272144" crc="e8e43bd5" sha1="4e459b90097917d357e893357e14d850e87772f3"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 10).bin" size="27024480" crc="d0da4755" sha1="e9ee9f875e1e14ecd3f45246d2b71e058b61c73f"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 11).bin" size="19051200" crc="242553df" sha1="57b0b83b3dd67dbf5611a69237d9f402ebefd24f"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 12).bin" size="32149488" crc="42bde95d" sha1="44e4e2e1afadbf3e08b21d3533d2650c6ce74589"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 13).bin" size="30893520" crc="2e70f133" sha1="2fadb1f3c1494846d32cc21b158ff37247a345bf"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 14).bin" size="6303360" crc="50ed98b1" sha1="8e6bcc8676e54162a0a9aad8d590a17e81a9acbe"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo) (Track 15).bin" size="6903120" crc="482bddb6" sha1="fc14aead3bd8f7e2f555892e1f908bc4af64041b"/>
+		<rom name="Indiana Jones and the Last Crusade (Japan) (En,Ja) (Demo).cue" size="2285" crc="fd98018f" sha1="6402420e2c910d1f62d90312a8cf9e6a047caf22"/>
+		-->
+		<description>Indiana Jones and the Last Crusade (Pre-Release Version)</description>
+		<year>1990</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-916"/>
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="indiana jones and the last crusade (japan) (en,ja) (demo)" sha1="469d1fe1a750ef91efa4423c80cd3efbea22659a" />
 			</diskarea>
 		</part>
 	</software>
@@ -10543,6 +10771,24 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="mmorphd" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="MegaMorph (Japan) (Demo).bin" size="73735200" crc="e05bc391" sha1="dbd835be0a52f6f2936ec1711db5f25b0c8ecca1"/>
+		<rom name="MegaMorph (Japan) (Demo).cue" size="90" crc="23936c6b" sha1="fbe2cb706be58fdbcc9d85322f5164a4d1d2081c"/>
+		-->
+		<description>Megamorph (Demo)</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMF-921"/>
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="megamorph (japan) (demo)" sha1="e48d4374ac4b66c5168d6276252151dcdffcd2fa" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="mode7">
 		<!--
 		Origin: Neo Kobe Collection
@@ -11638,8 +11884,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Wrong colors and other graphical glitches -->
-	<software name="niko2" supported="partial">
+	<software name="niko2">
 		<!--
 		Origin: redump.org
 		<rom name="Niko^2 (Japan).bin" size="10231200" crc="a0d255b9" sha1="16924ba91862c909730502cadec7eefb94150521"/>
@@ -11660,24 +11905,20 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="ningytsu">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Ningyou Tsukai.mdf" size="10648800" crc="29cf6174" sha1="0b85b784f55f2e8484524429e783c73ed3cf4bbe"/>
-		<rom name="Ningyou Tsukai.mds" size="486" crc="536f9a49" sha1="086e301d1cf7ed4e7b7d04eb2ae7a636a1fb79e7"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="ningyou tsukai.bin" size="10231200" crc="24337682" sha1="c1e947259e397f3e7ca1840fd8ac76b217835b96"/>
-		<rom name="ningyou tsukai.cue" size="75" crc="a2bb6b88" sha1="3d42988318ee1a6c052c2175242745b08e5b78f8"/>
+		Origin: redump.org
+		<rom name="Ningyou Tsukai (Japan).bin" size="10231200" crc="24337682" sha1="c1e947259e397f3e7ca1840fd8ac76b217835b96"/>
+		<rom name="Ningyou Tsukai (Japan).cue" size="111" crc="4d5625e1" sha1="2b950d5d8ce15d45a9a768e93b877da7bb0ae81f"/>
 		-->
 		<description>Ningyou Tsukai</description>
 		<year>1993</year>
 		<publisher>フォレスト (Forest)</publisher>
-		<info name="serial" value="HME-212"/>
+		<info name="serial" value="HME-212 / MTC-1029"/>
 		<info name="alt_title" value="人形使い" />
 		<info name="release" value="199310xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ningyou tsukai" sha1="d2e93204d3cc2557f26ee72c07d0ab1109bf5846" />
+				<disk name="ningyou tsukai (japan)" sha1="aac6064bcf6fd1665970017fa59c268ad3044aed" />
 			</diskarea>
 		</part>
 	</software>
@@ -12386,35 +12627,30 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!--
-	It should be possible to recreate the user disk by running the ユーザーディスク作成 program
-	on the CD, but it doesn't seem to work. Not sure if it's an emulation issue or
-	something else.
-
-	The system disk is needed only for installing the game into a hard disk.
-	-->
 	<software name="powdoll">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Power Dolls.ccd" size="2663" crc="ab55cc77" sha1="d99f063b36f3a7c0666211d5bcfd4a953f4c4264"/>
-		<rom name="Power Dolls.cue" size="467" crc="e7842606" sha1="3ac782b6fdb79c40cc43b2c1ac585bc69081d91d"/>
-		<rom name="Power Dolls.img" size="429181200" crc="fd3f758a" sha1="22ec8aa25ad7b2e24769a60545159d98a6fbc590"/>
-		<rom name="Power Dolls.sub" size="17517600" crc="6b532f45" sha1="41aae39e4c4d2f616bbdbe534593f35d5d5284c6"/>
+		Origin: redump.org
+		<rom name="Power DoLLS (Japan) (Track 01).bin" size="20815200" crc="995eb06d" sha1="1eb34c59c8cb3d35d17cd389ca8a2904bca0dc2d"/>
+		<rom name="Power DoLLS (Japan) (Track 02).bin" size="68266800" crc="d23eba28" sha1="8cf5ec75f7f83bfb850312f92aeef2c4ccedd138"/>
+		<rom name="Power DoLLS (Japan) (Track 03).bin" size="28753200" crc="8b9a3423" sha1="6ca592b7b6955cedbea1727bd7494e87e0eb694e"/>
+		<rom name="Power DoLLS (Japan) (Track 04).bin" size="34398000" crc="5882602b" sha1="1cb336b1682d8dbc93c5f4edfa0462d2abb37734"/>
+		<rom name="Power DoLLS (Japan) (Track 05).bin" size="47451600" crc="013689e5" sha1="7e2f8faf1f2b89abe7ea8470eb3f4ae068e5ae6a"/>
+		<rom name="Power DoLLS (Japan) (Track 06).bin" size="24696000" crc="0d01424e" sha1="d126267c7b4bb30405278e2001274218449239df"/>
+		<rom name="Power DoLLS (Japan) (Track 07).bin" size="33163200" crc="828cebf2" sha1="9812d1649a03a3f7c0ab73c7d7da38fee6532bac"/>
+		<rom name="Power DoLLS (Japan) (Track 08).bin" size="43923600" crc="3784d20b" sha1="74469704c48ef4c72323123eed6b72af9691cfc0"/>
+		<rom name="Power DoLLS (Japan) (Track 09).bin" size="46569600" crc="88d1d628" sha1="b137a2e68eb6a99d45e67489031b3eb07048b45a"/>
+		<rom name="Power DoLLS (Japan) (Track 10).bin" size="38808000" crc="f27b70b5" sha1="31414c297bffc8fc09600be46c9f7854d1ecb64f"/>
+		<rom name="Power DoLLS (Japan) (Track 11).bin" size="42336000" crc="a689700a" sha1="1d31dcd374dde7eabe1ee8fc4fab8c475a266a4a"/>
+		<rom name="Power DoLLS (Japan).cue" size="1259" crc="77402c57" sha1="1a53f6a68a8ff7d640df632bb8e49797c5a48aa6"/>
 		-->
-		<description>Power Dolls</description>
+		<description>Power DoLLS</description>
 		<year>1994</year>
 		<publisher>工画堂 (Kogado)</publisher>
-		<info name="serial" value="HMF-151"/>
+		<info name="serial" value="HMF-151 / MTC-1097"/>
 		<info name="alt_title" value="パワードール" />
 		<info name="release" value="199407xx" />
-		<info name="usage" value="Requires 2 MB RAM"/>
+		<info name="usage" value="Requires 2 MB RAM. The first time running the game, hold both mouse buttons while booting to go to TownsMENU, then run the ユーザーディスク作成 icon to create a bootable user disk."/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="User Disk" />
-			<dataarea name="flop" size="1261568">
-				<rom name="power dolls (user disk).hdm" size="1261568" crc="7b90b036" sha1="8cc2d7cdf2ffde4133cddd039f6620ba17b1e553" offset="000000" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
 				<rom name="power dolls (system disk).hdm" size="1261568" crc="5f6c44c7" sha1="721dd113dc6bedfb2d212e3a4de15260c41805f7" offset="000000" />
@@ -12422,29 +12658,37 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power dolls" sha1="22c895ef1b29fe4f01b1956d323657fe67a9c832" />
+				<disk name="power dolls (japan)" sha1="879bb700ba35d56112459077e4b44802ead42338" />
 			</diskarea>
 		</part>
 	</software>
 
 	<software name="powdoll2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Power Dolls 2.ccd" size="2677" crc="c81560b2" sha1="ace60c9b20a9bb09477bb767d62fad8db3c05f22"/>
-		<rom name="Power Dolls 2.cue" size="469" crc="5a2f1ab9" sha1="68867b0c58e456177ab554c3155185696bbd0a5b"/>
-		<rom name="Power Dolls 2.img" size="385664496" crc="c3df8690" sha1="f7299ccaf16f4b0c5d69138f8932749aac211015"/>
-		<rom name="Power Dolls 2.sub" size="15741408" crc="19698eb9" sha1="c3219d969a89f9e1b00c678fec7a3be845d233d5"/>
+		Origin: redump.org
+		<rom name="Power DoLLS 2 (Japan) (Track 01).bin" size="34804896" crc="5e7fdb30" sha1="221012898575070ed5b89e9044aff334a2c3468c"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 02).bin" size="40748400" crc="e7b2896b" sha1="4825386c998e0fbb2363b3a86905e3395fd38968"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 03).bin" size="44100000" crc="ae2504d6" sha1="9313cbf9c0533bb7dd29a3a7a093293f61f22009"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 04).bin" size="34221600" crc="ad12003c" sha1="8f275daa4e6322659388136dae2953145a2323bf"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 05).bin" size="40395600" crc="10f6922d" sha1="6675a6264d503b20983131b6f9c9ad7f87a19d62"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 06).bin" size="34045200" crc="a1596881" sha1="ce47b300cae0146504b7bbb57f7826b2d6f9cf34"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 07).bin" size="24343200" crc="dbadaddf" sha1="9d104674d6afd7fb31078662f9f02d13dfcbd612"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 08).bin" size="26460000" crc="06c51d6b" sha1="7b9f361e725ffdb1a49e17f987534f0baae494e9"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 09).bin" size="35632800" crc="3da8f3c6" sha1="1f0fd7e903d361a53f64332a2159bf8ab9ee7454"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 10).bin" size="31575600" crc="9823a691" sha1="73d199e2c270b0783ce93bd7570a8030602fdd7f"/>
+		<rom name="Power DoLLS 2 (Japan) (Track 11).bin" size="39337200" crc="02a5cce6" sha1="b3f1b7518f46290c6aaf74dd6164147a78a02448"/>
+		<rom name="Power DoLLS 2 (Japan).cue" size="1258" crc="24d953cf" sha1="0ce5efca69c368c48e311d4f061bf2af9dd7cbee"/>
 		-->
-		<description>Power Dolls 2</description>
+		<description>Power DoLLS 2</description>
 		<year>1995</year>
 		<publisher>工画堂 (Kogado)</publisher>
-		<info name="serial" value="HMF-152"/>
+		<info name="serial" value="HMF-152 / MTC-1136"/>
 		<info name="alt_title" value="パワードール2" />
 		<info name="release" value="199511xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power dolls 2" sha1="248ec3f239e8d069490867d437ac0465dbf878b4" />
+				<disk name="power dolls 2 (japan)" sha1="deed55b2d47dc251334c7f5afc1e2bb69718ebff" />
 			</diskarea>
 		</part>
 	</software>
@@ -12520,6 +12764,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="prince of persia 2" sha1="7e46f99eb028afc8f955e5d4d7d3e38b6fefbc73" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="presence">
+		<!--
+		Origin: redump.org
+		<rom name="Presence (Japan) (Track 1).bin" size="52567200" crc="0316ba84" sha1="1cfd93b2f3352429a772be812f5e89b195cacb69"/>
+		<rom name="Presence (Japan) (Track 2).bin" size="23731680" crc="3d96353a" sha1="49e4dfdc72dfe56ced0a98304dc850e12c436154"/>
+		<rom name="Presence (Japan).cue" size="225" crc="134334ca" sha1="6794a75a89615db8f90c25b6053ce468015d7ef0"/>
+		-->
+		<description>Presence</description>
+		<year>1992</year>
+		<publisher>シュールド・ウェーブ (Sur De Wave)</publisher>
+		<info name="serial" value="HMD-204"/>
+		<info name="release" value="199212xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="presence (japan)" sha1="2a67dfc67b6b8b93a900bb13d3958a4f95f927b0" />
 			</diskarea>
 		</part>
 	</software>
@@ -12699,6 +12963,42 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 2 - memories (japan)" sha1="72b60294314bb95a2f5574ee769bc00c675faa40" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="psydet2d">
+		<!--
+		Origin: redump.org
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 01).bin" size="63504000" crc="e898c0db" sha1="d50e2f0d1846d094a37d62d8cdeaef3949e066a2"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 02).bin" size="57635760" crc="6902b4bf" sha1="179e32b22664d5b5d9f2f8b7ec5af6b0245e8e61"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 03).bin" size="11124960" crc="e18f8c09" sha1="809d9d0cfd3db2ad365070c4a47d550613da52f5"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 04).bin" size="29929200" crc="7f4ae24d" sha1="9df4da8f631ae733a0086d26847ee3c1f1b0bd4c"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 05).bin" size="19533360" crc="4ce1dd75" sha1="827fab5766a61b58ad37bb8d46181f40184f3bf2"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 06).bin" size="17004960" crc="38cc42f4" sha1="60435678841850cf0987a6018774ad6bb6c4d672"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 07).bin" size="43547280" crc="caeb3ff7" sha1="8725589b3e8bf71bb9bb6b45a78af5fe001da316"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 08).bin" size="17757600" crc="0ade8aa6" sha1="ab15f1adeb724dbd87f46ff3c356827131514b26"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 09).bin" size="12406800" crc="89d426c3" sha1="fe6de082ef7397045c95fc5be35a9a85f447ec63"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 10).bin" size="10960320" crc="683a41b3" sha1="f9f73ac14cb1dda1d3b7267db989d057acda3509"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 11).bin" size="10337040" crc="6b6ff12d" sha1="3bd5e4fc24637c836af8a45d77d4f7ec50b903d1"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 12).bin" size="13912080" crc="0f66bd26" sha1="c858fd179e5a46ee884804bf6ea2e5ff075d9b0f"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 13).bin" size="35585760" crc="0b94f73d" sha1="a62cabce24a56f22f63f87bf92cb3ccea77ac2c9"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 14).bin" size="67196640" crc="b97e96f5" sha1="00d915afe3ff0c251b96653a5f78b632990a3d3b"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 15).bin" size="11842320" crc="4d7d8bfa" sha1="852dfaba68ccbf32bea3dc78e1b60b604de29826"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 16).bin" size="54295920" crc="56b59927" sha1="6231347976335ddd6d61b898acd9ee9c1862157e"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 17).bin" size="6550320" crc="e3bdf902" sha1="54dc453b2e539caf9fa1e69acf3b04b206e3754e"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo) (Track 18).bin" size="4233600" crc="4580866a" sha1="aaefaba5020efb03452df764e2897d0f278e3151"/>
+		<rom name="Psychic Detective Series Vol. 2 - Memories (Japan) (Demo).cue" size="2718" crc="c7d46131" sha1="3371a920e62f42b2285e90eba63d272bcd1f3af3"/>
+		-->
+		<description>Psychic Detective Series Vol. 2 - Memories (Demo)</description>
+		<year>1989</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="HMA-900"/>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.2　メモリーズ" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="psychic detective series vol. 2 - memories (japan) (demo)" sha1="9066c9e1a44fe71db90d435ed1a72a8b4cdc2e4f" />
 			</diskarea>
 		</part>
 	</software>
@@ -13452,23 +13752,29 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Windows / PC-9821 / FM Towns hybrid -->
 	<software name="rinkan">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="2046" crc="54f0ec1f" sha1="686a7ecc6a53e9b2ede8ff3396ad0c6e38b87e3c"/>
-		<rom name="Image.cue" size="340" crc="c0ad3f7d" sha1="6d39c08ccbd98363f1cc7bbc79038baacae268f4"/>
-		<rom name="Image.img" size="379859760" crc="fef77566" sha1="fd7569f8c41405fd2898577ffc1806d57e47bd7d"/>
-		<rom name="Image.sub" size="15504480" crc="1d0cc31c" sha1="8f56ddae02360a9f22821ba35ae1c7def1462c13"/>
+		Origin: redump.org
+		<rom name="Rinkan Gakkou (Japan) (Track 1).bin" size="189886368" crc="99408606" sha1="08fff78831fbed3bef02bf81f8cc019991120d75"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 2).bin" size="24811248" crc="6488b2eb" sha1="8342c060cb187d84e788f4bec69151e13d84e749"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 3).bin" size="38041248" crc="7d6e820c" sha1="52fae0b8bc659f7d488afe12643b98a33d82850a"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 4).bin" size="40146288" crc="5be3c7cb" sha1="6a64562586c0c54c0420a9c34854f83b39dd841d"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 5).bin" size="9652608" crc="7dc41706" sha1="96a5d812b6e2b1c990b4a157817ff465d10be2de"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 6).bin" size="34158096" crc="8ed52a93" sha1="ce63608dd70441708d0ccf18221fa8f1cb18ed06"/>
+		<rom name="Rinkan Gakkou (Japan) (Track 7).bin" size="43163904" crc="625345df" sha1="6af51fb830e0c0ad23ee80ff64f7c9ce4a02ec3b"/>
+		<rom name="Rinkan Gakkou (Japan).cue" size="672" crc="59e824a1" sha1="6378dba1a7eff4dc9ab178d100d1e587a583702f"/>
 		-->
 		<description>Rinkan Gakkou</description>
 		<year>1996</year>
 		<publisher>フォスター (Foster)</publisher>
+		<info name="serial" value="CBF-0002"/>
 		<info name="alt_title" value="林間学校" />
 		<info name="release" value="199602xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rinkan" sha1="2574f07d8495ea197b5a04136f860b5466fa1ad5" />
+				<disk name="rinkan gakkou (japan)" sha1="1cc77c9ca07d7cf8364431442367efd6b1cebc89" />
 			</diskarea>
 		</part>
 	</software>
@@ -14005,6 +14311,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sherlock holmes - consulting detective (japan)" sha1="e0e0767fbde8bb455641666f7f2fe48c45e0048a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="sherlockd">
+		<!--
+		Origin: redump.org
+		<rom name="Sherlock Holmes - Consulting Detective (Japan) (Demo).bin" size="730836960" crc="31b97a17" sha1="7684a941a2a4c6c3521007597de249511e49f546"/>
+		<rom name="Sherlock Holmes - Consulting Detective (Japan) (Demo).cue" size="119" crc="1b51a0d8" sha1="b6e8ecc1b0903e00e9b194b93aa6b3f58bb0a388"/>
+		-->
+		<description>Sherlock Holmes - Consulting Detective (Demo)</description>
+		<year>1990</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMC-901"/>
+		<info name="alt_title" value="シャーロックホームズの探偵講座" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="sherlock holmes - consulting detective (japan) (demo)" sha1="a0b64d1a73dc43995133191d1a00d564044e8973" />
 			</diskarea>
 		</part>
 	</software>
@@ -15205,13 +15530,37 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="steepialt">
+		<!--
+		Origin: redump.org
+		<rom name="Steepia Lite (Japan) (Track 1).bin" size="31046400" crc="60663fe9" sha1="200b9a56356710e7614c90109f5d41404fe07bed"/>
+		<rom name="Steepia Lite (Japan) (Track 2).bin" size="43218000" crc="b293ff0f" sha1="d477712a942edf338d9636a2aacea6fdf020c13f"/>
+		<rom name="Steepia Lite (Japan) (Track 3).bin" size="58917600" crc="397a945f" sha1="02a7e2f4fca7d876880a317033b10211684fc0bd"/>
+		<rom name="Steepia Lite (Japan) (Track 4).bin" size="51685200" crc="b7c3b9d9" sha1="4f41184fa1dd26136373d9c2479494bd39c268ad"/>
+		<rom name="Steepia Lite (Japan) (Track 5).bin" size="34574400" crc="f7282eb1" sha1="bb57b1e764b0097d0298172afdad09f0b6fa179d"/>
+		<rom name="Steepia Lite (Japan) (Track 6).bin" size="53449200" crc="e039a537" sha1="3023f550f150078c7c24213d9f1901a650e028c5"/>
+		<rom name="Steepia Lite (Japan) (Track 7).bin" size="31928400" crc="1c8a94e1" sha1="e70de558fd71e68e9df330d39d8c89b3fe74ae0d"/>
+		<rom name="Steepia Lite (Japan).cue" size="780" crc="312dc4c4" sha1="890e42982a0b94c572237001cee585b5a42430c3"/>
+		-->
+		<description>Steepia Lite</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-118 / A2760400 / TSC330"/>
+		<info name="alt_title" value="スティーピア　ライト" />
+		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="steepia lite (japan)" sha1="9622e76e629eeef2676ef2e3b489b7b4610d120f" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="strike">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Strike Commander.ccd" size="770" crc="91c09160" sha1="c1b6eb7520ccc118fb806363f08f130d414057fb"/>
-		<rom name="Strike Commander.cue" size="80" crc="2aeb3159" sha1="c5aa55eee16773628a5d891961eae748af64122e"/>
-		<rom name="Strike Commander.img" size="126321216" crc="58db3c67" sha1="e7c96197ef9252234bbed00a33332b71ed82f5d4"/>
-		<rom name="Strike Commander.sub" size="5155968" crc="b1b319dd" sha1="f67a0af1c4e9bf9561f57ded66dbaa1bf46d8bb6"/>
+		Origin: redump.org
+		<rom name="Strike Commander (Japan).bin" size="126321216" crc="58db3c67" sha1="e7c96197ef9252234bbed00a33332b71ed82f5d4"/>
+		<rom name="Strike Commander (Japan).cue" size="113" crc="2a777bfa" sha1="fbb5eafd1ce0f222dcdcc70f7f8ffd446b0688af"/>
 		-->
 		<description>Strike Commander</description>
 		<year>1994</year>
@@ -15219,10 +15568,10 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="EFT-7010 / HMDC-1915"/>
 		<info name="alt_title" value="ストライク・コマンダー" />
 		<info name="release" value="199408xx" />
-		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
+		<info name="usage" value="Requires HDD installation and 6 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strike commander" sha1="4ce5635dfe368cedfe0d61fb46a11d8f7fb2c083" />
+				<disk name="strike commander (japan)" sha1="297385db8fc933594b7316d87ff1001849785be8" />
 			</diskarea>
 		</part>
 	</software>
@@ -15240,7 +15589,7 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ストライク・コマンダーPLUS" />
 		<info name="release" value="199504xx" />
-		<info name="usage" value="Requires HDD installation and 4 MB RAM"/>
+		<info name="usage" value="Requires HDD installation and 6 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="strike commander plus" sha1="c926c123e3c0c8e439b16c27ecca3b420e1964bb" />
@@ -16178,6 +16527,41 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9821 / FM Towns hybrid -->
+	<software name="trigger2">
+		<!--
+		Origin: redump.org
+		<rom name="Trigger 2 (Japan) (Track 01).bin" size="197702064" crc="e23e140b" sha1="29f14f5667e2a3c80320006e202cb2a56b639bd7"/>
+		<rom name="Trigger 2 (Japan) (Track 02).bin" size="29581104" crc="8d228907" sha1="ba1d1612a3b75f9a20750aacd9afab1d09ff7627"/>
+		<rom name="Trigger 2 (Japan) (Track 03).bin" size="28165200" crc="81b2d682" sha1="73e334ef49dd89d65dcfc3a1e929f1defb956593"/>
+		<rom name="Trigger 2 (Japan) (Track 04).bin" size="19864992" crc="feaf1071" sha1="bb139364c23f73612d5d290081b64d44374ceb83"/>
+		<rom name="Trigger 2 (Japan) (Track 05).bin" size="25822608" crc="4b72fd21" sha1="5feeda73ae3d5d8983e495c4e8da413f335f8436"/>
+		<rom name="Trigger 2 (Japan) (Track 06).bin" size="22656816" crc="14104365" sha1="63d0e5bbaa76ade5e6f3c5443aa55e858a54bb38"/>
+		<rom name="Trigger 2 (Japan) (Track 07).bin" size="18855984" crc="c18f7ff8" sha1="9d40b9ff13c04a282c1476bed522a8bb4e25ff7e"/>
+		<rom name="Trigger 2 (Japan) (Track 08).bin" size="22929648" crc="26350032" sha1="1832c4c711ec077912c909049c5b02228765bec9"/>
+		<rom name="Trigger 2 (Japan) (Track 09).bin" size="24152688" crc="84bc2ae5" sha1="892b7d71d71d8fea4f53bb8ed86d7ad7523bc0e7"/>
+		<rom name="Trigger 2 (Japan) (Track 10).bin" size="35992656" crc="162cb2b0" sha1="7f3d0af63af755214676cd8b6340f8c78e504b73"/>
+		<rom name="Trigger 2 (Japan) (Track 11).bin" size="20161344" crc="b5b7f108" sha1="f5e3b18fddc831dbab978d80e5bd74a2f40c4554"/>
+		<rom name="Trigger 2 (Japan) (Track 12).bin" size="21828912" crc="9ff8672f" sha1="8bec717b590b34d65afe66d2e6956c08198c4f2e"/>
+		<rom name="Trigger 2 (Japan) (Track 13).bin" size="25702656" crc="0d199dd8" sha1="818bf0b257761c0d8c82e57185f61cadc765e75f"/>
+		<rom name="Trigger 2 (Japan) (Track 14).bin" size="26081328" crc="b8801a50" sha1="9c0e379cd293f4dff631b71cfa57d6b31007ada8"/>
+		<rom name="Trigger 2 (Japan) (Track 15).bin" size="29679888" crc="571811e0" sha1="1e1d33582c719651da311386fbe1b525f7891a37"/>
+		<rom name="Trigger 2 (Japan).cue" size="1363" crc="f3add79a" sha1="6579b0567611414285f6cecf1c244973d6c93b7f"/>
+		-->
+		<description>Trigger 2</description>
+		<year>1995</year>
+		<publisher>ジックス (ZyX)</publisher>
+		<info name="serial" value="ZYX-0004"/>
+		<info name="alt_title" value="トリガー2" />
+		<info name="release" value="199509xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="trigger 2 (japan)" sha1="80e939c23b7ccd2fdb53728a49c450f319feacd8" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Missing a floppy disk -->
 	<software name="truheart" supported="no">
 		<!--
@@ -16624,11 +17008,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="viperv6">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Viper V6 Turbo RS.ccd" size="750" crc="318ccd71" sha1="a47f5847de0fe5af93fc8d3b19a85800774b5244"/>
-		<rom name="Viper V6 Turbo RS.cue" size="99" crc="159b0b0f" sha1="6775947743d352f6608709ca51514474990fac75"/>
-		<rom name="Viper V6 Turbo RS.img" size="63151200" crc="307627bb" sha1="832dced51299a3f13ffc4532c76215f1b558c6d0"/>
-		<rom name="Viper V6 Turbo RS.sub" size="2577600" crc="b7dcf321" sha1="0993fbd9fcd53cffd0ca231f5180a9d233af319c"/>
+		Origin: redump.org
+		<rom name="Viper-V6 Turbo RS (Japan).bin" size="63151200" crc="307627bb" sha1="832dced51299a3f13ffc4532c76215f1b558c6d0"/>
+		<rom name="Viper-V6 Turbo RS (Japan).cue" size="91" crc="83570136" sha1="3c38166463039365aa9afe31aa888c246edd4dba"/>
 		-->
 		<description>Viper-V6 Turbo RS</description>
 		<year>1995</year>
@@ -16638,7 +17020,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="viper v6 turbo rs" sha1="3ba0afc8b3cfbdae0e37c0e049d8ed6d9dd4e4ff" />
+				<disk name="viper-v6 turbo rs (japan)" sha1="2096b1b585e6460986857f9859ed34525bde38e1" />
 			</diskarea>
 		</part>
 	</software>
@@ -17589,35 +17971,64 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!--
+	zan2o boots from the CD and then accesses some files on the floppy disk, while zan2 boots from the floppy, which contains a later version of
+	the ZAN2.EXP executable. This was probably meant as a way of "patching" the game after the original release without having to re-master the CD.
+	-->
 	<software name="zan2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Zan 2 Towns Special.mdf" size="219771648" crc="b224b08b" sha1="a028d7223c0255cecf26380371ea4c817b683c71"/>
-		<rom name="Zan 2 Towns Special.mds" size="750" crc="c834648b" sha1="313182cab9a5ab3b09bd71d83e199f7ab7e2b182"/>
-
-		*after conversion with IsoBuster+EAC *
-		<rom name="track01.bin" size="10231200" crc="95767f0f" sha1="efd5a74ed5d8fa5706f0a2886782a642e0cc4822"/>
-		<rom name="track02.bin" size="36164352" crc="459bd0e2" sha1="4ed3f03b812df7222adbf3bb68d4dd3a80ae09ce"/>
-		<rom name="track03.bin" size="91198800" crc="d11ea63c" sha1="4fcd026081d3fdd3c49cc61fcbf575accc2b6611"/>
-		<rom name="track04.bin" size="73911600" crc="e6694e61" sha1="9c1611325495fdb80e957cc4eb5da819f4a4c10e"/>
-		<rom name="zan 2 towns special.cue" size="690" crc="a07806e3" sha1="02cf38214074c540b51eccb3642950957e12a2ef"/>
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Zan II - Towns Special (Japan) (Track 1).bin" size="10231200" crc="95767f0f" sha1="efd5a74ed5d8fa5706f0a2886782a642e0cc4822"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 2).bin" size="36164352" crc="20424e3c" sha1="537bce50972256a3ca9c2f4ef787ef801577abca"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 3).bin" size="91198800" crc="a7cd859a" sha1="f32327fa3af8018b5c2e85eb7d8e7cc7cfc0339d"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 4).bin" size="73911600" crc="f6f6deee" sha1="98c0250230a5357986c0bff56e129e29a0a712ef"/>
+		<rom name="Zan II - Towns Special (Japan).cue" size="501" crc="d9f46f20" sha1="c343b917aa4bf6a5b030b6a92eeb99b66b66879d"/>
 		-->
-		<description>Zan II - Towns Special</description>
+		<description>Zan II - Towns Special (1992-04-23)</description>
 		<year>1992</year>
 		<publisher>ウルフチーム (WolfTeam)</publisher>
-		<info name="serial" value="HMD-120"/>
+		<info name="serial" value="HMD-120 / CD-W19-TO"/>
 		<info name="alt_title" value="斬2タウンズスペシャル" />
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="zan 2 towns special (user disk).hdm" size="1261568" crc="863e02e3" sha1="28622691fd1a431055f4c586cfe585e0920a6153" offset="000000" />
+				<rom name="zan ii towns special (user disk) (1992-04-23).hdm" size="1261568" crc="ef5e668d" sha1="cc7120bd32053775b2916ab24d2edf2312e26cca" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zan 2 towns special" sha1="e1a85e9691abb531bdef1cdf9373630ffa2338d7" />
+				<disk name="zan ii - towns special (japan)" sha1="cd7501fe79be9445704ebb196a6c1921599169e9" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="zan2o" cloneof="zan2">
+		<!--
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Zan II - Towns Special (Japan) (Track 1).bin" size="10231200" crc="95767f0f" sha1="efd5a74ed5d8fa5706f0a2886782a642e0cc4822"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 2).bin" size="36164352" crc="20424e3c" sha1="537bce50972256a3ca9c2f4ef787ef801577abca"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 3).bin" size="91198800" crc="a7cd859a" sha1="f32327fa3af8018b5c2e85eb7d8e7cc7cfc0339d"/>
+		<rom name="Zan II - Towns Special (Japan) (Track 4).bin" size="73911600" crc="f6f6deee" sha1="98c0250230a5357986c0bff56e129e29a0a712ef"/>
+		<rom name="Zan II - Towns Special (Japan).cue" size="501" crc="d9f46f20" sha1="c343b917aa4bf6a5b030b6a92eeb99b66b66879d"/>
+		-->
+		<description>Zan II - Towns Special (1992-03-19)</description>
+		<year>1992</year>
+		<publisher>ウルフチーム (WolfTeam)</publisher>
+		<info name="serial" value="HMD-120 / CD-W19-TO"/>
+		<info name="alt_title" value="斬2タウンズスペシャル" />
+		<info name="release" value="199204xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="User Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="zan ii towns special (user disk) (1992-03-19).hdm" size="1261568" crc="863e02e3" sha1="28622691fd1a431055f4c586cfe585e0920a6153" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="zan ii - towns special (japan)" sha1="cd7501fe79be9445704ebb196a6c1921599169e9" />
 			</diskarea>
 		</part>
 	</software>
@@ -17651,13 +18062,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9821 / FM Towns hybrid -->
 	<software name="zatsuon">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Zatsuon Ryouiki.ccd" size="3446" crc="10ee6de3" sha1="0c4b1a6601826a41f9f459fcd7582d3453def178"/>
-		<rom name="Zatsuon Ryouiki.cue" size="631" crc="529007d8" sha1="db8c3270e3e27577d350dcf9318f53ed3b253ba0"/>
-		<rom name="Zatsuon Ryouiki.img" size="552301344" crc="36d5957f" sha1="faf0bb06a3e4bcf7963d2a845cb28ffa1436f2fe"/>
-		<rom name="Zatsuon Ryouiki.sub" size="22542912" crc="ab5c6fd4" sha1="f2992eeff16cce212cab087640be7a83d6ce52e2"/>
+		Origin: redump.org
+		<rom name="Zatsuon Ryouiki (Japan) (Track 01).bin" size="90982416" crc="7e7a3e44" sha1="22dfa64d2d419a752428c3bc1be28d99f162ac21"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 02).bin" size="18317376" crc="bf109d16" sha1="f9aa0be351b3630ff992a6c89a33ac2095663a4f"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 03).bin" size="37827216" crc="13707d14" sha1="80f9b42d8c330469370d806788ce896e14a8211f"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 04).bin" size="28734384" crc="c9c335b4" sha1="0a1bc849bf638a899d02714d0a2ee68ca515fea2"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 05).bin" size="41486928" crc="eb64b666" sha1="c96ea82fe70c614f62894ed0a4893957a386dae7"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 06).bin" size="18931248" crc="b580f111" sha1="60f41692c6fdd89fc15591f72638121a417d8a3d"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 07).bin" size="20796384" crc="8c3410d9" sha1="77b2b0b705fad9b7e0a935c98186ee13bc7488a9"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 08).bin" size="21845376" crc="0aabfb4c" sha1="9198018cffcd8e4200c7f8e018bb9eada8cefc1e"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 09).bin" size="29054256" crc="08a45417" sha1="7ae17c13bb8915291a0cabbb86f61ab79c2e6080"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 10).bin" size="42658224" crc="8a905b63" sha1="b381bf233da0dca28e1b5ef2e6ce26d39b17a120"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 11).bin" size="36752352" crc="c4944d4c" sha1="52986becf548700b2f647590da86146f286d1e11"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 12).bin" size="28734384" crc="1bce59e0" sha1="ab683ac4c718b9861a2140c752f90be14960bbfd"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 13).bin" size="54354720" crc="c5c8a56e" sha1="e12110e8413e026e46887e3258d5adc17983a835"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 14).bin" size="28365120" crc="3281d02a" sha1="e311908a04cc9688644fa23746712177eca2552d"/>
+		<rom name="Zatsuon Ryouiki (Japan) (Track 15).bin" size="53460960" crc="2e1ed7ba" sha1="eb269208f35d68cde165c302309a3b8c542fb614"/>
+		<rom name="Zatsuon Ryouiki (Japan).cue" size="1453" crc="8ba58399" sha1="589b52c9678ca2d52c4404e03f5ce6d2919266a6"/>
 		-->
 		<description>Zatsuon Ryouiki</description>
 		<year>1995</year>
@@ -17667,7 +18091,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zatsuon ryouiki" sha1="f61c4277ef4a2ec49f127d6b798e30d9b7b0b3af" />
+				<disk name="zatsuon ryouiki (japan)" sha1="a0fc53f0e69a538300eba1cc4a5d69b722577209" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
- New dumps from redump.org (working):

F-BASIC386 Compiler v2.1 L10
FM Towns Demonstration CD-ROM '90. Fuyu - The Galaxy of FM Towns
Ginga Eiyuu Densetsu II DX+ Towns Special
Indiana Jones and the Last Crusade (Pre-Release Version)
NHK Special - Ginga Uchuu Odyssey Vol. 2 - Choushinsei Bakuhatsu
Presence
Psychic Detective Series Vol. 2 - Memories (Demo)
Sherlock Holmes - Consulting Detective (Demo)
Steepia Lite
Trigger 2
Zan II - Towns Special (1992-04-23)

- New dumps from redump.org (not working):

Hyper Address Ver. 2.0
Megamorph (Demo)

- Replaced entries with dumps from redump.org:

Abel - Shin Mokushiroku Taisen
Cyberia
Dead of the Brain - Shiryou no Sakebi
Dragon Half
Dragon Knight III
Elm Knight - A Living Body Armor
Ningyou Tsukai
Power DoLLS
Power DoLLS 2
Rinkan Gakkou
Shinseiki Kouboushi - Dead Force
Strike Commander
The Best Play Baseball
Viper-V6 Turbo RS
Zan II - Towns Special (1992-03-19)
Zatsuon Ryouiki