### PR TITLE
[gbcolor.xml] New software list additions

### DIFF
--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -7,26 +7,26 @@ license:CC0
 	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
 
   Undumped:
-	- San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
+	- San Francisco Rush 2049 (Europe, fr/de/nl) [small pic]
 	
   Known dumps not yet verified against retail cartridge:
-	- Alice in Wonderland (Euro)
+	- Alice in Wonderland (Europe)
 	- AMF Bowling (USA)
 	- Donkey Kong Country (USA, Not for resale)
-	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn, Alt)	<- What is this version?
-	- Gakkyuu Ou Yamazaki (Jpn)
-	- Jissen ni Yakudatsu Tsumego (Jpn)
-	- Laura (Euro)
-	- Mission Impossible (Euro, Rev. 1)
-	- Monster Traveler (Jpn)
+	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)	<- What is this version?
+	- Gakkyuu Ou Yamazaki (Japan)
+	- Jissen ni Yakudatsu Tsumego (Japan)
+	- Laura (Europe)
+	- Mission Impossible (Europe, Rev. 1)
+	- Monster Traveler (Japan)
 	- NBA In the Zone (USA)
 	- Pro Pool (USA)
-	- Sei Hai Densetsu (Jpn)
+	- Sei Hai Densetsu (Japan)
 	- Super Mario Bros. Deluxe (USA, Rev. 2)	<- Was it released?
-	- Tsuri Sensei 2 (Jpn, Rev. 1)
-	- Turok - Rage Wars (Aus)
+	- Tsuri Sensei 2 (Japan, Rev. 1)
+	- Turok - Rage Wars (Australia)
 	- VR Sports Powerboat Racing (USA)
-	- Yakouchuu GB (Jpn)
+	- Yakouchuu GB (Japan)
 
   Undumped GBC protos:
 	- Jet Force Gemini
@@ -68,7 +68,7 @@ license:CC0
 
 	<software name="007twine">
 		<!-- Notes: GBC only -->
-		<description>007 - The World Is Not Enough (Euro, USA)</description>
+		<description>007 - The World Is Not Enough (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BO7E-USA, CGB-BO7P-EUR"/>
@@ -85,7 +85,7 @@ license:CC0
 
 	<software name="10pinb">
 		<!-- Notes: GBC only -->
-		<description>10-Pin Bowling (Euro)</description>
+		<description>10-Pin Bowling (Europe)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-AXPP-UKV"/>
@@ -121,7 +121,7 @@ license:CC0
 
 	<software name="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Euro, USA)</description>
+		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99E-USA, CGB-B99P-UKV"/>
@@ -138,7 +138,7 @@ license:CC0
 
 	<software name="102dalmaf" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's Les 102 Dalmatiens à la Rescousse (Fra)</description>
+		<description>Disney's Les 102 Dalmatiens à la Rescousse (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99F-FRA"/>
@@ -152,7 +152,7 @@ license:CC0
 
 	<software name="102dalmag" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatiner (Ger)</description>
+		<description>Disney's 102 Dalmatiner (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99D-NOE"/>
@@ -166,7 +166,7 @@ license:CC0
 
 	<software name="102dalmas" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spa)</description>
+		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spain)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99S-ESP"/>
@@ -183,7 +183,7 @@ license:CC0
 
 	<software name="1942">
 		<!-- Notes: GBC only -->
-		<description>1942 (Euro, USA)</description>
+		<description>1942 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AQ4E-USA, CGB-AQ4P-???"/>
@@ -221,7 +221,7 @@ license:CC0
 
 	<software name="3dpool">
 		<!-- Notes: GBC only -->
-		<description>3D Pocket Pool (Euro)</description>
+		<description>3D Pocket Pool (Europe)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BVPP-EUR"/>
@@ -235,7 +235,7 @@ license:CC0
 	</software>
 
 	<software name="4x4world">
-		<description>4x4 World Trophy (Euro)</description>
+		<description>4x4 World Trophy (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AQ3P-EUR"/>
@@ -250,7 +250,7 @@ license:CC0
 	</software>
 
 	<software name="720">
-		<description>720° (Euro, USA)</description>
+		<description>720° (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AA7E-USA, DMG-AA7P-EUR"/>
@@ -267,7 +267,7 @@ license:CC0
 
 	<software name="actionmn">
 		<!-- Notes: GBC only -->
-		<description>Action Man - Search for Base X (Euro, USA)</description>
+		<description>Action Man - Search for Base X (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAXE-USA, CGB-BAXP-EUR"/>
@@ -280,7 +280,7 @@ license:CC0
 	</software>
 
 	<software name="elmo">
-		<description>The Adventures of Elmo in Grouchland (Euro)</description>
+		<description>The Adventures of Elmo in Grouchland (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AELP-EUR"/>
@@ -310,7 +310,7 @@ license:CC0
 
 	<software name="smurfs">
 		<!-- Notes: GBC only -->
-		<description>The Adventures of the Smurfs (Euro)</description>
+		<description>The Adventures of the Smurfs (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSFP-FRA"/>
@@ -325,7 +325,7 @@ license:CC0
 	</software>
 
 	<software name="tintinpr">
-		<description>The Adventures of Tintin - Prisoners of the Sun (Euro)</description>
+		<description>The Adventures of Tintin - Prisoners of the Sun (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin - Prisoners of the Sun (Box?), Tintin - Le Temple du Soleil (French Box)"/>
@@ -340,7 +340,7 @@ license:CC0
 
 	<software name="airforcdj" cloneof="deadlysk">
 		<!-- Notes: GBC only -->
-		<description>AirForce Delta (Jpn)</description>
+		<description>AirForce Delta (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLJ-JPN (RK223-J1)"/>
@@ -370,7 +370,7 @@ license:CC0
 
 	<software name="aladdin">
 		<!-- Notes: GBC only -->
-		<description>Disney's Aladdin (Euro)</description>
+		<description>Disney's Aladdin (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BADP-EUR"/>
@@ -401,7 +401,7 @@ license:CC0
 
 	<software name="alfred">
 		<!-- Notes: GBC only -->
-		<description>Alfred's Adventure (Euro)</description>
+		<description>Alfred's Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BAAP-EUR"/>
@@ -415,7 +415,7 @@ license:CC0
 
 	<software name="alice">
 		<!-- Notes: GBC only -->
-		<description>Alice in Wonderland (Euro)</description>
+		<description>Alice in Wonderland (Europe)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AIWP-EUR"/>
@@ -432,7 +432,7 @@ license:CC0
 	<software name="aliceu" cloneof="alice">
 		<!-- Notes: GBC only -->
 		<!--	Retail cartridge of European version not yet secured	-->
-		<description>Alice in Wonderland (Euro, USA)</description>
+		<description>Alice in Wonderland (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AIWP-EUR, CGB-AIWE-USA"/>
@@ -448,7 +448,7 @@ license:CC0
 
 	<software name="aliens">
 		<!-- Notes: GBC only -->
-		<description>Aliens - Thanatos Encounter (Euro, USA)</description>
+		<description>Aliens - Thanatos Encounter (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAEE-USA, CGB-BAEP-EUR"/>
@@ -464,7 +464,7 @@ license:CC0
 	</software>
 
 	<software name="astenn2k">
-		<description>All Star Tennis 2000 (Euro)</description>
+		<description>All Star Tennis 2000 (Europe)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AZTP-EUR"/>
@@ -487,7 +487,7 @@ license:CC0
 
 	<software name="asbase2k">
 		<!-- Notes: GBC only -->
-		<description>All-Star Baseball 2000 (Euro, USA)</description>
+		<description>All-Star Baseball 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AATE-USA, CGB-AATP-EUR"/>
@@ -515,7 +515,7 @@ license:CC0
 
 	<software name="aitdnn">
 		<!-- Notes: GBC only -->
-		<description>Alone in the Dark - The New Nightmare (Euro)</description>
+		<description>Alone in the Dark - The New Nightmare (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BIDP-UKV"/>
@@ -564,7 +564,7 @@ license:CC0
 	</software>
 
 	<software name="animalb3">
-		<description>Animal Breeder 3 (Jpn)</description>
+		<description>Animal Breeder 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AA3J-JPN"/>
@@ -583,7 +583,7 @@ license:CC0
 
 	<software name="animalb4">
 		<!-- Notes: GBC only -->
-		<description>Animal Breeder 4 (Jpn)</description>
+		<description>Animal Breeder 4 (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A4AJ-JPN"/>
@@ -601,7 +601,7 @@ license:CC0
 
 	<software name="animasta">
 		<!-- Notes: GBC only -->
-		<description>Animastar GB (Jpn)</description>
+		<description>Animastar GB (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BNMJ-JPN"/>
@@ -619,7 +619,7 @@ license:CC0
 
 	<software name="animorph">
 		<!-- Notes: GBC only -->
-		<description>Animorphs (Euro)</description>
+		<description>Animorphs (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BAMP-EUR"/>
@@ -647,7 +647,7 @@ license:CC0
 
 	<software name="anpfiff" cloneof="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Anpfiff - Der RTL Fussball-Manager (Ger)</description>
+		<description>Anpfiff - Der RTL Fussball-Manager (Germany)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBD-NOE"/>
@@ -668,7 +668,7 @@ license:CC0
 	</software>
 
 	<software name="antz">
-		<description>Antz (Euro)</description>
+		<description>Antz (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ANXP-EUR"/>
@@ -698,7 +698,7 @@ license:CC0
 
 	<software name="antzracn">
 		<!-- Notes: GBC only -->
-		<description>Antz Racing (Euro)</description>
+		<description>Antz Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BAZP-UKV"/>
@@ -732,7 +732,7 @@ license:CC0
 
 	<software name="antzsprt">
 		<!-- Notes: GBC only -->
-		<description>Antz World Sportz (Euro)</description>
+		<description>Antz World Sportz (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BA7P-EUR"/>
@@ -745,7 +745,7 @@ license:CC0
 	</software>
 
 	<software name="aqualife">
-		<description>Aqualife (Jpn)</description>
+		<description>Aqualife (Japan)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AALJ-JPN"/>
@@ -763,7 +763,7 @@ license:CC0
 	</software>
 
 	<software name="arcadejd">
-		<description>Arcade Hits - Joust &amp; Defender (Euro, USA)</description>
+		<description>Arcade Hits - Joust &amp; Defender (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AADE-USA, DMG-AADP-EUR"/>
@@ -776,7 +776,7 @@ license:CC0
 	</software>
 
 	<software name="arcadems">
-		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Euro, USA)</description>
+		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ADUE-USA, DMG-ADUP-???"/>
@@ -789,7 +789,7 @@ license:CC0
 	</software>
 
 	<software name="arle">
-		<description>Arle no Bouken - Mahou no Jewel (Jpn)</description>
+		<description>Arle no Bouken - Mahou no Jewel (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-BRBJ-JPN"/>
@@ -824,7 +824,7 @@ license:CC0
 
 	<software name="armorine">
 		<!-- Notes: GBC only -->
-		<description>Armorines - Project S.W.A.R.M. (Euro, USA)</description>
+		<description>Armorines - Project S.W.A.R.M. (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AOXE-USA, CGB-AOXP-EUR"/>
@@ -841,7 +841,7 @@ license:CC0
 
 	<software name="armymen">
 		<!-- Notes: GBC only -->
-		<description>Army Men (Euro, USA)</description>
+		<description>Army Men (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVCE-USA, CGB-AVCP-(NOE/UKV)"/>
@@ -858,7 +858,7 @@ license:CC0
 
 	<software name="armymen2">
 		<!-- Notes: GBC only -->
-		<description>Army Men 2 (Euro, USA)</description>
+		<description>Army Men 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BA2E-USA, CGB-BA2P-EUR"/>
@@ -875,7 +875,7 @@ license:CC0
 
 	<software name="amenairc">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Air Combat (Euro, USA)</description>
+		<description>Army Men - Air Combat (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BATE-USA, CGB-BATP-EUR"/>
@@ -892,7 +892,7 @@ license:CC0
 
 	<software name="amensar2">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Sarge's Heroes 2 (Euro, USA)</description>
+		<description>Army Men - Sarge's Heroes 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BSHE-USA, CGB-BSHP-EUR"/>
@@ -923,7 +923,7 @@ license:CC0
 
 	<software name="astobelx">
 		<!-- Notes: GBC only -->
-		<description>Astérix &amp; Obélix (Euro)</description>
+		<description>Astérix &amp; Obélix (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="??"/>
@@ -936,7 +936,7 @@ license:CC0
 	</software>
 
 	<software name="astcesar">
-		<description>Astérix &amp; Obélix Contre César (Euro)</description>
+		<description>Astérix &amp; Obélix Contre César (Europe)</description>
 		<year>1999</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-BAOP-NOE"/>
@@ -953,7 +953,7 @@ license:CC0
 
 	<software name="astsearc">
 		<!-- Notes: GBC only -->
-		<description>Astérix - Search for Dogmatix (Euro)</description>
+		<description>Astérix - Search for Dogmatix (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AA6P-ESP"/>
@@ -966,7 +966,7 @@ license:CC0
 	</software>
 
 	<software name="asteroid">
-		<description>Asteroids (Euro, USA)</description>
+		<description>Asteroids (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AARE-USA, DMG-AARP-UKV"/>
@@ -980,7 +980,7 @@ license:CC0
 
 	<software name="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, English / Spanish / Italian)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, English / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABX-EUR"/>
@@ -997,7 +997,7 @@ license:CC0
 
 	<software name="atlantisa" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, French / German / Dutch)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, French / German / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABY-EUU"/>
@@ -1014,7 +1014,7 @@ license:CC0
 
 	<software name="atlantisu" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, USA)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABE-USA, CGB-BABP-UKV"/>
@@ -1028,7 +1028,7 @@ license:CC0
 
 	<software name="poohadvj" cloneof="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Jpn)</description>
+		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BPUJ-JPN"/>
@@ -1046,7 +1046,7 @@ license:CC0
 
 	<software name="apoweroh">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Oh, Behave! (Euro)</description>
+		<description>Austin Powers - Oh, Behave! (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BAPX-UKV"/>
@@ -1078,7 +1078,7 @@ license:CC0
 
 	<software name="apowerul">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Welcome to my Underground Lair! (Euro)</description>
+		<description>Austin Powers - Welcome to my Underground Lair! (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BEAX-(EUR/UKV/EUU)"/>
@@ -1110,7 +1110,7 @@ license:CC0
 
 	<software name="azarashi">
 		<!-- Notes: GBC only -->
-		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Jpn)</description>
+		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Japan)</description>
 		<year>2002</year>
 		<publisher>Omega Micott</publisher>
 		<info name="serial" value="CGB-BOAJ-JPN"/>
@@ -1127,7 +1127,7 @@ license:CC0
 	</software>
 
 	<software name="azured">
-		<description>Azure Dreams (Euro)</description>
+		<description>Azure Dreams (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAYP-EUR"/>
@@ -1157,7 +1157,7 @@ license:CC0
 	</software>
 
 	<software name="bdaman">
-		<description>B-Daman Bakugaiden - Victory e no Michi (Jpn)</description>
+		<description>B-Daman Bakugaiden - Victory e no Michi (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOKJ-JPN"/>
@@ -1182,7 +1182,7 @@ license:CC0
 
 	<software name="bdamanv">
 		<!-- Notes: GBC only -->
-		<description>B-Daman Bakugaiden V - Final Mega Tune (Jpn)</description>
+		<description>B-Daman Bakugaiden V - Final Mega Tune (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-AIRJ-JPN"/>
@@ -1199,7 +1199,7 @@ license:CC0
 	</software>
 
 	<software name="babe">
-		<description>Babe and Friends (Euro)</description>
+		<description>Babe and Friends (Europe)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AVAP-FAH"/>
@@ -1229,7 +1229,7 @@ license:CC0
 
 	<software name="babyflix">
 		<!-- Notes: GBC only -->
-		<description>Baby Felix - Halloween (Euro)</description>
+		<description>Baby Felix - Halloween (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BFHP-EUR"/>
@@ -1242,7 +1242,7 @@ license:CC0
 	</software>
 
 	<software name="backgamm">
-		<description>Backgammon (Euro)</description>
+		<description>Backgammon (Europe)</description>
 		<year>2000</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="DMG-AAKP-EUR"/>
@@ -1255,7 +1255,7 @@ license:CC0
 	</software>
 
 	<software name="backgammj" cloneof="backgamm">
-		<description>Backgammon (Jpn)</description>
+		<description>Backgammon (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AAKJ-JPN"/>
@@ -1273,7 +1273,7 @@ license:CC0
 
 	<software name="badbadtz">
 		<!-- Notes: GBC only -->
-		<description>Bad Badtz-Maru Robo Battle (Jpn)</description>
+		<description>Bad Badtz-Maru Robo Battle (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BBRJ-JPN"/>
@@ -1290,7 +1290,7 @@ license:CC0
 	</software>
 
 	<software name="bakukyuu">
-		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Jpn)</description>
+		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-A4RJ-JPN"/>
@@ -1308,7 +1308,7 @@ license:CC0
 
 	<software name="bakusodd">
 		<!-- Notes: GBC only -->
-		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Jpn)</description>
+		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Japan)</description>
 		<year>2000</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-BDBJ-JPN"/>
@@ -1325,7 +1325,7 @@ license:CC0
 	</software>
 
 	<software name="metalwlkj" cloneof="metalwlk">
-		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Jpn)</description>
+		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AUEJ-JPN"/>
@@ -1344,7 +1344,7 @@ license:CC0
 
 	<software name="bsbeybld">
 		<!-- Notes: GBC only -->
-		<description>Bakuten Shoot Beyblade (Jpn)</description>
+		<description>Bakuten Shoot Beyblade (Japan)</description>
 		<year>2001</year>
 		<publisher>Broccoli</publisher>
 		<info name="serial" value="CGB-BB3J-JPN"/>
@@ -1375,7 +1375,7 @@ license:CC0
 
 	<software name="balonfgt">
 		<!-- Also released by NP in 2000-08 -->
-		<description>Balloon Fight GB (Jpn, NP)</description>
+		<description>Balloon Fight GB (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BBKJ-JPN"/>
@@ -1393,7 +1393,7 @@ license:CC0
 	</software>
 
 	<software name="barbiefp">
-		<description>Barbie - Fashion Pack Games (Euro, USA)</description>
+		<description>Barbie - Fashion Pack Games (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="DMG-BFPE-USA, DMG-BFPP-EUR"/>
@@ -1423,7 +1423,7 @@ license:CC0
 	</software>
 
 	<software name="barbieoc">
-		<description>Barbie - Ocean Discovery (Euro)</description>
+		<description>Barbie - Ocean Discovery (Europe)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYP-UKV"/>
@@ -1452,7 +1452,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocf" cloneof="barbieoc">
-		<description>Barbie - Chasse au Trésor Sous-Marine (Fra)</description>
+		<description>Barbie - Chasse au Trésor Sous-Marine (France)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYF-FRA"/>
@@ -1465,7 +1465,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocg" cloneof="barbieoc">
-		<description>Barbie - Meeres Abenteuer (Ger)</description>
+		<description>Barbie - Meeres Abenteuer (Germany)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYD-NOE"/>
@@ -1478,7 +1478,7 @@ license:CC0
 	</software>
 
 	<software name="barbieoci" cloneof="barbieoc">
-		<description>Barbie - Avventure nell'Oceano (Ita)</description>
+		<description>Barbie - Avventure nell'Oceano (Italia)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYI-ITA"/>
@@ -1494,7 +1494,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocs" cloneof="barbieoc">
-		<description>Barbie - Aventura Submarina (Spa)</description>
+		<description>Barbie - Aventura Submarina (Spain)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYS-ESP"/>
@@ -1524,7 +1524,7 @@ license:CC0
 
 	<software name="barbiept">
 		<!-- Notes: GBC only -->
-		<description>Barbie - Pet Rescue (Euro)</description>
+		<description>Barbie - Pet Rescue (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BPEP-EUR"/>
@@ -1552,7 +1552,7 @@ license:CC0
 
 	<software name="shellycl">
 		<!-- Notes: GBC only -->
-		<description>Shelly Club (Euro)</description>
+		<description>Shelly Club (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BKIP-EUR"/>
@@ -1568,7 +1568,7 @@ license:CC0
 	</software>
 
 	<software name="barcode">
-		<description>Barcode Taisen Bardigun (Jpn)</description>
+		<description>Barcode Taisen Bardigun (Japan)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN"/>
@@ -1595,7 +1595,7 @@ license:CC0
 
 	<software name="barcodea" cloneof="barcode">
 		<!--	In lot check as "dmgabej1.f26"	-->
-		<description>Barcode Taisen Bardigun (Jpn, Rev. 1)</description>
+		<description>Barcode Taisen Bardigun (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN-1"/>
@@ -1615,7 +1615,7 @@ license:CC0
 
 	<software name="barca2k" cloneof="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Barça Total 2000 (Euro)</description>
+		<description>Barça Total 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -1630,7 +1630,7 @@ license:CC0
 	</software>
 
 	<software name="bassmasc">
-		<description>Bass Masters Classic (Euro, USA)</description>
+		<description>Bass Masters Classic (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AQME-USA, DMG-AQMP-EUR"/>
@@ -1647,7 +1647,7 @@ license:CC0
 
 	<software name="batmanbej" cloneof="batmanbe">
 		<!-- Notes: GBC only, NP only -->
-		<description>Batman Beyond - Return of the Joker (Jpn, NP)</description>
+		<description>Batman Beyond - Return of the Joker (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTKJ-JPN"/>
@@ -1677,7 +1677,7 @@ license:CC0
 
 	<software name="batmanbe">
 		<!-- Notes: GBC only -->
-		<description>Batman of the Future - Return of the Joker (Euro)</description>
+		<description>Batman of the Future - Return of the Joker (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTKP-EUR"/>
@@ -1691,7 +1691,7 @@ license:CC0
 
 	<software name="batlfish">
 		<!-- Notes: GBC only -->
-		<description>Battle Fishers (Jpn)</description>
+		<description>Battle Fishers (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BBAJ-JPN (RK198-J1)"/>
@@ -1708,7 +1708,7 @@ license:CC0
 	</software>
 
 	<software name="bship">
-		<description>Battleship (Euro, USA)</description>
+		<description>Battleship (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AIPE-USA, DMG-AIPP-EUR"/>
@@ -1725,7 +1725,7 @@ license:CC0
 
 	<software name="btanx">
 		<!-- Notes: GBC only -->
-		<description>BattleTanx (Euro)</description>
+		<description>BattleTanx (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVNP-UKV"/>
@@ -1756,7 +1756,7 @@ license:CC0
 
 	<software name="beachbal">
 		<!-- Notes: GBC only -->
-		<description>Beach'n Ball (Euro)</description>
+		<description>Beach'n Ball (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVBP-EUR"/>
@@ -1770,7 +1770,7 @@ license:CC0
 
 	<software name="bearblue">
 		<!-- Notes: GBC only -->
-		<description>Jim Henson's Bear in the Big Blue House (Euro)</description>
+		<description>Jim Henson's Bear in the Big Blue House (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBNP-EUR"/>
@@ -1801,7 +1801,7 @@ license:CC0
 
 	<software name="bmanigb">
 		<!-- Also released by NP in 2000-05 -->
-		<description>Beatmania GB (Jpn)</description>
+		<description>Beatmania GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AOOJ-JPN (RK184-J1)"/>
@@ -1818,7 +1818,7 @@ license:CC0
 
 	<software name="bmanigb3">
 		<!-- Notes: GBC only -->
-		<description>Beatmania GB - Gotcha Mix 2 (Jpn)</description>
+		<description>Beatmania GB - Gotcha Mix 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3GJ-JPN (RK220-J1)"/>
@@ -1833,7 +1833,7 @@ license:CC0
 	</software>
 
 	<software name="bmanigb2">
-		<description>Beatmania GB2 - Gotcha Mix (Jpn)</description>
+		<description>Beatmania GB2 - Gotcha Mix (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A2GJ-JPN (RK195-J1)"/>
@@ -1849,7 +1849,7 @@ license:CC0
 	</software>
 
 	<software name="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (Euro)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUP-EUR"/>
@@ -1870,7 +1870,7 @@ license:CC0
 	</software>
 
 	<software name="beautyu" cloneof="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (USA, Aus)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (USA, Australia)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUE-USA, DMG-AVUU-AUS"/>
@@ -1886,7 +1886,7 @@ license:CC0
 
 	<software name="benjamin">
 		<!-- Notes: GBC only -->
-		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Ger)</description>
+		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Germany)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BB5D-NOE"/>
@@ -1900,7 +1900,7 @@ license:CC0
 
 	<software name="beyblade">
 		<!-- Notes: GBC only -->
-		<description>Beyblade - Fighting Tournament (Jpn)</description>
+		<description>Beyblade - Fighting Tournament (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BBVJ-JPN"/>
@@ -1918,7 +1918,7 @@ license:CC0
 
 	<software name="bibibloc">
 		<!-- Notes: GBC only -->
-		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Ger)</description>
+		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Germany)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BIBD-NOE"/>
@@ -1932,7 +1932,7 @@ license:CC0
 
 	<software name="bibitina">
 		<!-- Notes: GBC only -->
-		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Ger)</description>
+		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Germany)</description>
 		<year>2002</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BFED-NOE-1"/>
@@ -1948,7 +1948,7 @@ license:CC0
 	</software>
 
 	<software name="bikkuri">
-		<description>Bikkuriman 2000 - Charging Card GB (Jpn)</description>
+		<description>Bikkuriman 2000 - Charging Card GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BC2J-JPN"/>
@@ -1967,7 +1967,7 @@ license:CC0
 
 	<software name="billybob">
 		<!-- Notes: GBC only -->
-		<description>Billy Bob's Huntin' 'n' Fishin' (Euro, USA)</description>
+		<description>Billy Bob's Huntin' 'n' Fishin' (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AHZE-USA, CGB-AHZP-EUR"/>
@@ -1984,7 +1984,7 @@ license:CC0
 
 	<software name="biohazg" cloneof="revilg">
 		<!-- Notes: GBC only -->
-		<description>BioHazard Gaiden (Jpn)</description>
+		<description>BioHazard Gaiden (Japan)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOJ-JPN"/>
@@ -2002,7 +2002,7 @@ license:CC0
 
 	<software name="bionicc">
 		<!-- Notes: GBC only -->
-		<description>Bionic Commando - Elite Forces (Aus, USA)</description>
+		<description>Bionic Commando - Elite Forces (Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AV4E-USA, CGB-AV4P-AUS"/>
@@ -2017,7 +2017,7 @@ license:CC0
 	</software>
 
 	<software name="blackbas">
-		<description>Black Bass - Lure Fishing (Euro, USA)</description>
+		<description>Black Bass - Lure Fishing (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-ALFE-USA, DMG-ALFP-EUR"/>
@@ -2034,7 +2034,7 @@ license:CC0
 
 	<software name="blckonyx">
 		<!-- Notes: GBC only -->
-		<description>The Black Onyx (Jpn)</description>
+		<description>The Black Onyx (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BBOJ-JPN"/>
@@ -2052,7 +2052,7 @@ license:CC0
 
 	<software name="blade">
 		<!-- Notes: GBC only -->
-		<description>Blade (Euro, USA)</description>
+		<description>Blade (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLEE-USA, CGB-BLEP-EUR"/>
@@ -2068,7 +2068,7 @@ license:CC0
 	</software>
 
 	<software name="bmaster">
-		<description>Blaster Master - Enemy Below (Euro, USA)</description>
+		<description>Blaster Master - Enemy Below (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AEHE-USA, DMG-AEHP-EUR"/>
@@ -2111,7 +2111,7 @@ license:CC0
 
 	<software name="bobbobet">
 		<!-- Notes: GBC only -->
-		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Euro)</description>
+		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBQP-FAH"/>
@@ -2128,7 +2128,7 @@ license:CC0
 
 	<software name="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / French / German / Spanish / Dutch)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / French / German / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBP-UKV"/>
@@ -2142,7 +2142,7 @@ license:CC0
 
 	<software name="bobbuilda" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / French / Italian)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBY-EUR"/>
@@ -2159,7 +2159,7 @@ license:CC0
 
 	<software name="bobbuildb" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / Swedish / Norwegian / Danish / Finnish)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / Swedish / Norwegian / Danish / Finnish)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBX-SCN"/>
@@ -2190,7 +2190,7 @@ license:CC0
 
 	<software name="bokucamp">
 		<!-- Notes: GBC only -->
-		<description>Boku no Camp-jou (Jpn)</description>
+		<description>Boku no Camp-jou (Japan)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="CGB-BDPJ-JPN"/>
@@ -2207,7 +2207,7 @@ license:CC0
 	</software>
 
 	<software name="bokujom2" cloneof="harvmon2">
-		<description>Bokujou Monogatari GB2 (Jpn)</description>
+		<description>Bokujou Monogatari GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-A37J-JPN"/>
@@ -2225,7 +2225,7 @@ license:CC0
 
 	<software name="bokujom3" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
@@ -2245,7 +2245,7 @@ license:CC0
 	<software name="bokujom3a" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbwaj1.350"	-->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn, Rev. 1)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
@@ -2263,7 +2263,7 @@ license:CC0
 
 	<software name="bombmmxa">
 		<!-- Notes: GBC only, this was the prize for a draw contest -->
-		<description>Bomberman Max - Ain Version (Jpn)</description>
+		<description>Bomberman Max - Ain Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -2300,7 +2300,7 @@ license:CC0
 
 	<software name="bombmmxh" cloneof="bombmmxb">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Hikari no Yuusha (Jpn)</description>
+		<description>Bomberman Max - Hikari no Yuusha (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A8BJ-JPN"/>
@@ -2340,7 +2340,7 @@ license:CC0
 
 	<software name="bombmmxy" cloneof="bombmmxr">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Yami no Senshi (Jpn)</description>
+		<description>Bomberman Max - Yami no Senshi (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A7BJ-JPN"/>
@@ -2357,7 +2357,7 @@ license:CC0
 	</software>
 
 	<software name="bombmqst">
-		<description>Bomberman Quest (Euro)</description>
+		<description>Bomberman Quest (Europe)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AQVP-EUR"/>
@@ -2373,7 +2373,7 @@ license:CC0
 
 	<software name="bombmqstj" cloneof="bombmqst">
 		<!-- Also released by NP in 2000-08 -->
-		<description>Bomberman Quest (Jpn)</description>
+		<description>Bomberman Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AB5J-JPN"/>
@@ -2428,7 +2428,7 @@ license:CC0
 
 	<software name="bouken">
 		<!-- Notes: GBC only -->
-		<description>Bouken! Dondoko-tou (Jpn)</description>
+		<description>Bouken! Dondoko-tou (Japan)</description>
 		<year>2002</year>
 		<publisher>Global A</publisher>
 		<info name="serial" value="CGB-BDVJ-JPN"/>
@@ -2446,7 +2446,7 @@ license:CC0
 
 	<software name="bravesag">
 		<!-- Notes: GBC only -->
-		<description>Brave Saga - Shinshou Astaria (Jpn)</description>
+		<description>Brave Saga - Shinshou Astaria (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BBSJ-JPN"/>
@@ -2464,7 +2464,7 @@ license:CC0
 
 	<software name="buffy">
 		<!-- Notes: GBC only -->
-		<description>Buffy the Vampire Slayer (Euro, USA)</description>
+		<description>Buffy the Vampire Slayer (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BVSE-USA, CGB-BVSP-EUR"/>
@@ -2480,7 +2480,7 @@ license:CC0
 	</software>
 
 	<software name="bugslife">
-		<description>A Bug's Life (Euro)</description>
+		<description>A Bug's Life (Europe)</description>
 		<year>1998</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-APXP-EUU"/>
@@ -2506,7 +2506,7 @@ license:CC0
 	</software>
 
 	<software name="bugsblol">
-		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Euro)</description>
+		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Europe)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ABLP-FRA"/>
@@ -2520,7 +2520,7 @@ license:CC0
 
 	<software name="bugsbcc3">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny - Crazy Castle 3 (Euro, USA)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6E-USA, DMG-AB6P-EUR"/>
@@ -2536,7 +2536,7 @@ license:CC0
 	</software>
 
 	<software name="bugsbcc3j" cloneof="bugsbcc3">
-		<description>Bugs Bunny - Crazy Castle 3 (Jpn)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6J-JPN"/>
@@ -2552,7 +2552,7 @@ license:CC0
 
 	<software name="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Euro)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4P-EUU-1"/>
@@ -2566,7 +2566,7 @@ license:CC0
 
 	<software name="bugsbcc4f" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny et le Château des Catastrophes (Fra)</description>
+		<description>Bugs Bunny et le Château des Catastrophes (France)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4F-FRA"/>
@@ -2583,7 +2583,7 @@ license:CC0
 
 	<software name="bugsbcc4j" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Jpn)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4J-JPN"/>
@@ -2612,7 +2612,7 @@ license:CC0
 	</software>
 
 	<software name="bundl2k1" cloneof="fa2001">
-		<description>Bundesliga Stars 2001 (Ger)</description>
+		<description>Bundesliga Stars 2001 (Germany)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -2626,7 +2626,7 @@ license:CC0
 
 	<software name="buraicol" cloneof="spacemar">
 		<!-- Notes: GBC only -->
-		<description>Burai Senshi Color (Jpn)</description>
+		<description>Burai Senshi Color (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZYJ-JPN"/>
@@ -2641,7 +2641,7 @@ license:CC0
 	</software>
 
 	<software name="burgerb">
-		<description>Burger Burger Pocket (Jpn)</description>
+		<description>Burger Burger Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-ABNJ-JPN"/>
@@ -2658,7 +2658,7 @@ license:CC0
 
 	<software name="burgerpi">
 		<!-- Notes: GBC only -->
-		<description>Burger Paradise International (Jpn)</description>
+		<description>Burger Paradise International (Japan)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="CGB-AEYJ-JPN"/>
@@ -2675,7 +2675,7 @@ license:CC0
 	</software>
 
 	<software name="bam4">
-		<description>Bust-A-Move 4 (Euro, USA)</description>
+		<description>Bust-A-Move 4 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AA4E-USA, DMG-AA4P-EUR"/>
@@ -2689,7 +2689,7 @@ license:CC0
 
 	<software name="bammill">
 		<!-- Notes: GBC only -->
-		<description>Bust-A-Move Millennium (Euro, USA)</description>
+		<description>Bust-A-Move Millennium (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BANE-USA, CGB-BANP-EUR"/>
@@ -2703,7 +2703,7 @@ license:CC0
 
 	<software name="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Buzz Lightyear of Star Command (Euro, USA)</description>
+		<description>Buzz Lightyear of Star Command (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZE-USA, CGB-BUZP-UKV"/>
@@ -2720,7 +2720,7 @@ license:CC0
 
 	<software name="buzzlghtf" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Les Aventures de Buzz l'Eclair (Fra)</description>
+		<description>Les Aventures de Buzz l'Eclair (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZF-FRA"/>
@@ -2734,7 +2734,7 @@ license:CC0
 
 	<software name="buzzlghtg" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Captain Buzz Lightyear - Star Command (Ger)</description>
+		<description>Captain Buzz Lightyear - Star Command (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZD-NOE"/>
@@ -2748,7 +2748,7 @@ license:CC0
 
 	<software name="caesars2">
 		<!-- Notes: GBC only -->
-		<description>Caesars Palace II (Euro, USA)</description>
+		<description>Caesars Palace II (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AI2E-USA, CGB-AI2P-EUR"/>
@@ -2770,7 +2770,7 @@ license:CC0
 
 	<software name="cfodder">
 		<!-- Notes: GBC only -->
-		<description>Cannon Fodder (Euro)</description>
+		<description>Cannon Fodder (Europe)</description>
 		<year>2000</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BCFP-EUR"/>
@@ -2820,7 +2820,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. 2)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2844,7 +2844,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuita" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. 1)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2862,7 +2862,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuitb" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2881,7 +2881,7 @@ license:CC0
 
 	<software name="ccsakuto">
 		<!-- Notes: GBC only -->
-		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Jpn)</description>
+		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BS7J-JPN"/>
@@ -2900,7 +2900,7 @@ license:CC0
 
 	<software name="clewis2k">
 		<!-- Notes: GBC only -->
-		<description>Carl Lewis Athletics 2000 (Euro)</description>
+		<description>Carl Lewis Athletics 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCLP-EUR"/>
@@ -2917,7 +2917,7 @@ license:CC0
 	<software name="carmgedd">
 		<!-- Notes: GBC only -->
 		<!--	USA cartridges have the European sticker underneath.	-->
-		<description>Carmageddon - Carpocalypse Now (Euro, USA)</description>
+		<description>Carmageddon - Carpocalypse Now (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
@@ -2935,7 +2935,7 @@ license:CC0
 
 	<software name="carmgeddg" cloneof="carmgedd">
 		<!-- Notes: GBC only -->
-		<description>Carmageddon - Carpocalypse Now (Ger)</description>
+		<description>Carmageddon - Carpocalypse Now (Germany)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-AKWD-NOE"/>
@@ -2949,7 +2949,7 @@ license:CC0
 
 	<software name="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Euro, English / Spanish / Italian)</description>
+		<description>Casper (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9X-EUU"/>
@@ -2972,7 +2972,7 @@ license:CC0
 
 	<software name="caspera" cloneof="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Euro, English / French / German)</description>
+		<description>Casper (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9P-EUR"/>
@@ -3005,7 +3005,7 @@ license:CC0
 	</software>
 
 	<software name="caterpil">
-		<description>Caterpillar Construction Zone (Euro, USA)</description>
+		<description>Caterpillar Construction Zone (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AR4E-USA, DMG-AR4P-EUU?"/>
@@ -3019,7 +3019,7 @@ license:CC0
 
 	<software name="catwoman">
 		<!-- Notes: GBC only -->
-		<description>Catwoman (Euro)</description>
+		<description>Catwoman (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CP-EUR"/>
@@ -3049,7 +3049,7 @@ license:CC0
 
 	<software name="catz">
 		<!-- Notes: GBC only -->
-		<description>Catz - Your Virtual Petz Palz (Euro)</description>
+		<description>Catz - Your Virtual Petz Palz (Europe)</description>
 		<year>1999</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AZCP-EUR"/>
@@ -3080,7 +3080,7 @@ license:CC0
 	</software>
 
 	<software name="centiped">
-		<description>Centipede (Euro)</description>
+		<description>Centipede (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AC5P-EUR"/>
@@ -3107,7 +3107,7 @@ license:CC0
 
 	<software name="motox2k1">
 		<!-- Notes: GBC only -->
-		<description>Championship Motocross 2001 featuring Ricky Carmichael (Euro, USA)</description>
+		<description>Championship Motocross 2001 featuring Ricky Carmichael (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCME-USA, CGB-BCMP-EUR"/>
@@ -3123,7 +3123,7 @@ license:CC0
 	</software>
 
 	<software name="chasehq">
-		<description>Chase H.Q. - Secret Police (Euro)</description>
+		<description>Chase H.Q. - Secret Police (Europe)</description>
 		<year>2000</year>
 		<publisher>Gaga</publisher>
 		<info name="serial" value="DMG-AH9P-EUR"/>
@@ -3149,7 +3149,7 @@ license:CC0
 	</software>
 
 	<software name="checkmat">
-		<description>Checkmate (Jpn)</description>
+		<description>Checkmate (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ACZJ-JPN"/>
@@ -3167,7 +3167,7 @@ license:CC0
 
 	<software name="cheechai">
 		<!-- Notes: GBC only -->
-		<description>Chee-Chai Alien (Jpn)</description>
+		<description>Chee-Chai Alien (Japan)</description>
 		<year>2001</year>
 		<publisher>Creatures</publisher>
 		<info name="serial" value="CGB-VCAJ-JPN"/>
@@ -3192,7 +3192,7 @@ license:CC0
 	</software>
 
 	<software name="chessmst">
-		<description>Chessmaster (Euro, USA)</description>
+		<description>Chessmaster (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Mindascape</publisher>
 		<info name="serial" value="DMG-AC9E-USA, DMG-AC9P-EUR"/>
@@ -3206,7 +3206,7 @@ license:CC0
 
 	<software name="chitoase">
 		<!-- Notes: GBC only -->
-		<description>Chi to Ase to Namida no Koukou Yakyuu (Jpn)</description>
+		<description>Chi to Ase to Namida no Koukou Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-BBJJ-JPN"/>
@@ -3224,7 +3224,7 @@ license:CC0
 
 	<software name="chibim">
 		<!-- Notes: GBC only -->
-		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Jpn)</description>
+		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BCNJ-JPN"/>
@@ -3242,7 +3242,7 @@ license:CC0
 
 	<software name="chickrun">
 		<!-- Notes: GBC only -->
-		<description>Chicken Run (Euro, USA)</description>
+		<description>Chicken Run (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCKE-USA, CGB-BCKP-EUR"/>
@@ -3259,7 +3259,7 @@ license:CC0
 
 	<software name="chikirac" cloneof="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Chiki Chiki Machine Mou Race (Jpn)</description>
+		<description>Chiki Chiki Machine Mou Race (Japan)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-AW9J-JPN"/>
@@ -3274,7 +3274,7 @@ license:CC0
 	</software>
 
 	<software name="choroq">
-		<description>Choro Q - Hyper Customable GB (Jpn)</description>
+		<description>Choro Q - Hyper Customable GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACQJ-JPN"/>
@@ -3292,7 +3292,7 @@ license:CC0
 	</software>
 
 	<software name="bublbobl">
-		<description>Classic Bubble Bobble (Euro)</description>
+		<description>Classic Bubble Bobble (Europe)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AVWP-EUR-1"/>
@@ -3319,7 +3319,7 @@ license:CC0
 
 	<software name="mcrae">
 		<!-- Notes: GBC only -->
-		<description>Colin McRae Rally (Euro)</description>
+		<description>Colin McRae Rally (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCOP-EUR"/>
@@ -3334,7 +3334,7 @@ license:CC0
 	</software>
 
 	<software name="columns">
-		<description>Columns GB - Tezuka Osamu Characters (Jpn)</description>
+		<description>Columns GB - Tezuka Osamu Characters (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOYJ-JPN"/>
@@ -3353,7 +3353,7 @@ license:CC0
 
 	<software name="commandm" supported="no">
 		<!-- Notes: GBC only.  The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Command Master (Jpn)</description>
+		<description>Command Master (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-KCEJ-JPN"/>
@@ -3376,7 +3376,7 @@ license:CC0
 
 	<software name="commandk">
 		<!-- Notes: GBC only -->
-		<description>Commander Keen (Euro, USA)</description>
+		<description>Commander Keen (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BCBE-USA, CGB-BCBP-EUR"/>
@@ -3389,7 +3389,7 @@ license:CC0
 	</software>
 
 	<software name="conker">
-		<description>Conker's Pocket Tales (Euro, USA)</description>
+		<description>Conker's Pocket Tales (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACRE-USA, DMG-ACRP-EUR"/>
@@ -3411,7 +3411,7 @@ license:CC0
 
 	<software name="coolbric">
 		<!-- Notes: GBC only -->
-		<description>Cool Bricks (Euro)</description>
+		<description>Cool Bricks (Europe)</description>
 		<year>1999</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BOGP-EUR"/>
@@ -3424,7 +3424,7 @@ license:CC0
 	</software>
 
 	<software name="coolhand">
-		<description>Cool Hand (Euro)</description>
+		<description>Cool Hand (Europe)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-ACWP-EUU"/>
@@ -3438,7 +3438,7 @@ license:CC0
 
 	<software name="crazybik">
 		<!-- Notes: GBC only -->
-		<description>Crazy Bikers (Euro)</description>
+		<description>Crazy Bikers (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AMHP-EUR"/>
@@ -3454,7 +3454,7 @@ license:CC0
 
 	<software name="croc">
 		<!-- Notes: GBC only -->
-		<description>Croc (Euro, USA)</description>
+		<description>Croc (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRCE-USA, CGB-BRCP-EUR"/>
@@ -3471,7 +3471,7 @@ license:CC0
 
 	<software name="croc2">
 		<!-- Notes: GBC only -->
-		<description>Croc 2 (Euro, USA)</description>
+		<description>Croc 2 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BK2E-USA, CGB-BK2P-EUR"/>
@@ -3484,7 +3484,7 @@ license:CC0
 	</software>
 
 	<software name="xcountry">
-		<description>Cross Country Racing (Euro)</description>
+		<description>Cross Country Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLP-EUR"/>
@@ -3498,7 +3498,7 @@ license:CC0
 
 	<software name="xhunterm">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Monster Hunter Version (Jpn)</description>
+		<description>Cross Hunter - Monster Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC8J-JPN"/>
@@ -3516,7 +3516,7 @@ license:CC0
 
 	<software name="xhuntert">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Treasure Hunter Version (Jpn)</description>
+		<description>Cross Hunter - Treasure Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC7J-JPN"/>
@@ -3540,7 +3540,7 @@ license:CC0
 
 	<software name="xhunterx">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - X Hunter Version (Jpn)</description>
+		<description>Cross Hunter - X Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC9J-JPN"/>
@@ -3603,7 +3603,7 @@ license:CC0
 
 	<software name="cybertgr">
 		<!-- Notes: GBC only -->
-		<description>CyberTiger (Euro, USA)</description>
+		<description>CyberTiger (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BCTE-USA, CGB-BCTP-UKV"/>
@@ -3620,7 +3620,7 @@ license:CC0
 
 	<software name="cyborgku">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan - Devil Fukkatsu (Jpn)</description>
+		<description>Cyborg Kuro-chan - Devil Fukkatsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSKJ-JPN (RK204-J1)"/>
@@ -3638,7 +3638,7 @@ license:CC0
 
 	<software name="cyborgk2">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Jpn)</description>
+		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSBJ-JPN (RK219-J1)"/>
@@ -3656,7 +3656,7 @@ license:CC0
 
 	<software name="daadaada">
 		<!-- Notes: GBC only -->
-		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Jpn)</description>
+		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Japan)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BDOJ-JPN"/>
@@ -3673,7 +3673,7 @@ license:CC0
 	</software>
 
 	<software name="daffyfow">
-		<description>Daffy Duck - Fowl Play (Euro, USA)</description>
+		<description>Daffy Duck - Fowl Play (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7E-USA, DMG-AD7P-UKV"/>
@@ -3686,7 +3686,7 @@ license:CC0
 	</software>
 
 	<software name="daffysub">
-		<description>Daffy Duck - Subette Koron de Ougane Mochi (Jpn)</description>
+		<description>Daffy Duck - Subette Koron de Ougane Mochi (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7J-JPN"/>
@@ -3701,7 +3701,7 @@ license:CC0
 	</software>
 
 	<software name="miraclz2">
-		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Jpn)</description>
+		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AM6J-JPN"/>
@@ -3726,7 +3726,7 @@ license:CC0
 
 	<software name="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Euro, English / French / Italian)</description>
+		<description>Daikatana (Europe, English / French / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22X-EUR"/>
@@ -3743,7 +3743,7 @@ license:CC0
 
 	<software name="daikatana" cloneof="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Euro, French / German / Spanish)</description>
+		<description>Daikatana (Europe, French / German / Spanish)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22Y-EUU"/>
@@ -3775,7 +3775,7 @@ license:CC0
 
 	<software name="daikatanj" cloneof="daikatan">
 		<!-- Notes: GBC only, NP only -->
-		<description>Daikatana GB (Jpn, NP)</description>
+		<description>Daikatana GB (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22J-JPN"/>
@@ -3792,7 +3792,7 @@ license:CC0
 	</software>
 
 	<software name="daikugen">
-		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Jpn)</description>
+		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Japan)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-BGNJ-JPN"/>
@@ -3811,7 +3811,7 @@ license:CC0
 
 	<software name="ddr">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB (Jpn)</description>
+		<description>Dance Dance Revolution GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDGJ-JPN (RK209-J1)"/>
@@ -3830,7 +3830,7 @@ license:CC0
 
 	<software name="ddrdisny">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB - Disney Mix (Jpn)</description>
+		<description>Dance Dance Revolution GB - Disney Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD7J-JPN (RK237-J1)"/>
@@ -3848,7 +3848,7 @@ license:CC0
 
 	<software name="ddr2">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB2 (Jpn)</description>
+		<description>Dance Dance Revolution GB2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD2J-JPN (RK224-J1)"/>
@@ -3867,7 +3867,7 @@ license:CC0
 
 	<software name="ddr3">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB3 (Jpn)</description>
+		<description>Dance Dance Revolution GB3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BD6J-JPN (RK235-J1)"/>
@@ -3882,7 +3882,7 @@ license:CC0
 	</software>
 
 	<software name="dancefrb">
-		<description>Dancing Furby (Jpn)</description>
+		<description>Dancing Furby (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BFBJ-JPN"/>
@@ -3900,7 +3900,7 @@ license:CC0
 
 	<software name="dnyakyu">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu (Jpn)</description>
+		<description>Data-Navi Pro Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-A89J-JPN"/>
@@ -3918,7 +3918,7 @@ license:CC0
 
 	<software name="dnyakyu2">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu 2 (Jpn)</description>
+		<description>Data-Navi Pro Yakyuu 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-B8QJ-JPN"/>
@@ -3936,7 +3936,7 @@ license:CC0
 
 	<software name="mirrabmx">
 		<!-- Notes: GBC only -->
-		<description>Dave Mirra Freestyle BMX (Euro, USA)</description>
+		<description>Dave Mirra Freestyle BMX (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMXE-USA, CGB-BMXP-EUR"/>
@@ -3950,7 +3950,7 @@ license:CC0
 
 	<software name="beckham">
 		<!-- Notes: GBC only -->
-		<description>David Beckham Soccer (Euro)</description>
+		<description>David Beckham Soccer (Europe)</description>
 		<year>2002</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BJ2P-EUR"/>
@@ -3966,7 +3966,7 @@ license:CC0
 	</software>
 
 	<software name="deadlysk">
-		<description>Deadly Skies (Euro)</description>
+		<description>Deadly Skies (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLP-EUR"/>
@@ -3979,7 +3979,7 @@ license:CC0
 	</software>
 
 	<software name="deardani">
-		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Jpn)</description>
+		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BSAJ-JPN"/>
@@ -4012,7 +4012,7 @@ license:CC0
 
 	<software name="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, English / French)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, English / French)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTX-EUR"/>
@@ -4028,7 +4028,7 @@ license:CC0
 
 	<software name="dejavua" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, French / German)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, French / German)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTY-EUU"/>
@@ -4044,7 +4044,7 @@ license:CC0
 
 	<software name="dejavuj" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Jpn)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTJ-JPN"/>
@@ -4077,7 +4077,7 @@ license:CC0
 	</software>
 
 	<software name="dejikomj">
-		<description>Dejiko no Mahjong Party (Jpn)</description>
+		<description>Dejiko no Mahjong Party (Japan)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQSJ-JPN (KIG-11)"/>
@@ -4095,7 +4095,7 @@ license:CC0
 
 	<software name="denkiblk">
 		<!-- Notes: GBC only -->
-		<description>Denki Blocks! (Euro)</description>
+		<description>Denki Blocks! (Europe)</description>
 		<year>2001</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BD9P-EUR"/>
@@ -4112,7 +4112,7 @@ license:CC0
 
 	<software name="dendego">
 		<!-- Notes: GBC only -->
-		<description>Densha de Go! (Jpn)</description>
+		<description>Densha de Go! (Japan)</description>
 		<year>1999</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-A72J-JPN"/>
@@ -4131,7 +4131,7 @@ license:CC0
 	<software name="dendego2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbb82j0.538"	-->
-		<description>Densha de Go! 2 (Jpn)</description>
+		<description>Densha de Go! 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-B82J-JPN"/>
@@ -4159,7 +4159,7 @@ license:CC0
 
 	<software name="dexterlb" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Dexter's Laboratory - Robot Rampage (Euro, USA)</description>
+		<description>Dexter's Laboratory - Robot Rampage (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BROE-USA, CGB-BROP-EUR"/>
@@ -4175,7 +4175,7 @@ license:CC0
 	</software>
 
 	<software name="dinobrd3">
-		<description>Dino Breeder 3 - Gaia Fukkatsu (Jpn)</description>
+		<description>Dino Breeder 3 - Gaia Fukkatsu (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A3DJ-JPN"/>
@@ -4193,7 +4193,7 @@ license:CC0
 	</software>
 
 	<software name="dinobrd4">
-		<description>Dino Breeder 4 (Jpn)</description>
+		<description>Dino Breeder 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A4DJ-JPN"/>
@@ -4212,7 +4212,7 @@ license:CC0
 
 	<software name="dinosaur">
 		<!-- Notes: GBC only -->
-		<description>Dinosaur (Euro)</description>
+		<description>Dinosaur (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BDNP-EUR"/>
@@ -4260,7 +4260,7 @@ license:CC0
 	<software name="dinosrus">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "CGBBDSP0.602", "KENSA\CGBBDSE0.0"	-->
-		<description>Dinosaur'us (Euro)</description>
+		<description>Dinosaur'us (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BDSP-EUR"/>
@@ -4282,7 +4282,7 @@ license:CC0
 
 	<software name="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Euro)</description>
+		<description>Diva Starz (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8P-EUR"/>
@@ -4299,7 +4299,7 @@ license:CC0
 
 	<software name="divastarf" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Fra)</description>
+		<description>Diva Starz (France)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8F-FRA"/>
@@ -4316,7 +4316,7 @@ license:CC0
 
 	<software name="divastarg" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Ger)</description>
+		<description>Diva Starz (Germany)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8D-NOE"/>
@@ -4347,7 +4347,7 @@ license:CC0
 
 	<software name="dogz">
 		<!-- Notes: GBC only -->
-		<description>Dogz - Your Virtual Petz Palz (Euro)</description>
+		<description>Dogz - Your Virtual Petz Palz (Europe)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AOZP-EUR"/>
@@ -4378,7 +4378,7 @@ license:CC0
 	</software>
 
 	<software name="dokapon">
-		<description>Dokapon! - Millennium Quest (Jpn)</description>
+		<description>Dokapon! - Millennium Quest (Japan)</description>
 		<year>2000</year>
 		<publisher>Asmik Ace</publisher>
 		<info name="serial" value="DMG-BDKJ-JPN"/>
@@ -4396,7 +4396,7 @@ license:CC0
 
 	<software name="dokixdok">
 		<!-- Notes: GBC only -->
-		<description>Doki x Doki Sasete!! (Jpn)</description>
+		<description>Doki x Doki Sasete!! (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BP6J-JPN"/>
@@ -4414,7 +4414,7 @@ license:CC0
 
 	<software name="dokidoki">
 		<!-- Notes: GBC only -->
-		<description>Dokidoki Densetsu - Mahoujin Guruguru (Jpn)</description>
+		<description>Dokidoki Densetsu - Mahoujin Guruguru (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-B96J-JPN"/>
@@ -4432,7 +4432,7 @@ license:CC0
 
 	<software name="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's "Donald" @#Duck?*! (Euro)</description>
+		<description>Disney's "Donald" @#Duck?*! (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Disney's Donald Duck - &quot;Qu@ck &quot;Att@ck&quot;?*! (Box, Cart)"/>
@@ -4450,7 +4450,7 @@ license:CC0
 
 	<software name="donalddj" cloneof="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's Donald Duck - Daisy o Sukue! (Jpn)</description>
+		<description>Disney's Donald Duck - Daisy o Sukue! (Japan)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUDJ-JPN"/>
@@ -4481,7 +4481,7 @@ license:CC0
 
 	<software name="dkong2k1" cloneof="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong 2001 (Jpn)</description>
+		<description>Donkey Kong 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDJ-JPN"/>
@@ -4499,7 +4499,7 @@ license:CC0
 
 	<software name="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong Country (Euro, Aus, USA)</description>
+		<description>Donkey Kong Country (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDE-USA, CGB-BDDP-(EUR/AUS)"/>
@@ -4520,7 +4520,7 @@ license:CC0
 	</software>
 
 	<software name="dkongcs" cloneof="dkongc">
-		<description>Donkey Kong Country (Euro, USA, Sample)</description>
+		<description>Donkey Kong Country (Europe, USA, Sample)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -4555,7 +4555,7 @@ license:CC0
 
 	<software name="dkonggb">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Jpn)</description>
+		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AD3J-JPN"/>
@@ -4578,7 +4578,7 @@ license:CC0
 	</software>
 
 	<software name="doralaby">
-		<description>Doraemon - Aruke Aruke Labyrinth (Jpn)</description>
+		<description>Doraemon - Aruke Aruke Labyrinth (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADAJ-JPN"/>
@@ -4595,7 +4595,7 @@ license:CC0
 	</software>
 
 	<software name="dorapetm">
-		<description>Doraemon - Kimi to Pet no Monogatari (Jpn)</description>
+		<description>Doraemon - Kimi to Pet no Monogatari (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BRDJ-JPN"/>
@@ -4612,7 +4612,7 @@ license:CC0
 	</software>
 
 	<software name="dorakrt2">
-		<description>Doraemon Kart 2 (Jpn)</description>
+		<description>Doraemon Kart 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADOJ-JPN"/>
@@ -4636,7 +4636,7 @@ license:CC0
 	</software>
 
 	<software name="doramemo">
-		<description>Doraemon Memories - Nobita no Omoide Daibouken (Jpn)</description>
+		<description>Doraemon Memories - Nobita no Omoide Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BDMJ-JPN"/>
@@ -4654,7 +4654,7 @@ license:CC0
 
 	<software name="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Jpn, Rev. 1)</description>
+		<description>Doraemon no Quiz Boy (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4678,7 +4678,7 @@ license:CC0
 
 	<software name="doraqzba" cloneof="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Jpn)</description>
+		<description>Doraemon no Quiz Boy (Japan)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4696,7 +4696,7 @@ license:CC0
 
 	<software name="doraqzb2">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy 2 (Jpn)</description>
+		<description>Doraemon no Quiz Boy 2 (Japan)</description>
 		<year>2002</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQ7J-JPN"/>
@@ -4720,7 +4720,7 @@ license:CC0
 
 	<software name="dorakang">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Jpn)</description>
+		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Japan)</description>
 		<year>2001</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BGKJ-JPN"/>
@@ -4738,7 +4738,7 @@ license:CC0
 
 	<software name="dorakany">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Jpn)</description>
+		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Japan)</description>
 		<year>2003</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BKYJ-JPN"/>
@@ -4756,7 +4756,7 @@ license:CC0
 
 	<software name="dorakuku">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kuku Game (Jpn)</description>
+		<description>Doraemon no Study Boy - Kuku Game (Japan)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQQJ-JPN"/>
@@ -4774,7 +4774,7 @@ license:CC0
 
 	<software name="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Euro)</description>
+		<description>Disney's Doug's Big Game (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUP-EUR"/>
@@ -4791,7 +4791,7 @@ license:CC0
 
 	<software name="dougf" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug - La Grande Aventure (Fra)</description>
+		<description>Disney's Doug - La Grande Aventure (France)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUF-FRA"/>
@@ -4805,7 +4805,7 @@ license:CC0
 
 	<software name="dougg" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Ger)</description>
+		<description>Disney's Doug's Big Game (Germany)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUD-NOE"/>
@@ -4836,7 +4836,7 @@ license:CC0
 
 	<software name="drrin">
 		<!-- Notes: GBC only -->
-		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Jpn)</description>
+		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BDFJ-JPN"/>
@@ -4860,7 +4860,7 @@ license:CC0
 
 	<software name="draccraz">
 		<!-- Notes: GBC only -->
-		<description>Dracula - Crazy Vampire (Euro)</description>
+		<description>Dracula - Crazy Vampire (Europe)</description>
 		<year>2001</year>
 		<publisher>DreamCatcher Interactive</publisher>
 		<info name="serial" value="CGB-BUAP-EUR"/>
@@ -4888,7 +4888,7 @@ license:CC0
 
 	<software name="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendary Super Warriors (Euro)</description>
+		<description>Dragon Ball Z - Legendary Super Warriors (Europe)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZP-UKV"/>
@@ -4904,7 +4904,7 @@ license:CC0
 
 	<software name="dbzj" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Jpn)</description>
+		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Japan)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="CGB-BBZJ-JPN"/>
@@ -4922,7 +4922,7 @@ license:CC0
 
 	<software name="dbzf" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Les Guerriers Légendaires (Fra)</description>
+		<description>Dragon Ball Z - Les Guerriers Légendaires (France)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZF-FRA"/>
@@ -4938,7 +4938,7 @@ license:CC0
 
 	<software name="dbzg" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendäre Superkämpfer (Ger)</description>
+		<description>Dragon Ball Z - Legendäre Superkämpfer (Germany)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZD-NOE"/>
@@ -4960,7 +4960,7 @@ license:CC0
 
 	<software name="dbzi" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Ita)</description>
+		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Italia)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZI-ITA"/>
@@ -4982,7 +4982,7 @@ license:CC0
 
 	<software name="dbzs" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Guerreros de Leyenda (Spa)</description>
+		<description>Dragon Ball Z - Guerreros de Leyenda (Spain)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZS-ESP"/>
@@ -5033,7 +5033,7 @@ license:CC0
 	</software>
 
 	<software name="dquest12" cloneof="dwarr12">
-		<description>Dragon Quest I &amp; II (Jpn)</description>
+		<description>Dragon Quest I &amp; II (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-AEDJ-JPN"/>
@@ -5058,7 +5058,7 @@ license:CC0
 
 	<software name="dquest3" cloneof="dwarr3">
 		<!-- Notes: GBC only -->
-		<description>Dragon Quest III - Soshite Densetsu e... (Jpn)</description>
+		<description>Dragon Quest III - Soshite Densetsu e... (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-BD3J-JPN"/>
@@ -5075,7 +5075,7 @@ license:CC0
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. 1)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
@@ -5099,7 +5099,7 @@ license:CC0
 	</software>
 
 	<software name="dqma" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
@@ -5123,7 +5123,7 @@ license:CC0
 	</software>
 
 	<software name="dqmg" cloneof="dwm">
-		<description>Dragon Quest Monsters (Ger)</description>
+		<description>Dragon Quest Monsters (Germany)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQD-NOE"/>
@@ -5138,7 +5138,7 @@ license:CC0
 	</software>
 
 	<software name="dqm2i" cloneof="dwm2t">
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Jpn)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQIJ-JPN"/>
@@ -5157,7 +5157,7 @@ license:CC0
 	</software>
 
 	<software name="dqm2r" cloneof="dwm2c">
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
@@ -5183,7 +5183,7 @@ license:CC0
 
 	<software name="dqm2ra" cloneof="dwm2c">
 		<!--	In lot check as "dmgbqlj1.j93"	-->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn, Rev. 1)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
@@ -5220,7 +5220,7 @@ license:CC0
 
 	<software name="dtalesdw">
 		<!-- Notes: GBC only -->
-		<description>Dragon Tales - Dragon Wings (Euro)</description>
+		<description>Dragon Tales - Dragon Wings (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDZP-EUR"/>
@@ -5282,7 +5282,7 @@ license:CC0
 	</software>
 
 	<software name="dwm">
-		<description>Dragon Warrior Monsters (Euro, USA)</description>
+		<description>Dragon Warrior Monsters (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQE-USA, DMG-AWQP-UKV"/>
@@ -5334,7 +5334,7 @@ license:CC0
 
 	<software name="dlair">
 		<!-- Notes: GBC only -->
-		<description>Dragon's Lair (Euro, USA)</description>
+		<description>Dragon's Lair (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BDXE-USA, CGB-BDXP-EUR"/>
@@ -5351,7 +5351,7 @@ license:CC0
 
 	<software name="driver">
 		<!-- Notes: GBC only -->
-		<description>Driver (Euro)</description>
+		<description>Driver (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BDRP-EUR"/>
@@ -5382,7 +5382,7 @@ license:CC0
 	</software>
 
 	<software name="dropzone">
-		<description>Dropzone (Euro)</description>
+		<description>Dropzone (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AD4P-EUR"/>
@@ -5398,7 +5398,7 @@ license:CC0
 	</software>
 
 	<software name="dtlords">
-		<description>DT - Lords of Genomes (Jpn)</description>
+		<description>DT - Lords of Genomes (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-BBDJ-JPN"/>
@@ -5417,7 +5417,7 @@ license:CC0
 
 	<software name="dukenuke">
 		<!-- Notes: GBC only -->
-		<description>Duke Nukem (Euro)</description>
+		<description>Duke Nukem (Europe)</description>
 		<year>1999</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="CGB-ADIP-EUR"/>
@@ -5449,7 +5449,7 @@ license:CC0
 
 	<software name="hazzard">
 		<!-- Notes: GBC only -->
-		<description>The Dukes of Hazzard - Racing for Home (Euro)</description>
+		<description>The Dukes of Hazzard - Racing for Home (Europe)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-BDCP-EUR"/>
@@ -5486,7 +5486,7 @@ license:CC0
 	</software>
 
 	<software name="dsavior">
-		<description>Dungeon Savior (Jpn)</description>
+		<description>Dungeon Savior (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-ADWJ-JPN"/>
@@ -5506,7 +5506,7 @@ license:CC0
 
 	<software name="dxjinsei">
 		<!-- Notes: GBC only -->
-		<description>DX Jinsei Game (Jpn)</description>
+		<description>DX Jinsei Game (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BZGJ-JPN"/>
@@ -5523,7 +5523,7 @@ license:CC0
 	</software>
 
 	<software name="dxmono">
-		<description>DX Monopoly GB (Jpn)</description>
+		<description>DX Monopoly GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-BMPJ-JPN"/>
@@ -5542,7 +5542,7 @@ license:CC0
 
 	<software name="dynamike">
 		<!-- Notes: GBC only -->
-		<description>DynaMike (Euro, Prototype)</description>
+		<description>DynaMike (Europe, Prototype)</description>
 		<year>19??</year>
 		<publisher>Engine Software</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -5557,7 +5557,7 @@ license:CC0
 
 	<software name="etcg">
 		<!-- Notes: GBC only -->
-		<description>E.T. and the Cosmic Garden (Euro)</description>
+		<description>E.T. and the Cosmic Garden (Europe)</description>
 		<year>2002</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BEOP-EUR"/>
@@ -5609,7 +5609,7 @@ license:CC0
 
 	<software name="et">
 		<!-- Notes: GBC only -->
-		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Euro)</description>
+		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Europe)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BERP-EUR"/>
@@ -5641,7 +5641,7 @@ license:CC0
 
 	<software name="ejim">
 		<!-- Notes: GBC only -->
-		<description>Earthworm Jim - Menace 2 the Galaxy (Euro, USA)</description>
+		<description>Earthworm Jim - Menace 2 the Galaxy (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEBE-USA, DMG-AEBP-EUR"/>
@@ -5658,7 +5658,7 @@ license:CC0
 
 	<software name="ecwhard">
 		<!-- Notes: GBC only -->
-		<description>ECW Hardcore Revolution (Euro, USA)</description>
+		<description>ECW Hardcore Revolution (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BECE-USA, CGB-BECP-EUR"/>
@@ -5675,7 +5675,7 @@ license:CC0
 
 	<software name="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Euro)</description>
+		<description>Elevator Action EX (Europe)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="alt_title" value="Elevator Action (Box)"/>
@@ -5690,7 +5690,7 @@ license:CC0
 
 	<software name="elevatorj" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Jpn)</description>
+		<description>Elevator Action EX (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BEXJ-JPN"/>
@@ -5705,7 +5705,7 @@ license:CC0
 	</software>
 
 	<software name="atelelie">
-		<description>Elie no Atelier GB (Jpn)</description>
+		<description>Elie no Atelier GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8EJ-JPN"/>
@@ -5729,7 +5729,7 @@ license:CC0
 	</software>
 
 	<software name="elmo123">
-		<description>Elmo's 123s (Euro)</description>
+		<description>Elmo's 123s (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AE3P-EUR"/>
@@ -5755,7 +5755,7 @@ license:CC0
 	</software>
 
 	<software name="elmoabc">
-		<description>Elmo's ABCs (Euro)</description>
+		<description>Elmo's ABCs (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AEAP-EUR"/>
@@ -5786,7 +5786,7 @@ license:CC0
 	<software name="emperorunk" cloneof="emperor">
 		<!-- Notes: GBC only -->
 		<!-- Old dump of unknown origin -->
-		<description>The Emperor's New Groove (Euro, bad dump?)</description>
+		<description>The Emperor's New Groove (Europe, bad dump?)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
@@ -5803,7 +5803,7 @@ license:CC0
 	<software name="emperor">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbenp0.641"	-->
-		<description>The Emperor's New Groove (Euro)</description>
+		<description>The Emperor's New Groove (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
@@ -5870,7 +5870,7 @@ license:CC0
 
 	<software name="estpolis" cloneof="lufia">
 		<!-- Notes: GBC only -->
-		<description>Estpolis Denki - Yomigaeru Densetsu (Jpn)</description>
+		<description>Estpolis Denki - Yomigaeru Densetsu (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BLCJ-JPN"/>
@@ -5894,7 +5894,7 @@ license:CC0
 
 	<software name="euroleag">
 		<!-- Notes: GBC only -->
-		<description>European Super League (Euro)</description>
+		<description>European Super League (Europe)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="??"/>
@@ -5909,7 +5909,7 @@ license:CC0
 	</software>
 
 	<software name="evelkni">
-		<description>Evel Knievel (Euro)</description>
+		<description>Evel Knievel (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AEVP-EUR"/>
@@ -5939,7 +5939,7 @@ license:CC0
 
 	<software name="exghostb">
 		<!-- Notes: GBC only -->
-		<description>Extreme Ghostbusters (Euro)</description>
+		<description>Extreme Ghostbusters (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BEBP-EUR"/>
@@ -5953,7 +5953,7 @@ license:CC0
 
 	<software name="extsport">
 		<!-- Notes: GBC only -->
-		<description>Extreme Sports with the Berenstain Bears (Euro, USA)</description>
+		<description>Extreme Sports with the Berenstain Bears (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Sound Source</publisher>
 		<info name="serial" value="CGB-BESE-USA, CGB-BESP-EUR"/>
@@ -5972,7 +5972,7 @@ license:CC0
 	<software name="f1wgp">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbafip0.028", "KENSA\cgbafie0.0"	-->
-		<description>F-1 World Grand Prix (Euro)</description>
+		<description>F-1 World Grand Prix (Europe)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-AFIP-EUR"/>
@@ -5989,7 +5989,7 @@ license:CC0
 
 	<software name="f18thund">
 		<!-- Notes: GBC only -->
-		<description>F-18 Thunder Strike (Euro, USA)</description>
+		<description>F-18 Thunder Strike (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-B18E-USA, CGB-B18P-NOE"/>
@@ -6006,7 +6006,7 @@ license:CC0
 
 	<software name="fa2001">
 		<!-- Notes: GBC only -->
-		<description>The F.A. Premier League Stars 2001 (Euro)</description>
+		<description>The F.A. Premier League Stars 2001 (Europe)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BSJP-?"/>
@@ -6021,7 +6021,7 @@ license:CC0
 
 	<software name="f1chmp2k">
 		<!-- Notes: GBC only -->
-		<description>F1 Championship Season 2000 (Euro)</description>
+		<description>F1 Championship Season 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BFIP-?"/>
@@ -6053,7 +6053,7 @@ license:CC0
 	<software name="f1racing">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaeqp0.381"	-->
-		<description>F1 Racing Championship (Euro)</description>
+		<description>F1 Racing Championship (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AEQP-EUR"/>
@@ -6070,7 +6070,7 @@ license:CC0
 
 	<software name="f1racingp" cloneof="f1racing">
 		<!-- Notes: GBC only -->
-		<description>F1 Racing Championship (Euro, Prototype)</description>
+		<description>F1 Racing Championship (Europe, Prototype)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6086,7 +6086,7 @@ license:CC0
 	<software name="f1racingunk" cloneof="f1racing">
 		<!-- Notes: GBC only -->
 		<!-- Old dump of unknown origin -->
-		<description>F1 Racing Championship (Euro, bad dump?)</description>
+		<description>F1 Racing Championship (Europe, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6101,7 +6101,7 @@ license:CC0
 
 	<software name="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Euro)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Europe)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2P-EUR"/>
@@ -6117,7 +6117,7 @@ license:CC0
 
 	<software name="f1wgp2j" cloneof="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Jpn)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Japan)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2J-JPN"/>
@@ -6157,7 +6157,7 @@ license:CC0
 
 	<software name="fairykit">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. 1)</description>
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
@@ -6176,7 +6176,7 @@ license:CC0
 
 	<software name="fairykita" cloneof="fairykit">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn)</description>
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
@@ -6195,7 +6195,7 @@ license:CC0
 
 	<software name="ferret">
 		<!-- Notes: GBC only -->
-		<description>Ferret Monogatari (Jpn)</description>
+		<description>Ferret Monogatari (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BBIJ-JPN"/>
@@ -6212,7 +6212,7 @@ license:CC0
 	</software>
 
 	<software name="fifa2k">
-		<description>FIFA 2000 (Euro, USA)</description>
+		<description>FIFA 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AFOE-USA, DMG-AFOP-UKV"/>
@@ -6229,7 +6229,7 @@ license:CC0
 
 	<software name="fishfile">
 		<!-- Notes: GBC only -->
-		<description>The Fish Files (Euro)</description>
+		<description>The Fish Files (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BFQP-EUR"/>
@@ -6245,7 +6245,7 @@ license:CC0
 
 	<software name="fixfoxi">
 		<!-- Notes: GBC only -->
-		<description>Fix &amp; Foxi - Episode 1: Lupo (Euro)</description>
+		<description>Fix &amp; Foxi - Episode 1: Lupo (Europe)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BFFP-EUR"/>
@@ -6259,7 +6259,7 @@ license:CC0
 
 	<software name="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Euro)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6274,7 +6274,7 @@ license:CC0
 <!-- The header is wrong, can it be a bad dump? a beta? investigations are needed on this older dump -->
 	<software name="flintbba" cloneof="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Euro, Alt?)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Europe, Alt?)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6302,7 +6302,7 @@ license:CC0
 
 	<software name="flipperl">
 		<!-- Notes: GBC only -->
-		<description>Flipper &amp; Lopaka (Euro)</description>
+		<description>Flipper &amp; Lopaka (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BFLP-EUR"/>
@@ -6346,7 +6346,7 @@ license:CC0
 
 	<software name="fortboya">
 		<!-- Notes: GBC only -->
-		<description>Fort Boyard (Euro)</description>
+		<description>Fort Boyard (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BYDP-EUR"/>
@@ -6359,7 +6359,7 @@ license:CC0
 	</software>
 
 	<software name="frogger">
-		<description>Frogger (Euro)</description>
+		<description>Frogger (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRP-EUR"/>
@@ -6449,7 +6449,7 @@ license:CC0
 	</software>
 
 	<software name="onepglin">
-		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Jpn)</description>
+		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BZOJ-JPN"/>
@@ -6474,7 +6474,7 @@ license:CC0
 	</software>
 
 	<software name="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. 1)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
@@ -6499,7 +6499,7 @@ license:CC0
 	</software>
 
 	<software name="onepyumea" cloneof="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
@@ -6525,7 +6525,7 @@ license:CC0
 
 	<software name="frontlin">
 		<!-- Notes: GBC only -->
-		<description>Front Line - The Next Mission (Jpn)</description>
+		<description>Front Line - The Next Mission (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFRJ-JPN"/>
@@ -6541,7 +6541,7 @@ license:CC0
 
 	<software name="frontrow">
 		<!-- Notes: GBC only -->
-		<description>Front Row (Jpn)</description>
+		<description>Front Row (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZDJ-JPN"/>
@@ -6559,7 +6559,7 @@ license:CC0
 
 	<software name="furaish2">
 		<!-- Notes: GBC only -->
-		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn)</description>
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-AFMJ-JPN"/>
@@ -6581,7 +6581,7 @@ license:CC0
 		<!--	In lot check as "cgbbfwj0.814"	-->
 		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to feature the common retail release)	-->
-		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn, Alt)</description>
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-BFWJ-JPN?"/>
@@ -6599,7 +6599,7 @@ license:CC0
 
 	<software name="gaiamast">
 		<!-- Notes: GBC only -->
-		<description>Gaiamaster Duel - Card Attackers (Jpn)</description>
+		<description>Gaiamaster Duel - Card Attackers (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BGIJ-JPN"/>
@@ -6616,7 +6616,7 @@ license:CC0
 	</software>
 
 	<software name="gakkyamaa">
-		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. 1)</description>
+		<description>Gakkyuu Ou Yamazaki (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
@@ -6642,7 +6642,7 @@ license:CC0
 	<software name="gakkyama" cloneof="gakkyamaa">
 		<!--	In lot check as "dmgaymj0.g22"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Gakkyuu Ou Yamazaki (Jpn)</description>
+		<description>Gakkyuu Ou Yamazaki (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN?"/>
@@ -6675,7 +6675,7 @@ license:CC0
 
 	<software name="gamblert">
 		<!-- Notes: GBC only -->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN"/>
@@ -6695,7 +6695,7 @@ license:CC0
 	<software name="gamblerta" cloneof="gamblert">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbgyj1.607"	-->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn, Rev. 1)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN?"/>
@@ -6712,7 +6712,7 @@ license:CC0
 	</software>
 
 	<software name="gwatch2">
-		<description>Game &amp; Watch Gallery 2 (Euro, USA)</description>
+		<description>Game &amp; Watch Gallery 2 (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLE-USA, DMG-AGLP-EUR"/>
@@ -6727,7 +6727,7 @@ license:CC0
 	</software>
 
 	<software name="gwatch3">
-		<description>Game &amp; Watch Gallery 3 (Euro, USA)</description>
+		<description>Game &amp; Watch Gallery 3 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQE-USA, DMG-AGQP-EUR"/>
@@ -6743,7 +6743,7 @@ license:CC0
 
 	<software name="gbpromo">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Color Promotional Demo (Euro, USA)</description>
+		<description>Game Boy Color Promotional Demo (Europe, USA)</description>
 		<year>19??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6755,7 +6755,7 @@ license:CC0
 	</software>
 
 	<software name="gbgall3" cloneof="gwatch2">
-		<description>Game Boy Gallery 3 (Aus)</description>
+		<description>Game Boy Gallery 3 (Australia)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLU-AUS"/>
@@ -6771,7 +6771,7 @@ license:CC0
 
 	<software name="gbgall3j" cloneof="gwatch3">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Game Boy Gallery 3 (Jpn)</description>
+		<description>Game Boy Gallery 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQJ-JPN"/>
@@ -6791,7 +6791,7 @@ license:CC0
 	</software>
 
 	<software name="gbgall4" cloneof="gwatch3">
-		<description>Game Boy Gallery 4 (Aus)</description>
+		<description>Game Boy Gallery 4 (Australia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQU-AUS"/>
@@ -6812,7 +6812,7 @@ license:CC0
 	</software>
 
 	<software name="gbwars2">
-		<description>Game Boy Wars 2 (Jpn)</description>
+		<description>Game Boy Wars 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AWOJ-JPN"/>
@@ -6832,7 +6832,7 @@ license:CC0
 
 	<software name="gbwars3">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Wars 3 (Jpn)</description>
+		<description>Game Boy Wars 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BWWJ-JPN"/>
@@ -6851,7 +6851,7 @@ license:CC0
 	</software>
 
 	<software name="gameconv">
-		<description>Game Conveni 21 (Jpn)</description>
+		<description>Game Conveni 21 (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BG2J-JPN"/>
@@ -6867,7 +6867,7 @@ license:CC0
 
 	<software name="gamefrnz">
 		<!-- Notes: GBC only -->
-		<description>Games Frenzy (Euro)</description>
+		<description>Games Frenzy (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BFGP-EUR"/>
@@ -6881,7 +6881,7 @@ license:CC0
 
 	<software name="ggoemdyn">
 		<!-- Notes: GBC only, also released by NP in 2001-07 -->
-		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Jpn)</description>
+		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BEKJ-JPN (RK234-J1)"/>
@@ -6898,7 +6898,7 @@ license:CC0
 	</software>
 
 	<software name="ggoemnab">
-		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Jpn)</description>
+		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AEFJ-JPN (RK192-J1)"/>
@@ -6917,7 +6917,7 @@ license:CC0
 
 	<software name="ggoemtng">
 		<!-- Also released by NP in 2000-05 -->
-		<description>Ganbare Goemon - Tengutou no Gyakushuu (Jpn)</description>
+		<description>Ganbare Goemon - Tengutou no Gyakushuu (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AGUJ-JPN (RK182-J1)"/>
@@ -6935,7 +6935,7 @@ license:CC0
 
 	<software name="olymp2k" cloneof="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>Ganbare! Nippon! Olympic 2000 (Jpn)</description>
+		<description>Ganbare! Nippon! Olympic 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HJ-JPN (RK208-J1)"/>
@@ -6953,7 +6953,7 @@ license:CC0
 
 	<software name="harobots">
 		<!-- Notes: GBC only -->
-		<description>GB Harobots (Jpn)</description>
+		<description>GB Harobots (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunrise Interactive</publisher>
 		<info name="serial" value="CGB-BHRJ-JPN"/>
@@ -6971,7 +6971,7 @@ license:CC0
 
 	<software name="gbmemory">
 		<!-- Notes: GBC only -->
-		<description>GB Memory Multi Menu (Jpn, NP)</description>
+		<description>GB Memory Multi Menu (Japan, NP)</description>
 		<year>20??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6984,7 +6984,7 @@ license:CC0
 
 	<software name="happyhip">
 		<!-- Notes: GBC only -->
-		<description>Das Geheimnis der Happy Hippo-Insel (Ger)</description>
+		<description>Das Geheimnis der Happy Hippo-Insel (Germany)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BHOD-NOE"/>
@@ -7001,7 +7001,7 @@ license:CC0
 
 	<software name="dangunrc">
 		<!-- Notes: GBC only -->
-		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Jpn)</description>
+		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BDJJ-JPN"/>
@@ -7018,7 +7018,7 @@ license:CC0
 	</software>
 
 	<software name="gemgem" cloneof="lilmonst">
-		<description>Gem Gem Monster (Jpn)</description>
+		<description>Gem Gem Monster (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AJYJ-JPN"/>
@@ -7037,7 +7037,7 @@ license:CC0
 
 	<software name="gmsayuki">
 		<!-- Notes: GBC only -->
-		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Jpn)</description>
+		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BGSJ-JPN"/>
@@ -7054,7 +7054,7 @@ license:CC0
 	</software>
 
 	<software name="getchuu">
-		<description>Get Chuu Club - Minna no Konchuu Daizukan (Jpn)</description>
+		<description>Get Chuu Club - Minna no Konchuu Daizukan (Japan)</description>
 		<year>1999</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="DMG-VRKJ-JPN"/>
@@ -7079,7 +7079,7 @@ license:CC0
 	</software>
 
 	<software name="gex2">
-		<description>Gex - Enter the Gecko (Euro, USA)</description>
+		<description>Gex - Enter the Gecko (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEXE-USA, DMG-AEXP-EUR"/>
@@ -7093,7 +7093,7 @@ license:CC0
 
 	<software name="gex3">
 		<!-- Notes: GBC only -->
-		<description>Gex 3 - Deep Cover Gecko (Euro)</description>
+		<description>Gex 3 - Deep Cover Gecko (Europe)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="CGB-AXGP-EUR"/>
@@ -7120,7 +7120,7 @@ license:CC0
 	</software>
 
 	<software name="gng">
-		<description>Ghosts'n Goblins (Euro, USA)</description>
+		<description>Ghosts'n Goblins (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AG9E-USA, DMG-AG9P-EUR"/>
@@ -7136,7 +7136,7 @@ license:CC0
 	</software>
 
 	<software name="gifts" cloneof="gift">
-		<description>Gift (Euro, Sample)</description>
+		<description>Gift (Europe, Sample)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7149,7 +7149,7 @@ license:CC0
 
 	<software name="gift">
 		<!-- Notes: GBC only -->
-		<description>Gift (Euro)</description>
+		<description>Gift (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFP-EUR"/>
@@ -7164,7 +7164,7 @@ license:CC0
 
 	<software name="gifty" cloneof="gift">
 		<!-- Notes: GBC only -->
-		<description>Gifty (Ger)</description>
+		<description>Gifty (Germany)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFD-?"/>
@@ -7178,7 +7178,7 @@ license:CC0
 	</software>
 
 	<software name="glochex" cloneof="hexcite">
-		<description>Glocal Hexcite (Jpn)</description>
+		<description>Glocal Hexcite (Japan)</description>
 		<year>1998</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="DMG-AICJ-JPN"/>
@@ -7210,7 +7210,7 @@ license:CC0
 	</software>
 
 	<software name="godzilla">
-		<description>Godzilla - The Series (Euro)</description>
+		<description>Godzilla - The Series (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AZIP-EUR"/>
@@ -7237,7 +7237,7 @@ license:CC0
 
 	<software name="godzmwar">
 		<!-- Notes: GBC only -->
-		<description>Godzilla - The Series - Monster Wars (Euro)</description>
+		<description>Godzilla - The Series - Monster Wars (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BGDP-EUR"/>
@@ -7268,7 +7268,7 @@ license:CC0
 
 	<software name="goldglry">
 		<!-- Notes: GBC only -->
-		<description>Gold and Glory - The Road to El Dorado (Euro)</description>
+		<description>Gold and Glory - The Road to El Dorado (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BEDP-EUR"/>
@@ -7295,7 +7295,7 @@ license:CC0
 	</software>
 
 	<software name="goldgoal">
-		<description>Golden Goal (Euro)</description>
+		<description>Golden Goal (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFX-EUR"/>
@@ -7316,7 +7316,7 @@ license:CC0
 	</software>
 
 	<software name="goldgoalg" cloneof="goldgoal">
-		<description>Golden Goal (Ger)</description>
+		<description>Golden Goal (Germany)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFD-NOE"/>
@@ -7331,7 +7331,7 @@ license:CC0
 	</software>
 
 	<software name="golfdai">
-		<description>Golf Daisuki! (Jpn)</description>
+		<description>Golf Daisuki! (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AAGJ-JPN"/>
@@ -7349,7 +7349,7 @@ license:CC0
 	</software>
 
 	<software name="golfohas" cloneof="holein1">
-		<description>Golf de Ohasuta (Jpn)</description>
+		<description>Golf de Ohasuta (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOHJ-JPN"/>
@@ -7366,7 +7366,7 @@ license:CC0
 	</software>
 
 	<software name="golfou">
-		<description>Golf Ou (Jpn)</description>
+		<description>Golf Ou (Japan)</description>
 		<year>1999</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-AZAJ-JPN"/>
@@ -7386,7 +7386,7 @@ license:CC0
 
 	<software name="gonta">
 		<!-- Notes: GBC only -->
-		<description>Gonta no Okiraku Daibouken (Jpn)</description>
+		<description>Gonta no Okiraku Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Lay-Up</publisher>
 		<info name="serial" value="CGB-B54J-JPN"/>
@@ -7403,7 +7403,7 @@ license:CC0
 	</software>
 
 	<software name="goraku">
-		<description>Goraku Ou Tango! (Jpn)</description>
+		<description>Goraku Ou Tango! (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AOEJ-JPN"/>
@@ -7420,7 +7420,7 @@ license:CC0
 	</software>
 
 	<software name="gta">
-		<description>Grand Theft Auto (Euro)</description>
+		<description>Grand Theft Auto (Europe)</description>
 		<year>1999</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="DMG-AOAP-EUR"/>
@@ -7451,7 +7451,7 @@ license:CC0
 
 	<software name="gta2">
 		<!-- Notes: GBC only -->
-		<description>Grand Theft Auto 2 (Euro)</description>
+		<description>Grand Theft Auto 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BGTP-(EUR/UKV)"/>
@@ -7479,7 +7479,7 @@ license:CC0
 
 	<software name="grandia">
 		<!-- Notes: GBC only -->
-		<description>Grandia - Parallel Trippers (Jpn)</description>
+		<description>Grandia - Parallel Trippers (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BGEJ-JPN"/>
@@ -7497,7 +7497,7 @@ license:CC0
 
 	<software name="granduel">
 		<!-- Notes: GBC only -->
-		<description>Granduel - Shinki Dungeon no Hihou (Jpn)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-ADVJ-JPN"/>
@@ -7514,7 +7514,7 @@ license:CC0
 	</software>
 
 	<software name="granduels" cloneof="granduel">
-		<description>Granduel - Shinki Dungeon no Hihou (Jpn, Sample)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Japan, Sample)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7526,7 +7526,7 @@ license:CC0
 	</software>
 
 	<software name="gbattlep">
-		<description>The Great Battle Pocket (Jpn)</description>
+		<description>The Great Battle Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AGVJ-JPN"/>
@@ -7546,7 +7546,7 @@ license:CC0
 
 	<software name="gremlins">
 		<!-- Notes: GBC only -->
-		<description>Gremlins Unleashed (Euro)</description>
+		<description>Gremlins Unleashed (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BGPP-EUR"/>
@@ -7559,7 +7559,7 @@ license:CC0
 	</software>
 
 	<software name="gremlinsp" cloneof="gremlins">
-		<description>Gremlins Unleashed (Euro, Prototype)</description>
+		<description>Gremlins Unleashed (Europe, Prototype)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7572,7 +7572,7 @@ license:CC0
 
 	<software name="grinch">
 		<!-- Notes: GBC only -->
-		<description>The Grinch (Euro)</description>
+		<description>The Grinch (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGHP-EUR"/>
@@ -7589,7 +7589,7 @@ license:CC0
 
 	<software name="grinchj" cloneof="grinch">
 		<!-- Notes: GBC only -->
-		<description>Grinch (Jpn)</description>
+		<description>Grinch (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUGJ-JPN (RK221-J1)"/>
@@ -7627,7 +7627,7 @@ license:CC0
 
 	<software name="gurugugr">
 		<!-- Also released by NP in 2000-07 -->
-		<description>Guruguru Garakutas (Jpn)</description>
+		<description>Guruguru Garakutas (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AUGJ-JPN"/>
@@ -7646,7 +7646,7 @@ license:CC0
 
 	<software name="guruguth">
 		<!-- Notes: GBC only -->
-		<description>Guruguru Town Hanamaru-kun (Jpn)</description>
+		<description>Guruguru Town Hanamaru-kun (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BHJJ-JPN"/>
@@ -7661,7 +7661,7 @@ license:CC0
 	</software>
 
 	<software name="gutequiz">
-		<description>Gute Zeiten Schlechte Zeiten Quiz (Ger)</description>
+		<description>Gute Zeiten Schlechte Zeiten Quiz (Germany)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="DMG-BGQD-NOE"/>
@@ -7675,7 +7675,7 @@ license:CC0
 
 	<software name="docguy">
 		<!-- Notes: GBC only -->
-		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Jpn)</description>
+		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BB6J-JPN (RK266-J1) "/>
@@ -7693,7 +7693,7 @@ license:CC0
 
 	<software name="hallowen">
 		<!-- Notes: GBC only -->
-		<description>Halloween Racer (Euro)</description>
+		<description>Halloween Racer (Europe)</description>
 		<year>1999</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-AHIP-EUR"/>
@@ -7706,7 +7706,7 @@ license:CC0
 	</software>
 
 	<software name="hamstclb">
-		<description>Hamster Club (Jpn)</description>
+		<description>Hamster Club (Japan)</description>
 		<year>1999</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-AJNJ-JPN"/>
@@ -7723,7 +7723,7 @@ license:CC0
 	</software>
 
 	<software name="hamstcla">
-		<description>Hamster Club - Awasete Chuu (Jpn)</description>
+		<description>Hamster Club - Awasete Chuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJHJ-JPN"/>
@@ -7739,7 +7739,7 @@ license:CC0
 
 	<software name="hamstclo">
 		<!-- Notes: GBC only -->
-		<description>Hamster Club - Oshiema Chuu (Jpn)</description>
+		<description>Hamster Club - Oshiema Chuu (Japan)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJSJ-JPN"/>
@@ -7756,7 +7756,7 @@ license:CC0
 	</software>
 
 	<software name="hamstcl2">
-		<description>Hamster Club 2 (Jpn)</description>
+		<description>Hamster Club 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJNJ-JPN"/>
@@ -7780,7 +7780,7 @@ license:CC0
 
 	<software name="hamstmon">
 		<!-- Notes: GBC only -->
-		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Jpn)</description>
+		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Japan)</description>
 		<year>2002</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-B8MJ-JPN"/>
@@ -7804,7 +7804,7 @@ license:CC0
 
 	<software name="hamstpar">
 		<!-- Also released by NP in 2001-06 -->
-		<description>Hamster Paradise (Jpn)</description>
+		<description>Hamster Paradise (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AHMJ-JPN"/>
@@ -7823,7 +7823,7 @@ license:CC0
 
 	<software name="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Jpn, Rev. 1)</description>
+		<description>Hamster Paradise 2 (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7841,7 +7841,7 @@ license:CC0
 
 	<software name="hamstpa2a" cloneof="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Jpn)</description>
+		<description>Hamster Paradise 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7859,7 +7859,7 @@ license:CC0
 
 	<software name="hamstpa3">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 3 (Jpn)</description>
+		<description>Hamster Paradise 3 (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BH3J-JPN"/>
@@ -7877,7 +7877,7 @@ license:CC0
 
 	<software name="hamstpa4">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 4 (Jpn)</description>
+		<description>Hamster Paradise 4 (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BCUJ-JPN"/>
@@ -7895,7 +7895,7 @@ license:CC0
 
 	<software name="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Hamtaro - Ham-Hams Unite! (Euro)</description>
+		<description>Hamtaro - Ham-Hams Unite! (Europe)</description>
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86P-EUR"/>
@@ -7927,7 +7927,7 @@ license:CC0
 
 	<software name="hamunapt" cloneof="mummy">
 		<!-- Notes: GBC only -->
-		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Jpn)</description>
+		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUMJ-JPN (RK222-J1)"/>
@@ -7945,7 +7945,7 @@ license:CC0
 
 	<software name="hanayori">
 		<!-- Notes: GBC only -->
-		<description>Hana Yori Dango - Another Love Story (Jpn)</description>
+		<description>Hana Yori Dango - Another Love Story (Japan)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-B87J-JPN"/>
@@ -7969,7 +7969,7 @@ license:CC0
 
 	<software name="hanasaka">
 		<!-- Also released by NP in 2001-04 -->
-		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Jpn)</description>
+		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHTJ-JPN (RK186-J1)"/>
@@ -7988,7 +7988,7 @@ license:CC0
 
 	<software name="handtime">
 		<!-- Notes: GBC only -->
-		<description>Hands of Time (Euro, USA)</description>
+		<description>Hands of Time (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BWCE-USA, CGB-BWCP-EUR"/>
@@ -8021,7 +8021,7 @@ license:CC0
 
 	<software name="hpotcsec">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Chamber of Secrets (Euro, USA)</description>
+		<description>Harry Potter and the Chamber of Secrets (Europe, USA)</description>
 		<year>2002</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BH6E-USA, CGB-BH6P-EUR"/>
@@ -8037,7 +8037,7 @@ license:CC0
 
 	<software name="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Philosopher's Stone (Euro) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
+		<description>Harry Potter and the Philosopher's Stone (Europe) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BHVE-USA, CGB-BHVP-EUR"/>
@@ -8053,7 +8053,7 @@ license:CC0
 
 	<software name="hpotkenj" cloneof="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter to Kenja no Ishi (Jpn)</description>
+		<description>Harry Potter to Kenja no Ishi (Japan)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts Victor</publisher>
 		<info name="serial" value="CGB-BHVJ-JPN"/>
@@ -8070,7 +8070,7 @@ license:CC0
 	</software>
 
 	<software name="harvmon2">
-		<description>Harvest Moon 2 GBC (Euro)</description>
+		<description>Harvest Moon 2 GBC (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2P-EUR"/>
@@ -8085,7 +8085,7 @@ license:CC0
 	</software>
 
 	<software name="harvmon2g" cloneof="harvmon2">
-		<description>Harvest Moon 2 GBC (Ger)</description>
+		<description>Harvest Moon 2 GBC (Germany)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2D-NOE"/>
@@ -8131,7 +8131,7 @@ license:CC0
 	</software>
 
 	<software name="harvmoon">
-		<description>Harvest Moon GB (Euro)</description>
+		<description>Harvest Moon GB (Europe)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXP-EUR"/>
@@ -8147,7 +8147,7 @@ license:CC0
 	</software>
 
 	<software name="harvmoong" cloneof="harvmoon">
-		<description>Harvest Moon GB (Ger)</description>
+		<description>Harvest Moon GB (Germany)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXD-NOE"/>
@@ -8185,7 +8185,7 @@ license:CC0
 	</software>
 
 	<software name="hellokbf">
-		<description>Hello Kitty no Beads Factory (Jpn)</description>
+		<description>Hello Kitty no Beads Factory (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHBJ-JPN"/>
@@ -8204,7 +8204,7 @@ license:CC0
 
 	<software name="hellokhh">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty no Happy House (Jpn)</description>
+		<description>Hello Kitty no Happy House (Japan)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BK7J-JPN"/>
@@ -8221,7 +8221,7 @@ license:CC0
 	</software>
 
 	<software name="hellokmm">
-		<description>Hello Kitty no Magical Museum (Jpn)</description>
+		<description>Hello Kitty no Magical Museum (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHKJ-JPN"/>
@@ -8245,7 +8245,7 @@ license:CC0
 	</software>
 
 	<software name="helloksa">
-		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Jpn)</description>
+		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BKTJ-JPN"/>
@@ -8264,7 +8264,7 @@ license:CC0
 
 	<software name="hellokdd">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty to Dear Daniel no Dream Adventure (Jpn)</description>
+		<description>Hello Kitty to Dear Daniel no Dream Adventure (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BK8J-JPN"/>
@@ -8296,7 +8296,7 @@ license:CC0
 
 	<software name="hercules">
 		<!-- Notes: GBC only -->
-		<description>Hercules - The Legendary Journeys (Euro)</description>
+		<description>Hercules - The Legendary Journeys (Europe)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -8312,7 +8312,7 @@ license:CC0
 
 	<software name="herohero">
 		<!-- Notes: GBC only -->
-		<description>Hero Hero Kun (Jpn)</description>
+		<description>Hero Hero Kun (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BH9J-JPN"/>
@@ -8330,7 +8330,7 @@ license:CC0
 
 	<software name="mightmag">
 		<!-- Notes: GBC only -->
-		<description>Heroes of Might and Magic (Euro)</description>
+		<description>Heroes of Might and Magic (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHP-EUR"/>
@@ -8386,7 +8386,7 @@ license:CC0
 
 	<software name="hexcite">
 		<!--	European cartridges have USA sticker underneath.	-->
-		<description>Hexcite (Euro, USA)</description>
+		<description>Hexcite (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AICE-USA, DMG-AICP-EUR"/>
@@ -8410,7 +8410,7 @@ license:CC0
 
 	<software name="hiryuken">
 		<!-- Notes: GBC only -->
-		<description>Hiryuu no Ken - Retsuden GB (Jpn)</description>
+		<description>Hiryuu no Ken - Retsuden GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BKEJ-JPN"/>
@@ -8426,7 +8426,7 @@ license:CC0
 
 	<software name="pachiboy">
 		<!-- Notes: GBC only -->
-		<description>Hissatsu Pachinko Boy - CR Monster House (Jpn)</description>
+		<description>Hissatsu Pachinko Boy - CR Monster House (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-BHPJ-JPN"/>
@@ -8464,7 +8464,7 @@ license:CC0
 	</software>
 
 	<software name="hollywpb">
-		<description>Hollywood Pinball (Euro)</description>
+		<description>Hollywood Pinball (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AHLP-EUR"/>
@@ -8477,7 +8477,7 @@ license:CC0
 	</software>
 
 	<software name="hollywpbj" cloneof="hollywpb">
-		<description>Hollywood Pinball (Jpn)</description>
+		<description>Hollywood Pinball (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AHNJ-JPN"/>
@@ -8492,7 +8492,7 @@ license:CC0
 	</software>
 
 	<software name="holymagc">
-		<description>Holy Magic Century (Euro)</description>
+		<description>Holy Magic Century (Europe)</description>
 		<year>1999</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="DMG-AQTP-EUR"/>
@@ -8506,7 +8506,7 @@ license:CC0
 
 	<software name="honkhana">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Honkaku Hanafuda GB (Jpn)</description>
+		<description>Honkaku Hanafuda GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-AH3J-JPN"/>
@@ -8523,7 +8523,7 @@ license:CC0
 	</software>
 
 	<software name="honkshog">
-		<description>Honkaku Shougi - Shougi Ou (Jpn)</description>
+		<description>Honkaku Shougi - Shougi Ou (Japan)</description>
 		<year>1998</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AG8J-JPN"/>
@@ -8541,7 +8541,7 @@ license:CC0
 	</software>
 
 	<software name="honktsho">
-		<description>Honkaku Taisen Shougi Ayumu (Jpn)</description>
+		<description>Honkaku Taisen Shougi Ayumu (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AIBJ-JPN"/>
@@ -8559,7 +8559,7 @@ license:CC0
 
 	<software name="honkmj">
 		<!-- Also released by NP in 2000-04 -->
-		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Jpn)</description>
+		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Japan)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AAAJ-JPN"/>
@@ -8577,7 +8577,7 @@ license:CC0
 	</software>
 
 	<software name="hotwheel">
-		<description>Hot Wheels - Stunt Track Driver (Euro, USA)</description>
+		<description>Hot Wheels - Stunt Track Driver (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AHEE-USA, DMG-AHEP-EUR"/>
@@ -8621,7 +8621,7 @@ license:CC0
 
 	<software name="hugobdf">
 		<!-- Notes: GBC only -->
-		<description>Hugo - Black Diamond Fever (Euro)</description>
+		<description>Hugo - Black Diamond Fever (Europe)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHUP-EUR"/>
@@ -8635,7 +8635,7 @@ license:CC0
 
 	<software name="hugoevmr">
 		<!-- Notes: GBC only -->
-		<description>Hugo - The Evil Mirror (Euro)</description>
+		<description>Hugo - The Evil Mirror (Europe)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHXP-EUR"/>
@@ -8651,7 +8651,7 @@ license:CC0
 	</software>
 
 	<software name="hugo2hlf">
-		<description>Hugo 2½ (Ger)</description>
+		<description>Hugo 2½ (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AHOP-NOE"/>
@@ -8665,7 +8665,7 @@ license:CC0
 
 	<software name="hxhhunke">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Hunter no Keifu (Jpn)</description>
+		<description>Hunter X Hunter - Hunter no Keifu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHHJ-JPN (RK203-J1)"/>
@@ -8683,7 +8683,7 @@ license:CC0
 
 	<software name="hxhkindn">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Kindan no Hihou (Jpn)</description>
+		<description>Hunter X Hunter - Kindan no Hihou (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHKJ-JPN (RK236-J1)"/>
@@ -8701,7 +8701,7 @@ license:CC0
 
 	<software name="hype">
 		<!-- Notes: GBC only -->
-		<description>Hype - The Time Quest (Euro)</description>
+		<description>Hype - The Time Quest (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BHQP-EUR"/>
@@ -8732,7 +8732,7 @@ license:CC0
 
 	<software name="hyprol2k" cloneof="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Hyper Olympic - Winter 2000 (Jpn)</description>
+		<description>Hyper Olympic - Winter 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HJ-JPN (RK196-J1)"/>
@@ -8749,7 +8749,7 @@ license:CC0
 	</software>
 
 	<software name="hyperol" cloneof="itf">
-		<description>Hyper Olympic Series - Track &amp; Field GB (Jpn)</description>
+		<description>Hyper Olympic Series - Track &amp; Field GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDJ-JPN (RK183-J1)"/>
@@ -8768,7 +8768,7 @@ license:CC0
 
 	<software name="ideyumjk">
 		<!-- Notes: GBC only -->
-		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Jpn)</description>
+		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BIMJ-JPN"/>
@@ -8786,7 +8786,7 @@ license:CC0
 
 	<software name="indyinfm">
 		<!-- Notes: GBC only -->
-		<description>Indiana Jones and the Infernal Machine (Euro, USA)</description>
+		<description>Indiana Jones and the Infernal Machine (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BIJE-USA, CGB-BIJP-EUR"/>
@@ -8803,7 +8803,7 @@ license:CC0
 
 	<software name="inspgadg">
 		<!-- Notes: GBC only -->
-		<description>Inspector Gadget - Operation Madkactus (Euro)</description>
+		<description>Inspector Gadget - Operation Madkactus (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BIGP-EUR"/>
@@ -8831,7 +8831,7 @@ license:CC0
 
 	<software name="ik2000">
 		<!-- Notes: GBC only -->
-		<description>International Karate 2000 (Euro)</description>
+		<description>International Karate 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BIKP-EUU"/>
@@ -8860,7 +8860,7 @@ license:CC0
 	</software>
 
 	<software name="iss99">
-		<description>International Superstar Soccer '99 (Euro)</description>
+		<description>International Superstar Soccer '99 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZP-EUR"/>
@@ -8893,7 +8893,7 @@ license:CC0
 
 	<software name="iss2k">
 		<!-- Notes: GBC only -->
-		<description>International Superstar Soccer 2000 (Euro)</description>
+		<description>International Superstar Soccer 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSP-EUR"/>
@@ -8930,7 +8930,7 @@ license:CC0
 	</software>
 
 	<software name="itf">
-		<description>International Track &amp; Field (Euro)</description>
+		<description>International Track &amp; Field (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDP-EUR"/>
@@ -8961,7 +8961,7 @@ license:CC0
 
 	<software name="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>International Track &amp; Field - Summer Games (Euro)</description>
+		<description>International Track &amp; Field - Summer Games (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HP-EUR"/>
@@ -8977,7 +8977,7 @@ license:CC0
 
 	<software name="wldrally" cloneof="xcountry">
 		<!-- Also released by NP in 2000-08 -->
-		<description>It's a World Rally (Jpn)</description>
+		<description>It's a World Rally (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLJ-JPN (RX187-J1)"/>
@@ -8996,7 +8996,7 @@ license:CC0
 
 	<software name="itsudemo">
 		<!-- Notes: GBC only -->
-		<description>Itsudemo Pachinko GB - CR Monster House (Jpn)</description>
+		<description>Itsudemo Pachinko GB - CR Monster House (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BCRJ-JPN"/>
@@ -9014,7 +9014,7 @@ license:CC0
 
 	<software name="jlexcstg">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage GB (Jpn)</description>
+		<description>J.League Excite Stage GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AESJ-JPN"/>
@@ -9032,7 +9032,7 @@ license:CC0
 
 	<software name="jlexcstt">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage Tactics (Jpn)</description>
+		<description>J.League Excite Stage Tactics (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AJEJ-JPN"/>
@@ -9049,7 +9049,7 @@ license:CC0
 	</software>
 
 	<software name="jackdaib" cloneof="questrpg">
-		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Jpn)</description>
+		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AQJJ-JPN"/>
@@ -9068,7 +9068,7 @@ license:CC0
 
 	<software name="jagainu">
 		<!-- Also released by NP in 2000-12 -->
-		<description>Jagainu-kun (Jpn)</description>
+		<description>Jagainu-kun (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-B39J-JPN"/>
@@ -9086,7 +9086,7 @@ license:CC0
 
 	<software name="jankyus">
 		<!-- Notes: GBC only -->
-		<description>Jankyuusei - Cosplay Paradise (Jpn)</description>
+		<description>Jankyuusei - Cosplay Paradise (Japan)</description>
 		<year>2001</year>
 		<publisher>Elf</publisher>
 		<info name="serial" value="CGB-BHGJ-JPN"/>
@@ -9104,7 +9104,7 @@ license:CC0
 
 	<software name="janosch">
 		<!-- Notes: GBC only -->
-		<description>Janosch - Das grosse Panama-Spiel (Ger)</description>
+		<description>Janosch - Das grosse Panama-Spiel (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AJOD-NOE"/>
@@ -9118,7 +9118,7 @@ license:CC0
 
 	<software name="jayspiel">
 		<!-- Notes: GBC only -->
-		<description>Jay und die Spielzeugdiebe (Ger)</description>
+		<description>Jay und die Spielzeugdiebe (Germany)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BJYD-NOE"/>
@@ -9146,7 +9146,7 @@ license:CC0
 
 	<software name="jmg2k">
 		<!-- Notes: GBC only -->
-		<description>Jeremy McGrath Supercross 2000 (Euro, USA)</description>
+		<description>Jeremy McGrath Supercross 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AJUE-USA, CGB-AJUP-EUR"/>
@@ -9164,7 +9164,7 @@ license:CC0
 
 	<software name="jetdego">
 		<!-- Notes: GBC only -->
-		<description>Jet de Go! (Jpn)</description>
+		<description>Jet de Go! (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BJEJ-JPN"/>
@@ -9182,7 +9182,7 @@ license:CC0
 
 	<software name="jimmywhi">
 		<!-- Notes: GBC only -->
-		<description>Jimmy White's Cueball (Euro)</description>
+		<description>Jimmy White's Cueball (Europe)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BJWP-EUR"/>
@@ -9196,7 +9196,7 @@ license:CC0
 	</software>
 
 	<software name="jinsei">
-		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Jpn)</description>
+		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACJJ-JPN"/>
@@ -9215,7 +9215,7 @@ license:CC0
 
 	<software name="jisedai">
 		<!-- Notes: GBC only -->
-		<description>Jisedai Begoma Battle Beyblade (Jpn)</description>
+		<description>Jisedai Begoma Battle Beyblade (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-AG5J-JPN"/>
@@ -9233,7 +9233,7 @@ license:CC0
 
 	<software name="jissena">
 		<!-- Notes: GBC only -->
-		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. 1)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
@@ -9255,7 +9255,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbjtj0.313"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Jissen ni Yakudatsu Tsumego (Jpn)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Japan)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN?"/>
@@ -9270,7 +9270,7 @@ license:CC0
 	</software>
 
 	<software name="joryujan">
-		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Jpn)</description>
+		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-A55J-JPN"/>
@@ -9303,7 +9303,7 @@ license:CC0
 
 	<software name="jungle">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Euro)</description>
+		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BJGP-EUR"/>
@@ -9331,7 +9331,7 @@ license:CC0
 
 	<software name="jukosenk">
 		<!-- Notes: GBC only -->
-		<description>Juukou Senki Bullet Battlers (Jpn)</description>
+		<description>Juukou Senki Bullet Battlers (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AZXJ-JPN (RX173-J1)"/>
@@ -9349,7 +9349,7 @@ license:CC0
 
 	<software name="koprobox">
 		<!-- Notes: GBC only -->
-		<description>K.O. - The Pro Boxing (Jpn)</description>
+		<description>K.O. - The Pro Boxing (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BKOJ-JPN"/>
@@ -9367,7 +9367,7 @@ license:CC0
 
 	<software name="kaptnblb">
 		<!-- Notes: GBC only -->
-		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Ger)</description>
+		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Germany)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BVRD-NOE"/>
@@ -9380,7 +9380,7 @@ license:CC0
 	</software>
 
 	<software name="kaiteide">
-		<description>Kaitei Densetsu!! Treasure World (Jpn)</description>
+		<description>Kaitei Densetsu!! Treasure World (Japan)</description>
 		<year>2000</year>
 		<publisher>Dazz</publisher>
 		<info name="serial" value="DMG-BDTJ-JPN"/>
@@ -9398,7 +9398,7 @@ license:CC0
 
 	<software name="kakurenb">
 		<!-- Notes: GBC only -->
-		<description>Kakurenbo Battle Monster Tactics (Jpn)</description>
+		<description>Kakurenbo Battle Monster Tactics (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BMFJ-JPN"/>
@@ -9422,7 +9422,7 @@ license:CC0
 
 	<software name="bistrokb">
 		<!-- Also released by NP in 2000-12 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Jpn)</description>
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A2WJ-JPN"/>
@@ -9441,7 +9441,7 @@ license:CC0
 
 	<software name="bistrogf">
 		<!-- Also released by NP in 2000-10 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Jpn)</description>
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AWRJ-JPN"/>
@@ -9465,7 +9465,7 @@ license:CC0
 	</software>
 
 	<software name="kanjiboy">
-		<description>Kanji Boy (Jpn)</description>
+		<description>Kanji Boy (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWKJ-JPN"/>
@@ -9481,7 +9481,7 @@ license:CC0
 	</software>
 
 	<software name="kanjibo2">
-		<description>Kanji Boy 2 (Jpn)</description>
+		<description>Kanji Boy 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2CJ-JPN"/>
@@ -9500,7 +9500,7 @@ license:CC0
 
 	<software name="kanjibo3">
 		<!-- Notes: GBC only -->
-		<description>Kanji Boy 3 (Jpn)</description>
+		<description>Kanji Boy 3 (Japan)</description>
 		<year>2003</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BK3J-JPN"/>
@@ -9517,7 +9517,7 @@ license:CC0
 	</software>
 
 	<software name="kanjipzl">
-		<description>Kanji de Puzzle (Jpn)</description>
+		<description>Kanji de Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BKAJ-JPN"/>
@@ -9533,7 +9533,7 @@ license:CC0
 
 	<software name="kanzumep">
 		<!-- Also released by NP in 2000-06 -->
-		<description>Kanzume Monsters Parfait (Jpn)</description>
+		<description>Kanzume Monsters Parfait (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AQPJ-JPN"/>
@@ -9551,7 +9551,7 @@ license:CC0
 
 	<software name="karamuok">
 		<!-- NP only -->
-		<description>Karamuchou wa Oosawagi! - Okawari! (Jpn, NP)</description>
+		<description>Karamuchou wa Oosawagi! - Okawari! (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BOOJ-JPN"/>
@@ -9570,7 +9570,7 @@ license:CC0
 
 	<software name="karamupl">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Jpn)</description>
+		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Japan)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AOPJ-JPN"/>
@@ -9589,7 +9589,7 @@ license:CC0
 
 	<software name="karankor">
 		<!-- Notes: GBC only -->
-		<description>Karan Koron Gakuen - Hanafuda Mahjong (Jpn)</description>
+		<description>Karan Koron Gakuen - Hanafuda Mahjong (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AHFJ-JPN"/>
@@ -9605,7 +9605,7 @@ license:CC0
 
 	<software name="kaseki2">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Kaseki Sousei Reborn II - Monster Digger (Jpn)</description>
+		<description>Kaseki Sousei Reborn II - Monster Digger (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ARMJ-JPN"/>
@@ -9623,7 +9623,7 @@ license:CC0
 	</software>
 
 	<software name="katohifu">
-		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Jpn)</description>
+		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AKHJ-JPN"/>
@@ -9639,7 +9639,7 @@ license:CC0
 	</software>
 
 	<software name="kawanus4" cloneof="rivking2">
-		<description>Kawa no Nushi Tsuri 4 (Jpn)</description>
+		<description>Kawa no Nushi Tsuri 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-VUTJ-JPN"/>
@@ -9666,7 +9666,7 @@ license:CC0
 	</software>
 
 	<software name="kawaipet">
-		<description>Kawaii Pet Shop Monogatari (Jpn)</description>
+		<description>Kawaii Pet Shop Monogatari (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AEIJ-JPN"/>
@@ -9685,7 +9685,7 @@ license:CC0
 
 	<software name="kawaipt2a">
 		<!--	In lot check as "dmgbmnj1.j90"	-->
-		<description>Kawaii Pet Shop Monogatari 2 (Jpn, Rev. 1)</description>
+		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
@@ -9702,7 +9702,7 @@ license:CC0
 	</software>
 
 	<software name="kawaipt2" cloneof="kawaipt2a">
-		<description>Kawaii Pet Shop Monogatari 2 (Jpn)</description>
+		<description>Kawaii Pet Shop Monogatari 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
@@ -9721,7 +9721,7 @@ license:CC0
 
 	<software name="keepblnc">
 		<!-- Notes: GBC only -->
-		<description>Keep the Balance (Euro)</description>
+		<description>Keep the Balance (Europe)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment AG</publisher>
 		<info name="serial" value="CGB-BKNP-EUR"/>
@@ -9734,7 +9734,7 @@ license:CC0
 	</software>
 
 	<software name="keibajou">
-		<description>Keibajou e Ikou! Wide (Jpn)</description>
+		<description>Keibajou e Ikou! Wide (Japan)</description>
 		<year>2000</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-ASCJ-JPN"/>
@@ -9753,7 +9753,7 @@ license:CC0
 	<software name="telefngp">
 		<!-- Notes: This game uses an accessory called "Power Antenna", which is just a LED light connected
 		        to the GB accessories port. It is used ingame to simulate a mobile phone. -->
-		<description>Keitai Denjuu Telefang - Power Version (Jpn)</description>
+		<description>Keitai Denjuu Telefang - Power Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTXJ-JPN"/>
@@ -9777,7 +9777,7 @@ license:CC0
 	</software>
 
 	<software name="telefngs">
-		<description>Keitai Denjuu Telefang - Speed Version (Jpn)</description>
+		<description>Keitai Denjuu Telefang - Speed Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTZJ-JPN"/>
@@ -9825,7 +9825,7 @@ license:CC0
 	</software>
 
 	<software name="kettoubw">
-		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Jpn)</description>
+		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AB7J-JPN"/>
@@ -9842,7 +9842,7 @@ license:CC0
 
 	<software name="nadesico">
 		<!-- Notes: GBC only -->
-		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Jpn)</description>
+		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQNJ-JPN (KIG-9)"/>
@@ -9860,7 +9860,7 @@ license:CC0
 
 	<software name="kikathom">
 		<!-- Notes: GBC only -->
-		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Jpn)</description>
+		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Japan)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BBWJ-JPN"/>
@@ -9877,7 +9877,7 @@ license:CC0
 	</software>
 
 	<software name="kindajik">
-		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Jpn)</description>
+		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BKSJ-JPN"/>
@@ -9897,7 +9897,7 @@ license:CC0
 	</software>
 
 	<software name="kinniban">
-		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Jpn)</description>
+		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A5KJ-JPN (RK197-J1)"/>
@@ -9915,7 +9915,7 @@ license:CC0
 	</software>
 
 	<software name="kinnibn2">
-		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Jpn)</description>
+		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B6KJ-JPN (RK213-J1)"/>
@@ -9936,7 +9936,7 @@ license:CC0
 
 	<software name="kinnibn3">
 		<!-- Notes: GBC only -->
-		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Jpn)</description>
+		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B7KJ-JPN (RK233-J1)"/>
@@ -9976,7 +9976,7 @@ license:CC0
 
 	<software name="kiriku">
 		<!-- Notes: GBC only -->
-		<description>Kirikou (Euro)</description>
+		<description>Kirikou (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BKKP-EUR"/>
@@ -9990,7 +9990,7 @@ license:CC0
 
 	<software name="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Jpn, Rev. 1)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -10008,7 +10008,7 @@ license:CC0
 
 	<software name="kisekae2a" cloneof="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Jpn)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -10026,7 +10026,7 @@ license:CC0
 
 	<software name="kisekae3">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 3 - Kisekae Hamster (Jpn)</description>
+		<description>Kisekae Series 3 - Kisekae Hamster (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BKHJ-JPN"/>
@@ -10043,7 +10043,7 @@ license:CC0
 	</software>
 
 	<software name="klustar">
-		<description>Klustar (Euro)</description>
+		<description>Klustar (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AKUP-EUR"/>
@@ -10057,7 +10057,7 @@ license:CC0
 
 	<software name="kokings">
 		<!-- Notes: GBC only -->
-		<description>Knockout Kings (Euro, USA)</description>
+		<description>Knockout Kings (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AXKE-USA, CGB-AXKP-EUR"/>
@@ -10074,7 +10074,7 @@ license:CC0
 
 	<software name="klax">
 		<!-- Notes: GBC only -->
-		<description>Klax (Euro, USA)</description>
+		<description>Klax (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ALXE-USA, CGB-ALXP-EUR"/>
@@ -10104,7 +10104,7 @@ license:CC0
 
 	<software name="kogurugu">
 		<!-- NP only -->
-		<description>Koguru Guruguru - Guruguru to Nakayoshi (Jpn, NP)</description>
+		<description>Koguru Guruguru - Guruguru to Nakayoshi (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Sting</publisher>
 		<info name="serial" value="DMG-BKGJ-JPN"/>
@@ -10121,7 +10121,7 @@ license:CC0
 	</software>
 
 	<software name="konamic1">
-		<description>Konami GB Collection Vol.1 (Euro)</description>
+		<description>Konami GB Collection Vol.1 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF5P-EUR"/>
@@ -10134,7 +10134,7 @@ license:CC0
 	</software>
 
 	<software name="konamic2">
-		<description>Konami GB Collection Vol.2 (Euro)</description>
+		<description>Konami GB Collection Vol.2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF6P-EUR"/>
@@ -10147,7 +10147,7 @@ license:CC0
 	</software>
 
 	<software name="konamic3">
-		<description>Konami GB Collection Vol.3 (Euro)</description>
+		<description>Konami GB Collection Vol.3 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF7P-EUR"/>
@@ -10160,7 +10160,7 @@ license:CC0
 	</software>
 
 	<software name="konamic4">
-		<description>Konami GB Collection Vol.4 (Euro)</description>
+		<description>Konami GB Collection Vol.4 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF8P-EUR"/>
@@ -10174,7 +10174,7 @@ license:CC0
 
 	<software name="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Konami Winter Games (Euro)</description>
+		<description>Konami Winter Games (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HP-EUR"/>
@@ -10190,7 +10190,7 @@ license:CC0
 
 	<software name="konchufg">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Fighters (Jpn)</description>
+		<description>Konchuu Fighters (Japan)</description>
 		<year>2002</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-BZZJ-JPN"/>
@@ -10207,7 +10207,7 @@ license:CC0
 	</software>
 
 	<software name="konchuh2">
-		<description>Konchuu Hakase 2 (Jpn)</description>
+		<description>Konchuu Hakase 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2KJ-JPN"/>
@@ -10226,7 +10226,7 @@ license:CC0
 
 	<software name="konchuh3">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Hakase 3 (Jpn)</description>
+		<description>Konchuu Hakase 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A3KJ-JPN"/>
@@ -10244,7 +10244,7 @@ license:CC0
 
 	<software name="korokoro" cloneof="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Korokoro Kirby (Jpn)</description>
+		<description>Korokoro Kirby (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-KKKJ-JPN"/>
@@ -10267,7 +10267,7 @@ license:CC0
 
 	<software name="kotobatt">
 		<!-- Notes: GBC only -->
-		<description>Koto Battle - Tengai no Moribito (Jpn)</description>
+		<description>Koto Battle - Tengai no Moribito (Japan)</description>
 		<year>2001</year>
 		<publisher>Alphadream</publisher>
 		<info name="serial" value="CGB-BAJJ-JPN"/>
@@ -10284,7 +10284,7 @@ license:CC0
 	</software>
 
 	<software name="koshien">
-		<description>Koushien Pocket (Jpn)</description>
+		<description>Koushien Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AKSJ-JPN"/>
@@ -10303,7 +10303,7 @@ license:CC0
 
 	<software name="landbtim">
 		<!-- Notes: GBC only -->
-		<description>The Land Before Time (Euro)</description>
+		<description>The Land Before Time (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BLBP-EUR"/>
@@ -10346,7 +10346,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbldp0.420"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Laura (Euro)</description>
+		<description>Laura (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -10363,7 +10363,7 @@ license:CC0
 	<software name="lauraunk" cloneof="laura">
 		<!-- Notes: GBC only -->
 		<!-- Old dump of unknown origin -->
-		<description>Laura (Euro, bad dump?)</description>
+		<description>Laura (Europe, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -10394,7 +10394,7 @@ license:CC0
 
 	<software name="lemans24">
 		<!-- Notes: GBC only -->
-		<description>Le Mans 24 Hours (Euro)</description>
+		<description>Le Mans 24 Hours (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-B24P-NOE"/>
@@ -10409,7 +10409,7 @@ license:CC0
 	</software>
 
 	<software name="rivking2">
-		<description>Legend of the River King 2 (Euro)</description>
+		<description>Legend of the River King 2 (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BRKP-EUR"/>
@@ -10439,7 +10439,7 @@ license:CC0
 	</software>
 
 	<software name="rivking">
-		<description>Legend of the River King GB (Euro)</description>
+		<description>Legend of the River King GB (Europe)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-ARKP-EUR"/>
@@ -10454,7 +10454,7 @@ license:CC0
 	</software>
 
 	<software name="rivkingg" cloneof="rivking">
-		<description>Legend of the River King GB (Ger)</description>
+		<description>Legend of the River King GB (Germany)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="??"/>
@@ -10484,7 +10484,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, Aus, USA, Rev. 2)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, Australia, USA, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-(EUR/AUS)"/>
@@ -10499,7 +10499,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
@@ -10514,7 +10514,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxb" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
@@ -10536,7 +10536,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxf" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Fra, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (France, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10556,7 +10556,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxfa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Fra)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (France)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10578,7 +10578,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxg" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Ger, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Germany, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10598,7 +10598,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxga" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Ger)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Germany)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10614,7 +10614,7 @@ license:CC0
 
 	<software name="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Euro)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8P-EUR"/>
@@ -10636,7 +10636,7 @@ license:CC0
 
 	<software name="zeldaageu" cloneof="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Aus, USA)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8U-AUS, CGB-AZ8E-USA"/>
@@ -10658,7 +10658,7 @@ license:CC0
 
 	<software name="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Euro)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7P-EUR"/>
@@ -10680,7 +10680,7 @@ license:CC0
 
 	<software name="zeldaseau" cloneof="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Aus, USA)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7U-AUS, CGB-AZ7E-USA"/>
@@ -10702,7 +10702,7 @@ license:CC0
 
 	<software name="legoatm">
 		<!-- Notes: GBC only -->
-		<description>LEGO Alpha Team (Euro)</description>
+		<description>LEGO Alpha Team (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLPP-(EUR/SCN)"/>
@@ -10734,7 +10734,7 @@ license:CC0
 
 	<software name="legoisl2">
 		<!-- Notes: GBC only -->
-		<description>LEGO Island 2 - The Brickster's Revenge (Euro)</description>
+		<description>LEGO Island 2 - The Brickster's Revenge (Europe)</description>
 		<year>2001</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BL2P-EUR"/>
@@ -10766,7 +10766,7 @@ license:CC0
 
 	<software name="legorace">
 		<!-- Notes: GBC only -->
-		<description>LEGO Racers (Euro)</description>
+		<description>LEGO Racers (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLRP-EUU"/>
@@ -10804,7 +10804,7 @@ license:CC0
 
 	<software name="legostnt">
 		<!-- Notes: GBC only -->
-		<description>LEGO Stunt Rally (Euro)</description>
+		<description>LEGO Stunt Rally (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLYP-SCN"/>
@@ -10867,7 +10867,7 @@ license:CC0
 
 	<software name="lionking">
 		<!-- Notes: GBC only -->
-		<description>The Lion King - Simba's Mighty Adventure (Euro, USA)</description>
+		<description>The Lion King - Simba's Mighty Adventure (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKE-USA, CGB-BLKP-UKV"/>
@@ -10884,7 +10884,7 @@ license:CC0
 
 	<software name="lionkingf" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Le Roi Lion - Les Adventures de Simba (Fra)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
@@ -10900,7 +10900,7 @@ license:CC0
 	<software name="lionkingfa" cloneof="lionking">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbblkf1.573"	-->
-		<description>Le Roi Lion - Les Adventures de Simba (Fra, Rev. 1)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (France, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
@@ -10915,7 +10915,7 @@ license:CC0
 
 	<software name="lionkingg" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Der König der Löwen - Simbas grosses Abenteuer (Ger)</description>
+		<description>Der König der Löwen - Simbas grosses Abenteuer (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKD-NOE"/>
@@ -10932,7 +10932,7 @@ license:CC0
 
 	<software name="lilmagic">
 		<!-- Notes: GBC only -->
-		<description>Little Magic (Jpn)</description>
+		<description>Little Magic (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-ALJJ-JPN"/>
@@ -10950,7 +10950,7 @@ license:CC0
 
 	<software name="mermaid2">
 		<!-- Notes: GBC only -->
-		<description>Disney's The Little Mermaid II - Pinball Frenzy (Euro)</description>
+		<description>Disney's The Little Mermaid II - Pinball Frenzy (Europe)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="CGB-BY2P-EUR"/>
@@ -11004,7 +11004,7 @@ license:CC0
 
 	<software name="lnf2001" cloneof="fa2001">
 		<!-- Notes: GBC only -->
-		<description>LNF Stars 2001 (Fra)</description>
+		<description>LNF Stars 2001 (France)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -11017,7 +11017,7 @@ license:CC0
 	</software>
 
 	<software name="ldrun">
-		<description>Lode Runner - Domudomu Dan no Yabou (Jpn)</description>
+		<description>Lode Runner - Domudomu Dan no Yabou (Japan)</description>
 		<year>2000</year>
 		<publisher>Xing Entertainment</publisher>
 		<info name="serial" value="DMG-BXLJ-JPN"/>
@@ -11034,7 +11034,7 @@ license:CC0
 	</software>
 
 	<software name="lodoss">
-		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Jpn)</description>
+		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Japan)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-ARAJ-JPN"/>
@@ -11051,7 +11051,7 @@ license:CC0
 
 	<software name="logical">
 		<!-- Notes: GBC only -->
-		<description>Logical (Euro)</description>
+		<description>Logical (Europe)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AOGP-EUR"/>
@@ -11079,7 +11079,7 @@ license:CC0
 
 	<software name="looney">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes (Euro)</description>
+		<description>Looney Tunes (Europe)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALTP-(EUR/UKV)"/>
@@ -11152,7 +11152,7 @@ license:CC0
 
 	<software name="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Alert! (Euro)</description>
+		<description>Looney Tunes Collector - Martian Alert! (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALMP-UKV"/>
@@ -11168,7 +11168,7 @@ license:CC0
 
 	<software name="looneymaj" cloneof="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Quest! (Jpn)</description>
+		<description>Looney Tunes Collector - Martian Quest! (Japan)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-ALMJ-JPN"/>
@@ -11192,7 +11192,7 @@ license:CC0
 
 	<software name="looneymr">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Revenge! (Euro)</description>
+		<description>Looney Tunes Collector - Martian Revenge! (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLAP-UKV"/>
@@ -11208,7 +11208,7 @@ license:CC0
 
 	<software name="looneyrc">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Racing (Euro)</description>
+		<description>Looney Tunes Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLQP-EUR"/>
@@ -11246,7 +11246,7 @@ license:CC0
 
 	<software name="hirapzl2">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
@@ -11265,7 +11265,7 @@ license:CC0
 
 	<software name="hirapzl2a" cloneof="hirapzl2">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
@@ -11284,7 +11284,7 @@ license:CC0
 
 	<software name="hirapzl3">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
@@ -11303,7 +11303,7 @@ license:CC0
 
 	<software name="hirapzl3a" cloneof="hirapzl3">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
@@ -11322,7 +11322,7 @@ license:CC0
 
 	<software name="hirapzls">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
@@ -11341,7 +11341,7 @@ license:CC0
 
 	<software name="hirapzlsa" cloneof="hirapzls">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
@@ -11360,7 +11360,7 @@ license:CC0
 
 	<software name="kangpzl2a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
@@ -11379,7 +11379,7 @@ license:CC0
 
 	<software name="kangpzl2" cloneof="kangpzl2a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
@@ -11398,7 +11398,7 @@ license:CC0
 
 	<software name="kangpzl3a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
@@ -11417,7 +11417,7 @@ license:CC0
 
 	<software name="kangpzl3" cloneof="kangpzl3a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
@@ -11436,7 +11436,7 @@ license:CC0
 
 	<software name="kangpzlsa">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
@@ -11455,7 +11455,7 @@ license:CC0
 
 	<software name="kangpzls" cloneof="kangpzlsa">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
@@ -11474,7 +11474,7 @@ license:CC0
 
 	<software name="lovehpty">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Party (Jpn)</description>
+		<description>Love Hina Party (Japan)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BLHJ-JPN"/>
@@ -11498,7 +11498,7 @@ license:CC0
 
 	<software name="lovehina">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Pocket (Jpn)</description>
+		<description>Love Hina Pocket (Japan)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
@@ -11518,7 +11518,7 @@ license:CC0
 	<software name="lovehinaa" cloneof="lovehina">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbphj1.290"	-->
-		<description>Love Hina Pocket (Jpn, Rev. 1)</description>
+		<description>Love Hina Pocket (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
@@ -11535,7 +11535,7 @@ license:CC0
 	</software>
 
 	<software name="lucapuzl">
-		<description>Luca no Puzzle de Daibouken! (Jpn)</description>
+		<description>Luca no Puzzle de Daibouken! (Japan)</description>
 		<year>1999</year>
 		<publisher>Human Entertainment</publisher>
 		<info name="serial" value="DMG-ARCJ-JPN"/>
@@ -11554,7 +11554,7 @@ license:CC0
 
 	<software name="luckyluk">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke (Euro)</description>
+		<description>Lucky Luke (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALQP-EUR"/>
@@ -11585,7 +11585,7 @@ license:CC0
 
 	<software name="luckyldt">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke - Desperado Train (Euro)</description>
+		<description>Lucky Luke - Desperado Train (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLLP-(FRA/NOE)"/>
@@ -11599,7 +11599,7 @@ license:CC0
 
 	<software name="lufia">
 		<!-- Notes: GBC only -->
-		<description>Lufia - The Legend Returns (Euro)</description>
+		<description>Lufia - The Legend Returns (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLFP-EUR"/>
@@ -11631,7 +11631,7 @@ license:CC0
 
 	<software name="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Euro)</description>
+		<description>M&amp;M's Minis Madness (Europe)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMIP-UKV"/>
@@ -11648,7 +11648,7 @@ license:CC0
 
 	<software name="mmsg" cloneof="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Ger)</description>
+		<description>M&amp;M's Minis Madness (Germany)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMID-NOE"/>
@@ -11691,7 +11691,7 @@ license:CC0
 
 	<software name="macross7">
 		<!-- Notes: GBC only -->
-		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Jpn)</description>
+		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BM7J-JPN"/>
@@ -11708,7 +11708,7 @@ license:CC0
 	</software>
 
 	<software name="madden2k">
-		<description>Madden NFL 2000 (Euro, USA)</description>
+		<description>Madden NFL 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AEME-USA, DMG-AEMP-EUR"/>
@@ -11770,7 +11770,7 @@ license:CC0
 
 	<software name="magchase">
 		<!-- Notes: GBC only -->
-		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Jpn)</description>
+		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="CGB-AIFJ-JPN"/>
@@ -11786,7 +11786,7 @@ license:CC0
 
 	<software name="magdrop">
 		<!-- Notes: GBC only -->
-		<description>Magical Drop (Euro)</description>
+		<description>Magical Drop (Europe)</description>
 		<year>2000</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AXJP-EUR"/>
@@ -11814,7 +11814,7 @@ license:CC0
 
 	<software name="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Euro, Rev. 1)</description>
+		<description>Magical Tetris Challenge (Europe, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
@@ -11830,7 +11830,7 @@ license:CC0
 
 	<software name="mtetrisca" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Euro)</description>
+		<description>Magical Tetris Challenge (Europe)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
@@ -11861,7 +11861,7 @@ license:CC0
 	</software>
 
 	<software name="mjjoo">
-		<description>Mahjong Joou (Jpn)</description>
+		<description>Mahjong Joou (Japan)</description>
 		<year>2000</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-A56J-JPN"/>
@@ -11879,7 +11879,7 @@ license:CC0
 	</software>
 
 	<software name="mjquest">
-		<description>Mahjong Quest (Jpn)</description>
+		<description>Mahjong Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AMJJ-JPN"/>
@@ -11897,7 +11897,7 @@ license:CC0
 	</software>
 
 	<software name="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. 1)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN-1"/>
@@ -11915,7 +11915,7 @@ license:CC0
 	</software>
 
 	<software name="majomaria" cloneof="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Japan)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN"/>
@@ -11934,7 +11934,7 @@ license:CC0
 
 	<software name="marble">
 		<!-- Notes: GBC only -->
-		<description>Marble Madness (Euro, USA)</description>
+		<description>Marble Madness (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ANNE-USA, CGB-ANNP-EUR"/>
@@ -11947,7 +11947,7 @@ license:CC0
 	</software>
 
 	<software name="atelmari">
-		<description>Marie no Atelier GB (Jpn)</description>
+		<description>Marie no Atelier GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8MJ-JPN"/>
@@ -11972,7 +11972,7 @@ license:CC0
 
 	<software name="mariofam">
 		<!-- Notes: GBC only, bundled with Jaguar Sewing Machine (Nuotto Expansion)? -->
-		<description>Mario Family (Jpn)</description>
+		<description>Mario Family (Japan)</description>
 		<year>2001</year>
 		<publisher>Jaguar</publisher>
 		<info name="serial" value="CGB-BJMJ-JPN"/>
@@ -11990,7 +11990,7 @@ license:CC0
 
 	<software name="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf (Euro)</description>
+		<description>Mario Golf (Europe)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXP-EUR"/>
@@ -12022,7 +12022,7 @@ license:CC0
 
 	<software name="marioglfj" cloneof="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf GB (Jpn)</description>
+		<description>Mario Golf GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXJ-JPN"/>
@@ -12046,7 +12046,7 @@ license:CC0
 
 	<software name="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis (Euro)</description>
+		<description>Mario Tennis (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8P-EUR"/>
@@ -12084,7 +12084,7 @@ license:CC0
 
 	<software name="mariotenj" cloneof="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis GB (Jpn)</description>
+		<description>Mario Tennis GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8J-JPN"/>
@@ -12118,7 +12118,7 @@ license:CC0
 
 	<software name="mnacrush">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Crush Course (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Crush Course (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BCVE-USA, CGB-BCVP-UKV"/>
@@ -12134,7 +12134,7 @@ license:CC0
 	</software>
 
 	<software name="mnaclue">
-		<description>Mary-Kate &amp; Ashley - Get a Clue! (Euro, USA)</description>
+		<description>Mary-Kate &amp; Ashley - Get a Clue! (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BXFE-USA, DMG-BXFP-EUR"/>
@@ -12150,7 +12150,7 @@ license:CC0
 	</software>
 
 	<software name="mnaplann">
-		<description>Mary-Kate and Ashley - Pocket Planner (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Pocket Planner (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BMAE-USA, DMG-BMAP-EUR"/>
@@ -12173,7 +12173,7 @@ license:CC0
 
 	<software name="mnacircl">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Winners Circle (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Winners Circle (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BHFE-USA, CGB-BHFP-EUR"/>
@@ -12190,7 +12190,7 @@ license:CC0
 
 	<software name="zorro">
 		<!-- Notes: GBC only -->
-		<description>The Mask of Zorro (Euro)</description>
+		<description>The Mask of Zorro (Europe)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AZRP-EUR"/>
@@ -12218,7 +12218,7 @@ license:CC0
 
 	<software name="hoffbmx">
 		<!-- Notes: GBC only -->
-		<description>Mat Hoffman's Pro BMX (Euro, USA)</description>
+		<description>Mat Hoffman's Pro BMX (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-BM5P-EUR"/>
@@ -12232,7 +12232,7 @@ license:CC0
 
 	<software name="matchbox">
 		<!-- Notes: GBC only -->
-		<description>Matchbox Emergency Patrol (Euro, USA)</description>
+		<description>Matchbox Emergency Patrol (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BEPE-USA, CGB-BEPP-EUR"/>
@@ -12249,7 +12249,7 @@ license:CC0
 
 	<software name="maus">
 		<!-- Notes: GBC only -->
-		<description>Die Maus (Euro)</description>
+		<description>Die Maus (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ADXP-NOE"/>
@@ -12263,7 +12263,7 @@ license:CC0
 
 	<software name="mausvo">
 		<!-- Notes: GBC only -->
-		<description>Die Maus - Verrückte Olympiade (Ger)</description>
+		<description>Die Maus - Verrückte Olympiade (Germany)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVOD-NOE"/>
@@ -12279,7 +12279,7 @@ license:CC0
 	</software>
 
 	<software name="mayabeef">
-		<description>Maya the Bee &amp; Her Friends (Euro)</description>
+		<description>Maya the Bee &amp; Her Friends (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -12293,7 +12293,7 @@ license:CC0
 
 	<software name="mayabee">
 		<!-- Notes: GBC only -->
-		<description>Maya the Bee - Garden Adventures (Euro)</description>
+		<description>Maya the Bee - Garden Adventures (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMJP-EUR"/>
@@ -12307,7 +12307,7 @@ license:CC0
 
 	<software name="mcdonald">
 		<!-- Notes: GBC only -->
-		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Jpn)</description>
+		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Japan)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-BI9J-JPN"/>
@@ -12324,7 +12324,7 @@ license:CC0
 	</software>
 
 	<software name="medar2ka">
-		<description>Medarot 2 - Kabuto Version (Jpn)</description>
+		<description>Medarot 2 - Kabuto Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2MJ-JPN"/>
@@ -12347,7 +12347,7 @@ license:CC0
 	</software>
 
 	<software name="medar2ku">
-		<description>Medarot 2 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 2 - Kuwagata Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2NJ-JPN"/>
@@ -12370,7 +12370,7 @@ license:CC0
 	</software>
 
 	<software name="medar2cl">
-		<description>Medarot 2 - Parts Collection (Jpn)</description>
+		<description>Medarot 2 - Parts Collection (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A7CJ-JPN"/>
@@ -12395,7 +12395,7 @@ license:CC0
 
 	<software name="medar3ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kabuto Version (Jpn)</description>
+		<description>Medarot 3 - Kabuto Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B32J-JPN"/>
@@ -12413,7 +12413,7 @@ license:CC0
 
 	<software name="medar3ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 3 - Kuwagata Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B33J-JPN"/>
@@ -12431,7 +12431,7 @@ license:CC0
 
 	<software name="medar3cl">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Jpn)</description>
+		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B3PJ-JPN"/>
@@ -12449,7 +12449,7 @@ license:CC0
 
 	<software name="medar4ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kabuto Version (Jpn)</description>
+		<description>Medarot 4 - Kabuto Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4MJ-JPN"/>
@@ -12467,7 +12467,7 @@ license:CC0
 
 	<software name="medar4ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 4 - Kuwagata Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4NJ-JPN"/>
@@ -12485,7 +12485,7 @@ license:CC0
 
 	<software name="medar5ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Jpn)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5MJ-JPN"/>
@@ -12503,7 +12503,7 @@ license:CC0
 
 	<software name="medar5ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Jpn)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5NJ-JPN"/>
@@ -12520,7 +12520,7 @@ license:CC0
 	</software>
 
 	<software name="medarcka">
-		<description>Medarot Cardrobottle - Kabuto Version (Jpn)</description>
+		<description>Medarot Cardrobottle - Kabuto Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8CJ-JPN"/>
@@ -12538,7 +12538,7 @@ license:CC0
 	</software>
 
 	<software name="medarcku">
-		<description>Medarot Cardrobottle - Kuwagata Version (Jpn)</description>
+		<description>Medarot Cardrobottle - Kuwagata Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A9CJ-JPN"/>
@@ -12556,7 +12556,7 @@ license:CC0
 	</software>
 
 	<software name="megamnx">
-		<description>Mega Man Xtreme (Euro, USA)</description>
+		<description>Mega Man Xtreme (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BM6E-USA, DMG-BM6P-EUR?"/>
@@ -12572,7 +12572,7 @@ license:CC0
 
 	<software name="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Mega Man Xtreme 2 (Euro, USA)</description>
+		<description>Mega Man Xtreme 2 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-B2XP-EUR"/>
@@ -12594,7 +12594,7 @@ license:CC0
 
 	<software name="lastbibl" cloneof="revelat">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible (Jpn)</description>
+		<description>Megami Tensei Gaiden - Last Bible (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-ALBJ-JPN"/>
@@ -12613,7 +12613,7 @@ license:CC0
 
 	<software name="lastbib2">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible II (Jpn)</description>
+		<description>Megami Tensei Gaiden - Last Bible II (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-A2LJ-JPN"/>
@@ -12631,7 +12631,7 @@ license:CC0
 	</software>
 
 	<software name="mconankj">
-		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Jpn)</description>
+		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A4BJ-JPN"/>
@@ -12655,7 +12655,7 @@ license:CC0
 	</software>
 
 	<software name="mconankh">
-		<description>Meitantei Conan - Kigantou Hihou Densetsu (Jpn)</description>
+		<description>Meitantei Conan - Kigantou Hihou Densetsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A5BJ-JPN"/>
@@ -12679,7 +12679,7 @@ license:CC0
 	</software>
 
 	<software name="mconannk">
-		<description>Meitantei Conan - Norowareta Kouro (Jpn)</description>
+		<description>Meitantei Conan - Norowareta Kouro (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BC3J-JPN"/>
@@ -12697,7 +12697,7 @@ license:CC0
 	</software>
 
 	<software name="mib">
-		<description>Men in Black - The Series (Euro, USA)</description>
+		<description>Men in Black - The Series (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AMNE-USA, DMG-AMNP-EUR"/>
@@ -12714,7 +12714,7 @@ license:CC0
 
 	<software name="mib2">
 		<!-- Notes: GBC only -->
-		<description>Men in Black 2 - The Series (Euro)</description>
+		<description>Men in Black 2 - The Series (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BB2P-EUR"/>
@@ -12743,7 +12743,7 @@ license:CC0
 	<software name="merlin">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "CGBBMBP0.603", "KENSA\CGBBMBE0.0"	-->
-		<description>Merlin (Euro)</description>
+		<description>Merlin (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BMBP-EUR"/>
@@ -12757,7 +12757,7 @@ license:CC0
 
 	<software name="metafght">
 		<!-- Notes: GBC only -->
-		<description>Meta Fight EX (Jpn)</description>
+		<description>Meta Fight EX (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A5MJ-JPN"/>
@@ -12773,7 +12773,7 @@ license:CC0
 
 	<software name="mgsj" cloneof="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear - Ghost Babel (Jpn)</description>
+		<description>Metal Gear - Ghost Babel (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMGJ-JPN (RK202-J1)"/>
@@ -12791,7 +12791,7 @@ license:CC0
 
 	<software name="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear Solid (Euro)</description>
+		<description>Metal Gear Solid (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMSP-EUR"/>
@@ -12844,7 +12844,7 @@ license:CC0
 
 	<software name="metamode">
 		<!-- Notes: GBC only -->
-		<description>Metamode (Jpn)</description>
+		<description>Metamode (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BTMJ-JPN"/>
@@ -12884,7 +12884,7 @@ license:CC0
 
 	<software name="mickeyra">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Racing Adventure (Euro, USA)</description>
+		<description>Mickey's Racing Adventure (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-ARNE-USA, CGB-ARNP-EUR"/>
@@ -12900,7 +12900,7 @@ license:CC0
 
 	<software name="micksped">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Speedway USA (Euro, USA)</description>
+		<description>Mickey's Speedway USA (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BSNE-USA, CGB-BSNP-EUR"/>
@@ -12922,7 +12922,7 @@ license:CC0
 
 	<software name="microm12">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines 1 and 2 - Twin Turbo (Euro, USA)</description>
+		<description>Micro Machines 1 and 2 - Twin Turbo (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-AT8E-USA, CGB-AT8P-EUR"/>
@@ -12939,7 +12939,7 @@ license:CC0
 
 	<software name="micromc3">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines V3 (Euro, USA)</description>
+		<description>Micro Machines V3 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BM3E-USA, CGB-BM3P-EUR"/>
@@ -12956,7 +12956,7 @@ license:CC0
 
 	<software name="microman">
 		<!-- Notes: GBC only -->
-		<description>Micro Maniacs (Euro)</description>
+		<description>Micro Maniacs (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B3NP-EUR"/>
@@ -12970,7 +12970,7 @@ license:CC0
 
 	<software name="msep">
 		<!-- Notes: GBC only -->
-		<description>Microsoft - The Best of Entertainment Pack (Euro)</description>
+		<description>Microsoft - The Best of Entertainment Pack (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BMZP-EUR"/>
@@ -12998,7 +12998,7 @@ license:CC0
 
 	<software name="mspinb">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Pinball Arcade (Euro)</description>
+		<description>Microsoft Pinball Arcade (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo Interactive</publisher>
 		<info name="serial" value="CGB-BMQP-EUR"/>
@@ -13032,7 +13032,7 @@ license:CC0
 
 	<software name="mspuzzle">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Puzzle Collection (Euro)</description>
+		<description>Microsoft Puzzle Collection (Europe)</description>
 		<year>2000</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="alt_title" value="Microsoft - The 6 in 1 Puzzle Collection Entertainment Pack (Box)"/>
@@ -13080,7 +13080,7 @@ license:CC0
 	</software>
 
 	<software name="minnashg">
-		<description>Minna no Shougi - Shokyuu Hen (Jpn)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
@@ -13099,7 +13099,7 @@ license:CC0
 
 	<software name="minnashga" cloneof="minnashg">
 		<!--	In lot check as "dmga7yj1.i18"	-->
-		<description>Minna no Shougi - Shokyuu Hen (Jpn, Rev. 1)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
@@ -13118,7 +13118,7 @@ license:CC0
 
 	<software name="minnie">
 		<!-- Notes: GBC only -->
-		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Jpn)</description>
+		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BYKJ-JPN"/>
@@ -13142,7 +13142,7 @@ license:CC0
 
 	<software name="missile">
 		<!-- Notes: GBC only -->
-		<description>Missile Command (Euro)</description>
+		<description>Missile Command (Europe)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ALCP-EUR"/>
@@ -13178,7 +13178,7 @@ license:CC0
 
 	<software name="missimp">
 		<!-- Notes: GBC only -->
-		<description>Mission Impossible (Euro)</description>
+		<description>Mission Impossible (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-(NOE/UKV/FAH)"/>
@@ -13197,7 +13197,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaimp1.076"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Mission Impossible (Euro, Rev. 1)</description>
+		<description>Mission Impossible (Europe, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-?"/>
@@ -13231,7 +13231,7 @@ license:CC0
 
 	<software name="mizuki">
 		<!-- Notes: GBC only -->
-		<description>Mizuki Shigeru no Shin Youkaiden (Jpn)</description>
+		<description>Mizuki Shigeru no Shin Youkaiden (Japan)</description>
 		<year>2000</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BYPJ-JPN"/>
@@ -13258,7 +13258,7 @@ license:CC0
 		            * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		        Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		        manufactured by Mitsumi. -->
-		<description>Mobile Golf (Jpn)</description>
+		<description>Mobile Golf (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BGOJ-JPN"/>
@@ -13292,7 +13292,7 @@ license:CC0
 		        * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		    Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		    manufactured by Mitsumi. -->
-		<description>Mobile Trainer (Jpn)</description>
+		<description>Mobile Trainer (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B9AJ-JPN"/>
@@ -13315,7 +13315,7 @@ license:CC0
 
 	<software name="momo">
 		<!-- Notes: GBC only -->
-		<description>Momotarou Densetsu 1-2 (Jpn)</description>
+		<description>Momotarou Densetsu 1-2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BI2J-JPN"/>
@@ -13333,7 +13333,7 @@ license:CC0
 
 	<software name="monkeyp">
 		<!-- Notes: GBC only -->
-		<description>Monkey Puncher (Euro)</description>
+		<description>Monkey Puncher (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-BSPP-EUR"/>
@@ -13348,7 +13348,7 @@ license:CC0
 	</software>
 
 	<software name="monopolyj" cloneof="monopoly">
-		<description>Monopoly (Jpn)</description>
+		<description>Monopoly (Japan)</description>
 		<year>1998</year>
 		<publisher>Hasbro</publisher>
 		<info name="serial" value="DMG-AHAJ-JPN"/>
@@ -13377,7 +13377,7 @@ license:CC0
 	</software>
 
 	<software name="mfarmbc" cloneof="mranchbc">
-		<description>Monster Farm Battle Card GB (Jpn)</description>
+		<description>Monster Farm Battle Card GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TJ-JPN"/>
@@ -13395,7 +13395,7 @@ license:CC0
 	</software>
 
 	<software name="monstrc2">
-		<description>Monster Race 2 (Jpn)</description>
+		<description>Monster Race 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AMWJ-JPN"/>
@@ -13446,7 +13446,7 @@ license:CC0
 
 	<software name="monstrvla">
 		<!-- Notes: GBC only -->
-		<description>Monster Traveler (Jpn, Rev. 1)</description>
+		<description>Monster Traveler (Japan, Rev. 1)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
@@ -13467,7 +13467,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbfvj0.949"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Monster Traveler (Jpn)</description>
+		<description>Monster Traveler (Japan)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
@@ -13485,7 +13485,7 @@ license:CC0
 
 	<software name="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, Rev. 1)</description>
+		<description>Monsters, Inc. (Europe, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QP-UKV"/>
@@ -13502,7 +13502,7 @@ license:CC0
 
 	<software name="monstincu" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, USA)</description>
+		<description>Monsters, Inc. (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QE-USA, CGB-B4QP-UKV"/>
@@ -13519,7 +13519,7 @@ license:CC0
 
 	<software name="monstinca" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, English / Spanish / Dutch)</description>
+		<description>Monsters, Inc. (Europe, English / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QX-EUR"/>
@@ -13536,7 +13536,7 @@ license:CC0
 
 	<software name="monstincb" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, English / French / Italian)</description>
+		<description>Monsters, Inc. (Europe, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QY-EUU"/>
@@ -13553,7 +13553,7 @@ license:CC0
 
 	<software name="monstincg" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Die Monster AG (Ger)</description>
+		<description>Die Monster AG (Germany)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QD-NOE"/>
@@ -13566,7 +13566,7 @@ license:CC0
 	</software>
 
 	<software name="montezum">
-		<description>Montezuma's Return! (Euro)</description>
+		<description>Montezuma's Return! (Europe)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AZMP-EUR"/>
@@ -13593,7 +13593,7 @@ license:CC0
 
 	<software name="moominj" cloneof="moomin">
 		<!-- Notes: GBC only -->
-		<description>Moomin no Daibouken (Jpn)</description>
+		<description>Moomin no Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A36J-JPN"/>
@@ -13612,7 +13612,7 @@ license:CC0
 	<software name="moomin">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "CGBAM9P0.471", "KENSA\CGBAM9E0.0"	-->
-		<description>Moomin's Tale (Euro)</description>
+		<description>Moomin's Tale (Europe)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AM9P-EUR"/>
@@ -13626,7 +13626,7 @@ license:CC0
 
 	<software name="moorhun2">
 		<!-- Notes: GBC only -->
-		<description>Moorhuhn 2 - Die Jagd geht weiter (Ger)</description>
+		<description>Moorhuhn 2 - Die Jagd geht weiter (Germany)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BDED-NOE"/>
@@ -13648,7 +13648,7 @@ license:CC0
 
 	<software name="moorhen3">
 		<!-- Notes: GBC only -->
-		<description>Moorhen 3 - The Chicken Chase! (Euro)</description>
+		<description>Moorhen 3 - The Chicken Chase! (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Moorhuhn 3: ...Es Gibt Huhn! (Box)"/>
@@ -13670,7 +13670,7 @@ license:CC0
 	</software>
 
 	<software name="mk4">
-		<description>Mortal Kombat 4 (Euro, USA)</description>
+		<description>Mortal Kombat 4 (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KE-USA, DMG-A4KP-EUR"/>
@@ -13683,7 +13683,7 @@ license:CC0
 	</software>
 
 	<software name="mk4g" cloneof="mk4">
-		<description>Mortal Kombat 4 (Ger)</description>
+		<description>Mortal Kombat 4 (Germany)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KD-NOE"/>
@@ -13716,7 +13716,7 @@ license:CC0
 
 	<software name="mrnutz">
 		<!-- Notes: GBC only -->
-		<description>Mr Nutz (Euro)</description>
+		<description>Mr Nutz (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ANUP-(EUR/FAH/NOE)"/>
@@ -13747,7 +13747,7 @@ license:CC0
 
 	<software name="mrdrillr">
 		<!-- Notes: GBC only -->
-		<description>Mr. Driller (Euro)</description>
+		<description>Mr. Driller (Europe)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDP-EUR"/>
@@ -13764,7 +13764,7 @@ license:CC0
 
 	<software name="mrdrillrja" cloneof="mrdrillr">
 		<!-- Notes: GBC only -->
-		<description>Mr. Driller (Jpn)</description>
+		<description>Mr. Driller (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDJ-JPN"/>
@@ -13784,7 +13784,7 @@ license:CC0
 	<software name="mrdrillrjnp" cloneof="mrdrillr">
 		<!-- Notes: GBC only, NP only -->
 		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
-		<description>Mr. Driller (Jpn, NP)</description>
+		<description>Mr. Driller (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BV3J-JPN"/>
@@ -13830,7 +13830,7 @@ license:CC0
 
 	<software name="mspacman">
 		<!-- Notes: GBC only -->
-		<description>Ms. Pac-Man - Special Colour Edition (Euro)</description>
+		<description>Ms. Pac-Man - Special Colour Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AQCP-EUR"/>
@@ -13844,7 +13844,7 @@ license:CC0
 
 	<software name="mtvride">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Pure Ride (Euro, USA)</description>
+		<description>MTV Sports - Pure Ride (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BPVE-USA, CGB-BPVP-EUR"/>
@@ -13861,7 +13861,7 @@ license:CC0
 
 	<software name="mtvskate">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Euro, USA)</description>
+		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BMTE-USA, CGB-BMTP-EUR"/>
@@ -13878,7 +13878,7 @@ license:CC0
 
 	<software name="mtvbmx">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Euro, USA)</description>
+		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTVE-USA, CGB-BTVP-EUR"/>
@@ -13895,7 +13895,7 @@ license:CC0
 
 	<software name="mummyr">
 		<!-- Notes: GBC only -->
-		<description>The Mummy Returns (Euro)</description>
+		<description>The Mummy Returns (Europe)</description>
 		<year>2001</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-B2RP-EUR"/>
@@ -13926,7 +13926,7 @@ license:CC0
 
 	<software name="mummy">
 		<!-- Notes: GBC only -->
-		<description>The Mummy (Euro)</description>
+		<description>The Mummy (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMYP-EUR"/>
@@ -13954,7 +13954,7 @@ license:CC0
 
 	<software name="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Euro, Black Cart)</description>
+		<description>The Muppets (Europe, Black Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="alt_title" value="Jim Henson's Puppets (Cart)"/>
@@ -13977,7 +13977,7 @@ license:CC0
 
 	<software name="muppetsa" cloneof="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Euro, Transparent Cart)</description>
+		<description>The Muppets (Europe, Transparent Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AX9P-EUR"/>
@@ -14015,7 +14015,7 @@ license:CC0
 
 	<software name="trizenon">
 		<!-- Notes: GBC only -->
-		<description>Muteki Ou Tri-Zenon (Jpn)</description>
+		<description>Muteki Ou Tri-Zenon (Japan)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BZNJ-JPN"/>
@@ -14033,7 +14033,7 @@ license:CC0
 
 	<software name="nyrace">
 		<!-- Notes: GBC only -->
-		<description>N.Y. Race (Euro)</description>
+		<description>N.Y. Race (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BNXP-EUR"/>
@@ -14047,7 +14047,7 @@ license:CC0
 
 	<software name="ncook1">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Jpn)</description>
+		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7CJ-JPN"/>
@@ -14065,7 +14065,7 @@ license:CC0
 
 	<software name="ncook2">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Jpn)</description>
+		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7PJ-JPN"/>
@@ -14083,7 +14083,7 @@ license:CC0
 
 	<software name="ncook3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Jpn)</description>
+		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7BJ-JPN"/>
@@ -14101,7 +14101,7 @@ license:CC0
 
 	<software name="ncook4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Jpn)</description>
+		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3DJ-JPN"/>
@@ -14125,7 +14125,7 @@ license:CC0
 
 	<software name="ncook5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Jpn)</description>
+		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3CJ-JPN"/>
@@ -14150,7 +14150,7 @@ license:CC0
 
 
 	<software name="nakapet1">
-		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Jpn)</description>
+		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7HJ-JPN"/>
@@ -14167,7 +14167,7 @@ license:CC0
 	</software>
 
 	<software name="nakapet2">
-		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Jpn)</description>
+		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7UJ-JPN"/>
@@ -14185,7 +14185,7 @@ license:CC0
 
 	<software name="nakapet3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Jpn)</description>
+		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7IJ-JPN"/>
@@ -14203,7 +14203,7 @@ license:CC0
 
 	<software name="nakapet4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Jpn)</description>
+		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7NJ-JPN"/>
@@ -14221,7 +14221,7 @@ license:CC0
 
 	<software name="nakapet5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Jpn)</description>
+		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B2HJ-JPN"/>
@@ -14239,7 +14239,7 @@ license:CC0
 
 	<software name="naminori" cloneof="ultsurf">
 		<!-- Notes: GBC only, NP only -->
-		<description>Naminori Yarou! (Jpn, NP)</description>
+		<description>Naminori Yarou! (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BNYJ-JPN"/>
@@ -14257,7 +14257,7 @@ license:CC0
 
 	<software name="nascar2k">
 		<!-- Notes: GBC only -->
-		<description>NASCAR 2000 (Euro, USA)</description>
+		<description>NASCAR 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BN2E-USA, CGB-BN2P-EUR"/>
@@ -14322,7 +14322,7 @@ license:CC0
 
 	<software name="nations">
 		<!-- Notes: GBC only -->
-		<description>The Nations - Land of Legends (Euro)</description>
+		<description>The Nations - Land of Legends (Europe)</description>
 		<year>2002</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-BNLP-EUR"/>
@@ -14400,7 +14400,7 @@ license:CC0
 
 	<software name="nbazon2k">
 		<!-- Notes: GBC only -->
-		<description>NBA In the Zone 2000 (Euro)</description>
+		<description>NBA In the Zone 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AJ7P-EUR"/>
@@ -14432,7 +14432,7 @@ license:CC0
 	</software>
 
 	<software name="nbajam99">
-		<description>NBA Jam '99 (Euro, USA)</description>
+		<description>NBA Jam '99 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AJME-USA, DMG-AJMP-EUR"/>
@@ -14449,7 +14449,7 @@ license:CC0
 
 	<software name="nbajm2k1">
 		<!-- Notes: GBC only -->
-		<description>NBA Jam 2001 (Euro, USA)</description>
+		<description>NBA Jam 2001 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BJAE-USA, CGB-BJAP-EUR"/>
@@ -14465,7 +14465,7 @@ license:CC0
 	</software>
 
 	<software name="nbapro99">
-		<description>NBA Pro '99 (Euro)</description>
+		<description>NBA Pro '99 (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZP-EUR"/>
@@ -14497,7 +14497,7 @@ license:CC0
 
 	<software name="netdeget">
 		<!-- Notes: GBC only -->
-		<description>Net de Get - Minigame @ 100 (Jpn)</description>
+		<description>Net de Get - Minigame @ 100 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMVJ-JPN (RK215-J1)"/>
@@ -14523,7 +14523,7 @@ license:CC0
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Alpha Version (Jpn)</description>
+		<description>Network Boukenki Bugsite - Alpha Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BAUJ-JPN"/>
@@ -14543,7 +14543,7 @@ license:CC0
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Beta Version (Jpn)</description>
+		<description>Network Boukenki Bugsite - Beta Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BBUJ-JPN"/>
@@ -14567,7 +14567,7 @@ license:CC0
 
 	<software name="newaddfm">
 		<!-- Notes: GBC only -->
-		<description>The New Addams Family Series (Euro)</description>
+		<description>The New Addams Family Series (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BAIP-EUR"/>
@@ -14583,7 +14583,7 @@ license:CC0
 	</software>
 
 	<software name="newmna">
-		<description>The New Adventures of Mary-Kate &amp; Ashley (Euro, USA)</description>
+		<description>The New Adventures of Mary-Kate &amp; Ashley (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AXFE-USA, DMG-AXFP-EUR"/>
@@ -14600,7 +14600,7 @@ license:CC0
 
 	<software name="newbatmn">
 		<!-- Notes: GBC only -->
-		<description>The New Batman Adventures - Chaos in Gotham (Euro)</description>
+		<description>The New Batman Adventures - Chaos in Gotham (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBBP-EUR"/>
@@ -14627,7 +14627,7 @@ license:CC0
 	</software>
 
 	<software name="blitz">
-		<description>NFL Blitz (Euro, USA, Rev. 1)</description>
+		<description>NFL Blitz (Europe, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ABZE-USA, DMG-ABZP-EUU"/>
@@ -14684,7 +14684,7 @@ license:CC0
 	</software>
 
 	<software name="nhl2k">
-		<description>NHL 2000 (Euro, USA)</description>
+		<description>NHL 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ANRE-USA, DMG-ANRP-EUR"/>
@@ -14744,7 +14744,7 @@ license:CC0
 
 	<software name="nintama">
 		<!-- Notes: GBC only -->
-		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Jpn)</description>
+		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Japan)</description>
 		<year>2001</year>
 		<publisher>ASK</publisher>
 		<info name="serial" value="CGB-BNAJ-JPN"/>
@@ -14762,7 +14762,7 @@ license:CC0
 
 	<software name="nisemon">
 		<!-- Notes: GBC only -->
-		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Jpn)</description>
+		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Japan)</description>
 		<year>2001</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BNPJ-JPN"/>
@@ -14780,7 +14780,7 @@ license:CC0
 
 	<software name="nofear">
 		<!-- Notes: GBC only -->
-		<description>No Fear - Downhill Mountain Biking (Euro)</description>
+		<description>No Fear - Downhill Mountain Biking (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BKFP-EUR"/>
@@ -14793,7 +14793,7 @@ license:CC0
 	</software>
 
 	<software name="nobugb2">
-		<description>Nobunaga no Yabou - Game Boy Ban 2 (Jpn)</description>
+		<description>Nobunaga no Yabou - Game Boy Ban 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AGYJ-JPN"/>
@@ -14811,7 +14811,7 @@ license:CC0
 
 	<software name="noddy">
 		<!-- Notes: GBC only -->
-		<description>Noddy and the Birthday Party (Euro)</description>
+		<description>Noddy and the Birthday Party (Europe)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-AZEP-UKV"/>
@@ -14841,7 +14841,7 @@ license:CC0
 
 	<software name="nushiadv">
 		<!-- Notes: GBC only -->
-		<description>Nushi Tsuri Adventure - Kite no Bouken (Jpn)</description>
+		<description>Nushi Tsuri Adventure - Kite no Bouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-VVJJ-JPN"/>
@@ -14867,7 +14867,7 @@ license:CC0
 
 	<software name="oleary">
 		<!-- Notes: GBC only -->
-		<description>O'Leary Manager 2000 (Euro)</description>
+		<description>O'Leary Manager 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -14882,7 +14882,7 @@ license:CC0
 	</software>
 
 	<software name="oddworld">
-		<description>Oddworld Adventures II (Euro)</description>
+		<description>Oddworld Adventures II (Europe)</description>
 		<year>2000</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="DMG-AOWP-EUR"/>
@@ -14909,7 +14909,7 @@ license:CC0
 
 	<software name="ohasuddr">
 		<!-- Notes: GBC only -->
-		<description>Ohasuta Dance Dance Revolution GB (Jpn)</description>
+		<description>Ohasuta Dance Dance Revolution GB (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD5J-JPN (RK231-J1)"/>
@@ -14926,7 +14926,7 @@ license:CC0
 	</software>
 
 	<software name="ohasuynr">
-		<description>Ohasuta Yama-chan &amp; Raymond (Jpn)</description>
+		<description>Ohasuta Yama-chan &amp; Raymond (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOSJ-JPN"/>
@@ -14945,7 +14945,7 @@ license:CC0
 
 	<software name="oiderasc">
 		<!-- Notes: GBC only -->
-		<description>Oide Rascal (Jpn)</description>
+		<description>Oide Rascal (Japan)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BLSJ-JPN"/>
@@ -14962,7 +14962,7 @@ license:CC0
 	</software>
 
 	<software name="ojarumam">
-		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Jpn)</description>
+		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BOJJ-JPN"/>
@@ -14979,7 +14979,7 @@ license:CC0
 	</software>
 
 	<software name="ojarumat">
-		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Jpn)</description>
+		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Japan)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-BORJ-JPN"/>
@@ -14997,7 +14997,7 @@ license:CC0
 
 	<software name="moorhun">
 		<!-- Notes: GBC only -->
-		<description>Die Original Moorhuhn Jagd (Ger)</description>
+		<description>Die Original Moorhuhn Jagd (Germany)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BOMD-NOE"/>
@@ -15013,7 +15013,7 @@ license:CC0
 	</software>
 
 	<software name="othellom">
-		<description>Othello Millennium (Jpn)</description>
+		<description>Othello Millennium (Japan)</description>
 		<year>1999</year>
 		<publisher>Tsukuda Original</publisher>
 		<info name="serial" value="DMG-AO7J-JPN"/>
@@ -15031,7 +15031,7 @@ license:CC0
 
 	<software name="azuredj" cloneof="azured">
 		<!-- Also released by NP in 2000-08 -->
-		<description>Other Life - Azure Dreams GB (Jpn)</description>
+		<description>Other Life - Azure Dreams GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAZJ-JPN (RK179-J1)"/>
@@ -15050,7 +15050,7 @@ license:CC0
 
 	<software name="ottifant">
 		<!-- Notes: GBC only -->
-		<description>Ottifanten - Kommando Störtebeker (Ger)</description>
+		<description>Ottifanten - Kommando Störtebeker (Germany)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -15063,7 +15063,7 @@ license:CC0
 	</software>
 
 	<software name="oudoroan">
-		<description>Ou Dorobou Jing - Angel Version (Jpn)</description>
+		<description>Ou Dorobou Jing - Angel Version (Japan)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZWJ-JPN"/>
@@ -15081,7 +15081,7 @@ license:CC0
 	</software>
 
 	<software name="oudorodv">
-		<description>Ou Dorobou Jing - Devil Version (Jpn)</description>
+		<description>Ou Dorobou Jing - Devil Version (Japan)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZKJ-JPN"/>
@@ -15099,7 +15099,7 @@ license:CC0
 	</software>
 
 	<software name="owarai">
-		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Jpn)</description>
+		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYIJ-JPN (RK194-J1)"/>
@@ -15130,7 +15130,7 @@ license:CC0
 	</software>
 
 	<software name="pacmansp">
-		<description>Pac-Man - Special Colour Edition (Euro)</description>
+		<description>Pac-Man - Special Colour Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AACP-EUR"/>
@@ -15143,7 +15143,7 @@ license:CC0
 	</software>
 
 	<software name="pachicrt">
-		<description>Pachinko CR Mouretsu Genshijin T (Jpn)</description>
+		<description>Pachinko CR Mouretsu Genshijin T (Japan)</description>
 		<year>1999</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-AXAJ-JPN"/>
@@ -15158,7 +15158,7 @@ license:CC0
 	</software>
 
 	<software name="pachihis">
-		<description>Pachinko Hisshou Guide - Data no Ousama (Jpn)</description>
+		<description>Pachinko Hisshou Guide - Data no Ousama (Japan)</description>
 		<year>1999</year>
 		<publisher>BOSS Communications</publisher>
 		<info name="serial" value="DMG-AYEJ-JPN"/>
@@ -15176,7 +15176,7 @@ license:CC0
 
 	<software name="pachislt">
 		<!-- Also released by NP in 2000-06 -->
-		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Jpn)</description>
+		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ANPJ-JPN"/>
@@ -15195,7 +15195,7 @@ license:CC0
 
 	<software name="paperboy">
 		<!-- Notes: GBC only -->
-		<description>Paperboy (Euro, USA)</description>
+		<description>Paperboy (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AYPE-USA, CGB-AYPP-EUR"/>
@@ -15209,7 +15209,7 @@ license:CC0
 
 	<software name="papyrus">
 		<!-- Notes: GBC only -->
-		<description>Papyrus (Euro)</description>
+		<description>Papyrus (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AY9P-EUR"/>
@@ -15223,7 +15223,7 @@ license:CC0
 
 	<software name="pchoroq">
 		<!-- Notes: GBC only -->
-		<description>Perfect Choro Q (Jpn)</description>
+		<description>Perfect Choro Q (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BPQJ-JPN"/>
@@ -15241,7 +15241,7 @@ license:CC0
 
 	<software name="pdark">
 		<!-- Notes: GBC only -->
-		<description>Perfect Dark (Euro, USA)</description>
+		<description>Perfect Dark (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VPDE-USA, CGB-VPDP-EUR"/>
@@ -15264,7 +15264,7 @@ license:CC0
 	</software>
 
 	<software name="phantomz">
-		<description>Phantom Zona - Kaijin Zona (Jpn)</description>
+		<description>Phantom Zona - Kaijin Zona (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BKZJ-JPN"/>
@@ -15289,7 +15289,7 @@ license:CC0
 
 	<software name="picarro2">
 		<!-- Notes: GBC only -->
-		<description>Pia Carrot e Youkoso!! 2.2 (Jpn)</description>
+		<description>Pia Carrot e Youkoso!! 2.2 (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="CGB-B22J-JPN"/>
@@ -15306,7 +15306,7 @@ license:CC0
 	</software>
 
 	<software name="pitfall">
-		<description>Pitfall - Beyond the Jungle (Euro, USA)</description>
+		<description>Pitfall - Beyond the Jungle (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AFLE-USA, DMG-AFLP-EUR"/>
@@ -15322,7 +15322,7 @@ license:CC0
 	</software>
 
 	<software name="pitfallj" cloneof="pitfall">
-		<description>Pitfall GB (Jpn)</description>
+		<description>Pitfall GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AFLJ-JPN (PCPE-10003)"/>
@@ -15338,7 +15338,7 @@ license:CC0
 
 	<software name="planapes">
 		<!-- Notes: GBC only -->
-		<description>Planet of the Apes (Euro)</description>
+		<description>Planet of the Apes (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BYNP-EUR"/>
@@ -15369,7 +15369,7 @@ license:CC0
 
 	<software name="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Player Manager 2001 (Euro)</description>
+		<description>Player Manager 2001 (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBP-EUR"/>
@@ -15384,7 +15384,7 @@ license:CC0
 	</software>
 
 	<software name="pockbill">
-		<description>Pocket Billiards - Funk the 9 Ball (Jpn)</description>
+		<description>Pocket Billiards - Funk the 9 Ball (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-A9BJ-JPN"/>
@@ -15401,7 +15401,7 @@ license:CC0
 	</software>
 
 	<software name="pockbman">
-		<description>Pocket Bomberman (Euro, USA)</description>
+		<description>Pocket Bomberman (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AKQE-USA, DMG-AKQP-EUR"/>
@@ -15417,7 +15417,7 @@ license:CC0
 	</software>
 
 	<software name="pockbwlj" cloneof="pockbwl">
-		<description>Pocket Bowling (Jpn)</description>
+		<description>Pocket Bowling (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AVBJ-JPN"/>
@@ -15448,7 +15448,7 @@ license:CC0
 	</software>
 
 	<software name="pockcbil">
-		<description>Pocket Color Billiards (Jpn)</description>
+		<description>Pocket Color Billiards (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A3AJ-JPN"/>
@@ -15463,7 +15463,7 @@ license:CC0
 	</software>
 
 	<software name="pockcblk" cloneof="ddance">
-		<description>Pocket Color Block (Jpn)</description>
+		<description>Pocket Color Block (Japan)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-AC6J-JPN"/>
@@ -15479,7 +15479,7 @@ license:CC0
 	</software>
 
 	<software name="pockcmj">
-		<description>Pocket Color Mahjong (Jpn)</description>
+		<description>Pocket Color Mahjong (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A2AJ-JPN"/>
@@ -15494,7 +15494,7 @@ license:CC0
 	</software>
 
 	<software name="pockctrm">
-		<description>Pocket Color Trump (Jpn)</description>
+		<description>Pocket Color Trump (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A4CJ-JPN"/>
@@ -15510,7 +15510,7 @@ license:CC0
 
 	<software name="pockcook">
 		<!-- Notes: GBC only -->
-		<description>Pocket Cooking (Jpn)</description>
+		<description>Pocket Cooking (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-APJJ-JPN"/>
@@ -15533,7 +15533,7 @@ license:CC0
 	</software>
 
 	<software name="pockden2">
-		<description>Pocket Densha 2 (Jpn)</description>
+		<description>Pocket Densha 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Coconuts Japan</publisher>
 		<info name="serial" value="DMG-AP8J-JPN"/>
@@ -15551,7 +15551,7 @@ license:CC0
 	<software name="pockfam2">
 		<!-- Notes: GBC only
 		    The game cart has an integrated speaker and a replaceable battery (CR2025). -->
-		<description>Pocket Family GB2 (Jpn)</description>
+		<description>Pocket Family GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-HF2J-JPN"/>
@@ -15575,7 +15575,7 @@ license:CC0
 	</software>
 
 	<software name="pockgis">
-		<description>Pocket GI Stable (Jpn)</description>
+		<description>Pocket GI Stable (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-APUJ-JPN (RK156-J1)"/>
@@ -15594,7 +15594,7 @@ license:CC0
 
 	<software name="pockgt" cloneof="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket GT (Jpn)</description>
+		<description>Pocket GT (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-A7GJ-JPN"/>
@@ -15612,7 +15612,7 @@ license:CC0
 	</software>
 
 	<software name="pockgtp" cloneof="pockrace">
-		<description>Pocket GT (Euro, Prototype?)</description>
+		<description>Pocket GT (Europe, Prototype?)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -15627,7 +15627,7 @@ license:CC0
 
 	<software name="pockhana">
 		<!-- Notes: GBC only -->
-		<description>Pocket Hanafuda (Jpn)</description>
+		<description>Pocket Hanafuda (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A6PJ-JPN"/>
@@ -15642,7 +15642,7 @@ license:CC0
 	</software>
 
 	<software name="pockking">
-		<description>Pocket King (Jpn)</description>
+		<description>Pocket King (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AV5J-JPN"/>
@@ -15660,7 +15660,7 @@ license:CC0
 
 	<software name="pocklure">
 		<!-- Notes: GBC only -->
-		<description>Pocket Lure Boy (Jpn)</description>
+		<description>Pocket Lure Boy (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQIJ-JPN (KIG-8)"/>
@@ -15711,7 +15711,7 @@ license:CC0
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Jpn, Rev. 1)</description>
+		<description>Pocket Monsters Gin (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
@@ -15736,7 +15736,7 @@ license:CC0
 	</software>
 
 	<software name="pokegina" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Jpn)</description>
+		<description>Pocket Monsters Gin (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
@@ -15755,7 +15755,7 @@ license:CC0
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Jpn, Rev. 1)</description>
+		<description>Pocket Monsters Kin (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
@@ -15774,7 +15774,7 @@ license:CC0
 	</software>
 
 	<software name="pokekina" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Jpn)</description>
+		<description>Pocket Monsters Kin (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
@@ -15794,7 +15794,7 @@ license:CC0
 
 	<software name="pokecrysj" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pocket Monsters - Crystal Version (Jpn)</description>
+		<description>Pocket Monsters - Crystal Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BXTJ-JPN"/>
@@ -15820,7 +15820,7 @@ license:CC0
 
 	<software name="pockmus">
 		<!-- Notes: GBC only -->
-		<description>Pocket Music (Euro)</description>
+		<description>Pocket Music (Europe)</description>
 		<year>2002</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BP9P-EUR?"/>
@@ -15837,7 +15837,7 @@ license:CC0
 
 	<software name="pocknaka">
 		<!-- Notes: GBC only -->
-		<description>Pocket no Naka no Ookoku (Jpn, Prototype)</description>
+		<description>Pocket no Naka no Ookoku (Japan, Prototype)</description>
 		<year>2000</year>   <!-- scheduled to be released January 2001 (3/11/2000 Famitsu) -->
 		<publisher>Hector</publisher>
 		<info name="alt_title" value="ポケットの中の王国"/>
@@ -15853,7 +15853,7 @@ license:CC0
 
 	<software name="pockprow">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Wrestling - Perfect Wrestler (Jpn)</description>
+		<description>Pocket Pro Wrestling - Perfect Wrestler (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AJVJ-JPN"/>
@@ -15869,7 +15869,7 @@ license:CC0
 
 	<software name="pockyak">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Yakyuu (Jpn)</description>
+		<description>Pocket Pro Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BPPJ-JPN"/>
@@ -15886,7 +15886,7 @@ license:CC0
 	</software>
 
 	<software name="poktpuys">
-		<description>Pocket Puyo Puyo Sun (Jpn)</description>
+		<description>Pocket Puyo Puyo Sun (Japan)</description>
 		<year>1998</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AYSJ-JPN"/>
@@ -15905,7 +15905,7 @@ license:CC0
 
 	<software name="poktpuyn">
 		<!-- Notes: GBC only -->
-		<description>Pocket Puyo Puyo-n (Jpn)</description>
+		<description>Pocket Puyo Puyo-n (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15925,7 +15925,7 @@ license:CC0
 	<software name="poktpuyna" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj1.327"	-->
-		<description>Pocket Puyo Puyo-n (Jpn, Rev. 1)</description>
+		<description>Pocket Puyo Puyo-n (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15944,7 +15944,7 @@ license:CC0
 	<software name="poktpuynb" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj2.327"	-->
-		<description>Pocket Puyo Puyo-n (Jpn, Rev. 2)</description>
+		<description>Pocket Puyo Puyo-n (Japan, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15962,7 +15962,7 @@ license:CC0
 
 	<software name="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket Racing (Euro)</description>
+		<description>Pocket Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BPKP-EUR"/>
@@ -15979,7 +15979,7 @@ license:CC0
 	<software name="pocksocr">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "CGBBPSP0.618", "KENSA\CGBBPSE0.0"	-->
-		<description>Pocket Soccer (Euro)</description>
+		<description>Pocket Soccer (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="GCB-BPSP-EUR"/>
@@ -15996,7 +15996,7 @@ license:CC0
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
 		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
-		<description>Pokémon - Crystal Version (Euro, USA, Rev. 1)</description>
+		<description>Pokémon - Crystal Version (Europe, USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
@@ -16034,7 +16034,7 @@ license:CC0
 
 	<software name="pokecrysf" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Version Cristal (Fra)</description>
+		<description>Pokémon - Version Cristal (France)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTF-FRA"/>
@@ -16053,7 +16053,7 @@ license:CC0
 
 	<software name="pokecrysg" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Kristall-Edition (Ger)</description>
+		<description>Pokémon - Kristall-Edition (Germany)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTD-NOE"/>
@@ -16072,7 +16072,7 @@ license:CC0
 
 	<software name="pokecrysi" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Versione Cristallo (Ita)</description>
+		<description>Pokémon - Versione Cristallo (Italia)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTI-ITA"/>
@@ -16097,7 +16097,7 @@ license:CC0
 
 	<software name="pokecryss" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Edición Cristal (Spa)</description>
+		<description>Pokémon - Edición Cristal (Spain)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTS-ESP"/>
@@ -16117,7 +16117,7 @@ license:CC0
 	<software name="pokecrysaus" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbytu0.834"	-->
-		<description>Pokémon - Crystal Version (Aus)</description>
+		<description>Pokémon - Crystal Version (Australia)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="gold" value="20010724"/>
@@ -16135,7 +16135,7 @@ license:CC0
 	</software>
 
 	<software name="pokegold">
-		<description>Pokémon - Gold Version (Euro, USA)</description>
+		<description>Pokémon - Gold Version (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUE-USA, DMG-AAUP-(EUR/EUR-1)"/>
@@ -16153,7 +16153,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldf" cloneof="pokegold">
-		<description>Pokémon - Version Or (Fra)</description>
+		<description>Pokémon - Version Or (France)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUF-FRA"/>
@@ -16169,7 +16169,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldg" cloneof="pokegold">
-		<description>Pokémon - Goldene Edition (Ger)</description>
+		<description>Pokémon - Goldene Edition (Germany)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUD-NOE"/>
@@ -16185,7 +16185,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldi" cloneof="pokegold">
-		<description>Pokémon - Versione Oro (Ita)</description>
+		<description>Pokémon - Versione Oro (Italia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AAUI-ITA"/>
@@ -16207,7 +16207,7 @@ license:CC0
 	</software>
 
 	<software name="pokegolds" cloneof="pokegold">
-		<description>Pokémon - Edición Oro (Spa)</description>
+		<description>Pokémon - Edición Oro (Spain)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUS-ESP"/>
@@ -16229,7 +16229,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilv">
-		<description>Pokémon - Silver Version (Euro, Aus, USA)</description>
+		<description>Pokémon - Silver Version (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXE-USA, DMG-AAXP-(EUR/AUS)"/>
@@ -16245,7 +16245,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvf" cloneof="pokesilv">
-		<description>Pokémon - Version Argent (Fra)</description>
+		<description>Pokémon - Version Argent (France)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXF-FRA"/>
@@ -16261,7 +16261,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvg" cloneof="pokesilv">
-		<description>Pokémon - Silberne Edition (Ger)</description>
+		<description>Pokémon - Silberne Edition (Germany)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXD-NOE"/>
@@ -16283,7 +16283,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvi" cloneof="pokesilv">
-		<description>Pokémon - Versione Argento (Ita)</description>
+		<description>Pokémon - Versione Argento (Italia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXI-ITA"/>
@@ -16299,7 +16299,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvs" cloneof="pokesilv">
-		<description>Pokémon - Edición Plata (Spa)</description>
+		<description>Pokémon - Edición Plata (Spain)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXS-ESP"/>
@@ -16316,7 +16316,7 @@ license:CC0
 
 	<software name="pokecardj" cloneof="pokecard">
 		<!-- This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
-		<description>Pokémon Card GB (Jpn)</description>
+		<description>Pokémon Card GB (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACXJ-JPN"/>
@@ -16341,7 +16341,7 @@ license:CC0
 
 	<software name="pokecrd2">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Card GB2 - GR Dan Sanjou! (Jpn)</description>
+		<description>Pokémon Card GB2 - GR Dan Sanjou! (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BP7J-JPN"/>
@@ -16359,7 +16359,7 @@ license:CC0
 
 	<software name="pokepuzlj" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon de Panepon (Jpn)</description>
+		<description>Pokémon de Panepon (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNJ-JPN"/>
@@ -16376,7 +16376,7 @@ license:CC0
 	</software>
 
 	<software name="pokepinb">
-		<description>Pokémon Pinball (Euro)</description>
+		<description>Pokémon Pinball (Europe)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHP-EUR"/>
@@ -16399,7 +16399,7 @@ license:CC0
 	</software>
 
 	<software name="pokepinbj" cloneof="pokepinb">
-		<description>Pokémon Pinball (Jpn)</description>
+		<description>Pokémon Pinball (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHJ-JPN"/>
@@ -16419,7 +16419,7 @@ license:CC0
 
 	<software name="pokepinbu" cloneof="pokepinb">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Pinball (Aus, USA)</description>
+		<description>Pokémon Pinball (Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHE-USA, DMG-VPHU-AUS"/>
@@ -16436,7 +16436,7 @@ license:CC0
 
 	<software name="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Puzzle Challenge (Euro)</description>
+		<description>Pokémon Puzzle Challenge (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNP-EUR"/>
@@ -16469,7 +16469,7 @@ license:CC0
 
 	<software name="pokecard">
 		<!--	In lot check as "dmgaxqx1.j85"	-->
-		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian, Rev. 1)</description>
+		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR-1"/>
@@ -16486,7 +16486,7 @@ license:CC0
 	</software>
 
 	<software name="pokecardx" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian)</description>
+		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR"/>
@@ -16503,7 +16503,7 @@ license:CC0
 	</software>
 
 	<software name="pokecarde" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Euro, English / French / German)</description>
+		<description>Pokémon Trading Card Game (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE"/>
@@ -16527,7 +16527,7 @@ license:CC0
 
 	<software name="pokecardaa" cloneof="pokecard">
 		<!--	In lot check as "dmgaxqp1.j84"	-->
-		<description>Pokémon Trading Card Game (Euro, English / French / German, Rev. 1)</description>
+		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE?"/>
@@ -16544,7 +16544,7 @@ license:CC0
 	</software>
 
 	<software name="pokecardu" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Aus, USA)</description>
+		<description>Pokémon Trading Card Game (Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQE-USA, DMG-AXQU-AUS"/>
@@ -16580,7 +16580,7 @@ license:CC0
 
 	<software name="pongtnl">
 		<!-- Notes: GBC only -->
-		<description>Pong - The Next Level (Euro, USA)</description>
+		<description>Pong - The Next Level (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-AOVE-USA, CGB-AOVP-EUR"/>
@@ -16594,7 +16594,7 @@ license:CC0
 
 	<software name="poohhuns">
 		<!-- Notes: GBC only -->
-		<description>Pooh and Tigger's Hunny Safari (Euro)</description>
+		<description>Pooh and Tigger's Hunny Safari (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BP8P-EUR"/>
@@ -16625,7 +16625,7 @@ license:CC0
 
 	<software name="popngb">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB (Jpn)</description>
+		<description>Pop'n Music GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPMJ-JPN (RK207-J1)"/>
@@ -16641,7 +16641,7 @@ license:CC0
 
 	<software name="popngbam">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Animation Melody (Jpn)</description>
+		<description>Pop'n Music GB - Animation Melody (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPAJ-JPN (RK216-J1)"/>
@@ -16657,7 +16657,7 @@ license:CC0
 
 	<software name="popngbdt">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Disney Tunes (Jpn)</description>
+		<description>Pop'n Music GB - Disney Tunes (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPDJ-JPN (RK218-J1)"/>
@@ -16673,7 +16673,7 @@ license:CC0
 
 	<software name="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Euro)</description>
+		<description>Pop'n Pop (Europe)</description>
 		<year>2001</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="??"/>
@@ -16687,7 +16687,7 @@ license:CC0
 
 	<software name="popnpopj" cloneof="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Jpn)</description>
+		<description>Pop'n Pop (Japan)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJPJ-JPN"/>
@@ -16716,7 +16716,7 @@ license:CC0
 	</software>
 
 	<software name="powrpkp">
-		<description>Power Pro Kun Pocket (Jpn, Rev. 1)</description>
+		<description>Power Pro Kun Pocket (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
@@ -16734,7 +16734,7 @@ license:CC0
 	</software>
 
 	<software name="powrpkpa" cloneof="powrpkp">
-		<description>Power Pro Kun Pocket (Jpn)</description>
+		<description>Power Pro Kun Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
@@ -16752,7 +16752,7 @@ license:CC0
 	</software>
 
 	<software name="powrpkp2">
-		<description>Power Pro Kun Pocket 2 (Jpn)</description>
+		<description>Power Pro Kun Pocket 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BPWJ-JPN (RK205-J1)"/>
@@ -16776,7 +16776,7 @@ license:CC0
 	</software>
 
 	<software name="powerqst">
-		<description>Power Quest (Euro)</description>
+		<description>Power Quest (Europe)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-APQP-EUR"/>
@@ -16806,7 +16806,7 @@ license:CC0
 
 	<software name="prlr">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Lightspeed Rescue (Euro, USA)</description>
+		<description>Power Rangers - Lightspeed Rescue (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRSE-USA, CGB-BRSP-EUR"/>
@@ -16823,7 +16823,7 @@ license:CC0
 
 	<software name="prtf">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Time Force (Euro, USA)</description>
+		<description>Power Rangers - Time Force (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4TE-USA, CGB-B4TP-EUR"/>
@@ -16854,7 +16854,7 @@ license:CC0
 
 	<software name="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (Euro)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (Europe)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJP-UKV"/>
@@ -16876,7 +16876,7 @@ license:CC0
 
 	<software name="powrpfbmf" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (Fra)</description>
+		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (France)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJF-FRA"/>
@@ -16898,7 +16898,7 @@ license:CC0
 
 	<software name="powrpfbms" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - El Malvado Mojo Jojo (Spa)</description>
+		<description>Las Super Nenas - El Malvado Mojo Jojo (Spain)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJS-ESP"/>
@@ -16976,7 +16976,7 @@ license:CC0
 
 	<software name="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (Euro)</description>
+		<description>The Powerpuff Girls - Battle Him (Europe)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHP-EUR"/>
@@ -16998,7 +16998,7 @@ license:CC0
 
 	<software name="powrpfbhf" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bulle Contre Lui (Fra)</description>
+		<description>The Powerpuff Girls - Bulle Contre Lui (France)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHF-FRA"/>
@@ -17020,7 +17020,7 @@ license:CC0
 
 	<software name="powrpfbhs" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Lucha con Ese (Spa)</description>
+		<description>Las Super Nenas - Lucha con Ese (Spain)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHS-ESP"/>
@@ -17075,7 +17075,7 @@ license:CC0
 
 	<software name="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (Euro)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (Europe)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTP-(EUR, UKV)"/>
@@ -17097,7 +17097,7 @@ license:CC0
 
 	<software name="powrpfpnf" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Panique a Townsville (Fra)</description>
+		<description>The Powerpuff Girls - Panique a Townsville (France)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTF-FRA"/>
@@ -17119,7 +17119,7 @@ license:CC0
 
 	<software name="powrpfpns" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Pánico en Townsville (Spa)</description>
+		<description>Las Super Nenas - Pánico en Townsville (Spain)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTS-ESP"/>
@@ -17186,7 +17186,7 @@ license:CC0
 	</software>
 
 	<software name="poyondr">
-		<description>Poyon no Dungeon Room (Jpn)</description>
+		<description>Poyon no Dungeon Room (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-ADZJ-JPN"/>
@@ -17205,7 +17205,7 @@ license:CC0
 
 	<software name="poyondr2">
 		<!-- Notes: GBC only -->
-		<description>Poyon no Dungeon Room 2 (Jpn)</description>
+		<description>Poyon no Dungeon Room 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BP2J-JPN"/>
@@ -17223,7 +17223,7 @@ license:CC0
 
 	<software name="pnaseem">
 		<!-- Notes: GBC only -->
-		<description>Prince Naseem Boxing (Euro)</description>
+		<description>Prince Naseem Boxing (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNCP-EUR"/>
@@ -17238,7 +17238,7 @@ license:CC0
 	</software>
 
 	<software name="ppersia">
-		<description>Prince of Persia (Euro, USA)</description>
+		<description>Prince of Persia (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-ARIE-USA, DMG-ARIP-EUR"/>
@@ -17270,7 +17270,7 @@ license:CC0
 
 	<software name="mjkiwam2">
 		<!-- Also released by NP in 2001-06 -->
-		<description>Pro Mahjong Kiwame GB II (Jpn)</description>
+		<description>Pro Mahjong Kiwame GB II (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AA2J-JPN"/>
@@ -17288,7 +17288,7 @@ license:CC0
 	</software>
 
 	<software name="mjtsuwa">
-		<description>Pro Mahjong Tsuwamono GB (Jpn)</description>
+		<description>Pro Mahjong Tsuwamono GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AQDJ-JPN"/>
@@ -17307,7 +17307,7 @@ license:CC0
 
 	<software name="mjtsuwa2">
 		<!-- Notes: GBC only -->
-		<description>Pro Mahjong Tsuwamono GB2 (Jpn)</description>
+		<description>Pro Mahjong Tsuwamono GB2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BMWJ-JPN"/>
@@ -17324,7 +17324,7 @@ license:CC0
 	</software>
 
 	<software name="profoot" cloneof="goldgoal">
-		<description>Pro:Foot (Fra)</description>
+		<description>Pro:Foot (France)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFF-FAH"/>
@@ -17340,7 +17340,7 @@ license:CC0
 
 	<software name="propool">
 		<!-- Notes: GBC only -->
-		<description>Pro Pool (Euro)</description>
+		<description>Pro Pool (Europe)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLP-EUU"/>
@@ -17413,7 +17413,7 @@ license:CC0
 	</software>
 
 	<software name="puchicar">
-		<description>Puchi Carat (Euro)</description>
+		<description>Puchi Carat (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-AIQP-EUR"/>
@@ -17430,7 +17430,7 @@ license:CC0
 
 	<software name="puchicarj" cloneof="puchicar">
 		<!-- Also released by NP in 2000-07 -->
-		<description>Puchi Carat (Jpn)</description>
+		<description>Puchi Carat (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-ACUJ-JPN"/>
@@ -17450,7 +17450,7 @@ license:CC0
 
 	<software name="pumucklp">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer bei den Piraten (Ger)</description>
+		<description>Pumuckls Abenteuer bei den Piraten (Germany)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AVED-NOE"/>
@@ -17464,7 +17464,7 @@ license:CC0
 
 	<software name="pumucklg">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer im Geisterschloss (Ger)</description>
+		<description>Pumuckls Abenteuer im Geisterschloss (Germany)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BPCD-NOE"/>
@@ -17477,7 +17477,7 @@ license:CC0
 	</software>
 
 	<software name="puyopuyg">
-		<description>Puyo Puyo Gaiden - Puyo Wars (Jpn)</description>
+		<description>Puyo Puyo Gaiden - Puyo Wars (Japan)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AWYJ-JPN"/>
@@ -17495,7 +17495,7 @@ license:CC0
 	</software>
 
 	<software name="puzzloop" cloneof="ballistc">
-		<description>Puzz Loop (Jpn)</description>
+		<description>Puzz Loop (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BPZJ-JPN"/>
@@ -17512,7 +17512,7 @@ license:CC0
 	</software>
 
 	<software name="pbobble4" cloneof="bam4">
-		<description>Puzzle Bobble 4 (Jpn)</description>
+		<description>Puzzle Bobble 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AA4J-JPN"/>
@@ -17528,7 +17528,7 @@ license:CC0
 
 	<software name="pbobblem" cloneof="bammill">
 		<!-- Notes: GBC only -->
-		<description>Puzzle Bobble Millennium (Jpn)</description>
+		<description>Puzzle Bobble Millennium (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BP5J-JPN"/>
@@ -17543,7 +17543,7 @@ license:CC0
 	</software>
 
 	<software name="puzlshou">
-		<description>Puzzle de Shoubuyo! Wootama-chan (Jpn)</description>
+		<description>Puzzle de Shoubuyo! Wootama-chan (Japan)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="DMG-BKUJ-JPN"/>
@@ -17574,7 +17574,7 @@ license:CC0
 
 	<software name="puzzled">
 		<!-- Notes: GBC only -->
-		<description>Puzzled (Euro)</description>
+		<description>Puzzled (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AZWP-EUR"/>
@@ -17616,7 +17616,7 @@ license:CC0
 
 	<software name="qixadv">
 		<!-- Notes: GBC only -->
-		<description>Qix Adventure (Euro)</description>
+		<description>Qix Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="CGB-AQYP-EUR"/>
@@ -17633,7 +17633,7 @@ license:CC0
 
 	<software name="qixadvj" cloneof="qixadv">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Qix Adventure (Jpn)</description>
+		<description>Qix Adventure (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-AQSJ-JPN"/>
@@ -17663,7 +17663,7 @@ license:CC0
 	</software>
 
 	<software name="questcam">
-		<description>Quest for Camelot (Euro)</description>
+		<description>Quest for Camelot (Europe)</description>
 		<year>1998</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ACNP-EUR"/>
@@ -17709,7 +17709,7 @@ license:CC0
 	</software>
 
 	<software name="quiqui">
-		<description>Qui Qui (Jpn)</description>
+		<description>Qui Qui (Japan)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AQUJ-JPN"/>
@@ -17726,7 +17726,7 @@ license:CC0
 	</software>
 
 	<software name="rtypedx">
-		<description>R-Type DX (Euro, Aus, USA)</description>
+		<description>R-Type DX (Europe, Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWHE-USA, DMG-AWHP-(AUS/EUR)"/>
@@ -17747,7 +17747,7 @@ license:CC0
 	</software>
 
 	<software name="rtypedxj" cloneof="rtypedx">
-		<description>R-Type DX (Jpn)</description>
+		<description>R-Type DX (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ARUJ-JPN"/>
@@ -17779,7 +17779,7 @@ license:CC0
 
 	<software name="radikal">
 		<!-- Notes: GBC only -->
-		<description>Radikal Bikers (Euro, Prototype)</description>
+		<description>Radikal Bikers (Europe, Prototype)</description>
 		<year>1998?</year>
 		<publisher>Bit Managers</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -17794,7 +17794,7 @@ license:CC0
 
 	<software name="rbisland">
 		<!-- Notes: GBC only -->
-		<description>Rainbow Islands (Euro)</description>
+		<description>Rainbow Islands (Europe)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BISP-EUR"/>
@@ -17808,7 +17808,7 @@ license:CC0
 
 	<software name="rakuxcs">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Cut Shuu (Jpn)</description>
+		<description>Raku x Raku - Cut Shuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BELJ-JPN"/>
@@ -17825,7 +17825,7 @@ license:CC0
 
 	<software name="rakuxmis">
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Raku x Raku - Mishin (Jpn)</description>
+		<description>Raku x Raku - Mishin (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAJ-JPN"/>
@@ -17847,7 +17847,7 @@ license:CC0
 
 	<software name="rakuxmoj">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Moji (Jpn)</description>
+		<description>Raku x Raku - Moji (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BEMJ-JPN"/>
@@ -17863,7 +17863,7 @@ license:CC0
 	</software>
 
 	<software name="rampage">
-		<description>Rampage - World Tour (Euro, USA)</description>
+		<description>Rampage - World Tour (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ARPE-USA, DMG-ARPP-EUR"/>
@@ -17877,7 +17877,7 @@ license:CC0
 
 	<software name="rampage2">
 		<!-- Notes: GBC only -->
-		<description>Rampage 2 - Universal Tour (Euro, USA)</description>
+		<description>Rampage 2 - Universal Tour (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AUTE-USA, CGB-AUTP-EUR"/>
@@ -17921,7 +17921,7 @@ license:CC0
 
 	<software name="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman (Euro)</description>
+		<description>Rayman (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AYQP-EUR"/>
@@ -17949,7 +17949,7 @@ license:CC0
 
 	<software name="raymanj" cloneof="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman - Mister Dark no Wana (Jpn)</description>
+		<description>Rayman - Mister Dark no Wana (Japan)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BURJ-JPN"/>
@@ -17965,7 +17965,7 @@ license:CC0
 
 	<software name="rayman2">
 		<!-- Notes: GBC only -->
-		<description>Rayman 2 - The Great Escape (Euro)</description>
+		<description>Rayman 2 - The Great Escape (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BRYP-EUR"/>
@@ -18003,7 +18003,7 @@ license:CC0
 
 	<software name="freestyl">
 		<!-- Notes: GBC only -->
-		<description>Freestyle Scooter (Euro)</description>
+		<description>Freestyle Scooter (Europe)</description>
 		<year>2001</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BRZP-EUR"/>
@@ -18034,7 +18034,7 @@ license:CC0
 
 	<software name="r2rumble">
 		<!-- Notes: GBC only -->
-		<description>Ready 2 Rumble Boxing (Euro)</description>
+		<description>Ready 2 Rumble Boxing (Europe)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AQOP-EUR"/>
@@ -18066,7 +18066,7 @@ license:CC0
 	</software>
 
 	<software name="rpyakyuc">
-		<description>Real Pro Yakyuu! - Central League Hen (Jpn)</description>
+		<description>Real Pro Yakyuu! - Central League Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AECJ-JPN"/>
@@ -18084,7 +18084,7 @@ license:CC0
 	</software>
 
 	<software name="rpyakyup">
-		<description>Real Pro Yakyuu! - Pacific League Hen (Jpn)</description>
+		<description>Real Pro Yakyuu! - Pacific League Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AEPJ-JPN"/>
@@ -18116,7 +18116,7 @@ license:CC0
 	</software>
 
 	<software name="resrvrat">
-		<description>Reservoir Rat (Euro)</description>
+		<description>Reservoir Rat (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AVTP-EUR"/>
@@ -18160,7 +18160,7 @@ license:CC0
 
 	<software name="revilg">
 		<!-- Notes: GBC only -->
-		<description>Resident Evil Gaiden (Euro)</description>
+		<description>Resident Evil Gaiden (Europe)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOP-EUR"/>
@@ -18192,7 +18192,7 @@ license:CC0
 
 	<software name="retninja">
 		<!-- Notes: GBC only -->
-		<description>Return of the Ninja (Euro)</description>
+		<description>Return of the Ninja (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BNJP-EUR"/>
@@ -18235,7 +18235,7 @@ license:CC0
 
 	<software name="rhino">
 		<!-- Notes: GBC only -->
-		<description>Rhino Rumble (Euro, USA)</description>
+		<description>Rhino Rumble (Europe, USA)</description>
 		<year>2002</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-BRNE-USA, CGB-BRNP-EUR"/>
@@ -18248,7 +18248,7 @@ license:CC0
 	</software>
 
 	<software name="riptide">
-		<description>Rip-Tide Racer (Euro)</description>
+		<description>Rip-Tide Racer (Europe)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-AXYP-EUR"/>
@@ -18262,7 +18262,7 @@ license:CC0
 
 	<software name="roadchmp">
 		<!-- Notes: GBC only -->
-		<description>Road Champs - BXS Stunt Biking (Euro, USA)</description>
+		<description>Road Champs - BXS Stunt Biking (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXSE-USA, CGB-BXSP-EUR"/>
@@ -18279,7 +18279,7 @@ license:CC0
 
 	<software name="roadrash">
 		<!-- Notes: GBC only -->
-		<description>Road Rash (Euro, USA)</description>
+		<description>Road Rash (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRRE-USA, CGB-BRRP-EUR"/>
@@ -18309,7 +18309,7 @@ license:CC0
 	</software>
 
 	<software name="roadster">
-		<description>Roadsters Trophy (Euro)</description>
+		<description>Roadsters Trophy (Europe)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -18336,7 +18336,7 @@ license:CC0
 
 	<software name="robin">
 		<!-- Notes: GBC only -->
-		<description>Robin Hood (Euro)</description>
+		<description>Robin Hood (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRHP-EUR"/>
@@ -18350,7 +18350,7 @@ license:CC0
 
 	<software name="robocop">
 		<!-- Notes: GBC only -->
-		<description>RoboCop (Euro)</description>
+		<description>RoboCop (Europe)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BR9P-EUR"/>
@@ -18391,7 +18391,7 @@ license:CC0
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Jpn)</description>
+		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H5UJ-JPN"/>
@@ -18420,7 +18420,7 @@ license:CC0
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Moon Version (Jpn)</description>
+		<description>Robot Ponkottsu - Moon Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H3UJ-JPN"/>
@@ -18449,7 +18449,7 @@ license:CC0
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Star Version (Jpn)</description>
+		<description>Robot Ponkottsu - Star Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HRCJ-JPN"/>
@@ -18474,7 +18474,7 @@ license:CC0
 	</software>
 
 	<software name="robopsunj" cloneof="robopsun">
-		<description>Robot Ponkottsu - Sun Version (Jpn)</description>
+		<description>Robot Ponkottsu - Sun Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HREJ-JPN"/>
@@ -18495,7 +18495,7 @@ license:CC0
 
 	<software name="robowars">
 		<!-- Notes: GBC only -->
-		<description>Robot Wars - Metal Mayhem (Euro)</description>
+		<description>Robot Wars - Metal Mayhem (Europe)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-BRWP-UKV"/>
@@ -18511,7 +18511,7 @@ license:CC0
 
 	<software name="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - Gettin' Air (Euro, USA)</description>
+		<description>Rocket Power - Gettin' Air (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRUP-EUR, CGB-BRUE-USA"/>
@@ -18528,7 +18528,7 @@ license:CC0
 
 	<software name="rcktpwf" cloneof="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - La Glisse de l'Extreme (Fra)</description>
+		<description>Rocket Power - La Glisse de l'Extreme (France)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="??"/>
@@ -18541,7 +18541,7 @@ license:CC0
 	</software>
 
 	<software name="rockmnx" cloneof="megamnx">
-		<description>Rockman X - Cyber Mission (Jpn)</description>
+		<description>Rockman X - Cyber Mission (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BRXJ-JPN"/>
@@ -18559,7 +18559,7 @@ license:CC0
 
 	<software name="rockmnx2" cloneof="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Rockman X2 - Soul Eraser (Jpn)</description>
+		<description>Rockman X2 - Soul Eraser (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BXRJ-JPN"/>
@@ -18591,7 +18591,7 @@ license:CC0
 
 	<software name="rokumon">
 		<!-- Notes: GBC only -->
-		<description>Rokumon Tengai Mon-Colle-Knight GB (Jpn)</description>
+		<description>Rokumon Tengai Mon-Colle-Knight GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Kadokawa Shoten</publisher>
 		<info name="serial" value="CGB-BKDJ-JPN"/>
@@ -18609,7 +18609,7 @@ license:CC0
 
 	<software name="rolandg">
 		<!-- Notes: GBC only -->
-		<description>Roland Garros French Open (Euro)</description>
+		<description>Roland Garros French Open (Europe)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BRGP-EUR"/>
@@ -18622,7 +18622,7 @@ license:CC0
 	</software>
 
 	<software name="ronaldov">
-		<description>Ronaldo V-Football (Euro)</description>
+		<description>Ronaldo V-Football (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AORP-(EUR/FAH)"/>
@@ -18653,7 +18653,7 @@ license:CC0
 
 	<software name="roswell">
 		<!-- Notes: GBC only -->
-		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Euro)</description>
+		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCPP-EUR"/>
@@ -18680,7 +18680,7 @@ license:CC0
 	</software>
 
 	<software name="rox">
-		<description>Rox - 6=Six (Euro, USA)</description>
+		<description>Rox - 6=Six (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ARXE-USA, DMG-ARXP-EUR"/>
@@ -18697,7 +18697,7 @@ license:CC0
 
 	<software name="roxj" cloneof="rox">
 		<!-- Notes: GBC only -->
-		<description>Rox - 6=Six (Jpn)</description>
+		<description>Rox - 6=Six (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ARXJ-JPN"/>
@@ -18715,7 +18715,7 @@ license:CC0
 
 	<software name="rpgtsuku">
 		<!-- Notes: GBC only -->
-		<description>RPG Tsukuru GB (Jpn)</description>
+		<description>RPG Tsukuru GB (Japan)</description>
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-A2QJ-JPN"/>
@@ -18733,7 +18733,7 @@ license:CC0
 	</software>
 
 	<software name="rugtimet">
-		<description>Rugrats - Time Travelers (Euro, USA)</description>
+		<description>Rugrats - Time Travelers (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AVME-USA, DMG-AVMP-EUR"/>
@@ -18749,7 +18749,7 @@ license:CC0
 	</software>
 
 	<software name="rugtimetf" cloneof="rugtimet">
-		<description>Les Razmoket - Voyage dans le Temps (Fra)</description>
+		<description>Les Razmoket - Voyage dans le Temps (France)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRTF-FRA"/>
@@ -18763,7 +18763,7 @@ license:CC0
 
 	<software name="rugtotanf" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket - 100% Angelica (Fra)</description>
+		<description>Les Razmoket - 100% Angelica (France)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGF-FRA"/>
@@ -18777,7 +18777,7 @@ license:CC0
 
 	<software name="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Totally Angelica (Euro, USA)</description>
+		<description>Rugrats - Totally Angelica (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGE-USA, CGB-BAGP-EUR"/>
@@ -18794,7 +18794,7 @@ license:CC0
 
 	<software name="rugtotang" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Typisch Angelica (Ger)</description>
+		<description>Rugrats - Typisch Angelica (Germany)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGD-NOE"/>
@@ -18808,7 +18808,7 @@ license:CC0
 
 	<software name="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Euro)</description>
+		<description>Rugrats in Paris - The Movie (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPX-ESP"/>
@@ -18822,7 +18822,7 @@ license:CC0
 
 	<software name="rugparisa" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Euro, USA)</description>
+		<description>Rugrats in Paris - The Movie (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPE-USA, CGB-BRPP-EUR"/>
@@ -18839,7 +18839,7 @@ license:CC0
 
 	<software name="rugparisf" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket à Paris - Le Film (Fra)</description>
+		<description>Les Razmoket à Paris - Le Film (France)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPF-FRA"/>
@@ -18855,7 +18855,7 @@ license:CC0
 	</software>
 
 	<software name="rugmovie">
-		<description>The Rugrats Movie (Euro)</description>
+		<description>The Rugrats Movie (Europe)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ARZP-(NOE/UKV)"/>
@@ -18885,7 +18885,7 @@ license:CC0
 
 	<software name="sabrinas">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Spooked! (Euro, USA)</description>
+		<description>Sabrina - The Animated Series - Spooked! (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-B4PE-USA, CGB-B4PP-UKV"/>
@@ -18902,7 +18902,7 @@ license:CC0
 
 	<software name="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Euro)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Europe)</description>
 		<year>2000</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-BSGX-EUU"/>
@@ -18916,7 +18916,7 @@ license:CC0
 
 	<software name="sabrinazu" cloneof="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Euro, USA)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-BSGE-USA, CGB-BSGP-EUR"/>
@@ -18932,7 +18932,7 @@ license:CC0
 	</software>
 
 	<software name="sakata">
-		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Jpn)</description>
+		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AREJ-JPN"/>
@@ -18951,7 +18951,7 @@ license:CC0
 		<!-- Notes: GBC only, 10 variant packs got released!
 		            This game is compatible with an external pedometer named "Pocket Sakura" (same hardware as the Pokémon Pikachu Color / Pokémon Pikachu 2 GS pedometer)
 		            wich connects to the GBC via the console's IR port -->
-		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Jpn)</description>
+		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BRJJ-JPN"/>
@@ -18975,7 +18975,7 @@ license:CC0
 
 	<software name="sakura2">
 		<!-- Notes: GBC only -->
-		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Jpn)</description>
+		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Japan)</description>
 		<year>2001</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="CGB-BQYJ-JPN (Limited Edition got serial HGB-0001)"/>
@@ -18993,7 +18993,7 @@ license:CC0
 
 	<software name="samurai">
 		<!-- Notes: GBC only -->
-		<description>Samurai Kid (Jpn)</description>
+		<description>Samurai Kid (Japan)</description>
 		<year>2001</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BS5J-JPN"/>
@@ -19011,7 +19011,7 @@ license:CC0
 
 	<software name="sf2049">
 		<!-- Notes: GBC only -->
-		<description>San Francisco Rush 2049 (Euro, USA)</description>
+		<description>San Francisco Rush 2049 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ASXE-USA, CGB-ASXP-EUU, CGB-ASXP-EUR"/>
@@ -19027,7 +19027,7 @@ license:CC0
 	</software>
 
 	<software name="sangogb2">
-		<description>Sangokushi - Game Boy Ban 2 (Jpn)</description>
+		<description>Sangokushi - Game Boy Ban 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AS9J-JPN"/>
@@ -19046,7 +19046,7 @@ license:CC0
 
 	<software name="sanriotk">
 		<!-- Also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Kako Hen (Jpn)</description>
+		<description>Sanrio Timenet - Kako Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
@@ -19072,7 +19072,7 @@ license:CC0
 
 	<software name="sanriotka" cloneof="sanriotk">
 		<!--	In lot check as "dmgatpj1.f14"	-->
-		<description>Sanrio Timenet - Kako Hen (Jpn, Rev. 1)</description>
+		<description>Sanrio Timenet - Kako Hen (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
@@ -19092,7 +19092,7 @@ license:CC0
 
 	<software name="sanriotm">
 		<!-- Also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Mirai Hen (Jpn)</description>
+		<description>Sanrio Timenet - Mirai Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
@@ -19112,7 +19112,7 @@ license:CC0
 
 	<software name="sanriotma" cloneof="sanriotm">
 		<!--	In lot check as "dmgatfj1.f15"	-->
-		<description>Sanrio Timenet - Mirai Hen (Jpn, Rev. 1)</description>
+		<description>Sanrio Timenet - Mirai Hen (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
@@ -19131,7 +19131,7 @@ license:CC0
 	</software>
 
 	<software name="santajr">
-		<description>Santa Claus Junior (Euro)</description>
+		<description>Santa Claus Junior (Europe)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-B3JP-EUR"/>
@@ -19144,7 +19144,7 @@ license:CC0
 	</software>
 
 	<software name="sarupnch" cloneof="monkeyp">
-		<description>Saru Puncher (Jpn)</description>
+		<description>Saru Puncher (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSPJ-JPN"/>
@@ -19169,7 +19169,7 @@ license:CC0
 
 	<software name="scooby">
 		<!-- Notes: GBC only -->
-		<description>Scooby-Doo! - Classic Creep Capers (Euro, USA)</description>
+		<description>Scooby-Doo! - Classic Creep Capers (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCCE-USA, CGB-BCCP-EUR-1"/>
@@ -19186,7 +19186,7 @@ license:CC0
 
 	<software name="scrabble">
 		<!-- Notes: GBC only -->
-		<description>Scrabble (Euro)</description>
+		<description>Scrabble (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B9QP-EUR"/>
@@ -19201,7 +19201,7 @@ license:CC0
 	</software>
 
 	<software name="sdhiryux">
-		<description>SD Hiryuu no Ken EX (Jpn)</description>
+		<description>SD Hiryuu no Ken EX (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AUXJ-JPN"/>
@@ -19219,7 +19219,7 @@ license:CC0
 	<software name="seihai">
 		<!--	In lot check as "dmgaeoj0.j01"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Sei Hai Densetsu (Jpn)</description>
+		<description>Sei Hai Densetsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN?"/>
@@ -19237,7 +19237,7 @@ license:CC0
 
 	<software name="seihaiunk" cloneof="seihai">
 		<!-- Old dump of unknown origin -->
-		<description>Sei Hai Densetsu (Jpn, bad dump?)</description>
+		<description>Sei Hai Densetsu (Japan, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN"/>
@@ -19255,7 +19255,7 @@ license:CC0
 	</software>
 
 	<software name="semecom">
-		<description>Seme COM Dungeon - Drururuaga (Jpn)</description>
+		<description>Seme COM Dungeon - Drururuaga (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-BV6J-JPN"/>
@@ -19272,7 +19272,7 @@ license:CC0
 	</software>
 
 	<software name="senkai">
-		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Jpn)</description>
+		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BHSJ-JPN"/>
@@ -19291,7 +19291,7 @@ license:CC0
 
 	<software name="sesamesp">
 		<!-- Notes: GBC only -->
-		<description>Sesame Street Sports (Euro)</description>
+		<description>Sesame Street Sports (Europe)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BSQP-???"/>
@@ -19332,7 +19332,7 @@ license:CC0
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate Classic (Euro, USA, Rev. 1)</description>
+		<description>Shadowgate Classic (Europe, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-EUR"/>
@@ -19353,7 +19353,7 @@ license:CC0
 	</software>
 
 	<software name="shadgatea" cloneof="shadgate">
-		<description>Shadowgate Classic (Aus, USA)</description>
+		<description>Shadowgate Classic (Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-AUS"/>
@@ -19374,7 +19374,7 @@ license:CC0
 	</software>
 
 	<software name="shadgatej" cloneof="shadgate">
-		<description>Shadowgate Return (Jpn)</description>
+		<description>Shadowgate Return (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWJ-JPN"/>
@@ -19392,7 +19392,7 @@ license:CC0
 
 	<software name="shamcrdf">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Jpn)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQUJ-JPN (KIG-12)"/>
@@ -19410,7 +19410,7 @@ license:CC0
 
 	<software name="shamcrdm">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Jpn)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQVJ-JPN (KIG-13)"/>
@@ -19427,7 +19427,7 @@ license:CC0
 	</software>
 
 	<software name="shamus">
-		<description>Shamus (Euro, USA)</description>
+		<description>Shamus (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="DMG-AVXE-USA, DMG-AVXP-EUR"/>
@@ -19443,7 +19443,7 @@ license:CC0
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Euro, Rev. 1)</description>
+		<description>Shanghai Pocket (Europe, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
@@ -19457,7 +19457,7 @@ license:CC0
 	</software>
 
 	<software name="shanghaij" cloneof="shanghai">
-		<description>Shanghai Pocket (Jpn)</description>
+		<description>Shanghai Pocket (Japan)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ASEJ-JPN?"/>
@@ -19521,7 +19521,7 @@ license:CC0
 
 	<software name="shaunsnw">
 		<!-- Notes: GBC only -->
-		<description>Shaun Palmer's Pro Snowboarder (Aus, USA)</description>
+		<description>Shaun Palmer's Pro Snowboarder (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3SE-USA, CGB-B3SP-AUS"/>
@@ -19535,7 +19535,7 @@ license:CC0
 
 	<software name="shinmtaa">
 		<!--	In lot check as "dmgbhnj1.j70"	-->
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn, Rev. 1)</description>
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
@@ -19554,7 +19554,7 @@ license:CC0
 	</software>
 
 	<software name="shinmta" cloneof="shinmtaa">
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn)</description>
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
@@ -19580,7 +19580,7 @@ license:CC0
 
 	<software name="shinmtka">
 		<!--	In lot check as "dmgbhej1.j69"	-->
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn, Rev. 1)</description>
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
@@ -19599,7 +19599,7 @@ license:CC0
 	</software>
 
 	<software name="shinmtk" cloneof="shinmtka">
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn)</description>
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
@@ -19625,7 +19625,7 @@ license:CC0
 
 	<software name="shinmts">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Jpn)</description>
+		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHWJ-JPN"/>
@@ -19650,7 +19650,7 @@ license:CC0
 
 	<software name="shinmtcd">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Trading Card - Card Summoner (Jpn)</description>
+		<description>Shin Megami Tensei Trading Card - Card Summoner (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-BT8J-JPN"/>
@@ -19674,7 +19674,7 @@ license:CC0
 
 	<software name="evangeln">
 		<!-- Notes: GBC only -->
-		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Jpn)</description>
+		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Japan)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQRJ-JPN (KIG-10)"/>
@@ -19692,7 +19692,7 @@ license:CC0
 
 	<software name="shougi2">
 		<!-- Also released by NP in 2000-04 -->
-		<description>Shougi 2 (Jpn)</description>
+		<description>Shougi 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AS8J-JPN (PCPE-10002)"/>
@@ -19707,7 +19707,7 @@ license:CC0
 	</software>
 
 	<software name="shougi3">
-		<description>Shougi 3 (Jpn)</description>
+		<description>Shougi 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-B9SJ-JPN (PCPE-1000?)"/>
@@ -19723,7 +19723,7 @@ license:CC0
 
 	<software name="shrek">
 		<!-- Notes: GBC only -->
-		<description>Shrek - Fairy Tale Freakdown (Euro, USA)</description>
+		<description>Shrek - Fairy Tale Freakdown (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BFUE-USA, CGB-BFUP-EUR"/>
@@ -19740,7 +19740,7 @@ license:CC0
 
 	<software name="shutoku">
 		<!-- Also released by NP in 2000-04 -->
-		<description>The Shutokou Racing (Jpn)</description>
+		<description>The Shutokou Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-ASUJ-JPN (PCPE-10001)"/>
@@ -19759,7 +19759,7 @@ license:CC0
 
 	<software name="simpsons">
 		<!-- Notes: GBC only -->
-		<description>The Simpsons - Night of the Living Treehouse of Horror (Euro, USA)</description>
+		<description>The Simpsons - Night of the Living Treehouse of Horror (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNOE-USA, CGB-BNOP-EUR"/>
@@ -19794,7 +19794,7 @@ license:CC0
 	<software name="sewingose" cloneof="sewingos">
 		<!--	In lot check as "dmgbraz0.k25"	-->
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Sewing Machine Operation Software (Euro)</description>
+		<description>Sewing Machine Operation Software (Europe)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAZ-EUU"/>
@@ -19812,7 +19812,7 @@ license:CC0
 
 	<software name="smurfnig">
 		<!-- Notes: GBC only -->
-		<description>The Smurfs Nightmare (Euro)</description>
+		<description>The Smurfs Nightmare (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ASNP-EUR"/>
@@ -19843,7 +19843,7 @@ license:CC0
 
 	<software name="snobochm">
 		<!-- Notes: GBC only -->
-		<description>Snobow Champion (Jpn)</description>
+		<description>Snobow Champion (Japan)</description>
 		<year>2000</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-B5CJ-JPN"/>
@@ -19859,7 +19859,7 @@ license:CC0
 
 	<software name="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Euro)</description>
+		<description>Snoopy Tennis (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9P-NOE"/>
@@ -19876,7 +19876,7 @@ license:CC0
 
 	<software name="snoopytnj" cloneof="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Jpn)</description>
+		<description>Snoopy Tennis (Japan)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9J-JPN"/>
@@ -19906,7 +19906,7 @@ license:CC0
 
 	<software name="snowhite">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's Snow White and the Seven Dwarfs (Euro)</description>
+		<description>Walt Disney's Snow White and the Seven Dwarfs (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B7DP-EUR"/>
@@ -19937,7 +19937,7 @@ license:CC0
 
 	<software name="snowcros">
 		<!-- Notes: GBC only -->
-		<description>SnowCross (Euro)</description>
+		<description>SnowCross (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-B3OP-EUR"/>
@@ -19951,7 +19951,7 @@ license:CC0
 
 	<software name="socmanag">
 		<!-- Notes: GBC only -->
-		<description>Soccer Manager (Euro)</description>
+		<description>Soccer Manager (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BSMP-EUR"/>
@@ -19967,7 +19967,7 @@ license:CC0
 
 	<software name="solomon" cloneof="mranchex">
 		<!-- Notes: GBC only -->
-		<description>Solomon (Jpn)</description>
+		<description>Solomon (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="CGB-BSOJ-JPN"/>
@@ -19985,7 +19985,7 @@ license:CC0
 
 	<software name="anpan5to">
 		<!-- Notes: GBC only -->
-		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Jpn)</description>
+		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BS2J-JPN"/>
@@ -20002,7 +20002,7 @@ license:CC0
 	</software>
 
 	<software name="anpanfna">
-		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Jpn)</description>
+		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Japan)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AANJ-JPN"/>
@@ -20020,7 +20020,7 @@ license:CC0
 	</software>
 
 	<software name="sokoban">
-		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Jpn)</description>
+		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWIJ-JPN"/>
@@ -20037,7 +20037,7 @@ license:CC0
 	</software>
 
 	<software name="soulget">
-		<description>Soul Getter - Houkago Bouken RPG (Jpn)</description>
+		<description>Soul Getter - Houkago Bouken RPG (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="DMG-AL9J-JPN"/>
@@ -20054,7 +20054,7 @@ license:CC0
 	</software>
 
 	<software name="spaceinv">
-		<description>Space Invaders (Euro, USA)</description>
+		<description>Space Invaders (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AIVE-USA, DMG-AIVP-(EUR/NOE)"/>
@@ -20067,7 +20067,7 @@ license:CC0
 	</software>
 
 	<software name="spaceinvx" cloneof="spaceinv">
-		<description>Space Invaders X (Jpn)</description>
+		<description>Space Invaders X (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSIJ-JPN"/>
@@ -20097,7 +20097,7 @@ license:CC0
 
 	<software name="spacentb">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Blue (Jpn)</description>
+		<description>Space-Net - Cosmo Blue (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BNBJ-JPN"/>
@@ -20115,7 +20115,7 @@ license:CC0
 
 	<software name="spacentr">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Red (Jpn)</description>
+		<description>Space-Net - Cosmo Red (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BREJ-JPN"/>
@@ -20132,7 +20132,7 @@ license:CC0
 	</software>
 
 	<software name="silicon">
-		<description>Spacestation Silicon Valley (Euro)</description>
+		<description>Spacestation Silicon Valley (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AV2P-EUR"/>
@@ -20161,7 +20161,7 @@ license:CC0
 	</software>
 
 	<software name="speedy">
-		<description>Speedy Gonzales - Aztec Adventure (Euro, USA)</description>
+		<description>Speedy Gonzales - Aztec Adventure (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALZE-USA, DMG-ALZP-(NOE/UKV)"/>
@@ -20178,7 +20178,7 @@ license:CC0
 
 	<software name="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Euro, USA)</description>
+		<description>Spider-Man (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEE-USA, CGB-BSEP-EUR"/>
@@ -20192,7 +20192,7 @@ license:CC0
 
 	<software name="spidermnf" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Fra)</description>
+		<description>Spider-Man (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEF-FRA"/>
@@ -20206,7 +20206,7 @@ license:CC0
 
 	<software name="spidermnj" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Jpn)</description>
+		<description>Spider-Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BSEJ-JPN"/>
@@ -20222,7 +20222,7 @@ license:CC0
 
 	<software name="spiderm2">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man 2 - The Sinister Six (Euro, USA)</description>
+		<description>Spider-Man 2 - The Sinister Six (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2SE-USA, CGB-B2SP-EUR"/>
@@ -20239,7 +20239,7 @@ license:CC0
 
 	<software name="spirou">
 		<!-- Notes: GBC only -->
-		<description>Spirou Robbedoes - The Robot Invasion (Euro)</description>
+		<description>Spirou Robbedoes - The Robot Invasion (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSCP-EUR"/>
@@ -20253,7 +20253,7 @@ license:CC0
 
 	<software name="spongebb">
 		<!-- Notes: GBC only -->
-		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Euro, USA)</description>
+		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BQPE-USA, CGB-BQPP-EUR"/>
@@ -20270,7 +20270,7 @@ license:CC0
 
 	<software name="spyvsspy">
 		<!-- Notes: GBC only -->
-		<description>Spy vs. Spy (Euro)</description>
+		<description>Spy vs. Spy (Europe)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6P-EUR"/>
@@ -20285,7 +20285,7 @@ license:CC0
 
 	<software name="spyvsspyj" cloneof="spyvsspy">
 		<!-- Notes: GBC only, also released by NP in 2001-05 -->
-		<description>Spy vs. Spy (Jpn)</description>
+		<description>Spy vs. Spy (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6J-JPN"/>
@@ -20331,7 +20331,7 @@ license:CC0
 	</software>
 
 	<software name="starocbs">
-		<description>Star Ocean - Blue Sphere (Jpn)</description>
+		<description>Star Ocean - Blue Sphere (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BO2J-JPN"/>
@@ -20349,7 +20349,7 @@ license:CC0
 
 	<software name="swep1obi">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Obi-Wan's Adventures (Euro)</description>
+		<description>Star Wars Episode I - Obi-Wan's Adventures (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BOWP-EUR"/>
@@ -20377,7 +20377,7 @@ license:CC0
 
 	<software name="swracer">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Racer (Euro, USA)</description>
+		<description>Star Wars Episode I - Racer (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VYHE-USA, CGB-VYHP-EUR"/>
@@ -20400,7 +20400,7 @@ license:CC0
 	</software>
 
 	<software name="stranded">
-		<description>Stranded Kids (Euro)</description>
+		<description>Stranded Kids (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKP-EUR"/>
@@ -20416,7 +20416,7 @@ license:CC0
 
 	<software name="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Euro)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-AFZP-EUR"/>
@@ -20431,7 +20431,7 @@ license:CC0
 
 	<software name="sfaj" cloneof="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Jpn)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BFZJ-JPN"/>
@@ -20463,7 +20463,7 @@ license:CC0
 
 	<software name="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Euro, USA)</description>
+		<description>Stuart Little - The Journey Home (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIE-USA, CGB-BJIP-UKV"/>
@@ -20480,7 +20480,7 @@ license:CC0
 
 	<software name="stuartla" cloneof="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Euro)</description>
+		<description>Stuart Little - The Journey Home (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIX-EUR"/>
@@ -20497,7 +20497,7 @@ license:CC0
 
 	<software name="sblkbass">
 		<!-- Notes: GBC only -->
-		<description>Super Black Bass - Real Fight (Jpn)</description>
+		<description>Super Black Bass - Real Fight (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-VRFJ-JPN"/>
@@ -20523,7 +20523,7 @@ license:CC0
 
 	<software name="sblkbap3" cloneof="tnnofc">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Super Black Bass Pocket 3 (Jpn)</description>
+		<description>Super Black Bass Pocket 3 (Japan)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ABQJ-JPN"/>
@@ -20541,7 +20541,7 @@ license:CC0
 	</software>
 
 	<software name="sbomblis">
-		<description>Super Bombliss DX (Jpn)</description>
+		<description>Super Bombliss DX (Japan)</description>
 		<year>1999</year>
 		<publisher>Bullet-Proof Software</publisher>
 		<info name="serial" value="DMG-A2OJ-JPN"/>
@@ -20557,7 +20557,7 @@ license:CC0
 	</software>
 
 	<software name="sbrkout">
-		<description>Super Breakout! (Euro)</description>
+		<description>Super Breakout! (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AOTP-EUR"/>
@@ -20584,7 +20584,7 @@ license:CC0
 
 	<software name="supchinf">
 		<!-- Notes: GBC only -->
-		<description>Super Chinese Fighter EX (Jpn)</description>
+		<description>Super Chinese Fighter EX (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-A66J-JPN"/>
@@ -20602,7 +20602,7 @@ license:CC0
 
 	<software name="sdoll">
 		<!-- Notes: GBC only -->
-		<description>Super Doll Licca-chan - Kisekae Daisakusen (Jpn)</description>
+		<description>Super Doll Licca-chan - Kisekae Daisakusen (Japan)</description>
 		<year>2000</year>
 		<publisher>VR1 Japan</publisher>
 		<info name="serial" value="CGB-BSLJ-JPN"/>
@@ -20620,7 +20620,7 @@ license:CC0
 
 	<software name="sgals">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran (Jpn)</description>
+		<description>Super Gals! Kotobuki Ran (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGLJ-JPN (RK251-J1)"/>
@@ -20644,7 +20644,7 @@ license:CC0
 
 	<software name="sgals2">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Jpn)</description>
+		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGUJ-JPN (RK283-J1)"/>
@@ -20663,7 +20663,7 @@ license:CC0
 	<software name="smbdxj" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
 		<!--	In lot check as "POOL\cgbahyj0.0"	-->
-		<description>Super Mario Bros. Deluxe (Jpn, NP)</description>
+		<description>Super Mario Bros. Deluxe (Japan, NP)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -20682,7 +20682,7 @@ license:CC0
 	<software name="smbdxja" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
 		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
-		<description>Super Mario Bros. Deluxe (Jpn, NP, Rev. 1)</description>
+		<description>Super Mario Bros. Deluxe (Japan, NP, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -20702,7 +20702,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. 2)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -20718,7 +20718,7 @@ license:CC0
 
 	<software name="smbdxa" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. 1)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -20734,7 +20734,7 @@ license:CC0
 
 	<software name="smbdxb" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -20750,7 +20750,7 @@ license:CC0
 
 	<software name="smemail">
 		<!-- Notes: GBC only -->
-		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Jpn)</description>
+		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHAJ-JPN"/>
@@ -20768,7 +20768,7 @@ license:CC0
 
 	<software name="srfish">
 		<!-- Notes: GBC only -->
-		<description>Super Real Fishing (Jpn)</description>
+		<description>Super Real Fishing (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-VPFJ-JPN"/>
@@ -20788,7 +20788,7 @@ license:CC0
 
 	<software name="srobopin">
 		<!-- Notes: GBC only -->
-		<description>Super Robot Pinball (Jpn)</description>
+		<description>Super Robot Pinball (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BSUJ-JPN"/>
@@ -20805,7 +20805,7 @@ license:CC0
 	</software>
 
 	<software name="srobotlb">
-		<description>Super Robot Taisen - Link Battler (Jpn)</description>
+		<description>Super Robot Taisen - Link Battler (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AL6J-JPN"/>
@@ -20824,7 +20824,7 @@ license:CC0
 
 	<software name="superx">
 		<!-- Notes: GBC only -->
-		<description>Supercross Freestyle (Euro)</description>
+		<description>Supercross Freestyle (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSXP-EUR"/>
@@ -20840,7 +20840,7 @@ license:CC0
 
 	<software name="supreme">
 		<!-- Notes: GBC only -->
-		<description>Supreme Snowboarding (Euro)</description>
+		<description>Supreme Snowboarding (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AXWP-NOE"/>
@@ -20870,7 +20870,7 @@ license:CC0
 	<software name="survkidsj" cloneof="stranded">
 		<!-- Also released by NP in 2001-02 -->
 		<!--	In lot check as "dmgavkj0.g64"	-->
-		<description>Survival Kids - Kotou no Boukensha (Jpn)</description>
+		<description>Survival Kids - Kotou no Boukensha (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKJ-JPN (RK189-J1)"/>
@@ -20891,7 +20891,7 @@ license:CC0
 	<software name="survkidsjunk" cloneof="stranded">
 		<!-- Also released by NP in 2001-02 -->
 		<!-- Old dump of unknown origin -->
-		<description>Survival Kids - Kotou no Boukensha (Jpn, bad dump?)</description>
+		<description>Survival Kids - Kotou no Boukensha (Japan, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
@@ -20907,7 +20907,7 @@ license:CC0
 	</software>
 
 	<software name="survkid2">
-		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Jpn)</description>
+		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B2VJ-JPN (RK210-J1)"/>
@@ -20927,7 +20927,7 @@ license:CC0
 
 	<software name="suzuki">
 		<!-- Notes: GBC only -->
-		<description>Suzuki Alstare Extreme Racing (Euro)</description>
+		<description>Suzuki Alstare Extreme Racing (Europe)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AXRP-EUR?"/>
@@ -20942,7 +20942,7 @@ license:CC0
 	</software>
 
 	<software name="sweetang">
-		<description>Sweet Ange (Jpn)</description>
+		<description>Sweet Ange (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AUBJ-JPN"/>
@@ -20961,7 +20961,7 @@ license:CC0
 
 	<software name="swing">
 		<!-- Notes: GBC only -->
-		<description>Swing (Ger)</description>
+		<description>Swing (Germany)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="CGB-BSWD-NOE"/>
@@ -20977,7 +20977,7 @@ license:CC0
 
 	<software name="swiv">
 		<!-- Notes: GBC only -->
-		<description>SWIV (Euro)</description>
+		<description>SWIV (Europe)</description>
 		<year>2001</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BSVP-EUR"/>
@@ -20990,7 +20990,7 @@ license:CC0
 	</software>
 
 	<software name="sylvan">
-		<description>Sylvanian Families - Otogi no Kuni no Pendant (Jpn)</description>
+		<description>Sylvanian Families - Otogi no Kuni no Pendant (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ALVJ-JPN"/>
@@ -21014,7 +21014,7 @@ license:CC0
 
 	<software name="sylvan2">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Jpn)</description>
+		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BLVJ-JPN"/>
@@ -21033,7 +21033,7 @@ license:CC0
 
 	<software name="sylvan3">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Jpn)</description>
+		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BL3J-JPN"/>
@@ -21050,7 +21050,7 @@ license:CC0
 	</software>
 
 	<software name="sylvmel">
-		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Jpn)</description>
+		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BMKJ-JPN"/>
@@ -21068,7 +21068,7 @@ license:CC0
 	</software>
 
 	<software name="sylvestr">
-		<description>Sylvester and Tweety - Breakfast on the Run (Euro)</description>
+		<description>Sylvester and Tweety - Breakfast on the Run (Europe)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AYRP-NOE, DMG-AYRP-UKV, DMG-AYRP-EUR)"/>
@@ -21082,7 +21082,7 @@ license:CC0
 
 	<software name="tabaluga">
 		<!-- Notes: GBC only -->
-		<description>Tabaluga (Ger)</description>
+		<description>Tabaluga (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ALUP-NOE"/>
@@ -21096,7 +21096,7 @@ license:CC0
 
 	<software name="ttshogi">
 		<!-- NP only -->
-		<description>Taisen Tsumeshougi (Jpn, NP)</description>
+		<description>Taisen Tsumeshougi (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-BTSJ-JPN"/>
@@ -21111,7 +21111,7 @@ license:CC0
 	</software>
 
 	<software name="bublboblj" cloneof="bublbobl">
-		<description>Taito Memorial - Bubble Bobble (Jpn)</description>
+		<description>Taito Memorial - Bubble Bobble (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJBJ-JPN"/>
@@ -21127,7 +21127,7 @@ license:CC0
 	</software>
 
 	<software name="chasehqj" cloneof="chasehq">
-		<description>Taito Memorial - Chase H.Q. - Secret Police (Jpn)</description>
+		<description>Taito Memorial - Chase H.Q. - Secret Police (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJCJ-JPN"/>
@@ -21143,7 +21143,7 @@ license:CC0
 	</software>
 
 	<software name="tophant">
-		<description>Tales of Phantasia - Narikiri Dungeon (Jpn)</description>
+		<description>Tales of Phantasia - Narikiri Dungeon (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AN6J-JPN"/>
@@ -21161,7 +21161,7 @@ license:CC0
 	</software>
 
 	<software name="donqix">
-		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Jpn)</description>
+		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BDHJ-JPN"/>
@@ -21180,7 +21180,7 @@ license:CC0
 
 	<software name="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Euro, USA)</description>
+		<description>Disney's Tarzan (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHE-USA, CGB-ATHP-UKV"/>
@@ -21194,7 +21194,7 @@ license:CC0
 
 	<software name="tarzanf" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Fra)</description>
+		<description>Disney's Tarzan (France)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHF-FRA"/>
@@ -21211,7 +21211,7 @@ license:CC0
 
 	<software name="tarzang" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Ger)</description>
+		<description>Disney's Tarzan (Germany)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHD-NOE"/>
@@ -21225,7 +21225,7 @@ license:CC0
 
 	<software name="tarzanj" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Jpn)</description>
+		<description>Disney's Tarzan (Japan)</description>
 		<year>2000</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-BTHJ-JPN"/>
@@ -21240,7 +21240,7 @@ license:CC0
 	</software>
 
 	<software name="taxi2">
-		<description>Taxi 2 (Fra)</description>
+		<description>Taxi 2 (France)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BT2F-FRA"/>
@@ -21254,7 +21254,7 @@ license:CC0
 	</software>
 
 	<software name="taxi3">
-		<description>Taxi 3 (Fra)</description>
+		<description>Taxi 3 (France)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BXIF-FRA"/>
@@ -21270,7 +21270,7 @@ license:CC0
 	</software>
 
 	<software name="tazmandv">
-		<description>Tazmanian Devil - Munching Madness (Euro)</description>
+		<description>Tazmanian Devil - Munching Madness (Europe)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AVZP-UKV"/>
@@ -21297,7 +21297,7 @@ license:CC0
 
 	<software name="techdeck">
 		<!-- Notes: GBC only -->
-		<description>Tech Deck Skateboarding (Euro, USA)</description>
+		<description>Tech Deck Skateboarding (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTUE-USA, CGB-BTUP-EUR"/>
@@ -21326,7 +21326,7 @@ license:CC0
 	</software>
 
 	<software name="td6a" cloneof="td6">
-		<description>Test Drive 6 (Euro, Sample 'Destinations Toutes Sensations')</description>
+		<description>Test Drive 6 (Europe, Sample 'Destinations Toutes Sensations')</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -21340,7 +21340,7 @@ license:CC0
 	</software>
 
 	<software name="td6">
-		<description>Test Drive 6 (Euro)</description>
+		<description>Test Drive 6 (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AW6P-EUR"/>
@@ -21426,7 +21426,7 @@ license:CC0
 
 	<software name="tetrisad" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN"/>
@@ -21446,7 +21446,7 @@ license:CC0
 	<software name="tetrisada" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbat7j1.070"	-->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn, Rev. 1)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN?"/>
@@ -21483,7 +21483,7 @@ license:CC0
 
 	<software name="tgrall2a" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>TG Rally 2 (Euro)</description>
+		<description>TG Rally 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33X-UKV"/>
@@ -21505,7 +21505,7 @@ license:CC0
 	</software>
 
 	<software name="3lions" cloneof="goldgoal">
-		<description>Three Lions (Euro)</description>
+		<description>Three Lions (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFP-UKV"/>
@@ -21521,7 +21521,7 @@ license:CC0
 
 	<software name="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Euro, English / French / German / Italian / Spanish)</description>
+		<description>Thunderbirds (Europe, English / French / German / Italian / Spanish)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNX-EUR"/>
@@ -21538,7 +21538,7 @@ license:CC0
 
 	<software name="tbirdsa" cloneof="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Euro)</description>
+		<description>Thunderbirds (Europe)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNP-UKV"/>
@@ -21551,7 +21551,7 @@ license:CC0
 	</software>
 
 	<software name="twoods2k">
-		<description>Tiger Woods PGA Tour 2000 (Euro, USA)</description>
+		<description>Tiger Woods PGA Tour 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYGE-USA, DMG-AYGP-EUR"/>
@@ -21568,7 +21568,7 @@ license:CC0
 
 	<software name="tintin">
 		<!-- Notes: GBC only -->
-		<description>Tintin in Tibet (Euro)</description>
+		<description>Tintin in Tibet (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin au Tibet (Box)"/>
@@ -21583,7 +21583,7 @@ license:CC0
 
 	<software name="ttoonbsd">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Buster Saves the Day (Euro)</description>
+		<description>Tiny Toon Adventures - Buster Saves the Day (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BUSP-EUR"/>
@@ -21611,7 +21611,7 @@ license:CC0
 
 	<software name="ttoondiz">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Euro)</description>
+		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BDQP-EUR"/>
@@ -21626,7 +21626,7 @@ license:CC0
 
 	<software name="titi" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Titi - Le Tour du Monde en 80 Chats (Fra)</description>
+		<description>Titi - Le Tour du Monde en 80 Chats (France)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWF-FRA"/>
@@ -21641,7 +21641,7 @@ license:CC0
 	</software>
 
 	<software name="titus">
-		<description>Titus the Fox to Marrakech and Back (Euro)</description>
+		<description>Titus the Fox to Marrakech and Back (Europe)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-BFXP-EUR"/>
@@ -21684,7 +21684,7 @@ license:CC0
 
 	<software name="toca">
 		<!-- Notes: GBC only -->
-		<description>TOCA Touring Car Championship (Euro, USA)</description>
+		<description>TOCA Touring Car Championship (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTCE-USA, CGB-BTCP-EUR"/>
@@ -21698,7 +21698,7 @@ license:CC0
 
 	<software name="tokitori">
 		<!-- Notes: GBC only -->
-		<description>Toki Tori (Euro, USA)</description>
+		<description>Toki Tori (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2TE-USA, CGB-B2TP-EUR"/>
@@ -21713,7 +21713,7 @@ license:CC0
 	</software>
 
 	<software name="tokimclt">
-		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Jpn)</description>
+		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AC7J-JPN (RK172-J1)"/>
@@ -21731,7 +21731,7 @@ license:CC0
 	</software>
 
 	<software name="tokimspt">
-		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Jpn)</description>
+		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AS7J-JPN (RK171-J1)"/>
@@ -21749,7 +21749,7 @@ license:CC0
 	</software>
 
 	<software name="tokoro">
-		<description>Tokoro-san no Setagaya C.C. (Jpn)</description>
+		<description>Tokoro-san no Setagaya C.C. (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BGBJ-JPN"/>
@@ -21769,7 +21769,7 @@ license:CC0
 
 	<software name="tomjerry">
 		<!-- Notes: GBC only -->
-		<description>Tom &amp; Jerry (Euro, USA)</description>
+		<description>Tom &amp; Jerry (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-ATXE-USA, CGB-ATXP-EUR"/>
@@ -21786,7 +21786,7 @@ license:CC0
 
 	<software name="tomjermh">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry - Mousehunt (Euro)</description>
+		<description>Tom and Jerry - Mousehunt (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
@@ -21802,7 +21802,7 @@ license:CC0
 	<software name="tomjermha" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbtjp1.487"	-->
-		<description>Tom and Jerry - Mousehunt (Euro, Rev. 1)</description>
+		<description>Tom and Jerry - Mousehunt (Europe, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
@@ -21847,7 +21847,7 @@ license:CC0
 
 	<software name="tomjerma">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry in Mouse Attacks! (Euro)</description>
+		<description>Tom and Jerry in Mouse Attacks! (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTQP-EUR"/>
@@ -21876,7 +21876,7 @@ license:CC0
 
 	<software name="rainbow6">
 		<!-- Notes: GBC only -->
-		<description>Tom Clancy's Rainbow Six (Euro, USA)</description>
+		<description>Tom Clancy's Rainbow Six (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-AR6E-USA, CGB-AR6P-EUR"/>
@@ -21898,7 +21898,7 @@ license:CC0
 
 	<software name="traid">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider (Euro, USA)</description>
+		<description>Tomb Raider (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="alt_title" value="Tomb Raider Starring Lara Croft (US Box)"/>
@@ -21920,7 +21920,7 @@ license:CC0
 	</software>
 
 	<software name="traidp" cloneof="traid">
-		<description>Tomb Raider (Euro, USA, Prototype)</description>
+		<description>Tomb Raider (Europe, USA, Prototype)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -21935,7 +21935,7 @@ license:CC0
 
 	<software name="traid2">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider - Curse of the Sword (Euro, USA)</description>
+		<description>Tomb Raider - Curse of the Sword (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="alt_title" value="Lara Croft - Tomb Raider - Curse of the Sword (Box)"/>
@@ -21958,7 +21958,7 @@ license:CC0
 
 	<software name="tonictr">
 		<!-- Notes: GBC only -->
-		<description>Tonic Trouble (Euro)</description>
+		<description>Tonic Trouble (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AXTP-EUR"/>
@@ -21987,7 +21987,7 @@ license:CC0
 
 	<software name="tonkarac">
 		<!-- Notes: GBC only -->
-		<description>Tonka Raceway (Euro)</description>
+		<description>Tonka Raceway (Europe)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ATQP-EUR"/>
@@ -22037,7 +22037,7 @@ license:CC0
 
 	<software name="thps">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTFE-USA-1, CGB-BTFP-EUR"/>
@@ -22055,7 +22055,7 @@ license:CC0
 
 	<software name="thps2">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 2 (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTGE-USA, CGB-BTGE-USA-1, CGB-BTGP-EUR"/>
@@ -22072,7 +22072,7 @@ license:CC0
 
 	<software name="thps3">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 3 (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater 3 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3TE-USA, CGB-B3TP-EUR"/>
@@ -22108,7 +22108,7 @@ license:CC0
 
 	<software name="toonsylv">
 		<!-- Notes: GBC only -->
-		<description>Toonsylvania (Euro)</description>
+		<description>Toonsylvania (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSYP-EUR"/>
@@ -22136,7 +22136,7 @@ license:CC0
 
 	<software name="tootuff">
 		<!-- Notes: GBC only -->
-		<description>Tootuff (Euro)</description>
+		<description>Tootuff (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BT9P-UKV"/>
@@ -22150,7 +22150,7 @@ license:CC0
 
 	<software name="topgearj" cloneof="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket (Jpn)</description>
+		<description>Top Gear Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRJ-JPN"/>
@@ -22186,7 +22186,7 @@ license:CC0
 
 	<software name="topgear2j" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket 2 (Jpn)</description>
+		<description>Top Gear Pocket 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-V33J-JPN"/>
@@ -22224,7 +22224,7 @@ license:CC0
 
 	<software name="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally (Euro)</description>
+		<description>Top Gear Rally (Europe)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRP-(NOE/UKV)"/>
@@ -22239,7 +22239,7 @@ license:CC0
 
 	<software name="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally 2 (Euro)</description>
+		<description>Top Gear Rally 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33P-(EUR/FRA)"/>
@@ -22256,7 +22256,7 @@ license:CC0
 
 	<software name="topgunfs">
 		<!-- Notes: GBC only -->
-		<description>Top Gun - Fire Storm (Euro, USA)</description>
+		<description>Top Gun - Fire Storm (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BICE-USA, CGB-BICP-EUR"/>
@@ -22273,7 +22273,7 @@ license:CC0
 
 	<software name="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Total Soccer 2000 (Euro)</description>
+		<description>Total Soccer 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="David O'Leary's Total Soccer 2000 (Box)"/>
@@ -22289,7 +22289,7 @@ license:CC0
 	</software>
 
 	<software name="totsuge">
-		<description>Totsugeki! Papparatai (Jpn)</description>
+		<description>Totsugeki! Papparatai (Japan)</description>
 		<year>2000</year>
 		<publisher>J-WIng</publisher>
 		<info name="serial" value="DMG-APHJ-JPN"/>
@@ -22308,7 +22308,7 @@ license:CC0
 
 	<software name="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn, Rev. 1)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22333,7 +22333,7 @@ license:CC0
 
 	<software name="tottokha" cloneof="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22352,7 +22352,7 @@ license:CC0
 
 	<software name="tottokh2" cloneof="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Jpn)</description>
+		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86J-JPN"/>
@@ -22370,7 +22370,7 @@ license:CC0
 
 	<software name="towers">
 		<!-- Notes: GBC only -->
-		<description>Towers - Lord Baniff's Deceit (Euro, USA)</description>
+		<description>Towers - Lord Baniff's Deceit (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-ALHE-USA, CGB-ALHP-EUR"/>
@@ -22385,7 +22385,7 @@ license:CC0
 	</software>
 
 	<software name="toystor2">
-		<description>Toy Story 2 (Euro, USA)</description>
+		<description>Toy Story 2 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AOQE-USA, DMG-AOQP-(FRA/UKV)"/>
@@ -22402,7 +22402,7 @@ license:CC0
 
 	<software name="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Euro)</description>
+		<description>Toy Story Racer (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5X-EUU"/>
@@ -22416,7 +22416,7 @@ license:CC0
 
 	<software name="toystracu" cloneof="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Euro, USA)</description>
+		<description>Toy Story Racer (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5E-USA, CGB-BT5P-EUR"/>
@@ -22435,7 +22435,7 @@ license:CC0
 		<!--	Never released as physical cartridge	-->
 		<!--	Released on the 3DS Virtual Console	-->
 		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
-		<description>Trade &amp; Battle Card Hero (Jpn, Rev. 1)</description>
+		<description>Trade &amp; Battle Card Hero (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
@@ -22453,7 +22453,7 @@ license:CC0
 	</software>
 
 	<software name="tradebat" cloneof="tradebata">
-		<description>Trade &amp; Battle Card Hero (Jpn)</description>
+		<description>Trade &amp; Battle Card Hero (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
@@ -22474,7 +22474,7 @@ license:CC0
 
 	<software name="trickbrd">
 		<!-- Notes: GBC only -->
-		<description>Trick Boarder (Euro)</description>
+		<description>Trick Boarder (Europe)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BTBP-EUR"/>
@@ -22505,7 +22505,7 @@ license:CC0
 
 	<software name="trickbrdj" cloneof="trickbrd">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Trickboarder GP (Jpn)</description>
+		<description>Trickboarder GP (Japan)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BTBJ-JPN"/>
@@ -22521,7 +22521,7 @@ license:CC0
 
 	<software name="tplay2k1">
 		<!-- Notes: GBC only -->
-		<description>Triple Play 2001 (Euro, USA)</description>
+		<description>Triple Play 2001 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTPE-USA, CGB-BTPP-EUR"/>
@@ -22551,7 +22551,7 @@ license:CC0
 	</software>
 
 	<software name="tsurisn2">
-		<description>Tsuri Sensei 2 (Jpn)</description>
+		<description>Tsuri Sensei 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN"/>
@@ -22574,7 +22574,7 @@ license:CC0
 	<software name="tsurisn2a" cloneof="tsurisn2">
 		<!--	In lot check as "dmga2kj1.g93"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Tsuri Sensei 2 (Jpn, Rev. 1)</description>
+		<description>Tsuri Sensei 2 (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN?"/>
@@ -22593,7 +22593,7 @@ license:CC0
 
 	<software name="tsuriiko">
 		<!-- Notes: GBC only -->
-		<description>Tsuriiko!! (Jpn)</description>
+		<description>Tsuriiko!! (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BAFJ-JPN"/>
@@ -22610,7 +22610,7 @@ license:CC0
 	</software>
 
 	<software name="turok2">
-		<description>Turok 2 - Seeds of Evil (Euro, USA)</description>
+		<description>Turok 2 - Seeds of Evil (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-A2TE-USA, DMG-A2TP-EUR"/>
@@ -22626,7 +22626,7 @@ license:CC0
 	</software>
 
 	<software name="turok2j" cloneof="turok2">
-		<description>Turok 2 - Seeds of Evil (Jpn)</description>
+		<description>Turok 2 - Seeds of Evil (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-A2TJ-JPN"/>
@@ -22642,7 +22642,7 @@ license:CC0
 
 	<software name="turok3">
 		<!-- Notes: GBC only -->
-		<description>Turok 3 - Shadow of Oblivion (Euro, USA)</description>
+		<description>Turok 3 - Shadow of Oblivion (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BT3E-USA, CGB-BT3P-EUR"/>
@@ -22660,7 +22660,7 @@ license:CC0
 	<software name="turokrag">
 		<!-- Notes: GBC only -->
 		<!--	Retail cartridge of Australian version not yet secured, does it exist?	-->
-		<description>Turok - Rage Wars (Euro, Aus, USA)</description>
+		<description>Turok - Rage Wars (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AR7E-USA, CGB-AR7P-(EUR/AUS)"/>
@@ -22677,7 +22677,7 @@ license:CC0
 
 	<software name="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Euro, English / German / Spanish / Italian)</description>
+		<description>Tweenies - Doodles' Bones (Europe, English / German / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZP-UKV"/>
@@ -22691,7 +22691,7 @@ license:CC0
 
 	<software name="tweeniesds" cloneof="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Euro, English / Dutch / Swedish / Norwegian / Danish)</description>
+		<description>Tweenies - Doodles' Bones (Europe, English / Dutch / Swedish / Norwegian / Danish)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZX-HOL"/>
@@ -22708,7 +22708,7 @@ license:CC0
 
 	<software name="tweetyj" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Jpn)</description>
+		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Japan)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWJ-JPN"/>
@@ -22726,7 +22726,7 @@ license:CC0
 
 	<software name="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Euro, English / Spanish / Italian)</description>
+		<description>Tweety's High-Flying Adventure (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWY-EUU-1"/>
@@ -22748,7 +22748,7 @@ license:CC0
 
 	<software name="tweetya" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Euro, English / French / German)</description>
+		<description>Tweety's High-Flying Adventure (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWX-UKV-1"/>
@@ -22816,7 +22816,7 @@ license:CC0
 
 	<software name="rpgtsuk2">
 		<!-- Notes: GBC only -->
-		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Jpn)</description>
+		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-B3QJ-JPN"/>
@@ -22834,7 +22834,7 @@ license:CC0
 
 	<software name="uefa2k">
 		<!-- Notes: GBC only -->
-		<description>UEFA 2000 (Euro)</description>
+		<description>UEFA 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BUEP-(EUR/NOE/FRA/UKV)"/>
@@ -22850,7 +22850,7 @@ license:CC0
 
 	<software name="ufc">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Fighting Championship (Euro)</description>
+		<description>Ultimate Fighting Championship (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUCP-EUR-1"/>
@@ -22881,7 +22881,7 @@ license:CC0
 
 	<software name="ultpaint">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Paint Ball (Euro, USA)</description>
+		<description>Ultimate Paint Ball (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BUPE-USA, CGB-BUPP-EUR"/>
@@ -22895,7 +22895,7 @@ license:CC0
 
 	<software name="ultsurf">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Surfing (Euro)</description>
+		<description>Ultimate Surfing (Europe)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BSUP-EUR"/>
@@ -22925,7 +22925,7 @@ license:CC0
 	</software>
 
 	<software name="uno">
-		<description>Uno (Euro)</description>
+		<description>Uno (Europe)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AUNP-EUR"/>
@@ -22952,7 +22952,7 @@ license:CC0
 
 	<software name="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Euro)</description>
+		<description>V-Rally - Championship Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AVYP-NOE"/>
@@ -22966,7 +22966,7 @@ license:CC0
 
 	<software name="vrallyj" cloneof="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Jpn)</description>
+		<description>V-Rally - Championship Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-AVJJ-JPN"/>
@@ -22997,7 +22997,7 @@ license:CC0
 
 	<software name="vegas">
 		<!-- Notes: GBC only -->
-		<description>Vegas Games (Euro)</description>
+		<description>Vegas Games (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFP-EUR"/>
@@ -23048,7 +23048,7 @@ license:CC0
 		<!-- The US box of V.I.P usually contains the european cart. This was also shown on a youtube unboxing video with a sealed copy. Therefore the dump is labeled USA + Europe.
 		But recently it was discovered some boxes also contain a real US shaped cart (see vipu below). -->
 		<!-- Notes: GBC only -->
-		<description>VIP (Euro, USA)</description>
+		<description>VIP (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BVIE-USA, CGB-BVIP-EUR"/>
@@ -23078,7 +23078,7 @@ license:CC0
 	</software>
 
 	<software name="visiteur">
-		<description>Les Visiteurs (Fra)</description>
+		<description>Les Visiteurs (France)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AVGF-FRA"/>
@@ -23109,7 +23109,7 @@ license:CC0
 
 	<software name="vslemmin" cloneof="lemmings">
 		<!-- Notes: GBC only -->
-		<description>VS Lemmings (Jpn)</description>
+		<description>VS Lemmings (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-ALEJ-JPN"/>
@@ -23128,7 +23128,7 @@ license:CC0
 
 	<software name="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Wacky Races (Euro)</description>
+		<description>Wacky Races (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AW9P-(NOE/UKV)"/>
@@ -23156,7 +23156,7 @@ license:CC0
 
 	<software name="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Euro, USA)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDE-USA, CGB-BWDP-UKV"/>
@@ -23173,7 +23173,7 @@ license:CC0
 
 	<software name="magraceta" cloneof="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Euro)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Europe)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDX-EUR"/>
@@ -23190,7 +23190,7 @@ license:CC0
 
 	<software name="warauinu">
 		<!-- Notes: GBC only -->
-		<description>Warau Inu no Bouken - Silly Go Lucky! (Jpn)</description>
+		<description>Warau Inu no Bouken - Silly Go Lucky! (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BWBJ-JPN"/>
@@ -23213,7 +23213,7 @@ license:CC0
 	</software>
 
 	<software name="wario2j" cloneof="wario2">
-		<description>Wario Land 2 (Jpn)</description>
+		<description>Wario Land 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AW2J-JPN"/>
@@ -23256,7 +23256,7 @@ license:CC0
 
 	<software name="wario2">
 		<!-- Notes: GBC only -->
-		<description>Wario Land II (Euro, USA)</description>
+		<description>Wario Land II (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWLE-USA, DMG-AWLP-EUR"/>
@@ -23310,7 +23310,7 @@ license:CC0
 
 	<software name="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Jpn, Rev. 1)</description>
+		<description>Watashi no Kitchen (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23328,7 +23328,7 @@ license:CC0
 
 	<software name="watashika" cloneof="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Jpn)</description>
+		<description>Watashi no Kitchen (Japan)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23352,7 +23352,7 @@ license:CC0
 
 	<software name="watashir">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Restaurant (Jpn)</description>
+		<description>Watashi no Restaurant (Japan)</description>
 		<year>2002</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BWNJ-JPN"/>
@@ -23371,7 +23371,7 @@ license:CC0
 
 	<software name="wcwmayhm">
 		<!-- Notes: GBC only -->
-		<description>WCW Mayhem (Euro, USA)</description>
+		<description>WCW Mayhem (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AYHE-USA, CGB-AYHP-NOE"/>
@@ -23388,7 +23388,7 @@ license:CC0
 
 	<software name="wendy">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Every Witch Way (Euro, USA)</description>
+		<description>Wendy - Every Witch Way (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWGE-USA, CGB-BWGP-EUR"/>
@@ -23405,7 +23405,7 @@ license:CC0
 
 	<software name="wendydta">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Der Traum von Arizona (Ger)</description>
+		<description>Wendy - Der Traum von Arizona (Germany)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWYD-NOE"/>
@@ -23420,7 +23420,7 @@ license:CC0
 
 	<software name="wetrix">
 		<!-- Notes: GBC only -->
-		<description>Wetrix GB (Euro)</description>
+		<description>Wetrix GB (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Wetrix (Box)"/>
@@ -23434,7 +23434,7 @@ license:CC0
 	</software>
 
 	<software name="wetrixj" cloneof="wetrix">
-		<description>Wetrix GB (Jpn)</description>
+		<description>Wetrix GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AW5J-JPN"/>
@@ -23478,7 +23478,7 @@ license:CC0
 	</software>
 
 	<software name="wingfury">
-		<description>Wings of Fury (Euro)</description>
+		<description>Wings of Fury (Europe)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-AFXP-EUR"/>
@@ -23505,7 +23505,7 @@ license:CC0
 
 	<software name="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Euro)</description>
+		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BPOP-EUR-1"/>
@@ -23537,7 +23537,7 @@ license:CC0
 
 	<software name="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Jpn, Rev. 1)</description>
+		<description>Wizardry Empire (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23555,7 +23555,7 @@ license:CC0
 
 	<software name="wizardema" cloneof="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Jpn)</description>
+		<description>Wizardry Empire (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23573,7 +23573,7 @@ license:CC0
 
 	<software name="wizarde2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire - Fukkatsu no Tsue (Jpn)</description>
+		<description>Wizardry Empire - Fukkatsu no Tsue (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-BFTJ-JPN"/>
@@ -23591,7 +23591,7 @@ license:CC0
 
 	<software name="wizardry">
 		<!-- Notes: GBC only -->
-		<description>Wizardry I - Proving Grounds of the Mad Overlord (Jpn)</description>
+		<description>Wizardry I - Proving Grounds of the Mad Overlord (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BWIJ-JPN"/>
@@ -23609,7 +23609,7 @@ license:CC0
 
 	<software name="wizardr2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry II - Llylgamyn no Isan (Jpn)</description>
+		<description>Wizardry II - Llylgamyn no Isan (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW2J-JPN"/>
@@ -23627,7 +23627,7 @@ license:CC0
 
 	<software name="wizardr3">
 		<!-- Notes: GBC only -->
-		<description>Wizardry III - Diamond no Kishi (Jpn)</description>
+		<description>Wizardry III - Diamond no Kishi (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW3J-JPN"/>
@@ -23645,7 +23645,7 @@ license:CC0
 
 	<software name="woody">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker (Euro)</description>
+		<description>Woody Woodpecker (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BWPP-EUR"/>
@@ -23673,7 +23673,7 @@ license:CC0
 
 	<software name="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker Racing (Euro)</description>
+		<description>Woody Woodpecker Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRP-EUR"/>
@@ -23695,7 +23695,7 @@ license:CC0
 
 	<software name="woodyracj" cloneof="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker no Go! Go! Racing (Jpn)</description>
+		<description>Woody Woodpecker no Go! Go! Racing (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRJ-JPN (RK225-J1)"/>
@@ -23743,7 +23743,7 @@ license:CC0
 
 	<software name="wsoccr2k" cloneof="iss2k">
 		<!-- Notes: GBC only -->
-		<description>World Soccer GB 2000 (Jpn)</description>
+		<description>World Soccer GB 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSJ-JPN (RK200-J1)"/>
@@ -23760,7 +23760,7 @@ license:CC0
 	</software>
 
 	<software name="wsoccer2" cloneof="iss99">
-		<description>World Soccer GB2 (Jpn)</description>
+		<description>World Soccer GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZJ-JPN (RK176-J1)"/>
@@ -23779,7 +23779,7 @@ license:CC0
 
 	<software name="wormsarm">
 		<!-- Notes: GBC only -->
-		<description>Worms Armageddon (Euro)</description>
+		<description>Worms Armageddon (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AWUP-(UKV/NOE)"/>
@@ -23810,7 +23810,7 @@ license:CC0
 
 	<software name="wwfattit">
 		<!-- Notes: GBC only -->
-		<description>WWF Attitude (Euro, USA)</description>
+		<description>WWF Attitude (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AWTE-USA, CGB-AWTP-EUR"/>
@@ -23827,7 +23827,7 @@ license:CC0
 
 	<software name="wwfbtray">
 		<!-- Notes: GBC only -->
-		<description>WWF Betrayal (Euro, USA)</description>
+		<description>WWF Betrayal (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BWFE-USA, CGB-BWFP-EUR"/>
@@ -23843,7 +23843,7 @@ license:CC0
 	</software>
 
 	<software name="wmania2k">
-		<description>WWF WrestleMania 2000 (Euro, USA)</description>
+		<description>WWF WrestleMania 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AUWE-USA, DMG-AUWP-EUR"/>
@@ -23860,7 +23860,7 @@ license:CC0
 
 	<software name="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Euro, USA, Rev. 1)</description>
+		<description>X-Men - Mutant Academy (Europe, USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-NOE"/>
@@ -23877,7 +23877,7 @@ license:CC0
 
 	<software name="xmenma1" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Euro, USA)</description>
+		<description>X-Men - Mutant Academy (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-UKV"/>
@@ -23894,7 +23894,7 @@ license:CC0
 
 	<software name="xmenmaj" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Jpn)</description>
+		<description>X-Men - Mutant Academy (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BXAJ-JPN"/>
@@ -23910,7 +23910,7 @@ license:CC0
 
 	<software name="xmenmw">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Wars (Euro, USA)</description>
+		<description>X-Men - Mutant Wars (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXME-USA, CGB-BXMP-EUR"/>
@@ -23927,7 +23927,7 @@ license:CC0
 
 	<software name="wolvrage">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Wolverine's Rage (Euro)</description>
+		<description>X-Men - Wolverine's Rage (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWOP-EUR"/>
@@ -23958,7 +23958,7 @@ license:CC0
 
 	<software name="xena">
 		<!-- Notes: GBC only -->
-		<description>Xena - Warrior Princess (Euro, USA)</description>
+		<description>Xena - Warrior Princess (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BXWE-USA, CGB-BXWP-EUR"/>
@@ -23990,7 +23990,7 @@ license:CC0
 
 	<software name="xtremew">
 		<!-- Notes: GBC only -->
-		<description>Xtreme Wheels (Euro)</description>
+		<description>Xtreme Wheels (Europe)</description>
 		<year>2001</year>
 		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-BXCP-EUR"/>
@@ -24026,7 +24026,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaytj0.066"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Yakouchuu GB (Jpn)</description>
+		<description>Yakouchuu GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
@@ -24046,7 +24046,7 @@ license:CC0
 	<software name="yakouchuunk" cloneof="yakouchu">
 		<!-- Notes: GBC only -->
 		<!-- Old dump of unknown origin -->
-		<description>Yakouchuu GB (Jpn, bad dump?)</description>
+		<description>Yakouchuu GB (Japan, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
@@ -24064,7 +24064,7 @@ license:CC0
 
 
 	<software name="yarsrev">
-		<description>Yars' Revenge (Euro, USA)</description>
+		<description>Yars' Revenge (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="DMG-AYVE-USA, DMG-AYVP-EUR"/>
@@ -24077,7 +24077,7 @@ license:CC0
 	</software>
 
 	<software name="yodastor">
-		<description>Yoda Stories (Euro, USA)</description>
+		<description>Yoda Stories (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYDE-USA, DMG-AYDP-EUR"/>
@@ -24105,7 +24105,7 @@ license:CC0
 
 	<software name="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Dark Duel Stories (Euro)</description>
+		<description>Yu-Gi-Oh! - Dark Duel Stories (Europe)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3P-EUR"/>
@@ -24128,7 +24128,7 @@ license:CC0
 
 	<software name="yugiddsf" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duel des Tenebres (Fra)</description>
+		<description>Yu-Gi-Oh! - Duel des Tenebres (France)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3F-FRA-1"/>
@@ -24151,7 +24151,7 @@ license:CC0
 
 	<software name="yugiddsg" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Das Dunkle Duell (Ger)</description>
+		<description>Yu-Gi-Oh! - Das Dunkle Duell (Germany)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3D-NOE"/>
@@ -24174,7 +24174,7 @@ license:CC0
 
 	<software name="yugiddsi" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Racconti Oscuri (Ita)</description>
+		<description>Yu-Gi-Oh! - Racconti Oscuri (Italia)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3I-ITA"/>
@@ -24197,7 +24197,7 @@ license:CC0
 
 	<software name="yugiddss" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spa)</description>
+		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spain)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3S-ESP"/>
@@ -24238,7 +24238,7 @@ license:CC0
 
 	<software name="yugimcap">
 		<!-- Also released by NP in 2001-02-01 -->
-		<description>Yu-Gi-Oh! - Monster Capsule GB (Jpn)</description>
+		<description>Yu-Gi-Oh! - Monster Capsule GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYCJ-JPN (RK206-J1)"/>
@@ -24258,7 +24258,7 @@ license:CC0
 
 	<software name="yugidm4j">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY6J-JPN (RK228-J1)"/>
@@ -24282,7 +24282,7 @@ license:CC0
 
 	<software name="yugidm4k">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY5J-JPN (RK229-J1)"/>
@@ -24300,7 +24300,7 @@ license:CC0
 
 	<software name="yugidm4y">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY4J-JPN (RK227-J1)"/>
@@ -24323,7 +24323,7 @@ license:CC0
 	</software>
 
 	<software name="yugidm2">
-		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYKJ-JPN (RK188-J1)"/>
@@ -24347,7 +24347,7 @@ license:CC0
 
 	<software name="yugidm3" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3J-JPN (RK211-J1)"/>
@@ -24390,7 +24390,7 @@ license:CC0
 
 	<software name="zeldadai">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Jpn)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7J-JPN"/>
@@ -24408,7 +24408,7 @@ license:CC0
 
 	<software name="zeldajik">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Jpn)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8J-JPN"/>
@@ -24426,7 +24426,7 @@ license:CC0
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. 2)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24451,7 +24451,7 @@ license:CC0
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. 1)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24470,7 +24470,7 @@ license:CC0
 
 	<software name="zeldaldxjb" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24489,7 +24489,7 @@ license:CC0
 
 	<software name="znsst">
 		<!-- Notes: GBC only -->
-		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Jpn)</description>
+		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BJFJ-JPN"/>
@@ -24507,7 +24507,7 @@ license:CC0
 
 	<software name="zidane">
 		<!-- Notes: GBC only -->
-		<description>Zidane Football Generation (Euro)</description>
+		<description>Zidane Football Generation (Europe)</description>
 		<year>2002</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BZSP-EUR"/>
@@ -24536,7 +24536,7 @@ license:CC0
 	</software>
 
 	<software name="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. 1)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
@@ -24554,7 +24554,7 @@ license:CC0
 	</software>
 
 	<software name="zoidsjasa" cloneof="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
@@ -24573,7 +24573,7 @@ license:CC0
 
 	<software name="zoidsshi">
 		<!-- Notes: GBC only -->
-		<description>Zoids - Shirogane no Juukishin Liger Zero (Jpn)</description>
+		<description>Zoids - Shirogane no Juukishin Liger Zero (Japan)</description>
 		<year>2001</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BZ2J-JPN"/>
@@ -24602,7 +24602,7 @@ license:CC0
 		    It has a Fujitsu MB89135L (undumped), four leds, a speaker and an IR emitter.
 		    It connects with the Game Boy using the console IR, but just one way (device to console).
 		    The peripheral device is named "Furu Changer". -->
-		<description>Zok Zok Heroes (Jpn)</description>
+		<description>Zok Zok Heroes (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BZHJ-JPN"/>
@@ -24636,7 +24636,7 @@ license:CC0
 
 	<software name="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Euro)</description>
+		<description>ATV Racing &amp; Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24652,7 +24652,7 @@ license:CC0
 
 	<software name="atvrackja" cloneof="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Euro, Alt)</description>
+		<description>ATV Racing &amp; Karate Joe (Europe, Alt)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24667,7 +24667,7 @@ license:CC0
 	</software>
 
 	<software name="atvracin">
-		<description>ATV Racing (Euro)</description>
+		<description>ATV Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24683,7 +24683,7 @@ license:CC0
 
 	<software name="fullhang" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Full Time Soccer &amp; Hang Time Basketball (Euro)</description>
+		<description>Full Time Soccer &amp; Hang Time Basketball (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24698,7 +24698,7 @@ license:CC0
 	</software>
 
 	<software name="fulltime">
-		<description>Full Time Soccer (Euro)</description>
+		<description>Full Time Soccer (Europe)</description>
 		<year>2000</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24714,7 +24714,7 @@ license:CC0
 
 	<software name="hangtime">
 		<!-- Notes: GBC only -->
-		<description>Hang Time Basketball (Euro)</description>
+		<description>Hang Time Basketball (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24730,7 +24730,7 @@ license:CC0
 
 	<software name="pocksmrt" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out &amp; Race Time (Euro)</description>
+		<description>Pocket Smash Out &amp; Race Time (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24744,7 +24744,7 @@ license:CC0
 
 	<software name="pocksm" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out (Euro)</description>
+		<description>Pocket Smash Out (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24760,7 +24760,7 @@ license:CC0
 
 	<software name="karatej" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Karate Joe (Euro)</description>
+		<description>Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24773,7 +24773,7 @@ license:CC0
 	</software>
 
 	<software name="painter">
-		<description>Painter (Euro)</description>
+		<description>Painter (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24787,7 +24787,7 @@ license:CC0
 
 	<software name="racetime">
 		<!-- Notes: GBC only -->
-		<description>Race Time (Euro)</description>
+		<description>Race Time (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24801,7 +24801,7 @@ license:CC0
 
 	<software name="sinkj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Karate Joe (Euro)</description>
+		<description>Space Invasion &amp; Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24817,7 +24817,7 @@ license:CC0
 
 	<software name="sinpntr" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Painter (Euro)</description>
+		<description>Space Invasion &amp; Painter (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24833,7 +24833,7 @@ license:CC0
 
 	<software name="sinvasn" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion (Euro)</description>
+		<description>Space Invasion (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24851,7 +24851,7 @@ license:CC0
 <!-- Sachen games -->
 
 	<software name="beastfgt">
-		<description>Beast Fighter (Tw)</description>
+		<description>Beast Fighter (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-001"/>
@@ -24864,7 +24864,7 @@ license:CC0
 	</software>
 
 	<software name="beastfgth" cloneof="beastfgt">
-		<description>Beast Fighter (Tw, Hacked?)</description>
+		<description>Beast Fighter (Taiwan, Hacked?)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="EB-001?"/>
@@ -24917,7 +24917,7 @@ license:CC0
 	</software>
 
 	<software name="rocmanx" supported="no">
-		<description>Rocman-X (Tw)</description>
+		<description>Rocman-X (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24929,7 +24929,7 @@ license:CC0
 	</software>
 
 	<software name="shero" supported="no">
-		<description>Street Hero (Tw)</description>
+		<description>Street Hero (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-004" />
@@ -24942,7 +24942,7 @@ license:CC0
 	</software>
 
 	<software name="thundbmna" cloneof="thundbmn" supported="no">
-		<description>Thunder Blast Man (Euro)</description>
+		<description>Thunder Blast Man (Europe)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="SA-114" />
@@ -24955,7 +24955,7 @@ license:CC0
 	</software>
 
 	<software name="mc_8in1">
-		<description>8 in 1 (Tw)</description>
+		<description>8 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="??"/>
@@ -25019,7 +25019,7 @@ license:CC0
 	</software>
 
 	<software name="mc_6in1">
-		<description>Super 6 in 1 (Tw)</description>
+		<description>Super 6 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="6B-001" />
@@ -25032,7 +25032,7 @@ license:CC0
 	</software>
 
 	<software name="mc_16in1">
-		<description>Super 16 in 1 (Tw)</description>
+		<description>Super 16 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25044,7 +25044,7 @@ license:CC0
 	</software>
 
 	<software name="mc_31t" cloneof="mc_31" supported="no">
-		<description>31 in 1 Mighty Mix (Tw)</description>
+		<description>31 in 1 Mighty Mix (Taiwan)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25056,7 +25056,7 @@ license:CC0
 	</software>
 
 	<software name="mc_31" supported="no">
-		<description>31-in-1 Mighty Mix (Aus)</description>
+		<description>31-in-1 Mighty Mix (Australia)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25078,7 +25078,7 @@ license:CC0
 
 	<software name="leinujs" supported="no">
 	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Lei Nu Ji Shen (Tw)</description>
+		<description>Lei Nu Ji Shen (Taiwan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25096,7 +25096,7 @@ license:CC0
 	<software name="leinujsh" cloneof="leinujs">
 	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
 		 the real card, so it can be removed once we properly emulate the parent -->
-		<description>Lei Nu Ji Shen (Tw, Hacked)</description>
+		<description>Lei Nu Ji Shen (Taiwan, Hacked)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25112,7 +25112,7 @@ license:CC0
 	</software>
 
 	<software name="magicmnk">
-		<description>Magic Monkey (Tw)</description>
+		<description>Magic Monkey (Taiwan)</description>
 		<year>200?</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25125,7 +25125,7 @@ license:CC0
 	</software>
 
 	<software name="binmnst3">
-		<description>Binary Monster III (Tw)</description>
+		<description>Binary Monster III (Taiwan)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25138,7 +25138,7 @@ license:CC0
 	</software>
 
 	<software name="amaznrob">
-		<description>Amazing Robot (Tw)</description>
+		<description>Amazing Robot (Taiwan)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25151,7 +25151,7 @@ license:CC0
 	</software>
 
 	<software name="magiclmpjp" cloneof="magiclmp" supported="no">
-		<description>Magic Lamp (Jpn)</description>
+		<description>Magic Lamp (Japan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25164,7 +25164,7 @@ license:CC0
 	</software>
 
 	<software name="magiclmp" supported="no">
-		<description>Magic Lamp (US)</description>
+		<description>Magic Lamp (USA)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25177,7 +25177,7 @@ license:CC0
 	</software>
 
 	<software name="binmnst2" supported="no">
-		<description>Binary Monster 2 - Adventure of Hell(TW)</description>
+		<description>Binary Monster 2 - Adventure of Hell (Taiwan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25224,7 +25224,7 @@ license:CC0
 -->
 
 	<software name="emochndx" supported="partial">
-		<description>Emo Cheng DX (Chi)</description>
+		<description>Emo Cheng DX (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25238,7 +25238,7 @@ license:CC0
 	</software>
 
 	<software name="shuihusslc" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (Chi, Li Cheng)</description>
+		<description>Shui Hu Shen Shou (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA010"/>
@@ -25254,7 +25254,7 @@ license:CC0
 	</software>
 
 	<software name="smbl3lc" cloneof="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi, Li Cheng)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA011"/>
@@ -25270,7 +25270,7 @@ license:CC0
 	</software>
 
 	<software name="digid3">
-		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (Chi)</description>
+		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA012"/>
@@ -25286,7 +25286,7 @@ license:CC0
 	</software>
 
 	<software name="emochen2">
-		<description>Emo Cheng 2 - Fengyun Pian (Chi)</description>
+		<description>Emo Cheng 2 - Fengyun Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA033"/>
@@ -25303,7 +25303,7 @@ license:CC0
 
 	<software name="mingzhu2">
 	<!-- AKA Digimon D-4 published by SKOB -->
-		<description>Ming Zhu Kou Dai Guai Shou II (Chi)</description>
+		<description>Ming Zhu Kou Dai Guai Shou II (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA060"/>
@@ -25319,7 +25319,7 @@ license:CC0
 	</software>
 
 	<software name="taikonzs">
-		<description>Taikong Zhan Shi - Jing Dian Ban (Chi)</description>
+		<description>Taikong Zhan Shi - Jing Dian Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA063"/>
@@ -25335,7 +25335,7 @@ license:CC0
 	</software>
 
 	<software name="gangdanw">
-		<description>Gang Dan Wu Yu II (Chi)</description>
+		<description>Gang Dan Wu Yu II (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA064"/>
@@ -25351,7 +25351,7 @@ license:CC0
 	</software>
 
 	<software name="mingzhu3">
-		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (Chi)</description>
+		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA065"/>
@@ -25367,7 +25367,7 @@ license:CC0
 	</software>
 
 	<software name="shuihujd">
-		<description>Shui Hu Zhuan - Jing Dian Ban (Chi)</description>
+		<description>Shui Hu Zhuan - Jing Dian Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA073"/>
@@ -25383,7 +25383,7 @@ license:CC0
 	</software>
 
 	<software name="yingxj2">
-		<description>Ying Xiong Jian 2 (Chi)</description>
+		<description>Ying Xiong Jian 2 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA075"/>
@@ -25399,7 +25399,7 @@ license:CC0
 	</software>
 
 	<software name="xiyouji">
-		<description>Xi You Ji (Chi)</description>
+		<description>Xi You Ji (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA076"/>
@@ -25413,7 +25413,7 @@ license:CC0
 	</software>
 
 	<software name="smbldnp">
-		<description>Shu Ma Bao Long - Dian Nao Pian (Chi)</description>
+		<description>Shu Ma Bao Long - Dian Nao Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA078"/>
@@ -25429,7 +25429,7 @@ license:CC0
 	</software>
 
 	<software name="yxtx">
-		<description>Ying Xiong Tian Xia (Chi)</description>
+		<description>Ying Xiong Tian Xia (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA079"/>
@@ -25443,7 +25443,7 @@ license:CC0
 	</software>
 
 	<software name="sanguowd">
-		<description>San Guo Zhi Wu Dai (Chi)</description>
+		<description>San Guo Zhi Wu Dai (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA080"/>
@@ -25459,7 +25459,7 @@ license:CC0
 	</software>
 
 	<software name="taikonglc" cloneof="firmbaby">
-		<description>Tai Kong Bao Bei (Chi, Li Cheng)</description>
+		<description>Tai Kong Bao Bei (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA083"/>
@@ -25475,7 +25475,7 @@ license:CC0
 	</software>
 
 	<software name="smbbhjbt">
-		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (Chi)</description>
+		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA085"/>
@@ -25491,7 +25491,7 @@ license:CC0
 	</software>
 
 	<software name="smbbcmm">
-		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (Chi)</description>
+		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA086"/>
@@ -25507,7 +25507,7 @@ license:CC0
 	</software>
 
 	<software name="smbbhzs">
-		<description>Shu Ma Bao Bei - Hai Zhi Shen (Chi)</description>
+		<description>Shu Ma Bao Bei - Hai Zhi Shen (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA087"/>
@@ -25523,7 +25523,7 @@ license:CC0
 	</software>
 
 	<software name="mojie3">
-		<description>Mo Jie 3 - Bu Wanme De Shijie (Chi)</description>
+		<description>Mo Jie 3 - Bu Wanme De Shijie (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA089"/>
@@ -25539,7 +25539,7 @@ license:CC0
 	</software>
 
 	<software name="xinshdyx">
-		<description>Xin Shediao Ying Xiong Chuan (Chi)</description>
+		<description>Xin Shediao Ying Xiong Chuan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng / Sintax</publisher>
 		<info name="serial" value="CBA090"/>
@@ -25556,7 +25556,7 @@ license:CC0
 
 	<software name="lkrdx6">
 	<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
-		<description>Luo Ke Ren DX6 (Chi)</description>
+		<description>Luo Ke Ren DX6 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA091"/>
@@ -25572,7 +25572,7 @@ license:CC0
 	</software>
 
 	<software name="xinguam2">
-		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (Chi)</description>
+		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA095"/>
@@ -25588,7 +25588,7 @@ license:CC0
 	</software>
 
 	<software name="smbbdx6">
-		<description>Shu Ma Bao Bei - DX6 (Chi)</description>
+		<description>Shu Ma Bao Bei - DX6 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA097"/>
@@ -25605,7 +25605,7 @@ license:CC0
 
 	<software name="teshu2k1" cloneof="mslug2k1">
 	<!-- probably developed by BDD -->
-		<description>Teshu Budui 2001 (Chi, Li Cheng)</description>
+		<description>Teshu Budui 2001 (China, Li Cheng)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA100"/>
@@ -25621,7 +25621,7 @@ license:CC0
 	</software>
 
 	<software name="taikond3">
-		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (Chi)</description>
+		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA145"/>
@@ -25638,7 +25638,7 @@ license:CC0
 
 	<software name="terr911">
 	<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
-		<description>Teshu Budui 2 - Jidi (Chi)</description>
+		<description>Teshu Budui 2 - Jidi (China)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA146"/>
@@ -25654,7 +25654,7 @@ license:CC0
 	</software>
 
 	<software name="shimianm">
-		<description>Shi Mian Maifu - Feng Yun Pian (Chi)</description>
+		<description>Shi Mian Maifu - Feng Yun Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA147"/>
@@ -25699,7 +25699,7 @@ license:CC0
 
 	<software name="hpotter">
 	<!-- probably developed by BDD -->
-		<description>Harry Potter (Chi)</description>
+		<description>Harry Potter (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25713,7 +25713,7 @@ license:CC0
 	</software>
 
 	<software name="iceage">
-		<description>Ice Age (Chi)</description>
+		<description>Ice Age (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25727,7 +25727,7 @@ license:CC0
 	</software>
 
 	<software name="iceage2a" cloneof="iceage2">
-		<description>Ice Age II (Chi)</description>
+		<description>Ice Age II (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -25742,7 +25742,7 @@ license:CC0
 	</software>
 
 	<software name="zhwsj">
-		<description>Zuizhong Huanxiang - Wujin Sha Jia (Chi)</description>
+		<description>Zuizhong Huanxiang - Wujin Sha Jia (China)</description>
 		<year>2002?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="最終幻想 無盡沙加 (Final Fantasy Endless Saga), Crystal Age (Official English Name by Sintax)"/>
@@ -25757,7 +25757,7 @@ license:CC0
 	</software>
 
 	<software name="zzqb">
-		<description>Zhong Zhuan Qi Bing (Chi)</description>
+		<description>Zhong Zhuan Qi Bing (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="重裝機兵 , Metal Max (Official English Name by Sintax)"/>
@@ -25789,7 +25789,7 @@ license:CC0
 	</software>
 
 	<software name="digicrs2" cloneof="pokesaph">
-		<description>Digimon Crystal II (Chi)</description>
+		<description>Digimon Crystal II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25803,7 +25803,7 @@ license:CC0
 	</software>
 
 	<software name="laofuzi">
-		<description>Lao Fuzi Chuanqi (Chi)</description>
+		<description>Lao Fuzi Chuanqi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="老夫子傳奇"/>
@@ -25818,7 +25818,7 @@ license:CC0
 	</software>
 
 	<software name="yuenanzx">
-		<description>Yuenan Zhanyi X - Shenru Dihou (Chi)</description>
+		<description>Yuenan Zhanyi X - Shenru Dihou (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役X-深入敵後"/>
@@ -25833,7 +25833,7 @@ license:CC0
 	</software>
 
 	<software name="dballadv">
-		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (Chi)</description>
+		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="七龍珠Z3"/>
@@ -25849,7 +25849,7 @@ license:CC0
 
 	<software name="moshosj">
 	<!-- World WarCraft? -->
-		<description>Mo Shou Shi Ji - Zhan Shen (Chi)</description>
+		<description>Mo Shou Shi Ji - Zhan Shen (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="魔獸世紀-戰神"/>
@@ -25864,7 +25864,7 @@ license:CC0
 	</software>
 
 	<software name="fengzg2">
-		<description>Feng Zhi Gou II (Chi)</description>
+		<description>Feng Zhi Gou II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="风之谷II"/>
@@ -25879,7 +25879,7 @@ license:CC0
 	</software>
 
 	<software name="digigdb">
-		<description>2003 Shu Ma Bao Long - Ge Dou Ban (Chi)</description>
+		<description>2003 Shu Ma Bao Long - Ge Dou Ban (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003数码暴龙 格斗版"/>
@@ -25894,7 +25894,7 @@ license:CC0
 	</software>
 
 	<software name="lkrx5">
-		<description>Luo Ke Ren X5 (Chi)</description>
+		<description>Luo Ke Ren X5 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="洛克人X5, 络克英雄EXE5 ~ Luo Ke Ying Xiong EXE5 (Cart)"/>
@@ -25909,7 +25909,7 @@ license:CC0
 	</software>
 
 	<software name="crash2c" cloneof="crash2">
-		<description>2003 Gu Huo Lang II - The Huge Adventure (Chi)</description>
+		<description>2003 Gu Huo Lang II - The Huge Adventure (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 古惑狼II (Cart)"/>
@@ -25924,7 +25924,7 @@ license:CC0
 	</software>
 
 	<software name="iceage2">
-		<description>Bing Yuan Li Xian Ji II (Chi)</description>
+		<description>Bing Yuan Li Xian Ji II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="冰原歷險記II"/>
@@ -25940,7 +25940,7 @@ license:CC0
 
 	<software name="pokeplat">
 	<!-- Pokemon Platinum? -->
-		<description>Kou Dai Yao Guai - Bai Jin Ban (Chi)</description>
+		<description>Kou Dai Yao Guai - Bai Jin Ban (China)</description>
 		<year>2005</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋妖怪-白金版"/>
@@ -25956,7 +25956,7 @@ license:CC0
 
 	<software name="ynzy3">
 	<!-- Metal Slug 3? -->
-		<description>Yue Nan Zhan Yi 3 (Chi)</description>
+		<description>Yue Nan Zhan Yi 3 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役3"/>
@@ -25972,7 +25972,7 @@ license:CC0
 
 	<software name="m_digi10" supported="no">
 	<!-- TODO: study the menu and writes of this cart! -->
-		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (Chi)</description>
+		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (China)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="數碼暴龍專集 10 in 1"/>
@@ -25986,7 +25986,7 @@ license:CC0
 
 	<software name="digid3h" cloneof="digid3">
 	<!-- This got ripped by m_digi10 -->
-		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (Chi, Ripped from 10 in 1 multicart)</description>
+		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (China, Ripped from 10 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="超進化 數碼寶貝D-3"/>
@@ -26001,7 +26001,7 @@ license:CC0
 	</software>
 
 	<software name="fkdfw">
-		<description>Feng Kuang Da Fu Weng (Chi, Ripped from multicart)</description>
+		<description>Feng Kuang Da Fu Weng (China, Ripped from multicart)</description>
 		<year>200?</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="疯狂大富翁"/>
@@ -26016,7 +26016,7 @@ license:CC0
 	</software>
 
 	<software name="onimush2">
-		<description>Gui Wu Zhe 2 (Chi)</description>
+		<description>Gui Wu Zhe 2 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="鬼武者2"/>
@@ -26033,7 +26033,7 @@ license:CC0
 	<software name="hjtaiyou">
 	<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
 	<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
-		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (Chi)</description>
+		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="篇外章 黃金太陽-封印的遠古煉金術 ~ Pian Wai Zhang Huang Jin Tai Yang - Feng Yin De Yuan Gu Lian Jin Shu"/>
@@ -26049,7 +26049,7 @@ license:CC0
 
 	<software name="dquest8">
 	<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
-		<description>Yong Zhe Dou E Long VIII (Chi)</description>
+		<description>Yong Zhe Dou E Long VIII (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="勇者鬥惡龍VIII"/>
@@ -26064,7 +26064,7 @@ license:CC0
 	</software>
 
 	<software name="mgear2">
-		<description>He Jin Zhuang Bei II (Chi)</description>
+		<description>He Jin Zhuang Bei II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="合金裝備II"/>
@@ -26079,7 +26079,7 @@ license:CC0
 	</software>
 
 	<software name="shaolin">
-		<description>Fantasic ShaoLin Kungfu (Chi)</description>
+		<description>Fantasic ShaoLin Kungfu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Shaoling Legend - Hero, the saver (Cart)"/>
@@ -26094,7 +26094,7 @@ license:CC0
 	</software>
 
 	<software name="shaolinc" cloneof="shaolin">
-		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (Chi)</description>
+		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="少林十三棍-英雄救主"/>
@@ -26109,7 +26109,7 @@ license:CC0
 	</software>
 
 	<software name="digiyjad">
-		<description>Digimon Yellow Jade (Chi)</description>
+		<description>Digimon Yellow Jade (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26123,7 +26123,7 @@ license:CC0
 	</software>
 
 	<software name="hpottr2c">
-		<description>Xiao Shi Mi Shi (Chi)</description>
+		<description>Xiao Shi Mi Shi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003哈利波特2-消失的密室 ~ 2003 Harry Potter 2 - Xiao Shi De Mi Shi"/>
@@ -26138,7 +26138,7 @@ license:CC0
 	</software>
 
 	<software name="hpotter4" cloneof="hpottr2c">
-		<description>Harry Xiao Zi IV (Chi)</description>
+		<description>Harry Xiao Zi IV (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子IV, 2003哈利小子IV ~ 2003 Ha Li Xiao Zi IV (Cart)"/>
@@ -26153,7 +26153,7 @@ license:CC0
 	</software>
 
 	<software name="emodao">
-		<description>E Mo Dao (Chi, Ripped from 8 in 1 multicart)</description>
+		<description>E Mo Dao (China, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>Vast Fame</publisher>
 		<info name="alt_title" value="惡魔島"/>
@@ -26168,7 +26168,7 @@ license:CC0
 	</software>
 
 	<software name="qtdsheng" cloneof="xiyouji">
-		<description>Qi Tian Da Sheng - Sun Wu Kong (Chi, Ripped from 8 in 1 multicart)</description>
+		<description>Qi Tian Da Sheng - Sun Wu Kong (China, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="齊天大聖 - 孫悟空"/>
@@ -26181,7 +26181,7 @@ license:CC0
 	</software>
 
 	<software name="sswy">
-		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="聖獸物語 - 神龍傳說"/>
@@ -26197,7 +26197,7 @@ license:CC0
 
 	<software name="pokeruby">
 	<!-- 4MB rom with crc 4a68fd38 is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Ruby (Chi)</description>
+		<description>Pocket Monster Ruby (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Pocket Monster Carbuncle (Cart)"/>
@@ -26213,7 +26213,7 @@ license:CC0
 
 	<software name="pokesaph">
 	<!-- 4MB rom with crc 81d1e6ff is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Saphire (Chi)</description>
+		<description>Pocket Monster Saphire (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Pokémon - Sapphire Version (Cart)"/>
@@ -26230,7 +26230,7 @@ license:CC0
 	<software name="pokesaphc" cloneof="pokesaph">
 	<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<!-- 4MB rom with crc 3a08c8eb is taizou's cracked version running on base MBC5 -->
-		<description>Kou Dai Guai Shou - Lan Bao Shi (Chi)</description>
+		<description>Kou Dai Guai Shou - Lan Bao Shi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋怪獸 - 藍寶石, 2003 口袋怪獸-藍寶石 (Cart)"/>
@@ -26246,7 +26246,7 @@ license:CC0
 
 	<software name="shuiji2" cloneof="pokesaph">
 	<!-- 4MB rom with crc 5f2472ad is taizou's cracked version running on base MBC5 -->
-		<description>Shu Ma Bao Long - Shui Jing Ban II (Chi)</description>
+		<description>Shu Ma Bao Long - Shui Jing Ban II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="數碼暴龍 - 水晶版II"/>
@@ -26262,7 +26262,7 @@ license:CC0
 
 	<software name="firmbaby">
 	<!-- 4MB rom with crc 66539153 is taizou's cracked version running on base MBC5 -->
-		<description>The Firmament Baby (Chi)</description>
+		<description>The Firmament Baby (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Space Baby (Cart)"/>
@@ -26278,7 +26278,7 @@ license:CC0
 
 	<software name="taikong" cloneof="firmbaby">
 	<!-- 4MB rom with crc 5b49af92 is taizou's cracked version running on base MBC5 -->
-		<description>Tai Kong Bao Bei (Chi, Sintax)</description>
+		<description>Tai Kong Bao Bei (China, Sintax)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="太空寶貝"/>
@@ -26294,7 +26294,7 @@ license:CC0
 
 	<software name="taichi">
 	<!-- 4MB rom with crc fab140ab is taizou's cracked version running on base MBC5 -->
-		<description>Xiao Taichi - Shen Hua Li Xian (Chi)</description>
+		<description>Xiao Taichi - Shen Hua Li Xian (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="小太极 - 神话历险"/>
@@ -26310,7 +26310,7 @@ license:CC0
 
 	<software name="crash2">
 	<!-- 4MB rom with crc 0af243bf is taizou's cracked version running on base MBC5 -->
-		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (Chi)</description>
+		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Crash II Advance (Cart)"/>
@@ -26326,7 +26326,7 @@ license:CC0
 
 	<software name="bwarr5" cloneof="dballadv">
 	<!-- 4MB rom with crc 9d332731 is taizou's cracked version running on base MBC5 -->
-		<description>Bynasty Warriors Advance 5 (Chi)</description>
+		<description>Bynasty Warriors Advance 5 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="叁國無雙5 ~ San Guo Wu Shang 5 (Cart)"/>
@@ -26342,7 +26342,7 @@ license:CC0
 
 	<software name="cjjqx">
 	<!-- 4MB rom with crc 378b182d is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -26358,7 +26358,7 @@ license:CC0
 
 	<software name="cjjqx1" cloneof="cjjqx">
 	<!-- 4MB rom with crc 0cea6b33 is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi, Alt)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (China, Alt)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -26374,7 +26374,7 @@ license:CC0
 
 	<software name="jinglw3">
 	<!-- rom with crc 15a4b4ec is taizou's cracked version running on base MBC5 -->
-		<description>Jing Ling Wang III (Chi)</description>
+		<description>Jing Ling Wang III (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="精靈王III"/>
@@ -26390,7 +26390,7 @@ license:CC0
 
 	<software name="qbtx">
 	<!-- rom with crc 5bcf90fa is taizou's cracked version running on base MBC5 -->
-		<description>Quan Ba Tian Xia (Chi)</description>
+		<description>Quan Ba Tian Xia (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="拳霸天下"/>
@@ -26406,7 +26406,7 @@ license:CC0
 
 	<software name="zhihuanw">
 	<!-- 4MB rom with crc 49e77dd9 is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Huan Wang - Shou Bu Qu (Chi)</description>
+		<description>Zhi Huan Wang - Shou Bu Qu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="指环王 - 首部曲"/>
@@ -26422,7 +26422,7 @@ license:CC0
 
 	<software name="xqdz2">
 	<!-- 4MB rom with crc e8fd000f is taizou's cracked version running on base MBC5 -->
-		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (Chi)</description>
+		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="星球大战2 - 克隆人战役"/>
@@ -26438,7 +26438,7 @@ license:CC0
 
 	<software name="mishidem">
 	<!-- 4MB rom with crc 88a86ff4 is taizou's cracked version running on base MBC5 -->
-		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (Chi)</description>
+		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子第二部 - 密室的秘"/>
@@ -26454,7 +26454,7 @@ license:CC0
 
 	<software name="hzqibing">
 	<!-- 4MB rom with crc bb78f17e is taizou's cracked version running on base MBC5 -->
-		<description>Hai Zhan Qi Bing (Chi)</description>
+		<description>Hai Zhan Qi Bing (China)</description>
 		<year>200?</year>
 		<publisher>Jump Technology ~ Sintax</publisher>
 		<info name="alt_title" value="海戰奇兵"/>
@@ -26470,7 +26470,7 @@ license:CC0
 
 	<software name="3gokum2">
 	<!-- 4MB rom with crc 8de5f8d5 is taizou's cracked version running on base MBC5 -->
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -26485,7 +26485,7 @@ license:CC0
 	</software>
 
 	<software name="3gokum2a" cloneof="3gokum2">
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi, Pirate)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China, Pirate)</description>
 		<year>200?</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -26500,7 +26500,7 @@ license:CC0
 	</software>
 
 	<software name="spiderm3">
-		<description>Spider-Man 3 (Chi)</description>
+		<description>Spider-Man 3 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Movie Version Spider-Man 3 (Cart)"/>
@@ -26516,7 +26516,7 @@ license:CC0
 
 	<software name="chuanshu" cloneof="spiderm3">
 	<!-- Same game as spiderm3 but alt sprite (still uses spider-man in status bar!) -->
-		<description>Chuan Shuo (Chi)</description>
+		<description>Chuan Shuo (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="傳說"/>
@@ -26532,7 +26532,7 @@ license:CC0
 
 	<software name="zzx3" cloneof="spiderm3">
 	<!-- 4MB rom with crc 66442e7d is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Zhu Xia III (Chi)</description>
+		<description>Zhi Zhu Xia III (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="蜘蛛侠3-电影版 ~ Zhi Zhu Xia 3 - Dian Ying Ban (Spider-Man 3 Movie Version)"/>
@@ -26547,7 +26547,7 @@ license:CC0
 	</software>
 
 	<software name="xfsb">
-		<description>Xin Feng Shen Bang (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Xin Feng Shen Bang (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="新封神榜"/>
@@ -26563,7 +26563,7 @@ license:CC0
 
 	<software name="digisaph">
 	<!-- 4MB rom with crc 88da70ac is taizou's cracked version running on base MBC5 -->
-		<description>2003 Digitmon Sapphire (Chi)</description>
+		<description>2003 Digitmon Sapphire (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="2003 Digimom Sapphii (Cart)"/>
@@ -26578,7 +26578,7 @@ license:CC0
 	</software>
 
 	<software name="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="數碼暴龍3-水晶版"/>
@@ -26593,7 +26593,7 @@ license:CC0
 	</software>
 
 	<software name="smbl9">
-		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (Chi)</description>
+		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="CK019-1"/>
@@ -26615,7 +26615,7 @@ license:CC0
 	     where it gets stuck. if comparison works, then the code goes to 0x150 as the
 	     patched version does (because the single modified byte replaces the jump to
 	     0x1e0 with the jump to 0x150). Not sure yet if current workaround is correct... -->
-		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (Chi)</description>
+		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="宠物小精灵 结金塔之王"/>
@@ -26630,7 +26630,7 @@ license:CC0
 	</software>
 
 	<software name="jyqxc2">
-		<description>Jin Yong Qun Xia Chuan II (Chi)</description>
+		<description>Jin Yong Qun Xia Chuan II (China)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="金庸群侠传II"/>
@@ -26645,7 +26645,7 @@ license:CC0
 	</software>
 
 	<software name="soulfalc">
-		<description>Soul Falchion - Ge Dou Jian Shen (Chi)</description>
+		<description>Soul Falchion - Ge Dou Jian Shen (China)</description>
 		<year>2002</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="格鬥劍神"/>
@@ -26660,7 +26660,7 @@ license:CC0
 	</software>
 
 	<software name="capf2k3" cloneof="soulfalc">
-		<description>Capcom Fight 2003 (Chi)</description>
+		<description>Capcom Fight 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26674,7 +26674,7 @@ license:CC0
 	</software>
 
 	<software name="heroswrd">
-		<description>Heroic Sword (Chi)</description>
+		<description>Heroic Sword (China)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="英雄剑"/>
@@ -26689,7 +26689,7 @@ license:CC0
 	</software>
 
 	<software name="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26703,7 +26703,7 @@ license:CC0
 	</software>
 
 	<software name="crzyric2a" cloneof="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi, Alt)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26717,7 +26717,7 @@ license:CC0
 	</software>
 
 	<software name="ffantx">
-		<description>Final Fantasy X: Fantasy War (Chi)</description>
+		<description>Final Fantasy X: Fantasy War (China)</description>
 		<year>20??</year>
 		<publisher>SKOB ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26732,7 +26732,7 @@ license:CC0
 
 	<software name="rockmnx3">
 	<!-- This is a title hack of the undumped 'Zook Hero 2' -->
-		<description>Rockman X3 (Chi)</description>
+		<description>Rockman X3 (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -26747,7 +26747,7 @@ license:CC0
 	</software>
 
 	<software name="rockmnx3a" cloneof="rockmnx3">
-		<description>Rockman X3 (Chi, Alt)</description>
+		<description>Rockman X3 (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -26763,7 +26763,7 @@ license:CC0
 
 	<software name="sf99">
 	<!-- This is a title hack of the undumped 'Super Fighter S' -->
-		<description>Super Fighters '99 (Chi)</description>
+		<description>Super Fighters '99 (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26775,7 +26775,7 @@ license:CC0
 	</software>
 
 	<software name="garou">
-		<description>Garou - Mark of the Wolves (Chi)</description>
+		<description>Garou - Mark of the Wolves (China)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26789,7 +26789,7 @@ license:CC0
 	</software>
 
 	<software name="garou2k3" cloneof="garou">
-		<description>Garou 2003 - Mark of the Wolfs (Chi)</description>
+		<description>Garou 2003 - Mark of the Wolfs (China)</description>
 		<year>2003?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26803,7 +26803,7 @@ license:CC0
 	</software>
 
 	<software name="fighthot">
-		<description>E' Fighter HOT (Chi)</description>
+		<description>E' Fighter HOT (China)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26818,7 +26818,7 @@ license:CC0
 
 	<software name="dbf2005">
 	<!-- This is a title hack of an undumped Dragon Ball fighting game -->
-		<description>Dragonball Fight 2005 (Chi)</description>
+		<description>Dragonball Fight 2005 (China)</description>
 		<year>2005?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26845,7 +26845,7 @@ license:CC0
 
 	<software name="hpotter3c" cloneof="hpotter2">
 	<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
-		<description>Harry Potter 3 2003 (Chi)</description>
+		<description>Harry Potter 3 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>V.Fame?</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26859,7 +26859,7 @@ license:CC0
 	</software>
 
 	<software name="skxs">
-		<description>Shi Kong Xing Shou (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Shi Kong Xing Shou (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="時空星獸"/>
@@ -26874,7 +26874,7 @@ license:CC0
 	</software>
 
 	<software name="shjmlwc">
-		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (Chi)</description>
+		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (China)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<info name="alt_title" value="聖火降魔錄外傳 - 光與暗的輪迴, 聖火降魔錄 (Box)"/>
@@ -26889,7 +26889,7 @@ license:CC0
 	</software>
 
 	<software name="xgmyha" cloneof="shjmlwc">
-		<description>Xin Guang Ming Yu Hei An (Chi)</description>
+		<description>Xin Guang Ming Yu Hei An (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="新光明与黑暗"/>
@@ -26905,7 +26905,7 @@ license:CC0
 
 	<software name="mszb3" cloneof="shjmlwc">
 	<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
-		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (Chi)</description>
+		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26919,7 +26919,7 @@ license:CC0
 	</software>
 
 	<software name="shuihuss">
-		<description>Shui Hu Shen Shou (Chi)</description>
+		<description>Shui Hu Shen Shou (China)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -26934,7 +26934,7 @@ license:CC0
 	</software>
 
 	<software name="shuihussa" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (Chi, Alt)</description>
+		<description>Shui Hu Shen Shou (China, Alt)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -26950,7 +26950,7 @@ license:CC0
 
 	<software name="shuihuz" cloneof="shuihuss">
 	<!-- Title hack of the above, with VF logo removed -->
-		<description>Shui Hu Zhuan (Chi)</description>
+		<description>Shui Hu Zhuan (China)</description>
 		<year>2002</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="水滸傳"/>
@@ -26966,7 +26966,7 @@ license:CC0
 
 	<software name="kof2003">
 	<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
-		<description>Ge Dou Zhi Zun 2003 (Chi)</description>
+		<description>Ge Dou Zhi Zun 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="格斗至尊2003"/>
@@ -26981,7 +26981,7 @@ license:CC0
 	</software>
 
 	<software name="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (Chi)</description>
+		<description>Super Robot Taisen Final Vol.1 (China)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26996,7 +26996,7 @@ license:CC0
 	</software>
 
 	<software name="srobotf1a" cloneof="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (Chi, Alt)</description>
+		<description>Super Robot Taisen Final Vol.1 (China, Alt)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27011,7 +27011,7 @@ license:CC0
 	</software>
 
 	<software name="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27026,7 +27026,7 @@ license:CC0
 	</software>
 
 	<software name="sanguoasa" cloneof="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27042,7 +27042,7 @@ license:CC0
 
 	<software name="sanguoasb" cloneof="sanguoas">
 	<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt Bad?)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt Bad?)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27058,7 +27058,7 @@ license:CC0
 
 	<software name="cbzz">
 	<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
-		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (Chi)</description>
+		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs)"/>
@@ -27073,7 +27073,7 @@ license:CC0
 	</software>
 
 	<software name="smmftu">
-		<description>Shi Mian Mai Fu - Tu Long Pian (Chi)</description>
+		<description>Shi Mian Mai Fu - Tu Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter)"/>
@@ -27088,7 +27088,7 @@ license:CC0
 	</software>
 
 	<software name="smmftian">
-		<description>Shi Mian Mai Fu - Tian Long Pian (Chi)</description>
+		<description>Shi Mian Mai Fu - Tian Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter)"/>
@@ -27103,7 +27103,7 @@ license:CC0
 	</software>
 
 	<software name="unk01" supported="no">
-		<description>Unknown RPG - Digimon? Zelda? (Chi, Encrypted?)</description>
+		<description>Unknown RPG - Digimon? Zelda? (China, Encrypted?)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27117,7 +27117,7 @@ license:CC0
 	</software>
 
 	<software name="pokedmnda" cloneof="telefngp">
-		<description>Pocket Monsters Diamond (Chi)</description>
+		<description>Pocket Monsters Diamond (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27132,7 +27132,7 @@ license:CC0
 	</software>
 
 	<software name="pokedmnd" cloneof="telefngp">
-		<description>Pokémon Diamond (Chi)</description>
+		<description>Pokémon Diamond (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27147,7 +27147,7 @@ license:CC0
 	</software>
 
 	<software name="yxcs" supported="no">
-		<description>Ying Xiong Chuan Shuo (Chi)</description>
+		<description>Ying Xiong Chuan Shuo (China)</description>
 		<year>20??</year>
 		<publisher>Waixing</publisher>
 		<info name="alt_title" value="英雄传说 (Legend of Heroes)"/>
@@ -27162,7 +27162,7 @@ license:CC0
 	</software>
 
 	<software name="sqsd">
-		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (Chi)</description>
+		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (China)</description>
 		<year>20??</year>
 		<publisher>GOWIN</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -27178,7 +27178,7 @@ license:CC0
 	</software>
 
 	<software name="dquest4">
-		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (Chi)</description>
+		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="勇者斗恶龙4"/>
@@ -27213,7 +27213,7 @@ license:CC0
 
 	<software name="pikangtm" cloneof="smurfnig">
 		<!-- Notes: GBC only -->
-		<description>The Pikachu Nightmare (Chi)</description>
+		<description>The Pikachu Nightmare (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27225,7 +27225,7 @@ license:CC0
 	</software>
 
 	<software name="pokegogo" cloneof="smurfnig">
-		<description>Pocket Monsters GO!GO! GO!! (Chi)</description>
+		<description>Pocket Monsters GO!GO! GO!! (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27239,7 +27239,7 @@ license:CC0
 <!-- These are basically the same game as Sonic 3D Blast 5, always by Yong Yong (see gameboy.xml) -->
 	<software name="sonicad7">
 		<!-- Alt. Title: Sonic 7, Sonic Adventure 7 -->
-		<description>Sonic Adventure (Chi)</description>
+		<description>Sonic Adventure (China)</description>
 		<year>1999</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27251,7 +27251,7 @@ license:CC0
 	</software>
 
 	<software name="pokeadv">
-		<description>Pokémon Adventure (Chi)</description>
+		<description>Pokémon Adventure (China)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27263,7 +27263,7 @@ license:CC0
 	</software>
 
 	<software name="dkong5">
-		<description>Donkey Kong 5 (Chi, Bad?)</description>
+		<description>Donkey Kong 5 (China, Bad?)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27276,7 +27276,7 @@ license:CC0
 
 	<software name="dkong5ts">
 	<!-- 4MB rom with crc f27a687e is taizou's cracked version running on base MBC5 -->
-		<description>Donkey Kong 5 - The Journey of Over Time and Space (Chi)</description>
+		<description>Donkey Kong 5 - The Journey of Over Time and Space (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27299,7 +27299,7 @@ license:CC0
 	used here repeated twice. we need to redump the standalone cart to confirm the size
 	but the 256KB version is definitely underdumped and misses sprite data
 	-->
-		<description>Super Mario 3 Special (Chi)</description>
+		<description>Super Mario 3 Special (China)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27312,7 +27312,7 @@ license:CC0
 
 	<software name="digimn2" supported="no">
 	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Digimon 2 (Chi)</description>
+		<description>Digimon 2 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27328,7 +27328,7 @@ license:CC0
 	<software name="digimn2h" cloneof="digimn2">
 	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
      the real card, so it can be removed once we properly emulate the parent -->
-		<description>Digimon 2 (Chi, Hacked)</description>
+		<description>Digimon 2 (China, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27342,7 +27342,7 @@ license:CC0
 	</software>
 
 	<software name="digimn3c">
-		<description>Digimon 3 Crystal (Chi)</description>
+		<description>Digimon 3 Crystal (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27357,7 +27357,7 @@ license:CC0
 
 	<software name="digimn4" supported="no">
 	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Digimon 02 4 (Chi)</description>
+		<description>Digimon 02 4 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27373,7 +27373,7 @@ license:CC0
 	<software name="digimn4h" cloneof="digimn4">
 	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
      the real card, so it can be removed once we properly emulate the parent -->
-		<description>Digimon 02 4 (Chi, Hacked)</description>
+		<description>Digimon 02 4 (China, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27387,7 +27387,7 @@ license:CC0
 	</software>
 
 	<software name="digijade" cloneof="digimn4">
-		<description>Digimon 02 Jade (Chi)</description>
+		<description>Digimon 02 Jade (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27401,7 +27401,7 @@ license:CC0
 	</software>
 
 	<software name="digimn5">
-		<description>Digimon 02 5 (Chi)</description>
+		<description>Digimon 02 5 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27415,7 +27415,7 @@ license:CC0
 	</software>
 
 	<software name="digimn5c" cloneof="digimn5">
-		<description>Digimon 02 5 Crystal (Chi)</description>
+		<description>Digimon 02 5 Crystal (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27432,7 +27432,7 @@ license:CC0
 <!-- Once sorted out what is good and what not, the entry should be moved among the Sintax games above! -->
 	<software name="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi)</description>
+		<description>Metal Slug 2001 (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27447,7 +27447,7 @@ license:CC0
 
 	<software name="mslug2k1a" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi, Alt 1)</description>
+		<description>Metal Slug 2001 (China, Alt 1)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27462,7 +27462,7 @@ license:CC0
 
 	<software name="mslug2k1b" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi, Alt 2)</description>
+		<description>Metal Slug 2001 (China, Alt 2)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27484,7 +27484,7 @@ license:CC0
 
 	<software name="ar" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Action Replay Online BIOS (Euro)</description>
+		<description>Action Replay Online BIOS (Europe)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -28891,7 +28891,7 @@ license:CC0
 		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs)"/>
+		<info name="alt_title" value="吞食天地 赤壁之戰"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -28906,7 +28906,7 @@ license:CC0
 		<description>Shi Mian Mai Fu - Tu Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter)"/>
+		<info name="alt_title" value="十面埋伏 屠龍篇"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -28921,7 +28921,7 @@ license:CC0
 		<description>Shi Mian Mai Fu - Tian Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter)"/>
+		<info name="alt_title" value="十面埋伏 天龍篇"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -28980,7 +28980,7 @@ license:CC0
 		<description>Ying Xiong Chuan Shuo (China)</description>
 		<year>20??</year>
 		<publisher>Waixing</publisher>
-		<info name="alt_title" value="英雄传说 (Legend of Heroes)"/>
+		<info name="alt_title" value="英雄传说"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_digimon" />
 			<dataarea name="rom" size="1048576">
@@ -28996,7 +28996,7 @@ license:CC0
 		<year>20??</year>
 		<publisher>GOWIN</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
-		<info name="alt_title" value="石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King)"/>
+		<info name="alt_title" value="石器時代 精靈王誕生"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_yong" />
 			<dataarea name="rom" size="4194304">

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -10884,11 +10884,12 @@ license:CC0
 
 	<software name="lionkingf" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Le Roi Lion - Les Adventures de Simba (France)</description>
+		<description>Les Roi Lion - Les Adventures de Simba (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
 		<info name="gold" value="20001113"/>
+		<info name="alt_title" value="Le Roi Lion - La formidable aventure de Simba"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -10900,11 +10901,12 @@ license:CC0
 	<software name="lionkingfa" cloneof="lionking">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbblkf1.573"	-->
-		<description>Le Roi Lion - Les Adventures de Simba (France, Rev 1)</description>
+		<description>Les Roi Lion - Les Adventures de Simba (France, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
 		<info name="gold" value="20010406"/>
+		<info name="alt_title" value="Le Roi Lion - La formidable aventure de Simba"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -17,13 +17,13 @@ license:CC0
 	- Gakkyuu Ou Yamazaki (Jpn)
 	- Jissen ni Yakudatsu Tsumego (Jpn)
 	- Laura (Euro)
-	- Mission Impossible (Euro, Rev. A)
+	- Mission Impossible (Euro, Rev. 1)
 	- Monster Traveler (Jpn)
 	- NBA In the Zone (USA)
 	- Pro Pool (USA)
 	- Sei Hai Densetsu (Jpn)
-	- Super Mario Bros. Deluxe (USA, Rev. B)	<- Was it released?
-	- Tsuri Sensei 2 (Jpn, Rev. A)
+	- Super Mario Bros. Deluxe (USA, Rev. 2)	<- Was it released?
+	- Tsuri Sensei 2 (Jpn, Rev. 1)
 	- Turok - Rage Wars (Aus)
 	- VR Sports Powerboat Racing (USA)
 	- Yakouchuu GB (Jpn)
@@ -1595,7 +1595,7 @@ license:CC0
 
 	<software name="barcodea" cloneof="barcode">
 		<!--	In lot check as "dmgabej1.f26"	-->
-		<description>Barcode Taisen Bardigun (Jpn, Rev. A)</description>
+		<description>Barcode Taisen Bardigun (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN-1"/>
@@ -2245,7 +2245,7 @@ license:CC0
 	<software name="bokujom3a" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbwaj1.350"	-->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn, Rev. A)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
@@ -2820,7 +2820,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. B)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2836,7 +2836,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev b).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 2).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2844,7 +2844,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuita" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. A)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2854,7 +2854,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev a).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 1).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -4654,7 +4654,7 @@ license:CC0
 
 	<software name="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Jpn, Rev. A)</description>
+		<description>Doraemon no Quiz Boy (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -5075,7 +5075,7 @@ license:CC0
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. A)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
@@ -5183,7 +5183,7 @@ license:CC0
 
 	<software name="dqm2ra" cloneof="dwm2c">
 		<!--	In lot check as "dmgbqlj1.j93"	-->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn, Rev. A)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
@@ -6157,7 +6157,7 @@ license:CC0
 
 	<software name="fairykit">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. A)</description>
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
@@ -6167,7 +6167,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (rev. a).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
+				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (Rev. 1).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6372,7 +6372,7 @@ license:CC0
 	</software>
 
 	<software name="froggeru" cloneof="frogger">
-		<description>Frogger (USA, Rev. B)</description>
+		<description>Frogger (USA, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-3"/>
@@ -6388,14 +6388,14 @@ license:CC0
 	</software>
 
 	<software name="froggerua" cloneof="frogger">
-		<description>Frogger (USA, Rev. A)</description>
+		<description>Frogger (USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="frogger (usa) (rev a).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
+				<rom name="frogger (usa) (rev 1).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
 			</dataarea>
 		</part>
 	</software>
@@ -6433,7 +6433,7 @@ license:CC0
 	<software name="frogger2a" cloneof="frogger2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbh2e1.351"	-->
-		<description>Frogger 2 (USA, Rev. A)</description>
+		<description>Frogger 2 (USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
@@ -6474,7 +6474,7 @@ license:CC0
 	</software>
 
 	<software name="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. A)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
@@ -6491,7 +6491,7 @@ license:CC0
 			<feature name="battery" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (rev. a).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
+				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (Rev. 1).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6616,7 +6616,7 @@ license:CC0
 	</software>
 
 	<software name="gakkyamaa">
-		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. A)</description>
+		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
@@ -6695,7 +6695,7 @@ license:CC0
 	<software name="gamblerta" cloneof="gamblert">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbgyj1.607"	-->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn, Rev. A)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN?"/>
@@ -7823,7 +7823,7 @@ license:CC0
 
 	<software name="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Jpn, Rev. A)</description>
+		<description>Hamster Paradise 2 (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7832,7 +7832,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="hamster paradise 2 (japan) (rev a).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
+				<rom name="hamster paradise 2 (japan) (rev 1).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -9233,7 +9233,7 @@ license:CC0
 
 	<software name="jissena">
 		<!-- Notes: GBC only -->
-		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. A)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
@@ -9685,7 +9685,7 @@ license:CC0
 
 	<software name="kawaipt2a">
 		<!--	In lot check as "dmgbmnj1.j90"	-->
-		<description>Kawaii Pet Shop Monogatari 2 (Jpn, Rev. A)</description>
+		<description>Kawaii Pet Shop Monogatari 2 (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
@@ -9990,7 +9990,7 @@ license:CC0
 
 	<software name="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Jpn, Rev. A)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Jpn, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -9999,7 +9999,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="kisekae series 2 - oshare nikki (japan) (rev. a).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
+				<rom name="kisekae series 2 - oshare nikki (japan) (Rev. 1).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -10484,14 +10484,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, Aus, USA, Rev. B)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Euro, Aus, USA, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-(EUR/AUS)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev b).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 2).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10499,14 +10499,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev a).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 1).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10536,7 +10536,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxf" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Fra, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Fra, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10578,7 +10578,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxg" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Ger, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Ger, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10900,7 +10900,7 @@ license:CC0
 	<software name="lionkingfa" cloneof="lionking">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbblkf1.573"	-->
-		<description>Le Roi Lion - Les Adventures de Simba (Fra, Rev. A)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (Fra, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
@@ -11246,7 +11246,7 @@ license:CC0
 
 	<software name="hirapzl2">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
@@ -11256,7 +11256,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11284,7 +11284,7 @@ license:CC0
 
 	<software name="hirapzl3">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. 1, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
@@ -11294,7 +11294,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11322,7 +11322,7 @@ license:CC0
 
 	<software name="hirapzls">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
@@ -11332,7 +11332,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11360,7 +11360,7 @@ license:CC0
 
 	<software name="kangpzl2a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
@@ -11370,7 +11370,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11398,7 +11398,7 @@ license:CC0
 
 	<software name="kangpzl3a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
@@ -11408,7 +11408,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11436,7 +11436,7 @@ license:CC0
 
 	<software name="kangpzlsa">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. A, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
@@ -11446,7 +11446,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11518,7 +11518,7 @@ license:CC0
 	<software name="lovehinaa" cloneof="lovehina">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbphj1.290"	-->
-		<description>Love Hina Pocket (Jpn, Rev. A)</description>
+		<description>Love Hina Pocket (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
@@ -11814,14 +11814,14 @@ license:CC0
 
 	<software name="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Euro, Rev. A)</description>
+		<description>Magical Tetris Challenge (Euro, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev a).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
+				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev 1).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11897,7 +11897,7 @@ license:CC0
 	</software>
 
 	<software name="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. A)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN-1"/>
@@ -11907,7 +11907,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="majokko mari-chan no kisekae monogatari (japan) (rev. a).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
+				<rom name="majokko mari-chan no kisekae monogatari (japan) (Rev. 1).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13099,7 +13099,7 @@ license:CC0
 
 	<software name="minnashga" cloneof="minnashg">
 		<!--	In lot check as "dmga7yj1.i18"	-->
-		<description>Minna no Shougi - Shokyuu Hen (Jpn, Rev. A)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
@@ -13197,7 +13197,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaimp1.076"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Mission Impossible (Euro, Rev. A)</description>
+		<description>Mission Impossible (Euro, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-?"/>
@@ -13446,7 +13446,7 @@ license:CC0
 
 	<software name="monstrvla">
 		<!-- Notes: GBC only -->
-		<description>Monster Traveler (Jpn, Rev. A)</description>
+		<description>Monster Traveler (Jpn, Rev. 1)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
@@ -13456,7 +13456,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="monster traveler (japan) (rev a).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
+				<rom name="monster traveler (japan) (rev 1).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13485,7 +13485,7 @@ license:CC0
 
 	<software name="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, Rev. A)</description>
+		<description>Monsters, Inc. (Euro, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QP-UKV"/>
@@ -14364,7 +14364,7 @@ license:CC0
 	</software>
 
 	<software name="nbazonea" cloneof="nbapro99">
-		<description>NBA In the Zone (USA, Rev. A)</description>
+		<description>NBA In the Zone (USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
@@ -14372,7 +14372,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="nba in the zone (usa) (rev a).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
+				<rom name="nba in the zone (usa) (rev 1).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -14627,7 +14627,7 @@ license:CC0
 	</software>
 
 	<software name="blitz">
-		<description>NFL Blitz (Euro, USA, Rev. A)</description>
+		<description>NFL Blitz (Euro, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ABZE-USA, DMG-ABZP-EUU"/>
@@ -15711,7 +15711,7 @@ license:CC0
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Jpn, Rev. A)</description>
+		<description>Pocket Monsters Gin (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
@@ -15728,7 +15728,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters gin (japan) (rev a).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
+				<rom name="pocket monsters gin (japan) (rev 1).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15755,7 +15755,7 @@ license:CC0
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Jpn, Rev. A)</description>
+		<description>Pocket Monsters Kin (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
@@ -15766,7 +15766,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters kin (japan) (rev a).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
+				<rom name="pocket monsters kin (japan) (rev 1).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15925,7 +15925,7 @@ license:CC0
 	<software name="poktpuyna" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj1.327"	-->
-		<description>Pocket Puyo Puyo-n (Jpn, Rev. A)</description>
+		<description>Pocket Puyo Puyo-n (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15944,7 +15944,7 @@ license:CC0
 	<software name="poktpuynb" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj2.327"	-->
-		<description>Pocket Puyo Puyo-n (Jpn, Rev. B)</description>
+		<description>Pocket Puyo Puyo-n (Jpn, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15996,7 +15996,7 @@ license:CC0
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
 		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
-		<description>Pokémon - Crystal Version (Euro, USA, Rev. A)</description>
+		<description>Pokémon - Crystal Version (Euro, USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
@@ -16006,7 +16006,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
-				<rom name="pokemon - crystal version (usa, europe) (rev a).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
+				<rom name="pokemon - crystal version (usa, europe) (rev 1).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16469,7 +16469,7 @@ license:CC0
 
 	<software name="pokecard">
 		<!--	In lot check as "dmgaxqx1.j85"	-->
-		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian, Rev. A)</description>
+		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR-1"/>
@@ -16527,7 +16527,7 @@ license:CC0
 
 	<software name="pokecardaa" cloneof="pokecard">
 		<!--	In lot check as "dmgaxqp1.j84"	-->
-		<description>Pokémon Trading Card Game (Euro, English / French / German, Rev. A)</description>
+		<description>Pokémon Trading Card Game (Euro, English / French / German, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE?"/>
@@ -16716,7 +16716,7 @@ license:CC0
 	</software>
 
 	<software name="powrpkp">
-		<description>Power Pro Kun Pocket (Jpn, Rev. A)</description>
+		<description>Power Pro Kun Pocket (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
@@ -16726,7 +16726,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="power pro kun pocket (japan) (rev a).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
+				<rom name="power pro kun pocket (japan) (rev 1).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16920,7 +16920,7 @@ license:CC0
 
 	<software name="powrpfbmu" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. B)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-2"/>
@@ -16938,7 +16938,7 @@ license:CC0
 
 	<software name="powrpfbmua" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-1"/>
@@ -17042,7 +17042,7 @@ license:CC0
 
 	<software name="powrpfbhu" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Battle Him (USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHE-USA-1"/>
@@ -17141,28 +17141,28 @@ license:CC0
 
 	<software name="powrpfpnu" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. B)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-2?"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev b).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 2).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="powrpfpnua" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-1"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev a).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 1).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19072,7 +19072,7 @@ license:CC0
 
 	<software name="sanriotka" cloneof="sanriotk">
 		<!--	In lot check as "dmgatpj1.f14"	-->
-		<description>Sanrio Timenet - Kako Hen (Jpn, Rev. A)</description>
+		<description>Sanrio Timenet - Kako Hen (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
@@ -19112,7 +19112,7 @@ license:CC0
 
 	<software name="sanriotma" cloneof="sanriotm">
 		<!--	In lot check as "dmgatfj1.f15"	-->
-		<description>Sanrio Timenet - Mirai Hen (Jpn, Rev. A)</description>
+		<description>Sanrio Timenet - Mirai Hen (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
@@ -19332,7 +19332,7 @@ license:CC0
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate Classic (Euro, USA, Rev. A)</description>
+		<description>Shadowgate Classic (Euro, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-EUR"/>
@@ -19443,7 +19443,7 @@ license:CC0
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Euro, Rev. A)</description>
+		<description>Shanghai Pocket (Euro, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
@@ -19451,7 +19451,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (europe) (rev a).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
+				<rom name="shanghai pocket (europe) (rev 1).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
 			</dataarea>
 		</part>
 	</software>
@@ -19535,7 +19535,7 @@ license:CC0
 
 	<software name="shinmtaa">
 		<!--	In lot check as "dmgbhnj1.j70"	-->
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn, Rev. A)</description>
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
@@ -19580,7 +19580,7 @@ license:CC0
 
 	<software name="shinmtka">
 		<!--	In lot check as "dmgbhej1.j69"	-->
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn, Rev. A)</description>
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
@@ -20304,7 +20304,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
 		<!--	Never released as physical cartridge	-->
-		<description>Spy vs. Spy (Japan, Rev. A, NP)</description>
+		<description>Spy vs. Spy (Japan, Rev. 1, NP)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -20682,7 +20682,7 @@ license:CC0
 	<software name="smbdxja" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
 		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
-		<description>Super Mario Bros. Deluxe (Jpn, NP, Rev. A)</description>
+		<description>Super Mario Bros. Deluxe (Jpn, NP, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -20702,14 +20702,14 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. B)</description>
+		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev b).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev 2).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20718,14 +20718,14 @@ license:CC0
 
 	<software name="smbdxa" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. A)</description>
+		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev a).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev 1).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -21446,7 +21446,7 @@ license:CC0
 	<software name="tetrisada" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbat7j1.070"	-->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn, Rev. A)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN?"/>
@@ -21802,7 +21802,7 @@ license:CC0
 	<software name="tomjermha" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbtjp1.487"	-->
-		<description>Tom and Jerry - Mousehunt (Euro, Rev. A)</description>
+		<description>Tom and Jerry - Mousehunt (Euro, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
@@ -21832,7 +21832,7 @@ license:CC0
 	<software name="tomjermhua" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbtqe1.541"	-->
-		<description>Tom and Jerry - Mousehunt (USA, Rev. A)</description>
+		<description>Tom and Jerry - Mousehunt (USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJE-USA?"/>
@@ -22308,7 +22308,7 @@ license:CC0
 
 	<software name="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn, Rev. A)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22324,7 +22324,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev a).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
+				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev 1).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -22435,7 +22435,7 @@ license:CC0
 		<!--	Never released as physical cartridge	-->
 		<!--	Released on the 3DS Virtual Console	-->
 		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
-		<description>Trade &amp; Battle Card Hero (Jpn, Rev. A)</description>
+		<description>Trade &amp; Battle Card Hero (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
@@ -22574,7 +22574,7 @@ license:CC0
 	<software name="tsurisn2a" cloneof="tsurisn2">
 		<!--	In lot check as "dmga2kj1.g93"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Tsuri Sensei 2 (Jpn, Rev. A)</description>
+		<description>Tsuri Sensei 2 (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN?"/>
@@ -23310,7 +23310,7 @@ license:CC0
 
 	<software name="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Jpn, Rev. A)</description>
+		<description>Watashi no Kitchen (Jpn, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23319,7 +23319,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="watashi no kitchen (japan) (rev a).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
+				<rom name="watashi no kitchen (japan) (rev 1).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -23537,7 +23537,7 @@ license:CC0
 
 	<software name="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Jpn, Rev. A)</description>
+		<description>Wizardry Empire (Jpn, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23546,7 +23546,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="wizardry empire (japan) (rev a).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
+				<rom name="wizardry empire (japan) (rev 1).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -23860,7 +23860,7 @@ license:CC0
 
 	<software name="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Euro, USA, Rev. A)</description>
+		<description>X-Men - Mutant Academy (Euro, USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-NOE"/>
@@ -24426,7 +24426,7 @@ license:CC0
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. B)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24451,7 +24451,7 @@ license:CC0
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. A)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24461,7 +24461,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev a).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
+				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev 1).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -24536,7 +24536,7 @@ license:CC0
 	</software>
 
 	<software name="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. A)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
@@ -24546,7 +24546,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev a).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
+				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev 1).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -1334,7 +1334,7 @@ license:CC0
 		<info name="serial" value="DMG-AUEJ-JPN"/>
 		<info name="gold" value="19991104"/>
 		<info name="release" value="19991224"/>
-		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
+		<info name="alt_title" value="爆走戦記 メタルウォーカーGB 鋼鉄の友情"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6454,7 +6454,7 @@ license:CC0
 		<info name="serial" value="DMG-BZOJ-JPN"/>
 		<info name="gold" value="20020510"/>
 		<info name="release" value="20020628"/>
-		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
+		<info name="alt_title" value="From TV Animation One Piece 幻のグランドライン冒険記！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
@@ -6479,7 +6479,7 @@ license:CC0
 		<info name="serial" value="DMG-BLUJ-JPN"/>
 		<info name="gold" value="20010615"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
+		<info name="alt_title" value="From TV Animation One Piece 夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
@@ -6504,7 +6504,7 @@ license:CC0
 		<info name="serial" value="DMG-BLUJ-JPN"/>
 		<info name="gold" value="20010307"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
+		<info name="alt_title" value="From TV Animation One Piece 夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
@@ -22545,7 +22545,7 @@ license:CC0
 		<info name="serial" value="DMG-AF2J-JPN"/>
 		<info name="gold" value="19990624"/>
 		<info name="release" value="19990723"/>
-		<info name="alt_title" value="昆虫博士 ２"/>
+		<info name="alt_title" value="昆虫博士2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
@@ -22566,7 +22566,7 @@ license:CC0
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN?"/>
 		<info name="gold" value="19990908"/>
-		<info name="alt_title" value="昆虫博士 ２"/>
+		<info name="alt_title" value="昆虫博士2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -5788,7 +5788,8 @@ license:CC0
 
 	<software name="emperorunk" cloneof="emperor">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	Two different bytes in header, ends padding areas with FF	-->
 		<description>The Emperor's New Groove (Europe, bad dump?)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
@@ -6085,7 +6086,8 @@ license:CC0
 
 	<software name="f1racingunk" cloneof="f1racing">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	One different byte in header, two different bytes in rest of the ROM	-->
 		<description>F1 Racing Championship (Europe, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
@@ -6271,10 +6273,11 @@ license:CC0
 		</part>
 	</software>
 
-<!-- The header is wrong, can it be a bad dump? a beta? investigations are needed on this older dump -->
 	<software name="flintbba" cloneof="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Europe, Alt?)</description>
+		<!--	Old dump of unknown origin	-->
+		<!--	Possible prototype?	-->
+		<description>The Flintstones - Burgertime in Bedrock (Europe, Prototype?)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -10358,8 +10361,8 @@ license:CC0
 
 	<software name="lauraunk" cloneof="laura">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>Laura (Europe, bad dump?)</description>
+		<!--	Old dump of unknown origin	-->
+		<description>Laura (Europe, Prototype?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -17373,8 +17376,8 @@ license:CC0
 
 	<software name="propooluunk" cloneof="propool">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>Pro Pool (USA, bad dump?)</description>
+		<!--	Old dump of unknown origin	-->
+		<description>Pro Pool (USA, Prototype?)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLE-USA"/>
@@ -19229,7 +19232,8 @@ license:CC0
 	</software>
 
 	<software name="seihaiunk" cloneof="seihai">
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	Four different bytes in header	-->
 		<description>Sei Hai Densetsu (Japan, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
@@ -19445,23 +19449,6 @@ license:CC0
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="shanghai pocket (europe) (rev 1).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shanghaij" cloneof="shanghai">
-		<description>Shanghai Pocket (Japan)</description>
-		<year>1998</year>
-		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-ASEJ-JPN?"/>
-		<info name="gold" value="19980701"/>
-		<info name="release" value="19980806"/>
-		<info name="alt_title" value="上海 ポケット"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (japan).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20881,7 +20868,8 @@ license:CC0
 
 	<software name="survkidsjunk" cloneof="stranded">
 		<!-- Also released by NP in 2001-02 -->
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	Four different bytes in header	-->
 		<description>Survival Kids - Kotou no Boukensha (Japan, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -24030,7 +24018,8 @@ license:CC0
 
 	<software name="yakouchuunk" cloneof="yakouchu">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	Four different bytes in header	-->
 		<description>Yakouchuu GB (Japan, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -4,7 +4,8 @@
 license:CC0
 
   To investigate:
-	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
+	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)	<- What is this version?
+	- Super Mario Bros. Deluxe (USA, Rev 2)	<- Was it released?
 
   Undumped:
 	- San Francisco Rush 2049 (Europe, fr/de/nl) [small pic]
@@ -12,17 +13,20 @@ license:CC0
   Known dumps not yet verified against retail cartridge:
 	- Alice in Wonderland (Europe)
 	- AMF Bowling (USA)
+	- Cruis'n Exotica (USA)
 	- Donkey Kong Country (USA, Not for resale)
-	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)	<- What is this version?
+	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)
 	- Gakkyuu Ou Yamazaki (Japan)
 	- Jissen ni Yakudatsu Tsumego (Japan)
 	- Laura (Europe)
 	- Mission Impossible (Europe, Rev 1)
+	- Merlin (Europe)
 	- Monster Traveler (Japan)
+	- Moomin's Tale (Europe)
 	- NBA In the Zone (USA)
 	- Pro Pool (USA)
 	- Sei Hai Densetsu (Japan)
-	- Super Mario Bros. Deluxe (USA, Rev 2)	<- Was it released?
+	- Super Mario Bros. Deluxe (USA, Rev 2)
 	- Tsuri Sensei 2 (Japan, Rev 1)
 	- Turok - Rage Wars (Australia)
 	- VR Sports Powerboat Racing (USA)
@@ -547,7 +551,6 @@ license:CC0
 
 	<software name="amfbowli">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbafpe0.339"	-->
 		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<description>AMF Bowling (USA)</description>
 		<year>2000</year>
@@ -558,7 +561,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbafpe0.339" size="1048576" crc="392559ee" sha1="1dd7d94f320d119682fd4df80297c8df1b28141b"/>
+				<rom name="cgb-afpe-0.u1" size="1048576" crc="392559ee" sha1="1dd7d94f320d119682fd4df80297c8df1b28141b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1594,7 +1597,6 @@ license:CC0
 	</software>
 
 	<software name="barcodea" cloneof="barcode">
-		<!--	In lot check as "dmgabej1.f26"	-->
 		<description>Barcode Taisen Bardigun (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
@@ -1606,7 +1608,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgabej1.f26" size="1048576" crc="f6d291a9" sha1="21e386f60fcd3694c4a308de9e178762c5175b6c"/>
+				<rom name="dmg-abej-1.u1" size="1048576" crc="f6d291a9" sha1="21e386f60fcd3694c4a308de9e178762c5175b6c"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -2245,7 +2247,6 @@ license:CC0
 
 	<software name="bokujom3a" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbwaj1.350"	-->
 		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
@@ -2255,7 +2256,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbbwaj1.350" size="2097152" crc="75af0e84" sha1="acb2e549fb7d107d20507af88c36f40234f74958"/>
+				<rom name="cgb-bwaj-1.u1" size="2097152" crc="75af0e84" sha1="acb2e549fb7d107d20507af88c36f40234f74958"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -3561,7 +3562,8 @@ license:CC0
 
 	<software name="crusnexo">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBXOE0.382", "KENSA\CGBBXOP0.0"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<!--	Planned for release in Europe as "cgb-bxop-0"	-->
 		<description>Cruis'n Exotica (USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
@@ -3569,7 +3571,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cruis'n exotica (usa).bin" size="2097152" crc="9562e7e8" sha1="e3f7bab776d76048a6cf1745fb4d8ecaf2d44f46"/>
+				<rom name="cgb-bxoe-0.u1" size="2097152" crc="9562e7e8" sha1="e3f7bab776d76048a6cf1745fb4d8ecaf2d44f46"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4134,7 +4136,6 @@ license:CC0
 
 	<software name="dendego2">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbb82j0.538"	-->
 		<description>Densha de Go! 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
@@ -4263,7 +4264,7 @@ license:CC0
 
 	<software name="dinosrus">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBDSP0.602", "KENSA\CGBBDSE0.0"	-->
+		<!--	Planned for release in USA as "cgb-bdse-0"	-->
 		<description>Dinosaur'us (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
@@ -4539,7 +4540,6 @@ license:CC0
 
 	<software name="dkongcd" cloneof="dkongc">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbdye0.326"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Donkey Kong Country (USA, Not for resale)</description>
 		<year>2000</year>
@@ -4550,7 +4550,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbbdye0.326" size="4194304" crc="080605a3" sha1="38fedd71736d258e31d3062864d28449e7c3f1c5"/>
+				<rom name="cgb-bdye-0.u1" size="4194304" crc="080605a3" sha1="38fedd71736d258e31d3062864d28449e7c3f1c5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5186,7 +5186,6 @@ license:CC0
 	</software>
 
 	<software name="dqm2ra" cloneof="dwm2c">
-		<!--	In lot check as "dmgbqlj1.j93"	-->
 		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
@@ -5198,7 +5197,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="dmgbqlj1.j93" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
+				<rom name="dmg-bqlj-1.u1" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -5806,7 +5805,6 @@ license:CC0
 
 	<software name="emperor">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbenp0.641"	-->
 		<description>The Emperor's New Groove (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
@@ -5815,7 +5813,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbbenp0.641" size="2097152" crc="eb29c584" sha1="2f53318aa7f1c82df95bf3da6b29701a2c563d13"/>
+				<rom name="cgb-benp-0.u1" size="2097152" crc="eb29c584" sha1="2f53318aa7f1c82df95bf3da6b29701a2c563d13"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5975,7 +5973,7 @@ license:CC0
 
 	<software name="f1wgp">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbafip0.028", "KENSA\cgbafie0.0"	-->
+		<!--	Planned for release in USA as "cgb-afie-0"	-->
 		<description>F-1 World Grand Prix (Europe)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
@@ -5984,7 +5982,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="f-1 world grand prix (europe) (en,fr,de,es).bin" size="2097152" crc="8d9a9182" sha1="16aa2e02e9b7f236f12a49c3224ca4cc89cdf98c"/>
+				<rom name="cgb-afip-0.u1" size="2097152" crc="8d9a9182" sha1="16aa2e02e9b7f236f12a49c3224ca4cc89cdf98c"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6040,7 +6038,6 @@ license:CC0
 
 	<software name="f1chmp2kb" cloneof="f1chmp2k">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfib0.579"	-->
 		<description>F1 Championship Season 2000 (Brazil)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
@@ -6049,14 +6046,13 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbbfib0.579" size="2097152" crc="f4f5ed18" sha1="4731a7442bbff31c6d470b84938a3f148a4f1f6c"/>
+				<rom name="cgb-bfib-0.u1" size="2097152" crc="f4f5ed18" sha1="4731a7442bbff31c6d470b84938a3f148a4f1f6c"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="f1racing">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaeqp0.381"	-->
 		<description>F1 Racing Championship (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
@@ -6065,7 +6061,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbaeqp0.381" size="4194304" crc="93a9789f" sha1="ea844051c0b5c6f9a6a8c472f4f67ee6b9b3d8e7"/>
+				<rom name="cgb-aeqp-0.u1" size="4194304" crc="93a9789f" sha1="ea844051c0b5c6f9a6a8c472f4f67ee6b9b3d8e7"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6436,7 +6432,6 @@ license:CC0
 
 	<software name="frogger2a" cloneof="frogger2">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbh2e1.351"	-->
 		<description>Frogger 2 (USA, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
@@ -6445,7 +6440,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbh2e1.351" size="1048576" crc="e3227b7d" sha1="0d5028ca6fcc10df46d11cd4b56e5add1dc5e63e"/>
+				<rom name="cgb-bh2e-1.u1" size="1048576" crc="e3227b7d" sha1="0d5028ca6fcc10df46d11cd4b56e5add1dc5e63e"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6582,9 +6577,8 @@ license:CC0
 
 	<software name="furaish2a" cloneof="furaish2">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfwj0.814"	-->
 		<!--	Retail cartridge not yet secured, might be unreleased	-->
-		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to feature the common retail release)	-->
+		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to include the common retail release)	-->
 		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
@@ -6594,7 +6588,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbbfwj0.814" size="4194304" crc="f3c20fbe" sha1="d9c490af97c08ac7053bbb9f7ae06d3501035127"/>
+				<rom name="cgb-bfwj-0.u1" size="4194304" crc="f3c20fbe" sha1="d9c490af97c08ac7053bbb9f7ae06d3501035127"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -6644,7 +6638,6 @@ license:CC0
 	</software>
 
 	<software name="gakkyama" cloneof="gakkyamaa">
-		<!--	In lot check as "dmgaymj0.g22"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Gakkyuu Ou Yamazaki (Japan)</description>
 		<year>1999</year>
@@ -6656,7 +6649,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgaymj0.g22" size="1048576" crc="b8147b5c" sha1="132b872391565d418ccc9d0e1c643510d778c066"/>
+				<rom name="dmg-aymj-0.u1" size="1048576" crc="b8147b5c" sha1="132b872391565d418ccc9d0e1c643510d778c066"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6698,17 +6691,16 @@ license:CC0
 
 	<software name="gamblerta" cloneof="gamblert">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbgyj1.607"	-->
 		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
-		<info name="serial" value="CGB-BGYJ-JPN?"/>
+		<info name="serial" value="CGB-BGYJ-JPN"/>
 		<info name="gold" value="20010307"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbgyj1.607" size="1048576" crc="91739def" sha1="b62f8e56b995874c0e1a2533df5a37f6996df12e"/>
+				<rom name="cgb-bgyj-1.u1" size="1048576" crc="91739def" sha1="b62f8e56b995874c0e1a2533df5a37f6996df12e"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -8722,7 +8714,6 @@ license:CC0
 
 	<software name="hypeb" cloneof="hype">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpfe0.737"	-->
 		<description>Hype - The Time Quest (Brazil)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
@@ -8731,7 +8722,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpfe0.737" size="1048576" crc="cafb8035" sha1="7c7dca7c48dc478d0278c273ba37723b9e9dce5b"/>
+				<rom name="cgb-bpfe-0.u1" size="1048576" crc="cafb8035" sha1="7c7dca7c48dc478d0278c273ba37723b9e9dce5b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -9259,7 +9250,6 @@ license:CC0
 
 	<software name="jissen" cloneof="jissena">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbjtj0.313"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Jissen ni Yakudatsu Tsumego (Japan)</description>
 		<year>2000</year>
@@ -9270,7 +9260,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="cgbbjtj0.313" size="262144" crc="69c6dbef" sha1="f7ed6cdce7637a11d7fa7f5cb59b8f8ce131f9d1"/>
+				<rom name="cgb-bjtj-0.u1" size="262144" crc="69c6dbef" sha1="f7ed6cdce7637a11d7fa7f5cb59b8f8ce131f9d1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -9690,7 +9680,6 @@ license:CC0
 	</software>
 
 	<software name="kawaipt2a">
-		<!--	In lot check as "dmgbmnj1.j90"	-->
 		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
@@ -9700,7 +9689,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgbmnj1.j90" size="2097152" crc="6fce1ad0" sha1="58ea410ebbee5edc18644c0467fe9ea03d179b1c"/>
+				<rom name="dmg-bmnj-1.u1" size="2097152" crc="6fce1ad0" sha1="58ea410ebbee5edc18644c0467fe9ea03d179b1c"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -9960,7 +9949,7 @@ license:CC0
 
 	<software name="kirbytlt" supported="no">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBKTNE0.638", "KENSA\CGBKTNP0.0"	-->
+		<!--	Planned for release in Europe as "cgb-ktnp-0"	-->
 		<!--	The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console.	-->
 		<description>Kirby Tilt 'n' Tumble (USA)</description>
 		<year>2001</year>
@@ -9974,7 +9963,7 @@ license:CC0
 			<feature name="u4" value="U4 ADXL202" />
 			<feature name="slot" value="rom_mbc7" />
 			<dataarea name="rom" size="1048576">
-				<rom name="kirby tilt 'n' tumble (usa).bin" size="1048576" crc="e541acf1" sha1="6ab8d666e2bebbb3fee7796c8968aab2ea21b8f9"/>
+				<rom name="cgb-ktne-0.u1" size="1048576" crc="e541acf1" sha1="6ab8d666e2bebbb3fee7796c8968aab2ea21b8f9"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -10352,7 +10341,6 @@ license:CC0
 
 	<software name="laura">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbldp0.420"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Laura (Europe)</description>
 		<year>2000</year>
@@ -10363,7 +10351,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbldp0.420" size="1048576" crc="a58c8282" sha1="47e5c4c7fa447efc8a0abf019e8d2cd227c5e0e3"/>
+				<rom name="cgb-bldp-0.u1" size="1048576" crc="a58c8282" sha1="47e5c4c7fa447efc8a0abf019e8d2cd227c5e0e3"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10908,7 +10896,6 @@ license:CC0
 
 	<software name="lionkingfa" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbblkf1.573"	-->
 		<description>Les Roi Lion - Les Adventures de Simba (France, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
@@ -10918,7 +10905,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbblkf1.573" size="1048576" crc="c7aae1b3" sha1="b8cc2f1d3a8d40c7588d5c535f28e2f80446a793"/>
+				<rom name="cgb-blkf-1.u1" size="1048576" crc="c7aae1b3" sha1="b8cc2f1d3a8d40c7588d5c535f28e2f80446a793"/>
 			</dataarea>
 		</part>
 	</software>
@@ -11527,7 +11514,6 @@ license:CC0
 
 	<software name="lovehinaa" cloneof="lovehina">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbphj1.290"	-->
 		<description>Love Hina Pocket (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
@@ -11537,7 +11523,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbbphj1.290" size="4194304" crc="55dd0ba6" sha1="b29abee319ccb223e5d1a4f88982fb53e538d527"/>
+				<rom name="cgb-bphj-1.u1" size="4194304" crc="55dd0ba6" sha1="b29abee319ccb223e5d1a4f88982fb53e538d527"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -12753,7 +12739,8 @@ license:CC0
 
 	<software name="merlin">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBMBP0.603", "KENSA\CGBBMBE0.0"	-->
+		<!--	Planned for release in USA as "cgb-bmbe-0"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Merlin (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
@@ -12761,7 +12748,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="merlin (europe) (en,fr,de,es,it,nl).bin" size="1048576" crc="c5290cee" sha1="96ee6a40abf4bcbb90f3ea7c232fb3866333a202"/>
+				<rom name="cgb-bmbp-0.u1" size="1048576" crc="c5290cee" sha1="96ee6a40abf4bcbb90f3ea7c232fb3866333a202"/>
 			</dataarea>
 		</part>
 	</software>
@@ -13109,7 +13096,6 @@ license:CC0
 	</software>
 
 	<software name="minnashga" cloneof="minnashg">
-		<!--	In lot check as "dmga7yj1.i18"	-->
 		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
@@ -13120,7 +13106,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmga7yj1.i18" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
+				<rom name="dmg-a7yj-1.u1" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13206,7 +13192,6 @@ license:CC0
 
 	<software name="missimpa" cloneof="missimp">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaimp1.076"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Mission Impossible (Europe, Rev 1)</description>
 		<year>2000</year>
@@ -13216,7 +13201,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbaimp1.076" size="1048576" crc="9c51f4c7" sha1="f822bda01d881f34d1e17664465faf6a3ff64356"/>
+				<rom name="cgb-aimp-1.u1" size="1048576" crc="9c51f4c7" sha1="f822bda01d881f34d1e17664465faf6a3ff64356"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -13476,7 +13461,6 @@ license:CC0
 
 	<software name="monstrvl" cloneof="monstrvla">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfvj0.949"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Monster Traveler (Japan)</description>
 		<year>2002</year>
@@ -13487,7 +13471,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbbfvj0.949" size="4194304" crc="5d596cf6" sha1="5195f55ad6aaa302c0a0e11c0ec6ecad4efe0e27"/>
+				<rom name="cgb-bfvj-0.u1" size="4194304" crc="5d596cf6" sha1="5195f55ad6aaa302c0a0e11c0ec6ecad4efe0e27"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13622,7 +13606,8 @@ license:CC0
 
 	<software name="moomin">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBAM9P0.471", "KENSA\CGBAM9E0.0"	-->
+		<!--	Planned for release in USA as "cgb-am9e-0"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Moomin's Tale (Europe)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
@@ -13630,7 +13615,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="moomin's tale (europe) (en,fr,de).bin" size="1048576" crc="45543ba2" sha1="06e57b38b7f9ec71809f309aa7d220af48ca96b6"/>
+				<rom name="cgb-am9p-0.u1" size="1048576" crc="45543ba2" sha1="06e57b38b7f9ec71809f309aa7d220af48ca96b6"/>
 			</dataarea>
 		</part>
 	</software>
@@ -13795,7 +13780,7 @@ license:CC0
 	<software name="mrdrillrjnp" cloneof="mrdrillr">
 		<!-- Notes: GBC only -->
 		<!-- NP only -->
-		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
+		<!--	Planned for physical release?	-->
 		<description>Mr. Driller (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
@@ -13805,7 +13790,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
-				<rom name="cgbbv3j0.0" size="524288" crc="35fd440d" sha1="fb64fa7da6a0fec3e358bb3357e66d68473ada67"/>
+				<rom name="cgb-bv3j-0.u1" size="524288" crc="35fd440d" sha1="fb64fa7da6a0fec3e358bb3357e66d68473ada67"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -14393,7 +14378,6 @@ license:CC0
 	</software>
 
 	<software name="nbazone" cloneof="nbapro99">
-		<!--	In lot check as "dmganze0.g29"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>NBA In the Zone (USA)</description>
 		<year>1999</year>
@@ -14404,7 +14388,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmganze0.g29" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
+				<rom name="dmg-anze-0.u1" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -15937,7 +15921,6 @@ license:CC0
 
 	<software name="poktpuyna" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpyj1.327"	-->
 		<description>Pocket Puyo Puyo-n (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
@@ -15947,7 +15930,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpyj1.327" size="1048576" crc="c884037a" sha1="3d52805f712e6d1ce22b88dfebfcac2a31743ff3"/>
+				<rom name="cgb-bpyj-1.u1" size="1048576" crc="c884037a" sha1="3d52805f712e6d1ce22b88dfebfcac2a31743ff3"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -15956,7 +15939,6 @@ license:CC0
 
 	<software name="poktpuynb" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpyj2.327"	-->
 		<description>Pocket Puyo Puyo-n (Japan, Rev 2)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
@@ -15966,7 +15948,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpyj2.327" size="1048576" crc="573613d7" sha1="09b217161ac326da63887693281b60751ca2dfcf"/>
+				<rom name="cgb-bpyj-2.u1" size="1048576" crc="573613d7" sha1="09b217161ac326da63887693281b60751ca2dfcf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -15991,7 +15973,7 @@ license:CC0
 
 	<software name="pocksocr">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBPSP0.618", "KENSA\CGBBPSE0.0"	-->
+		<!--	Planned for release in USA as "cgb-bpse-0"	-->
 		<description>Pocket Soccer (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -15999,7 +15981,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="pocket soccer (europe) (en,fr,de,es,it,pt).bin" size="2097152" crc="e8f5824f" sha1="4d06ea937a02a8f458186a9382994b09a97481a4"/>
+				<rom name="cgb-bpsp-0.u1" size="2097152" crc="e8f5824f" sha1="4d06ea937a02a8f458186a9382994b09a97481a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -16008,7 +15990,7 @@ license:CC0
 
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
-		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
+		<!--	European version 0 does not exist	-->
 		<description>Pokémon - Crystal Version (Europe, USA, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -16129,7 +16111,6 @@ license:CC0
 
 	<software name="pokecrysaus" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbytu0.834"	-->
 		<description>Pokémon - Crystal Version (Australia)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -16140,7 +16121,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbbytu0.834" size="2097152" crc="bb6dd80c" sha1="a0fc810f1d4e124434f7be2c989ab5b5892ddf36"/>
+				<rom name="cgb-bytu-0.u1" size="2097152" crc="bb6dd80c" sha1="a0fc810f1d4e124434f7be2c989ab5b5892ddf36"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16481,7 +16462,6 @@ license:CC0
 	</software>
 
 	<software name="pokecard">
-		<!--	In lot check as "dmgaxqx1.j85"	-->
 		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -16491,7 +16471,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgaxqx1.j85" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
+				<rom name="dmg-axqx-1.u1" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16539,7 +16519,6 @@ license:CC0
 	</software>
 
 	<software name="pokecardaa" cloneof="pokecard">
-		<!--	In lot check as "dmgaxqp1.j84"	-->
 		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -16549,7 +16528,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgaxqp1.j84" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
+				<rom name="dmg-axqp-1.u1" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -17376,7 +17355,6 @@ license:CC0
 
 	<software name="propoolu" cloneof="propool">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbple0.298"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Pro Pool (USA)</description>
 		<year>2000?</year>
@@ -17386,7 +17364,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbple0.298" size="1048576" crc="2611fa3d" sha1="c85e514c24c82071907c6495243dae448b46c2b2"/>
+				<rom name="cgb-bple-0.u1" size="1048576" crc="2611fa3d" sha1="c85e514c24c82071907c6495243dae448b46c2b2"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19089,7 +19067,6 @@ license:CC0
 	</software>
 
 	<software name="sanriotka" cloneof="sanriotk">
-		<!--	In lot check as "dmgatpj1.f14"	-->
 		<description>Sanrio Timenet - Kako Hen (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
@@ -19101,7 +19078,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgatpj1.f14" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
+				<rom name="dmg-atpj-1.u1" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -19129,7 +19106,6 @@ license:CC0
 	</software>
 
 	<software name="sanriotma" cloneof="sanriotm">
-		<!--	In lot check as "dmgatfj1.f15"	-->
 		<description>Sanrio Timenet - Mirai Hen (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
@@ -19141,7 +19117,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgatfj1.f15" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
+				<rom name="dmg-atfj-1.u1" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -19235,7 +19211,6 @@ license:CC0
 	</software>
 
 	<software name="seihai">
-		<!--	In lot check as "dmgaeoj0.j01"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Sei Hai Densetsu (Japan)</description>
 		<year>2000</year>
@@ -19248,7 +19223,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgaeoj0.j01" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
+				<rom name="dmg-aeoj-0.u1" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
 			</dataarea>
 		</part>
 	</software>
@@ -19506,7 +19481,6 @@ license:CC0
 	</software>
 
 	<software name="shanghaiu" cloneof="shanghai">
-		<!--	In lot check as "dmgahpe0.f55"	-->
 		<description>Shanghai Pocket (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
@@ -19516,7 +19490,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
+				<rom name="dmg-ahpe-0.u1" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
 			</dataarea>
 		</part>
 	</software>
@@ -19552,7 +19526,6 @@ license:CC0
 	</software>
 
 	<software name="shinmtaa">
-		<!--	In lot check as "dmgbhnj1.j70"	-->
 		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
@@ -19564,7 +19537,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgbhnj1.j70" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
+				<rom name="dmg-bhnj-1.u1" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -19597,7 +19570,6 @@ license:CC0
 	</software>
 
 	<software name="shinmtka">
-		<!--	In lot check as "dmgbhej1.j69"	-->
 		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
@@ -19609,7 +19581,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgbhej1.j69" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
+				<rom name="dmg-bhej-1.u1" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -19810,7 +19782,6 @@ license:CC0
 	</software>
 
 	<software name="sewingose" cloneof="sewingos">
-		<!--	In lot check as "dmgbraz0.k25"	-->
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
 		<description>Sewing Machine Operation Software (Europe)</description>
 		<year>2000</year>
@@ -19821,7 +19792,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgbraz0.k25" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
+				<rom name="dmg-braz-0.u1" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20322,14 +20293,14 @@ license:CC0
 	<software name="spyvsspyjanp" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<!-- NP only -->
-		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
+		<!--	Planned for physical release?	-->
 		<description>Spy vs. Spy (Japan, Rev 1, NP)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbas6j1.0" size="1048576" crc="eb47d63b" sha1="9e203f04857cd84ec49b0e6c6d4917b1a5cc199e"/>
+				<rom name="cgb-as6j-1.u1" size="1048576" crc="eb47d63b" sha1="9e203f04857cd84ec49b0e6c6d4917b1a5cc199e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20682,7 +20653,7 @@ license:CC0
 	<software name="smbdxj" cloneof="smbdx">
 		<!-- Notes: GBC only -->
 		<!-- NP only -->
-		<!--	In lot check as "POOL\cgbahyj0.0"	-->
+		<!--	Planned for physical release?	-->
 		<description>Super Mario Bros. Deluxe (Japan, NP)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -20692,7 +20663,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (japan) (np).bin" size="1048576" crc="866b1212" sha1="94466f48d8b4f811608ce8641de5f82315cd60b5"/>
+				<rom name="cgb-ahyj-0.u1" size="1048576" crc="866b1212" sha1="94466f48d8b4f811608ce8641de5f82315cd60b5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20702,7 +20673,7 @@ license:CC0
 	<software name="smbdxja" cloneof="smbdx">
 		<!-- Notes: GBC only -->
 		<!-- NP only -->
-		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
+		<!--	Planned for physical release?	-->
 		<description>Super Mario Bros. Deluxe (Japan, NP, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -20712,7 +20683,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbahyj1.0" size="1048576" crc="f4e91f63" sha1="e61d564e1ff19eb4b7c62a6cd96214f2bca4b01d"/>
+				<rom name="cgb-ahyj-1.u1" size="1048576" crc="f4e91f63" sha1="e61d564e1ff19eb4b7c62a6cd96214f2bca4b01d"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20721,7 +20692,7 @@ license:CC0
 
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
+		<!--	Planned for release in USA as "cgb-ahye-2"	-->
 		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<description>Super Mario Bros. Deluxe (Europe, USA, Rev 2)</description>
 		<year>1999</year>
@@ -20730,7 +20701,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev 2).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
+				<rom name="cgb-ahyp-2.u1" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20890,7 +20861,6 @@ license:CC0
 
 	<software name="survkidsj" cloneof="stranded">
 		<!-- Also released by NP in 2001-02 -->
-		<!--	In lot check as "dmgavkj0.g64"	-->
 		<description>Survival Kids - Kotou no Boukensha (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -20902,7 +20872,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgavkj0.g64" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
+				<rom name="dmg-avkj-0.u1" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -21466,7 +21436,6 @@ license:CC0
 
 	<software name="tetrisada" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbat7j1.070"	-->
 		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
@@ -21476,7 +21445,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbat7j1.070" size="1048576" crc="b7c0831f" sha1="a8842e85f2c6de4db40b47c9640dad59ae9d1c51"/>
+				<rom name="cgb-at7j-1.u1" size="1048576" crc="b7c0831f" sha1="a8842e85f2c6de4db40b47c9640dad59ae9d1c51"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -21822,7 +21791,6 @@ license:CC0
 
 	<software name="tomjermha" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbtjp1.487"	-->
 		<description>Tom and Jerry - Mousehunt (Europe, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
@@ -21831,7 +21799,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbtjp1.487" size="1048576" crc="4b4553e0" sha1="bf5faf4c5c2aabe9636f8f5afbbf526aba59e21d"/>
+				<rom name="cgb-btjp-1.u1" size="1048576" crc="4b4553e0" sha1="bf5faf4c5c2aabe9636f8f5afbbf526aba59e21d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -21852,7 +21820,6 @@ license:CC0
 
 	<software name="tomjermhua" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbtqe1.541"	-->
 		<description>Tom and Jerry - Mousehunt (USA, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
@@ -21861,7 +21828,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbbtqe1.541" size="2097152" crc="ce4ca7b1" sha1="89374d81045a3bedf24e42b58ce403b0a5fbcddb"/>
+				<rom name="cgb-btqe-1.u1" size="2097152" crc="ce4ca7b1" sha1="89374d81045a3bedf24e42b58ce403b0a5fbcddb"/>
 			</dataarea>
 		</part>
 	</software>
@@ -22454,7 +22421,7 @@ license:CC0
 
 	<software name="tradebata">
 		<!--	Only released on the 3DS Virtual Console?	-->
-		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
+		<!--	Planned for physical release?	-->
 		<description>Trade &amp; Battle Card Hero (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -22465,7 +22432,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmgahhj1.1" size="2097152" crc="d98a877d" sha1="c6c1e0365166b53d25a1f84bc380948a9661df30"/>
+				<rom name="dmg-ahhj-1.u1" size="2097152" crc="d98a877d" sha1="c6c1e0365166b53d25a1f84bc380948a9661df30"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -22593,7 +22560,6 @@ license:CC0
 	</software>
 	
 	<software name="tsurisn2a" cloneof="tsurisn2">
-		<!--	In lot check as "dmga2kj1.g93"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Tsuri Sensei 2 (Japan, Rev 1)</description>
 		<year>1999</year>
@@ -22605,7 +22571,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="dmga2kj1.g93" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
+				<rom name="dmg-a2kj-1.u1" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -23113,7 +23079,6 @@ license:CC0
 
 	<software name="vrspower">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpbe0.340"	-->
 		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<description>VR Sports Powerboat Racing (USA)</description>
 		<year>2000</year>
@@ -23123,7 +23088,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpbe0.340" size="1048576" crc="cff671f1" sha1="1c77f032cdd373bfa108ea82c463f8f9f6874c71"/>
+				<rom name="cgb-bpbe-0.u1" size="1048576" crc="cff671f1" sha1="1c77f032cdd373bfa108ea82c463f8f9f6874c71"/>
 			</dataarea>
 		</part>
 	</software>
@@ -24045,7 +24010,6 @@ license:CC0
 
 	<software name="yakouchu">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaytj0.066"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Yakouchuu GB (Japan)</description>
 		<year>1999</year>
@@ -24057,7 +24021,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="cgbaytj0.066" size="2097152" crc="e0a06018" sha1="a7efd41d0ad17892132788bd90cdfb9df6806a78"/>
+				<rom name="cgb-aytj-0.u1" size="2097152" crc="e0a06018" sha1="a7efd41d0ad17892132788bd90cdfb9df6806a78"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -3,20 +3,39 @@
 <!--
 license:CC0
 
-To investigate:
+  To investigate:
+	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
 
+  Undumped:
+	- San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
+	
+  Known dumps not yet verified against retail cartridge:
+	- Alice in Wonderland (Euro)
+	- AMF Bowling (USA)
+	- Donkey Kong Country (USA, Not for resale)
+	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn, Alt)	<- What is this version?
+	- Gakkyuu Ou Yamazaki (Jpn)
+	- Jissen ni Yakudatsu Tsumego (Jpn)
+	- Laura (Euro)
+	- Mission Impossible (Euro, Rev. A)
+	- Monster Traveler (Jpn)
+	- NBA In the Zone (USA)
+	- Pro Pool (USA)
+	- Sei Hai Densetsu (Jpn)
+	- Super Mario Bros. Deluxe (USA, Rev. B)	<- Was it released?
+	- Tsuri Sensei 2 (Jpn, Rev. A)
+	- Turok - Rage Wars (Aus)
+	- VR Sports Powerboat Racing (USA)
+	- Yakouchuu GB (Jpn)
 
-Undumped:
-- San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
+  Undumped GBC protos:
+	- Jet Force Gemini
 
-Undumped GBC protos:
-  - Jet Force Gemini
-
-Unreleased (music source code exists, possibly no prototypes exist)
-- Crimson
-- Hard Truck
-- Katharsis
-- Hero's Quest
+  Unreleased (music source code exists, possibly no prototypes exist)
+	- Crimson
+	- Hard Truck
+	- Katharsis
+	- Hero's Quest
 
 
  Info on the PCB codes, based on Tauwasser's notes and research
@@ -206,7 +225,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BVPP-EUR"/>
-		<info name="submitted" value="20010215"/>
+		<info name="gold" value="20010215"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -412,10 +431,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="aliceu" cloneof="alice">
 		<!-- Notes: GBC only -->
-		<description>Alice in Wonderland (USA)</description>
+		<!--	Retail cartridge of European version not yet secured	-->
+		<description>Alice in Wonderland (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="CGB-AIWE-USA"/>
+		<info name="serial" value="CGB-AIWP-EUR, CGB-AIWE-USA"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -448,7 +468,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AZTP-EUR"/>
-		<info name="submitted" value="20000223"/>
+		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -528,12 +548,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="amfbowli">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbafpe0.339"	-->
-		<!--	Retail cartridge not yet located, might be unreleased	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<description>AMF Bowling (USA)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-AFPE-USA?"/>
-		<info name="submitted" value="20000727"/>
+		<info name="gold" value="20000727"/>
 		<info name="alt_title" value="AMF Xtreme Bowling"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -544,7 +564,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="animalb3">
-		<!-- Notes: SGB enhanced -->
 		<description>Animal Breeder 3 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
@@ -552,6 +571,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="あにまるぶりーだー3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="animal breeder 3 (japan).bin" size="4194304" crc="c62a4c30" sha1="f5e6e770a681bb6eba255e2584f9ed343e5d9f98"/>
@@ -725,7 +745,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="aqualife">
-		<!-- Notes: SGB enhanced -->
 		<description>Aqualife (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
@@ -733,6 +752,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991022"/>
 		<info name="alt_title" value="アクアライフ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="aqualife (japan).bin" size="1048576" crc="e243feb4" sha1="69eaf53eccdaf98cd7cc0d436209f511b558d761"/>
@@ -769,7 +789,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="arle">
-		<!-- Notes: SGB enhanced -->
 		<description>Arle no Bouken - Mahou no Jewel (Jpn)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
@@ -777,6 +796,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="アルルの冒険 まほうのジュエル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="arle no bouken - mahou no jewel (japan).bin" size="1048576" crc="8ee043ea" sha1="fb781637ddac30cebb1865ba939f49bb2b0b5146"/>
@@ -1137,7 +1157,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bdaman">
-		<!-- Notes: SGB enhanced -->
 		<description>B-Daman Bakugaiden - Victory e no Michi (Jpn)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
@@ -1145,6 +1164,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990129"/>
 		<info name="alt_title" value="Bビーダマン爆 外伝 ビクトリーへのみち"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [MX23C8003-20]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -1309,7 +1329,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AUEJ-JPN"/>
-		<info name="submitted" value="19991104"/>
+		<info name="gold" value="19991104"/>
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
 		<part name="cart" interface="gameboy_cart">
@@ -1354,7 +1374,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="balonfgt">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Also released by NP in 2000-08 -->
 		<description>Balloon Fight GB (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -1362,6 +1382,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="2000-07-31 / 20000801"/>
 		<info name="alt_title" value="BALLOON FIGHT GB バルーンファイトGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="balloon fight gb (japan) (np).bin" size="262144" crc="d2af64ce" sha1="dbaa1bf9061de0f052704d6a33892341a38f2152"/>
@@ -1547,15 +1568,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barcode">
-		<!-- Notes: SGB enhanced -->
 		<description>Barcode Taisen Bardigun (Jpn)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN"/>
-		<info name="submitted" value="19981105"/>
+		<info name="gold" value="19981105"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="バーコード対戦 バーディガン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC3A [MBC3A]" />
@@ -1573,15 +1594,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barcodea" cloneof="barcode">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgabej1.f26"	-->
 		<description>Barcode Taisen Bardigun (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN-1"/>
-		<info name="submitted" value="19990323"/>
+		<info name="gold" value="19990323"/>
 		<info name="alt_title" value="バーコード対戦 バーディガン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -1779,7 +1800,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bmanigb">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<!-- Also released by NP in 2000-05 -->
 		<description>Beatmania GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -1787,6 +1808,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990311"/>
 		<info name="alt_title" value="ビートマニアGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb (japan).bin" size="1048576" crc="0d9cb195" sha1="640c4633fe8ec60b767c15a094c87ab7e113d555"/>
@@ -1811,7 +1833,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bmanigb2">
-		<!-- Notes: SGB enhanced -->
 		<description>Beatmania GB2 - Gotcha Mix (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -1819,6 +1840,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="ビートマニア GB2 ガチャミックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb2 - gotcha mix (japan).bin" size="1048576" crc="59beb372" sha1="b6273c434e880d6f9b5f4f6f53307bda9902fff1"/>
@@ -1926,7 +1948,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bikkuri">
-		<!-- Notes: SGB enhanced -->
 		<description>Bikkuriman 2000 - Charging Card GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -1934,6 +1955,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000610"/>
 		<info name="alt_title" value="ビックリマン2000 チャージングカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="bikkuriman 2000 - charging card gb (japan).bin" size="2097152" crc="5be2517c" sha1="c3c608f1b3581a070c9b7eb65b6fb6d1b72d98d3"/>
@@ -2064,7 +2086,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="CGB-BALE-USA"/>
-		<info name="submitted" value="20000926"/>
+		<info name="gold" value="20000926"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2207,7 +2229,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
-		<info name="submitted" value="20000731"/>
+		<info name="gold" value="20000731"/>
 		<info name="release" value="20000929"/>
 		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2227,7 +2249,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
-		<info name="submitted" value="20001205"/>
+		<info name="gold" value="20001205"/>
 		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -2350,7 +2372,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bombmqstj" cloneof="bombmqst">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Also released by NP in 2000-08 -->
 		<description>Bomberman Quest (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -2358,6 +2380,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981224"/>
 		<info name="alt_title" value="ボンバーマンクエスト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-DFCN-20" /><!-- DMG-DECN? -->
 			<feature name="slot" value="rom_mbc1" />
@@ -2390,7 +2413,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-B2CK-KOR"/>
-		<info name="submitted" value="20030409"/>
+		<info name="gold" value="20030409"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-M-BFAN-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -2618,7 +2641,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="burgerb">
-		<!-- Notes: SGB enhanced -->
 		<description>Burger Burger Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Gaps</publisher>
@@ -2626,6 +2648,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="バーガーバーガーポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="burger burger pocket (japan).bin" size="1048576" crc="1abcedbe" sha1="f4579d4bb3b39f572fdf033df01a84a925fb3f2e"/>
@@ -2862,7 +2885,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BS7J-JPN"/>
-		<info name="submitted" value="20000824"/>
+		<info name="gold" value="20000824"/>
 		<info name="release" value="20001006"/>
 		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2898,7 +2921,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
-		<info name="submitted" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
+		<info name="gold" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -2930,7 +2953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9X-EUU"/>
-		<info name="submitted" value="20000831"/>
+		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -2953,7 +2976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9P-EUR"/>
-		<info name="submitted" value="20000831"/>
+		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2970,7 +2993,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9E-USA"/>
-		<info name="submitted" value="20000404"/>
+		<info name="gold" value="20000404"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3000,7 +3023,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CP-EUR"/>
-		<info name="submitted" value="19991018"/>
+		<info name="gold" value="19991018"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3015,7 +3038,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CE-USA"/>
-		<info name="submitted" value="19991101"/>
+		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3251,7 +3274,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="choroq">
-		<!-- Notes: SGB enhanced -->
 		<description>Choro Q - Hyper Customable GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
@@ -3259,6 +3281,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="チョロQ ハイパーカスタマブルGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="choro q - hyper customable gb (japan).bin" size="2097152" crc="65610ca4" sha1="8af215c632599aaab9bc4614194ac45802407bbc"/>
@@ -3311,7 +3334,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="columns">
-		<!-- Notes: SGB enhanced -->
 		<description>Columns GB - Tezuka Osamu Characters (Jpn)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
@@ -3319,6 +3341,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991105"/>
 		<info name="alt_title" value="コラムスGB手塚治虫キャラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="columns gb - tezuka osamu characters (japan).bin" size="524288" crc="fbe5de37" sha1="a8d9a6631f1d203d99be38fb90135c10e5f0c880"/>
@@ -3535,6 +3558,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="crusnexo">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBBXOE0.382", "KENSA\CGBBXOP0.0"	-->
 		<description>Cruis'n Exotica (USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
@@ -3677,7 +3701,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="miraclz2">
-		<!-- Notes: SGB enhanced -->
 		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
@@ -3685,6 +3708,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="大貝獣物語 ザ・ミラクル オブ ザ・ゾーンII"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC1A [HuC-1]" />
@@ -3706,7 +3730,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22X-EUR"/>
-		<info name="submitted" value="20000727"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3723,7 +3747,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22Y-EUU"/>
-		<info name="submitted" value="20000727"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3768,7 +3792,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="daikugen">
-		<!-- Notes: SGB enhanced -->
 		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Jpn)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
@@ -3776,6 +3799,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="大工の源さん 〜カチカチのトンカチガカチ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="daiku no gen-san - kachikachi no tonkachi ga kachi (japan).bin" size="1048576" crc="e2071293" sha1="2d961353e7242babce49dda8d017a459f4ef7609"/>
@@ -3930,7 +3954,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BJ2P-EUR"/>
-		<info name="submitted" value="20011127"/>
+		<info name="gold" value="20011127"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3955,7 +3979,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="deardani">
-		<!-- Notes: SGB enhanced -->
 		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -3963,6 +3986,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dear daniel no sweet adventure - kitty-chan o sagashite (japan).bin" size="1048576" crc="0fd34427" sha1="8598594285f0342b3d93c447b475fadd4722c6cb"/>
@@ -4075,7 +4099,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BD9P-EUR"/>
-		<info name="submitted" value="20010830"/>
+		<info name="gold" value="20010830"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -4111,7 +4135,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-B82J-JPN"/>
-		<info name="submitted" value="20001020"/>
+		<info name="gold" value="20001020"/>
 		<info name="release" value="20001208"/>
 		<info name="alt_title" value="電車でＧＯ！ ２"/>
 		<part name="cart" interface="gameboy_cart">
@@ -4151,7 +4175,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dinobrd3">
-		<!-- Notes: SGB enhanced -->
 		<description>Dino Breeder 3 - Gaia Fukkatsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
@@ -4159,6 +4182,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ディノブリーダー3 ガイア復活"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 3 - gaia fukkatsu (japan).bin" size="2097152" crc="d9f071bb" sha1="f571a591a2f4fc4f70897e380fdbe9011be75f8d"/>
@@ -4169,7 +4193,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dinobrd4">
-		<!-- Notes: SGB enhanced -->
 		<description>Dino Breeder 4 (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
@@ -4177,6 +4200,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="ディノブリーダー4"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 4 (japan).bin" size="2097152" crc="b0106777" sha1="b25681defda961837a28be1432076b65574fd1be"/>
@@ -4235,6 +4259,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dinosrus">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBBDSP0.602", "KENSA\CGBBDSE0.0"	-->
 		<description>Dinosaur'us (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
@@ -4511,12 +4536,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="dkongcd" cloneof="dkongc">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbdye0.326"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Donkey Kong Country (USA, Not for resale)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DIS-CGB-BDYE-USA"/>
-		<info name="submitted" value="20000719"/>
+		<info name="gold" value="20000719"/>
 		<info name="alt_title" value="DONKEY KONG COUNTRY (DISPLAY)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -4587,7 +4612,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dorakrt2">
-		<!-- Notes: SGB enhanced -->
 		<description>Doraemon Kart 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
@@ -4595,6 +4619,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="ドラえもんカート2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WW3]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -4998,7 +5023,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-BDAE-USA"/>
-		<info name="submitted" value="20000623"/>
+		<info name="gold" value="20000623"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
@@ -5008,7 +5033,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dquest12" cloneof="dwarr12">
-		<!-- Notes: SGB enhanced -->
 		<description>Dragon Quest I &amp; II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
@@ -5016,6 +5040,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="ドラゴンクエストI・II"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5050,7 +5075,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<!-- Notes: SGB enhanced -->
 		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
@@ -5058,6 +5082,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -5074,7 +5099,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqma" cloneof="dwm">
-		<!-- Notes: SGB enhanced -->
 		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
@@ -5082,6 +5106,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -5113,15 +5138,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm2i" cloneof="dwm2t">
-		<!-- Notes: SGB enhanced -->
 		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQIJ-JPN"/>
-		<info name="submitted" value="20001222"/>
+		<info name="gold" value="20001222"/>
 		<info name="release" value="20010412"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 イルの冒険"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dragon quest monsters 2 - maruta no fushigi na kagi - iru no bouken (japan).bin" size="4194304" crc="68ba18d7" sha1="9193778b28e2e4a6303e09cb4170ca00d0058ae5"/>
@@ -5132,15 +5157,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm2r" cloneof="dwm2c">
-		<!-- Notes: SGB enhanced -->
 		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
-		<info name="submitted" value="20001208"/>
+		<info name="gold" value="20001208"/>
 		<info name="release" value="20010309"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5157,16 +5182,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm2ra" cloneof="dwm2c">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgbqlj1.j93"	-->
 		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
-		<info name="submitted" value="20001228"/>
+		<info name="gold" value="20001228"/>
 		<info name="release" value="20010309"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dmgbqlj1.j93" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
@@ -5373,7 +5398,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dtlords">
-		<!-- Notes: SGB enhanced -->
 		<description>DT - Lords of Genomes (Jpn)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
@@ -5381,6 +5405,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010525"/>
 		<info name="alt_title" value="DT ローズ・オブ・ゲノム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dt - lords of genomes (japan).bin" size="4194304" crc="42ceb854" sha1="66988a201f77cd4c33fb0a9b3981ff5831206c9d"/>
@@ -5461,15 +5486,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dsavior">
-		<!-- Notes: SGB enhanced -->
 		<description>Dungeon Savior (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-ADWJ-JPN"/>
-		<info name="submitted" value="20000616"/>
+		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ダンジョンセイバー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dungeon savior (japan).bin" size="4194304" crc="2bcb5f78" sha1="766ab65d9420f361d8d9a4754ea8c6b692e34c36"/>
@@ -5498,7 +5523,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dxmono">
-		<!-- Notes: SGB enhanced -->
 		<description>DX Monopoly GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
@@ -5506,6 +5530,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000421"/>
 		<info name="alt_title" value="デラックスモノポリーGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dx monopoly gb (japan).bin" size="1048576" crc="3f1e076c" sha1="524d9459d357e209d64a2ef17b4072478f290806"/>
@@ -5570,7 +5595,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BETE-USA"/>
-		<info name="submitted" value="20011015"/>
+		<info name="gold" value="20011015"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -5680,7 +5705,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="atelelie">
-		<!-- Notes: SGB enhanced -->
 		<description>Elie no Atelier GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -5688,6 +5712,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="エリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5782,7 +5807,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
-		<info name="submitted" value="20010123"/>
+		<info name="gold" value="20010123"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5800,7 +5825,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENE-USA"/>
-		<info name="submitted" value="20010123"/>
+		<info name="gold" value="20010123"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5946,11 +5971,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1wgp">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbafip0.028", "KENSA\cgbafie0.0"	-->
 		<description>F-1 World Grand Prix (Euro)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-AFIP-EUR"/>
-		<info name="submitted" value="19990526"/>
+		<info name="gold" value="19990526"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5984,7 +6010,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BSJP-?"/>
-		<info name="submitted" value="20010413"/>
+		<info name="gold" value="20010413"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -5999,7 +6025,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BFIP-?"/>
-		<info name="submitted" value="20001117"/>
+		<info name="gold" value="20001117"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -6015,7 +6041,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BFIB-?"/>
-		<info name="submitted" value="20001107"/>
+		<info name="gold" value="20001107"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -6031,7 +6057,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AEQP-EUR"/>
-		<info name="submitted" value="20000829"/>
+		<info name="gold" value="20000829"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -6130,7 +6156,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="fairykit">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
@@ -6138,6 +6164,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (rev. a).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
@@ -6148,7 +6175,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="fairykita" cloneof="fairykit">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
@@ -6156,6 +6183,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan).bin" size="1048576" crc="b59a51c4" sha1="a27b498c6170b4136d2ca8a75c3d529dd6c06639"/>
@@ -6391,7 +6419,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
-		<info name="submitted" value="20000731"/>
+		<info name="gold" value="20000731"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6409,7 +6437,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
-		<info name="submitted" value="20000821"/>
+		<info name="gold" value="20000821"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6421,15 +6449,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="onepglin">
-		<!-- Notes: SGB enhanced -->
 		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Jpn)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BZOJ-JPN"/>
-		<info name="submitted" value="20020510"/>
+		<info name="gold" value="20020510"/>
 		<info name="release" value="20020628"/>
 		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6446,15 +6474,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="onepyume">
-		<!-- Notes: SGB enhanced -->
 		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
-		<info name="submitted" value="20010615"/>
+		<info name="gold" value="20010615"/>
 		<info name="release" value="20010427"/>
 		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C3203-12A2]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -6471,15 +6499,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="onepyumea" cloneof="onepyume">
-		<!-- Notes: SGB enhanced -->
 		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
-		<info name="submitted" value="20010307"/>
+		<info name="gold" value="20010307"/>
 		<info name="release" value="20010427"/>
 		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6535,7 +6563,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-AFMJ-JPN"/>
-		<info name="submitted" value="20010622"/>
+		<info name="gold" value="20010622"/>
 		<info name="release" value="20010719"/>
 		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6551,12 +6579,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="furaish2a" cloneof="furaish2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbfwj0.814"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
+		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to feature the common retail release)	-->
 		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn, Alt)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-BFWJ-JPN?"/>
-		<info name="submitted" value="20010703"/>
+		<info name="gold" value="20010703"/>
 		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -6591,7 +6620,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
-		<info name="submitted" value="19990428"/>
+		<info name="gold" value="19990428"/>
 		<info name="release" value="19990529"/>
 		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6612,12 +6641,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gakkyama" cloneof="gakkyamaa">
 		<!--	In lot check as "dmgaymj0.g22"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Gakkyuu Ou Yamazaki (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN?"/>
-		<info name="submitted" value="19990226"/>
+		<info name="gold" value="19990226"/>
 		<info name="release" value="19990529"/>
 		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6650,7 +6679,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN"/>
-		<info name="submitted" value="20001218"/>
+		<info name="gold" value="20001218"/>
 		<info name="release" value="20010209"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6670,7 +6699,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN?"/>
-		<info name="submitted" value="20010307"/>
+		<info name="gold" value="20010307"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -6741,7 +6770,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbgall3j" cloneof="gwatch3">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Game Boy Gallery 3 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -6749,6 +6778,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990408"/>
 		<info name="alt_title" value="ゲームボーイギャラリー3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-Z02-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -6782,7 +6812,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbwars2">
-		<!-- Notes: SGB enhanced -->
 		<description>Game Boy Wars 2 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -6790,6 +6819,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981120"/>
 		<info name="alt_title" value="ゲームボーイウォーズ2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 			<!-- 2nd half is filled with 0xff, confirmed with the real cart -->
@@ -6868,7 +6898,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ggoemnab">
-		<!-- Notes: SGB enhanced -->
 		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -6876,6 +6905,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991216"/>
 		<info name="alt_title" value="がんばれゴエモン もののけ道中飛び出せ鍋奉行!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="ganbare goemon - mononoke douchuu tobisuise nabebugyou (japan).bin" size="2097152" crc="73311cfa" sha1="4bc3928f3528a2c566b09613e538253dd128864c"/>
@@ -6886,7 +6916,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ggoemtng">
-		<!-- Notes: Also released by NP in 2000-05 -->
+		<!-- Also released by NP in 2000-05 -->
 		<description>Ganbare Goemon - Tengutou no Gyakushuu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -6988,7 +7018,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gemgem" cloneof="lilmonst">
-		<!-- Notes: SGB enhanced -->
 		<description>Gem Gem Monster (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
@@ -6996,6 +7025,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="ジェムジェムモンスター"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="gem gem monster (japan).bin" size="1048576" crc="de7505c0" sha1="8b1396cf9dbc77246b3443810282b8b9bcb65a67"/>
@@ -7123,7 +7153,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFP-EUR"/>
-		<info name="submitted" value="20001026"/>
+		<info name="gold" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7138,7 +7168,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFD-?"/>
-		<info name="submitted" value="20001026"/>
+		<info name="gold" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7148,7 +7178,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="glochex" cloneof="hexcite">
-		<!-- Notes: SGB enhanced -->
 		<description>Glocal Hexcite (Jpn)</description>
 		<year>1998</year>
 		<publisher>NEC Interchannel</publisher>
@@ -7156,6 +7185,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="グローカルヘキサイト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="glocal hexcite (japan).bin" size="1048576" crc="f1908391" sha1="7d13220593c8d89af1b4cae955caacff7df3817a"/>
@@ -7301,7 +7331,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="golfdai">
-		<!-- Notes: SGB enhanced -->
 		<description>Golf Daisuki! (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
@@ -7309,6 +7338,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ゴルフだいすき!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="golf daisuki (japan).bin" size="2097152" crc="80444a86" sha1="d245a267b1b1d056e0f5af4ba732c66c8deadde2"/>
@@ -7336,15 +7366,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="golfou">
-		<!-- Notes: SGB enhanced -->
 		<description>Golf Ou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-AZAJ-JPN"/>
-		<info name="submitted" value="19990617"/>
+		<info name="gold" value="19990617"/>
 		<info name="release" value="19990716"/>
 		<info name="alt_title" value="ゴルフ王 THE KING OF GOLF"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="golf ou (japan).bin" size="4194304" crc="634b2d43" sha1="d196af0aaf77ca67f9784d0ccd1ef4b25abed5c2"/>
@@ -7496,7 +7526,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbattlep">
-		<!-- Notes: SGB enhanced -->
 		<description>The Great Battle Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
@@ -7504,6 +7533,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="ザ・グレイトバトル ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -7596,7 +7626,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gurugugr">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
+		<!-- Also released by NP in 2000-07 -->
 		<description>Guruguru Garakutas (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
@@ -7604,6 +7634,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990910"/>
 		<info name="alt_title" value="ぐるぐるガラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="guruguru garakutas (japan).bin" size="1048576" crc="7eaeeeac" sha1="86fea7dd8d815a51c1b75b816125ab4ba731dba1"/>
@@ -7772,7 +7803,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hamstpar">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
+		<!-- Also released by NP in 2001-06 -->
 		<description>Hamster Paradise (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
@@ -7780,6 +7811,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="ハムスターパラダイス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hamster paradise (japan).bin" size="1048576" crc="f520cb19" sha1="87ebc7e0cfb0803e6e14da7eec1b2fad51c83ba0"/>
@@ -7936,7 +7968,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hanasaka">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-04 -->
+		<!-- Also released by NP in 2001-04 -->
 		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -7944,6 +7976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="花さか天使テンテンくんのBeat Breaker"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hanasaka tenshi tenten-kun no beat breaker (japan).bin" size="1048576" crc="6e988c07" sha1="791ea554de774de622bb4fb6bc2bf42955a201b3"/>
@@ -8152,7 +8185,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hellokbf">
-		<!-- Notes: SGB enhanced -->
 		<description>Hello Kitty no Beads Factory (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -8160,6 +8192,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990717"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのビーズ工房"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no beads factory (japan).bin" size="1048576" crc="12f74cd4" sha1="539ddbe7f73b33ffb886143dd14869d486f3fecf"/>
@@ -8188,7 +8221,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hellokmm">
-		<!-- Notes: SGB enhanced -->
 		<description>Hello Kitty no Magical Museum (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -8196,6 +8228,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのマジカルミュージアム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -8212,7 +8245,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="helloksa">
-		<!-- Notes: SGB enhanced -->
 		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -8220,6 +8252,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no sweet adventure - daniel-kun ni aitai (japan).bin" size="1048576" crc="45f4159b" sha1="c290dbd29a6246eb001f35f973c0e664af2c97b1"/>
@@ -8252,7 +8285,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AF4E-USA"/>
-		<info name="submitted" value="19991027"/>
+		<info name="gold" value="19991027"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8301,7 +8334,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHP-EUR"/>
-		<info name="submitted" value="20000727"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8324,7 +8357,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHE-USA"/>
-		<info name="submitted" value="20000508"/>
+		<info name="gold" value="20000508"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8490,7 +8523,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="honkshog">
-		<!-- Notes: SGB enhanced -->
 		<description>Honkaku Shougi - Shougi Ou (Jpn)</description>
 		<year>1998</year>
 		<publisher>Warashi</publisher>
@@ -8498,6 +8530,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981113"/>
 		<info name="alt_title" value="本格将棋 将棋王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku shougi - shougi ou (japan).bin" size="1048576" crc="3a96e868" sha1="a0e5a6b00cc31670949f7d8cdeec2486d0ec986f"/>
@@ -8525,7 +8558,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="honkmj">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
+		<!-- Also released by NP in 2000-04 -->
 		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
@@ -8533,6 +8566,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990219"/>
 		<info name="alt_title" value="本格四人打麻雀 麻雀王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku yonin uchi mahjong - mahjong ou (japan).bin" size="1048576" crc="8ed4bbba" sha1="222487f14aaaa8f0bb536a09238e63ac95636208"/>
@@ -8671,7 +8705,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BHQP-EUR"/>
-		<info name="submitted" value="20000707"/>
+		<info name="gold" value="20000707"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8687,7 +8721,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BPFE-?"/>
-		<info name="submitted" value="20010411"/>
+		<info name="gold" value="20010411"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8715,7 +8749,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hyperol" cloneof="itf">
-		<!-- Notes: SGB enhanced -->
 		<description>Hyper Olympic Series - Track &amp; Field GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -8723,6 +8756,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990701"/>
 		<info name="alt_title" value="ハイパーオリンピックシリーズ トラック&amp;フィールドGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hyper olympic series - track &amp; field gb (japan).bin" size="1048576" crc="77f76ebc" sha1="6dabafe260b53e61a810cbae2f14287adafffd8e"/>
@@ -8826,12 +8860,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="iss99">
-		<!-- Notes: SGB enhanced -->
 		<description>International Superstar Soccer '99 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (europe).bin" size="1048576" crc="1b76d115" sha1="d9d9fffb463d4c35f8a1a753908cddfbe17fc671"/>
@@ -8842,12 +8876,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="iss99u" cloneof="iss99">
-		<!-- Notes: SGB enhanced -->
 		<description>International Superstar Soccer '99 (USA)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZE-USA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (usa).bin" size="1048576" crc="9d0290a7" sha1="6f491e6f919a677627090f949b8e69abb8bfd1db"/>
@@ -8942,7 +8976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wldrally" cloneof="xcountry">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Also released by NP in 2000-08 -->
 		<description>It's a World Rally (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -8950,6 +8984,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990513"/>
 		<info name="alt_title" value="It's a ワールドラリー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="it's a world rally (japan).bin" size="1048576" crc="39e34650" sha1="31a289823468285ac786afe7de38201235983e35"/>
@@ -9014,7 +9049,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jackdaib" cloneof="questrpg">
-		<!-- Notes: SGB enhanced -->
 		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -9022,6 +9056,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000115"/>
 		<info name="alt_title" value="ジャックの大冒険 〜大魔王の逆襲〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="jack no daibouken - daimaou no gyakushuu (japan).bin" size="2097152" crc="cff5325a" sha1="c2d9548e845ed9a76a0e6dae81bb80023564a9f2"/>
@@ -9032,7 +9067,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jagainu">
-		<!-- Notes: Also released by NP in 2000-12 -->
+		<!-- Also released by NP in 2000-12 -->
 		<description>Jagainu-kun (Jpn)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
@@ -9100,7 +9135,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AJZE-USA"/>
-		<info name="submitted" value="19990930"/>
+		<info name="gold" value="19990930"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -9115,7 +9150,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AJUE-USA, CGB-AJUP-EUR"/>
-		<info name="submitted" value="20000218"/>
+		<info name="gold" value="20000218"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -9151,7 +9186,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BJWP-EUR"/>
-		<info name="submitted" value="20001019"/>
+		<info name="gold" value="20001019"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -9161,7 +9196,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jinsei">
-		<!-- Notes: SGB enhanced -->
 		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
@@ -9169,6 +9203,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="人生ゲーム 友達たくさんつくろうよ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="jinsei game - tomodachi takusan tsukurou yo (japan).bin" size="1048576" crc="c8d46e99" sha1="d2c4ae3808d9a24cbd4c6c8e43184ca0ef2d8373"/>
@@ -9202,7 +9237,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
-		<info name="submitted" value="20000711"/>
+		<info name="gold" value="20000711"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="実戦に役立つ詰碁"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9219,12 +9254,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="jissen" cloneof="jissena">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbjtj0.313"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Jissen ni Yakudatsu Tsumego (Jpn)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN?"/>
-		<info name="submitted" value="20001004"/>
+		<info name="gold" value="20001004"/>
 		<info name="alt_title" value="実戦に役立つ詰碁"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -9235,7 +9270,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="joryujan">
-		<!-- Notes: SGB enhanced -->
 		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
@@ -9243,6 +9277,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="女流雀士に挑戦GB 〜私達に挑戦してネ!〜 ~ Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene! (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="joryuu janshi ni chousen gb - watashi-tachi ni chousen shitene (japan).bin" size="1048576" crc="9fa5cdb5" sha1="a332817b9561dcab7d1f3dc0cf300e1656b253c3"/>
@@ -9386,7 +9421,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bistrokb">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-12 -->
+		<!-- Also released by NP in 2000-12 -->
 		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
@@ -9394,6 +9429,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 決闘★ビストガルム編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kakutou ryouri densetsu bistro recipe - kettou bistgarm hen (japan).bin" size="1048576" crc="4fbec464" sha1="c9fa1b1a24a0098eadd7e3fa4ee19f1b615a618f"/>
@@ -9404,7 +9440,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bistrogf">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-10 -->
+		<!-- Also released by NP in 2000-10 -->
 		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
@@ -9412,6 +9448,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991008"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 激闘★フードンバトル編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -9428,7 +9465,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanjiboy">
-		<!-- Notes: SGB enhanced -->
 		<description>Kanji Boy (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
@@ -9436,6 +9472,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990603"/>
 		<info name="alt_title" value="漢字BOY"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy (japan).bin" size="4194304" crc="18caa513" sha1="3876d5f64113e5365b42d30945f51f40b1d22d47"/>
@@ -9444,7 +9481,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanjibo2">
-		<!-- Notes: SGB enhanced -->
 		<description>Kanji Boy 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
@@ -9452,6 +9488,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000630"/>
 		<info name="alt_title" value="漢字BOY2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy 2 (japan).bin" size="4194304" crc="81fd8918" sha1="4d382de7fd6912c0cd8ca15032e6f75409d0a97b"/>
@@ -9495,7 +9532,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanzumep">
-		<!-- Notes: Also released by NP in 2000-06 -->
+		<!-- Also released by NP in 2000-06 -->
 		<description>Kanzume Monsters Parfait (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
@@ -9513,7 +9550,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="karamuok">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Karamuchou wa Oosawagi! - Okawari! (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
@@ -9521,6 +9558,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000801"/>
 		<info name="alt_title" value="カラムー町は大さわぎ!おかわりっ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - okawari (japan) (np).bin" size="1048576" crc="6c568e06" sha1="9217169dc3f42562d71a7edabc3b42e36ec8304b"/>
@@ -9531,7 +9569,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="karamupl">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Jpn)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
@@ -9539,6 +9577,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="カラムー町は大さわぎ! 〜ポリンキーズとおかしな仲間たち〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - polinkies to okashina nakama-tachi (japan).bin" size="1048576" crc="dd948071" sha1="cb6079dc290ace0daafdd40353e4477e4a37c8f7"/>
@@ -9565,7 +9604,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kaseki2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Kaseki Sousei Reborn II - Monster Digger (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
@@ -9573,6 +9612,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990212"/>
 		<info name="alt_title" value="化石創世リボーンII 〜モンスターディガー〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kaseki sousei reborn ii - monster digger (japan).bin" size="1048576" crc="bf80c897" sha1="857fb62dc310268e0b92e9383c6b6fd61aa33fa0"/>
@@ -9583,7 +9623,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="katohifu">
-		<!-- Notes: SGB enhanced -->
 		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
@@ -9591,6 +9630,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990409"/>
 		<info name="alt_title" value="加藤一二三 九段の 将棋教室 "/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="katou hifumi kudan - shougi kyoushitsu (japan).bin" size="1048576" crc="a262269f" sha1="c3ba0d2b82d66ef1b5c0dee8813a5f965631ed75"/>
@@ -9599,15 +9639,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kawanus4" cloneof="rivking2">
-		<!-- Notes: SGB enhanced -->
 		<description>Kawa no Nushi Tsuri 4 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-VUTJ-JPN"/>
-		<info name="submitted" value="19990520"/>
+		<info name="gold" value="19990520"/>
 		<info name="release" value="19990716"/>
 		<info name="alt_title" value="川のぬし釣り４"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A04-01" />
 			<feature name="u1" value="U1 4M/8M MROM [M438011E-57]" />
 			<feature name="u2" value="U2 MBC5 [BMC-5]" />
@@ -9626,7 +9666,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kawaipet">
-		<!-- Notes: SGB enhanced -->
 		<description>Kawaii Pet Shop Monogatari (Jpn)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
@@ -9634,6 +9673,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="かわいいペットショップ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kawaii pet shop monogatari (japan).bin" size="1048576" crc="44767443" sha1="8392eccbac1d8ae23782c6d29d3ee604a03b5c05"/>
@@ -9649,7 +9689,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
-		<info name="submitted" value="20010201"/>
+		<info name="gold" value="20010201"/>
 		<info name="alt_title" value="かわいいペットショップ物語2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -9666,7 +9706,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
-		<info name="submitted" value="20001107"/>
+		<info name="gold" value="20001107"/>
 		<info name="release" value="20001222"/>
 		<info name="alt_title" value="かわいいペットショップ物語2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9785,7 +9825,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kettoubw">
-		<!-- Notes: SGB enhanced -->
 		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
@@ -9793,6 +9832,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="決闘トランスフォーマービーストウォーズ ビースト戦士最強決定戦 ~ Kettou Transformers Beast Wars - Beast Senshi Saikyou Ketteisen (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kettou beast wars - beast senshi saikyou ketteisen (japan).bin" size="1048576" crc="72895639" sha1="db690f46d37e0273c69f24badbb44588a363a84f"/>
@@ -9837,7 +9877,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kindajik">
-		<!-- Notes: SGB enhanced -->
 		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
@@ -9845,6 +9884,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20001216"/>
 		<info name="alt_title" value="金田一少年の事件簿 〜10年目の招待状〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9857,7 +9897,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kinniban">
-		<!-- Notes: SGB enhanced -->
 		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -9865,6 +9904,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="筋肉番付GB 〜挑戦者はキミだ!〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kinniku banzuke gb - chousensha wa kimida (japan).bin" size="1048576" crc="e2e4328b" sha1="75d7e35fea257d8da4c1efcdd6ebdca020c648a6"/>
@@ -9875,7 +9915,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kinnibn2">
-		<!-- Notes: SGB enhanced -->
 		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
@@ -9883,6 +9922,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000810"/>
 		<info name="alt_title" value="筋肉番付GB2 〜目指せ!マッスルチャンピオン!〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9914,6 +9954,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
+		<!--	In lot check as "CGBKTNE0.638", "KENSA\CGBKTNP0.0"	-->
 		<description>Kirby Tilt 'n' Tumble (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -10062,7 +10103,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kogurugu">
-		<!-- Notes: NP only -->
+		<!-- NP only -->
 		<description>Koguru Guruguru - Guruguru to Nakayoshi (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Sting</publisher>
@@ -10166,7 +10207,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konchuh2">
-		<!-- Notes: SGB enhanced -->
 		<description>Konchuu Hakase 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
@@ -10174,6 +10214,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="釣り先生2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="konchuu hakase 2 (japan).bin" size="2097152" crc="b6381744" sha1="e4bcfb94aa1c09a013a03f26f978b32e74f70d23"/>
@@ -10243,7 +10284,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="koshien">
-		<!-- Notes: SGB enhanced -->
 		<description>Koushien Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
@@ -10251,6 +10291,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="甲子園ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="koushien pocket (japan).bin" size="1048576" crc="6910ff3a" sha1="a677bf07c67925ded32799d6a8eb63ec99c01bb7"/>
@@ -10304,12 +10345,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="laura">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbldp0.420"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Laura (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
-		<info name="submitted" value="20000913"/>
+		<info name="gold" value="20000913"/>
 		<info name="alt_title" value="Laura's Happy Adventures"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -10473,12 +10514,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxb" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced -->
 		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10515,12 +10556,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxfa" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced -->
 		<description>The Legend of Zelda - Link's Awakening DX (Fra)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10847,7 +10888,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
-		<info name="submitted" value="20001113"/>
+		<info name="gold" value="20001113"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -10863,7 +10904,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
-		<info name="submitted" value="20010406"/>
+		<info name="gold" value="20010406"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -10993,7 +11034,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lodoss">
-		<!-- Notes: SGB enhanced -->
 		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Jpn)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
@@ -11001,6 +11041,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ロードス島戦記 英雄騎士伝 GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="lodoss-tou senki - eiyuu kishiden gb (japan).bin" size="1048576" crc="66e166bb" sha1="3431247ffae511b6c2a836759e5ed0545d11ba05"/>
@@ -11204,7 +11245,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl2">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11212,6 +11253,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
@@ -11222,7 +11264,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl2a" cloneof="hirapzl2">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11230,6 +11272,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (np).bin" size="262144" crc="29e193c5" sha1="8cc512784d323f7c0bfe36848c5f7fdc49257285"/>
@@ -11240,7 +11283,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl3">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
@@ -11248,6 +11291,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
@@ -11258,7 +11302,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl3a" cloneof="hirapzl3">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
@@ -11266,6 +11310,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (np).bin" size="262144" crc="e078d9f8" sha1="a7faa970e71d38c68948b646d3dcb9cbea1df995"/>
@@ -11276,7 +11321,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzls">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11284,6 +11329,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
@@ -11294,7 +11340,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzlsa" cloneof="hirapzls">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11302,6 +11348,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (np).bin" size="262144" crc="c0287cf2" sha1="7425bd94790866bf716fd3c23886a5cdc06f1aad"/>
@@ -11312,7 +11359,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzl2a">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11320,6 +11367,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
@@ -11330,7 +11378,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzl2" cloneof="kangpzl2a">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11338,6 +11386,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (np).bin" size="262144" crc="d457cc6c" sha1="cb14866337caecd5458edc72f2d56f2c8c028411"/>
@@ -11348,7 +11397,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzl3a">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11356,6 +11405,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
@@ -11366,7 +11416,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzl3" cloneof="kangpzl3a">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11374,6 +11424,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (np).bin" size="262144" crc="3ef25533" sha1="9822fecf183d3d0a6e9af80696463b09e1f31a60"/>
@@ -11384,7 +11435,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzlsa">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11392,6 +11443,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
@@ -11402,7 +11454,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kangpzls" cloneof="kangpzlsa">
-		<!-- Notes: SGB enhanced, NP only -->
+		<!-- NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
@@ -11410,6 +11462,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (np).bin" size="262144" crc="094ffd1e" sha1="5a476f79db61aa8c6f32bbabd82fade5cde811d2"/>
@@ -11449,7 +11502,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
-		<info name="submitted" value="20000616"/>
+		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ラブひなポケット"/>
 		<part name="cart" interface="gameboy_cart">
@@ -11469,7 +11522,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
-		<info name="submitted" value="20000824"/>
+		<info name="gold" value="20000824"/>
 		<info name="alt_title" value="ラブひなポケット"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -11482,7 +11535,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lucapuzl">
-		<!-- Notes: SGB enhanced -->
 		<description>Luca no Puzzle de Daibouken! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Human Entertainment</publisher>
@@ -11490,6 +11542,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990611"/>
 		<info name="alt_title" value="ルーカのぱずるで大冒険!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="luca no puzzle de daibouken (japan).bin" size="524288" crc="3aebfad8" sha1="3c06fe05909ad632b761c6a1c00bc69da81aa358"/>
@@ -11704,7 +11757,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Interactive Imagination</publisher>
 		<info name="serial" value="CGB-BNNE-USA"/>
-		<info name="submitted" value="20010112"/>
+		<info name="gold" value="20010112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -11808,7 +11861,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjjoo">
-		<!-- Notes: SGB enhanced -->
 		<description>Mahjong Joou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Warashi</publisher>
@@ -11816,6 +11868,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="麻雀女王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong joou (japan).bin" size="1048576" crc="7d83a5e8" sha1="68f2326f7fa70d0ed0207bd087c6fe26ec6f9a53"/>
@@ -11826,7 +11879,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjquest">
-		<!-- Notes: SGB enhanced -->
 		<description>Mahjong Quest (Jpn)</description>
 		<year>1998</year>
 		<publisher>J-Wing</publisher>
@@ -11834,6 +11886,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981223"/>
 		<info name="alt_title" value="麻雀クエスト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong quest (japan).bin" size="1048576" crc="c870b88f" sha1="3ab49ce8aa69013c1b2d9427926513e21d5efe1d"/>
@@ -11844,7 +11897,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="majomari">
-		<!-- Notes: SGB enhanced -->
 		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
@@ -11852,6 +11904,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="majokko mari-chan no kisekae monogatari (japan) (rev. a).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
@@ -11862,7 +11915,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="majomaria" cloneof="majomari">
-		<!-- Notes: SGB enhanced -->
 		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
@@ -11870,6 +11922,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="majokko mari-chan no kisekae monogatari (japan).bin" size="2097152" crc="934f4b0a" sha1="8bdd3bd414da91c6ea05bc29435e09b0b72e3790"/>
@@ -11894,7 +11947,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="atelmari">
-		<!-- Notes: SGB enhanced -->
 		<description>Marie no Atelier GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -11902,6 +11954,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="マリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -12271,7 +12324,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2ka">
-		<!-- Notes: SGB enhanced -->
 		<description>Medarot 2 - Kabuto Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -12279,6 +12331,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C1603-12 1]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12294,7 +12347,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2ku">
-		<!-- Notes: SGB enhanced -->
 		<description>Medarot 2 - Kuwagata Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -12302,6 +12354,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MTN]" />
 			<feature name="u2" value="U2 MBC-5 [MBC-5]" />
@@ -12317,7 +12370,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2cl">
-		<!-- Notes: SGB enhanced -->
 		<description>Medarot 2 - Parts Collection (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -12325,6 +12377,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="メダロット2 パーツコレクション"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [R531614G-12]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12467,7 +12520,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medarcka">
-		<!-- Notes: SGB enhanced -->
 		<description>Medarot Cardrobottle - Kabuto Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -12475,6 +12527,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kabuto version (japan).bin" size="2097152" crc="4f03d80a" sha1="b7a02cee93169f73675b562d09d10175684ec77f"/>
@@ -12485,7 +12538,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medarcku">
-		<!-- Notes: SGB enhanced -->
 		<description>Medarot Cardrobottle - Kuwagata Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
@@ -12493,6 +12545,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kuwagata version (japan).bin" size="2097152" crc="a3735f81" sha1="26b5516170ea0fa1669cafb9484e1aeb5d2cae6c"/>
@@ -12540,7 +12593,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lastbibl" cloneof="revelat">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Megami Tensei Gaiden - Last Bible (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
@@ -12548,6 +12601,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible (japan).bin" size="1048576" crc="bd9ba639" sha1="419c5afdbc9b59e05e7861de8cc59ee367cd29f0"/>
@@ -12558,7 +12612,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lastbib2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Megami Tensei Gaiden - Last Bible II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
@@ -12566,6 +12620,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990416"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブルII"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible ii (japan).bin" size="1048576" crc="9caa00b5" sha1="84df9508bdd8b24dfb19a74744fec492fffee56d"/>
@@ -12576,7 +12631,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconankj">
-		<!-- Notes: SGB enhanced -->
 		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
@@ -12584,6 +12638,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000224"/>
 		<info name="alt_title" value="名探偵コナン −からくり寺院殺人事件−"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WKH]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12600,7 +12655,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconankh">
-		<!-- Notes: SGB enhanced -->
 		<description>Meitantei Conan - Kigantou Hihou Densetsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
@@ -12608,6 +12662,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="名探偵コナン 奇岩島秘宝伝説"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -12624,7 +12679,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconannk">
-		<!-- Notes: SGB enhanced -->
 		<description>Meitantei Conan - Norowareta Kouro (Jpn)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
@@ -12632,6 +12686,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20010601"/>
 		<info name="alt_title" value="名探偵コナン−呪われた航路−"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="meitantei conan - norowareta kouro (japan).bin" size="2097152" crc="cabdd802" sha1="0858a619d716b0191713734d506d9f113f0d1c62"/>
@@ -12687,6 +12742,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="merlin">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBBMBP0.603", "KENSA\CGBBMBE0.0"	-->
 		<description>Merlin (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
@@ -13028,7 +13084,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
-		<info name="submitted" value="19991028"/>
+		<info name="gold" value="19991028"/>
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
 		<part name="cart" interface="gameboy_cart">
@@ -13042,15 +13098,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="minnashga" cloneof="minnashg">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmga7yj1.i18"	-->
 		<description>Minna no Shougi - Shokyuu Hen (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
-		<info name="submitted" value="20000811"/>
+		<info name="gold" value="20000811"/>
 		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmga7yj1.i18" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
@@ -13126,7 +13182,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-(NOE/UKV/FAH)"/>
-		<info name="submitted" value="19991006"/>
+		<info name="gold" value="19991006"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13140,12 +13196,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="missimpa" cloneof="missimp">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaimp1.076"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Mission Impossible (Euro, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-?"/>
-		<info name="submitted" value="19991227"/>
+		<info name="gold" value="19991227"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13162,7 +13218,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIME-USA"/>
-		<info name="submitted" value="19991227"/>
+		<info name="gold" value="19991227"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13192,7 +13248,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mobilglf">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		        This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		        for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		        There are different models depending on the target cellular phone:
@@ -13226,7 +13282,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<!-- when it checks for the connection, it checks for a value of 06 in C27D -->
 	<software name="mobiltrn" supported="partial">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		    This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		    for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		    There are different models depending on the target cellular phone:
@@ -13292,7 +13348,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="monopolyj" cloneof="monopoly">
-		<!-- Notes: SGB enhanced -->
 		<description>Monopoly (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hasbro</publisher>
@@ -13300,6 +13355,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ゲームボーイモノポリー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="monopoly (japan).bin" size="1048576" crc="0503e567" sha1="3f42d9b423c15b4c1b997c7a2292ab2cba1ab23f"/>
@@ -13321,7 +13377,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mfarmbc" cloneof="mranchbc">
-		<!-- Notes: SGB enhanced -->
 		<description>Monster Farm Battle Card GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tecmo</publisher>
@@ -13329,6 +13384,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="モンスターファーム バトルカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster farm battle card gb (japan).bin" size="2097152" crc="69b88f1e" sha1="7e036e175c9e865572ab613ae0f8e6d3642ffb0e"/>
@@ -13339,7 +13395,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="monstrc2">
-		<!-- Notes: SGB enhanced -->
 		<description>Monster Race 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
@@ -13347,6 +13402,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="もんすたあ★レース2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster race 2 (japan).bin" size="2097152" crc="b985f0d8" sha1="8d4a6b4cdaa37b9daaff5a05ac5926a407bacce3"/>
@@ -13357,12 +13413,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mranchbc">
-		<!-- Notes: SGB enhanced -->
 		<description>Monster Rancher Battle Card GB (USA)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TE-USA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster rancher battle card gb (usa).bin" size="2097152" crc="50ddf120" sha1="f94dc1dbdf25d9ab7f7abd3d7878209d404b206d"/>
@@ -13394,7 +13450,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
-		<info name="submitted" value="20020207"/>
+		<info name="gold" value="20020207"/>
 		<info name="release" value="20020308"/>
 		<info name="alt_title" value="モン☆スタートラベラー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -13410,12 +13466,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="monstrvl" cloneof="monstrvla">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbfvj0.949"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Monster Traveler (Jpn)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
-		<info name="submitted" value="20020122"/>
+		<info name="gold" value="20020122"/>
 		<info name="alt_title" value="モン☆スタートラベラー"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -13555,6 +13611,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moomin">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBAM9P0.471", "KENSA\CGBAM9E0.0"	-->
 		<description>Moomin's Tale (Euro)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
@@ -13711,7 +13768,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDJ-JPN"/>
-		<info name="submitted" value="20000510"/>
+		<info name="gold" value="20000510"/>
 		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ミスタードリラーGB版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -13726,7 +13783,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mrdrillrjnp" cloneof="mrdrillr">
 		<!-- Notes: GBC only, NP only -->
-		<!--	In lot check as "cgbbv3j0.0"	-->
+		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
 		<description>Mr. Driller (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
@@ -14072,7 +14129,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3CJ-JPN"/>
-		<info name="submitted" value="20020307"/>
+		<info name="gold" value="20020307"/>
 		<info name="release" value="20020405"/>
 		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
 		<part name="cart" interface="gameboy_cart">
@@ -14311,7 +14368,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
-		<info name="submitted" value="19990311"/>
+		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14323,15 +14380,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nbazone" cloneof="nbapro99">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmganze0.g29"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>NBA In the Zone (USA)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA?"/>
-		<info name="submitted" value="19990303"/>
+		<info name="gold" value="19990303"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmganze0.g29" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
@@ -14347,7 +14404,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AJ7P-EUR"/>
-		<info name="submitted" value="19990311"/>
+		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -14412,7 +14469,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZP-EUR"/>
-		<info name="submitted" value="19990716"/>
+		<info name="gold" value="19990716"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14429,7 +14486,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AA5E-USA"/>
-		<info name="submitted" value="19991124"/>
+		<info name="gold" value="19991124"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14514,7 +14571,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BAIP-EUR"/>
-		<info name="submitted" value="20011108"/>
+		<info name="gold" value="20011108"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -14869,7 +14926,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ohasuynr">
-		<!-- Notes: SGB enhanced -->
 		<description>Ohasuta Yama-chan &amp; Raymond (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
@@ -14877,6 +14933,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="おはスタ やまちゃん&amp;レイモンド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -14973,7 +15030,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="azuredj" cloneof="azured">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Also released by NP in 2000-08 -->
 		<description>Other Life - Azure Dreams GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -14981,6 +15038,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990805"/>
 		<info name="alt_title" value="アザーライフ アザードリームGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="other life - azure dreams gb (japan).bin" size="1048576" crc="c6f1abd4" sha1="9e473df09e962a9accc3f6446140b0333f6a088e"/>
@@ -15005,7 +15063,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="oudoroan">
-		<!-- Notes: SGB enhanced -->
 		<description>Ou Dorobou Jing - Angel Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
@@ -15013,6 +15070,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン エンジェルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - angel version (japan).bin" size="1048576" crc="d47c0dcf" sha1="493e37dac6d8b037e44e64f9f31dba7f08a89e08"/>
@@ -15023,7 +15081,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="oudorodv">
-		<!-- Notes: SGB enhanced -->
 		<description>Ou Dorobou Jing - Devil Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
@@ -15031,6 +15088,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン デビルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - devil version (japan).bin" size="1048576" crc="2a39a874" sha1="71797aa125b88614182ce3d0f8252d6ed8cfa08e"/>
@@ -15041,7 +15099,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="owarai">
-		<!-- Notes: SGB enhanced -->
 		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -15049,6 +15106,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991225"/>
 		<info name="alt_title" value="おわらいよゐこのげえむ道 〜おやじ探して3丁目〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="owarai yowiko no game-dou - oyaji sagashite sanchoume (japan).bin" size="1048576" crc="3f635a4f" sha1="21644c1ef67bdd6038686d8522e957e3de803237"/>
@@ -15117,7 +15175,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pachislt">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-06 -->
+		<!-- Also released by NP in 2000-06 -->
 		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
@@ -15125,6 +15183,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パチパチ パチス郎〜ニューパルサー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pachipachi pachi-slot - new pulsar hen (japan).bin" size="1048576" crc="1e443d1b" sha1="969d5352c15e3e5daa891edcda91bd48a8380308"/>
@@ -15205,7 +15264,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="phantomz">
-		<!-- Notes: SGB enhanced -->
 		<description>Phantom Zona - Kaijin Zona (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -15213,6 +15271,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20001021"/>
 		<info name="alt_title" value="怪人ゾナー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-Z03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -15404,7 +15463,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockcblk" cloneof="ddance">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Color Block (Jpn)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
@@ -15412,6 +15470,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケットカラー ブロック"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="pocket color block (japan).bin" size="131072" crc="389cf56f" sha1="84d243c64f98731965ca78b75ad48f8787d3c907"/>
@@ -15474,7 +15533,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockden2">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Densha 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Coconuts Japan</publisher>
@@ -15482,6 +15540,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="ポケット電車2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket densha 2 (japan).bin" size="1048576" crc="4d26e880" sha1="859331f57a964197f271acafa7e8dc586e598cf5"/>
@@ -15490,7 +15549,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockfam2">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		    The game cart has an integrated speaker and a replaceable battery (CR2025). -->
 		<description>Pocket Family GB2 (Jpn)</description>
 		<year>1999</year>
@@ -15516,7 +15575,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockgis">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket GI Stable (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -15524,6 +15582,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ポケットGIステイブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pocket gi stable (japan).bin" size="2097152" crc="c424874e" sha1="f818e6284d198f4b394f79cb8511c9b906d69f03"/>
@@ -15539,7 +15598,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-A7GJ-JPN"/>
-		<info name="submitted" value="19990920"/>
+		<info name="gold" value="19990920"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="ポケット ジーティー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15553,7 +15612,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockgtp" cloneof="pockrace">
-		<description>Pocket GT (Eur, Prototype?)</description>
+		<description>Pocket GT (Euro, Prototype?)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -15652,7 +15711,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Monsters Gin (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -15660,6 +15718,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-10" />
 			<feature name="u1" value="U1 PRG [M538011E-B9]" />
 			<feature name="u2" value="U2 MBC3A [MBC3 A]" />
@@ -15677,7 +15736,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegina" cloneof="pokesilv">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Monsters Gin (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -15685,6 +15743,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15696,7 +15755,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Monsters Kin (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -15704,6 +15762,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15715,7 +15774,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokekina" cloneof="pokegold">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Monsters Kin (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -15723,6 +15781,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15739,7 +15798,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BXTJ-JPN"/>
-		<info name="submitted" value="20001020"/>
+		<info name="gold" value="20001020"/>
 		<info name="release" value="20001214"/>
 		<info name="alt_title" value="ポケットモンスター クリスタルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15765,7 +15824,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BP9P-EUR?"/>
-		<info name="submitted" value="20010925"/>
+		<info name="gold" value="20010925"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -15827,7 +15886,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="poktpuys">
-		<!-- Notes: SGB enhanced -->
 		<description>Pocket Puyo Puyo Sun (Jpn)</description>
 		<year>1998</year>
 		<publisher>Compile</publisher>
@@ -15835,6 +15893,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ぽけっとぷよぷよSUN"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket puyo puyo sun (japan).bin" size="1048576" crc="45661ec3" sha1="c2f72fad1a26ad765eb3036f0c9e9e8945133d3a"/>
@@ -15850,7 +15909,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="submitted" value="20000721"/>
+		<info name="gold" value="20000721"/>
 		<info name="release" value="20000922"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15870,7 +15929,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="submitted" value="20010327"/>
+		<info name="gold" value="20010327"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -15889,7 +15948,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="submitted" value="20010719"/>
+		<info name="gold" value="20010719"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -15919,6 +15978,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pocksocr">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBBPSP0.618", "KENSA\CGBBPSE0.0"	-->
 		<description>Pocket Soccer (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -15935,11 +15995,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
+		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
 		<description>Pokémon - Crystal Version (Euro, USA, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
-		<info name="submitted" value="20010807, 20010726"/>
+		<info name="gold" value="20010807, 20010726"/>
 		<info name="release" value="?, 20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
@@ -15954,12 +16015,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysa" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<!--	European version unreleased (marked as "生産中止" in lot check)	-->
 		<description>Pokémon - Crystal Version (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
-		<info name="submitted" value="20010524, 20010101"/>
+		<info name="gold" value="20010524, 20010101"/>
 		<info name="release" value="20010729, unreleased"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
@@ -15978,7 +16038,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTF-FRA"/>
-		<info name="submitted" value="20010817"/>
+		<info name="gold" value="20010817"/>
 		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
@@ -15997,7 +16057,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTD-NOE"/>
-		<info name="submitted" value="20010726"/>
+		<info name="gold" value="20010726"/>
 		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
@@ -16016,7 +16076,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTI-ITA"/>
-		<info name="submitted" value="20010914"/>
+		<info name="gold" value="20010914"/>
 		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-KGDU-10" />
@@ -16041,7 +16101,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTS-ESP"/>
-		<info name="submitted" value="20010830"/>
+		<info name="gold" value="20010830"/>
 		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
@@ -16060,7 +16120,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>Pokémon - Crystal Version (Aus)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
-		<info name="submitted" value="20010724"/>
+		<info name="gold" value="20010724"/>
 		<info name="release" value="20010930"/>
 		<info name="serial" value="CGB-BYTU-AUS"/>
 		<part name="cart" interface="gameboy_cart">
@@ -16255,8 +16315,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecardj" cloneof="pokecard">
-		<!-- Notes: SGB enhanced.
-		        This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
+		<!-- This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
 		<description>Pokémon Card GB (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -16264,6 +16323,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケモンカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG [KM23C8000DG]" />
 			<feature name="u2" value="U2 HuC1A" />
@@ -16339,7 +16399,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokepinbj" cloneof="pokepinb">
-		<!-- Notes: SGB enhanced -->
 		<description>Pokémon Pinball (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -16347,6 +16406,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990414"/>
 		<info name="alt_title" value="ポケモンピンボール"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<feature name="rumble" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -16392,6 +16452,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokepuzlu" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
+		<!-- Includes a limited version of Panel de Pon GB as an easter egg	-->
 		<description>Pokémon Puzzle Challenge (USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -16407,14 +16468,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecard">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgaxqx1.j85"	-->
 		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR-1"/>
-		<info name="submitted" value="20001108"/>
+		<info name="gold" value="20001108"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmgaxqx1.j85" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
@@ -16429,8 +16490,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR"/>
-		<info name="submitted" value="20001013"/>
+		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pokemon trading card game (europe) (en,es,it).bin" size="2097152" crc="966daef1" sha1="2138a422d135a13c49fce71229ae36bc1dc4fbb5"/>
@@ -16445,8 +16507,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE"/>
-		<info name="submitted" value="20001013"/>
+		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -16463,14 +16526,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecardaa" cloneof="pokecard">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgaxqp1.j84"	-->
 		<description>Pokémon Trading Card Game (Euro, English / French / German, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE?"/>
-		<info name="submitted" value="20001108"/>
+		<info name="gold" value="20001108"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmgaxqp1.j84" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
@@ -16486,6 +16549,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQE-USA, DMG-AXQU-AUS"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pokemon trading card game (usa).bin" size="1048576" crc="81069d53" sha1="0f8670a583255cff3e5b7ca71b5d7454d928fc48"/>
@@ -16652,7 +16716,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkp">
-		<!-- Notes: SGB enhanced -->
 		<description>Power Pro Kun Pocket (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -16660,6 +16723,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="power pro kun pocket (japan) (rev a).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
@@ -16670,7 +16734,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkpa" cloneof="powrpkp">
-		<!-- Notes: SGB enhanced -->
 		<description>Power Pro Kun Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -16678,6 +16741,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="power pro kun pocket (japan).bin" size="2097152" crc="145540d8" sha1="f796f9cb259646555f0d429b9337ac6b423755a3"/>
@@ -16688,7 +16752,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkp2">
-		<!-- Notes: SGB enhanced -->
 		<description>Power Pro Kun Pocket 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
@@ -16696,6 +16759,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000330"/>
 		<info name="alt_title" value="パワプロクンポケット2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC5 [MBC-5]" />
@@ -17122,7 +17186,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="poyondr">
-		<!-- Notes: SGB enhanced -->
 		<description>Poyon no Dungeon Room (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
@@ -17130,6 +17193,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="大貝獣物語 ポヨンのダンジョンルーム ~ Daikaijuu Monogatari - Poyon no Dungeon Room (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="daikaijuu monogatari - poyon no dungeon room (japan).bin" size="2097152" crc="2f368da6" sha1="0854b7ea4791a460c75ce9096583934b1af053e8"/>
@@ -17178,7 +17242,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-ARIE-USA, DMG-ARIP-EUR"/>
-		<info name="submitted" value="19990303, 19990525"/>
+		<info name="gold" value="19990303, 19990525"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -17205,7 +17269,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjkiwam2">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
+		<!-- Also released by NP in 2001-06 -->
 		<description>Pro Mahjong Kiwame GB II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
@@ -17213,6 +17277,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="プロ麻雀 極II GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong kiwame gb ii (japan).bin" size="1048576" crc="14f91f86" sha1="2c9c2967400ab9bad95ffe104763b3190f28aa39"/>
@@ -17223,7 +17288,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjtsuwa">
-		<!-- Notes: SGB enhanced -->
 		<description>Pro Mahjong Tsuwamono GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
@@ -17231,6 +17295,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990709"/>
 		<info name="alt_title" value="プロ麻雀 兵 GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong tsuwamono gb (japan).bin" size="1048576" crc="1461d8d8" sha1="b9e7cd7e53fda3db329c57971a47d35255bd0b34"/>
@@ -17279,7 +17344,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLP-EUU"/>
-		<info name="submitted" value="20000621"/>
+		<info name="gold" value="20000621"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -17299,12 +17364,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="propoolu" cloneof="propool">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbple0.298"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Pro Pool (USA)</description>
 		<year>2000?</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLE-USA?"/>
-		<info name="submitted" value="20000621"/>
+		<info name="gold" value="20000621"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -17352,7 +17417,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-AIQP-EUR"/>
-		<info name="submitted" value="20000112"/>
+		<info name="gold" value="20000112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -17364,15 +17429,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puchicarj" cloneof="puchicar">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
+		<!-- Also released by NP in 2000-07 -->
 		<description>Puchi Carat (Jpn)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-ACUJ-JPN"/>
-		<info name="submitted" value="19990311"/>
+		<info name="gold" value="19990311"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="プチカラット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puchi carat (japan).bin" size="1048576" crc="f0d0c36d" sha1="25abda13f97140d412bb00e109baca8574d5af6e"/>
@@ -17411,7 +17477,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puyopuyg">
-		<!-- Notes: SGB enhanced -->
 		<description>Puyo Puyo Gaiden - Puyo Wars (Jpn)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
@@ -17419,6 +17484,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990827"/>
 		<info name="alt_title" value="ぷよぷよ外伝 ぷよウォーズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puyo puyo gaiden - puyo wars (japan).bin" size="1048576" crc="67350bc9" sha1="b1802797e892d09e4da53304d096bdf35bac1118"/>
@@ -17554,7 +17620,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="CGB-AQYP-EUR"/>
-		<info name="submitted" value="20001017"/>
+		<info name="gold" value="20001017"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -18000,7 +18066,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rpyakyuc">
-		<!-- Notes: SGB enhanced -->
 		<description>Real Pro Yakyuu! - Central League Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
@@ -18008,6 +18073,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 セントラルリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - central league hen (japan).bin" size="524288" crc="afff6bb9" sha1="02c18d98a07b3af9a1d26d0c3003f8e75c81f4d9"/>
@@ -18018,7 +18084,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rpyakyup">
-		<!-- Notes: SGB enhanced -->
 		<description>Real Pro Yakyuu! - Pacific League Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
@@ -18026,6 +18091,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 パシフィックリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - pacific league hen (japan).bin" size="524288" crc="16b81c36" sha1="a7a2cd7bbb4cae171b5f2c798293afefe2882afc"/>
@@ -18320,7 +18386,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopspc">
-		<!-- Notes: GBC only..
+		<!-- Notes: GBC only
 		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
@@ -18329,7 +18395,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H5UJ-JPN"/>
-		<info name="submitted" value="19990618"/>
+		<info name="gold" value="19990618"/>
 		<info name="alt_title" value="ロボットポンコッツ ボンボンスペシャルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
@@ -18350,8 +18416,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopmon">
-		<!-- Notes: SGB enhanced.
-		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
@@ -18362,6 +18427,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="ロボットポンコッツ月バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-10" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -18379,8 +18445,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopstr">
-		<!-- Notes: SGB enhanced.
-		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
@@ -18391,6 +18456,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ星バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -18408,7 +18474,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopsunj" cloneof="robopsun">
-		<!-- Notes: SGB enhanced -->
 		<description>Robot Ponkottsu - Sun Version (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -18416,6 +18481,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ太陽バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="slot" value="rom_huc3" />
@@ -18653,7 +18719,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-A2QJ-JPN"/>
-		<info name="submitted" value="20000209"/>
+		<info name="gold" value="20000209"/>
 		<info name="release" value="20000317"/>
 		<info name="alt_title" value="ＲＰＧ ツクール ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18866,7 +18932,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sakata">
-		<!-- Notes: SGB enhanced -->
 		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
@@ -18874,6 +18939,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990625"/>
 		<info name="alt_title" value="坂田吾朗 九段の 連珠教室"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sakata gorou kudan no renju kyoushitsu (japan).bin" size="1048576" crc="b5412c6f" sha1="f2330533b10c22e98c140bb550827618985253cb"/>
@@ -18961,7 +19027,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sangogb2">
-		<!-- Notes: SGB enhanced -->
 		<description>Sangokushi - Game Boy Ban 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
@@ -18969,6 +19034,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="三國志 ゲームボーイ版2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sangokushi - game boy ban 2 (japan).bin" size="1048576" crc="e787b44c" sha1="ec6089ff2cfcb17faf6a8ea9a4171869b3c7289b"/>
@@ -18979,15 +19045,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sanriotk">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<!-- Also released by NP in 2000-05 -->
 		<description>Sanrio Timenet - Kako Hen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
-		<info name="submitted" value="19981027"/>
+		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 過去編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WNE]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -19004,16 +19071,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sanriotka" cloneof="sanriotk">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgatpj1.f14"	-->
 		<description>Sanrio Timenet - Kako Hen (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
-		<info name="submitted" value="19981130"/>
+		<info name="gold" value="19981130"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 過去編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmgatpj1.f14" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
@@ -19024,15 +19091,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sanriotm">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<!-- Also released by NP in 2000-05 -->
 		<description>Sanrio Timenet - Mirai Hen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
-		<info name="submitted" value="19981027"/>
+		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 未来編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sanrio timenet - mirai hen (japan).bin" size="1048576" crc="efe51e17" sha1="65c4113401336784be4c53a51fe8d9b4b3d287da"/>
@@ -19043,16 +19111,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sanriotma" cloneof="sanriotm">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgatfj1.f15"	-->
 		<description>Sanrio Timenet - Mirai Hen (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
-		<info name="submitted" value="19981130"/>
+		<info name="gold" value="19981130"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 未来編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmgatfj1.f15" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
@@ -19076,7 +19144,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sarupnch" cloneof="monkeyp">
-		<!-- Notes: SGB enhanced -->
 		<description>Saru Puncher (Jpn)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
@@ -19084,6 +19151,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="さるパンチャー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MYY]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -19133,7 +19201,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sdhiryux">
-		<!-- Notes: SGB enhanced -->
 		<description>SD Hiryuu no Ken EX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
@@ -19141,6 +19208,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990430"/>
 		<info name="alt_title" value="SD飛龍の拳EX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sd hiryuu no ken ex (japan).bin" size="1048576" crc="365bf43f" sha1="bed7b913a395ae4b62eac39ff8d6b3093529ed45"/>
@@ -19149,17 +19217,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="seihai">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgaeoj0.j01"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Sei Hai Densetsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN?"/>
-		<info name="submitted" value="20000221"/>
+		<info name="gold" value="20000221"/>
 		<info name="release" value="20000414"/>
 		<info name="alt_title" value="聖牌伝説"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmgaeoj0.j01" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
@@ -19168,7 +19236,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="seihaiunk" cloneof="seihai">
-		<!-- Notes: SGB enhanced -->
 		<!-- Old dump of unknown origin -->
 		<description>Sei Hai Densetsu (Jpn, bad dump?)</description>
 		<year>2000</year>
@@ -19177,6 +19244,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000414"/>
 		<info name="alt_title" value="聖牌伝説"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sei hai densetsu (japan).bin" size="1048576" crc="612f0529" sha1="1bada799254b220c1007a1dac6d13b1be4a04ff2"/>
@@ -19204,7 +19272,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="senkai">
-		<!-- Notes: SGB enhanced -->
 		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
@@ -19212,6 +19279,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20001124"/>
 		<info name="alt_title" value="仙界異聞録 準提大戦〜TVアニメーション「仙界伝封神演義」より〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="senkai ibunroku juntei taisen - tv animation senkaiden houshin engi yori (japan).bin" size="1048576" crc="23fa5f53" sha1="c10249ef96a1989c3532a48917862b4dd8bad12a"/>
@@ -19379,7 +19447,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
-		<info name="submitted" value="19981222"/>
+		<info name="gold" value="19981222"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19389,15 +19457,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shanghaij" cloneof="shanghai">
-		<!-- Notes: SGB enhanced -->
 		<description>Shanghai Pocket (Jpn)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ASEJ-JPN?"/>
-		<info name="submitted" value="19980701"/>
+		<info name="gold" value="19980701"/>
 		<info name="release" value="19980806"/>
 		<info name="alt_title" value="上海 ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="shanghai pocket (japan).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
@@ -19410,7 +19478,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
-		<info name="submitted" value="19981110"/>
+		<info name="gold" value="19981110"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19420,14 +19488,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shanghaiu" cloneof="shanghai">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgahpe0.f55"	-->
 		<description>Shanghai Pocket (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPE-USA"/>
-		<info name="submitted" value="19981112"/>
+		<info name="gold" value="19981112"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="shanghai pocket (usa).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
@@ -19466,16 +19534,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shinmtaa">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgbhnj1.j70"	-->
 		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
-		<info name="submitted" value="20010608"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmgbhnj1.j70" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
@@ -19486,15 +19554,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shinmta" cloneof="shinmtaa">
-		<!-- Notes: SGB enhanced -->
 		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
-		<info name="submitted" value="20000912"/>
+		<info name="gold" value="20000912"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -19511,16 +19579,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shinmtka">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgbhej1.j69"	-->
 		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
-		<info name="submitted" value="20010608"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmgbhej1.j69" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
@@ -19531,15 +19599,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shinmtk" cloneof="shinmtka">
-		<!-- Notes: SGB enhanced -->
 		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
-		<info name="submitted" value="20000912"/>
+		<info name="gold" value="20000912"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -19561,7 +19629,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHWJ-JPN"/>
-		<info name="submitted" value="20010608"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20010727"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 白の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19623,7 +19691,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shougi2">
-		<!-- Notes: Also released by NP in 2000-04 -->
+		<!-- Also released by NP in 2000-04 -->
 		<description>Shougi 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
@@ -19671,7 +19739,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shutoku">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
+		<!-- Also released by NP in 2000-04 -->
 		<description>The Shutokou Racing (Jpn)</description>
 		<year>1998</year>
 		<publisher>Pony Canyon</publisher>
@@ -19679,6 +19747,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ザ・首都高レーシング"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
 			<dataarea name="rom" size="131072">
 				<rom name="shutokou racing, the (japan).bin" size="131072" crc="36e781cd" sha1="0f29818190ea9ce8c242b648ba64d50cc5408e5a"/>
@@ -19711,7 +19780,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAE-USA"/>
-		<info name="submitted" value="20000921"/>
+		<info name="gold" value="20000921"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19723,15 +19792,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sewingose" cloneof="sewingos">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmgbraz0.k25"	-->
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Sewing Machine Operation Software (Eur)</description>
+		<description>Sewing Machine Operation Software (Euro)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAZ-EUU"/>
-		<info name="submitted" value="20010920"/>
+		<info name="gold" value="20010920"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmgbraz0.k25" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
@@ -19933,7 +20002,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="anpanfna">
-		<!-- Notes: SGB enhanced -->
 		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
@@ -19941,6 +20009,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="それいけ!!アンパンマン 不思議なにこにこアルバム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="soreike anpanman - fushigi na nikoniko album (japan).bin" size="1048576" crc="a80eeead" sha1="fe75b7b7a904ce76130d65b67d24e291ba3c2693"/>
@@ -20205,7 +20274,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6P-EUR"/>
-		<info name="submitted" value="19990506"/>
+		<info name="gold" value="19990506"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20220,7 +20289,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6J-JPN"/>
-		<info name="submitted" value="19990615"/>
+		<info name="gold" value="19990615"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="スパイ アンド スパイ"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20231,13 +20300,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="spyvsspyjanp" cloneof="spyvsspy">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
+		<!--	Never released as physical cartridge	-->
+		<description>Spy vs. Spy (Japan, Rev. A, NP)</description>
+		<year>1999</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbas6j1.0" size="1048576" crc="eb47d63b" sha1="9e203f04857cd84ec49b0e6c6d4917b1a5cc199e"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="spyvsspyu" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<description>Spy vs. Spy (USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6E-USA"/>
-		<info name="submitted" value="19990512"/>
+		<info name="gold" value="19990512"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20336,7 +20420,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-AFZP-EUR"/>
-		<info name="submitted" value="19991101"/>
+		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20351,7 +20435,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BFZJ-JPN"/>
-		<info name="submitted" value="20010206"/>
+		<info name="gold" value="20010206"/>
 		<info name="release" value="20010330"/>
 		<info name="alt_title" value="ストリートファイター アルファ WARRIORS' DREAMS"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20368,7 +20452,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AFZE-USA"/>
-		<info name="submitted" value="20000120"/>
+		<info name="gold" value="20000120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20438,7 +20522,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sblkbap3" cloneof="tnnofc">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Super Black Bass Pocket 3 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
@@ -20446,6 +20530,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="スーパーブラックバス ポケット3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super black bass pocket 3 (japan).bin" size="1048576" crc="ae466545" sha1="b416f8fe1d229bd4e90259f2e6a7d78dd1f7bf3e"/>
@@ -20456,7 +20541,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sbomblis">
-		<!-- Notes: SGB enhanced -->
 		<description>Super Bombliss DX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bullet-Proof Software</publisher>
@@ -20464,6 +20548,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="スーパーボンブリス デラックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="super bombliss dx (japan).bin" size="262144" crc="34c8a4a5" sha1="44070e77eb2b56b67f979e444d404e56b67edbb0"/>
@@ -20577,6 +20662,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdxj" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
+		<!--	In lot check as "POOL\cgbahyj0.0"	-->
 		<description>Super Mario Bros. Deluxe (Jpn, NP)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -20595,7 +20681,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdxja" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
-		<!--	In lot check as "cgbahyj1.0"	-->
+		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
 		<description>Super Mario Bros. Deluxe (Jpn, NP, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -20614,6 +20700,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
+		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
+		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
 		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. B)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -20717,7 +20805,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="srobotlb">
-		<!-- Notes: SGB enhanced -->
 		<description>Super Robot Taisen - Link Battler (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
@@ -20725,6 +20812,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991001"/>
 		<info name="alt_title" value="スーパーロボット大戦 リンクバトラー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super robot taisen - link battler (japan).bin" size="1048576" crc="d24e592d" sha1="e6c715042adc4c1b52a7295e082953ada79cf95e"/>
@@ -20780,16 +20868,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="survkidsj" cloneof="stranded">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
+		<!-- Also released by NP in 2001-02 -->
 		<!--	In lot check as "dmgavkj0.g64"	-->
 		<description>Survival Kids - Kotou no Boukensha (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKJ-JPN (RK189-J1)"/>
-		<info name="submitted" value="19990423"/>
+		<info name="gold" value="19990423"/>
 		<info name="release" value="19990617"/>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmgavkj0.g64" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
@@ -20800,13 +20889,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="survkidsjunk" cloneof="stranded">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
+		<!-- Also released by NP in 2001-02 -->
 		<!-- Old dump of unknown origin -->
 		<description>Survival Kids - Kotou no Boukensha (Jpn, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids - kotou no boukensha (japan).bin" size="1048576" crc="19c2bd07" sha1="091afc2743425e1846cfe356cf8cb0f3c4e14ed7"/>
@@ -20817,15 +20907,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="survkid2">
-		<!-- Notes: SGB enhanced -->
 		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B2VJ-JPN (RK210-J1)"/>
-		<info name="submitted" value="20000606"/>
+		<info name="gold" value="20000606"/>
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids 2 - dasshutsu futago shima (japan).bin" size="1048576" crc="ab8b25d8" sha1="8fd720d5b035939b553910a3ec45c1bd052484eb"/>
@@ -20841,7 +20931,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AXRP-EUR?"/>
-		<info name="submitted" value="19991001"/>
+		<info name="gold" value="19991001"/>
 		<info name="release" value="20000719"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -20852,7 +20942,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sweetang">
-		<!-- Notes: SGB enhanced -->
 		<description>Sweet Ange (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
@@ -20860,6 +20949,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="スウィートアンジェ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sweet ange (japan).bin" size="1048576" crc="4be9b159" sha1="5b6f268d945bcdb070195459582f01b434c01495"/>
@@ -20900,7 +20990,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sylvan">
-		<!-- Notes: SGB enhanced -->
 		<description>Sylvanian Families - Otogi no Kuni no Pendant (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
@@ -20908,6 +20997,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="シルバニアファミリー 〜おとぎの国のペンダント〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -20928,7 +21018,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BLVJ-JPN"/>
-		<info name="submitted" value="20001117"/>
+		<info name="gold" value="20001117"/>
 		<info name="release" value="20001222"/>
 		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20960,7 +21050,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sylvmel">
-		<!-- Notes: SGB enhanced -->
 		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
@@ -20968,6 +21057,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000317"/>
 		<info name="alt_title" value="シルバニアメロディー 森のなかまと踊りましょ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sylvanian melodies - mori no nakama to odori mashi (japan).bin" size="1048576" crc="6dd8ac91" sha1="55230e865958f7301076a4354b6b8b083a494bae"/>
@@ -21005,7 +21095,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ttshogi">
-		<!-- Notes: NP only -->
+		<!-- NP only -->
 		<description>Taisen Tsumeshougi (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
@@ -21021,7 +21111,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bublboblj" cloneof="bublbobl">
-		<!-- Notes: SGB enhanced -->
 		<description>Taito Memorial - Bubble Bobble (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
@@ -21029,6 +21118,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル バブルボブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - bubble bobble (japan).bin" size="1048576" crc="388c6760" sha1="6a30d328417e085dcd10588d0a5af90ff4bfa40d"/>
@@ -21037,7 +21127,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="chasehqj" cloneof="chasehq">
-		<!-- Notes: SGB enhanced -->
 		<description>Taito Memorial - Chase H.Q. - Secret Police (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
@@ -21045,6 +21134,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル チェイス・エイチ・キュー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - chase h.q. - secret police (japan).bin" size="1048576" crc="6a0c272d" sha1="d6d90667ebf295016f01b4604ab03ab5b1876d00"/>
@@ -21053,7 +21143,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tophant">
-		<!-- Notes: SGB enhanced -->
 		<description>Tales of Phantasia - Narikiri Dungeon (Jpn)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
@@ -21061,6 +21150,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20001110"/>
 		<info name="alt_title" value="テイルズオブファンタジア なりきりダンジョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tales of phantasia - narikiri dungeon (japan).bin" size="2097152" crc="725cf31c" sha1="ef322f4160ceebd8da67758ebd73225190af6d23"/>
@@ -21071,7 +21161,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="donqix">
-		<!-- Notes: SGB enhanced -->
 		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
@@ -21079,6 +21168,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="谷村ひとし流パチンコ攻略大作戦 ドン・キホーテが行く"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tanimura hitoshi ryuu pachinko kouryaku daisakusen - don quijote ga iku (japan).bin" size="2097152" crc="ce8ae58c" sha1="f752e96602274a29006425a06086d8ab45e1075c"/>
@@ -21154,7 +21244,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BT2F-FRA"/>
-		<info name="submitted" value="20000323"/>
+		<info name="gold" value="20000323"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21340,7 +21430,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN"/>
-		<info name="submitted" value="19991004"/>
+		<info name="gold" value="19991004"/>
 		<info name="release" value="19991112"/>
 		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
 		<part name="cart" interface="gameboy_cart">
@@ -21360,7 +21450,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN?"/>
-		<info name="submitted" value="20000623"/>
+		<info name="gold" value="20000623"/>
 		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -21373,7 +21463,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tetrisdx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-09 -->
+		<!-- Also released by NP in 2000-09 -->
 		<description>Tetris DX (World)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -21381,6 +21471,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981021 (JPN)"/>
 		<info name="alt_title" value="テトリスデラックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="tetris dx (world).bin" size="524288" crc="69989152" sha1="7183bcb54dd35f3a07d8fe63339b768f13b8168d"/>
@@ -21396,7 +21487,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33X-UKV"/>
-		<info name="submitted" value="20000223"/>
+		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -21524,7 +21615,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BDQP-EUR"/>
-		<info name="submitted" value="20010529"/>
+		<info name="gold" value="20010529"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21580,7 +21671,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AFCE-USA"/>
-		<info name="submitted" value="19990917"/>
+		<info name="gold" value="19990917"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21622,7 +21713,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tokimclt">
-		<!-- Notes: SGB enhanced -->
 		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -21630,6 +21720,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET カルチャー編 〜木漏れ日のメロディ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - culture hen - komorebi no melody (japan).bin" size="4194304" crc="4be4a8ed" sha1="0f64c4afe74b6cfd693b6c65f0168dcb26224443"/>
@@ -21640,7 +21731,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tokimspt">
-		<!-- Notes: SGB enhanced -->
 		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -21648,6 +21738,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET スポーツ編 〜桜庭のフォトグラフ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - sport hen - koutei no photograph (japan).bin" size="4194304" crc="78e14fa9" sha1="ce39fcf903bb3b0529205cab4a412bfa0e8a2ebf"/>
@@ -21699,7 +21790,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
-		<info name="submitted" value="20000928"/>
+		<info name="gold" value="20000928"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21715,7 +21806,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
-		<info name="submitted" value="20010223"/>
+		<info name="gold" value="20010223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21734,6 +21825,22 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="tom and jerry - mousehunt (usa) (en,fr,es).bin" size="1048576" crc="5fc6bec0" sha1="99c71a51921d802a0fcaea1f67b54ef4ec653900"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tomjermhua" cloneof="tomjermh">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbtqe1.541"	-->
+		<description>Tom and Jerry - Mousehunt (USA, Rev. A)</description>
+		<year>2001</year>
+		<publisher>Conspiracy Entertainment</publisher>
+		<info name="serial" value="CGB-BTJE-USA?"/>
+		<info name="gold" value="20010129"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbtqe1.541" size="2097152" crc="ce4ca7b1" sha1="89374d81045a3bedf24e42b58ce403b0a5fbcddb"/>
 			</dataarea>
 		</part>
 	</software>
@@ -21758,7 +21865,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BTQE-USA"/>
-		<info name="submitted" value="20001020"/>
+		<info name="gold" value="20001020"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -21869,7 +21976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BCZE-USA"/>
-		<info name="submitted" value="20020411"/>
+		<info name="gold" value="20020411"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21934,7 +22041,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTFE-USA-1, CGB-BTFP-EUR"/>
-		<info name="submitted" value="20000201"/>
+		<info name="gold" value="20000201"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -22083,7 +22190,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-V33J-JPN"/>
-		<info name="submitted" value="19991028"/>
+		<info name="gold" value="19991028"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="トップギア・ポケット2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22103,7 +22210,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-A33E-USA"/>
-		<info name="submitted" value="19991203"/>
+		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22136,7 +22243,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33P-(EUR/FRA)"/>
-		<info name="submitted" value="20000221"/>
+		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22182,7 +22289,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="totsuge">
-		<!-- Notes: SGB enhanced -->
 		<description>Totsugeki! Papparatai (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-WIng</publisher>
@@ -22190,6 +22296,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="突撃!パッパラ隊"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="totsugeki papparatai (japan).bin" size="4194304" crc="0aeae8fb" sha1="4c98beab325cd058445102c85d30b3724325f2ce"/>
@@ -22325,16 +22432,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tradebata">
-		<!-- Notes: SGB enhanced -->
 		<!--	Never released as physical cartridge	-->
 		<!--	Released on the 3DS Virtual Console	-->
-		<!--	In lot check as "dmgahhj1.1"	-->
+		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
 		<description>Trade &amp; Battle Card Hero (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
 		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
@@ -22346,15 +22453,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tradebat" cloneof="tradebata">
-		<!-- Notes: SGB enhanced -->
 		<description>Trade &amp; Battle Card Hero (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
-		<info name="submitted" value="20000111"/>
+		<info name="gold" value="20000111"/>
 		<info name="release" value="20000221"/>
 		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
@@ -22444,15 +22551,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tsurisn2">
-		<!-- Notes: SGB enhanced -->
 		<description>Tsuri Sensei 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN"/>
-		<info name="submitted" value="19990624"/>
+		<info name="gold" value="19990624"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="昆虫博士 ２"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -22465,16 +22572,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 	
 	<software name="tsurisn2a" cloneof="tsurisn2">
-		<!-- Notes: SGB enhanced -->
 		<!--	In lot check as "dmga2kj1.g93"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Tsuri Sensei 2 (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN?"/>
-		<info name="submitted" value="19990908"/>
+		<info name="gold" value="19990908"/>
 		<info name="alt_title" value="昆虫博士 ２"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmga2kj1.g93" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
@@ -22552,6 +22659,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="turokrag">
 		<!-- Notes: GBC only -->
+		<!--	Retail cartridge of Australian version not yet secured, does it exist?	-->
 		<description>Turok - Rage Wars (Euro, Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -22893,7 +23001,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFP-EUR"/>
-		<info name="submitted" value="20000221"/>
+		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22908,7 +23016,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFE-USA"/>
-		<info name="submitted" value="19991203"/>
+		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22985,12 +23093,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="vrspower">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpbe0.340"	-->
-		<!--	Retail cartridge not yet located, might be unreleased	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<description>VR Sports Powerboat Racing (USA)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BPBE-USA?"/>
-		<info name="submitted" value="20000727"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -23005,7 +23113,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-ALEJ-JPN"/>
-		<info name="submitted" value="20000225"/>
+		<info name="gold" value="20000225"/>
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="VSレミングス"/>
 		<part name="cart" interface="gameboy_cart">
@@ -23105,7 +23213,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wario2j" cloneof="wario2">
-		<!-- Notes: SGB enhanced -->
 		<description>Wario Land 2 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -23113,6 +23220,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="ワリオランド2ワリオランド2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="wario land 2 (japan).bin" size="2097152" crc="b30fdbf5" sha1="cd6266e48df816219fb38d223b0ec6760259616d"/>
@@ -23248,7 +23356,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BWNJ-JPN"/>
-		<info name="submitted" value="20020322"/>
+		<info name="gold" value="20020322"/>
 		<info name="release" value="20020426"/>
 		<info name="alt_title" value="わたしのレストラン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -23301,7 +23409,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWYD-NOE"/>
-		<info name="submitted" value="20021120"/>
+		<info name="gold" value="20021120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -23326,7 +23434,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wetrixj" cloneof="wetrix">
-		<!-- Notes: SGB enhanced -->
 		<description>Wetrix GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
@@ -23334,6 +23441,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ウエットリスGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="wetrix gb (japan).bin" size="1048576" crc="6215c5b3" sha1="92944052b6e4448abf0103f085998662e0140825"/>
@@ -23652,7 +23760,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wsoccer2" cloneof="iss99">
-		<!-- Notes: SGB enhanced -->
 		<description>World Soccer GB2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -23660,6 +23767,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ワールドサッカーGB2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="world soccer gb2 (japan).bin" size="1048576" crc="dd18db5f" sha1="b58c969510aab4930a1846d857f58d57ed342592"/>
@@ -23886,7 +23994,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-BXCP-EUR"/>
-		<info name="submitted" value="20000922"/>
+		<info name="gold" value="20000922"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -23903,7 +24011,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BXCE-USA"/>
-		<info name="submitted" value="20010307"/>
+		<info name="gold" value="20010307"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -23917,12 +24025,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="yakouchu">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaytj0.066"	-->
-		<!--	Retail cartridge not yet located	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Yakouchuu GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
-		<info name="submitted" value="19990924"/>
+		<info name="gold" value="19990924"/>
 		<info name="release" value="19991022"/>
 		<info name="alt_title" value="夜光虫GB"/>
 		<part name="cart" interface="gameboy_cart">
@@ -24001,7 +24109,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3P-EUR"/>
-		<info name="submitted" value="20020906"/>
+		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -24024,7 +24132,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3F-FRA-1"/>
-		<info name="submitted" value="20020906"/>
+		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24047,7 +24155,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3D-NOE"/>
-		<info name="submitted" value="20030116"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24070,7 +24178,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3I-ITA"/>
-		<info name="submitted" value="20030116"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24093,7 +24201,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3S-ESP"/>
-		<info name="submitted" value="20030116"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24116,7 +24224,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3E-USA"/>
-		<info name="submitted" value="20011217"/>
+		<info name="gold" value="20011217"/>
 		<info name="alt_title" value="Yu-Gi-Oh! Duel Monsters: Dark Duel Stories"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -24129,15 +24237,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="yugimcap">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-02-01 -->
+		<!-- Also released by NP in 2001-02-01 -->
 		<description>Yu-Gi-Oh! - Monster Capsule GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYCJ-JPN (RK206-J1)"/>
-		<info name="submitted" value="20000217"/>
+		<info name="gold" value="20000217"/>
 		<info name="release" value="20000413"/>
 		<info name="alt_title" value="遊戯王 モンスターカプセル ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="yu-gi-oh - monster capsule gb (japan).bin" size="1048576" crc="1371e872" sha1="4ed5607dd83ebe7975c492b08d36870f8dd6e302"/>
@@ -24214,7 +24323,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="yugidm2">
-		<!-- Notes: SGB enhanced -->
 		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
@@ -24222,6 +24330,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19990708"/>
 		<info name="alt_title" value="遊戯王デュエルモンスターズII 闇界決闘記"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -24316,7 +24425,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. B)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -24324,6 +24433,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -24340,7 +24450,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -24348,6 +24458,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev a).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
@@ -24358,7 +24469,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxjb" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Also released by NP in 2000-03 -->
 		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -24366,6 +24477,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="zelda no densetsu - yume o miru shima dx (japan).bin" size="1048576" crc="d974abea" sha1="b810925bf9d9f4f6cd97c5e46c94c1a9dd61a113"/>
@@ -24424,7 +24536,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zoidsjas">
-		<!-- Notes: SGB enhanced -->
 		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
@@ -24432,6 +24543,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev a).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
@@ -24442,7 +24554,6 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zoidsjasa" cloneof="zoidsjas">
-		<!-- Notes: SGB enhanced -->
 		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
@@ -24450,6 +24561,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="zoids - jashin fukkatsu genobreaker hen (japan).bin" size="2097152" crc="f36c874d" sha1="4ddb1d66d909d453374bd195a4a7dbe328ed41be"/>
@@ -24512,16 +24624,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-
-
 <!--
-List of pirate cartridges
+	List of pirate cartridges
 -->
 
 <!--
-Rocket Games
+	Rocket Games
 
-These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
+	These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="atvrackj" supported="partial">
@@ -24793,8 +24903,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 
-	<!-- also data from ThunderBlast Man -->
 	<software name="jboy2a" cloneof="jboy2">
+	<!-- also data from ThunderBlast Man -->
 		<description>Jurassic Boy II</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
@@ -24966,8 +25076,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 -->
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="leinujs" supported="no">
+	<!-- This version should be the real dump, protected as the original cart -->
 		<description>Lei Nu Ji Shen (Tw)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
@@ -24983,9 +25093,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="leinujsh" cloneof="leinujs">
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+		 the real card, so it can be removed once we properly emulate the parent -->
 		<description>Lei Nu Ji Shen (Tw, Hacked)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
@@ -25191,8 +25301,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- AKA Digimon D-4 published by SKOB -->
 	<software name="mingzhu2">
+	<!-- AKA Digimon D-4 published by SKOB -->
 		<description>Ming Zhu Kou Dai Guai Shou II (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
@@ -25444,8 +25554,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
 	<software name="lkrdx6">
+	<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
 		<description>Luo Ke Ren DX6 (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
@@ -25494,7 +25604,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="teshu2k1" cloneof="mslug2k1">
-		<!-- probably developed by BDD -->
+	<!-- probably developed by BDD -->
 		<description>Teshu Budui 2001 (Chi, Li Cheng)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
@@ -25526,8 +25636,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
 	<software name="terr911">
+	<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
 		<description>Teshu Budui 2 - Jidi (Chi)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
@@ -25588,7 +25698,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="hpotter">
-		<!-- probably developed by BDD -->
+	<!-- probably developed by BDD -->
 		<description>Harry Potter (Chi)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
@@ -25664,6 +25774,20 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 <!-- Other Asian Pirate dumps to sort -->
 
+	<software name="188in1" supported="partial">
+	<!--	This dump comes from the "GBCK003" board that's soldered inside some GB Boy Colour units	-->
+		<description>Color GameBoy 188 in 1 (Hong Kong)</description>
+		<year>199?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="pcb" value="GBCK003" />
+			<feature name="slot" value="rom_188in1" />
+			<dataarea name="rom" size="8388608">
+				<rom name="m29w640ft.u2" size="8388608" crc="e4068d7d" sha1="e61ee50ed39fd5b5cc8bdcb96fe1c3cccdcfc76f" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="digicrs2" cloneof="pokesaph">
 		<description>Digimon Crystal II (Chi)</description>
 		<year>200?</year>
@@ -25723,8 +25847,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- World WarCraft? -->
 	<software name="moshosj">
+	<!-- World WarCraft? -->
 		<description>Mo Shou Shi Ji - Zhan Shen (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
@@ -25814,8 +25938,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Pokemon Platinum? -->
 	<software name="pokeplat">
+	<!-- Pokemon Platinum? -->
 		<description>Kou Dai Yao Guai - Bai Jin Ban (Chi)</description>
 		<year>2005</year>
 		<publisher>Sintax</publisher>
@@ -25830,8 +25954,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Metal Slug 3? -->
 	<software name="ynzy3">
+	<!-- Metal Slug 3? -->
 		<description>Yue Nan Zhan Yi 3 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
@@ -25846,8 +25970,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- TODO: study the menu and writes of this cart! -->
 	<software name="m_digi10" supported="no">
+	<!-- TODO: study the menu and writes of this cart! -->
 		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (Chi)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
@@ -25860,8 +25984,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This got ripped by m_digi10 -->
 	<software name="digid3h" cloneof="digid3">
+	<!-- This got ripped by m_digi10 -->
 		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (Chi, Ripped from 10 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
@@ -25906,9 +26030,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
-<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
 	<software name="hjtaiyou">
+	<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
+	<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
 		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
@@ -25923,8 +26047,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
 	<software name="dquest8">
+	<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
 		<description>Yong Zhe Dou E Long VIII (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
@@ -26103,8 +26227,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<software name="pokesaphc" cloneof="pokesaph">
+	<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<!-- 4MB rom with crc 3a08c8eb is taizou's cracked version running on base MBC5 -->
 		<description>Kou Dai Guai Shou - Lan Bao Shi (Chi)</description>
 		<year>200?</year>
@@ -26484,8 +26608,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<software name="chongwu">
+	<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<!-- at 0x1e0 starts a routine which (at 0x1ec) reads from $41c3, then compares
 	     the value with 0x5d. if comparison fails, the code enters a routine at 0x780
 	     where it gets stuck. if comparison works, then the code goes to 0x150 as the
@@ -26606,8 +26730,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of the undumped 'Zook Hero 2' -->
 	<software name="rockmnx3">
+	<!-- This is a title hack of the undumped 'Zook Hero 2' -->
 		<description>Rockman X3 (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
@@ -26637,8 +26761,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of the undumped 'Super Fighter S' -->
 	<software name="sf99">
+	<!-- This is a title hack of the undumped 'Super Fighter S' -->
 		<description>Super Fighters '99 (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
@@ -26692,8 +26816,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped Dragon Ball fighting game -->
 	<software name="dbf2005">
+	<!-- This is a title hack of an undumped Dragon Ball fighting game -->
 		<description>Dragonball Fight 2005 (Chi)</description>
 		<year>2005?</year>
 		<publisher>Fiver Firm</publisher>
@@ -26719,8 +26843,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
 	<software name="hpotter3c" cloneof="hpotter2">
+	<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
 		<description>Harry Potter 3 2003 (Chi)</description>
 		<year>2003?</year>
 		<publisher>V.Fame?</publisher>
@@ -26780,7 +26904,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mszb3" cloneof="shjmlwc">
-		<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
+	<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
 		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -26824,8 +26948,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Title hack of the above, with VF logo removed -->
 	<software name="shuihuz" cloneof="shuihuss">
+	<!-- Title hack of the above, with VF logo removed -->
 		<description>Shui Hu Zhuan (Chi)</description>
 		<year>2002</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -26840,8 +26964,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
 	<software name="kof2003">
+	<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
 		<description>Ge Dou Zhi Zun 2003 (Chi)</description>
 		<year>2003?</year>
 		<publisher>SKOB?</publisher>
@@ -26916,8 +27040,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
 	<software name="sanguoasb" cloneof="sanguoas">
+	<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
 		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt Bad?)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
@@ -26932,12 +27056,12 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
 	<software name="cbzz">
-		<!-- Alt. Title: 吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs) -->
+	<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
 		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -26949,10 +27073,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smmftu">
-		<!-- Alt. Title: 十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter) -->
 		<description>Shi Mian Mai Fu - Tu Long Pian (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -26964,10 +27088,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smmftian">
-		<!-- Alt. Title: 十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter) -->
 		<description>Shi Mian Mai Fu - Tian Long Pian (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -27026,7 +27150,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		<description>Ying Xiong Chuan Shuo (Chi)</description>
 		<year>20??</year>
 		<publisher>Waixing</publisher>
-		<info name="alt_title" value="英雄传说 (Legend of Heroes) "/>
+		<info name="alt_title" value="英雄传说 (Legend of Heroes)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_digimon" />
 			<dataarea name="rom" size="1048576">
@@ -27038,11 +27162,11 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sqsd">
-		<!-- Alt. Title: 石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King) -->
 		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (Chi)</description>
 		<year>20??</year>
 		<publisher>GOWIN</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
+		<info name="alt_title" value="石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_yong" />
 			<dataarea name="rom" size="4194304">
@@ -27068,11 +27192,11 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-	<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
-	(apparently it got sent to US by a Vietnamese guy back in the 2000)
-	it can be seen on youtube. -->
 	<software name="pokecrysb" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
+		<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
+		(apparently it got sent to US by a Vietnamese guy back in the 2000)
+		it can be seen on youtube. -->
 		<description>Pocket Monsters - Crystal Version (Bootleg)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -27087,8 +27211,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-	<!-- Notes: GBC only -->
 	<software name="pikangtm" cloneof="smurfnig">
+		<!-- Notes: GBC only -->
 		<description>The Pikachu Nightmare (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -27165,16 +27289,16 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!--
-There are various dumps of this:
-2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
-256KB version (CRC 791f8c86) which contains the first half of the rom used here
-
-taizou dumped the game also from a multicart and got a 1MB dump containing the rom
-used here repeated twice. we need to redump the standalone cart to confirm the size
-but the 256KB version is definitely underdumped and misses sprite data
--->
 	<software name="sm3sp" supported="no">
+	<!--
+	There are various dumps of this:
+	2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
+	256KB version (CRC 791f8c86) which contains the first half of the rom used here
+
+	taizou dumped the game also from a multicart and got a 1MB dump containing the rom
+	used here repeated twice. we need to redump the standalone cart to confirm the size
+	but the 256KB version is definitely underdumped and misses sprite data
+	-->
 		<description>Super Mario 3 Special (Chi)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
@@ -27186,8 +27310,8 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn2" supported="no">
+	<!-- This version should be the real dump, protected as the original cart -->
 		<description>Digimon 2 (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
@@ -27201,9 +27325,9 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="digimn2h" cloneof="digimn2">
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+     the real card, so it can be removed once we properly emulate the parent -->
 		<description>Digimon 2 (Chi, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
@@ -27231,8 +27355,8 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn4" supported="no">
+	<!-- This version should be the real dump, protected as the original cart -->
 		<description>Digimon 02 4 (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
@@ -27246,9 +27370,9 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="digimn4h" cloneof="digimn4">
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+     the real card, so it can be removed once we properly emulate the parent -->
 		<description>Digimon 02 4 (Chi, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
@@ -27352,7 +27476,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 <!--
-List of unclassified roms
+	List of unclassified roms
 -->
 
 
@@ -27383,5 +27507,4 @@ List of unclassified roms
 			</dataarea>
 		</part>
 	</software>
-
 </softwarelist>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -1646,7 +1646,8 @@ license:CC0
 	</software>
 
 	<software name="batmanbej" cloneof="batmanbe">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<description>Batman Beyond - Return of the Joker (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
@@ -2262,7 +2263,8 @@ license:CC0
 	</software>
 
 	<software name="bombmmxa">
-		<!-- Notes: GBC only, this was the prize for a draw contest -->
+		<!-- Notes: GBC only -->
+		<!--	This was the prize for a draw contest	-->
 		<description>Bomberman Max - Ain Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
@@ -3352,7 +3354,8 @@ license:CC0
 	</software>
 
 	<software name="commandm" supported="no">
-		<!-- Notes: GBC only.  The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
+		<!-- Notes: GBC only -->
+		<!--	The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console.	-->
 		<description>Command Master (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
@@ -3774,7 +3777,8 @@ license:CC0
 	</software>
 
 	<software name="daikatanj" cloneof="daikatan">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<description>Daikatana GB (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
@@ -6880,7 +6884,8 @@ license:CC0
 	</software>
 
 	<software name="ggoemdyn">
-		<!-- Notes: GBC only, also released by NP in 2001-07 -->
+		<!-- Notes: GBC only -->
+		<!-- Also released by NP in 2001-07 -->
 		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
@@ -8505,7 +8510,8 @@ license:CC0
 	</software>
 
 	<software name="honkhana">
-		<!-- Notes: GBC only, also released by NP in 2000-12 -->
+		<!-- Notes: GBC only -->
+		<!-- Also released by NP in 2000-12 -->
 		<description>Honkaku Hanafuda GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
@@ -9953,8 +9959,9 @@ license:CC0
 	</software>
 
 	<software name="kirbytlt" supported="no">
-		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
+		<!-- Notes: GBC only -->
 		<!--	In lot check as "CGBKTNE0.638", "KENSA\CGBKTNP0.0"	-->
+		<!--	The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console.	-->
 		<description>Kirby Tilt 'n' Tumble (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -10243,7 +10250,8 @@ license:CC0
 	</software>
 
 	<software name="korokoro" cloneof="kirbytlt" supported="no">
-		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
+		<!-- Notes: GBC only -->
+		<!--	The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console.	-->
 		<description>Korokoro Kirby (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -11973,7 +11981,8 @@ license:CC0
 	</software>
 
 	<software name="mariofam">
-		<!-- Notes: GBC only, bundled with Jaguar Sewing Machine (Nuotto Expansion)? -->
+		<!-- Notes: GBC only -->
+		<!--	Bundled with Jaguar Sewing Machine (Nuotto Expansion)?	-->
 		<description>Mario Family (Japan)</description>
 		<year>2001</year>
 		<publisher>Jaguar</publisher>
@@ -13784,7 +13793,8 @@ license:CC0
 	</software>
 
 	<software name="mrdrillrjnp" cloneof="mrdrillr">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
 		<description>Mr. Driller (Japan, NP)</description>
 		<year>2000</year>
@@ -14240,7 +14250,8 @@ license:CC0
 	</software>
 
 	<software name="naminori" cloneof="ultsurf">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<description>Naminori Yarou! (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
@@ -14522,9 +14533,9 @@ license:CC0
 	</software>
 
 	<software name="networka">
-		<!-- Notes: GBC only
-		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
-		        which is just a LED light connected to the GB accessories port. -->
+		<!-- Notes: GBC only -->
+		<!--	This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently
+				shaped plastic case), which is just a LED light connected to the GB accessories port. -->
 		<description>Network Boukenki Bugsite - Alpha Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
@@ -14542,9 +14553,9 @@ license:CC0
 	</software>
 
 	<software name="networkb">
-		<!-- Notes: GBC only
-		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
-		        which is just a LED light connected to the GB accessories port. -->
+		<!-- Notes: GBC only -->
+		<!--	This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently
+				shaped plastic case), which is just a LED light connected to the GB accessories port. -->
 		<description>Network Boukenki Bugsite - Beta Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
@@ -15551,8 +15562,8 @@ license:CC0
 	</software>
 
 	<software name="pockfam2">
-		<!-- Notes: GBC only
-		    The game cart has an integrated speaker and a replaceable battery (CR2025). -->
+		<!-- Notes: GBC only -->
+		<!--	The game cart has an integrated speaker and a replaceable battery (CR2025).	-->
 		<description>Pocket Family GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
@@ -17634,7 +17645,8 @@ license:CC0
 	</software>
 
 	<software name="qixadvj" cloneof="qixadv">
-		<!-- Notes: GBC only, also released by NP in 2000-12 -->
+		<!-- Notes: GBC only -->
+		<!-- Also released by NP in 2000-12 -->
 		<description>Qix Adventure (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
@@ -17809,7 +17821,8 @@ license:CC0
 	</software>
 
 	<software name="rakuxcs">
-		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
+		<!-- Notes: GBC only -->
+		<!--	For use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000	-->
 		<description>Raku x Raku - Cut Shuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
@@ -17848,7 +17861,8 @@ license:CC0
 	</software>
 
 	<software name="rakuxmoj">
-		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
+		<!-- Notes: GBC only -->
+		<!--	For use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000	-->
 		<description>Raku x Raku - Moji (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
@@ -18388,8 +18402,8 @@ license:CC0
 	</software>
 
 	<software name="robopspc">
-		<!-- Notes: GBC only
-		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Notes: GBC only -->
+		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
@@ -18950,9 +18964,11 @@ license:CC0
 	</software>
 
 	<software name="sakura">
-		<!-- Notes: GBC only, 10 variant packs got released!
-		            This game is compatible with an external pedometer named "Pocket Sakura" (same hardware as the Pokémon Pikachu Color / Pokémon Pikachu 2 GS pedometer)
-		            wich connects to the GBC via the console's IR port -->
+		<!-- Notes: GBC only -->
+		<!--	10 variant packs got released!
+				This game is compatible with an external pedometer named "Pocket Sakura"
+				(same hardware as the Pokémon Pikachu Color / Pokémon Pikachu 2 GS pedometer),
+				which connects to the GBC via the console's IR port -->
 		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
@@ -20286,7 +20302,8 @@ license:CC0
 	</software>
 
 	<software name="spyvsspyj" cloneof="spyvsspy">
-		<!-- Notes: GBC only, also released by NP in 2001-05 -->
+		<!-- Notes: GBC only -->
+		<!-- Also released by NP in 2001-05 -->
 		<description>Spy vs. Spy (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
@@ -20304,8 +20321,8 @@ license:CC0
 
 	<software name="spyvsspyjanp" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
-		<!--	Never released as physical cartridge	-->
 		<description>Spy vs. Spy (Japan, Rev 1, NP)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
@@ -20663,7 +20680,8 @@ license:CC0
 	</software>
 
 	<software name="smbdxj" cloneof="smbdx">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<!--	In lot check as "POOL\cgbahyj0.0"	-->
 		<description>Super Mario Bros. Deluxe (Japan, NP)</description>
 		<year>1999</year>
@@ -20682,7 +20700,8 @@ license:CC0
 	</software>
 
 	<software name="smbdxja" cloneof="smbdx">
-		<!-- Notes: GBC only, NP only -->
+		<!-- Notes: GBC only -->
+		<!-- NP only -->
 		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
 		<description>Super Mario Bros. Deluxe (Japan, NP, Rev 1)</description>
 		<year>1999</year>
@@ -20702,8 +20721,8 @@ license:CC0
 
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
-		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
+		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<description>Super Mario Bros. Deluxe (Europe, USA, Rev 2)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
@@ -22434,8 +22453,7 @@ license:CC0
 	</software>
 
 	<software name="tradebata">
-		<!--	Never released as physical cartridge	-->
-		<!--	Released on the 3DS Virtual Console	-->
+		<!--	Only released on the 3DS Virtual Console?	-->
 		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
 		<description>Trade &amp; Battle Card Hero (Japan, Rev 1)</description>
 		<year>2000</year>
@@ -22506,7 +22524,8 @@ license:CC0
 	</software>
 
 	<software name="trickbrdj" cloneof="trickbrd">
-		<!-- Notes: GBC only, also released by NP in 2000-12 -->
+		<!-- Notes: GBC only -->
+		<!-- Also released by NP in 2000-12 -->
 		<description>Trickboarder GP (Japan)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
@@ -24598,8 +24617,8 @@ license:CC0
 	</software>
 
 	<software name="zokzok">
-		<!-- Notes: GBC only.
-		    Zok Zok Heroes works with an external peripheral that acts like a motion controller.
+		<!-- Notes: GBC only -->
+		<!-- Zok Zok Heroes works with an external peripheral that acts like a motion controller.
 		    Internally, this device has a weighted analog joystick that moves when you shake the device.
 		    It has a Fujitsu MB89135L (undumped), four leds, a speaker and an IR emitter.
 		    It connects with the Game Boy using the console IR, but just one way (device to console).
@@ -24622,1836 +24641,6 @@ license:CC0
 				<rom name="cgb-bzhj-0.u1" size="2097152" crc="c09f9e1b" sha1="91ab908fddebd926e7db8d61295a40955b2adc39"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-<!--
-	List of Release Candidates
--->
-
-	<software name="speedyjrc0" cloneof="speedy">
-		<!--	In lot check as "KENSA\dmga35j0.0"	-->
-		<description>Speedy Gonzales - Aztec Adventure (Japan, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Sunsoft</publisher>
-		<info name="alt_title" value="スピーディーゴンザレスアステカアドベンチャー!"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmga35j0.0" size="1048576" crc="c97d74f5" sha1="b65cd4a60014ecef55b1daca7e17379987f1d983"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pockgolfrc1" cloneof="golfdai">
-		<!--	In lot check as "KENSA\dmgaage0.1"	-->
-		<description>Pocket Golf! (USA, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>KID</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgaage0.1" size="2097152" crc="d06ecb1f" sha1="bbe2651547c1f3c79bbf822b41ddbb54133a489f"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="klustarjrc0" cloneof="klustar">
-		<!--	In lot check as "KENSA\dmgaahj0.0"	-->
-		<description>Klustar (Japan, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Infogrames</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgaahj0.0" size="262144" crc="65da9075" sha1="9c60c858f647b42007fc27c5d21f3f57923c4cda"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ddanceurc1" cloneof="ddance">
-		<!--	In lot check as "KENSA\dmgad5e0.1"	-->
-		<description>Dragon Dance (USA, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Infogrames</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgad5e0.1" size="262144" crc="9a90adbe" sha1="5fc97752a98a18b7e2db238d1ab88c6b09e34602"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dqmarc1" cloneof="dwm">
-		<!--	In lot check as "KENSA\dmgadqj1.1"	-->
-		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev 1, Release Candidate 1)</description>
-		<year>1998</year>
-		<publisher>Enix</publisher>
-		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgadqj1.1" size="2097152" crc="66b83e3a" sha1="378794e041f2eb286f2d5243a3cada2faf265bb5"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dsaviorarc1" cloneof="dsavior">
-		<!--	In lot check as "KENSA\dmgadwj1.1"	-->
-		<description>Dungeon Savior (Japan, Rev 1, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>J-Wing</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dmgadwj1.1" size="4194304" crc="0180364b" sha1="c5e93f04cc41404320aaf70eb10b55465edb1083"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hellokcferc1" cloneof="hellokcf">
-		<!--	In lot check as "KENSA\dmgaf4p0.1"	-->
-		<description>Hello Kitty's Cube Frenzy (Europe, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>NewKidCo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaf4p0.1" size="1048576" crc="9606a07f" sha1="2225da8a68e489c0f562afcb8e90fc9387321af0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="espcfishrc0" cloneof="tnnofc">
-		<!--	In lot check as "KENSA\dmgafcp0.0"	-->
-		<description>EuroSport Pro Champ Fishing (Europe, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>ASC Games</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgafcp0.0" size="1048576" crc="32083abd" sha1="565c16da5d2bc5dacffa992ed3f0466ec4888e73"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gbgall2jrc1" cloneof="gwatch2">
-		<!--	In lot check as "KENSA\dmgaglj0.1"	-->
-		<description>Game Boy Gallery 2 (Japan, Release Candidate 1)</description>
-		<year>1998</year>
-		<publisher>Nintendo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaglj0.1" size="1048576" crc="e99beba5" sha1="90a9b368bca0f47fe72028ff4d50fb3d3060c32f"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shanghaiuarc0" cloneof="shanghai">
-		<!--	In lot check as "KENSA\dmgahpe1.0"	-->
-		<description>Shanghai Pocket (USA, Rev 1, Release Candidate 0)</description>
-		<year>1998</year>
-		<publisher>Sunsoft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgahpe1.0" size="1048576" crc="d529dafd" sha1="b36edbb0721fb71aafecd6f48609c14c1107e3f0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hexciteerc4" cloneof="hexcite">
-		<!--	In lot check as "KENSA\dmgaicp0.4"	-->
-		<description>Hexcite (Europe, Release Candidate 4)</description>
-		<year>1999</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaicp0.4" size="1048576" crc="2c6bdcfa" sha1="9380ad9ccc193682eb98be7d7447dabadd67beae"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="puchicarurc3" cloneof="puchicar">
-		<!--	In lot check as "KENSA\dmgaiqe0.3"	-->
-		<description>Puchi Carat (USA, Release Candidate 3)</description>
-		<year>2000</year>
-		<publisher>Event Horizon Software</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaiqe0.3" size="1048576" crc="a97ea742" sha1="de755124425f9de8bef5eea8026751c54f7f1e00"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="esxsracirc1" cloneof="xsracing">
-		<!--	In lot check as "KENSA\dmgajzp0.1"	-->
-		<description>EuroSport XS Racing (Europe, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>ASC Games</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgajzp0.1" size="1048576" crc="ca0abfca" sha1="b3dda41ef755cc78680858103bad07d064e155ac"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pokepicr">
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\dmgakvj0.1"	-->
-		<description>Pokémon Picross (Japan, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>Nintendo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgakvj0.1" size="2097152" crc="cf647f4b" sha1="8204064b7149357939b57342820e7955749183b6"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suttehakrc2">
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\dmgaspj0.2"	-->
-		<description>Sutte Hakkun GB (Japan, Release Candidate 2)</description>
-		<year>1999</year>
-		<publisher>Nintendo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="524288">
-				<rom name="dmgaspj0.2" size="524288" crc="e0386f84" sha1="6efd637f039d4f3a2240640921724a69a2844cc7"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="metalwlkjarc0" cloneof="metalwlk">
-		<!--	In lot check as "KENSA\dmgauej1.0"	-->
-		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Capcom</publisher>
-		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgauej1.0" size="1048576" crc="570bafdb" sha1="3d6ea44dd8426e3d7bf87a8778dd91e8095ddd35"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="td6uarc0" cloneof="td6">
-		<!--	In lot check as "KENSA\dmgaw6e1.0"	-->
-		<description>Test Drive 6 (USA, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Infogrames</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaw6e1.0" size="1048576" crc="5333c5db" sha1="f9519940ed05bdb59cd3878db8c479760d93a5bd"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="astenn2kurc3" cloneof="astenn2k">
-		<!--	In lot check as "KENSA\dmgazte0.3"	-->
-		<description>All Star Tennis 2000 (USA, Release Candidate 3)</description>
-		<year>1999</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgazte0.3" size="1048576" crc="9890bcb4" sha1="f6829ac5bba08732f875fc5812284d62f3d727e6"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="astenn2kxrco" cloneof="astenn2k">
-		<!--	In lot check as "KENSA\dmgaztx0.0"	-->
-		<description>All Star Tennis 2000 (UK?, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaztx0.0" size="1048576" crc="deff8dfb" sha1="c9db40e3e348668fe6fc41d031263acbe9041a67"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="survkid2arc0" cloneof="survkid2">
-		<!--	In lot check as "KENSA\dmgb2vj1.0"	-->
-		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Konami</publisher>
-		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgb2vj1.0" size="1048576" crc="bd366d22" sha1="505ffc930057719cf28560333342dfd6944c15da"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kangpzl2arc0" cloneof="kangpzl2a">
-		<!--	In lot check as "KENSA\dmgb62j1.0"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Success</publisher>
-		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgb62j1.0" size="262144" crc="27ab2187" sha1="49a63339bc253d1bd55f6db75f7324980572925a"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kangpzl3arc0" cloneof="kangpzl3a">
-		<!--	In lot check as "KENSA\dmgb63j1.0"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Success</publisher>
-		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgb63j1.0" size="262144" crc="62d3f1e5" sha1="a3ddd9794e05f2962481b802f84e783495e853b2"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kangpzlsarc1" cloneof="kangpzlsa">
-		<!--	In lot check as "KENSA\dmgb6ij1.1"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev 1, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Success</publisher>
-		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgb6ij1.1" size="262144" crc="88ce5c13" sha1="7e493878e0b755df3c6d6ab93c7b15b4b10a0896"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ddanceerco" cloneof="ddance">
-		<!--	In lot check as "KENSA\dmgbdap0.0"	-->
-		<description>Dragon Dance (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Crave Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="dmgbdap0.0" size="262144" crc="8b0dd3b2" sha1="76de183317c952276dbdad9d8f0592493652f31e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="golfrobo" cloneof="golfou">
-		<!--	In lot check as "KENSA\dmgbgre0.1"	-->
-		<description>SuperShot Golf Robot (USA, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Crave Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgbgre0.1" size="2097152" crc="b6a7f781" sha1="aa1447d78e380d2a936fb5f713521e34420fe68c"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="golfking" cloneof="golfou">
-		<!--	In lot check as "KENSA\dmgbgrp0.2"	-->
-		<description>Golf King (Europe, Release Candidate 2)</description>
-		<year>2000</year>
-		<publisher>Crave Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgbgrp0.2" size="2097152" crc="3019b4e7" sha1="d02e09251e7c5078e4b641e6d334958c2c814285"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ppersiajrc0" cloneof="ppersia">
-		<!--	In lot check as "KENSA\dmgbprj0.0"	-->
-		<description>Prince Of Persia (Japan, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Red Orb Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgbprj0.0" size="1048576" crc="d7dbbe1e" sha1="6fd97e1f75570e7568b3dc4ab28834813afb4484"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sewingosxrc0" cloneof="sewingos">
-		<!--	In lot check as "KENSA\dmgbrax0.0"	-->
-		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Sewing Machine Operation Software (UK?, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Natsume</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgbrax0.0" size="1048576" crc="9f1dbedd" sha1="35d242fbbde2f6f1fb869fd68396e6be4aad8f9b"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sewingosyrc0" cloneof="sewingos">
-		<!--	In lot check as "KENSA\dmgbray0.0"	-->
-		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Sewing Machine Operation Software (Euro?, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Natsume</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgbray0.0" size="1048576" crc="e34b5ce8" sha1="500439c5e14400ef2bc45cacf5ff834b70c2acd4"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="robopstrurc2" cloneof="robopstr">
-		<!--	In lot check as "KENSA\dmghrce0.2"	-->
-		<description>Robopon - Star Version (USA, Release Candidate 2)</description>
-		<year>1998</year>
-		<publisher>Hudson Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_huc3" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmghrce0.2" size="1048576" crc="cf5f0a63" sha1="54e064a24cd50b7e25df5c827c54a20643ec314a"/>
-			</dataarea>
-			<dataarea name="ram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kawanus4arc0" cloneof="rivking2">
-		<!--	In lot check as "KENSA\dmgvutj1.0"	-->
-		<description>Kawa no Nushi Tsuri 4 (Japan, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Victor Interactive Software</publisher>
-		<info name="alt_title" value="川のぬし釣り４"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgvutj1.0" size="1048576" crc="456d4dfc" sha1="69e56fd73eb365dba87713c2a3ea2e74bd63f63c"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="daikatanurc0" cloneof="daikatan">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgba22e0.0"	-->
-		<description>Daikatana (USA, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgba22e0.0" size="1048576" crc="7d451688" sha1="6eef48f4d467596ff3734bb9ac12db392170eb14"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rpgtsukuarc0" cloneof="rpgtsuku">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgba2qj1.0"	-->
-		<description>RPG Tsukuru GB (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>ASCII</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgba2qj1.0" size="2097152" crc="57f82031" sha1="f4c36b3cbb13d3cbaaa81e97b0636c4515ce501e"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topgear2arc0" cloneof="tgrally2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgba33e1.0"	-->
-		<description>Top Gear Pocket 2 (USA, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgba33e1.0" size="1048576" crc="eb0838d6" sha1="5d2ea0b976833f2e3866214e602993ee4653ab96"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="catwomanjrc0" cloneof="catwoman">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgba3cj0.0"	-->
-		<description>Catwoman (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgba3cj0.0" size="1048576" crc="e8dfae9d" sha1="f4cb746b4bc9b16acc0f3cf38cefc6cbd6db24be"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nbashowtarc0" cloneof="nbashowt">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbaa5e1.0"	-->
-		<description>NBA Show Time - NBA on NBC (USA, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Midway</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbaa5e1.0" size="1048576" crc="8bc9be45" sha1="fd4bb16f306e309834e276ed768e8e2ed402e138"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1racingurc0" cloneof="f1racing">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbaeqe0.0"	-->
-		<description>F1 Racing Championship (USA, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbaeqe0.0" size="4194304" crc="9ec98cab" sha1="83f1791b5fc7d7e589c105d87a14abb8087edaed"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sfaarc0" cloneof="sfa">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbafzp1.0"	-->
-		<description>Street Fighter Alpha - Warriors' Dreams (Europe, Rev 1, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Capcom</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbafzp1.0" size="1048576" crc="cdf56f1a" sha1="b7c04a24e7f0355a0113109b5e97ad044057a006"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jmg2kjrc0" cloneof="jmg2k">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbajuj0.0"	-->
-		<description>Jeremy McGrath Supercross 2000 (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Acclaim Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbajuj0.0" size="1048576" crc="666d2a75" sha1="dd204c1d47290f52ef264ce32d59cb5f58a2701d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spyvsspyuarc0" cloneof="spyvsspy">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbas6e1.0"	-->
-		<description>Spy vs. Spy (USA, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbas6e1.0" size="1048576" crc="549bf1e4" sha1="38dd0c729c0d878ea05df7de0b3aba2d098d2975"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spyvsspyarc0" cloneof="spyvsspy">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbas6p1.0"	-->
-		<description>Spy vs. Spy (Europe, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbas6p1.0" size="1048576" crc="6ca71209" sha1="ec249546a4652ef9375b67ddbac882b13ed4a807"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bounced">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbaudp0.0"	-->
-		<description>Bounced (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Midas Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbaudp0.0" size="1048576" crc="3948aee9" sha1="06d2d0eaea07d7a41834d4c9a5dfdbdda6889be9"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mightmaguarc0" cloneof="mightmag">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbauhe1.0"	-->
-		<description>Heroes of Might and Magic (USA, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>3DO</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbauhe1.0" size="1048576" crc="0753927e" sha1="2ad31a64d113909180fd85dc6707a3c487ec2bfb"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="vegasuarc0" cloneof="vegas">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbavfe1.0"	-->
-		<description>Vegas Games (USA, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>3DO</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbavfe1.0" size="1048576" crc="4167cf29" sha1="658cc13bc436a9ec613400b91288831900e3443e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="suzukiurc0" cloneof="suzuki">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbaxre0.0"	-->
-		<description>Suzuki Alstare Extreme Racing (USA, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="524288">
-				<rom name="cgbaxre0.0" size="524288" crc="a13cf42e" sha1="b2816e8585e03b7d547e8acfda716b7adddf3b41"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="apowers3rc3">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\CGBBA3P0.3"	-->
-		<description>Austin Powers - Yeah, Baby, Yeah! (Europe, Release Candidate 3)</description>
-		<year>2000</year>
-		<publisher>Rockstar Games</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbba3p0.3" size="2097152" crc="0903ed53" sha1="b409782cc478104c41668360b63f8589f7677e2a"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="apowers4rc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbba4p0.0"	-->
-		<description>Austin Powers - Why Make Millions...? (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Rockstar Games</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbba4p0.0" size="2097152" crc="f038cda7" sha1="937df6944709732d8d372ad5f629a665ffd12eac"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="newaddfmarc0" cloneof="newaddfm">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbaip1.0"	-->
-		<description>The New Addams Family Series (Europe, Rev 1, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Microids</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbaip1.0" size="2097152" crc="910df34b" sha1="c0582e350ade53908a9f091a4796d58b3c1806f8"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gimmlandrc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbakj0.0"	-->
-		<description>Gimmick Land (Japan, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Nintendo</publisher>
-		<info name="alt_title" value="ギミックランド"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbakj0.0" size="2097152" crc="228d0b0c" sha1="f63adff202d7351c61411766c5b57efefac58bcd"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bluecluearc0" cloneof="blueclue">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbale1.0"	-->
-		<description>Blue's Clues - Blue's Alphabet Book (USA, Rev 1, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Mattel Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbale1.0" size="1048576" crc="f89f58b7" sha1="7fdedfe8acde9557a5ff57661ed17082813e09a1"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="blrdclubrc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbbcj0.0"	-->
-		<description>Billiard Club (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Altron</publisher>
-		<info name="alt_title" value="ビリヤードクラブ"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbbcj0.0" size="1048576" crc="210c4137" sha1="eb994e523550a8a7fe8a77fd2e85de011bec8627"/>
-			</dataarea>
-		</part>
-	</software>
-	
-	<software name="carnivalerc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbcae0.1"	-->
-		<description>Carnivalé (USA, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>Vatical Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbcae0.1" size="1048576" crc="e9503c71" sha1="07d41e21bc82f64d788e720583169fb0e588da89"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="carrerarc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbcep0.0"	-->
-		<description>Carrera (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Take-Two Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbcep0.0" size="2097152" crc="f8000653" sha1="1b70600b9e3a0f2736b5a23d88ebc1ad52597426"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="denkiblkurc0" cloneof="denkiblk">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbd9e0.0"	-->
-		<description>Denki Blocks! (USA, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Rage Software</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbd9e0.0" size="1048576" crc="aafc35c3" sha1="bca594d5d90219b263638dd86a96e3e9a64ce71e"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="grndcasirc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbgcj0.0"	-->
-		<description>Grand Casino (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Altron</publisher>
-		<info name="alt_title" value="グランドカジノ"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbgcj0.0" size="1048576" crc="8ba3988b" sha1="556e1a6c27c792605925f6f67daa953809f81bfb"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="beckhamurc0" cloneof="beckham">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbj2e0.0"	-->
-		<description>David Beckham Soccer (USA, Release Candidate 0)</description>
-		<year>2002</year>
-		<publisher>Majesco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbj2e0.0" size="1048576" crc="c08f3254" sha1="1d8970ed5aacadd0bdb7e4d78a7eb70a2d0f9650"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="powrpfbmirc4" cloneof="powrpfbm">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbjji0.4"	-->
-		<description>The Powerpuff Girls - Il Terribile Mojo Jojo (Italia, Release Candidate 4)</description>
-		<year>2000</year>
-		<publisher>BAM! Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbjji0.4" size="2097152" crc="5c265103" sha1="5ca837632930689fad9086b772928bf5995193f9"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="powrpfbmx" cloneof="powrpfbm">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbjjx0.0"	-->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (UK?, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>BAM! Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbjjx0.0" size="2097152" crc="24b23af1" sha1="cffa029b5aa51b2ce1c192e66bd2881eddd532fd"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kirbfamirc0">
-		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbjvj0.0"	-->
-		<description>Kirby Family (Japan, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Jaguar</publisher>
-		<info name="alt_title" value="カービィファミリー"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbjvj0.0" size="2097152" crc="bd65b109" sha1="709c612c13b70226a919a168b03427ec0f33f8f8"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kanjishirc0">
-		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbkbj0.0"	-->
-		<description>Kanji Shishuu (Japan, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Jaguar</publisher>
-		<info name="alt_title" value="漢字刺しゅう"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="8388608">
-				<rom name="cgbbkbj0.0" size="8388608" crc="29a1932f" sha1="09d5b0f6e3b17f670820265dcb2477e5c869ed79"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lauraarc0" cloneof="laura">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbldp1.0"	-->
-		<description>Laura (Europe, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbldp1.0" size="1048576" crc="cf8e2371" sha1="f7b19c1501d325dd8ee219ccae2eaca130a5a21b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="misbravorc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbm9e0.0"	-->
-		<description>Mission Bravo (USA, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Mattel Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbm9e0.0" size="1048576" crc="b8fc72b6" sha1="2833855bb2b9fde988f8efcac3e357ef9f0f4f50"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacentnrc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbnej0.0"	-->
-		<description>Space-Net - Cosmo Neo (Japan, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Imagineer</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbnej0.0" size="2097152" crc="3a9d791b" sha1="077006fce23059c40bc7135d195766504e376aa8"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="powrpfpnxrc0" cloneof="powrpfpn">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbptx0.0"	-->
-		<description>The Powerpuff Girls - Paint the Townsville Green (UK?, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>BAM! Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbptx0.0" size="2097152" crc="310b52f7" sha1="6522029f585c6ab4b5ca342e2127f6403e735222"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dejikomjarc0" cloneof="dejikomj">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbqsj1.0"	-->
-		<description>Dejiko no Mahjong Party (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>King Records</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbqsj1.0" size="2097152" crc="7e515a7e" sha1="fbc2b66a6595bbb3ed85f35545152442283eaea3"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ccsakutoarc0" cloneof="ccsakuto">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbs7j1.0"	-->
-		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan, Rev 1, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>MTO</publisher>
-		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbs7j1.0" size="2097152" crc="d2cc40c2" sha1="031b00495b3700b2145a741f2d03cc820ffa6fde"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="taxi2erc0" cloneof="taxi2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbt2p0.0"	-->
-		<description>Taxi 2 (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbt2p0.0" size="1048576" crc="288bef6e" sha1="28d245a6504694443ddff5f85ba2bfaecf794ff1"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="thpsjrc0" cloneof="thps">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbtfj0.0"	-->
-		<description>Tony Hawk's Pro Skater (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Activision</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbtfj0.0" size="1048576" crc="48f17f97" sha1="e399c7d67e3bb1f466002f24f60b9c036e234c4e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="cmgtdr2krc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbtlp0.0"	-->
-		<description>Carmageddon TDR 2000 (Europe, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>SCI</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbtlp0.0" size="2097152" crc="0bd8e676" sha1="fe059ee25e2a00a129842f452bcc86ce78213c6b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="towers2rc0">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbtoe0.0"	-->
-		<description>Towers II - Plight of the Stargazer (USA, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Telegames</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbtoe0.0" size="1048576" crc="39e4bfd0" sha1="e9db495992490d88a65df1741f0294357bb96998"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="xtremewjrc0" cloneof="xtremew">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbxcj0.0"	-->
-		<description>Xtreme Wheels (Japan, Release Candidate 0)</description>
-		<year>2001</year>
-		<publisher>Spike</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbxcj0.0" size="1048576" crc="30132ab8" sha1="a9f67640d20771e64b1474144fcca9beebdde85d"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mermaid2jrc0" cloneof="mermaid2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbby2j0.0"	-->
-		<description>Little Mermaid II - Pinball (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Disney Interactive</publisher>
-		<info name="alt_title" value="リトル・マーメイドIIピンボール"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbby2j0.0" size="1048576" crc="6b974b2d" sha1="ed001b5792e1afb35178e22d3adf45bbf0c4d721"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="topgear2jarc0" cloneof="tgrally2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbv33j1.0"	-->
-		<description>Top Gear Pocket 2 (Japan, Rev 1, Release Candidate 0)</description>
-		<year>1999</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbv33j1.0" size="1048576" crc="fc680273" sha1="52354d36a301b26895eb26ecf152bf696656f4b2"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pockgturc1" cloneof="pockrace">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgba7ge0.1"	-->
-		<description>Pocket GT (USA, Release Candidate 1)</description>
-		<year>1999</year>
-		<publisher>MTO</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgba7ge0.1" size="1048576" crc="9e120d94" sha1="c48f302009c405aa379ebf048bc46a284a74c84c"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="casperuarc1" cloneof="casper">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbaf9e1.1"	-->
-		<description>Casper (USA, Rev 1, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Interplay</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbaf9e1.1" size="1048576" crc="5edd88b5" sha1="6f44a817c7424a5b24919b01e1e868d2c2650341"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1wgpjrc0" cloneof="f1wgp">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbafij0.0"	-->
-		<description>F-1 World Grand Prix (Japan, Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>Video System</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbafij0.0" size="1048576" crc="5e24811e" sha1="25c83cb589ce85917b99757090a94e588cb799b9"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="hajimarirc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbahjj0.1"	-->
-		<description>Famicom Bunko - Hajimari no Mori (Japan, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Nintendo</publisher>
-		<info name="alt_title" value="ファミコン文庫 はじまりの森"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbahjj0.1" size="2097152" crc="fecc8ee8" sha1="75a3e1794fd6bd6d35f0a357a82612c016dfba24"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="carmgeddurc3" cloneof="carmgedd">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbakwe0.3"	-->
-		<description>Carmageddon - Carpocalypse Now (USA, Release Candidate 3)</description>
-		<year>2000</year>
-		<publisher>Titus</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbakwe0.3" size="2097152" crc="e9751f81" sha1="9f41f86214031dad6440206863bffc13c3e61fc4"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lemmingserc2" cloneof="lemmings">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbalep0.2"	-->
-		<description>Lemmings (Europe, Release Candidate 2)</description>
-		<year>2000</year>
-		<publisher>Take-Two Interactive?</publisher>
-		<info name="gold" value="20001005"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "4194304">
-				<rom name="cgbalep0.2" size="4194304" crc="5ea0796b" sha1="f1f9ab3878c606b488e89c24068af10060b1640f"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="qixadvurc2" cloneof="qixadv">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbaqye0.2"	-->
-		<description>Qix Adventure (USA, Release Candidate 2)</description>
-		<year>2000</year>
-		<publisher>Natsume</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbaqye0.2" size="1048576" crc="bb3744a9" sha1="43ebf78cf1ce4024d23a211a8dfb006b16c1a168"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="douburanrc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbbgj0.1"	-->
-		<description>Ganso! Doubutsu Uranai + Ren'ai Puzzle (Japan, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Culture Brain</publisher>
-		<info name="alt_title" value="元祖！動物占い＋恋愛パズル"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbbgj0.1" size="1048576" crc="58421179" sha1="d2512b7bb05771deac7b732cce17671d7807273d"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ttoondizurc2" cloneof="ttoondiz">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbdqe0.2"	-->
-		<description>Tiny Toon Adventures - Dizzy's Candy Quest (USA, Release Candidate 2)</description>
-		<year>2001</year>
-		<publisher>Conspiracy Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbdqe0.2" size="1048576" crc="23bb87a5" sha1="4eb0359a278173ae6c12e9452a7a2a9573a58c77"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="equest2krc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbegp0.1"	-->
-		<description>Equestriad 2001 (Europe, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Midas Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbegp0.1" size="1048576" crc="626f978f" sha1="7698801ef38b63d45fdd2110f9b3ea87e59b9476"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="etdcerc2" cloneof="etdc">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbetp0.2"	-->
-		<description>E.T. The Extra Terrestrial - Digital Companion (Europe, Release Candidate 2)</description>
-		<year>2001</year>
-		<publisher>NewKidCo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc3" />
-			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbetp0.2" size="1048576" crc="513f38b7" sha1="14ad36a7939be12d1212c12a59de31d27e4df8f3"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fone2kerc8" cloneof="fone2k">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbfmp0.8"	-->
-		<description>Formula One 2000 (Europe, Release Candidate 8)</description>
-		<year>2000</year>
-		<publisher>Take-Two Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbfmp0.8" size="1048576" crc="e689bf16" sha1="7aa7073b7b494522f7cfcd268aa066b7fe52c671"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="giftyarc2" cloneof="gift">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbgfd1.2"	-->
-		<description>Gifty (Germany, Rev 1, Release Candidate 2)</description>
-		<year>2001</year>
-		<publisher>Cryo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbgfd1.2" size="1048576" crc="96b929e8" sha1="b0c9eb2ad7a41f17d8621c40a5c0ae3e53166253"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="giftarc1" cloneof="gift">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbgfp1.1"	-->
-		<description>Gift (Europe, Rev 1, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Cryo</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbgfp1.1" size="1048576" crc="19681ac2" sha1="12561be4c0979b9dc8ba22caff8ac3513e1611a6"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gbwarsptrc2" cloneof="gbwars3">
-		<!-- Notes: GBC only -->
-		<!--	Could be a prototype of Game Boy Wars 3 or an earlier special edition	-->
-		<!--	In lot check as "KENSA\cgbbgwj0.2"	-->
-		<description>Game Boy Wars: Pocket Tactics (Japan, Release Candidate 2)</description>
-		<year>2001</year>
-		<publisher>Nintendo</publisher>
-		<info name="alt_title" value="ゲームボーイウォーズ ポケットタクティクス"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbgwj0.2" size="1048576" crc="7e8ea9a5" sha1="a729d9ecd2b2abcd04b11122183f48c303d227b1"/>
-			</dataarea>
-			<dataarea name="nvram" size="131072">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shinmtsarc1" cloneof="shinmts">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbhwj1.1"	-->
-		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan, Rev 1, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Atlus</publisher>
-		<info name="alt_title" value="真・女神転生デビルチルドレン　白の書"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbbhwj1.1" size="2097152" crc="79ea53f4" sha1="6ba2a43d6975340852eb2ce85f36f35855b36eaf"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="seadoohcrc2">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbhye0.2"	-->
-		<description>Sea-Doo Hydro Cross (USA, Release Candidate 2)</description>
-		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbhye0.2" size="1048576" crc="fb1783f3" sha1="3612e549ba2a71585fc9a57033c97562386cdea4"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jibakukurc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbjkj0.1"	-->
-		<description>Jibaku-kun - Zero no Ki no Kajitsu (Japan, Release Candidate 1)</description>
-		<year>2002?</year>
-		<publisher>Media Factory</publisher>
-		<info name="alt_title" value="ジバクくん～零の樹の果実～～零の樹の果実～"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbbjkj0.1" size="2097152" crc="1900bcc8" sha1="fec43a82916e8504de685b928a0af73c2252b55d"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="jimmywhiurc7" cloneof="jimmywhi">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbjwe0.7"	-->
-		<description>Jimmy White's Cueball (USA, Release Candidate 7)</description>
-		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbjwe0.7" size="1048576" crc="62c49da9" sha1="54a72ed5ef210b947a97e81208752c4431ef715c"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="maginakqrc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbkqe0.1"	-->
-		<description>Magi-Nation - Keeper's Quest (USA, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Interactive Imagination</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbkqe0.1" size="1048576" crc="89de57b7" sha1="7c6b427810be2f0d7496ccb5eff2226d3ed1194e"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sylvan2arc1" cloneof="sylvan2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbblvj1.1"	-->
-		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan, Rev 1, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Epoch</publisher>
-		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbblvj1.1" size="2097152" crc="ad6f3bdf" sha1="c96044d57a2367ffb7b2325aa8d0c9b659e0aaba"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pockmusurc1" cloneof="pockmus">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbp9e0.1"	-->
-		<description>Pocket Music (USA, Release Candidate 1)</description>
-		<year>2002</year>
-		<publisher>Rage Software</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbp9e0.1" size="1048576" crc="c4387812" sha1="ad547a79af864eb56a18e1c2ad4346eb35df41ed"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="runelrdsrc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbrle0.1"	-->
-		<description>Runelords (USA, Release Candidate 1)</description>
-		<year>1998</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "4194304">
-				<rom name="cgbbrle0.1" size="4194304" crc="392af730" sha1="2bdcf8208cd0530c75195fd23f2f7839a3480bff"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="fa2001sprc3" cloneof="fa2001">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbsjs0.3"	-->
-		<description>Primera División Stars 2001 (Spain, Release Candidate 3)</description>
-		<year>2001</year>
-		<publisher>Electronic Arts</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbsjs0.3" size="1048576" crc="ce3a1022" sha1="ea2c721c905404a5a90e12eca598570d95e2812f"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="swingerc1" cloneof="swing">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbswp0.1"	-->
-		<description>Swing (Europe, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Software 2000</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbswp0.1" size="1048576" crc="60d06df9" sha1="576d4338665f159a88875819f0681fdc49443fe4"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="absolutxrc1">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbuxp0.1"	-->
-		<description>Absolute X (Europe, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Midas Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbuxp0.1" size="1048576" crc="5046c427" sha1="34fa9bc6b1fec75751f1f426528f18c833128ff7"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="3dpoolurc1" cloneof="3dpool">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbbvpe0.1"	-->
-		<description>3D Pool Allstars (USA, Release Candidate 1)</description>
-		<year>2001</year>
-		<publisher>Titus</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbvpe0.1" size="1048576" crc="245de3e2" sha1="f7289c3eed275286d0fb3dc7097098276b746786"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="maxsteelrc1">
-		<!-- Notes: GBC only -->
-		<!--	Unreleased game	-->
-		<!--	In lot check as "KENSA\cgbbxee0.1"	-->
-		<description>Max Steel - Covert Missions (USA, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Mattel Interactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbbxee0.1" size="1048576" crc="57b1e978" sha1="050a3f041328016c433d923b213674014546db6e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1wgpjrc1" cloneof="f1wgp">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbvfij0.1"	-->
-		<description>F-1 World Grand Prix (Japan, Release Candidate 1)</description>
-		<year>2000</year>
-		<publisher>Video System</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<feature name="rumble" value="yes" />
-			<dataarea name="rom" size = "2097152">
-				<rom name="cgbvfij0.1" size="2097152" crc="3122807b" sha1="afc4b8f0487b0c6b0ca6470d4002eaca6616a04b"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f18thundurc2" cloneof="f18thund">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbvtse0.2"	-->
-		<description>F-18 Thunder Strike (USA, Release Candidate 2)</description>
-		<year>2000</year>
-		<publisher>Majesco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<feature name="rumble" value="yes" />
-			<dataarea name="rom" size = "1048576">
-				<rom name="cgbvtse0.2" size="1048576" crc="9e253e73" sha1="f7ccfc1f0822bdc611751d77b9f164c6aaa64c01"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="onepglindrc0" cloneof="onepglin">
-		<!--	In lot check as "NG\dmgbzoj0.0"	-->
-		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan, discarded Release Candidate 0)</description>
-		<year>2002</year>
-		<publisher>Banpresto</publisher>
-		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dmgbzoj0.0" size="4194304" crc="a86de7b7" sha1="f2c04440f5d668b14623c924faec460f63158a29"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="onepglindrc1" cloneof="onepglin">
-		<!--	In lot check as "NG\dmgbzoj0.1"	-->
-		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan, discarded Release Candidate 1)</description>
-		<year>2002</year>
-		<publisher>Banpresto</publisher>
-		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dmgbzoj0.1" size="4194304" crc="419befcc" sha1="e11809babdca45527b81d7db02741263407aeb46"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bombmseldrc0" cloneof="bombmsel">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbb2ck0.0"	-->
-		<description>Bomberman Selection (Kor, discarded Release Candidate 0)</description>
-		<year>2003</year>
-		<publisher>Hudson Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbb2ck0.0" size="1048576" crc="005ad4b7" sha1="206a19a48a35bcff18d5872b85ba4e8963827cb3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="bombmseldrc1" cloneof="bombmsel">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbb2ck0.1"	-->
-		<description>Bomberman Selection (Kor, discarded Release Candidate 1)</description>
-		<year>2003</year>
-		<publisher>Hudson Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1col" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbb2ck0.1" size="1048576" crc="06cc1e9d" sha1="a3ce5d9ea4aa4203ea4bc17461e28257e4bd0a62"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ncook5drc1" cloneof="ncook5">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbb3cj0.1"	-->
-		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan, discarded Release Candidate 1)</description>
-		<year>2002</year>
-		<publisher>MTO</publisher>
-		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbb3cj0.1" size="4194304" crc="b65a9fb6" sha1="df98eed187a3691ff7fe07619bab1d01072daec6"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ncook5drc2" cloneof="ncook5">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbb3cj0.2"	-->
-		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan, discarded Release Candidate 2)</description>
-		<year>2002</year>
-		<publisher>MTO</publisher>
-		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbb3cj0.2" size="4194304" crc="f4e674be" sha1="aa5e2dd4590bbe9d20c76d8fb1ed408cfdc7350b"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tonkaczdrc0" cloneof="tonkacs">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbcze0.0"	-->
-		<description>Tonka Construction Zone (USA, discarded Release Candidate 0)</description>
-		<year>2002</year>
-		<publisher>TDK Mediactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbcze0.0" size="1048576" crc="901faa34" sha1="16fc094ef9a0af8376fedd6b7e6179d33c4f78bf"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kanjibo2drc0" cloneof="kanjibo2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbk3j0.0"	-->
-		<description>Kanji Boy 2 (Japan, discarded Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>J-Wing</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbbk3j0.0" size="4194304" crc="2ce7d758" sha1="f8b34e0834c7bff5bb06587e932dff2036d86c6e"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="watashirdrc0" cloneof="watashir">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbwnj0.0"	-->
-		<description>Watashi no Restaurant (Japan, discarded Release Candidate 0)</description>
-		<year>2002</year>
-		<publisher>Kirat</publisher>
-		<info name="alt_title" value="わたしのレストラン"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbwnj0.0" size="1048576" crc="5ff6b852" sha1="384f1f68e7331f992f1d311f1433ea9f205eddcb"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="watashirdrc1" cloneof="watashir">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbwnj0.1"	-->
-		<description>Watashi no Restaurant (Japan, discarded Release Candidate 1)</description>
-		<year>2002</year>
-		<publisher>Kirat</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbwnj0.1" size="1048576" crc="8571099f" sha1="98ff6b68b7c79229100f58311ee41e3fec4802e0"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="watashirdrc2" cloneof="watashir">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbwnj0.2"	-->
-		<description>Watashi no Restaurant (Japan, discarded Release Candidate 2)</description>
-		<year>2002</year>
-		<publisher>Kirat</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbwnj0.2" size="1048576" crc="a0ed2859" sha1="343bf8ebb6fa3ce89501f7c4c219fb7e864c38a3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="wendydtadrc0" cloneof="wendydta">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbbwyd0.0"	-->
-		<description>Wendy - Der Traum von Arizona (Germany, discarded Release Candidate 0)</description>
-		<year>2000</year>
-		<publisher>TDK Mediactive</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbwyd0.0" size="2097152" crc="20bdca55" sha1="fd39cb84f71ea414c0165a58bac98357739bc406"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yugiddsfdrc0" cloneof="yugidds">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbby3f0.0"	-->
-		<description>Yu-Gi-Oh! - Duel des Tenebres (France, discarded Release Candidate 0)</description>
-		<year>2003</year>
-		<publisher>Konami</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbby3f0.0" size="4194304" crc="c0dd1b26" sha1="7b44bee756fa5c81e050438f81f97fe56884a45d"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yugiddsdrc0" cloneof="yugidds">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "NG\cgbby3p0.0"	-->
-		<description>Yu-Gi-Oh! - Dark Duel Stories (Europe, discarded Release Candidate 0)</description>
-		<year>2003</year>
-		<publisher>Konami</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbby3p0.0" size="4194304" crc="1a60f198" sha1="f16e2d8d2ce20149c208621c3aa1309f80ce2390"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
 			</dataarea>
 		</part>
 	</software>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -6037,7 +6037,7 @@ license:CC0
 	<software name="f1chmp2kb" cloneof="f1chmp2k">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbfib0.579"	-->
-		<description>F1 Championship Season 2000 (Bra)</description>
+		<description>F1 Championship Season 2000 (Brazil)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BFIB-?"/>
@@ -8717,7 +8717,7 @@ license:CC0
 	<software name="hypeb" cloneof="hype">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpfe0.737"	-->
-		<description>Hype - The Time Quest (Bra)</description>
+		<description>Hype - The Time Quest (Brazil)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BPFE-?"/>
@@ -24620,6 +24620,1836 @@ license:CC0
 				<rom name="cgb-bzhj-0.u1" size="2097152" crc="c09f9e1b" sha1="91ab908fddebd926e7db8d61295a40955b2adc39"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+<!--
+	List of Release Candidates
+-->
+
+	<software name="speedyjrc0" cloneof="speedy">
+		<!--	In lot check as "KENSA\dmga35j0.0"	-->
+		<description>Speedy Gonzales - Aztec Adventure (Japan, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Sunsoft</publisher>
+		<info name="alt_title" value="スピーディーゴンザレスアステカアドベンチャー!"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmga35j0.0" size="1048576" crc="c97d74f5" sha1="b65cd4a60014ecef55b1daca7e17379987f1d983"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pockgolfrc1" cloneof="golfdai">
+		<!--	In lot check as "KENSA\dmgaage0.1"	-->
+		<description>Pocket Golf! (USA, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>KID</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgaage0.1" size="2097152" crc="d06ecb1f" sha1="bbe2651547c1f3c79bbf822b41ddbb54133a489f"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="klustarjrc0" cloneof="klustar">
+		<!--	In lot check as "KENSA\dmgaahj0.0"	-->
+		<description>Klustar (Japan, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Infogrames</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgaahj0.0" size="262144" crc="65da9075" sha1="9c60c858f647b42007fc27c5d21f3f57923c4cda"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ddanceurc1" cloneof="ddance">
+		<!--	In lot check as "KENSA\dmgad5e0.1"	-->
+		<description>Dragon Dance (USA, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Infogrames</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgad5e0.1" size="262144" crc="9a90adbe" sha1="5fc97752a98a18b7e2db238d1ab88c6b09e34602"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dqmarc1" cloneof="dwm">
+		<!--	In lot check as "KENSA\dmgadqj1.1"	-->
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1, Release Candidate 1)</description>
+		<year>1998</year>
+		<publisher>Enix</publisher>
+		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgadqj1.1" size="2097152" crc="66b83e3a" sha1="378794e041f2eb286f2d5243a3cada2faf265bb5"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dsaviorarc1" cloneof="dsavior">
+		<!--	In lot check as "KENSA\dmgadwj1.1"	-->
+		<description>Dungeon Savior (Japan, Rev. 1, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>J-Wing</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dmgadwj1.1" size="4194304" crc="0180364b" sha1="c5e93f04cc41404320aaf70eb10b55465edb1083"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hellokcferc1" cloneof="hellokcf">
+		<!--	In lot check as "KENSA\dmgaf4p0.1"	-->
+		<description>Hello Kitty's Cube Frenzy (Europe, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>NewKidCo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaf4p0.1" size="1048576" crc="9606a07f" sha1="2225da8a68e489c0f562afcb8e90fc9387321af0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="espcfishrc0" cloneof="tnnofc">
+		<!--	In lot check as "KENSA\dmgafcp0.0"	-->
+		<description>EuroSport Pro Champ Fishing (Europe, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>ASC Games</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgafcp0.0" size="1048576" crc="32083abd" sha1="565c16da5d2bc5dacffa992ed3f0466ec4888e73"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gbgall2jrc1" cloneof="gwatch2">
+		<!--	In lot check as "KENSA\dmgaglj0.1"	-->
+		<description>Game Boy Gallery 2 (Japan, Release Candidate 1)</description>
+		<year>1998</year>
+		<publisher>Nintendo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaglj0.1" size="1048576" crc="e99beba5" sha1="90a9b368bca0f47fe72028ff4d50fb3d3060c32f"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shanghaiuarc0" cloneof="shanghai">
+		<!--	In lot check as "KENSA\dmgahpe1.0"	-->
+		<description>Shanghai Pocket (USA, Rev. 1, Release Candidate 0)</description>
+		<year>1998</year>
+		<publisher>Sunsoft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgahpe1.0" size="1048576" crc="d529dafd" sha1="b36edbb0721fb71aafecd6f48609c14c1107e3f0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hexciteerc4" cloneof="hexcite">
+		<!--	In lot check as "KENSA\dmgaicp0.4"	-->
+		<description>Hexcite (Europe, Release Candidate 4)</description>
+		<year>1999</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaicp0.4" size="1048576" crc="2c6bdcfa" sha1="9380ad9ccc193682eb98be7d7447dabadd67beae"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="puchicarurc3" cloneof="puchicar">
+		<!--	In lot check as "KENSA\dmgaiqe0.3"	-->
+		<description>Puchi Carat (USA, Release Candidate 3)</description>
+		<year>2000</year>
+		<publisher>Event Horizon Software</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaiqe0.3" size="1048576" crc="a97ea742" sha1="de755124425f9de8bef5eea8026751c54f7f1e00"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="esxsracirc1" cloneof="xsracing">
+		<!--	In lot check as "KENSA\dmgajzp0.1"	-->
+		<description>EuroSport XS Racing (Europe, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>ASC Games</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgajzp0.1" size="1048576" crc="ca0abfca" sha1="b3dda41ef755cc78680858103bad07d064e155ac"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pokepicr">
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\dmgakvj0.1"	-->
+		<description>Pokémon Picross (Japan, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>Nintendo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgakvj0.1" size="2097152" crc="cf647f4b" sha1="8204064b7149357939b57342820e7955749183b6"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="suttehakrc2">
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\dmgaspj0.2"	-->
+		<description>Sutte Hakkun GB (Japan, Release Candidate 2)</description>
+		<year>1999</year>
+		<publisher>Nintendo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgaspj0.2" size="524288" crc="e0386f84" sha1="6efd637f039d4f3a2240640921724a69a2844cc7"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="metalwlkjarc0" cloneof="metalwlk">
+		<!--	In lot check as "KENSA\dmgauej1.0"	-->
+		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Capcom</publisher>
+		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgauej1.0" size="1048576" crc="570bafdb" sha1="3d6ea44dd8426e3d7bf87a8778dd91e8095ddd35"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="td6uarc0" cloneof="td6">
+		<!--	In lot check as "KENSA\dmgaw6e1.0"	-->
+		<description>Test Drive 6 (USA, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Infogrames</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaw6e1.0" size="1048576" crc="5333c5db" sha1="f9519940ed05bdb59cd3878db8c479760d93a5bd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="astenn2kurc3" cloneof="astenn2k">
+		<!--	In lot check as "KENSA\dmgazte0.3"	-->
+		<description>All Star Tennis 2000 (USA, Release Candidate 3)</description>
+		<year>1999</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgazte0.3" size="1048576" crc="9890bcb4" sha1="f6829ac5bba08732f875fc5812284d62f3d727e6"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="astenn2kxrco" cloneof="astenn2k">
+		<!--	In lot check as "KENSA\dmgaztx0.0"	-->
+		<description>All Star Tennis 2000 (UK?, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaztx0.0" size="1048576" crc="deff8dfb" sha1="c9db40e3e348668fe6fc41d031263acbe9041a67"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="survkid2arc0" cloneof="survkid2">
+		<!--	In lot check as "KENSA\dmgb2vj1.0"	-->
+		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Konami</publisher>
+		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgb2vj1.0" size="1048576" crc="bd366d22" sha1="505ffc930057719cf28560333342dfd6944c15da"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kangpzl2arc0" cloneof="kangpzl2a">
+		<!--	In lot check as "KENSA\dmgb62j1.0"	-->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Success</publisher>
+		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgb62j1.0" size="262144" crc="27ab2187" sha1="49a63339bc253d1bd55f6db75f7324980572925a"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kangpzl3arc0" cloneof="kangpzl3a">
+		<!--	In lot check as "KENSA\dmgb63j1.0"	-->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Success</publisher>
+		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgb63j1.0" size="262144" crc="62d3f1e5" sha1="a3ddd9794e05f2962481b802f84e783495e853b2"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kangpzlsarc1" cloneof="kangpzlsa">
+		<!--	In lot check as "KENSA\dmgb6ij1.1"	-->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Success</publisher>
+		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgb6ij1.1" size="262144" crc="88ce5c13" sha1="7e493878e0b755df3c6d6ab93c7b15b4b10a0896"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ddanceerco" cloneof="ddance">
+		<!--	In lot check as "KENSA\dmgbdap0.0"	-->
+		<description>Dragon Dance (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Crave Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgbdap0.0" size="262144" crc="8b0dd3b2" sha1="76de183317c952276dbdad9d8f0592493652f31e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="golfrobo" cloneof="golfou">
+		<!--	In lot check as "KENSA\dmgbgre0.1"	-->
+		<description>SuperShot Golf Robot (USA, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Crave Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbgre0.1" size="2097152" crc="b6a7f781" sha1="aa1447d78e380d2a936fb5f713521e34420fe68c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="golfking" cloneof="golfou">
+		<!--	In lot check as "KENSA\dmgbgrp0.2"	-->
+		<description>Golf King (Europe, Release Candidate 2)</description>
+		<year>2000</year>
+		<publisher>Crave Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbgrp0.2" size="2097152" crc="3019b4e7" sha1="d02e09251e7c5078e4b641e6d334958c2c814285"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ppersiajrc0" cloneof="ppersia">
+		<!--	In lot check as "KENSA\dmgbprj0.0"	-->
+		<description>Prince Of Persia (Japan, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Red Orb Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbprj0.0" size="1048576" crc="d7dbbe1e" sha1="6fd97e1f75570e7568b3dc4ab28834813afb4484"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sewingosxrc0" cloneof="sewingos">
+		<!--	In lot check as "KENSA\dmgbrax0.0"	-->
+		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<description>Sewing Machine Operation Software (UK?, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Natsume</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbrax0.0" size="1048576" crc="9f1dbedd" sha1="35d242fbbde2f6f1fb869fd68396e6be4aad8f9b"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sewingosyrc0" cloneof="sewingos">
+		<!--	In lot check as "KENSA\dmgbray0.0"	-->
+		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<description>Sewing Machine Operation Software (Euro?, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Natsume</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbray0.0" size="1048576" crc="e34b5ce8" sha1="500439c5e14400ef2bc45cacf5ff834b70c2acd4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="robopstrurc2" cloneof="robopstr">
+		<!--	In lot check as "KENSA\dmghrce0.2"	-->
+		<description>Robopon - Star Version (USA, Release Candidate 2)</description>
+		<year>1998</year>
+		<publisher>Hudson Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_huc3" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmghrce0.2" size="1048576" crc="cf5f0a63" sha1="54e064a24cd50b7e25df5c827c54a20643ec314a"/>
+			</dataarea>
+			<dataarea name="ram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kawanus4arc0" cloneof="rivking2">
+		<!--	In lot check as "KENSA\dmgvutj1.0"	-->
+		<description>Kawa no Nushi Tsuri 4 (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Victor Interactive Software</publisher>
+		<info name="alt_title" value="川のぬし釣り４"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgvutj1.0" size="1048576" crc="456d4dfc" sha1="69e56fd73eb365dba87713c2a3ea2e74bd63f63c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="daikatanurc0" cloneof="daikatan">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgba22e0.0"	-->
+		<description>Daikatana (USA, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgba22e0.0" size="1048576" crc="7d451688" sha1="6eef48f4d467596ff3734bb9ac12db392170eb14"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rpgtsukuarc0" cloneof="rpgtsuku">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgba2qj1.0"	-->
+		<description>RPG Tsukuru GB (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>ASCII</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgba2qj1.0" size="2097152" crc="57f82031" sha1="f4c36b3cbb13d3cbaaa81e97b0636c4515ce501e"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="topgear2arc0" cloneof="tgrally2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgba33e1.0"	-->
+		<description>Top Gear Pocket 2 (USA, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgba33e1.0" size="1048576" crc="eb0838d6" sha1="5d2ea0b976833f2e3866214e602993ee4653ab96"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="catwomanjrc0" cloneof="catwoman">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgba3cj0.0"	-->
+		<description>Catwoman (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgba3cj0.0" size="1048576" crc="e8dfae9d" sha1="f4cb746b4bc9b16acc0f3cf38cefc6cbd6db24be"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nbashowtarc0" cloneof="nbashowt">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbaa5e1.0"	-->
+		<description>NBA Show Time - NBA on NBC (USA, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Midway</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbaa5e1.0" size="1048576" crc="8bc9be45" sha1="fd4bb16f306e309834e276ed768e8e2ed402e138"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1racingurc0" cloneof="f1racing">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbaeqe0.0"	-->
+		<description>F1 Racing Championship (USA, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbaeqe0.0" size="4194304" crc="9ec98cab" sha1="83f1791b5fc7d7e589c105d87a14abb8087edaed"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sfaarc0" cloneof="sfa">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbafzp1.0"	-->
+		<description>Street Fighter Alpha - Warriors' Dreams (Europe, Rev. 1, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Capcom</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbafzp1.0" size="1048576" crc="cdf56f1a" sha1="b7c04a24e7f0355a0113109b5e97ad044057a006"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jmg2kjrc0" cloneof="jmg2k">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbajuj0.0"	-->
+		<description>Jeremy McGrath Supercross 2000 (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Acclaim Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbajuj0.0" size="1048576" crc="666d2a75" sha1="dd204c1d47290f52ef264ce32d59cb5f58a2701d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spyvsspyuarc0" cloneof="spyvsspy">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbas6e1.0"	-->
+		<description>Spy vs. Spy (USA, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbas6e1.0" size="1048576" crc="549bf1e4" sha1="38dd0c729c0d878ea05df7de0b3aba2d098d2975"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spyvsspyarc0" cloneof="spyvsspy">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbas6p1.0"	-->
+		<description>Spy vs. Spy (Europe, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbas6p1.0" size="1048576" crc="6ca71209" sha1="ec249546a4652ef9375b67ddbac882b13ed4a807"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bounced">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbaudp0.0"	-->
+		<description>Bounced (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Midas Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbaudp0.0" size="1048576" crc="3948aee9" sha1="06d2d0eaea07d7a41834d4c9a5dfdbdda6889be9"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mightmaguarc0" cloneof="mightmag">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbauhe1.0"	-->
+		<description>Heroes of Might and Magic (USA, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>3DO</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbauhe1.0" size="1048576" crc="0753927e" sha1="2ad31a64d113909180fd85dc6707a3c487ec2bfb"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="vegasuarc0" cloneof="vegas">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbavfe1.0"	-->
+		<description>Vegas Games (USA, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>3DO</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbavfe1.0" size="1048576" crc="4167cf29" sha1="658cc13bc436a9ec613400b91288831900e3443e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="suzukiurc0" cloneof="suzuki">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbaxre0.0"	-->
+		<description>Suzuki Alstare Extreme Racing (USA, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="524288">
+				<rom name="cgbaxre0.0" size="524288" crc="a13cf42e" sha1="b2816e8585e03b7d547e8acfda716b7adddf3b41"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="apowers3rc3">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\CGBBA3P0.3"	-->
+		<description>Austin Powers - Yeah, Baby, Yeah! (Europe, Release Candidate 3)</description>
+		<year>2000</year>
+		<publisher>Rockstar Games</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbba3p0.3" size="2097152" crc="0903ed53" sha1="b409782cc478104c41668360b63f8589f7677e2a"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="apowers4rc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbba4p0.0"	-->
+		<description>Austin Powers - Why Make Millions...? (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Rockstar Games</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbba4p0.0" size="2097152" crc="f038cda7" sha1="937df6944709732d8d372ad5f629a665ffd12eac"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="newaddfmarc0" cloneof="newaddfm">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbaip1.0"	-->
+		<description>The New Addams Family Series (Europe, Rev. 1, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Microids</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbaip1.0" size="2097152" crc="910df34b" sha1="c0582e350ade53908a9f091a4796d58b3c1806f8"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gimmlandrc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbakj0.0"	-->
+		<description>Gimmick Land (Japan, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<info name="alt_title" value="ギミックランド"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbakj0.0" size="2097152" crc="228d0b0c" sha1="f63adff202d7351c61411766c5b57efefac58bcd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bluecluearc0" cloneof="blueclue">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbale1.0"	-->
+		<description>Blue's Clues - Blue's Alphabet Book (USA, Rev. 1, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Mattel Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbale1.0" size="1048576" crc="f89f58b7" sha1="7fdedfe8acde9557a5ff57661ed17082813e09a1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="blrdclubrc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbbcj0.0"	-->
+		<description>Billiard Club (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Altron</publisher>
+		<info name="alt_title" value="ビリヤードクラブ"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbbcj0.0" size="1048576" crc="210c4137" sha1="eb994e523550a8a7fe8a77fd2e85de011bec8627"/>
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="carnivalerc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbcae0.1"	-->
+		<description>Carnivalé (USA, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>Vatical Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbcae0.1" size="1048576" crc="e9503c71" sha1="07d41e21bc82f64d788e720583169fb0e588da89"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="carrerarc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbcep0.0"	-->
+		<description>Carrera (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Take-Two Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbcep0.0" size="2097152" crc="f8000653" sha1="1b70600b9e3a0f2736b5a23d88ebc1ad52597426"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="denkiblkurc0" cloneof="denkiblk">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbd9e0.0"	-->
+		<description>Denki Blocks! (USA, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Rage Software</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbd9e0.0" size="1048576" crc="aafc35c3" sha1="bca594d5d90219b263638dd86a96e3e9a64ce71e"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="grndcasirc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbgcj0.0"	-->
+		<description>Grand Casino (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Altron</publisher>
+		<info name="alt_title" value="グランドカジノ"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbgcj0.0" size="1048576" crc="8ba3988b" sha1="556e1a6c27c792605925f6f67daa953809f81bfb"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="beckhamurc0" cloneof="beckham">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbj2e0.0"	-->
+		<description>David Beckham Soccer (USA, Release Candidate 0)</description>
+		<year>2002</year>
+		<publisher>Majesco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbj2e0.0" size="1048576" crc="c08f3254" sha1="1d8970ed5aacadd0bdb7e4d78a7eb70a2d0f9650"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="powrpfbmirc4" cloneof="powrpfbm">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbjji0.4"	-->
+		<description>The Powerpuff Girls - Il Terribile Mojo Jojo (Italia, Release Candidate 4)</description>
+		<year>2000</year>
+		<publisher>BAM! Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbjji0.4" size="2097152" crc="5c265103" sha1="5ca837632930689fad9086b772928bf5995193f9"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="powrpfbmx" cloneof="powrpfbm">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbjjx0.0"	-->
+		<description>The Powerpuff Girls - Bad Mojo Jojo (UK?, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>BAM! Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbjjx0.0" size="2097152" crc="24b23af1" sha1="cffa029b5aa51b2ce1c192e66bd2881eddd532fd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kirbfamirc0">
+		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbjvj0.0"	-->
+		<description>Kirby Family (Japan, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Jaguar</publisher>
+		<info name="alt_title" value="カービィファミリー"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbjvj0.0" size="2097152" crc="bd65b109" sha1="709c612c13b70226a919a168b03427ec0f33f8f8"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kanjishirc0">
+		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbkbj0.0"	-->
+		<description>Kanji Shishuu (Japan, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Jaguar</publisher>
+		<info name="alt_title" value="漢字刺しゅう"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="8388608">
+				<rom name="cgbbkbj0.0" size="8388608" crc="29a1932f" sha1="09d5b0f6e3b17f670820265dcb2477e5c869ed79"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lauraarc0" cloneof="laura">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbldp1.0"	-->
+		<description>Laura (Europe, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbldp1.0" size="1048576" crc="cf8e2371" sha1="f7b19c1501d325dd8ee219ccae2eaca130a5a21b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="misbravorc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbm9e0.0"	-->
+		<description>Mission Bravo (USA, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Mattel Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbm9e0.0" size="1048576" crc="b8fc72b6" sha1="2833855bb2b9fde988f8efcac3e357ef9f0f4f50"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="spacentnrc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbnej0.0"	-->
+		<description>Space-Net - Cosmo Neo (Japan, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Imagineer</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbnej0.0" size="2097152" crc="3a9d791b" sha1="077006fce23059c40bc7135d195766504e376aa8"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="powrpfpnxrc0" cloneof="powrpfpn">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbptx0.0"	-->
+		<description>The Powerpuff Girls - Paint the Townsville Green (UK?, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>BAM! Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbptx0.0" size="2097152" crc="310b52f7" sha1="6522029f585c6ab4b5ca342e2127f6403e735222"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dejikomjarc0" cloneof="dejikomj">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbqsj1.0"	-->
+		<description>Dejiko no Mahjong Party (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>King Records</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbqsj1.0" size="2097152" crc="7e515a7e" sha1="fbc2b66a6595bbb3ed85f35545152442283eaea3"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ccsakutoarc0" cloneof="ccsakuto">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbs7j1.0"	-->
+		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>MTO</publisher>
+		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbs7j1.0" size="2097152" crc="d2cc40c2" sha1="031b00495b3700b2145a741f2d03cc820ffa6fde"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="taxi2erc0" cloneof="taxi2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbt2p0.0"	-->
+		<description>Taxi 2 (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbt2p0.0" size="1048576" crc="288bef6e" sha1="28d245a6504694443ddff5f85ba2bfaecf794ff1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="thpsjrc0" cloneof="thps">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbtfj0.0"	-->
+		<description>Tony Hawk's Pro Skater (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Activision</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbtfj0.0" size="1048576" crc="48f17f97" sha1="e399c7d67e3bb1f466002f24f60b9c036e234c4e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cmgtdr2krc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbtlp0.0"	-->
+		<description>Carmageddon TDR 2000 (Europe, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>SCI</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbtlp0.0" size="2097152" crc="0bd8e676" sha1="fe059ee25e2a00a129842f452bcc86ce78213c6b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="towers2rc0">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbtoe0.0"	-->
+		<description>Towers II - Plight of the Stargazer (USA, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Telegames</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbtoe0.0" size="1048576" crc="39e4bfd0" sha1="e9db495992490d88a65df1741f0294357bb96998"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="xtremewjrc0" cloneof="xtremew">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbxcj0.0"	-->
+		<description>Xtreme Wheels (Japan, Release Candidate 0)</description>
+		<year>2001</year>
+		<publisher>Spike</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbxcj0.0" size="1048576" crc="30132ab8" sha1="a9f67640d20771e64b1474144fcca9beebdde85d"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mermaid2jrc0" cloneof="mermaid2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbby2j0.0"	-->
+		<description>Little Mermaid II - Pinball (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Disney Interactive</publisher>
+		<info name="alt_title" value="リトル・マーメイドIIピンボール"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbby2j0.0" size="1048576" crc="6b974b2d" sha1="ed001b5792e1afb35178e22d3adf45bbf0c4d721"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="topgear2jarc0" cloneof="tgrally2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbv33j1.0"	-->
+		<description>Top Gear Pocket 2 (Japan, Rev. 1, Release Candidate 0)</description>
+		<year>1999</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbv33j1.0" size="1048576" crc="fc680273" sha1="52354d36a301b26895eb26ecf152bf696656f4b2"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pockgturc1" cloneof="pockrace">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgba7ge0.1"	-->
+		<description>Pocket GT (USA, Release Candidate 1)</description>
+		<year>1999</year>
+		<publisher>MTO</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgba7ge0.1" size="1048576" crc="9e120d94" sha1="c48f302009c405aa379ebf048bc46a284a74c84c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="casperuarc1" cloneof="casper">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbaf9e1.1"	-->
+		<description>Casper (USA, Rev. 1, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Interplay</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbaf9e1.1" size="1048576" crc="5edd88b5" sha1="6f44a817c7424a5b24919b01e1e868d2c2650341"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1wgpjrc0" cloneof="f1wgp">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbafij0.0"	-->
+		<description>F-1 World Grand Prix (Japan, Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>Video System</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbafij0.0" size="1048576" crc="5e24811e" sha1="25c83cb589ce85917b99757090a94e588cb799b9"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hajimarirc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbahjj0.1"	-->
+		<description>Famicom Bunko - Hajimari no Mori (Japan, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="alt_title" value="ファミコン文庫 はじまりの森"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbahjj0.1" size="2097152" crc="fecc8ee8" sha1="75a3e1794fd6bd6d35f0a357a82612c016dfba24"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="carmgeddurc3" cloneof="carmgedd">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbakwe0.3"	-->
+		<description>Carmageddon - Carpocalypse Now (USA, Release Candidate 3)</description>
+		<year>2000</year>
+		<publisher>Titus</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbakwe0.3" size="2097152" crc="e9751f81" sha1="9f41f86214031dad6440206863bffc13c3e61fc4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lemmingserc2" cloneof="lemmings">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbalep0.2"	-->
+		<description>Lemmings (Europe, Release Candidate 2)</description>
+		<year>2000</year>
+		<publisher>Take-Two Interactive?</publisher>
+		<info name="gold" value="20001005"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "4194304">
+				<rom name="cgbalep0.2" size="4194304" crc="5ea0796b" sha1="f1f9ab3878c606b488e89c24068af10060b1640f"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="qixadvurc2" cloneof="qixadv">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbaqye0.2"	-->
+		<description>Qix Adventure (USA, Release Candidate 2)</description>
+		<year>2000</year>
+		<publisher>Natsume</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbaqye0.2" size="1048576" crc="bb3744a9" sha1="43ebf78cf1ce4024d23a211a8dfb006b16c1a168"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="douburanrc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbbgj0.1"	-->
+		<description>Ganso! Doubutsu Uranai + Ren'ai Puzzle (Japan, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Culture Brain</publisher>
+		<info name="alt_title" value="元祖！動物占い＋恋愛パズル"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbbgj0.1" size="1048576" crc="58421179" sha1="d2512b7bb05771deac7b732cce17671d7807273d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ttoondizurc2" cloneof="ttoondiz">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbdqe0.2"	-->
+		<description>Tiny Toon Adventures - Dizzy's Candy Quest (USA, Release Candidate 2)</description>
+		<year>2001</year>
+		<publisher>Conspiracy Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbdqe0.2" size="1048576" crc="23bb87a5" sha1="4eb0359a278173ae6c12e9452a7a2a9573a58c77"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="equest2krc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbegp0.1"	-->
+		<description>Equestriad 2001 (Europe, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Midas Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbegp0.1" size="1048576" crc="626f978f" sha1="7698801ef38b63d45fdd2110f9b3ea87e59b9476"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="etdcerc2" cloneof="etdc">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbetp0.2"	-->
+		<description>E.T. The Extra Terrestrial - Digital Companion (Europe, Release Candidate 2)</description>
+		<year>2001</year>
+		<publisher>NewKidCo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbetp0.2" size="1048576" crc="513f38b7" sha1="14ad36a7939be12d1212c12a59de31d27e4df8f3"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fone2kerc8" cloneof="fone2k">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbfmp0.8"	-->
+		<description>Formula One 2000 (Europe, Release Candidate 8)</description>
+		<year>2000</year>
+		<publisher>Take-Two Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbfmp0.8" size="1048576" crc="e689bf16" sha1="7aa7073b7b494522f7cfcd268aa066b7fe52c671"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="giftyarc2" cloneof="gift">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbgfd1.2"	-->
+		<description>Gifty (Germany, Rev. 1, Release Candidate 2)</description>
+		<year>2001</year>
+		<publisher>Cryo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbgfd1.2" size="1048576" crc="96b929e8" sha1="b0c9eb2ad7a41f17d8621c40a5c0ae3e53166253"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="giftarc1" cloneof="gift">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbgfp1.1"	-->
+		<description>Gift (Europe, Rev. 1, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Cryo</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbgfp1.1" size="1048576" crc="19681ac2" sha1="12561be4c0979b9dc8ba22caff8ac3513e1611a6"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gbwarsptrc2" cloneof="gbwars3">
+		<!-- Notes: GBC only -->
+		<!--	Could be a prototype of Game Boy Wars 3 or an earlier special edition	-->
+		<!--	In lot check as "KENSA\cgbbgwj0.2"	-->
+		<description>Game Boy Wars: Pocket Tactics (Japan, Release Candidate 2)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<info name="alt_title" value="ゲームボーイウォーズ ポケットタクティクス"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbgwj0.2" size="1048576" crc="7e8ea9a5" sha1="a729d9ecd2b2abcd04b11122183f48c303d227b1"/>
+			</dataarea>
+			<dataarea name="nvram" size="131072">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shinmtsarc1" cloneof="shinmts">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbhwj1.1"	-->
+		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan, Rev. 1, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Atlus</publisher>
+		<info name="alt_title" value="真・女神転生デビルチルドレン　白の書"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbbhwj1.1" size="2097152" crc="79ea53f4" sha1="6ba2a43d6975340852eb2ce85f36f35855b36eaf"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="seadoohcrc2">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbhye0.2"	-->
+		<description>Sea-Doo Hydro Cross (USA, Release Candidate 2)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbhye0.2" size="1048576" crc="fb1783f3" sha1="3612e549ba2a71585fc9a57033c97562386cdea4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jibakukurc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbjkj0.1"	-->
+		<description>Jibaku-kun - Zero no Ki no Kajitsu (Japan, Release Candidate 1)</description>
+		<year>2002?</year>
+		<publisher>Media Factory</publisher>
+		<info name="alt_title" value="ジバクくん～零の樹の果実～～零の樹の果実～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbbjkj0.1" size="2097152" crc="1900bcc8" sha1="fec43a82916e8504de685b928a0af73c2252b55d"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jimmywhiurc7" cloneof="jimmywhi">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbjwe0.7"	-->
+		<description>Jimmy White's Cueball (USA, Release Candidate 7)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbjwe0.7" size="1048576" crc="62c49da9" sha1="54a72ed5ef210b947a97e81208752c4431ef715c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="maginakqrc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbkqe0.1"	-->
+		<description>Magi-Nation - Keeper's Quest (USA, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Interactive Imagination</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbkqe0.1" size="1048576" crc="89de57b7" sha1="7c6b427810be2f0d7496ccb5eff2226d3ed1194e"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sylvan2arc1" cloneof="sylvan2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbblvj1.1"	-->
+		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan, Rev. 1, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Epoch</publisher>
+		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbblvj1.1" size="2097152" crc="ad6f3bdf" sha1="c96044d57a2367ffb7b2325aa8d0c9b659e0aaba"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pockmusurc1" cloneof="pockmus">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbp9e0.1"	-->
+		<description>Pocket Music (USA, Release Candidate 1)</description>
+		<year>2002</year>
+		<publisher>Rage Software</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbp9e0.1" size="1048576" crc="c4387812" sha1="ad547a79af864eb56a18e1c2ad4346eb35df41ed"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="runelrdsrc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbrle0.1"	-->
+		<description>Runelords (USA, Release Candidate 1)</description>
+		<year>1998</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "4194304">
+				<rom name="cgbbrle0.1" size="4194304" crc="392af730" sha1="2bdcf8208cd0530c75195fd23f2f7839a3480bff"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fa2001sprc3" cloneof="fa2001">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbsjs0.3"	-->
+		<description>Primera División Stars 2001 (Spain, Release Candidate 3)</description>
+		<year>2001</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbsjs0.3" size="1048576" crc="ce3a1022" sha1="ea2c721c905404a5a90e12eca598570d95e2812f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="swingerc1" cloneof="swing">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbswp0.1"	-->
+		<description>Swing (Europe, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Software 2000</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbswp0.1" size="1048576" crc="60d06df9" sha1="576d4338665f159a88875819f0681fdc49443fe4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="absolutxrc1">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbuxp0.1"	-->
+		<description>Absolute X (Europe, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Midas Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbuxp0.1" size="1048576" crc="5046c427" sha1="34fa9bc6b1fec75751f1f426528f18c833128ff7"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="3dpoolurc1" cloneof="3dpool">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbbvpe0.1"	-->
+		<description>3D Pool Allstars (USA, Release Candidate 1)</description>
+		<year>2001</year>
+		<publisher>Titus</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbvpe0.1" size="1048576" crc="245de3e2" sha1="f7289c3eed275286d0fb3dc7097098276b746786"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="maxsteelrc1">
+		<!-- Notes: GBC only -->
+		<!--	Unreleased game	-->
+		<!--	In lot check as "KENSA\cgbbxee0.1"	-->
+		<description>Max Steel - Covert Missions (USA, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Mattel Interactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbbxee0.1" size="1048576" crc="57b1e978" sha1="050a3f041328016c433d923b213674014546db6e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1wgpjrc1" cloneof="f1wgp">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbvfij0.1"	-->
+		<description>F-1 World Grand Prix (Japan, Release Candidate 1)</description>
+		<year>2000</year>
+		<publisher>Video System</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<feature name="rumble" value="yes" />
+			<dataarea name="rom" size = "2097152">
+				<rom name="cgbvfij0.1" size="2097152" crc="3122807b" sha1="afc4b8f0487b0c6b0ca6470d4002eaca6616a04b"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f18thundurc2" cloneof="f18thund">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbvtse0.2"	-->
+		<description>F-18 Thunder Strike (USA, Release Candidate 2)</description>
+		<year>2000</year>
+		<publisher>Majesco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<feature name="rumble" value="yes" />
+			<dataarea name="rom" size = "1048576">
+				<rom name="cgbvtse0.2" size="1048576" crc="9e253e73" sha1="f7ccfc1f0822bdc611751d77b9f164c6aaa64c01"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="onepglindrc0" cloneof="onepglin">
+		<!--	In lot check as "NG\dmgbzoj0.0"	-->
+		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan, discarded Release Candidate 0)</description>
+		<year>2002</year>
+		<publisher>Banpresto</publisher>
+		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dmgbzoj0.0" size="4194304" crc="a86de7b7" sha1="f2c04440f5d668b14623c924faec460f63158a29"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="onepglindrc1" cloneof="onepglin">
+		<!--	In lot check as "NG\dmgbzoj0.1"	-->
+		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan, discarded Release Candidate 1)</description>
+		<year>2002</year>
+		<publisher>Banpresto</publisher>
+		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dmgbzoj0.1" size="4194304" crc="419befcc" sha1="e11809babdca45527b81d7db02741263407aeb46"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bombmseldrc0" cloneof="bombmsel">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbb2ck0.0"	-->
+		<description>Bomberman Selection (Kor, discarded Release Candidate 0)</description>
+		<year>2003</year>
+		<publisher>Hudson Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1col" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbb2ck0.0" size="1048576" crc="005ad4b7" sha1="206a19a48a35bcff18d5872b85ba4e8963827cb3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bombmseldrc1" cloneof="bombmsel">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbb2ck0.1"	-->
+		<description>Bomberman Selection (Kor, discarded Release Candidate 1)</description>
+		<year>2003</year>
+		<publisher>Hudson Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1col" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbb2ck0.1" size="1048576" crc="06cc1e9d" sha1="a3ce5d9ea4aa4203ea4bc17461e28257e4bd0a62"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ncook5drc1" cloneof="ncook5">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbb3cj0.1"	-->
+		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan, discarded Release Candidate 1)</description>
+		<year>2002</year>
+		<publisher>MTO</publisher>
+		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbb3cj0.1" size="4194304" crc="b65a9fb6" sha1="df98eed187a3691ff7fe07619bab1d01072daec6"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ncook5drc2" cloneof="ncook5">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbb3cj0.2"	-->
+		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan, discarded Release Candidate 2)</description>
+		<year>2002</year>
+		<publisher>MTO</publisher>
+		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbb3cj0.2" size="4194304" crc="f4e674be" sha1="aa5e2dd4590bbe9d20c76d8fb1ed408cfdc7350b"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tonkaczdrc0" cloneof="tonkacs">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbcze0.0"	-->
+		<description>Tonka Construction Zone (USA, discarded Release Candidate 0)</description>
+		<year>2002</year>
+		<publisher>TDK Mediactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbcze0.0" size="1048576" crc="901faa34" sha1="16fc094ef9a0af8376fedd6b7e6179d33c4f78bf"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kanjibo2drc0" cloneof="kanjibo2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbk3j0.0"	-->
+		<description>Kanji Boy 2 (Japan, discarded Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>J-Wing</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbk3j0.0" size="4194304" crc="2ce7d758" sha1="f8b34e0834c7bff5bb06587e932dff2036d86c6e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="watashirdrc0" cloneof="watashir">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbwnj0.0"	-->
+		<description>Watashi no Restaurant (Japan, discarded Release Candidate 0)</description>
+		<year>2002</year>
+		<publisher>Kirat</publisher>
+		<info name="alt_title" value="わたしのレストラン"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbwnj0.0" size="1048576" crc="5ff6b852" sha1="384f1f68e7331f992f1d311f1433ea9f205eddcb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="watashirdrc1" cloneof="watashir">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbwnj0.1"	-->
+		<description>Watashi no Restaurant (Japan, discarded Release Candidate 1)</description>
+		<year>2002</year>
+		<publisher>Kirat</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbwnj0.1" size="1048576" crc="8571099f" sha1="98ff6b68b7c79229100f58311ee41e3fec4802e0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="watashirdrc2" cloneof="watashir">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbwnj0.2"	-->
+		<description>Watashi no Restaurant (Japan, discarded Release Candidate 2)</description>
+		<year>2002</year>
+		<publisher>Kirat</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbwnj0.2" size="1048576" crc="a0ed2859" sha1="343bf8ebb6fa3ce89501f7c4c219fb7e864c38a3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wendydtadrc0" cloneof="wendydta">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbbwyd0.0"	-->
+		<description>Wendy - Der Traum von Arizona (Germany, discarded Release Candidate 0)</description>
+		<year>2000</year>
+		<publisher>TDK Mediactive</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbwyd0.0" size="2097152" crc="20bdca55" sha1="fd39cb84f71ea414c0165a58bac98357739bc406"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="yugiddsfdrc0" cloneof="yugidds">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbby3f0.0"	-->
+		<description>Yu-Gi-Oh! - Duel des Tenebres (France, discarded Release Candidate 0)</description>
+		<year>2003</year>
+		<publisher>Konami</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbby3f0.0" size="4194304" crc="c0dd1b26" sha1="7b44bee756fa5c81e050438f81f97fe56884a45d"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="yugiddsdrc0" cloneof="yugidds">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "NG\cgbby3p0.0"	-->
+		<description>Yu-Gi-Oh! - Dark Duel Stories (Europe, discarded Release Candidate 0)</description>
+		<year>2003</year>
+		<publisher>Konami</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbby3p0.0" size="4194304" crc="1a60f198" sha1="f16e2d8d2ce20149c208621c3aa1309f80ce2390"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
 			</dataarea>
 		</part>
 	</software>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -2921,7 +2921,7 @@ license:CC0
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
-		<info name="gold" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
+		<info name="gold" value="19990910"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -4,7 +4,7 @@
 license:CC0
 
 To investigate:
-  - Shanghai Pocket by Sunsoft: are serial and release date correct or do they refer to the GB version?
+
 
 Undumped:
 - San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
@@ -206,6 +206,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BVPP-EUR"/>
+		<info name="submitted" value="20010215"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -447,6 +448,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AZTP-EUR"/>
+		<info name="submitted" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -519,6 +521,24 @@ Unreleased (music source code exists, possibly no prototypes exist)
 				<rom name="alone in the dark - the new nightmare (usa) (en,fr,es).bin" size="4194304" crc="c145c036" sha1="a348aeac500d0d8fdaf90f5277631a026504ff44"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amfbowli">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbafpe0.339"	-->
+		<!--	Retail cartridge not yet located, might be unreleased	-->
+		<description>AMF Bowling (USA)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<info name="serial" value="CGB-AFPE-USA?"/>
+		<info name="submitted" value="20000727"/>
+		<info name="alt_title" value="AMF Xtreme Bowling"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbafpe0.339" size="1048576" crc="392559ee" sha1="1dd7d94f320d119682fd4df80297c8df1b28141b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1289,8 +1309,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AUEJ-JPN"/>
+		<info name="submitted" value="19991104"/>
 		<info name="release" value="19991224"/>
-		<info name="alt_title" value="爆走戦記 メタルウォーカーGB 鋼鉄の友情"/>
+		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -1531,6 +1552,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN"/>
+		<info name="submitted" value="19981105"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="バーコード対戦 バーディガン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -1544,6 +1566,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmg-abej-0.u1" size="1048576" crc="ddfcf4b7" sha1="bc7847dee730ba274f3c3ccb511f1dad6b6a93c7"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="barcodea" cloneof="barcode">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgabej1.f26"	-->
+		<description>Barcode Taisen Bardigun (Jpn, Rev. A)</description>
+		<year>1998</year>
+		<publisher>Tamsoft</publisher>
+		<info name="serial" value="DMG-ABEJ-JPN-1"/>
+		<info name="submitted" value="19990323"/>
+		<info name="alt_title" value="バーコード対戦 バーディガン"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgabej1.f26" size="1048576" crc="f6d291a9" sha1="21e386f60fcd3694c4a308de9e178762c5175b6c"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -2022,6 +2064,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="CGB-BALE-USA"/>
+		<info name="submitted" value="20000926"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2164,12 +2207,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
+		<info name="submitted" value="20000731"/>
 		<info name="release" value="20000929"/>
 		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="bokujou monogatari gb3 - boy meets girl (japan).bin" size="2097152" crc="3a18b41f" sha1="e7fceb85a78c78403711521fe5fc8f86260425d0"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bokujom3a" cloneof="harvmon3">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbwaj1.350"	-->
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Victor Interactive Software</publisher>
+		<info name="serial" value="CGB-BWAJ-JPN"/>
+		<info name="submitted" value="20001205"/>
+		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbwaj1.350" size="2097152" crc="75af0e84" sha1="acb2e549fb7d107d20507af88c36f40234f74958"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -2327,6 +2390,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-B2CK-KOR"/>
+		<info name="submitted" value="20030409"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-M-BFAN-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -2337,6 +2401,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="bouken">
 		<!-- Notes: GBC only -->
@@ -2797,6 +2862,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BS7J-JPN"/>
+		<info name="submitted" value="20000824"/>
 		<info name="release" value="20001006"/>
 		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2827,10 +2893,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="carmgedd">
 		<!-- Notes: GBC only -->
+		<!--	USA cartridges have the European sticker underneath.	-->
 		<description>Carmageddon - Carpocalypse Now (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
+		<info name="submitted" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -2862,6 +2930,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9X-EUU"/>
+		<info name="submitted" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -2884,6 +2953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9P-EUR"/>
+		<info name="submitted" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2900,6 +2970,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9E-USA"/>
+		<info name="submitted" value="20000404"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2929,6 +3000,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CP-EUR"/>
+		<info name="submitted" value="19991018"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2943,6 +3015,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CE-USA"/>
+		<info name="submitted" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3633,6 +3706,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22X-EUR"/>
+		<info name="submitted" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3649,6 +3723,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22Y-EUU"/>
+		<info name="submitted" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3855,6 +3930,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BJ2P-EUR"/>
+		<info name="submitted" value="20011127"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3999,6 +4075,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BD9P-EUR"/>
+		<info name="submitted" value="20010830"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -4029,12 +4106,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dendego2">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbb82j0.538"	-->
 		<description>Densha de Go! 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-B82J-JPN"/>
+		<info name="submitted" value="20001020"/>
 		<info name="release" value="20001208"/>
-		<info name="alt_title" value="電車でGO ! 2"/>
+		<info name="alt_title" value="電車でＧＯ！ ２"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A15-10" />
 			<feature name="u1" value="U1 32M MROM 02" />
@@ -4423,6 +4502,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="donkey kong country (usa, europe) (en,fr,de,es,it) (sample).bin" size="4194304" crc="945c3653" sha1="6b21d4d43fe8ac234e7fb81a167f313cf044d5b6"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dkongcd" cloneof="dkongc">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbdye0.326"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Donkey Kong Country (USA, Not for resale)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DIS-CGB-BDYE-USA"/>
+		<info name="submitted" value="20000719"/>
+		<info name="alt_title" value="DONKEY KONG COUNTRY (DISPLAY)"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbdye0.326" size="4194304" crc="080605a3" sha1="38fedd71736d258e31d3062864d28449e7c3f1c5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -4899,6 +4998,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-BDAE-USA"/>
+		<info name="submitted" value="20000623"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
@@ -5018,6 +5118,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQIJ-JPN"/>
+		<info name="submitted" value="20001222"/>
 		<info name="release" value="20010412"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 イルの冒険"/>
 		<part name="cart" interface="gameboy_cart">
@@ -5036,6 +5137,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
+		<info name="submitted" value="20001208"/>
 		<info name="release" value="20010309"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
 		<part name="cart" interface="gameboy_cart">
@@ -5048,6 +5150,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dmg-bqlj-0.u1" size="4194304" crc="2c428a87" sha1="5d2daec53938805236328a0f8a614debffa34048"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dqm2ra" cloneof="dwm2c">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgbqlj1.j93"	-->
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn, Rev. A)</description>
+		<year>2001</year>
+		<publisher>Enix</publisher>
+		<info name="serial" value="DMG-BQLJ-JPN"/>
+		<info name="submitted" value="20001228"/>
+		<info name="release" value="20010309"/>
+		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dmgbqlj1.j93" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -5344,6 +5466,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-ADWJ-JPN"/>
+		<info name="submitted" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ダンジョンセイバー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -5447,6 +5570,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BETE-USA"/>
+		<info name="submitted" value="20011015"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -5634,9 +5758,10 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="emperor">
+	<software name="emperorunk" cloneof="emperor">
 		<!-- Notes: GBC only -->
-		<description>The Emperor's New Groove (Euro)</description>
+		<!-- Old dump of unknown origin -->
+		<description>The Emperor's New Groove (Euro, bad dump?)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
@@ -5650,12 +5775,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="emperor">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbenp0.641"	-->
+		<description>The Emperor's New Groove (Euro)</description>
+		<year>2001</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BENP-EUR"/>
+		<info name="submitted" value="20010123"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbenp0.641" size="2097152" crc="eb29c584" sha1="2f53318aa7f1c82df95bf3da6b29701a2c563d13"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+
 	<software name="emperoru" cloneof="emperor">
 		<!-- Notes: GBC only -->
 		<description>The Emperor's New Groove (USA)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENE-USA"/>
+		<info name="submitted" value="20010123"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5805,6 +5950,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-AFIP-EUR"/>
+		<info name="submitted" value="19990526"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5837,7 +5983,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>The F.A. Premier League Stars 2001 (Euro)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BSJP-?"/>
+		<info name="submitted" value="20010413"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -5851,7 +5998,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>F1 Championship Season 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BFIP-?"/>
+		<info name="submitted" value="20001117"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5860,16 +6008,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="f1chmp2kb" cloneof="f1chmp2k">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfib0.579"	-->
+		<description>F1 Championship Season 2000 (Bra)</description>
+		<year>2000</year>
+		<publisher>Electronic Arts</publisher>
+		<info name="serial" value="CGB-BFIB-?"/>
+		<info name="submitted" value="20001107"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbfib0.579" size="2097152" crc="f4f5ed18" sha1="4731a7442bbff31c6d470b84938a3f148a4f1f6c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="f1racing">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbaeqp0.381"	-->
 		<description>F1 Racing Championship (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AEQP-EUR"/>
+		<info name="submitted" value="20000829"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
+				<rom name="cgbaeqp0.381" size="4194304" crc="93a9789f" sha1="ea844051c0b5c6f9a6a8c472f4f67ee6b9b3d8e7"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5884,7 +6050,23 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta) (february, 2000).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1racingunk" cloneof="f1racing">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>F1 Racing Championship (Euro, bad dump?)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6209,10 +6391,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
+		<info name="submitted" value="20000731"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="frogger 2 (usa).bin" size="1048576" crc="6a2666aa" sha1="566e0afb3a6f25342399a3e39f3fbcacef68eb72"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="frogger2a" cloneof="frogger2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbh2e1.351"	-->
+		<description>Frogger 2 (USA, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Majesco</publisher>
+		<info name="serial" value="CGB-BH2E-USA"/>
+		<info name="submitted" value="20000821"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbh2e1.351" size="1048576" crc="e3227b7d" sha1="0d5028ca6fcc10df46d11cd4b56e5add1dc5e63e"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6225,8 +6426,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BZOJ-JPN"/>
+		<info name="submitted" value="20020510"/>
 		<info name="release" value="20020628"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 幻のグランドライン冒険記!"/>
+		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -6249,8 +6451,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
+		<info name="submitted" value="20010615"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
+		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C3203-12A2]" />
@@ -6273,8 +6476,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
+		<info name="submitted" value="20010307"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
+		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -6331,12 +6535,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-AFMJ-JPN"/>
+		<info name="submitted" value="20010622"/>
 		<info name="release" value="20010719"/>
-		<info name="alt_title" value="不思議のダンジョン 風来のシレンGB2 砂漠の魔城"/>
+		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="fushigi no dungeon - fuurai no shiren gb2 - sabaku no majou (japan).bin" size="4194304" crc="2c97e90f" sha1="5264f6d0c4f12c9144de1d12fddadbadd82b3e33"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="furaish2a" cloneof="furaish2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfwj0.814"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn, Alt)</description>
+		<year>2001</year>
+		<publisher>ChinSoft</publisher>
+		<info name="serial" value="CGB-BFWJ-JPN?"/>
+		<info name="submitted" value="20010703"/>
+		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbfwj0.814" size="4194304" crc="f3c20fbe" sha1="d9c490af97c08ac7053bbb9f7ae06d3501035127"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -6361,11 +6586,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="gakkyama">
+	<software name="gakkyamaa">
 		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
+		<info name="submitted" value="19990428"/>
 		<info name="release" value="19990529"/>
 		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6378,6 +6604,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmg-aymj-1.u1" size="1048576" crc="ef2cfd99" sha1="3a2718efa3d1cac7345fbbcddb7c3f666fc6c70c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gakkyama" cloneof="gakkyamaa">
+		<!--	In lot check as "dmgaymj0.g22"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Gakkyuu Ou Yamazaki (Jpn)</description>
+		<year>1999</year>
+		<publisher>Koei</publisher>
+		<info name="serial" value="DMG-AYMJ-JPN?"/>
+		<info name="submitted" value="19990226"/>
+		<info name="release" value="19990529"/>
+		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaymj0.g22" size="1048576" crc="b8147b5c" sha1="132b872391565d418ccc9d0e1c643510d778c066"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6404,12 +6650,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN"/>
+		<info name="submitted" value="20001218"/>
 		<info name="release" value="20010209"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="gambler densetsu tetsuya - shinjuku tenun hen (japan).bin" size="1048576" crc="28356950" sha1="8ba0973997bdaeecdf23c45a4fb7e18e06132dfb"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gamblerta" cloneof="gamblert">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbgyj1.607"	-->
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn, Rev. A)</description>
+		<year>2001</year>
+		<publisher>Athena</publisher>
+		<info name="serial" value="CGB-BGYJ-JPN?"/>
+		<info name="submitted" value="20010307"/>
+		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbgyj1.607" size="1048576" crc="91739def" sha1="b62f8e56b995874c0e1a2533df5a37f6996df12e"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6857,6 +7123,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFP-EUR"/>
+		<info name="submitted" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6870,7 +7137,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>Gifty (Ger)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BGFD-?"/>
+		<info name="submitted" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7073,8 +7341,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-AZAJ-JPN"/>
+		<info name="submitted" value="19990617"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="ゴルフ王"/>
+		<info name="alt_title" value="ゴルフ王 THE KING OF GOLF"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -7983,6 +8252,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AF4E-USA"/>
+		<info name="submitted" value="19991027"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8031,6 +8301,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHP-EUR"/>
+		<info name="submitted" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8053,6 +8324,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHE-USA"/>
+		<info name="submitted" value="20000508"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8080,6 +8352,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hexcite">
+		<!--	European cartridges have USA sticker underneath.	-->
 		<description>Hexcite (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
@@ -8398,10 +8671,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BHQP-EUR"/>
+		<info name="submitted" value="20000707"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hype - the time quest (europe) (en,fr,de,es,it,nl,sv,da).bin" size="1048576" crc="24846d65" sha1="8e26e7e2e64d4bf866b67387586fc5c4a9c56855"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hypeb" cloneof="hype">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpfe0.737"	-->
+		<description>Hype - The Time Quest (Bra)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BPFE-?"/>
+		<info name="submitted" value="20010411"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpfe0.737" size="1048576" crc="cafb8035" sha1="7c7dca7c48dc478d0278c273ba37723b9e9dce5b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -8810,6 +9100,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AJZE-USA"/>
+		<info name="submitted" value="19990930"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8824,6 +9115,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AJUE-USA, CGB-AJUP-EUR"/>
+		<info name="submitted" value="20000218"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8859,6 +9151,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BJWP-EUR"/>
+		<info name="submitted" value="20001019"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8903,12 +9196,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="jissen">
+	<software name="jissena">
 		<!-- Notes: GBC only -->
 		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
+		<info name="submitted" value="20000711"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="実戦に役立つ詰碁"/>
 		<part name="cart" interface="gameboy_cart">
@@ -8918,6 +9212,24 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="cgb-bjtj-1.u1" size="262144" crc="55efa05e" sha1="5ff7f6f2a1911e97eb71a3b3788a89745cfa5d31"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jissen" cloneof="jissena">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbjtj0.313"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Jissen ni Yakudatsu Tsumego (Jpn)</description>
+		<year>2000</year>
+		<publisher>Pony Canyon</publisher>
+		<info name="serial" value="CGB-BJTJ-JPN?"/>
+		<info name="submitted" value="20001004"/>
+		<info name="alt_title" value="実戦に役立つ詰碁"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="cgbbjtj0.313" size="262144" crc="69c6dbef" sha1="f7ed6cdce7637a11d7fa7f5cb59b8f8ce131f9d1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -9292,8 +9604,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-VUTJ-JPN"/>
+		<info name="submitted" value="19990520"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="川のぬし釣り4"/>
+		<info name="alt_title" value="川のぬし釣り４"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A04-01" />
 			<feature name="u1" value="U1 4M/8M MROM [M438011E-57]" />
@@ -9330,11 +9643,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kawaipt2">
+	<software name="kawaipt2a">
+		<!--	In lot check as "dmgbmnj1.j90"	-->
+		<description>Kawaii Pet Shop Monogatari 2 (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Taito</publisher>
+		<info name="serial" value="DMG-BMNJ-JPN"/>
+		<info name="submitted" value="20010201"/>
+		<info name="alt_title" value="かわいいペットショップ物語2"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbmnj1.j90" size="2097152" crc="6fce1ad0" sha1="58ea410ebbee5edc18644c0467fe9ea03d179b1c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kawaipt2" cloneof="kawaipt2a">
 		<description>Kawaii Pet Shop Monogatari 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
+		<info name="submitted" value="20001107"/>
 		<info name="release" value="20001222"/>
 		<info name="alt_title" value="かわいいペットショップ物語2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9971,7 +10303,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="laura">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbldp0.420"	-->
+		<!--	Retail cartridge not yet located	-->
 		<description>Laura (Euro)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BLDP-EUR"/>
+		<info name="submitted" value="20000913"/>
+		<info name="alt_title" value="Laura's Happy Adventures"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbldp0.420" size="1048576" crc="a58c8282" sha1="47e5c4c7fa447efc8a0abf019e8d2cd227c5e0e3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lauraunk" cloneof="laura">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Laura (Euro, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -10496,10 +10847,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
+		<info name="submitted" value="20001113"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="roi lion, les - les adventures de simba (france).bin" size="1048576" crc="6467fba0" sha1="a0bef7df1ba3d75e7958763f0cec9c76428415df"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lionkingfa" cloneof="lionking">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbblkf1.573"	-->
+		<description>Le Roi Lion - Les Adventures de Simba (Fra, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Activision</publisher>
+		<info name="serial" value="CGB-BLKF-FRA"/>
+		<info name="submitted" value="20010406"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbblkf1.573" size="1048576" crc="c7aae1b3" sha1="b8cc2f1d3a8d40c7588d5c535f28e2f80446a793"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10943,7 +11311,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl2">
+	<software name="kangpzl2a">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
@@ -10961,7 +11329,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl2a" cloneof="kangpzl2">
+	<software name="kangpzl2" cloneof="kangpzl2a">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, NP)</description>
 		<year>2001</year>
@@ -10979,7 +11347,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl3">
+	<software name="kangpzl3a">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
@@ -10997,7 +11365,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl3a" cloneof="kangpzl3">
+	<software name="kangpzl3" cloneof="kangpzl3a">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, NP)</description>
 		<year>2001</year>
@@ -11015,7 +11383,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzls">
+	<software name="kangpzlsa">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
@@ -11033,7 +11401,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzlsa" cloneof="kangpzls">
+	<software name="kangpzls" cloneof="kangpzlsa">
 		<!-- Notes: SGB enhanced, NP only -->
 		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, NP)</description>
 		<year>2001</year>
@@ -11081,12 +11449,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
+		<info name="submitted" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ラブひなポケット"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="love hina pocket (japan).bin" size="4194304" crc="1c877abd" sha1="912c09f99bdae6e7fcd62d0c6f727e5fff93db70"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lovehinaa" cloneof="lovehina">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbphj1.290"	-->
+		<description>Love Hina Pocket (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Marvelous Entertainment</publisher>
+		<info name="serial" value="CGB-BPHJ-JPN"/>
+		<info name="submitted" value="20000824"/>
+		<info name="alt_title" value="ラブひなポケット"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbphj1.290" size="4194304" crc="55dd0ba6" sha1="b29abee319ccb223e5d1a4f88982fb53e538d527"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11312,10 +11700,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="maginatn">
 		<!-- Notes: GBC only -->
-		<description>Magi Nation (USA)</description>
+		<description>Magi-Nation (USA)</description>
 		<year>2001</year>
 		<publisher>Interactive Imagination</publisher>
 		<info name="serial" value="CGB-BNNE-USA"/>
+		<info name="submitted" value="20010112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -12639,12 +13028,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
+		<info name="submitted" value="19991028"/>
 		<info name="release" value="19991210"/>
-		<info name="alt_title" value="みんなの将棋 初級編"/>
+		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="minna no shougi - shokyuu hen (japan).bin" size="1048576" crc="5cb4fc8a" sha1="777088b9a3963e55dd6f90a523a84ed58a008149"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="minnashga" cloneof="minnashg">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmga7yj1.i18"	-->
+		<description>Minna no Shougi - Shokyuu Hen (Jpn, Rev. A)</description>
+		<year>1999</year>
+		<publisher>MTO</publisher>
+		<info name="serial" value="DMG-A7YJ-JPN"/>
+		<info name="submitted" value="20000811"/>
+		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmga7yj1.i18" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -12717,10 +13126,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-(NOE/UKV/FAH)"/>
+		<info name="submitted" value="19991006"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mission impossible (europe) (en,fr,de,es,it).bin" size="1048576" crc="0af32baa" sha1="5eb8dad248ff23809016a2515657089116e8df33"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="missimpa" cloneof="missimp">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbaimp1.076"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Mission Impossible (Euro, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Infogrames</publisher>
+		<info name="serial" value="CGB-AIMP-?"/>
+		<info name="submitted" value="19991227"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbaimp1.076" size="1048576" crc="9c51f4c7" sha1="f822bda01d881f34d1e17664465faf6a3ff64356"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -12733,6 +13162,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIME-USA"/>
+		<info name="submitted" value="19991227"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -12958,18 +13388,41 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="monstrvl">
+	<software name="monstrvla">
 		<!-- Notes: GBC only -->
 		<description>Monster Traveler (Jpn, Rev. A)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
+		<info name="submitted" value="20020207"/>
 		<info name="release" value="20020308"/>
-		<info name="alt_title" value="モン★スタートラベラー"/>
+		<info name="alt_title" value="モン☆スタートラベラー"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="monster traveler (japan) (rev a).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="monstrvl" cloneof="monstrvla">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfvj0.949"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Monster Traveler (Jpn)</description>
+		<year>2002</year>
+		<publisher>Taito</publisher>
+		<info name="serial" value="CGB-BFVJ-JPN"/>
+		<info name="submitted" value="20020122"/>
+		<info name="alt_title" value="モン☆スタートラベラー"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbfvj0.949" size="4194304" crc="5d596cf6" sha1="5195f55ad6aaa302c0a0e11c0ec6ecad4efe0e27"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
 			</dataarea>
 		</part>
 	</software>
@@ -13252,18 +13705,38 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="mrdrillrj" cloneof="mrdrillr">
-		<!-- Notes: GBC only, also released by NP in 2001-06 -->
+	<software name="mrdrillrja" cloneof="mrdrillr">
+		<!-- Notes: GBC only -->
 		<description>Mr. Driller (Jpn)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDJ-JPN"/>
+		<info name="submitted" value="20000510"/>
 		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ミスタードリラーGB版"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mr. driller (japan).bin" size="1048576" crc="773729af" sha1="b0d725dacea717be7109bd6a81817e717641da86"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mrdrillrjnp" cloneof="mrdrillr">
+		<!-- Notes: GBC only, NP only -->
+		<!--	In lot check as "cgbbv3j0.0"	-->
+		<description>Mr. Driller (Jpn, NP)</description>
+		<year>2000</year>
+		<publisher>Namco</publisher>
+		<info name="serial" value="CGB-BV3J-JPN"/>
+		<info name="release" value="200106"/>
+		<info name="alt_title" value="ミスタードリラーGB版"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="524288">
+				<rom name="cgbbv3j0.0" size="524288" crc="35fd440d" sha1="fb64fa7da6a0fec3e358bb3357e66d68473ada67"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13599,8 +14072,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3CJ-JPN"/>
+		<info name="submitted" value="20020307"/>
 		<info name="release" value="20020405"/>
-		<info name="alt_title" value="なかよしクッキングシリーズ(5) こむぎちゃんのケーキをつくろう!"/>
+		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -13616,6 +14090,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="nakapet1">
 		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Jpn)</description>
@@ -13831,15 +14306,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="nbazone" cloneof="nbapro99">
+	<software name="nbazonea" cloneof="nbapro99">
 		<description>NBA In the Zone (USA, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
+		<info name="submitted" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="nba in the zone (usa) (rev a).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nbazone" cloneof="nbapro99">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmganze0.g29"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>NBA In the Zone (USA)</description>
+		<year>1999</year>
+		<publisher>Konami</publisher>
+		<info name="serial" value="DMG-ANZE-USA?"/>
+		<info name="submitted" value="19990303"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmganze0.g29" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13852,6 +14347,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AJ7P-EUR"/>
+		<info name="submitted" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -13916,6 +14412,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZP-EUR"/>
+		<info name="submitted" value="19990716"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13932,6 +14429,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AA5E-USA"/>
+		<info name="submitted" value="19991124"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14016,6 +14514,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BAIP-EUR"/>
+		<info name="submitted" value="20011108"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -15040,6 +15539,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-A7GJ-JPN"/>
+		<info name="submitted" value="19990920"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="ポケット ジーティー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15239,6 +15739,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BXTJ-JPN"/>
+		<info name="submitted" value="20001020"/>
 		<info name="release" value="20001214"/>
 		<info name="alt_title" value="ポケットモンスター クリスタルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15263,7 +15764,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>Pocket Music (Euro)</description>
 		<year>2002</year>
 		<publisher>Rage Software</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BP9P-EUR?"/>
+		<info name="submitted" value="20010925"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -15348,12 +15850,51 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="submitted" value="20000721"/>
 		<info name="release" value="20000922"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket puyo puyo-n (japan).bin" size="1048576" crc="870db337" sha1="a86d4a24b5da3444b1967362b13d321b5c4f7a64"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="poktpuyna" cloneof="poktpuyn">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpyj1.327"	-->
+		<description>Pocket Puyo Puyo-n (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Compile</publisher>
+		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="submitted" value="20010327"/>
+		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpyj1.327" size="1048576" crc="c884037a" sha1="3d52805f712e6d1ce22b88dfebfcac2a31743ff3"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="poktpuynb" cloneof="poktpuyn">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpyj2.327"	-->
+		<description>Pocket Puyo Puyo-n (Jpn, Rev. B)</description>
+		<year>2000</year>
+		<publisher>Compile</publisher>
+		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="submitted" value="20010719"/>
+		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpyj2.327" size="1048576" crc="573613d7" sha1="09b217161ac326da63887693281b60751ca2dfcf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -15398,6 +15939,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
+		<info name="submitted" value="20010807, 20010726"/>
+		<info name="release" value="?, 20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15411,10 +15954,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysa" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Crystal Version (Euro, USA)</description>
+		<!--	European version unreleased (marked as "生産中止" in lot check)	-->
+		<description>Pokémon - Crystal Version (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
+		<info name="submitted" value="20010524, 20010101"/>
+		<info name="release" value="20010729, unreleased"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15432,6 +15978,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTF-FRA"/>
+		<info name="submitted" value="20010817"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15449,6 +15997,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTD-NOE"/>
+		<info name="submitted" value="20010726"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15466,6 +16016,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTI-ITA"/>
+		<info name="submitted" value="20010914"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-KGDU-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -15489,11 +16041,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTS-ESP"/>
+		<info name="submitted" value="20010830"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pokemon - edicion cristal (spain).bin" size="2097152" crc="ff0a6f8a" sha1="889a06fc0bb863666865aa69def0adf97945ac2a"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pokecrysaus" cloneof="pokecrys">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbytu0.834"	-->
+		<description>Pokémon - Crystal Version (Aus)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<info name="submitted" value="20010724"/>
+		<info name="release" value="20010930"/>
+		<info name="serial" value="CGB-BYTU-AUS"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbytu0.834" size="2097152" crc="bb6dd80c" sha1="a0fc810f1d4e124434f7be2c989ab5b5892ddf36"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15833,10 +16407,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecard">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgaxqx1.j85"	-->
+		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AXQX-EUR-1"/>
+		<info name="submitted" value="20001108"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgaxqx1.j85" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pokecardx" cloneof="pokecard">
 		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR"/>
+		<info name="submitted" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -15847,11 +16440,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="pokecarda" cloneof="pokecard">
+	<software name="pokecarde" cloneof="pokecard">
 		<description>Pokémon Trading Card Game (Euro, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE"/>
+		<info name="submitted" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -15862,6 +16456,24 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmg-axqp-0.u1" size="2097152" crc="4523376e" sha1="868e7b376e39f7d65a735538d90fbe6bbc99d198"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pokecardaa" cloneof="pokecard">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgaxqp1.j84"	-->
+		<description>Pokémon Trading Card Game (Euro, English / French / German, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AXQP-NOE?"/>
+		<info name="submitted" value="20001108"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgaxqp1.j84" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16566,6 +17178,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-ARIE-USA, DMG-ARIP-EUR"/>
+		<info name="submitted" value="19990303, 19990525"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -16666,6 +17279,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLP-EUU"/>
+		<info name="submitted" value="20000621"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -16684,7 +17298,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="propoolu" cloneof="propool">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbple0.298"	-->
+		<!--	Retail cartridge not yet located	-->
 		<description>Pro Pool (USA)</description>
+		<year>2000?</year>
+		<publisher>Codemasters</publisher>
+		<info name="serial" value="CGB-BPLE-USA?"/>
+		<info name="submitted" value="20000621"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbple0.298" size="1048576" crc="2611fa3d" sha1="c85e514c24c82071907c6495243dae448b46c2b2"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="propooluunk" cloneof="propool">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Pro Pool (USA, bad dump?)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLE-USA"/>
@@ -16697,6 +17331,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="projs11">
 		<!-- Notes: GBC only -->
@@ -16717,6 +17352,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-AIQP-EUR"/>
+		<info name="submitted" value="20000112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -16733,6 +17369,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-ACUJ-JPN"/>
+		<info name="submitted" value="19990311"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="プチカラット"/>
 		<part name="cart" interface="gameboy_cart">
@@ -16917,6 +17554,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="CGB-AQYP-EUR"/>
+		<info name="submitted" value="20001017"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -17688,9 +18326,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
 		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Jpn)</description>
-		<year>1999?</year>
+		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H5UJ-JPN"/>
+		<info name="submitted" value="19990618"/>
+		<info name="alt_title" value="ロボットポンコッツ ボンボンスペシャルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-10" />
@@ -18013,8 +18653,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-A2QJ-JPN"/>
+		<info name="submitted" value="20000209"/>
 		<info name="release" value="20000317"/>
-		<info name="alt_title" value="RPGツクールGB"/>
+		<info name="alt_title" value="ＲＰＧ ツクール ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -18343,6 +18984,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
+		<info name="submitted" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 過去編"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18361,18 +19003,59 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="sanriotka" cloneof="sanriotk">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgatpj1.f14"	-->
+		<description>Sanrio Timenet - Kako Hen (Jpn, Rev. A)</description>
+		<year>1998</year>
+		<publisher>Imagineer</publisher>
+		<info name="serial" value="DMG-ATPJ-JPN"/>
+		<info name="submitted" value="19981130"/>
+		<info name="release" value="19981127"/>
+		<info name="alt_title" value="サンリオタイムネット 過去編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgatpj1.f14" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sanriotm">
 		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
 		<description>Sanrio Timenet - Mirai Hen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
+		<info name="submitted" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 未来編"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sanrio timenet - mirai hen (japan).bin" size="1048576" crc="efe51e17" sha1="65c4113401336784be4c53a51fe8d9b4b3d287da"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sanriotma" cloneof="sanriotm">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgatfj1.f15"	-->
+		<description>Sanrio Timenet - Mirai Hen (Jpn, Rev. A)</description>
+		<year>1998</year>
+		<publisher>Imagineer</publisher>
+		<info name="serial" value="DMG-ATFJ-JPN"/>
+		<info name="submitted" value="19981130"/>
+		<info name="release" value="19981127"/>
+		<info name="alt_title" value="サンリオタイムネット 未来編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgatfj1.f15" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -18467,7 +19150,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="seihai">
 		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgaeoj0.j01"	-->
+		<!--	Retail cartridge not yet located	-->
 		<description>Sei Hai Densetsu (Jpn)</description>
+		<year>2000</year>
+		<publisher>Gaps</publisher>
+		<info name="serial" value="DMG-AEOJ-JPN?"/>
+		<info name="submitted" value="20000221"/>
+		<info name="release" value="20000414"/>
+		<info name="alt_title" value="聖牌伝説"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaeoj0.j01" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="seihaiunk" cloneof="seihai">
+		<!-- Notes: SGB enhanced -->
+		<!-- Old dump of unknown origin -->
+		<description>Sei Hai Densetsu (Jpn, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN"/>
@@ -18672,14 +19375,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Euro, USA, Rev. A)</description>
+		<description>Shanghai Pocket (Euro, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-AHPE-USA, DMG-AHPP-(EUR/EUU)"/>
+		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
+		<info name="submitted" value="19981222"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa, europe) (rev a).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
+				<rom name="shanghai pocket (europe) (rev a).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18690,7 +19394,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ASEJ-JPN?"/>
-		<info name="release" value="19980806?"/>
+		<info name="submitted" value="19980701"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="上海 ポケット"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -18700,15 +19405,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="shanghaie" cloneof="shanghai">
+		<description>Shanghai Pocket (Europe)</description>
+		<year>1998</year>
+		<publisher>Sunsoft</publisher>
+		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
+		<info name="submitted" value="19981110"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="shanghai pocket (europe).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="shanghaiu" cloneof="shanghai">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgahpe0.f55"	-->
 		<description>Shanghai Pocket (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPE-USA"/>
+		<info name="submitted" value="19981112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
+				<rom name="shanghai pocket (usa).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18743,12 +19465,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="shinmta">
+	<software name="shinmtaa">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgbhnj1.j70"	-->
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Atlus</publisher>
+		<info name="serial" value="DMG-BHNJ-JPN"/>
+		<info name="submitted" value="20010608"/>
+		<info name="release" value="20001117"/>
+		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbhnj1.j70" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shinmta" cloneof="shinmtaa">
 		<!-- Notes: SGB enhanced -->
 		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
+		<info name="submitted" value="20000912"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18767,12 +19510,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="shinmtk">
+	<software name="shinmtka">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgbhej1.j69"	-->
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Atlus</publisher>
+		<info name="serial" value="DMG-BHEJ-JPN"/>
+		<info name="submitted" value="20010608"/>
+		<info name="release" value="20001117"/>
+		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbhej1.j69" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shinmtk" cloneof="shinmtka">
 		<!-- Notes: SGB enhanced -->
 		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
+		<info name="submitted" value="20000912"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18797,6 +19561,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHWJ-JPN"/>
+		<info name="submitted" value="20010608"/>
 		<info name="release" value="20010727"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 白の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18946,10 +19711,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAE-USA"/>
+		<info name="submitted" value="20000921"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sewing machine operation software (usa) (en,fr,es).bin" size="1048576" crc="e42fd7c4" sha1="a05a67f2d29bf29c56c9533c172da02ee0ad26b1"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sewingose" cloneof="sewingos">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmgbraz0.k25"	-->
+		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<description>Sewing Machine Operation Software (Eur)</description>
+		<year>2000</year>
+		<publisher>Natsume</publisher>
+		<info name="serial" value="DMG-BRAZ-EUU"/>
+		<info name="submitted" value="20010920"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbraz0.k25" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19420,6 +20205,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6P-EUR"/>
+		<info name="submitted" value="19990506"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19434,6 +20220,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6J-JPN"/>
+		<info name="submitted" value="19990615"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="スパイ アンド スパイ"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19450,6 +20237,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6E-USA"/>
+		<info name="submitted" value="19990512"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19548,6 +20336,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-AFZP-EUR"/>
+		<info name="submitted" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19562,6 +20351,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BFZJ-JPN"/>
+		<info name="submitted" value="20010206"/>
 		<info name="release" value="20010330"/>
 		<info name="alt_title" value="ストリートファイター アルファ WARRIORS' DREAMS"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19578,6 +20368,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AFZE-USA"/>
+		<info name="submitted" value="20000120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19802,6 +20593,25 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="smbdxja" cloneof="smbdx">
+		<!-- Notes: GBC only, NP only -->
+		<!--	In lot check as "cgbahyj1.0"	-->
+		<description>Super Mario Bros. Deluxe (Jpn, NP, Rev. A)</description>
+		<year>1999</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="CGB-AHYJ-JPN"/>
+		<info name="release" value="20000301"/>
+		<info name="alt_title" value="スーパーマリオブラザーズデラックス"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbahyj1.0" size="1048576" crc="f4e91f63" sha1="e61d564e1ff19eb4b7c62a6cd96214f2bca4b01d"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
 		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. B)</description>
@@ -19971,11 +20781,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="survkidsj" cloneof="stranded">
 		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
+		<!--	In lot check as "dmgavkj0.g64"	-->
 		<description>Survival Kids - Kotou no Boukensha (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKJ-JPN (RK189-J1)"/>
+		<info name="submitted" value="19990423"/>
 		<info name="release" value="19990617"/>
+		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgavkj0.g64" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="survkidsjunk" cloneof="stranded">
+		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
+		<!-- Old dump of unknown origin -->
+		<description>Survival Kids - Kotou no Boukensha (Jpn, bad dump?)</description>
+		<year>1999</year>
+		<publisher>Konami</publisher>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
@@ -19993,8 +20822,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B2VJ-JPN (RK210-J1)"/>
+		<info name="submitted" value="20000606"/>
 		<info name="release" value="20000719"/>
-		<info name="alt_title" value="サバイバルキッズ2 脱出!双子島!"/>
+		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20010,7 +20840,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<description>Suzuki Alstare Extreme Racing (Euro)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-AXRP-EUR?"/>
+		<info name="submitted" value="19991001"/>
+		<info name="release" value="20000719"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
@@ -20096,8 +20928,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BLVJ-JPN"/>
+		<info name="submitted" value="20001117"/>
 		<info name="release" value="20001222"/>
-		<info name="alt_title" value="シルバニアファミリー2 色づく森のファンタジー"/>
+		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -20318,9 +21151,10 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="taxi2">
 		<description>Taxi 2 (Fra)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BT2F-FRA"/>
+		<info name="submitted" value="20000323"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20506,12 +21340,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN"/>
+		<info name="submitted" value="19991004"/>
 		<info name="release" value="19991112"/>
 		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="tetris adventure - susume mickey to nakama-tachi (japan).bin" size="1048576" crc="eaf6e4f2" sha1="aa7dd2044a7e1535da67d7b9439e9771f736086a"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tetrisada" cloneof="mtetrisc">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbat7j1.070"	-->
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn, Rev. A)</description>
+		<year>1999</year>
+		<publisher>Capcom</publisher>
+		<info name="serial" value="CGB-AT7J-JPN?"/>
+		<info name="submitted" value="20000623"/>
+		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbat7j1.070" size="1048576" crc="b7c0831f" sha1="a8842e85f2c6de4db40b47c9640dad59ae9d1c51"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20542,6 +21396,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33X-UKV"/>
+		<info name="submitted" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -20669,6 +21524,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BDQP-EUR"/>
+		<info name="submitted" value="20010529"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20724,6 +21580,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AFCE-USA"/>
+		<info name="submitted" value="19990917"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20842,10 +21699,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
+		<info name="submitted" value="20000928"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="tom and jerry - mousehunt (europe) (en,fr,de,es,it).bin" size="1048576" crc="3e17d04a" sha1="6f837075d7493adcbd5b18ba1e27386b6fc31e62"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tomjermha" cloneof="tomjermh">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbtjp1.487"	-->
+		<description>Tom and Jerry - Mousehunt (Euro, Rev. A)</description>
+		<year>2001</year>
+		<publisher>Conspiracy Entertainment</publisher>
+		<info name="serial" value="CGB-BTJP-EUR"/>
+		<info name="submitted" value="20010223"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbtjp1.487" size="1048576" crc="4b4553e0" sha1="bf5faf4c5c2aabe9636f8f5afbbf526aba59e21d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20884,6 +21758,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BTQE-USA"/>
+		<info name="submitted" value="20001020"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -20994,6 +21869,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BCZE-USA"/>
+		<info name="submitted" value="20020411"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21058,6 +21934,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTFE-USA-1, CGB-BTFP-EUR"/>
+		<info name="submitted" value="20000201"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -21206,6 +22083,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-V33J-JPN"/>
+		<info name="submitted" value="19991028"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="トップギア・ポケット2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -21223,8 +22101,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only -->
 		<description>Top Gear Pocket 2 (USA)</description>
 		<year>2000</year>
-		<publisher>Kemco</publisher>
+		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-A33E-USA"/>
+		<info name="submitted" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21234,6 +22113,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="tgrally">
 		<!-- Notes: GBC only -->
@@ -21256,6 +22136,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33P-(EUR/FRA)"/>
+		<info name="submitted" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21443,12 +22324,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="tradebat">
+	<software name="tradebata">
+		<!-- Notes: SGB enhanced -->
+		<!--	Never released as physical cartridge	-->
+		<!--	Released on the 3DS Virtual Console	-->
+		<!--	In lot check as "dmgahhj1.1"	-->
+		<description>Trade &amp; Battle Card Hero (Jpn, Rev. A)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AHHJ-JPN"/>
+		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgahhj1.1" size="2097152" crc="d98a877d" sha1="c6c1e0365166b53d25a1f84bc380948a9661df30"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tradebat" cloneof="tradebata">
 		<!-- Notes: SGB enhanced -->
 		<description>Trade &amp; Battle Card Hero (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
+		<info name="submitted" value="20000111"/>
 		<info name="release" value="20000221"/>
 		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -21546,14 +22449,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN"/>
+		<info name="submitted" value="19990624"/>
 		<info name="release" value="19990723"/>
-		<info name="alt_title" value="昆虫博士2"/>
+		<info name="alt_title" value="昆虫博士 ２"/>
 		<part name="cart" interface="gameboy_cart">
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dmg-af2j-0.u1" size="2097152" crc="1be00a6e" sha1="ecc0b306501f1a2371a83db808bda38af8bc28ce"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+	
+	<software name="tsurisn2a" cloneof="tsurisn2">
+		<!-- Notes: SGB enhanced -->
+		<!--	In lot check as "dmga2kj1.g93"	-->
+		<!--	Retail cartridge not yet located	-->
+		<description>Tsuri Sensei 2 (Jpn, Rev. A)</description>
+		<year>1999</year>
+		<publisher>J-Wing</publisher>
+		<info name="serial" value="DMG-AF2J-JPN?"/>
+		<info name="submitted" value="19990908"/>
+		<info name="alt_title" value="昆虫博士 ２"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmga2kj1.g93" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -21969,6 +22893,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFP-EUR"/>
+		<info name="submitted" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21983,6 +22908,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFE-USA"/>
+		<info name="submitted" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22056,12 +22982,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="vrspower">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpbe0.340"	-->
+		<!--	Retail cartridge not yet located, might be unreleased	-->
+		<description>VR Sports Powerboat Racing (USA)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<info name="serial" value="CGB-BPBE-USA?"/>
+		<info name="submitted" value="20000727"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpbe0.340" size="1048576" crc="cff671f1" sha1="1c77f032cdd373bfa108ea82c463f8f9f6874c71"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="vslemmin" cloneof="lemmings">
 		<!-- Notes: GBC only -->
 		<description>VS Lemmings (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-ALEJ-JPN"/>
+		<info name="submitted" value="20000225"/>
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="VSレミングス"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22304,6 +23248,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BWNJ-JPN"/>
+		<info name="submitted" value="20020322"/>
 		<info name="release" value="20020426"/>
 		<info name="alt_title" value="わたしのレストラン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22356,6 +23301,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWYD-NOE"/>
+		<info name="submitted" value="20021120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -22938,8 +23884,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only -->
 		<description>Xtreme Wheels (Euro)</description>
 		<year>2001</year>
-		<publisher>BAM! Entertainment</publisher>
+		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-BXCP-EUR"/>
+		<info name="submitted" value="20000922"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22956,6 +23903,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BXCE-USA"/>
+		<info name="submitted" value="20010307"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22968,7 +23916,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yakouchu">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbaytj0.066"	-->
+		<!--	Retail cartridge not yet located	-->
 		<description>Yakouchuu GB (Jpn)</description>
+		<year>1999</year>
+		<publisher>Athena</publisher>
+		<info name="serial" value="CGB-AYTJ-JPN"/>
+		<info name="submitted" value="19990924"/>
+		<info name="release" value="19991022"/>
+		<info name="alt_title" value="夜光虫GB"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbaytj0.066" size="2097152" crc="e0a06018" sha1="a7efd41d0ad17892132788bd90cdfb9df6806a78"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="yakouchuunk" cloneof="yakouchu">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Yakouchuu GB (Jpn, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
@@ -22983,6 +23953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="yarsrev">
 		<description>Yars' Revenge (Euro, USA)</description>
@@ -23030,6 +24001,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3P-EUR"/>
+		<info name="submitted" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -23052,6 +24024,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3F-FRA-1"/>
+		<info name="submitted" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23074,6 +24047,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3D-NOE"/>
+		<info name="submitted" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23096,6 +24070,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3I-ITA"/>
+		<info name="submitted" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23118,6 +24093,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3S-ESP"/>
+		<info name="submitted" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23140,6 +24116,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3E-USA"/>
+		<info name="submitted" value="20011217"/>
+		<info name="alt_title" value="Yu-Gi-Oh! Duel Monsters: Dark Duel Stories"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -23156,8 +24134,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYCJ-JPN (RK206-J1)"/>
+		<info name="submitted" value="20000217"/>
 		<info name="release" value="20000413"/>
-		<info name="alt_title" value="遊戯王 モンスターカプセルGB"/>
+		<info name="alt_title" value="遊戯王 モンスターカプセル ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -26385,6 +27364,7 @@ List of unclassified roms
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="131072">
 				<rom name="action replay online bios (europe) (unl).bin" size="131072" crc="04c8c858" sha1="fa441c5e376b54b3503596fe8177b3a9ad79a9a8"/>
 			</dataarea>
@@ -26397,6 +27377,7 @@ List of unclassified roms
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="81920">
 				<rom name="gameshark online bios (usa) (unl).bin" size="81920" crc="c37d21d9" sha1="22f00e604acb827a48d4c9e109ba622f59a9d0a9"/>
 			</dataarea>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -17,13 +17,13 @@ license:CC0
 	- Gakkyuu Ou Yamazaki (Japan)
 	- Jissen ni Yakudatsu Tsumego (Japan)
 	- Laura (Europe)
-	- Mission Impossible (Europe, Rev. 1)
+	- Mission Impossible (Europe, Rev 1)
 	- Monster Traveler (Japan)
 	- NBA In the Zone (USA)
 	- Pro Pool (USA)
 	- Sei Hai Densetsu (Japan)
-	- Super Mario Bros. Deluxe (USA, Rev. 2)	<- Was it released?
-	- Tsuri Sensei 2 (Japan, Rev. 1)
+	- Super Mario Bros. Deluxe (USA, Rev 2)	<- Was it released?
+	- Tsuri Sensei 2 (Japan, Rev 1)
 	- Turok - Rage Wars (Australia)
 	- VR Sports Powerboat Racing (USA)
 	- Yakouchuu GB (Japan)
@@ -1595,7 +1595,7 @@ license:CC0
 
 	<software name="barcodea" cloneof="barcode">
 		<!--	In lot check as "dmgabej1.f26"	-->
-		<description>Barcode Taisen Bardigun (Japan, Rev. 1)</description>
+		<description>Barcode Taisen Bardigun (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN-1"/>
@@ -2245,7 +2245,7 @@ license:CC0
 	<software name="bokujom3a" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbwaj1.350"	-->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev. 1)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
@@ -2820,7 +2820,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 2)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev 2)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2844,7 +2844,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuita" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 1)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -4654,7 +4654,7 @@ license:CC0
 
 	<software name="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Japan, Rev. 1)</description>
+		<description>Doraemon no Quiz Boy (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -5075,7 +5075,7 @@ license:CC0
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
@@ -5183,7 +5183,7 @@ license:CC0
 
 	<software name="dqm2ra" cloneof="dwm2c">
 		<!--	In lot check as "dmgbqlj1.j93"	-->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev. 1)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
@@ -6157,7 +6157,7 @@ license:CC0
 
 	<software name="fairykit">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan, Rev. 1)</description>
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
@@ -6167,7 +6167,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (Rev. 1).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
+				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (Rev 1).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6372,7 +6372,7 @@ license:CC0
 	</software>
 
 	<software name="froggeru" cloneof="frogger">
-		<description>Frogger (USA, Rev. 2)</description>
+		<description>Frogger (USA, Rev 2)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-3"/>
@@ -6388,7 +6388,7 @@ license:CC0
 	</software>
 
 	<software name="froggerua" cloneof="frogger">
-		<description>Frogger (USA, Rev. 1)</description>
+		<description>Frogger (USA, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-2"/>
@@ -6433,7 +6433,7 @@ license:CC0
 	<software name="frogger2a" cloneof="frogger2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbh2e1.351"	-->
-		<description>Frogger 2 (USA, Rev. 1)</description>
+		<description>Frogger 2 (USA, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
@@ -6474,7 +6474,7 @@ license:CC0
 	</software>
 
 	<software name="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan, Rev. 1)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
@@ -6491,7 +6491,7 @@ license:CC0
 			<feature name="battery" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (Rev. 1).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
+				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (Rev 1).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6616,7 +6616,7 @@ license:CC0
 	</software>
 
 	<software name="gakkyamaa">
-		<description>Gakkyuu Ou Yamazaki (Japan, Rev. 1)</description>
+		<description>Gakkyuu Ou Yamazaki (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
@@ -6695,7 +6695,7 @@ license:CC0
 	<software name="gamblerta" cloneof="gamblert">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbgyj1.607"	-->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev. 1)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN?"/>
@@ -7823,7 +7823,7 @@ license:CC0
 
 	<software name="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Japan, Rev. 1)</description>
+		<description>Hamster Paradise 2 (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -9233,7 +9233,7 @@ license:CC0
 
 	<software name="jissena">
 		<!-- Notes: GBC only -->
-		<description>Jissen ni Yakudatsu Tsumego (Japan, Rev. 1)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
@@ -9685,7 +9685,7 @@ license:CC0
 
 	<software name="kawaipt2a">
 		<!--	In lot check as "dmgbmnj1.j90"	-->
-		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev. 1)</description>
+		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
@@ -9990,7 +9990,7 @@ license:CC0
 
 	<software name="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Japan, Rev. 1)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -9999,7 +9999,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="kisekae series 2 - oshare nikki (japan) (Rev. 1).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
+				<rom name="kisekae series 2 - oshare nikki (japan) (Rev 1).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -10484,7 +10484,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Europe, Australia, USA, Rev. 2)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, Australia, USA, Rev 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-(EUR/AUS)"/>
@@ -10499,7 +10499,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
@@ -10536,7 +10536,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxf" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (France, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (France, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10578,7 +10578,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxg" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Germany, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Germany, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10900,7 +10900,7 @@ license:CC0
 	<software name="lionkingfa" cloneof="lionking">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbblkf1.573"	-->
-		<description>Le Roi Lion - Les Adventures de Simba (France, Rev. 1)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (France, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
@@ -11246,7 +11246,7 @@ license:CC0
 
 	<software name="hirapzl2">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, Rev 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
@@ -11284,7 +11284,7 @@ license:CC0
 
 	<software name="hirapzl3">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, Rev 1, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
@@ -11322,7 +11322,7 @@ license:CC0
 
 	<software name="hirapzls">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, Rev 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
@@ -11360,7 +11360,7 @@ license:CC0
 
 	<software name="kangpzl2a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
@@ -11398,7 +11398,7 @@ license:CC0
 
 	<software name="kangpzl3a">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
@@ -11436,7 +11436,7 @@ license:CC0
 
 	<software name="kangpzlsa">
 		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, NP)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
@@ -11518,7 +11518,7 @@ license:CC0
 	<software name="lovehinaa" cloneof="lovehina">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbphj1.290"	-->
-		<description>Love Hina Pocket (Japan, Rev. 1)</description>
+		<description>Love Hina Pocket (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
@@ -11814,7 +11814,7 @@ license:CC0
 
 	<software name="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Europe, Rev. 1)</description>
+		<description>Magical Tetris Challenge (Europe, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
@@ -11897,7 +11897,7 @@ license:CC0
 	</software>
 
 	<software name="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Japan, Rev. 1)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN-1"/>
@@ -11907,7 +11907,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="majokko mari-chan no kisekae monogatari (japan) (Rev. 1).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
+				<rom name="majokko mari-chan no kisekae monogatari (japan) (Rev 1).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13099,7 +13099,7 @@ license:CC0
 
 	<software name="minnashga" cloneof="minnashg">
 		<!--	In lot check as "dmga7yj1.i18"	-->
-		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev. 1)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
@@ -13197,7 +13197,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbaimp1.076"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Mission Impossible (Europe, Rev. 1)</description>
+		<description>Mission Impossible (Europe, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-?"/>
@@ -13446,7 +13446,7 @@ license:CC0
 
 	<software name="monstrvla">
 		<!-- Notes: GBC only -->
-		<description>Monster Traveler (Japan, Rev. 1)</description>
+		<description>Monster Traveler (Japan, Rev 1)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
@@ -13485,7 +13485,7 @@ license:CC0
 
 	<software name="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Europe, Rev. 1)</description>
+		<description>Monsters, Inc. (Europe, Rev 1)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QP-UKV"/>
@@ -14364,7 +14364,7 @@ license:CC0
 	</software>
 
 	<software name="nbazonea" cloneof="nbapro99">
-		<description>NBA In the Zone (USA, Rev. 1)</description>
+		<description>NBA In the Zone (USA, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
@@ -14627,7 +14627,7 @@ license:CC0
 	</software>
 
 	<software name="blitz">
-		<description>NFL Blitz (Europe, USA, Rev. 1)</description>
+		<description>NFL Blitz (Europe, USA, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ABZE-USA, DMG-ABZP-EUU"/>
@@ -15711,7 +15711,7 @@ license:CC0
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Japan, Rev. 1)</description>
+		<description>Pocket Monsters Gin (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
@@ -15755,7 +15755,7 @@ license:CC0
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Japan, Rev. 1)</description>
+		<description>Pocket Monsters Kin (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
@@ -15925,7 +15925,7 @@ license:CC0
 	<software name="poktpuyna" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj1.327"	-->
-		<description>Pocket Puyo Puyo-n (Japan, Rev. 1)</description>
+		<description>Pocket Puyo Puyo-n (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15944,7 +15944,7 @@ license:CC0
 	<software name="poktpuynb" cloneof="poktpuyn">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbpyj2.327"	-->
-		<description>Pocket Puyo Puyo-n (Japan, Rev. 2)</description>
+		<description>Pocket Puyo Puyo-n (Japan, Rev 2)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
@@ -15996,7 +15996,7 @@ license:CC0
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
 		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
-		<description>Pokémon - Crystal Version (Europe, USA, Rev. 1)</description>
+		<description>Pokémon - Crystal Version (Europe, USA, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
@@ -16469,7 +16469,7 @@ license:CC0
 
 	<software name="pokecard">
 		<!--	In lot check as "dmgaxqx1.j85"	-->
-		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev. 1)</description>
+		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR-1"/>
@@ -16527,7 +16527,7 @@ license:CC0
 
 	<software name="pokecardaa" cloneof="pokecard">
 		<!--	In lot check as "dmgaxqp1.j84"	-->
-		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev. 1)</description>
+		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE?"/>
@@ -16716,7 +16716,7 @@ license:CC0
 	</software>
 
 	<software name="powrpkp">
-		<description>Power Pro Kun Pocket (Japan, Rev. 1)</description>
+		<description>Power Pro Kun Pocket (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
@@ -16920,7 +16920,7 @@ license:CC0
 
 	<software name="powrpfbmu" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 2)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-2"/>
@@ -16938,7 +16938,7 @@ license:CC0
 
 	<software name="powrpfbmua" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-1"/>
@@ -17042,7 +17042,7 @@ license:CC0
 
 	<software name="powrpfbhu" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Battle Him (USA, Rev 1)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHE-USA-1"/>
@@ -17141,7 +17141,7 @@ license:CC0
 
 	<software name="powrpfpnu" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 2)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-2?"/>
@@ -17155,7 +17155,7 @@ license:CC0
 
 	<software name="powrpfpnua" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-1"/>
@@ -19072,7 +19072,7 @@ license:CC0
 
 	<software name="sanriotka" cloneof="sanriotk">
 		<!--	In lot check as "dmgatpj1.f14"	-->
-		<description>Sanrio Timenet - Kako Hen (Japan, Rev. 1)</description>
+		<description>Sanrio Timenet - Kako Hen (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
@@ -19112,7 +19112,7 @@ license:CC0
 
 	<software name="sanriotma" cloneof="sanriotm">
 		<!--	In lot check as "dmgatfj1.f15"	-->
-		<description>Sanrio Timenet - Mirai Hen (Japan, Rev. 1)</description>
+		<description>Sanrio Timenet - Mirai Hen (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
@@ -19332,7 +19332,7 @@ license:CC0
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate Classic (Europe, USA, Rev. 1)</description>
+		<description>Shadowgate Classic (Europe, USA, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-EUR"/>
@@ -19443,7 +19443,7 @@ license:CC0
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Europe, Rev. 1)</description>
+		<description>Shanghai Pocket (Europe, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
@@ -19535,7 +19535,7 @@ license:CC0
 
 	<software name="shinmtaa">
 		<!--	In lot check as "dmgbhnj1.j70"	-->
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev. 1)</description>
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
@@ -19580,7 +19580,7 @@ license:CC0
 
 	<software name="shinmtka">
 		<!--	In lot check as "dmgbhej1.j69"	-->
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev. 1)</description>
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
@@ -20304,7 +20304,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
 		<!--	Never released as physical cartridge	-->
-		<description>Spy vs. Spy (Japan, Rev. 1, NP)</description>
+		<description>Spy vs. Spy (Japan, Rev 1, NP)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -20682,7 +20682,7 @@ license:CC0
 	<software name="smbdxja" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
 		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
-		<description>Super Mario Bros. Deluxe (Japan, NP, Rev. 1)</description>
+		<description>Super Mario Bros. Deluxe (Japan, NP, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -20702,7 +20702,7 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
 		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
-		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 2)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev 2)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -20718,7 +20718,7 @@ license:CC0
 
 	<software name="smbdxa" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 1)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -21446,7 +21446,7 @@ license:CC0
 	<software name="tetrisada" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbat7j1.070"	-->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev. 1)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN?"/>
@@ -21802,7 +21802,7 @@ license:CC0
 	<software name="tomjermha" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbtjp1.487"	-->
-		<description>Tom and Jerry - Mousehunt (Europe, Rev. 1)</description>
+		<description>Tom and Jerry - Mousehunt (Europe, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
@@ -21832,7 +21832,7 @@ license:CC0
 	<software name="tomjermhua" cloneof="tomjermh">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "cgbbtqe1.541"	-->
-		<description>Tom and Jerry - Mousehunt (USA, Rev. 1)</description>
+		<description>Tom and Jerry - Mousehunt (USA, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJE-USA?"/>
@@ -22308,7 +22308,7 @@ license:CC0
 
 	<software name="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan, Rev. 1)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22435,7 +22435,7 @@ license:CC0
 		<!--	Never released as physical cartridge	-->
 		<!--	Released on the 3DS Virtual Console	-->
 		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
-		<description>Trade &amp; Battle Card Hero (Japan, Rev. 1)</description>
+		<description>Trade &amp; Battle Card Hero (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
@@ -22574,7 +22574,7 @@ license:CC0
 	<software name="tsurisn2a" cloneof="tsurisn2">
 		<!--	In lot check as "dmga2kj1.g93"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Tsuri Sensei 2 (Japan, Rev. 1)</description>
+		<description>Tsuri Sensei 2 (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN?"/>
@@ -23310,7 +23310,7 @@ license:CC0
 
 	<software name="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Japan, Rev. 1)</description>
+		<description>Watashi no Kitchen (Japan, Rev 1)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23537,7 +23537,7 @@ license:CC0
 
 	<software name="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Japan, Rev. 1)</description>
+		<description>Wizardry Empire (Japan, Rev 1)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23860,7 +23860,7 @@ license:CC0
 
 	<software name="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Europe, USA, Rev. 1)</description>
+		<description>X-Men - Mutant Academy (Europe, USA, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-NOE"/>
@@ -24426,7 +24426,7 @@ license:CC0
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 2)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24451,7 +24451,7 @@ license:CC0
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
 		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 1)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
@@ -24536,7 +24536,7 @@ license:CC0
 	</software>
 
 	<software name="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan, Rev. 1)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan, Rev 1)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
@@ -24687,7 +24687,7 @@ license:CC0
 
 	<software name="dqmarc1" cloneof="dwm">
 		<!--	In lot check as "KENSA\dmgadqj1.1"	-->
-		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1, Release Candidate 1)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev 1, Release Candidate 1)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
@@ -24704,7 +24704,7 @@ license:CC0
 
 	<software name="dsaviorarc1" cloneof="dsavior">
 		<!--	In lot check as "KENSA\dmgadwj1.1"	-->
-		<description>Dungeon Savior (Japan, Rev. 1, Release Candidate 1)</description>
+		<description>Dungeon Savior (Japan, Rev 1, Release Candidate 1)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24765,7 +24765,7 @@ license:CC0
 
 	<software name="shanghaiuarc0" cloneof="shanghai">
 		<!--	In lot check as "KENSA\dmgahpe1.0"	-->
-		<description>Shanghai Pocket (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Shanghai Pocket (USA, Rev 1, Release Candidate 0)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24858,7 +24858,7 @@ license:CC0
 
 	<software name="metalwlkjarc0" cloneof="metalwlk">
 		<!--	In lot check as "KENSA\dmgauej1.0"	-->
-		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
@@ -24874,7 +24874,7 @@ license:CC0
 
 	<software name="td6uarc0" cloneof="td6">
 		<!--	In lot check as "KENSA\dmgaw6e1.0"	-->
-		<description>Test Drive 6 (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Test Drive 6 (USA, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24919,7 +24919,7 @@ license:CC0
 
 	<software name="survkid2arc0" cloneof="survkid2">
 		<!--	In lot check as "KENSA\dmgb2vj1.0"	-->
-		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
@@ -24936,7 +24936,7 @@ license:CC0
 
 	<software name="kangpzl2arc0" cloneof="kangpzl2a">
 		<!--	In lot check as "KENSA\dmgb62j1.0"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
@@ -24953,7 +24953,7 @@ license:CC0
 
 	<software name="kangpzl3arc0" cloneof="kangpzl3a">
 		<!--	In lot check as "KENSA\dmgb63j1.0"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
@@ -24970,7 +24970,7 @@ license:CC0
 
 	<software name="kangpzlsarc1" cloneof="kangpzlsa">
 		<!--	In lot check as "KENSA\dmgb6ij1.1"	-->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, Release Candidate 1)</description>
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev 1, Release Candidate 1)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
@@ -25094,7 +25094,7 @@ license:CC0
 
 	<software name="kawanus4arc0" cloneof="rivking2">
 		<!--	In lot check as "KENSA\dmgvutj1.0"	-->
-		<description>Kawa no Nushi Tsuri 4 (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Kawa no Nushi Tsuri 4 (Japan, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="alt_title" value="川のぬし釣り４"/>
@@ -25128,7 +25128,7 @@ license:CC0
 	<software name="rpgtsukuarc0" cloneof="rpgtsuku">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgba2qj1.0"	-->
-		<description>RPG Tsukuru GB (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>RPG Tsukuru GB (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25144,7 +25144,7 @@ license:CC0
 	<software name="topgear2arc0" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgba33e1.0"	-->
-		<description>Top Gear Pocket 2 (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Top Gear Pocket 2 (USA, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25174,7 +25174,7 @@ license:CC0
 	<software name="nbashowtarc0" cloneof="nbashowt">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbaa5e1.0"	-->
-		<description>NBA Show Time - NBA on NBC (USA, Rev. 1, Release Candidate 0)</description>
+		<description>NBA Show Time - NBA on NBC (USA, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25204,7 +25204,7 @@ license:CC0
 	<software name="sfaarc0" cloneof="sfa">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbafzp1.0"	-->
-		<description>Street Fighter Alpha - Warriors' Dreams (Europe, Rev. 1, Release Candidate 0)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Europe, Rev 1, Release Candidate 0)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25232,7 +25232,7 @@ license:CC0
 	<software name="spyvsspyuarc0" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbas6e1.0"	-->
-		<description>Spy vs. Spy (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Spy vs. Spy (USA, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25246,7 +25246,7 @@ license:CC0
 	<software name="spyvsspyarc0" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbas6p1.0"	-->
-		<description>Spy vs. Spy (Europe, Rev. 1, Release Candidate 0)</description>
+		<description>Spy vs. Spy (Europe, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25275,7 +25275,7 @@ license:CC0
 	<software name="mightmaguarc0" cloneof="mightmag">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbauhe1.0"	-->
-		<description>Heroes of Might and Magic (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Heroes of Might and Magic (USA, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25291,7 +25291,7 @@ license:CC0
 	<software name="vegasuarc0" cloneof="vegas">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbavfe1.0"	-->
-		<description>Vegas Games (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Vegas Games (USA, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25353,7 +25353,7 @@ license:CC0
 	<software name="newaddfmarc0" cloneof="newaddfm">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbaip1.0"	-->
-		<description>The New Addams Family Series (Europe, Rev. 1, Release Candidate 0)</description>
+		<description>The New Addams Family Series (Europe, Rev 1, Release Candidate 0)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25387,7 +25387,7 @@ license:CC0
 	<software name="bluecluearc0" cloneof="blueclue">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbale1.0"	-->
-		<description>Blue's Clues - Blue's Alphabet Book (USA, Rev. 1, Release Candidate 0)</description>
+		<description>Blue's Clues - Blue's Alphabet Book (USA, Rev 1, Release Candidate 0)</description>
 		<year>2001</year>
 		<publisher>Mattel Interactive</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25565,7 +25565,7 @@ license:CC0
 	<software name="lauraarc0" cloneof="laura">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbldp1.0"	-->
-		<description>Laura (Europe, Rev. 1, Release Candidate 0)</description>
+		<description>Laura (Europe, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25627,7 +25627,7 @@ license:CC0
 	<software name="dejikomjarc0" cloneof="dejikomj">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbqsj1.0"	-->
-		<description>Dejiko no Mahjong Party (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Dejiko no Mahjong Party (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25643,7 +25643,7 @@ license:CC0
 	<software name="ccsakutoarc0" cloneof="ccsakuto">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbs7j1.0"	-->
-		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan, Rev 1, Release Candidate 0)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
@@ -25753,7 +25753,7 @@ license:CC0
 	<software name="topgear2jarc0" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbv33j1.0"	-->
-		<description>Top Gear Pocket 2 (Japan, Rev. 1, Release Candidate 0)</description>
+		<description>Top Gear Pocket 2 (Japan, Rev 1, Release Candidate 0)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25785,7 +25785,7 @@ license:CC0
 	<software name="casperuarc1" cloneof="casper">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbaf9e1.1"	-->
-		<description>Casper (USA, Rev. 1, Release Candidate 1)</description>
+		<description>Casper (USA, Rev 1, Release Candidate 1)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25962,7 +25962,7 @@ license:CC0
 	<software name="giftyarc2" cloneof="gift">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbgfd1.2"	-->
-		<description>Gifty (Germany, Rev. 1, Release Candidate 2)</description>
+		<description>Gifty (Germany, Rev 1, Release Candidate 2)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25976,7 +25976,7 @@ license:CC0
 	<software name="giftarc1" cloneof="gift">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbgfp1.1"	-->
-		<description>Gift (Europe, Rev. 1, Release Candidate 1)</description>
+		<description>Gift (Europe, Rev 1, Release Candidate 1)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26008,7 +26008,7 @@ license:CC0
 	<software name="shinmtsarc1" cloneof="shinmts">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbbhwj1.1"	-->
-		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan, Rev. 1, Release Candidate 1)</description>
+		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan, Rev 1, Release Candidate 1)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="alt_title" value="真・女神転生デビルチルドレン　白の書"/>
@@ -26089,7 +26089,7 @@ license:CC0
 	<software name="sylvan2arc1" cloneof="sylvan2">
 		<!-- Notes: GBC only -->
 		<!--	In lot check as "KENSA\cgbblvj1.1"	-->
-		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan, Rev. 1, Release Candidate 1)</description>
+		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan, Rev 1, Release Candidate 1)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>


### PR DESCRIPTION
Just added every known retail release which hadn't been added yet, going by the info in no-intro and other sources. Fixed some bad dumps while leaving the old ones there just in case they could be prototypes, added "submitted" ROM info in many entries which gives us an estimate on the unknown release dates.

These are only those games listed as released, let me know when you want to add all the other GBC stuff (XMLs are ready to copy and paste).


New games:
		AMF Bowling (USA)
		VR Sports Powerboat Racing (USA)

New clones:
		Barcode Taisen Bardigun (Japan, Rev 1)
		Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev 1)
		Donkey Kong Country (USA, Not for resale)
		Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev 1)
		F1 Championship Season 2000 (Brazil)
		Frogger 2 (USA, Rev 1)
		Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)
		Gakkyuu Ou Yamazaki (Japan)
		Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev 1)
		Hype - The Time Quest (Brazil)
		Jissen ni Yakudatsu Tsumego (Japan)
		Kawaii Pet Shop Monogatari 2 (Japan, Rev 1)
		Le Roi Lion - Les Adventures de Simba (France, Rev 1)
		Love Hina Pocket (Japan, Rev 1)
		Minna no Shougi - Shokyuu Hen (Japan, Rev 1)
		Mission Impossible (Europe, Rev 1)
		Monster Traveler (Japan)
		Mr. Driller (Japan, NP)
		NBA In the Zone (USA)
		Pocket Puyo Puyo-n (Japan, Rev 1)
		Pocket Puyo Puyo-n (Japan, Rev 2)
		Pokémon - Crystal Version (Aus)
		Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev 1)
		Pokémon Trading Card Game (Europe, English / French / German, Rev 1)
		Sanrio Timenet - Kako Hen (Japan, Rev 1)
		Sanrio Timenet - Mirai Hen (Japan, Rev 1)
		Shanghai Pocket (Europe)
		Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev 1)
		Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev 1)
		Sewing Machine Operation Software (Europe)
		Super Mario Bros. Deluxe (Japan, NP, Rev 1)
		Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev 1)
		Tom and Jerry - Mousehunt (Europe, Rev 1)
		Trade & Battle Card Hero (Japan, Rev 1)
		Tsuri Sensei 2 (Japan, Rev 1)

Fixed bad dumps:
		The Emperor's New Groove (Europe)
		F1 Racing Championship (Europe)
		Laura (Europe)
		Pro Pool (USA)
		Sei Hai Densetsu (Japan)
		Survival Kids - Kotou no Boukensha (Japan)
		Yakouchuu GB (Japan)
