### PR TITLE
more consistent -confirm_quit support

### DIFF
--- a/src/emu/ui/uimain.h
+++ b/src/emu/ui/uimain.h
@@ -40,6 +40,8 @@ public:
 
 	virtual void menu_reset() { }
 
+	virtual void request_quit() { m_machine.schedule_exit(); };
+
 	template <typename Format, typename... Params> void popup_time(int seconds, Format &&fmt, Params &&... args);
 
 protected:

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -236,7 +236,7 @@ public:
 	void image_handler_ingame();
 	void increase_frameskip();
 	void decrease_frameskip();
-	void request_quit();
+	virtual void request_quit() override;
 	void draw_fps_counter(render_container &container);
 	void draw_timecode_counter(render_container &container);
 	void draw_timecode_total(render_container &container);

--- a/src/osd/modules/input/input_sdlcommon.cpp
+++ b/src/osd/modules/input/input_sdlcommon.cpp
@@ -58,6 +58,9 @@ void sdl_event_manager::process_events(running_machine &machine)
 	SDL_Event sdlevent;
 	while (SDL_PollEvent(&sdlevent))
 	{
+		if (sdlevent.type == SDL_QUIT)
+			machine.ui().request_quit();
+
 		// process window events if they come in
 		if (sdlevent.type == SDL_WINDOWEVENT)
 			process_window_event(machine, sdlevent);
@@ -91,7 +94,7 @@ void sdl_event_manager::process_window_event(running_machine &machine, SDL_Event
 		break;
 
 	case SDL_WINDOWEVENT_CLOSE:
-		machine.schedule_exit();
+		machine.ui().request_quit();
 		break;
 
 	case SDL_WINDOWEVENT_LEAVE:

--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -1344,7 +1344,7 @@ LRESULT CALLBACK win_window_info::video_window_proc(HWND wnd, UINT message, WPAR
 
 		// close: cause MAME to exit
 		case WM_CLOSE:
-			window->machine().schedule_exit();
+			window->machine().ui().request_quit();
 			break;
 
 		// destroy: clean up all attached rendering bits and nullptr out our hwnd


### PR DESCRIPTION
`-confirm_quit` is only effective when quitting via the ui escape key.

- SDL: support the `SDL_QUIT` message, generated by the OS X Quit menu item or ^C in the terminal (OS X, Linux, etc)
- move `request_quit` method from `mame_ui_manager` to `ui_manager` (as virtual) for easier access.
- when SDL driver receives the `SDL_QUIT` or `SDL_WINDOWEVENT_CLOSE` message, call `ui_manager::request_quit()` which will display a confirmation prompt, when `-confirm_quit` is active or quit immediately otherwise.  (The `SDL_QUIT` and `SDL_WINDOWEVENT_CLOSE` messages are a suggestion that can be ignored.)
- win32, same thing for the `WM_CLOSE` message.