### PR TITLE
Add MDCR support to P2000m

### DIFF
--- a/src/mame/drivers/p2000t.cpp
+++ b/src/mame/drivers/p2000t.cpp
@@ -276,6 +276,9 @@ void p2000m_state::p2000m(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 	SPEAKER_SOUND(config, m_speaker).add_route(ALL_OUTPUTS, "mono", 0.25);
+
+	/* the mini cassette driver */
+	MDCR(config, m_mdcr, 0);
 }
 
 

--- a/src/mame/includes/p2000t.h
+++ b/src/mame/includes/p2000t.h
@@ -54,8 +54,7 @@ protected:
 
 	required_device<cpu_device> m_maincpu;
 	required_device<speaker_sound_device> m_speaker;
-	// Only the P2000t has this device.
-    optional_device<mdcr_device> m_mdcr;
+    required_device<mdcr_device> m_mdcr;
 
 private:
 	required_ioport_array<10> m_keyboard;

--- a/src/mame/machine/p2000t_mdcr.cpp
+++ b/src/mame/machine/p2000t_mdcr.cpp
@@ -34,12 +34,12 @@ READ_LINE_MEMBER(mdcr_device::bet)
 
 READ_LINE_MEMBER(mdcr_device::cip)
 {
-	return true;
+	return m_cassette->get_image() != nullptr;
 }
 
 READ_LINE_MEMBER(mdcr_device::wen)
 {
-	return true;
+	return m_cassette->get_image() != nullptr && m_cassette->is_writeable();
 }
 
 WRITE_LINE_MEMBER(mdcr_device::rev)

--- a/src/mame/machine/p2000t_mdcr.cpp
+++ b/src/mame/machine/p2000t_mdcr.cpp
@@ -198,8 +198,14 @@ void mdcr_device::stop()
 bool mdcr_device::tape_start_or_end()
 {
 	auto pos = m_cassette->get_position();
-	return m_cassette->motor_on() &&
+	auto bet = m_cassette->motor_on() &&
 	       (pos <= 0 || pos >= m_cassette->get_length());
+
+	// Reset phase decoder at tape start/end.
+	if (bet)
+		m_phase_decoder.reset();
+
+	return bet;
 }
 
 void p2000_mdcr_devices(device_slot_interface &device)


### PR DESCRIPTION
The P2000M shipped with an MDCR as well. We now turn the mdcr into
a required device and initialize it for the M model as well.

This fixes a nullptr exception upon access of ports 0x10, 0x20.

Includes a fix to reset the phase decoder when the end of tape signal is
raised.