### PR TITLE
[gameboy.xml] New software list additions

### DIFF
--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -11920,10 +11920,13 @@ license:CC0
 	</software>
 
 	<software name="zeldalnka" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLE-1.858"	-->
+		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-UKV, DMG-ZL-ESP-1, DMG-ZL-CAN" />
+		<info name="gold" value="19930805" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
@@ -11935,10 +11938,13 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkb" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLE-0.858"	-->
+		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-CAN, DMG-ZL-UKV, DMG-ZL-USA" />
+		<info name="gold" value="19930602" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-DECN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -11956,10 +11962,12 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkc" cloneof="zeldalnk">
-		<description>The Legend of Zelda - Link's Awakening (Canada)</description>
+		<!--	In lot check as "DMGZCF-0.888"	-->
+		<description>The Legend of Zelda - Link's Awakening (Canada, French)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZC-CAN" />
+		<info name="gold" value="19930901" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-DECN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -11977,10 +11985,12 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkf" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLF-0.872"	-->
 		<description>The Legend of Zelda - Link's Awakening (France)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-FRA" />
+		<info name="gold" value="19930805" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-DECN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -11998,10 +12008,12 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkg" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLD-0.873"	-->
 		<description>The Legend of Zelda - Link's Awakening (Germany)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-NOE" />
+		<info name="gold" value="19930805" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-DECN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -26457,11 +26469,12 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkj" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLJ-1.836"	-->
 		<description>Zelda no Densetsu - Yume o Miru Shima (China, Japan, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZLJ, DMG-407 CHN" />
-		<info name="release" value="19930606" />
+		<info name="gold" value="19930728" />
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
@@ -26474,10 +26487,12 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkja" cloneof="zeldalnk">
+		<!--	In lot check as "DMGZLJ-0.836"	-->
 		<description>Zelda no Densetsu - Yume o Miru Shima (Japan)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZLJ" />
+		<info name="gold" value="19930430" />
 		<info name="release" value="19930606" />
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島" />
 		<part name="cart" interface="gameboy_cart">

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -5,36 +5,36 @@ license:CC0
 
   To investigate:
 	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
-	- Was Gargoyle's Quest (Rev. 1) released in the USA?
+	- Was Gargoyle's Quest (Rev 1) released in the USA?
 
   Known dumps not yet verified against retail cartridge:
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
 	- GI King! - Sanbiki no Yosouya (Japan)
 	- Hyper Lode Runner (World)
-	- The Jetsons - Robot Panic (USA, Rev. 1)
+	- The Jetsons - Robot Panic (USA, Rev 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Japan, Rev. 1)
+	- Kaseki Sousei Reborn (Japan, Rev 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Europe, Rev. 1)
+	- Pac-In-Time (Europe, Rev 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
-	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
 	- GI King! - Sanbiki no Yosouya (Japan)
 	- Hyper Lode Runner (World)
-	- The Jetsons - Robot Panic (USA, Rev. 1)
+	- The Jetsons - Robot Panic (USA, Rev 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Japan, Rev. 1)
+	- Kaseki Sousei Reborn (Japan, Rev 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Europe, Rev. 1)
+	- Pac-In-Time (Europe, Rev 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
-	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 
   Undumped pirate carts:
@@ -793,7 +793,7 @@ license:CC0
 
 	<software name="amoudan2a">
 		<!--	In lot check as "dmgauj-1.434"	-->
-		<description>America Oudan Ultra Quiz Part 2 (Japan, Rev. 1)</description>
+		<description>America Oudan Ultra Quiz Part 2 (Japan, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-AUJ" />
@@ -2447,7 +2447,7 @@ license:CC0
 
 	<software name="bokujom" cloneof="harvmoon">
 		<!-- Also released via the Nintendo Power service in 2000-08 -->
-		<description>Bokujou Monogatari GB (Japan, Rev. 1)</description>
+		<description>Bokujou Monogatari GB (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-AYWJ-JPN" />
@@ -2780,7 +2780,7 @@ license:CC0
 
 	<software name="boxxlea">
 		<!--	European release is a relabeled USA version	-->
-		<description>Boxxle (Europe, USA, Rev. 1)</description>
+		<description>Boxxle (Europe, USA, Rev 1)</description>
 		<year>1990</year>
 		<publisher>FCI</publisher>
 		<info name="serial" value="DMG-SO-UKV, DMG-SO-USA" />
@@ -3073,7 +3073,7 @@ license:CC0
 	</software>
 
 	<software name="bugsbcol">
-		<description>Bugs Bunny Collection (Japan, Rev. 1)</description>
+		<description>Bugs Bunny Collection (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AWBJ-JPN" />
@@ -3316,7 +3316,7 @@ license:CC0
 	</software>
 
 	<software name="caesarsu" cloneof="caesars">
-		<description>Caesars Palace (USA, Rev. 1)</description>
+		<description>Caesars Palace (USA, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Arcadia Systems</publisher>
 		<info name="serial" value="DMG-CE-USA-1" />
@@ -3738,7 +3738,7 @@ license:CC0
 	</software>
 
 	<software name="chessmstu" cloneof="chessmst">
-		<description>The Chessmaster (USA, Rev. 1)</description>
+		<description>The Chessmaster (USA, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Hi Tech Expressions</publisher>
 		<info name="serial" value="DMG-EM-USA?" />
@@ -4834,7 +4834,7 @@ license:CC0
 	</software>
 
 	<software name="dinobred">
-		<description>Dino Breeder (Japan, Rev. 1)</description>
+		<description>Dino Breeder (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWDJ-JPN-1" />
@@ -4935,7 +4935,7 @@ license:CC0
 
 	<software name="dkong">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Donkey Kong (World, Rev. 1)</description>
+		<description>Donkey Kong (World, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-QDA, DMG-QD-ESP-1, DMG-QD-EUR, DMG-QD-FRG, DMG-QD-NOE, DMG-QD-SCN, DMG-QD-USA" />
@@ -5048,7 +5048,7 @@ license:CC0
 	</software>
 
 	<software name="dkland3">
-		<description>Donkey Kong Land III (Australia, Europe, USA, Rev. 1)</description>
+		<description>Donkey Kong Land III (Australia, Europe, USA, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AD3E-USA, DMG-AD3P-AUS, DMG-AD3P-EUR" />
@@ -5482,7 +5482,7 @@ license:CC0
 
 	<software name="drmario">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Dr. Mario (World, Rev. 1)</description>
+		<description>Dr. Mario (World, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VUA, DMG-VU-EUR, DMG-VU-ITA, DMG-VU-UKV, DMG-VU-USA" />
@@ -5862,7 +5862,7 @@ license:CC0
 	</software>
 
 	<software name="dxbakeno">
-		<description>DX Bakenou Z (Japan, Rev. 1)</description>
+		<description>DX Bakenou Z (Japan, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Asmik Ace</publisher>
 		<info name="serial" value="DMG-DZJ" />
@@ -6022,7 +6022,7 @@ license:CC0
 
 	<software name="f1race" supported="partial">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>F-1 Race (World, Rev. 1)</description>
+		<description>F-1 Race (World, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-F1A, DMG-F1-EUR, DMG-F1-NOE, DMG-F1-USA" />
@@ -6408,7 +6408,7 @@ license:CC0
 	</software>
 
 	<software name="fifa98">
-		<description>FIFA Road to the World Cup '98 (Europe, Rev. 1)</description>
+		<description>FIFA Road to the World Cup '98 (Europe, Rev 1)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-A8SP-EUU" />
@@ -6968,7 +6968,7 @@ license:CC0
 	</software>
 
 	<software name="gwatchu" cloneof="gwatch">
-		<description>Game &amp; Watch Gallery (USA, Rev. 1)</description>
+		<description>Game &amp; Watch Gallery (USA, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGAE-USA" />
@@ -7337,7 +7337,7 @@ license:CC0
 		<!--	In lot check as "dmgrae-1.108"	-->
 		<!--	European release is a relabeled USA version	-->
 		<!--	Unreleased in USA?	-->
-		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev. 1)</description>
+		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-RA-NOE-1" />
@@ -8239,7 +8239,7 @@ license:CC0
 	</software>
 
 	<software name="gbsyoji">
-		<description>Goukaku Boy Series - Gakken - Yojijukugo 288 (Japan, Rev. 1)</description>
+		<description>Goukaku Boy Series - Gakken - Yojijukugo 288 (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AY3J-JPN" />
@@ -8536,7 +8536,7 @@ license:CC0
 	</software>
 
 	<software name="gbsasob">
-		<description>Goukaku Boy Series - Shikakui Atama o Maruku Suru - Suuji de Asobou Sansuu Hen (Japan, Rev. 1)</description>
+		<description>Goukaku Boy Series - Shikakui Atama o Maruku Suru - Suuji de Asobou Sansuu Hen (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AM5J-JPN" />
@@ -9243,7 +9243,7 @@ license:CC0
 
 	<software name="kirbyj" cloneof="kirby">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Hoshi no Kirby (Japan, Rev. 1)</description>
+		<description>Hoshi no Kirby (Japan, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-KYJ" />
@@ -9474,7 +9474,7 @@ license:CC0
 	</software>
 
 	<software name="hyperloda">
-		<description>Hyper Lode Runner (World, Rev. 1)</description>
+		<description>Hyper Lode Runner (World, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="DMG-HLA, DMG-HL-UKV, DMG-HL-USA" />
@@ -10177,7 +10177,7 @@ license:CC0
 	<software name="jetsonsa">
 		<!--	In lot check as "dmgjse-1.588"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>The Jetsons - Robot Panic (USA, Rev. 1)</description>
+		<description>The Jetsons - Robot Panic (USA, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-JS-USA?" />
@@ -10723,7 +10723,7 @@ license:CC0
 	<software name="kasekia">
 		<!--	In lot check as "dmgakrj1.e41"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Kaseki Sousei Reborn (Japan, Rev. 1)</description>
+		<description>Kaseki Sousei Reborn (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AKRJ-JPN?" />
@@ -11113,7 +11113,7 @@ license:CC0
 
 	<software name="kininkoa">
 		<!--	In lot check as "dmgonj-1.153"	-->
-		<description>Kinin Koumaroku Oni (Japan, Rev. 1)</description>
+		<description>Kinin Koumaroku Oni (Japan, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-ONJ?" />
@@ -11596,7 +11596,7 @@ license:CC0
 	</software>
 
 	<software name="konchuhk">
-		<description>Konchuu Hakase (Japan, Rev. 1)</description>
+		<description>Konchuu Hakase (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AKJJ-JPN" />
@@ -11914,7 +11914,7 @@ license:CC0
 	</software>
 
 	<software name="zeldalnk">
-		<description>The Legend of Zelda - Link's Awakening (Europe, USA, Rev. 2)</description>
+		<description>The Legend of Zelda - Link's Awakening (Europe, USA, Rev 2)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-USA-1, DMG-ZL-EUR" />
@@ -11929,7 +11929,7 @@ license:CC0
 	</software>
 
 	<software name="zeldalnka" cloneof="zeldalnk">
-		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-UKV, DMG-ZL-ESP-1, DMG-ZL-CAN" />
@@ -12029,7 +12029,7 @@ license:CC0
 	</software>
 
 	<software name="lemmings">
-		<description>Lemmings (Europe, Rev. 1)</description>
+		<description>Lemmings (Europe, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="DMG-L8-NOE" />
@@ -12609,7 +12609,7 @@ license:CC0
 	</software>
 
 	<software name="saga" cloneof="ffantleg">
-		<description>Makai Toushi Sa-Ga (Japan, Rev. 1)</description>
+		<description>Makai Toushi Sa-Ga (Japan, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Square</publisher>
 		<info name="serial" value="DMG-SAJ" />
@@ -12993,7 +12993,7 @@ license:CC0
 
 	<software name="medakabu">
 		<!-- Notes: Also released by NP in 2000-03 -->
-		<description>Medarot - Kabuto Version (Japan, Rev. 1)</description>
+		<description>Medarot - Kabuto Version (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AMXJ-JPN" />
@@ -13043,7 +13043,7 @@ license:CC0
 
 	<software name="medakuwa">
 		<!-- Notes: Also released by NP in 2000-03 -->
-		<description>Medarot - Kuwagata Version (Japan, Rev. 1)</description>
+		<description>Medarot - Kuwagata Version (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AMYJ-JPN" />
@@ -13530,7 +13530,7 @@ license:CC0
 
 	<software name="mickey5a" cloneof="mickeymw">
 		<!--	In lot check as "dmgi5j-1.933"	-->
-		<description>Mickey Mouse V (Japan, Rev. 1)</description>
+		<description>Mickey Mouse V (Japan, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-I5J?" />
@@ -15363,7 +15363,7 @@ license:CC0
 	</software>
 
 	<software name="samspir">
-		<description>Nettou Samurai Spirits (China, Japan, Rev. 1)</description>
+		<description>Nettou Samurai Spirits (China, Japan, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-406 CHN, DMG-X4J" />
@@ -15458,7 +15458,7 @@ license:CC0
 
 	<software name="toshinj" cloneof="toshin">
 		<!-- Notes: Also released by NP in 2000-03 -->
-		<description>Nettou Toushinden (Japan, Rev. 1)</description>
+		<description>Nettou Toushinden (Japan, Rev 1)</description>
 		<year>1996</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ATDJ-JPN" />
@@ -15512,7 +15512,7 @@ license:CC0
 
 	<software name="wh2ja" cloneof="wh2">
 		<!--	In lot check as "dmgawjj1.a40"	-->
-		<description>Nettou World Heroes 2 Jet (Japan, Rev. 1)</description>
+		<description>Nettou World Heroes 2 Jet (Japan, Rev 1)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AWJJ-JPN?" />
@@ -16372,7 +16372,7 @@ license:CC0
 	<software name="pacintima">
 		<!--	In lot check as "dmgaptp1.a96"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Pac-In-Time (Europe, Rev. 1)</description>
+		<description>Pac-In-Time (Europe, Rev 1)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-APTP-?" />
@@ -17672,7 +17672,7 @@ license:CC0
 	</software>
 
 	<software name="pokepika" cloneof="pokeyell">
-		<description>Pocket Monsters - Pikachu (Japan, Rev. 3)</description>
+		<description>Pocket Monsters - Pikachu (Japan, Rev 3)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-APSJ-JPN" />
@@ -17696,7 +17696,7 @@ license:CC0
 	</software>
 
 	<software name="pokepikaa" cloneof="pokeyell">
-		<description>Pocket Monsters - Pikachu (Japan, Rev. 2)</description>
+		<description>Pocket Monsters - Pikachu (Japan, Rev 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-APSJ-JPN" />
@@ -17720,7 +17720,7 @@ license:CC0
 	</software>
 
 	<software name="pokepikab" cloneof="pokeyell">
-		<description>Pocket Monsters - Pikachu (Japan, Rev. 1)</description>
+		<description>Pocket Monsters - Pikachu (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-APSJ-JPN" />
@@ -17768,7 +17768,7 @@ license:CC0
 	</software>
 
 	<software name="pokeaka" cloneof="pokered">
-		<description>Pocket Monsters Aka (Japan, Rev. 1)</description>
+		<description>Pocket Monsters Aka (Japan, Rev 1)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-APAJ-JPN (G743404)" />
@@ -17834,7 +17834,7 @@ license:CC0
 	</software>
 
 	<software name="pokemido">
-		<description>Pocket Monsters Midori (Japan, Rev. 1)</description>
+		<description>Pocket Monsters Midori (Japan, Rev 1)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-APBJ-JPN (G743412)" />
@@ -17878,7 +17878,7 @@ license:CC0
 	<software name="poktpuyoa">
 		<!--	In lot check as "KENSA\dmgapyj1.0"	-->
 		<!-- NP only -->
-		<description>Pocket Puyo Puyo Tsuu (Japan, Rev. 1, NP)</description>
+		<description>Pocket Puyo Puyo Tsuu (Japan, Rev 1, NP)</description>
 		<year>1996</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-APYJ-JPN?" />
@@ -18376,7 +18376,7 @@ license:CC0
 
 	<software name="popeye2ja" cloneof="popeye2">
 		<!--	In lot check as "dmgpgj-1.403"	-->
-		<description>Popeye 2 (Japan, Rev. 1)</description>
+		<description>Popeye 2 (Japan, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Sigma</publisher>
 		<info name="serial" value="DMG-PGJ" />
@@ -18435,7 +18435,7 @@ license:CC0
 	</software>
 
 	<software name="powermisj" cloneof="powermis">
-		<description>Power Mission (Japan, Rev. 1)</description>
+		<description>Power Mission (Japan, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Vap</publisher>
 		<info name="serial" value="DMG-XCA" />
@@ -18481,7 +18481,7 @@ license:CC0
 	</software>
 
 	<software name="powerpro">
-		<description>Power Pro GB (Japan, Rev. 1)</description>
+		<description>Power Pro GB (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-APWJ-JPN (RK144-J1)" />
@@ -18809,7 +18809,7 @@ license:CC0
 	<software name="purikuraa">
 		<!--	In lot check as "KENSA\dmgappj1.0"	-->
 		<!-- NP only -->
-		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev. 1, NP)</description>
+		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev 1, NP)</description>
 		<year>1997</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-APPJ-JPN?" />
@@ -18884,7 +18884,7 @@ license:CC0
 	</software>
 
 	<software name="puyopuyo">
-		<description>Puyo Puyo (Japan, Rev. 1)</description>
+		<description>Puyo Puyo (Japan, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-QQJ" />
@@ -19724,7 +19724,7 @@ license:CC0
 	</software>
 
 	<software name="robocop">
-		<description>RoboCop (Europe, USA, Rev. 1)</description>
+		<description>RoboCop (Europe, USA, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Ocean</publisher>
 		<info name="serial" value="DMG-CP-FAH, DMG-CP-NOE, DMG-CP-USA" />
@@ -19983,7 +19983,7 @@ license:CC0
 
 	<software name="mvpbba">
 		<!--	In lot check as "dmgvme-1.640"	-->
-		<description>Roger Clemens' MVP Baseball (USA, Rev. 1)</description>
+		<description>Roger Clemens' MVP Baseball (USA, Rev 1)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="DMG-VM-USA?" />
@@ -20085,7 +20085,7 @@ license:CC0
 	</software>
 
 	<software name="saga2" cloneof="ffantlg2">
-		<description>Sa-Ga 2 - Hihou Densetsu (Japan, Rev. 1)</description>
+		<description>Sa-Ga 2 - Hihou Densetsu (Japan, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Square</publisher>
 		<info name="serial" value="DMG-S2J" />
@@ -20308,7 +20308,7 @@ license:CC0
 	</software>
 
 	<software name="sanrioup">
-		<description>Sanrio Uranai Party (Japan, Rev. 1)</description>
+		<description>Sanrio Uranai Party (Japan, Rev 1)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AG7J-JPN" />
@@ -20961,7 +20961,7 @@ license:CC0
 	</software>
 
 	<software name="shogisai">
-		<description>Shougi Saikyou (Japan, Rev. 1)</description>
+		<description>Shougi Saikyou (Japan, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Magical Company</publisher>
 		<info name="serial" value="DMG-AMSJ-JPN" />
@@ -21199,7 +21199,7 @@ license:CC0
 	</software>
 
 	<software name="smurfs">
-		<description>The Smurfs (Europe, USA, Rev. 1)</description>
+		<description>The Smurfs (Europe, USA, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-UF-FAH-1, DMG-UF-NOE-1, DMG-UF-USA)" />
@@ -22117,7 +22117,7 @@ license:CC0
 	</software>
 
 	<software name="starwars">
-		<description>Star Wars (Europe, USA, Rev. 1)</description>
+		<description>Star Wars (Europe, USA, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-WS-EUR, DMG-WS-USA-1" />
@@ -22241,7 +22241,7 @@ license:CC0
 	</software>
 
 	<software name="sf2">
-		<description>Street Fighter II (Europe, USA, Rev. 1)</description>
+		<description>Street Fighter II (Europe, USA, Rev 1)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ASFE-USA, DMG-ASFE-USA-1, DMG-ASFP-EUR, DMG-ASFP-NOE" />
@@ -22712,7 +22712,7 @@ license:CC0
 
 	<software name="sml">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Super Mario Land (World, Rev. 1)</description>
+		<description>Super Mario Land (World, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-101 CHN, DMG-MLA, DMG-ML-CAN, DMG-ML-ESP-1, DMG-ML-FAH, DMG-ML-ITA, DMG-ML-NOE, DMG-ML-UKV, DMG-ML-USA, DMG-ML-USA-1" />
@@ -22751,7 +22751,7 @@ license:CC0
 	</software>
 
 	<software name="sml2">
-		<description>Super Mario Land 2 - 6 Golden Coins (Australia, China, Europe, USA, Rev. 2)</description>
+		<description>Super Mario Land 2 - 6 Golden Coins (Australia, China, Europe, USA, Rev 2)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-401 CHN, DMG-MQ-AUS, DMG-MQ-EUR, DMG-MQ-UKV, DMG-MQ-USA, DMG-MQ-USA-1" />
@@ -22776,7 +22776,7 @@ license:CC0
 	</software>
 
 	<software name="sml2a" cloneof="sml2">
-		<description>Super Mario Land 2 - 6 Golden Coins (Europe, USA, Rev. 1)</description>
+		<description>Super Mario Land 2 - 6 Golden Coins (Europe, USA, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-MQ-USA, DMG-MQ-ESP-1" />
@@ -22819,7 +22819,7 @@ license:CC0
 
 	<software name="sml2j" cloneof="sml2">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Super Mario Land 2 - 6-tsu no Kinka (Japan, Rev. 2)</description>
+		<description>Super Mario Land 2 - 6-tsu no Kinka (Japan, Rev 2)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-L6J" />
@@ -22843,7 +22843,7 @@ license:CC0
 
 	<software name="sml2ja" cloneof="sml2">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Super Mario Land 2 - 6-tsu no Kinka (Japan, Rev. 1)</description>
+		<description>Super Mario Land 2 - 6-tsu no Kinka (Japan, Rev 1)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-L6J" />
@@ -23626,7 +23626,7 @@ license:CC0
 	<software name="tmnt3a" cloneof="tmnt3">
 		<!--	In lot check as "dmgk8x-1.918"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)</description>
+		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-K8-UKV?" />
@@ -23868,7 +23868,7 @@ license:CC0
 
 	<software name="tetris">
 		<!-- Also released via the Nintendo Power service in 2000-09 -->
-		<description>Tetris (World, Rev. 1)</description>
+		<description>Tetris (World, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-104 CHN, DMG-TRA, DMG-TR-AUS, DMG-TR-CAN, DMG-TR-ESP, DMG-TR-ESP-1, DMG-TR-EUR, DMG-TR-HKG, DMG-TR-NOE, DMG-TR-SCN-1, DMG-TR-UKV, DMG-TR-USA" />
@@ -23902,7 +23902,7 @@ license:CC0
 
 	<software name="tetris2a">
 		<!--	In lot check as "dmgehx-1.@08"	-->
-		<description>Tetris 2 (Europe, Rev. 1)</description>
+		<description>Tetris 2 (Europe, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="gold" value="19961029"/>
@@ -23965,7 +23965,7 @@ license:CC0
 	</software>
 
 	<software name="tetrisat">
-		<description>Tetris Attack (Europe, USA, Rev. 1)</description>
+		<description>Tetris Attack (Europe, USA, Rev 1)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYLE-USA, DMG-AYLP-EUR" />
@@ -24525,7 +24525,7 @@ license:CC0
 	</software>
 
 	<software name="toystoryu" cloneof="toystory">
-		<description>Disney's Toy Story (USA, Rev. 1)</description>
+		<description>Disney's Toy Story (USA, Rev 1)</description>
 		<year>1996</year>
 		<publisher>Black Pearl</publisher>
 		<info name="serial" value="DMG-AQHE-USA" />
@@ -26187,7 +26187,7 @@ license:CC0
 
 	<software name="yakuman">
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
-		<description>Yakuman (Japan, Rev. 1)</description>
+		<description>Yakuman (Japan, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-MJJ" />
@@ -26461,7 +26461,7 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkj" cloneof="zeldalnk">
-		<description>Zelda no Densetsu - Yume o Miru Shima (China, Japan, Rev. 1)</description>
+		<description>Zelda no Densetsu - Yume o Miru Shima (China, Japan, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZLJ, DMG-407 CHN" />
@@ -27131,7 +27131,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 	</software>
 
 	<software name="pockcam" cloneof="gboycam" supported="no">
-		<description>Pocket Camera (Japan, Rev. 1)</description>
+		<description>Pocket Camera (Japan, Rev 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="MGB-006" />

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -22,6 +22,8 @@ license:CC0
 	- Suzuki Aguri no F-1 Super Driving (Japan)
 	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
+	- Robot Ponkottsu Taikenban
+	- From TV Animation Slam Dunk - Shueisha Limited Version
 
   Undumped pirate carts:
 	- GOWIN carts (see below the list of known games)
@@ -1857,33 +1859,33 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Battle Space requires Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards (all EAN-13):
-	    1 (up):
-	        4905672306367
-	    1 (down):
-	        4902776809367
-	    2 (up):
-	        4908052808369
-	    2 (down):
-	        4907981000301
-	    3 (up):
-	        4911826551347
-	    3 (down):
-	        4909062206350
-	    4 (up):
-	        4913508504399
-	    4 (down):
-	        4912713004366
-	    5 (up):
-	        4918156001351
-	    5 (down):
-	        4916911302309
-	There is also a "free card" without barcodes.
-	-->
 	<software name="bspace" supported="no">
+		<!--
+		Battle Space requires Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards (all EAN-13):
+			1 (up):
+				4905672306367
+			1 (down):
+				4902776809367
+			2 (up):
+				4908052808369
+			2 (down):
+				4907981000301
+			3 (up):
+				4911826551347
+			3 (down):
+				4909062206350
+			4 (up):
+				4913508504399
+			4 (down):
+				4912713004366
+			5 (up):
+				4918156001351
+			5 (down):
+				4916911302309
+		There is also a "free card" without barcodes.
+		-->
 		<description>Battle Space (Japan)</description>
 		<year>1992</year>
 		<publisher>Namcot</publisher>
@@ -2076,7 +2078,7 @@ license:CC0
 		<description>Beethoven (Europe)</description>
 		<year>1994</year>
 		<publisher>Hi Tech Expressions</publisher>
-		<info name="alt_title" value="Beethoven - The Ultimate Canine Caper! (Box)" />
+		<info name="alt_title" value="Beethoven - The Ultimate Canine Caper (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<dataarea name="rom" size="131072">
@@ -3989,8 +3991,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Game cart has an integrated infrared port for multiplayer play. -->
 	<software name="spinner">
+		<!-- Game cart has an integrated infrared port for multiplayer play. -->
 		<description>Chousoku Spinner (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -4488,12 +4490,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	The Miracle of the Zone supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
-	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
-	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
-	-->
 	<software name="miraclzn">
+		<!--
+		Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
+		port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
+		-->
 		<description>Daikaijuu Monogatari - The Miracle of the Zone (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -6156,25 +6158,25 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Family Jockey 2 is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards:
-	    バーコードカード No. 1 (barcode card #1)
-	        競争馬 A (Racehorse A): 5893713522816 (EAN-13)
-	        競争馬 B (Racehorse B): 1509843019075 (EAN-13)
-	    バーコードカード No. 2 (barcode card #2)
-	        繁殖馬 A (Breeding horse A): 2378649896765 (EAN-13)
-	        繁殖馬 B (Breeding horse B): 4232978865152 (EAN-13)
-	    バーコードカード No. 3 (barcode card #3)
-	        繁殖馬 C (Breeding horse C): 7164625542390 (EAN-13)
-	    バーコードカード No. 4 (barcode card #4)
-	        種馬 A (Stallion A): 9845554422318 (EAN-13)
-	        種馬 B (Stallion B): 3572821107673 (EAN-13)
-	    バーコードカード No. 5 (barcode card #5)
-	        種馬 C (Stallion C) : 6319537443513 (EAN-13)
-	-->
 	<software name="famjock2">
+		<!--
+		Family Jockey 2 is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards:
+			バーコードカード No. 1 (barcode card #1)
+				競争馬 A (Racehorse A): 5893713522816 (EAN-13)
+				競争馬 B (Racehorse B): 1509843019075 (EAN-13)
+			バーコードカード No. 2 (barcode card #2)
+				繁殖馬 A (Breeding horse A): 2378649896765 (EAN-13)
+				繁殖馬 B (Breeding horse B): 4232978865152 (EAN-13)
+			バーコードカード No. 3 (barcode card #3)
+				繁殖馬 C (Breeding horse C): 7164625542390 (EAN-13)
+			バーコードカード No. 4 (barcode card #4)
+				種馬 A (Stallion A): 9845554422318 (EAN-13)
+				種馬 B (Stallion B): 3572821107673 (EAN-13)
+			バーコードカード No. 5 (barcode card #5)
+				種馬 C (Stallion C) : 6319537443513 (EAN-13)
+		-->
 		<description>Family Jockey 2 - Meiba no Kettou (Japan)</description>
 		<year>1993</year>
 		<publisher>Namcot</publisher>
@@ -6233,20 +6235,20 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Family Stadium 3 (Famista 3) is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards (all EAN-13):
-	    No. 1: ホームランバッター
-	        8357933639923
-	    No. 2: 高打率バッター
-	        7814374127798
-	    No. 3: 駿足バッター
-	        9880692151263
-	    No. 4: ピッチャー
-	        1414213562177
-	-->
 	<software name="famista3">
+		<!--
+		Family Stadium 3 (Famista 3) is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards (all EAN-13):
+			No. 1: ホームランバッター
+				8357933639923
+			No. 2: 高打率バッター
+				7814374127798
+			No. 3: 駿足バッター
+				9880692151263
+			No. 4: ピッチャー
+				1414213562177
+		-->
 		<description>Famista 3 (Japan)</description>
 		<year>1993</year>
 		<publisher>Namcot</publisher>
@@ -7467,12 +7469,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	"GBKiss" is an integrated infrared port for cart-to-cart multiplayer play, but also for PC connection
-	with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel port (DB25) modem/adaptor for PC-DOS
-	for transfering files between the game and a computer.
-	-->
 	<software name="gbkiss">
+		<!--
+		"GBKiss" is an integrated infrared port for cart-to-cart multiplayer play, but also for PC connection
+		with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel port (DB25) modem/adaptor for PC-DOS
+		for transfering files between the game and a computer.
+		-->
 		<description>GBKiss Mini Games (Japan)</description>
 		<year>1997</year> <!-- Year printed on the cart label -->
 		<publisher>Hudson Soft</publisher>
@@ -9461,7 +9463,8 @@ license:CC0
 	</software>
 
 	<software name="hyperloda">
-		<!--	Region "A" according to filename	-->
+		<!--	In lot check as "dmghla-1.011"	-->
+		<!--	Region code "A"	-->
 		<description>Hyper Lode Runner (World, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
@@ -9480,7 +9483,7 @@ license:CC0
 	<software name="hyperlod" cloneof="hyperloda">
 		<!--	In lot check as "dmghla-0.011"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<!--	Region "A" according to filename	-->
+		<!--	Region code "A"	-->
 		<description>Hyper Lode Runner (Japan?)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
@@ -9983,6 +9986,7 @@ license:CC0
 		<year>1993</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="DMG-JVJ" />
+		<info name="gold" value="19930531" />
 		<info name="release" value="19930723" />
 		<info name="alt_title" value="ジャレコ J・カップサッカー" />
 		<part name="cart" interface="gameboy_cart">
@@ -10754,24 +10758,24 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Kattobi Road is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards (all EAN-13):
-	    No. 1:
-	        4903301160625
-	    No. 2:
-	        4987084410924
-	    No. 3:
-	        4902888119101
-	    No. 4:
-	        4901121110004
-	    No. 5 (up):
-	        4902105002063
-	    No. 5 (down):
-	        4901780161157
-	-->
 	<software name="kattobi">
+		<!--
+		Kattobi Road is compatible with Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards (all EAN-13):
+			No. 1:
+				4903301160625
+			No. 2:
+				4987084410924
+			No. 3:
+				4902888119101
+			No. 4:
+				4901121110004
+			No. 5 (up):
+				4902105002063
+			No. 5 (down):
+				4901780161157
+		-->
 		<description>Kattobi Road (Japan)</description>
 		<year>1993</year>
 		<publisher>Namcot</publisher>
@@ -11953,7 +11957,6 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Bad dump? -->
 	<software name="zeldalnkc" cloneof="zeldalnk">
 		<description>The Legend of Zelda - Link's Awakening (Canada)</description>
 		<year>1993</year>
@@ -14166,29 +14169,29 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Monster Maker requires Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards (all EAN-13):
-	    1 (fg up):
-	        9120153954577
-	    1 (fg down):
-	        9022038781998
-	    1 (bg up):
-	        9362462085911
-	    1 (bg down):
-	        9752412234900
-	    2 (fg up):
-	        9052091324955
-	    2 (fg down):
-	        9322158686716
-	    2 (bg up):
-	        9447410810323
-	    2 (bg down):
-	        9998017308336
-	Cards 3, 4 and 5 contains no barcodes.
-	-->
 	<software name="monstmkr">
+		<!--
+		Monster Maker requires Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards (all EAN-13):
+			1 (fg up):
+				9120153954577
+			1 (fg down):
+				9022038781998
+			1 (bg up):
+				9362462085911
+			1 (bg down):
+				9752412234900
+			2 (fg up):
+				9052091324955
+			2 (fg down):
+				9322158686716
+			2 (bg up):
+				9447410810323
+			2 (bg down):
+				9998017308336
+		Cards 3, 4 and 5 contains no barcodes.
+		-->
 		<description>Monster Maker (Japan)</description>
 		<year>1990</year>
 		<publisher>Sofel</publisher>
@@ -14205,29 +14208,29 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Monster Maker - Barcode Saga requires Barcode Boy, a barcode reader accessory for Game Boy.
-	The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
-	It came bundled with the following barcode cards (all EAN-13):
-	    1 (fg up):
-	        9120153954577
-	    1 (fg down):
-	        9022038781998
-	    1 (bg up):
-	        9362462085911
-	    1 (bg down):
-	        9752412234900
-	    2 (fg up):
-	        9052091324955
-	    2 (fg down):
-	        9322158686716
-	    2 (bg up):
-	        9447410810323
-	    2 (bg down):
-	        9998017308336
-	Cards 3, 4 and 5 contains no barcodes.
-	-->
 	<software name="monstmkb" supported="no">
+		<!--
+		Monster Maker - Barcode Saga requires Barcode Boy, a barcode reader accessory for Game Boy.
+		The Barcode Boy is based on Intel N80C51BH (internal ROM undumped).
+		It came bundled with the following barcode cards (all EAN-13):
+			1 (fg up):
+				9120153954577
+			1 (fg down):
+				9022038781998
+			1 (bg up):
+				9362462085911
+			1 (bg down):
+				9752412234900
+			2 (fg up):
+				9052091324955
+			2 (fg down):
+				9322158686716
+			2 (bg up):
+				9447410810323
+			2 (bg down):
+				9998017308336
+		Cards 3, 4 and 5 contains no barcodes.
+		-->
 		<description>Monster Maker - Barcode Saga (Japan)</description>
 		<year>1993</year>
 		<publisher>Namcot</publisher>
@@ -15152,12 +15155,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Nectaris supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
-	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
-	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
-	-->
 	<software name="nectaris">
+		<!--
+		Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
+		port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
+		-->
 		<description>Nectaris GB (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -16450,7 +16453,7 @@ license:CC0
 		<!--	In lot check as "dmgpca-0.159"	-->
 		<!--	Lot check ROM is padded with FFs to twice its size, but correct size is 512kb (64KB) according to the official release spreadsheet	-->
 		<!--	Retail cartridge not yet secured	-->
-		<!--	Region "A" according to filename	-->
+		<!--	Region code "A"	-->
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
 		<description>Pac-Man (Japan)</description>
 		<year>1990</year>
@@ -17225,12 +17228,13 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- is this a clone of pinbalfn? -->
 	<software name="pinbaldx">
+		<!--	Enhanced version of Pinball Fantasies with 3 extra tables	-->
 		<description>Pinball Deluxe (Europe)</description>
 		<year>1995</year>
 		<publisher>GameTek</publisher>
 		<info name="serial" value="DMG-APDP-EUR" />
+		<info name="gold" value="19950719" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" /> <!-- Also found with DMG-BEAN(K)-02 -->
 			<feature name="u1" value="U1 PRG" />
@@ -17262,7 +17266,8 @@ license:CC0
 		<description>Pinball Fantasies (Europe, USA)</description>
 		<year>1994</year>
 		<publisher>GameTek</publisher>
-		<info name="serial" value="DMG-APFE-USA, DMG-APFP-EUR" />
+		<info name="serial" value="DMG-APFP-EUR, DMG-APFE-USA" />
+		<info name="gold" value="19941216, 19950110" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -17463,12 +17468,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Pocket Bomberman (Japan) supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
-	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
-	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
-	-->
 	<software name="pockbmanj" cloneof="pockbman">
+		<!--
+		Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
+		port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
+		-->
 		<description>Pocket Bomberman (Japan)</description>
 		<year>1997</year>
 		<publisher>Hudson Soft</publisher>
@@ -17508,12 +17513,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Pocket Family supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
-	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
-	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
-	-->
 	<software name="pockfam">
+		<!--
+		Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
+		port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
+		-->
 		<description>Pocket Family (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -18670,7 +18675,6 @@ license:CC0
 		</part>
 	</software>
 
-<!-- Does this have a battery?!? -->
 	<software name="proyak91">
 		<description>Higashio Osamu Kanshuu Pro Yakyuu Stadium '91 (Japan)</description>
 		<year>1991</year>
@@ -18688,7 +18692,7 @@ license:CC0
 			<dataarea name="rom" size="131072">
 				<rom name="dmg-pij-0.u1" size="131072" crc="420881ae" sha1="cc6cbbcaabce4a63106da3c9b5e4a761511cae38" />
 			</dataarea>
-			<dataarea name="nvram" size="8192">
+			<dataarea name="nvram" size="8192"> <!-- unconfirmed size -->
 			</dataarea>
 		</part>
 	</software>
@@ -21248,12 +21252,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- "Snoopy's Magic Show"? -->
 	<software name="snoopy">
 		<description>Snoopy - Magic Show (Europe, USA)</description>
 		<year>1990</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-SN-ESP, DMG-SN-USA" />
+		<info name="alt_title" value="Snoopy's Magic Show" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -21586,8 +21590,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- is this really a clone of the 1994 release?? -->
 	<software name="spaceinvj" cloneof="spaceinv">
+		<!--	The 1994 release is technically an improved localization of this, since it shares its "SP" code	-->
 		<!-- Notes: Also release by NP in 2000-03 -->
 		<description>Space Invaders (Japan)</description>
 		<year>1990</year>
@@ -21769,6 +21773,7 @@ license:CC0
 		<year>1993</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-R5-UKV" />
+		<info name="gold" value="19930209" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="65536">
@@ -21795,11 +21800,13 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- how is this related to Splitz?? -->
-	<software name="uchiiwai">
+	<software name="uchiiwai" cloneof="splitz">
 		<description>Uchiiwai - Kyoudaijingi no Puzzle Game (Japan)</description>
 		<year>1994</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="serial" value="DMG-AWNJ-?" />
+		<info name="alt_title" value="内祝　兄弟神技のパズルゲーム" />
+		<info name="gold" value="19941006" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="65536">
@@ -22340,12 +22347,12 @@ license:CC0
 		</part>
 	</software>
 
-	<!--
-	Super B-Daman - Fighting Phoenix supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
-	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
-	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
-	-->
 	<software name="sbdaman">
+		<!--
+		Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
+		port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
+		-->
 		<description>Super B-Daman - Fighting Phoenix (Japan)</description>
 		<year>1997</year>
 		<publisher>Hudson Soft</publisher>
@@ -23369,12 +23376,13 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- is this a clone of goal too, or a real sequel to Jaleco J.Cup Soccer? -->
 	<software name="acestrik">
+		<!-- Is this a rebranded clone of Goal too or a sequel to Jaleco J.Cup Soccer, released half a year earlier? -->
 		<description>Takeda Nobuhiro no Ace Striker (Japan)</description>
 		<year>1994</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="DMG-JRJ" />
+		<info name="gold" value="19931215" />
 		<info name="release" value="19940218" />
 		<info name="alt_title" value="武田修宏のエースストライカー" />
 		<part name="cart" interface="gameboy_cart">
@@ -27152,14 +27160,14 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		</part>
 	</software>
 
-	<!--
-	The game cart includes a real 200MHz fishing sonar (developed in cooperation with Honda Electronics).
-	There is a separated PCB labeled "HD0B220002" for the sonar components and a jack connector for attaching the
-	sonar (20 meters cable with its head on the other end).
-	There is a Game Boy prototype version (undumped) named "Handy Watcher", and also a WonderSwan version named "Handy Sonar".
-	It's a Nintendo officially licensed product from Bandai.
-	-->
 	<software name="pocksonr">
+		<!--
+		The game cart includes a real 200MHz fishing sonar (developed in cooperation with Honda Electronics).
+		There is a separated PCB labeled "HD0B220002" for the sonar components and a jack connector for attaching the
+		sonar (20 meters cable with its head on the other end).
+		There is a Game Boy prototype version (undumped) named "Handy Watcher", and also a WonderSwan version named "Handy Sonar".
+		It's a Nintendo officially licensed product from Bandai.
+		-->
 		<description>Pocket Sonar (Japan)</description>
 		<year>1998</year>
 		<publisher>Bandai</publisher>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -11,21 +11,7 @@ license:CC0
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
 	- GI King! - Sanbiki no Yosouya (Japan)
-	- Hyper Lode Runner (World)
-	- The Jetsons - Robot Panic (USA, Rev 1)
-	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Japan, Rev 1)
-	- Disney's Mulan (USA)
-	- Pac-In-Time (Europe, Rev 1)
-	- Pac-Man (Japan)
-	- Pang (UK)
-	- Suzuki Aguri no F-1 Super Driving (Japan)
-	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
-	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
-	- The Adventures of Rocky and Bullwinkle (USA)
-	- Fastest Lap (USA)
-	- GI King! - Sanbiki no Yosouya (Japan)
-	- Hyper Lode Runner (World)
+	- Hyper Lode Runner (Japan?)
 	- The Jetsons - Robot Panic (USA, Rev 1)
 	- Jungle Strike (USA)
 	- Kaseki Sousei Reborn (Japan, Rev 1)
@@ -2090,8 +2076,9 @@ license:CC0
 		<description>Beethoven (Europe)</description>
 		<year>1994</year>
 		<publisher>Hi Tech Expressions</publisher>
-		<info name="alt_title" value="Beethoven - The Ultimate Canine Caper (Box)" />
+		<info name="alt_title" value="Beethoven - The Ultimate Canine Caper! (Box)" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<dataarea name="rom" size="131072">
 				<rom name="beethoven's 2nd (europe).bin" size="131072" crc="637e54e3" sha1="a175778faca00f096f0bfdbaa844a38816bbeb0f" />
 			</dataarea>
@@ -9474,6 +9461,7 @@ license:CC0
 	</software>
 
 	<software name="hyperloda">
+		<!--	Region "A" according to filename	-->
 		<description>Hyper Lode Runner (World, Rev 1)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
@@ -9492,7 +9480,8 @@ license:CC0
 	<software name="hyperlod" cloneof="hyperloda">
 		<!--	In lot check as "dmghla-0.011"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Hyper Lode Runner (World)</description>
+		<!--	Region "A" according to filename	-->
+		<description>Hyper Lode Runner (Japan?)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
 		<info name="gold" value="19890609" />
@@ -16461,7 +16450,7 @@ license:CC0
 		<!--	In lot check as "dmgpca-0.159"	-->
 		<!--	Lot check ROM is padded with FFs to twice its size, but correct size is 512kb (64KB) according to the official release spreadsheet	-->
 		<!--	Retail cartridge not yet secured	-->
-		<!--	World version according to region code	-->
+		<!--	Region "A" according to filename	-->
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
 		<description>Pac-Man (Japan)</description>
 		<year>1990</year>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -4,7 +4,7 @@
 license:CC0
 
   To investigate:
-	- Gargoyle's Quest - Ghosts'n Goblins (Rev 1)	<-	Unreleased in the USA?
+	- Gargoyle's Quest - Ghosts'n Goblins (Rev 1)	<-	Unreleased in USA?
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 
   Known dumps not yet verified against retail cartridge:
@@ -24,6 +24,8 @@ license:CC0
 	- Suzuki Aguri no F-1 Super Driving (Japan)
 	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
 	- World Cup Striker (Europe, En / Fra / Ger)
+	- Robot Ponkottsu Taikenban
+	- From TV Animation Slam Dunk - Shueisha Limited Version
 
   Undumped pirate carts:
 	- GOWIN carts (see below the list of known games)
@@ -291,7 +293,8 @@ license:CC0
 	</software>
 
 	<software name="rockybwunk" cloneof="rockybw">
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	Three different bytes in the header	-->
 		<description>The Adventures of Rocky and Bullwinkle (USA, bad dump?)</description>
 		<year>1992</year>
 		<publisher>T*HQ</publisher>
@@ -5969,6 +5972,7 @@ license:CC0
 		<info name="serial" value="DMG-YK-USA" />
 		<info name="gold" value="19940617" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="elite soccer (usa).bin" size="131072" crc="f54158a6" sha1="4576881ea25e29ebba91c49c89f8e70e105fbc60" />
@@ -7680,30 +7684,6 @@ license:CC0
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="DMG-GIJ" />
 		<info name="gold" value="19930204" />
-		<info name="release" value="19930326" />
-		<info name="alt_title" value="GIキング! 三匹の予想屋" />
-		<part name="cart" interface="gameboy_cart">
-			<feature name="pcb" value="DMG-DECN-02" />
-			<feature name="u1" value="U1 PRG" />
-			<feature name="u2" value="U2 MBC1/1A/1B" />
-			<feature name="u3" value="U3 RAM" />
-			<feature name="u4" value="U4 26A" />
-			<feature name="batt" value="Batt CR1616" />
-			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmg-gij-0.u1" size="131072" crc="f0dff737" sha1="65265b1c28173a6df0fede8c025cce56e752b1fd"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gikingunk" cloneof="giking">
-		<!-- Old dump of unknown origin -->
-		<description>GI King! - Sanbiki no Yosouya (Japan, bad dump?)</description>
-		<year>1993</year>
-		<publisher>Vic Tokai</publisher>
-		<info name="serial" value="DMG-GIJ" />
 		<info name="release" value="19930326" />
 		<info name="alt_title" value="GIキング! 三匹の予想屋" />
 		<part name="cart" interface="gameboy_cart">
@@ -16879,7 +16859,8 @@ license:CC0
 	</software>
 
 	<software name="pangunk" cloneof="pang">
-		<!-- Old dump of unknown origin -->
+		<!--	Old dump of unknown origin	-->
+		<!--	One different byte in the header, different padding at the end -->
 		<description>Pang (UK, bad dump?)</description>
 		<year>1993</year>
 		<publisher>Hudson Soft</publisher>
@@ -20728,8 +20709,9 @@ license:CC0
 		<description>Shanghai Pocket (Japan)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-ASEJ?" />
-		<info name="release" value="19980806?" />
+		<info name="serial" value="DMG-ASEJ-JPN?"/>
+		<info name="gold" value="19980701"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="上海 ポケット" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
@@ -23097,8 +23079,9 @@ license:CC0
 	</software>
 
 	<software name="suzukif1unk" cloneof="suzukif1">
-		<!-- Old dump of unknown origin -->
-		<description>Suzuki Aguri no F-1 Super Driving (Japan, bad dump?)</description>
+		<!--	Old dump of unknown origin	-->
+		<!--	Possible prototype?	-->
+		<description>Suzuki Aguri no F-1 Super Driving (Japan, prototype?)</description>
 		<year>1993</year>
 		<publisher>Logic</publisher>
 		<info name="alt_title" value="鈴木亜久里のF-1スーパードライビング" />

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -22,8 +22,6 @@ license:CC0
 	- Suzuki Aguri no F-1 Super Driving (Japan)
 	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
-	- Robot Ponkottsu Taikenban
-	- From TV Animation Slam Dunk - Shueisha Limited Version
 
   Undumped pirate carts:
 	- GOWIN carts (see below the list of known games)
@@ -21801,6 +21799,7 @@ license:CC0
 	</software>
 
 	<software name="uchiiwai" cloneof="splitz">
+		<!--	Reskinned version of Splitz, based on the manga Kyoudaijingi	-->
 		<description>Uchiiwai - Kyoudaijingi no Puzzle Game (Japan)</description>
 		<year>1994</year>
 		<publisher>&lt;unknown&gt;</publisher>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -5,36 +5,36 @@ license:CC0
 
   To investigate:
 	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
-	- Was Gargoyle's Quest (Rev. A) released in the USA?
+	- Was Gargoyle's Quest (Rev. 1) released in the USA?
 
   Known dumps not yet verified against retail cartridge:
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
 	- GI King! - Sanbiki no Yosouya (Japan)
 	- Hyper Lode Runner (World)
-	- The Jetsons - Robot Panic (USA, Rev. A)
+	- The Jetsons - Robot Panic (USA, Rev. 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Jpn, Rev. A)
+	- Kaseki Sousei Reborn (Jpn, Rev. 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Euro, Rev. A)
+	- Pac-In-Time (Euro, Rev. 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
-	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
 	- GI King! - Sanbiki no Yosouya (Japan)
 	- Hyper Lode Runner (World)
-	- The Jetsons - Robot Panic (USA, Rev. A)
+	- The Jetsons - Robot Panic (USA, Rev. 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Jpn, Rev. A)
+	- Kaseki Sousei Reborn (Jpn, Rev. 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Euro, Rev. A)
+	- Pac-In-Time (Euro, Rev. 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
-	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)
 	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 
   Undumped pirate carts:
@@ -793,7 +793,7 @@ license:CC0
 
 	<software name="amoudan2a">
 		<!--	In lot check as "dmgauj-1.434"	-->
-		<description>America Oudan Ultra Quiz Part 2 (Jpn, Rev. A)</description>
+		<description>America Oudan Ultra Quiz Part 2 (Jpn, Rev. 1)</description>
 		<year>1991</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-AUJ" />
@@ -6408,7 +6408,7 @@ license:CC0
 	</software>
 
 	<software name="fifa98">
-		<description>FIFA Road to the World Cup '98 (Euro, Rev. A)</description>
+		<description>FIFA Road to the World Cup '98 (Euro, Rev. 1)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-A8SP-EUU" />
@@ -6968,7 +6968,7 @@ license:CC0
 	</software>
 
 	<software name="gwatchu" cloneof="gwatch">
-		<description>Game &amp; Watch Gallery (USA, Rev. A)</description>
+		<description>Game &amp; Watch Gallery (USA, Rev. 1)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGAE-USA" />
@@ -7337,7 +7337,7 @@ license:CC0
 		<!--	In lot check as "dmgrae-1.108"	-->
 		<!--	European release is a relabeled USA version	-->
 		<!--	Unreleased in USA?	-->
-		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev. A)</description>
+		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev. 1)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-RA-NOE-1" />
@@ -10177,7 +10177,7 @@ license:CC0
 	<software name="jetsonsa">
 		<!--	In lot check as "dmgjse-1.588"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>The Jetsons - Robot Panic (USA, Rev. A)</description>
+		<description>The Jetsons - Robot Panic (USA, Rev. 1)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-JS-USA?" />
@@ -10723,7 +10723,7 @@ license:CC0
 	<software name="kasekia">
 		<!--	In lot check as "dmgakrj1.e41"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Kaseki Sousei Reborn (Jpn, Rev. A)</description>
+		<description>Kaseki Sousei Reborn (Jpn, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AKRJ-JPN?" />
@@ -11113,7 +11113,7 @@ license:CC0
 
 	<software name="kininkoa">
 		<!--	In lot check as "dmgonj-1.153"	-->
-		<description>Kinin Koumaroku Oni (Jpn, Rev. A)</description>
+		<description>Kinin Koumaroku Oni (Jpn, Rev. 1)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-ONJ?" />
@@ -13530,7 +13530,7 @@ license:CC0
 
 	<software name="mickey5a" cloneof="mickeymw">
 		<!--	In lot check as "dmgi5j-1.933"	-->
-		<description>Mickey Mouse V (Jpn, Rev. A)</description>
+		<description>Mickey Mouse V (Jpn, Rev. 1)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-I5J?" />
@@ -15512,7 +15512,7 @@ license:CC0
 
 	<software name="wh2ja" cloneof="wh2">
 		<!--	In lot check as "dmgawjj1.a40"	-->
-		<description>Nettou World Heroes 2 Jet (Jpn, Rev. A)</description>
+		<description>Nettou World Heroes 2 Jet (Jpn, Rev. 1)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AWJJ-JPN?" />
@@ -16372,7 +16372,7 @@ license:CC0
 	<software name="pacintima">
 		<!--	In lot check as "dmgaptp1.a96"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Pac-In-Time (Euro, Rev. A)</description>
+		<description>Pac-In-Time (Euro, Rev. 1)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-APTP-?" />
@@ -17878,7 +17878,7 @@ license:CC0
 	<software name="poktpuyoa">
 		<!--	In lot check as "KENSA\dmgapyj1.0"	-->
 		<!-- NP only -->
-		<description>Pocket Puyo Puyo Tsuu (Jpn, Rev. A, NP)</description>
+		<description>Pocket Puyo Puyo Tsuu (Jpn, Rev. 1, NP)</description>
 		<year>1996</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-APYJ-JPN?" />
@@ -18376,7 +18376,7 @@ license:CC0
 
 	<software name="popeye2ja" cloneof="popeye2">
 		<!--	In lot check as "dmgpgj-1.403"	-->
-		<description>Popeye 2 (Japan, Rev. A)</description>
+		<description>Popeye 2 (Japan, Rev. 1)</description>
 		<year>1991</year>
 		<publisher>Sigma</publisher>
 		<info name="serial" value="DMG-PGJ" />
@@ -18809,7 +18809,7 @@ license:CC0
 	<software name="purikuraa">
 		<!--	In lot check as "KENSA\dmgappj1.0"	-->
 		<!-- NP only -->
-		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev. A, NP)</description>
+		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev. 1, NP)</description>
 		<year>1997</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-APPJ-JPN?" />
@@ -19983,7 +19983,7 @@ license:CC0
 
 	<software name="mvpbba">
 		<!--	In lot check as "dmgvme-1.640"	-->
-		<description>Roger Clemens' MVP Baseball (USA, Rev. A)</description>
+		<description>Roger Clemens' MVP Baseball (USA, Rev. 1)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="DMG-VM-USA?" />
@@ -23626,7 +23626,7 @@ license:CC0
 	<software name="tmnt3a" cloneof="tmnt3">
 		<!--	In lot check as "dmgk8x-1.918"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)</description>
+		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. 1)</description>
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-K8-UKV?" />
@@ -23902,7 +23902,7 @@ license:CC0
 
 	<software name="tetris2a">
 		<!--	In lot check as "dmgehx-1.@08"	-->
-		<description>Tetris 2 (Europe, Rev. A)</description>
+		<description>Tetris 2 (Europe, Rev. 1)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="gold" value="19961029"/>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -380,7 +380,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="agrosoar" cloneof="wereback">
+	<software name="agrosoar" cloneof="babytrex">
 		<description>Agro Soar (Australia)</description>
 		<year>1993</year>
 		<publisher>Laser Beam Entertainment</publisher>
@@ -1339,7 +1339,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="babytrex" cloneof="wereback">
+	<software name="babytrex">
 		<description>Baby T-Rex (Europe)</description>
 		<year>1993</year>
 		<publisher>Laser Beam Entertainment</publisher>
@@ -1467,7 +1467,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="bamse" cloneof="wereback">
+	<software name="bamse" cloneof="babytrex">
 		<description>Bamse (Sweden)</description>
 		<year>1993</year>
 		<publisher>Laser Beam Entertainment</publisher>
@@ -6113,6 +6113,7 @@ license:CC0
 	</software>
 
 	<software name="f1polepo" supported="partial">
+		<!--	Region code "E" (USA)	-->
 		<description>F1 Pole Position (Europe, USA)</description>
 		<year>1993</year>
 		<publisher>Ubi Soft</publisher>
@@ -11905,10 +11906,13 @@ license:CC0
 	</software>
 
 	<software name="zeldalnk">
+		<!--	In lot check as "DMGZLE-2.858"	-->
+		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Europe, USA, Rev 2)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ZL-USA-1, DMG-ZL-EUR" />
+		<info name="gold" value="19941031" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
@@ -21602,7 +21606,7 @@ license:CC0
 
 	<software name="spaceinvj" cloneof="spaceinv">
 		<!--	The 1994 release is technically an improved localization of this, since it shares its "SP" code	-->
-		<!-- Notes: Also release by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Space Invaders (Japan)</description>
 		<year>1990</year>
 		<publisher>Taito</publisher>
@@ -22048,6 +22052,7 @@ license:CC0
 	</software>
 
 	<software name="stng">
+		<!--	Region code "E" (USA)	-->
 		<description>Star Trek - The Next Generation (Europe, USA)</description>
 		<year>1993</year>
 		<publisher>Absolute Entertainment</publisher>
@@ -25531,7 +25536,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="wereback">
+	<software name="wereback" cloneof="babytrex">
 		<description>We're Back! - A Dinosaur's Story (Europe, USA)</description>
 		<year>1993</year>
 		<publisher>Hi Tech Expressions</publisher>
@@ -26113,7 +26118,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="xj" cloneof="xu">
+	<software name="xj">
 		<description>X (Japan)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
@@ -26135,9 +26140,10 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="xu">
-		<description>X (USA, prototype)</description>
-		<year>1992</year>
+	<software name="lunchasep" cloneof="xj">
+		<!--	Very early prototype with different gameplay	-->
+		<description>Lunar Chase (USA, prototype)</description>
+		<year>1991</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
@@ -26667,6 +26673,10 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
+
+<!--
+	List of pirate cartridges
+-->
 
 <!-- Sachen multi-carts -->
 

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -14,9 +14,9 @@ license:CC0
 	- Hyper Lode Runner (World)
 	- The Jetsons - Robot Panic (USA, Rev. 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Jpn, Rev. 1)
+	- Kaseki Sousei Reborn (Japan, Rev. 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Euro, Rev. 1)
+	- Pac-In-Time (Europe, Rev. 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
@@ -28,9 +28,9 @@ license:CC0
 	- Hyper Lode Runner (World)
 	- The Jetsons - Robot Panic (USA, Rev. 1)
 	- Jungle Strike (USA)
-	- Kaseki Sousei Reborn (Jpn, Rev. 1)
+	- Kaseki Sousei Reborn (Japan, Rev. 1)
 	- Disney's Mulan (USA)
-	- Pac-In-Time (Euro, Rev. 1)
+	- Pac-In-Time (Europe, Rev. 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
@@ -793,7 +793,7 @@ license:CC0
 
 	<software name="amoudan2a">
 		<!--	In lot check as "dmgauj-1.434"	-->
-		<description>America Oudan Ultra Quiz Part 2 (Jpn, Rev. 1)</description>
+		<description>America Oudan Ultra Quiz Part 2 (Japan, Rev. 1)</description>
 		<year>1991</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-AUJ" />
@@ -3605,7 +3605,7 @@ license:CC0
 	</software>
 
 	<software name="centiped">
-		<description>Centipede (Euro, USA, Accolade)</description>
+		<description>Centipede (Europe, USA, Accolade)</description>
 		<year>1992</year>
 		<publisher>Accolade</publisher>
 		<info name="serial" value="DMG-CZ-USA, DMG-CZ-FRG" />
@@ -4146,7 +4146,7 @@ license:CC0
 	</software>
 
 	<software name="coolhanda" cloneof="coolhand" supported="partial">
-		<description>Cool Hand (Euro, French / German)</description>
+		<description>Cool Hand (Europe, French / German)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-ACDX-EUR" />
@@ -6408,7 +6408,7 @@ license:CC0
 	</software>
 
 	<software name="fifa98">
-		<description>FIFA Road to the World Cup '98 (Euro, Rev. 1)</description>
+		<description>FIFA Road to the World Cup '98 (Europe, Rev. 1)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-A8SP-EUU" />
@@ -8012,7 +8012,7 @@ license:CC0
 	</software>
 
 	<software name="gbsjousse" cloneof="gbsjous">
-		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Joushiki no Sho (Jpn, Special Edition)</description>
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Joushiki no Sho (Japan, Special Edition)</description>
 		<year>2002</year>
 		<publisher>IE Institute</publisher>
 		<info name="serial" value="DMG-BS4J-JPN" />
@@ -8036,7 +8036,7 @@ license:CC0
 
 	<software name="gbskjtatie">
 		<!--	In lot check as "dmgbq2j0.k33"	-->
-		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn, Alt)</description>
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Japan, Alt)</description>
 		<year>2003</year>
 		<publisher>IE Institute</publisher>
 		<info name="serial" value="DMG-BQ2J-JPN?" />
@@ -8053,7 +8053,7 @@ license:CC0
 	</software>
 
 	<software name="gbskjtat" cloneof="gbskjtatie">
-		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn, Special Edition)</description>
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Japan, Special Edition)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BK4J-JPN" />
@@ -10723,7 +10723,7 @@ license:CC0
 	<software name="kasekia">
 		<!--	In lot check as "dmgakrj1.e41"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Kaseki Sousei Reborn (Jpn, Rev. 1)</description>
+		<description>Kaseki Sousei Reborn (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AKRJ-JPN?" />
@@ -11113,7 +11113,7 @@ license:CC0
 
 	<software name="kininkoa">
 		<!--	In lot check as "dmgonj-1.153"	-->
-		<description>Kinin Koumaroku Oni (Jpn, Rev. 1)</description>
+		<description>Kinin Koumaroku Oni (Japan, Rev. 1)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-ONJ?" />
@@ -12252,7 +12252,7 @@ license:CC0
 		<publisher>Data East</publisher>
 		<info name="serial" value="DMG-LCA, DMG-LC-USA, DMG-LC-UKV, DMG-128 CHN" />
 		<info name="release" value="19900511 (JPN)" />
-		<info name="alt_title" value="ロックンチェイス ~ Lock 'n' Chase (Jpn Box), Lock n' Chase (Western Box), LOCK'N'CHASE 銀行大盗·银行大盗 (Chinese)" />
+		<info name="alt_title" value="ロックンチェイス ~ Lock 'n' Chase (Japan Box), Lock n' Chase (Western Box), LOCK'N'CHASE 銀行大盗·银行大盗 (Chinese)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" />  <!-- Also found with DMG-BBA-02 -->
 			<feature name="u1" value="U1 PRG" />
@@ -13402,7 +13402,7 @@ license:CC0
 	</software>
 
 	<software name="metroid2">
-		<!-- Also released via the Nintendo Power service in 2000-03 (Jpn) -->
+		<!-- Also released via the Nintendo Power service in 2000-03 (Japan) -->
 		<description>Metroid II - Return of Samus (World)</description>
 		<year>1992</year>
 		<publisher>Nintendo</publisher>
@@ -13530,7 +13530,7 @@ license:CC0
 
 	<software name="mickey5a" cloneof="mickeymw">
 		<!--	In lot check as "dmgi5j-1.933"	-->
-		<description>Mickey Mouse V (Jpn, Rev. 1)</description>
+		<description>Mickey Mouse V (Japan, Rev. 1)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-I5J?" />
@@ -14510,7 +14510,7 @@ license:CC0
 	</software>
 
 	<software name="motoxman">
-		<description>Motocross Maniacs (Euro, re-release)</description>
+		<description>Motocross Maniacs (Europe, re-release)</description>
 		<year>1991</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-MX-NOE-1" />
@@ -15512,7 +15512,7 @@ license:CC0
 
 	<software name="wh2ja" cloneof="wh2">
 		<!--	In lot check as "dmgawjj1.a40"	-->
-		<description>Nettou World Heroes 2 Jet (Jpn, Rev. 1)</description>
+		<description>Nettou World Heroes 2 Jet (Japan, Rev. 1)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AWJJ-JPN?" />
@@ -16372,7 +16372,7 @@ license:CC0
 	<software name="pacintima">
 		<!--	In lot check as "dmgaptp1.a96"	-->
 		<!--	Retail cartridge not yet secured	-->
-		<description>Pac-In-Time (Euro, Rev. 1)</description>
+		<description>Pac-In-Time (Europe, Rev. 1)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-APTP-?" />
@@ -17475,7 +17475,7 @@ license:CC0
 	</software>
 
 	<!--
-	Pocket Bomberman (Jpn) supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+	Pocket Bomberman (Japan) supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 	multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 	port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 	-->
@@ -17878,7 +17878,7 @@ license:CC0
 	<software name="poktpuyoa">
 		<!--	In lot check as "KENSA\dmgapyj1.0"	-->
 		<!-- NP only -->
-		<description>Pocket Puyo Puyo Tsuu (Jpn, Rev. 1, NP)</description>
+		<description>Pocket Puyo Puyo Tsuu (Japan, Rev. 1, NP)</description>
 		<year>1996</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-APYJ-JPN?" />
@@ -18752,7 +18752,7 @@ license:CC0
 	</software>
 
 	<software name="probot2s" cloneof="probot2">
-		<description>Probotector 2 (Euro, Sample)</description>
+		<description>Probotector 2 (Europe, Sample)</description>
 		<year>1995</year>
 		<publisher>Konami</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -23506,7 +23506,7 @@ license:CC0
 	</software>
 
 	<software name="tazdevl">
-		<description>Taz-Mania (Euro, USA, Sunsoft)</description>
+		<description>Taz-Mania (Europe, USA, Sunsoft)</description>
 		<year>1994</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ZT-USA, DMG-ZT-NOE" />
@@ -23523,7 +23523,7 @@ license:CC0
 	</software>
 
 	<software name="tazmania">
-		<description>Taz-Mania (Euro, THQ)</description>
+		<description>Taz-Mania (Europe, THQ)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ZM-UKV" />
@@ -24066,7 +24066,7 @@ license:CC0
 
 	<software name="tintinx">
 		<!--	In lot check as "dmgat6x0.c13"	-->
-		<description>Tintin in Tibet (Euro, En / Es / It / Sv)</description>
+		<description>Tintin in Tibet (Europe, En / Es / It / Sv)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AT6X-?"/>
@@ -24081,7 +24081,7 @@ license:CC0
 	</software>
 
 	<software name="tintin" cloneof="tintinx">
-		<description>Tintin in Tibet (Euro, En / Fr / De / Nl)</description>
+		<description>Tintin in Tibet (Europe, En / Fr / De / Nl)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AT6P-?"/>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -8036,7 +8036,7 @@ license:CC0
 
 	<software name="gbskjtatie">
 		<!--	In lot check as "dmgbq2j0.k33"	-->
-		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn)</description>
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn, Alt)</description>
 		<year>2003</year>
 		<publisher>IE Institute</publisher>
 		<info name="serial" value="DMG-BQ2J-JPN?" />
@@ -11112,7 +11112,7 @@ license:CC0
 	</software>
 
 	<software name="kininkoa">
-		<!--	In lot check as "dmgpgj-1.403"	-->
+		<!--	In lot check as "dmgonj-1.153"	-->
 		<description>Kinin Koumaroku Oni (Jpn, Rev. A)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
@@ -11121,8 +11121,8 @@ license:CC0
 		<info name="alt_title" value="鬼忍降魔録  ＯＮＩ　人々は、かれを「隠れ忍ぶ者－隠忍－」と呼んだ..." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
-			<dataarea name="rom" size="131072">
-				<rom name="dmgpgj-1.403" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd"/>
+			<dataarea name="rom" size = "131072">
+				<rom name="dmgonj-1.153.gb" size="131072" crc="aaf6366c" sha1="298965bc2b99e49339618914114abfd0962560c1" offset="0"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -16911,7 +16911,7 @@ license:CC0
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmg-agx-0.u1" size="131072" crc="9ae199df" sha1="ae97143e51b6f031efb83b245b1b2558e6cb9026" />
+				<rom name="pang (uk).bin" size="131072" crc="9ae199df" sha1="ae97143e51b6f031efb83b245b1b2558e6cb9026" />
 			</dataarea>
 		</part>
 	</software>
@@ -18370,6 +18370,22 @@ license:CC0
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="popeye 2 (japan).bin" size="131072" crc="4372ed68" sha1="d59986195bd74dde865245fae9c4081a8a24efb0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="popeye2ja" cloneof="popeye2">
+		<!--	In lot check as "dmgpgj-1.403"	-->
+		<description>Popeye 2 (Japan, Rev. A)</description>
+		<year>1991</year>
+		<publisher>Sigma</publisher>
+		<info name="serial" value="DMG-PGJ" />
+		<info name="release" value="19911122" />
+		<info name="alt_title" value="ポパイ2" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgpgj-1.403" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -4,10 +4,41 @@
 license:CC0
 
   To investigate:
-  - Shanghai Pocket by Sunsoft: are serial and release date correct or do they refer to the GBC version?
+	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
+	- Was Gargoyle's Quest (Rev. A) released in the USA?
+
+  Known dumps not yet verified against retail cartridge:
+	- The Adventures of Rocky and Bullwinkle (USA)
+	- Fastest Lap (USA)
+	- GI King! - Sanbiki no Yosouya (Japan)
+	- Hyper Lode Runner (World)
+	- The Jetsons - Robot Panic (USA, Rev. A)
+	- Jungle Strike (USA)
+	- Kaseki Sousei Reborn (Jpn, Rev. A)
+	- Disney's Mulan (USA)
+	- Pac-In-Time (Euro, Rev. A)
+	- Pac-Man (Japan)
+	- Pang (UK)
+	- Suzuki Aguri no F-1 Super Driving (Japan)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)
+	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
+	- The Adventures of Rocky and Bullwinkle (USA)
+	- Fastest Lap (USA)
+	- GI King! - Sanbiki no Yosouya (Japan)
+	- Hyper Lode Runner (World)
+	- The Jetsons - Robot Panic (USA, Rev. A)
+	- Jungle Strike (USA)
+	- Kaseki Sousei Reborn (Jpn, Rev. A)
+	- Disney's Mulan (USA)
+	- Pac-In-Time (Euro, Rev. A)
+	- Pac-Man (Japan)
+	- Pang (UK)
+	- Suzuki Aguri no F-1 Super Driving (Japan)
+	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)
+	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 
   Undumped pirate carts:
-  - GOWIN carts (see below the list of known games)
+	- GOWIN carts (see below the list of known games)
 
 
  Info on the PCB codes, based on Tauwasser's notes and research
@@ -256,7 +287,25 @@ license:CC0
 	</software>
 
 	<software name="rockybw">
+		<!--	In lot check as "dmgrye-0.647"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>The Adventures of Rocky and Bullwinkle (USA)</description>
+		<year>1992</year>
+		<publisher>T*HQ</publisher>
+		<info name="serial" value="DMG-RY-USA" />
+		<info name="alt_title" value="The Adventures of Rocky and Bullwinkle and Friends (Box)" />
+		<info name="gold" value="19920731"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgrye-0.647" size="131072" crc="362c841c" sha1="0ce98889e5d9d6167338e91119394537318810da"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rockybwunk" cloneof="rockybw">
+		<!-- Old dump of unknown origin -->
+		<description>The Adventures of Rocky and Bullwinkle (USA, bad dump?)</description>
 		<year>1992</year>
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="DMG-RY-USA" />
@@ -573,6 +622,7 @@ license:CC0
 	</software>
 
 	<software name="asbase99">
+		<!--	In lot check as "Dmgab9e0.e21", "KENSA\Dmgab9p0.1"	-->
 		<description>All-Star Baseball '99 (USA)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -741,11 +791,28 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="amoudan2">
+	<software name="amoudan2a">
+		<!--	In lot check as "dmgauj-1.434"	-->
+		<description>America Oudan Ultra Quiz Part 2 (Jpn, Rev. A)</description>
+		<year>1991</year>
+		<publisher>Tomy</publisher>
+		<info name="serial" value="DMG-AUJ" />
+		<info name="gold" value="19920127" />
+		<info name="alt_title" value="アメリカ横断ウルトラクイズ PART2" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgauj-1.434" size="262144" crc="739c26fc" sha1="cb3ed70f4d095405df2c322c528cab2a00d56557"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amoudan2" cloneof="amoudan2a">
 		<description>America Oudan Ultra Quiz Part 2 (Japan)</description>
 		<year>1991</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-AUJ" />
+		<info name="gold" value="19911017" />
 		<info name="release" value="19911220" />
 		<info name="alt_title" value="アメリカ横断ウルトラクイズ PART2" />
 		<part name="cart" interface="gameboy_cart">
@@ -2384,7 +2451,7 @@ license:CC0
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-AYWJ-JPN" />
-		<info name="release" value="19971219" />
+		<info name="gold" value="19980107" />
 		<info name="alt_title" value="牧場物語GB" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
@@ -2410,6 +2477,7 @@ license:CC0
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-AYWJ-JPN" />
+		<info name="gold" value="19971113" />
 		<info name="release" value="19971219" />
 		<info name="alt_title" value="牧場物語GB" />
 		<part name="cart" interface="gameboy_cart">
@@ -2424,6 +2492,25 @@ license:CC0
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
 				<rom name="dmg-aywj-0.u1" size="524288" crc="d3e2fd02" sha1="60ecafdb13213b3ac2daa3d71431ef8a89754edb" />
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="bokujomnp" cloneof="harvmoon">
+		<!--	In lot check as "KENSA\dmgbywj0.0"	-->
+		<description>Bokujou Monogatari GB (Japan, NP)</description>
+		<year>1997</year>
+		<publisher>Victor Interactive Software</publisher>
+		<info name="serial" value="DMG-BYWJ-JPN?" />
+		<info name="alt_title" value="牧場物語GB" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgbywj0.0" size="524288" crc="0424df85" sha1="551df2021d0e433e7f07cf881c7b1d534f54f6ad"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2558,7 +2645,7 @@ license:CC0
 	</software>
 
 	<software name="bombman3">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Bomberman GB 3 (Japan)</description>
 		<year>1996</year>
 		<publisher>Hudson Soft</publisher>
@@ -2691,16 +2778,33 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="boxxle">
+	<software name="boxxlea">
+		<!--	European release is a relabeled USA version	-->
 		<description>Boxxle (Europe, USA, Rev. 1)</description>
 		<year>1990</year>
 		<publisher>FCI</publisher>
 		<info name="serial" value="DMG-SO-UKV, DMG-SO-USA" />
+		<info name="gold" value="19891208"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" />
 			<feature name="u1" value="U1 PRG" />
 			<dataarea name="rom" size="32768">
 				<rom name="dmg-soe-1.u1" size="32768" crc="c09cee99" sha1="f9d5287bc9d6eda9ec36e9b5a8dbc38cf2cffecf" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="boxxle" cloneof="boxxlea">
+		<!--	In lot check as "dmgsoe-0.020"	-->
+		<description>Boxxle (USA)</description>
+		<year>1990</year>
+		<publisher>FCI</publisher>
+		<info name="serial" value="DMG-SO-USA" />
+		<info name="gold" value="19900426"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="32768">
+				<rom name="dmgsoe-0.020" size="32768" crc="24843867" sha1="3e169f1db16cc1c3ffbc8645aa7ce28194033d26"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3121,6 +3225,7 @@ license:CC0
 	</software>
 
 	<software name="bam3dx">
+		<!--	In lot check as "Dmga3vp0.e84", "KENSA\DMGA3VE0.0"	-->
 		<description>Bust-A-Move 3 DX (Europe)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -3659,7 +3764,7 @@ license:CC0
 	</software>
 
 	<software name="chibimdx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-11 -->
+		<!-- Notes: Also released by NP in 2000-11 -->
 		<description>Chibi Maruko-chan - Maruko Deluxe Gekijou (Japan)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
@@ -3873,7 +3978,7 @@ license:CC0
 	</software>
 
 	<software name="mazemon2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Notes: Also released by NP in 2000-08 -->
 		<description>Chou Mashin Eiyuu Den Wataru - Mazekko Monster 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Banpresto</publisher>
@@ -5038,7 +5143,7 @@ license:CC0
 	</software>
 
 	<software name="dorakart" supported="partial">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Notes: Also released by NP in 2000-08 -->
 		<description>Doraemon Kart (Japan)</description>
 		<year>1998</year>
 		<publisher>Epoch</publisher>
@@ -5062,7 +5167,7 @@ license:CC0
 	</software>
 
 	<software name="doradx10">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Notes: Also released by NP in 2000-08 -->
 		<description>Doraemon no Game Boy de Asobouyo Deluxe 10 (Japan)</description>
 		<year>1998</year>
 		<publisher>Epoch</publisher>
@@ -5876,6 +5981,7 @@ license:CC0
 		<year>1994</year>
 		<publisher>GameTek</publisher>
 		<info name="serial" value="DMG-YK-USA" />
+		<info name="gold" value="19940617" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
@@ -6176,12 +6282,30 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="fastlap">
-		<description>Fastest Lap (Japan, USA)</description>
+	<software name="fastlapu">
+		<!--	In lot check as "dmgf2e-0.411"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Fastest Lap (USA)</description>
 		<year>1991</year>
-		<publisher>Vap ~ NTVIC</publisher>
-		<info name="serial" value="DMG-F2A, DMG-F2-USA" />
-		<info name="release" value="19910320 (JPN)" />
+		<publisher>NTVIC</publisher>
+		<info name="serial" value="DMG-F2-USA" />
+		<info name="gold" value="19911118"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgf2e-0.411" size="131072" crc="a9ba7875" sha1="25bf89b112c9b134b2e4d07354d1a762ab0d4e92"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fastlap" cloneof="fastlapu">
+		<description>Fastest Lap (Japan)</description>
+		<year>1991</year>
+		<publisher>Vap</publisher>
+		<info name="serial" value="DMG-F2A" />
+		<info name="release" value="19910320" />
 		<info name="alt_title" value="ファーステスト・ラップ" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
@@ -6301,6 +6425,7 @@ license:CC0
 	</software>
 
 	<software name="fifa98a" cloneof="fifa98">
+		<!--	In lot check as "DMGA8SP0.D75", "KENSA\DMGA8SE0.4"	-->
 		<description>FIFA Road to the World Cup '98 (Europe)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
@@ -6620,7 +6745,7 @@ license:CC0
 	</software>
 
 	<software name="foreman">
-		<!-- Notes: SGB enhanced? (the box claims it supports SGB!) -->
+		<!-- Notes: The box claims it supports SGB, but it doesn't -->
 		<description>Foreman for Real (Europe, USA)</description>
 		<year>1995</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -6682,7 +6807,6 @@ license:CC0
 	</software>
 
 	<software name="friskyto">
-		<!-- Notes: SGB enhanced? (the box claims it supports SGB!) -->
 		<description>Frisky Tom (Japan)</description>
 		<year>1995</year>
 		<publisher>Nichibutsu</publisher>
@@ -6690,6 +6814,7 @@ license:CC0
 		<info name="release" value="19950714" />
 		<info name="alt_title" value="フリスキー・トム" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="frisky tom (japan).bin" size="131072" crc="0bef84a1" sha1="4162ca88c94c40e3fa6e09067b956cf4953ccf89" />
@@ -6780,7 +6905,7 @@ license:CC0
 	</software>
 
 	<software name="furaishi">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<!-- Notes: Also released by NP in 2000-08 -->
 		<description>Fushigi no Dungeon - Fuurai no Shiren GB - Tsukikage Mura no Kaibutsu (Japan)</description>
 		<year>1996</year>
 		<publisher>ChunSoft</publisher>
@@ -6903,7 +7028,7 @@ license:CC0
 	</software>
 
 	<software name="gbgallj" cloneof="gwatch">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Game Boy Gallery (Japan)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
@@ -6950,7 +7075,7 @@ license:CC0
 	</software>
 
 	<software name="gbgall2">
-		<!-- Notes: SGB enhanced, Euro/US version in gbcolor.xml -->
+		<!-- Notes: Euro/US version in gbcolor.xml -->
 		<description>Game Boy Gallery 2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
@@ -7208,12 +7333,32 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="gargoylea">
+		<!--	In lot check as "dmgrae-1.108"	-->
+		<!--	European release is a relabeled USA version	-->
+		<!--	Unreleased in USA?	-->
+		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev. A)</description>
+		<year>1990</year>
+		<publisher>Capcom</publisher>
+		<info name="serial" value="DMG-RA-NOE-1" />
+		<info name="gold" value="19960709"/>
+		<info name="alt_title" value="Gargoyle's Quest (Box)" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgrae-1.108" size="131072" crc="b86ef7a5" sha1="21fbe39014ffed80d0de2092517522d3cb9b03f9"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gargoyle">
+		<!--	European release is a relabeled USA version	-->
 		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, USA)</description>
 		<year>1990</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-RA-NOE, DMG-RA-USA" />
 		<info name="alt_title" value="Gargoyle's Quest (Box)" />
+		<info name="gold" value="19900423"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" /> <!-- Also found with DMG-BEAN-01 -->
 			<feature name="u1" value="U1 PRG" />
@@ -7278,7 +7423,7 @@ license:CC0
 	</software>
 
 	<software name="gbgenjn2" cloneof="bckid2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>GB Genjin 2 (China, Japan)</description>
 		<year>1994</year>
 		<publisher>Hudson Soft</publisher>
@@ -7544,7 +7689,34 @@ license:CC0
 	</software>
 
 	<software name="giking">
+		<!--	In lot check as "dmggij-0.777"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>GI King! - Sanbiki no Yosouya (Japan)</description>
+		<year>1993</year>
+		<publisher>Vic Tokai</publisher>
+		<info name="serial" value="DMG-GIJ" />
+		<info name="gold" value="19930204" />
+		<info name="release" value="19930326" />
+		<info name="alt_title" value="GIキング! 三匹の予想屋" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="pcb" value="DMG-DECN-02" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 MBC1/1A/1B" />
+			<feature name="u3" value="U3 RAM" />
+			<feature name="u4" value="U4 26A" />
+			<feature name="batt" value="Batt CR1616" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmggij-0.777" size="131072" crc="f0dff737" sha1="65265b1c28173a6df0fede8c025cce56e752b1fd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gikingunk" cloneof="giking">
+		<!-- Old dump of unknown origin -->
+		<description>GI King! - Sanbiki no Yosouya (Japan, bad dump?)</description>
 		<year>1993</year>
 		<publisher>Vic Tokai</publisher>
 		<info name="serial" value="DMG-GIJ" />
@@ -7862,11 +8034,30 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="gbskjtat">
+	<software name="gbskjtatie">
+		<!--	In lot check as "dmgbq2j0.k33"	-->
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn)</description>
+		<year>2003</year>
+		<publisher>IE Institute</publisher>
+		<info name="serial" value="DMG-BQ2J-JPN?" />
+		<info name="gold" value="20030514"/>
+		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 読み 書き 筆順 熟語 漢字の達人" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbq2j0.k33" size="1048576" crc="180d54a7" sha1="7dce0adcbac61f0caae33646847fd06ced8c8b67"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gbskjtat" cloneof="gbskjtatie">
 		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Jpn, Special Edition)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BK4J-JPN" />
+		<info name="gold" value="20010216" />
 		<info name="release" value="20010330" />
 		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 読み 書き 筆順 熟語 漢字の達人" />
 		<part name="cart" interface="gameboy_cart">
@@ -7885,11 +8076,30 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="gbskstat">
+	<software name="gbskstatie">
+		<!--	In lot check as "dmgbc6j0.k32"	-->
+		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Keisan no Tatsujin (Japan, Alt)</description>
+		<year>2003</year>
+		<publisher>IE Institute</publisher>
+		<info name="serial" value="DMG-BC6J-JPN?" />
+		<info name="gold" value="20030509" />
+		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 整数 小数 分数 単位 計算の達人" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbc6j0.k32" size="1048576" crc="04214f92" sha1="6b8726c69a31e674a4c5ab02631de073d42e7d52"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gbskstat" cloneof="gbskstatie">
 		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Keisan no Tatsujin (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BC4J-JPN" />
+		<info name="gold" value="20010219" />
 		<info name="release" value="20010330" />
 		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 整数 小数 分数 単位 計算の達人" />
 		<part name="cart" interface="gameboy_cart">
@@ -7913,6 +8123,7 @@ license:CC0
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BD4J-JPN" />
+		<info name="gold" value="20000125" />
 		<info name="release" value="20000317" />
 		<info name="alt_title" value="ゴールド シカクいアタマをマルくする。 合格ボーイGOLD ■いアタマを●くする。 国語 算数 理科 社会 難問の書" />
 		<part name="cart" interface="gameboy_cart">
@@ -9262,18 +9473,35 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="hyperlod">
+	<software name="hyperloda">
 		<description>Hyper Lode Runner (World, Rev. 1)</description>
 		<year>1989</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="DMG-HLA, DMG-HL-UKV, DMG-HL-USA" />
-		<info name="release" value="19890921 (JPN)" />
+		<info name="gold" value="19890629" />
 		<info name="alt_title" value="ハイパーロードランナー" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-AAA-03" /> <!-- Also found with DMG-AAA-01 and DMG-AAA-02 -->
 			<feature name="u1" value="U1 PRG" />
 			<dataarea name="rom" size="32768">
 				<rom name="dmg-hla-1.u1" size="32768" crc="b3a86164" sha1="261da795c7b4155f1b8083acc55da78699c8a0de" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="hyperlod" cloneof="hyperloda">
+		<!--	In lot check as "dmghla-0.011"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Hyper Lode Runner (World)</description>
+		<year>1989</year>
+		<publisher>Bandai</publisher>
+		<info name="gold" value="19890609" />
+		<info name="release" value="19890921 (JPN)" />
+		<info name="alt_title" value="ハイパーロードランナー" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="32768">
+				<rom name="dmghla-0.011" size="32768" crc="3fc21b74" sha1="37d0f2cbac0f95af8b22dea0c882612681ec5cc8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -9877,6 +10105,7 @@ license:CC0
 	</software>
 
 	<software name="jellyboy">
+		<!--	In lot check as "DMGAJBP0.A52", "POOL\DMGAJBE0"	-->
 		<description>Jelly Boy (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
@@ -9903,6 +10132,7 @@ license:CC0
 	</software>
 
 	<software name="jeopardp">
+		<!--	In lot check as "DMGAJPE0.C68", "POOL\DMGAJPP0"	-->
 		<description>Jeopardy! - Platinum Edition (USA)</description>
 		<year>1996</year>
 		<publisher>GameTek</publisher>
@@ -9930,6 +10160,7 @@ license:CC0
 	</software>
 
 	<software name="jeopardt">
+		<!--	In lot check as "DMGAJQE0.C69", "POOL\DMGAJQP0"	-->
 		<description>Jeopardy! - Teen Tournament (USA)</description>
 		<year>1996</year>
 		<publisher>GameTek</publisher>
@@ -9943,7 +10174,24 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="jetsons">
+	<software name="jetsonsa">
+		<!--	In lot check as "dmgjse-1.588"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>The Jetsons - Robot Panic (USA, Rev. A)</description>
+		<year>1992</year>
+		<publisher>Taito</publisher>
+		<info name="serial" value="DMG-JS-USA?" />
+		<info name="gold" value="19930113"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgjse-1.588" size="131072" crc="cc38cf0d" sha1="38b5ec2c74316696b7731cd88e56be4519084168"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jetsons" cloneof="jetsonsa">
+		<!--	European release is a relabeled USA version	-->
 		<description>The Jetsons - Robot Panic (Europe, USA)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
@@ -10011,7 +10259,7 @@ license:CC0
 	</software>
 
 	<software name="jinsei">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Jinsei Game (Japan)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
@@ -10185,18 +10433,35 @@ license:CC0
 	</software>
 
 	<software name="jstrike">
-		<description>Jungle Strike (Europe, USA)</description>
+		<description>Jungle Strike (Europe)</description>
 		<year>1995</year>
-		<publisher>Ocean</publisher> <!-- Malibu Games in USA -->
-		<info name="serial" value="DMG-AJGE-USA, DMG-AJGP-UKV" />
+		<publisher>Ocean</publisher>
+		<info name="serial" value="DMG-AJGP-UKV" />
+		<info name="gold" value="19950320" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
-			<feature name="pcb" value="DMG-BEAN-10" />  <!-- UKV cart -->
+			<feature name="pcb" value="DMG-BEAN-10" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC1/1B/1B1 [DMG MBC1B1]" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
 				<rom name="dmg-ajgp-0.u1" size="262144" crc="763ababb" sha1="b4c53804f6d7ed230c092232148e69b53f9eb597" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="jstrikeu" cloneof="jstrike">
+		<!--	In lot check as "dmgajge0.a85"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Jungle Strike (USA)</description>
+		<year>1995</year>
+		<publisher>Malibu Games</publisher>
+		<info name="serial" value="DMG-AJGE-USA" />
+		<info name="gold" value="19950427"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgajge0.a85" size="262144" crc="7a8cdbe8" sha1="ea8b7a5d8d16b4448a3d758fff1f91f27db60292"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10455,11 +10720,32 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kaseki">
+	<software name="kasekia">
+		<!--	In lot check as "dmgakrj1.e41"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Kaseki Sousei Reborn (Jpn, Rev. A)</description>
+		<year>1998</year>
+		<publisher>Starfish</publisher>
+		<info name="serial" value="DMG-AKRJ-JPN?" />
+		<info name="gold" value="19980908"/>
+		<info name="alt_title" value="化石創世リボーン" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgakrj1.e41" size="524288" crc="7c94197c" sha1="5759394e2e8bfd68ccf5519362572daaba003573"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kaseki" cloneof="kasekia">
 		<description>Kaseki Sousei Reborn (Japan)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AKRJ-JPN" />
+		<info name="gold" value="19980610"/>
 		<info name="release" value="19980717" />
 		<info name="alt_title" value="化石創世リボーン" />
 		<part name="cart" interface="gameboy_cart">
@@ -10520,7 +10806,7 @@ license:CC0
 	</software>
 
 	<software name="kawanus3" cloneof="rivking">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Kawa no Nushi Tsuri 3 (Japan)</description>
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
@@ -10825,14 +11111,33 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="kininkoa">
+		<!--	In lot check as "dmgpgj-1.403"	-->
+		<description>Kinin Koumaroku Oni (Jpn, Rev. A)</description>
+		<year>1990</year>
+		<publisher>Banpresto</publisher>
+		<info name="serial" value="DMG-ONJ?" />
+		<info name="gold" value="19910417" />
+		<info name="alt_title" value="鬼忍降魔録  ＯＮＩ　人々は、かれを「隠れ忍ぶ者－隠忍－」と呼んだ..." />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc2" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgpgj-1.403" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kininko" cloneof="kininkoa">
 <!-- does it have the battery? -->
-	<software name="kininko">
 		<description>Kinin Koumaroku Oni (Japan)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-ONJ" />
+		<info name="gold" value="19901001" />
 		<info name="release" value="19901208" />
-		<info name="alt_title" value="鬼忍降魔録 ONI" />
+		<info name="alt_title" value="鬼忍降魔録  ＯＮＩ　人々は、かれを「隠れ忍ぶ者－隠忍－」と呼んだ..." />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-GDAN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -10864,7 +11169,7 @@ license:CC0
 	</software>
 
 	<software name="kirbyblcj" cloneof="kirbyblc">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Kirby no Block Ball (Japan)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
@@ -10889,7 +11194,7 @@ license:CC0
 	</software>
 
 	<software name="kirbykk">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Kirby no Kirakira Kids (Japan)</description>
 		<year>1997</year>
 		<publisher>Nintendo</publisher>
@@ -10963,6 +11268,7 @@ license:CC0
 	</software>
 
 	<software name="kirby2">
+		<!--	In lot check as "DMGAKBE0.A66", "DMGAKBP0.A74", "POOL\DMGAKBP0"	-->
 		<description>Kirby's Dream Land 2 (Australia, Europe, USA)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
@@ -11146,7 +11452,7 @@ license:CC0
 	</software>
 
 	<software name="konamic1">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Konami GB Collection Vol.1 (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
@@ -11163,7 +11469,7 @@ license:CC0
 	</software>
 
 	<software name="konamic2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Konami GB Collection Vol.2 (Japan)</description>
 		<year>1997</year>
 		<publisher>Konami</publisher>
@@ -11196,7 +11502,7 @@ license:CC0
 	</software>
 
 	<software name="konamic4">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Konami GB Collection Vol.4 (Japan)</description>
 		<year>1998</year>
 		<publisher>Konami</publisher>
@@ -11591,6 +11897,7 @@ license:CC0
 	</software>
 
 	<software name="rivkingu" cloneof="rivking">
+		<!--	In lot check as "Dmgafhe0.e42", "KENSA\Dmgafhp0.2"	-->
 		<description>Legend of the River King GB (USA)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
@@ -11779,6 +12086,7 @@ license:CC0
 	</software>
 
 	<software name="lemming2">
+		<!--	In lot check as "DMGAL2P0.@93", "POOL\DMGAL2E0"	-->
 		<description>Lemmings 2 - The Tribes (Europe)</description>
 		<year>1994</year>
 		<publisher>Psygnosis</publisher>
@@ -12167,6 +12475,7 @@ license:CC0
 	</software>
 
 	<software name="madden97">
+		<!--	In lot check as "DMGA7ME0.C47", "POOL\DMGA7MP0"	-->
 		<description>Madden '97 (USA)</description>
 		<year>1995</year>
 		<publisher>Black Pearl</publisher>
@@ -12619,6 +12928,7 @@ license:CC0
 	</software>
 
 	<software name="mauimall">
+		<!--	In lot check as "Dmgamie0.e45", "KENSA\Dmgamip0.1"	-->
 		<description>Maui Mallard (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
@@ -12682,7 +12992,7 @@ license:CC0
 	</software>
 
 	<software name="medakabu">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Medarot - Kabuto Version (Japan, Rev. 1)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
@@ -12707,7 +13017,7 @@ license:CC0
 	</software>
 
 	<software name="medakabua" cloneof="medakabu">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Medarot - Kabuto Version (Japan)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
@@ -12732,7 +13042,7 @@ license:CC0
 	</software>
 
 	<software name="medakuwa">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Medarot - Kuwagata Version (Japan, Rev. 1)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
@@ -12757,7 +13067,7 @@ license:CC0
 	</software>
 
 	<software name="medakuwaa" cloneof="medakuwa">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Medarot - Kuwagata Version (Japan)</description>
 		<year>1997</year>
 		<publisher>Imagineer</publisher>
@@ -12776,7 +13086,7 @@ license:CC0
 	</software>
 
 	<software name="medacol">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-12 -->
+		<!-- Notes: Also released by NP in 2000-12 -->
 		<description>Medarot - Parts Collection (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
@@ -13202,16 +13512,34 @@ license:CC0
 	</software>
 
 	<software name="mickey5" cloneof="mickeymw">
+		<!--	In lot check as "dmgi5j-0.933"	-->
 		<description>Mickey Mouse V (Japan)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-I5J" />
+		<info name="gold" value="19931101"/>
 		<info name="release" value="19931222" />
 		<info name="alt_title" value="ミッキーマウスV 魔法のステッキ ~ Mickey Mouse V - Mahou no Stick (Box)" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="mickey mouse v (japan).bin" size="131072" crc="44cd01dd" sha1="b8537bef22696feadf51343b6e1697370c4a8d5a" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mickey5a" cloneof="mickeymw">
+		<!--	In lot check as "dmgi5j-1.933"	-->
+		<description>Mickey Mouse V (Jpn, Rev. A)</description>
+		<year>1993</year>
+		<publisher>Kemco</publisher>
+		<info name="serial" value="DMG-I5J?" />
+		<info name="gold" value="19940121"/>
+		<info name="alt_title" value="ミッキーマウスV 魔法のステッキ ~ Mickey Mouse V - Mahou no Stick (Box)" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgi5j-1.933" size="131072" crc="464eaa5d" sha1="095285ec078124e3a4cbbfa3ac0d7680ee491e2b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -13623,7 +13951,7 @@ license:CC0
 	</software>
 
 	<software name="mogurany" cloneof="mole">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Moguranya (Japan)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
@@ -13734,7 +14062,7 @@ license:CC0
 	</software>
 
 	<software name="momoden2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Momotarou Dengeki 2 (Japan)</description>
 		<year>1994</year>
 		<publisher>Hudson Soft</publisher>
@@ -13768,7 +14096,7 @@ license:CC0
 	</software>
 
 	<software name="momojr">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-12 -->
+		<!-- Notes: Also released by NP in 2000-12 -->
 		<description>Momotarou Dentetsu Jr. - Zenkoku Ramen Meguri no Maki (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -14247,6 +14575,7 @@ license:CC0
 	</software>
 
 	<software name="mrnutz">
+		<!--	In lot check as "DMGAN8P0.A12", "POOL\DMGAN8E0"	-->
 		<description>Mr Nutz (Europe)</description>
 		<year>1994</year>
 		<publisher>Ocean</publisher>
@@ -14362,10 +14691,11 @@ license:CC0
 	</software>
 
 	<software name="mulan">
-		<description>Disney's Mulan (Europe, USA)</description>
+		<description>Disney's Mulan (Europe)</description>
 		<year>1998</year>
 		<publisher>THQ</publisher>
-		<info name="serial" value="DMG-AMLE-USA, DMG-AMLP-EUR, DMG-AMLP-EUR-1" />
+		<info name="serial" value="DMG-AMLP-EUR, DMG-AMLP-EUR-1" />
+		<info name="gold" value="19980929" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-BEAN-10" />
@@ -14374,6 +14704,23 @@ license:CC0
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="dmg-amlp-0.u1" size="524288" crc="e285cf30" sha1="b039f13d7a4eac290ab2d0bf4a4a740cfc517959" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mulanu" cloneof="mulan">
+		<!--	In lot check as "dmgamle0.e74"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Disney's Mulan (USA)</description>
+		<year>1998</year>
+		<publisher>THQ</publisher>
+		<info name="serial" value="DMG-AMLE-USA" />
+		<info name="gold" value="19980903"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgamle0.e74" size="524288" crc="bfcf71a1" sha1="7832fcc373ff752e757550079519b39583665c82"/>
 			</dataarea>
 		</part>
 	</software>
@@ -14584,7 +14931,7 @@ license:CC0
 	</software>
 
 	<software name="namcogl1">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Namco Gallery Vol.1 (Japan)</description>
 		<year>1996</year>
 		<publisher>Namco</publisher>
@@ -14617,7 +14964,7 @@ license:CC0
 	</software>
 
 	<software name="namcogl3">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Namco Gallery Vol.3 (Japan)</description>
 		<year>1997</year>
 		<publisher>Namco</publisher>
@@ -15110,7 +15457,7 @@ license:CC0
 	</software>
 
 	<software name="toshinj" cloneof="toshin">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Nettou Toushinden (Japan, Rev. 1)</description>
 		<year>1996</year>
 		<publisher>Takara</publisher>
@@ -15127,7 +15474,7 @@ license:CC0
 	</software>
 
 	<software name="toshinja" cloneof="toshin">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Nettou Toushinden (Japan)</description>
 		<year>1996</year>
 		<publisher>Takara</publisher>
@@ -15148,6 +15495,7 @@ license:CC0
 		<year>1995</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AWJJ-JPN" />
+		<info name="gold" value="19941216" />
 		<info name="release" value="19950224" />
 		<info name="alt_title" value="熱闘ワールドヒーローズ2JET" />
 		<part name="cart" interface="gameboy_cart">
@@ -15158,6 +15506,23 @@ license:CC0
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="dmg-awjj-0.u1" size="524288" crc="0a12f53c" sha1="0dd04ca0ac61b449d3040587918b63d649fbbcc2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wh2ja" cloneof="wh2">
+		<!--	In lot check as "dmgawjj1.a40"	-->
+		<description>Nettou World Heroes 2 Jet (Jpn, Rev. A)</description>
+		<year>1995</year>
+		<publisher>Takara</publisher>
+		<info name="serial" value="DMG-AWJJ-JPN?" />
+		<info name="gold" value="19950411"/>
+		<info name="alt_title" value="熱闘ワールドヒーローズ2JET" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgawjj1.a40" size="524288" crc="7c5ffe52" sha1="14bc507f479e814b0131febfab19f2ef30eb23a5"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15872,7 +16237,7 @@ license:CC0
 	</software>
 
 	<software name="othellow">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<!-- Notes: Also released by NP in 2000-05 -->
 		<description>Othello World (Japan)</description>
 		<year>1994</year>
 		<publisher>Tsukuda Original</publisher>
@@ -16004,11 +16369,29 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pacintimu" cloneof="pacintim">
+	<software name="pacintima">
+		<!--	In lot check as "dmgaptp1.a96"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Pac-In-Time (Euro, Rev. A)</description>
+		<year>1995</year>
+		<publisher>Namco</publisher>
+		<info name="serial" value="DMG-APTP-?" />
+		<info name="gold" value="19950906"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgaptp1.a96" size="262144" crc="7ff79df9" sha1="f30108b8e422c4b9776c90c884710194508545ea"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pacintimu" cloneof="pacintima">
 		<description>Pac-In-Time (USA)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-APTE-USA" />
+		<info name="gold" value="19950111"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-BEAN-02" />
@@ -16021,11 +16404,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pacintimj" cloneof="pacintim">
+	<software name="pacintimj" cloneof="pacintima">
 		<description>Pac-In-Time (Japan)</description>
 		<year>1995</year>
 		<publisher>Namcot</publisher>
 		<info name="serial" value="DMG-APTJ-JPN" />
+		<info name="gold" value="19941111"/>
 		<info name="release" value="19950103" />
 		<info name="alt_title" value="パックインタイム" />
 		<part name="cart" interface="gameboy_cart">
@@ -16037,11 +16421,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pacintim">
+	<software name="pacintim" cloneof="pacintima">
 		<description>Pac-In-Time (Europe)</description>
 		<year>1995</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-APTP-FAH, DMG-APTP-NOE" />
+		<info name="gold" value="19950516"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-BEAN-02" />
@@ -16055,10 +16440,12 @@ license:CC0
 	</software>
 
 	<software name="pacman">
+		<!--	In lot check as "DMGPCX-0.412"	-->
 		<description>Pac-Man (Europe)</description>
 		<year>1991</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-PC-NOE" />
+		<info name="gold" value="19911024" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-02" />
 			<feature name="u1" value="U1 PRG" />
@@ -16071,6 +16458,10 @@ license:CC0
 	</software>
 
 	<software name="pacmanj" cloneof="pacman">
+		<!--	In lot check as "dmgpca-0.159"	-->
+		<!--	Lot check ROM is padded with FFs to twice its size, but correct size is 512kb (64KB) according to the official release spreadsheet	-->
+		<!--	Retail cartridge not yet secured	-->
+		<!--	World version according to region code	-->
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
 		<description>Pac-Man (Japan)</description>
 		<year>1990</year>
@@ -16087,10 +16478,12 @@ license:CC0
 	</software>
 
 	<software name="pacmanu" cloneof="pacman">
+		<!--	In lot check as "DMGPCE-0.264"	-->
 		<description>Pac-Man (USA)</description>
 		<year>1991</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-PC-USA" />
+		<info name="gold" value="19910208" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-BEAN-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -16488,7 +16881,27 @@ license:CC0
 	</software>
 
 	<software name="pang">
-		<description>Pang (Europe)</description>
+		<!--	In lot check as "dmgagx-0.897"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Pang (UK)</description>
+		<year>1993</year>
+		<publisher>Hudson Soft</publisher>
+		<info name="serial" value="DMG-AG-NOE" />
+		<info name="gold" value="19930917"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="pcb" value="DMG-BEAN-02" />
+			<feature name="u1" value="U1 PRG" />
+			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B1]" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmg-agx-0.u1" size="131072" crc="ea9615b4" sha1="7ca64a45ea6a68770658ae39ef21c41f806988c5"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pangunk" cloneof="pang">
+		<!-- Old dump of unknown origin -->
+		<description>Pang (UK, bad dump?)</description>
 		<year>1993</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AG-NOE" />
@@ -17047,6 +17460,7 @@ license:CC0
 	</software>
 
 	<software name="pockbman">
+		<!--	In lot check as "DMGAKOP0.D90", "KENSA\DMGAKOE0.0"	-->
 		<description>Pocket Bomberman (Europe)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -17461,11 +17875,30 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="poktpuyo">
+	<software name="poktpuyoa">
+		<!--	In lot check as "KENSA\dmgapyj1.0"	-->
+		<!-- NP only -->
+		<description>Pocket Puyo Puyo Tsuu (Jpn, Rev. A, NP)</description>
+		<year>1996</year>
+		<publisher>Compile</publisher>
+		<info name="serial" value="DMG-APYJ-JPN?" />
+		<info name="release" value="19961213" />
+		<info name="alt_title" value="ぽけっとぷよぷよ通" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgapyj1.0" size="262144" crc="cae8a317" sha1="36b677b76af12287cdbdec9ae06ca3f9dbfc1e67"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="poktpuyo" cloneof="poktpuyoa">
 		<description>Pocket Puyo Puyo Tsuu (Japan)</description>
 		<year>1996</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-APYJ-JPN" />
+		<info name="gold" value="19961107"/>
 		<info name="release" value="19961213" />
 		<info name="alt_title" value="ぽけっとぷよぷよ通" />
 		<part name="cart" interface="gameboy_cart">
@@ -18186,7 +18619,7 @@ license:CC0
 	</software>
 
 	<software name="mjkiwame">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Pro Mahjong Kiwame GB (Japan)</description>
 		<year>1994</year>
 		<publisher>Athena</publisher>
@@ -18357,12 +18790,32 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="purikura">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+	<software name="purikuraa">
+		<!--	In lot check as "KENSA\dmgappj1.0"	-->
+		<!-- NP only -->
+		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev. A, NP)</description>
+		<year>1997</year>
+		<publisher>Atlus</publisher>
+		<info name="serial" value="DMG-APPJ-JPN?" />
+		<info name="alt_title" value="プリクラポケット 不完全女子高生マニュアル" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="dmgappj1.0" size="524288" crc="57e9c17d" sha1="90929296b16d89130969041271327bcaa2b6a73e"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="purikura" cloneof="purikuraa">
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan)</description>
 		<year>1997</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-APPJ-JPN" />
+		<info name="gold" value="19970905"/>
 		<info name="release" value="19971017" />
 		<info name="alt_title" value="プリクラポケット 不完全女子高生マニュアル" />
 		<part name="cart" interface="gameboy_cart">
@@ -18377,7 +18830,7 @@ license:CC0
 	</software>
 
 	<software name="purikur2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Purikura Pocket 2 - Kareshi Kaizou Daisakusen (Japan)</description>
 		<year>1997</year>
 		<publisher>Atlus</publisher>
@@ -18396,7 +18849,7 @@ license:CC0
 	</software>
 
 	<software name="purikur3">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Purikura Pocket 3 - Talent Debut Daisakusen (Japan)</description>
 		<year>1998</year>
 		<publisher>Atlus</publisher>
@@ -19450,7 +19903,7 @@ license:CC0
 	</software>
 
 	<software name="rockman5" cloneof="megaman5">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-04 -->
+		<!-- Notes: Also released by NP in 2001-04 -->
 		<description>Rockman World 5 (Japan)</description>
 		<year>1994</year>
 		<publisher>Capcom</publisher>
@@ -19458,6 +19911,7 @@ license:CC0
 		<info name="release" value="19940722" />
 		<info name="alt_title" value="ロックマンワールド5" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="rockman world 5 (japan).bin" size="524288" crc="eeabd3c6" sha1="f3904d2069a888e45ca44878461324e4c2a8b03d" />
@@ -19496,7 +19950,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="mvpbbj" cloneof="mvpbb">
+	<software name="mvpbbj" cloneof="mvpbba">
 		<description>Roger Clemens MVP Baseball (Japan)</description>
 		<year>1993</year>
 		<publisher>Acclaim Japan</publisher>
@@ -19511,12 +19965,29 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="mvpbb">
-		<description>Roger Clemens MVP Baseball (USA)</description>
+	<software name="mvpbba">
+		<!--	In lot check as "dmgvme-1.640"	-->
+		<description>Roger Clemens' MVP Baseball (USA, Rev. A)</description>
+		<year>1992</year>
+		<publisher>LJN</publisher>
+		<info name="serial" value="DMG-VM-USA?" />
+		<info name="alt_title" value="Roger Clemens' MVP Baseball (Box)" />
+		<info name="gold" value="19921215"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgvme-1.640" size="262144" crc="fa955b39" sha1="678ea6ec765c467862be861d2c61fbb3a582c1f2"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mvpbb" cloneof="mvpbba">
+		<description>Roger Clemens' MVP Baseball (USA)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
 		<info name="serial" value="DMG-VM-USA" />
 		<info name="alt_title" value="Roger Clemens' MVP Baseball (Box)" />
+		<info name="gold" value="19920717"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
@@ -19730,7 +20201,7 @@ license:CC0
 	</software>
 
 	<software name="samegame">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Same Game (Japan)</description>
 		<year>1997</year>
 		<publisher>Hudson Soft</publisher>
@@ -20851,6 +21322,7 @@ license:CC0
 		<year>1994</year>
 		<publisher>GameTek</publisher>
 		<info name="serial" value="DMG-YK-AUS, DMG-YK-ESP-1, DMG-YK-EUR, DMG-YK-FAH, DMG-YK-ITA, DMG-YK-NOE-1, DMG-YK-UKV-1" />
+		<info name="gold" value="19940817" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-BEAN-02" />  <!-- Also found with DMG-BEAN-10 -->
@@ -21064,7 +21536,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sokoban" cloneof="boxxle">
+	<software name="sokoban" cloneof="boxxlea">
 		<description>Soukoban (Japan)</description>
 		<year>1989</year>
 		<publisher>Pony Canyon</publisher>
@@ -21736,7 +22208,7 @@ license:CC0
 	</software>
 
 	<software name="sf2j" cloneof="sf2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Street Fighter II (Japan)</description>
 		<year>1995</year>
 		<publisher>Capcom</publisher>
@@ -22609,11 +23081,28 @@ license:CC0
 	</software>
 
 	<software name="suzukif1">
+		<!--	In lot check as "dmgfqj-0.803", "POOL\dmgfqj-0"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Suzuki Aguri no F-1 Super Driving (Japan)</description>
 		<year>1993</year>
 		<publisher>Logic</publisher>
 		<info name="serial" value="DMG-FQJ" />
+		<info name="gold" value="19930405"/>
 		<info name="release" value="19930528" />
+		<info name="alt_title" value="鈴木亜久里のF-1スーパードライビング" />
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgfqj-0.803" size="262144" crc="7fe42a7f" sha1="40f1280c87918307ebc2a3f2ec1ce9b66ff9a67b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="suzukif1unk" cloneof="suzukif1">
+		<!-- Old dump of unknown origin -->
+		<description>Suzuki Aguri no F-1 Super Driving (Japan, bad dump?)</description>
+		<year>1993</year>
+		<publisher>Logic</publisher>
 		<info name="alt_title" value="鈴木亜久里のF-1スーパードライビング" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
@@ -22698,6 +23187,7 @@ license:CC0
 	</software>
 
 	<software name="swordho2">
+		<!--	In lot check as "DMGSIE0.C34", "POOL\DMGSIE-0.3", "POOL\DMGSIX-0.0"	-->
 		<description>The Sword of Hope II (USA)</description>
 		<year>1996</year>
 		<publisher>Kemco</publisher>
@@ -23030,6 +23520,7 @@ license:CC0
 	</software>
 
 	<software name="tazmani2u" cloneof="tazmania">
+		<!--	In lot check as "DMGATZE0.C83", "POOL\DMGATZP0"	-->
 		<description>Taz-Mania 2 (USA, THQ)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
@@ -23107,10 +23598,27 @@ license:CC0
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-K8-UKV" />
+		<info name="gold" value="19931012"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="teenage mutant hero turtles iii - radical rescue (europe).bin" size="131072" crc="9f3245f3" sha1="bd0aecb9b752eef5a9628ac9c649cad1efb8cb62" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tmnt3a" cloneof="tmnt3">
+		<!--	In lot check as "dmgk8x-1.918"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev. A)</description>
+		<year>1993</year>
+		<publisher>Konami</publisher>
+		<info name="serial" value="DMG-K8-UKV?" />
+		<info name="gold" value="19940202"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgk8x-1.918" size="131072" crc="5b7c9a54" sha1="5f01016c06c7d52bb434540b9ca327abe5039936"/>
 			</dataarea>
 		</part>
 	</software>
@@ -23163,6 +23671,7 @@ license:CC0
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-K8J" />
+		<info name="gold" value="19931004" />
 		<info name="release" value="19931126" />
 		<info name="alt_title" value="ティーンエイジ ミュータント ニンジャ タートルズ3 〜タートルズ危機一髪" />
 		<part name="cart" interface="gameboy_cart">
@@ -23191,6 +23700,7 @@ license:CC0
 		<year>1993</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-K8-USA" />
+		<info name="gold" value="19931007" />
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
@@ -23374,11 +23884,29 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tetris2">
+	<software name="tetris2a">
+		<!--	In lot check as "dmgehx-1.@08"	-->
+		<description>Tetris 2 (Europe, Rev. A)</description>
+		<year>1994</year>
+		<publisher>Nintendo</publisher>
+		<info name="gold" value="19961029"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgehx-1.@08" size="131072" crc="25c3100a" sha1="51bdceed8fc384b593444a5306b6a46a4672c96b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tetris2" cloneof="tetris2a">
+		<!--	In lot check as "dmgehx-0.@08"	-->
+		<!--	USA rerelease is a relabeled European cartridge?	-->
 		<description>Tetris 2 (Europe, USA)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-EH-USA-1, DMG-EH-(ESP-1/UKV)" />
+		<info name="gold" value="19940516"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-BEAN(K)-02" />   <!-- USA-1 cart -->
@@ -23391,11 +23919,14 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tetris2u" cloneof="tetris2">
+	<software name="tetris2u" cloneof="tetris2a">
+		<!--	In lot check as "dmgehe-0.926"	-->
+		<!--	Original USA-only release	-->
 		<description>Tetris 2 (USA)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-EH-USA" />
+		<info name="gold" value="19931026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
@@ -23446,7 +23977,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tetrisfl" cloneof="tetris2">
+	<software name="tetrisfl" cloneof="tetris2a">
 		<description>Tetris Flash (Japan)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
@@ -23517,11 +24048,30 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tintin">
-		<description>Tintin in Tibet (Europe)</description>
+	<software name="tintinx">
+		<!--	In lot check as "dmgat6x0.c13"	-->
+		<description>Tintin in Tibet (Euro, En / Es / It / Sv)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
+		<info name="serial" value="DMG-AT6X-?"/>
+		<info name="gold" value="19960425"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="dmgat6x0.c13" size="262144" crc="7a7d820f" sha1="a69bee8c26a520b648a780c67e4a73d54e1bf812"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tintin" cloneof="tintinx">
+		<description>Tintin in Tibet (Euro, En / Fr / De / Nl)</description>
+		<year>1994</year>
+		<publisher>Infogrames</publisher>
+		<info name="serial" value="DMG-AT6P-?"/>
+		<info name="gold" value="19960307"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
 				<rom name="tintin in tibet (europe) (en,fr,de,nl).bin" size="262144" crc="5d2bd778" sha1="8d8978fbd5a5634e2cce940122039d575e7b3646" />
@@ -24548,7 +25098,7 @@ license:CC0
 	</software>
 
 	<software name="uminus2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Umi no Nushi Tsuri 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Victor Interactive Software</publisher>
@@ -24900,6 +25450,7 @@ license:CC0
 	</software>
 
 	<software name="waterwrl">
+		<!--	In lot check as "DMGAWEP0.B72", "POOL\DMGAWEE0.1"	-->
 		<description>Water World (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
@@ -25289,11 +25840,28 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="wcstrikrx" cloneof="soccer">
+		<!--	In lot check as "dmgykx-0.999"	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
+		<description>World Cup Striker (Europe, En / Fra / Ger)</description>
+		<year>1994</year>
+		<publisher>Elite</publisher>
+		<info name="serial" value="GMG-YKX-?"/>
+		<info name="gold" value="19940412"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="dmgykx-0.999" size="131072" crc="40418964" sha1="4c976fc98a85089cfae7e7af7de6baef31e39f92"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wcstrikr" cloneof="soccer">
 		<description>World Cup Striker (Japan)</description>
 		<year>1994</year>
 		<publisher>Coconuts Japan</publisher>
 		<info name="serial" value="DMG-YKA" />
+		<info name="gold" value="19940426" />
 		<info name="release" value="19940617 (reprinted on 19970926, ハッピープライス, DMGYKA1, SGB enh?)" />
 		<info name="alt_title" value="ワールドカップストライカー" />
 		<part name="cart" interface="gameboy_cart">
@@ -25385,6 +25953,7 @@ license:CC0
 	</software>
 
 	<software name="worms">
+		<!--	In lot check as "DmGaw3P0.B96", "POOL\DMGAW3E0.0"	-->
 		<description>Worms (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
@@ -25738,7 +26307,7 @@ license:CC0
 	</software>
 
 	<software name="yossypnp" cloneof="tetrisat">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<!-- Notes: Also released by NP in 2000-03 -->
 		<description>Yossy no Panepon (Japan)</description>
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
@@ -26101,7 +26670,7 @@ license:CC0
 			<!-- TG-001 version has an epoxy blob ROM and an epoxy blob Sachen MMC1. -->
 			<feature name="slot" value="rom_sachen1" />
 			<dataarea name="rom" size="65536">
-				<rom name="mx27c512pc-70.u1" size="65536" crc="5e438db8" sha1="d9cb1721854709be7667f5dbce0adf2488c0919b" /> <!-- raal label: MX27C512PC-70 -->
+				<rom name="mx27c512pc-70.u1" size="65536" crc="5e438db8" sha1="d9cb1721854709be7667f5dbce0adf2488c0919b" /> <!-- real label: MX27C512PC-70 -->
 			</dataarea>
 		</part>
 	</software>
@@ -26219,111 +26788,6 @@ license:CC0
 		</part>
 	</software>
 
-<!-- Other Asian pirate carts -->
-
-	<software name="smw7" cloneof="advisln2">
-		<description>Super Mario World 7 (China, ripped from 18 in 1 multicart)</description>
-		<year>1998</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="262144">
-				<rom name="super mario world 7 (unlicensed) (multicart rip).bin" size="262144" crc="aad1226e" sha1="0ee89297e9d24c1b4247765c8561a2cc90e383c9" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="rockman8">
-		<description>Rockman 8 (China)</description>
-		<year>1999</year>
-		<publisher>Yong Yong</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_rock8" />
-			<dataarea name="rom" size="262144">
-				<rom name="rockman 8 (hong kong) [p1].bin" size="262144" crc="cc131a94" sha1="496575adfb1296f2f99c00e06e5ca5ee4daf1a12" />
-			</dataarea>
-			<dataarea name="ram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sml4" cloneof="crayon4">
-		<description>Super Mario Land 4 (China)</description>
-		<year>1997?</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="131072">
-				<rom name="super mario land 4 (unl).bin" size="131072" crc="d9f3eb9f" sha1="f0da6eced7492bf51ae5575522cca58726c34feb" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sonic3d5">
-		<description>Sonic 3D Blast 5 (China)</description>
-		<year>1998</year>
-		<publisher>Yong Yong</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_yong" />
-			<dataarea name="rom" size="262144">
-				<rom name="sonic 3d blast 5 (unl).bin" size="262144" crc="5fed0068" sha1="1eb403ee2550106cbb2e3e1d0715b7c9bc07d6be" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="sonic6" cloneof="speedy">
-		<description>Sonic 6</description>
-		<year>1998?</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="sonic 6 (unl).bin" size="524288" crc="aa4e9379" sha1="5f70ee1a1265536c6ed3657bfd5e54516add287d" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ffant4" cloneof="ffantlg3">
-		<description>Final Fantasy 4 (China)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc1" />
-			<dataarea name="rom" size="524288">
-				<rom name="final fantasy 4 (unl).bin" size="524288" crc="a6b6e233" sha1="0968289212c4ed0a4fb77d1b31e8eaf8663e6ed7" />
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mhzx">
-		<description>Meng Huan Zhi Xing (China, set 1)</description>
-		<year>19??</year>
-		<publisher>SKOB</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="meng huan zhi xing (unl).bin" size="262144" crc="76fd8bc5" sha1="40bf296ee9d89a8c4e7bd8ca9f19cd4e449dfd6c" />
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mhzxa" cloneof="mhzx">
-		<description>Meng Huan Zhi Xing (China, set 2)</description>
-		<year>19??</year>
-		<publisher>SKOB</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="meng huan zhi xing (alt) (unl).bin" size="262144" crc="e498d751" sha1="726158dc176c82cf02b8838a672a5206b72ae9d8" />
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
 
 <!-- GOWIN games -->
 <!--
@@ -26471,14 +26935,108 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 	</software>
 
 
-	<software name="188in1" supported="partial">
-		<description>Color GameBoy 188 in 1 (Hong Kong)</description>
-		<year>199?</year>
+<!-- Other Asian pirate carts -->
+
+	<software name="smw7" cloneof="advisln2">
+		<description>Super Mario World 7 (China, ripped from 18 in 1 multicart)</description>
+		<year>1998</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_188in1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="m29w640ft.u2" size="8388608" crc="e4068d7d" sha1="e61ee50ed39fd5b5cc8bdcb96fe1c3cccdcfc76f" />
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="262144">
+				<rom name="super mario world 7 (unlicensed) (multicart rip).bin" size="262144" crc="aad1226e" sha1="0ee89297e9d24c1b4247765c8561a2cc90e383c9" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rockman8">
+		<description>Rockman 8 (China)</description>
+		<year>1999</year>
+		<publisher>Yong Yong</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_rock8" />
+			<dataarea name="rom" size="262144">
+				<rom name="rockman 8 (hong kong) [p1].bin" size="262144" crc="cc131a94" sha1="496575adfb1296f2f99c00e06e5ca5ee4daf1a12" />
+			</dataarea>
+			<dataarea name="ram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sml4" cloneof="crayon4">
+		<description>Super Mario Land 4 (China)</description>
+		<year>1997?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="131072">
+				<rom name="super mario land 4 (unl).bin" size="131072" crc="d9f3eb9f" sha1="f0da6eced7492bf51ae5575522cca58726c34feb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sonic3d5">
+		<description>Sonic 3D Blast 5 (China)</description>
+		<year>1998</year>
+		<publisher>Yong Yong</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_yong" />
+			<dataarea name="rom" size="262144">
+				<rom name="sonic 3d blast 5 (unl).bin" size="262144" crc="5fed0068" sha1="1eb403ee2550106cbb2e3e1d0715b7c9bc07d6be" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sonic6" cloneof="speedy">
+		<description>Sonic 6</description>
+		<year>1998?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="sonic 6 (unl).bin" size="524288" crc="aa4e9379" sha1="5f70ee1a1265536c6ed3657bfd5e54516add287d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ffant4" cloneof="ffantlg3">
+		<description>Final Fantasy 4 (China)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc1" />
+			<dataarea name="rom" size="524288">
+				<rom name="final fantasy 4 (unl).bin" size="524288" crc="a6b6e233" sha1="0968289212c4ed0a4fb77d1b31e8eaf8663e6ed7" />
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mhzx">
+		<description>Meng Huan Zhi Xing (China, set 1)</description>
+		<year>19??</year>
+		<publisher>SKOB</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="meng huan zhi xing (unl).bin" size="262144" crc="76fd8bc5" sha1="40bf296ee9d89a8c4e7bd8ca9f19cd4e449dfd6c" />
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mhzxa" cloneof="mhzx">
+		<description>Meng Huan Zhi Xing (China, set 2)</description>
+		<year>19??</year>
+		<publisher>SKOB</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="meng huan zhi xing (alt) (unl).bin" size="262144" crc="e498d751" sha1="726158dc176c82cf02b8838a672a5206b72ae9d8" />
+			</dataarea>
+			<dataarea name="nvram" size="8192">
 			</dataarea>
 		</part>
 	</software>
@@ -26541,6 +27099,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="GBD-USA, GBD-EUR" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="MGB-MGBD-10" />
 			<feature name="u1" value="U1 [MAC-GBD 9808 SA]" />
 			<feature name="u2" value="U2 [MX23C8004-12]" />
@@ -26563,6 +27122,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<info name="release" value="19980221" />
 		<info name="alt_title" value="ポケットカメラ" />
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_camera" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket camera (japan) (rev a).bin" size="1048576" crc="73e8ef96" sha1="912205ea22e1dd735ed4f41d247039eebf39dddc" />
@@ -26577,6 +27137,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_camera" />
 			<dataarea name="rom" size="1048576">
 				<rom name="game boy camera gold (usa).bin" size="1048576" crc="a1a3f786" sha1="53a0dd6de3ebd0d3495f8bdc377ab08e5074c0ef" />
@@ -26636,7 +27197,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 		</part>
 	</software>
 
-	<!-- There is official Game Boy flash cart where players could load official games on stores.
+	<!-- There's an official Game Boy flash cart where players could load official games on stores.
 	    pcb="DMG-A20-01"
 	    u1="G-MMC1 (MX15002) [MX15002UCA]"
 	    u2="8M-FLASH [29F008ATC-14]"

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -3083,7 +3083,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="bugs bunny collection (japan) (rev a).bin" size="262144" crc="8244220b" sha1="9d69d72b7de0377cb0439aa301b1fb82d3ce786a" />
+				<rom name="bugs bunny collection (japan) (rev 1).bin" size="262144" crc="8244220b" sha1="9d69d72b7de0377cb0439aa301b1fb82d3ce786a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3745,7 +3745,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="65536">
-				<rom name="chessmaster, the (usa) (rev a).bin" size="65536" crc="59ed370c" sha1="f0351faab8b912967552684d4160f5cf94540d41" />
+				<rom name="chessmaster, the (usa) (rev 1).bin" size="65536" crc="59ed370c" sha1="f0351faab8b912967552684d4160f5cf94540d41" />
 			</dataarea>
 		</part>
 	</software>
@@ -5871,7 +5871,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dx bakenou z (japan) (rev a).bin" size="131072" crc="fadfd0f6" sha1="6e2b9b21ea7d8d482be1f17722a579f720f2029d" />
+				<rom name="dx bakenou z (japan) (rev 1).bin" size="131072" crc="fadfd0f6" sha1="6e2b9b21ea7d8d482be1f17722a579f720f2029d" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6976,7 +6976,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="game &amp; watch gallery (usa) (rev a).bin" size="262144" crc="9e6cdc96" sha1="4e4da0ed89c2baaed64600f7eaca90aeeadc084e" />
+				<rom name="game &amp; watch gallery (usa) (rev 1).bin" size="262144" crc="9e6cdc96" sha1="4e4da0ed89c2baaed64600f7eaca90aeeadc084e" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -8545,7 +8545,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan) (rev a).bin" size="262144" crc="74821248" sha1="b1626c1fe162a7b0292d292e8ba60a1c6823fc8d" />
+				<rom name="goukaku boy series - shikakui atama o marukusuru - suuji de asobou sansuu hen (japan) (rev 1).bin" size="262144" crc="74821248" sha1="b1626c1fe162a7b0292d292e8ba60a1c6823fc8d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9255,7 +9255,7 @@ license:CC0
 			<feature name="u2" value="U2 MBC1/1A/1B [DMG MBC1B]" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="hoshi no kirby (japan) (rev a).bin" size="262144" crc="04342c83" sha1="5fe35fab25299b6c53b40decfe2b1827b4a64d2a" />
+				<rom name="hoshi no kirby (japan) (rev 1).bin" size="262144" crc="04342c83" sha1="5fe35fab25299b6c53b40decfe2b1827b4a64d2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11606,7 +11606,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="konchuu hakase (japan) (rev a).bin" size="524288" crc="05753790" sha1="3e8e47b36a2171ad93d0e21fe5c22feff17c6d88" />
+				<rom name="konchuu hakase (japan) (rev 1).bin" size="524288" crc="05753790" sha1="3e8e47b36a2171ad93d0e21fe5c22feff17c6d88" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11921,7 +11921,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev b).bin" size="524288" crc="34d08e7b" sha1="5ab63def958728933571c3b4f6af54db14f3f8b2" />
+				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 2).bin" size="524288" crc="34d08e7b" sha1="5ab63def958728933571c3b4f6af54db14f3f8b2" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11936,7 +11936,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev a).bin" size="524288" crc="7d1b6cd6" sha1="5259e68522225a7a830e29ea17dfddc33263ced5" />
+				<rom name="legend of zelda, the - link's awakening (usa, europe) (rev 1).bin" size="524288" crc="7d1b6cd6" sha1="5259e68522225a7a830e29ea17dfddc33263ced5" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -15468,7 +15468,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="nettou toushinden (japan) (rev a).bin" size="524288" crc="d5a6b132" sha1="5fd55a5d01817c770b251dbb9a0dc73a02d8c566" />
+				<rom name="nettou toushinden (japan) (rev 1).bin" size="524288" crc="d5a6b132" sha1="5fd55a5d01817c770b251dbb9a0dc73a02d8c566" />
 			</dataarea>
 		</part>
 	</software>
@@ -18444,7 +18444,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="power mission (japan) (rev a).bin" size="131072" crc="e30ef8ab" sha1="89b2306ad9c9e296884354ec3be039b944d52d13" />
+				<rom name="power mission (japan) (rev 1).bin" size="131072" crc="e30ef8ab" sha1="89b2306ad9c9e296884354ec3be039b944d52d13" />
 			</dataarea>
 		</part>
 	</software>
@@ -18491,7 +18491,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="power pro gb (japan) (rev a).bin" size="262144" crc="71bea855" sha1="ebca3bce624d19a0fa3a92d30a5c543c12541ea4" />
+				<rom name="power pro gb (japan) (rev 1).bin" size="262144" crc="71bea855" sha1="ebca3bce624d19a0fa3a92d30a5c543c12541ea4" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20971,7 +20971,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="shougi saikyou (japan) (rev a).bin" size="262144" crc="a074bf7e" sha1="1c5a97aa3a09362c94fdd630456e5e59ae3af5fa" />
+				<rom name="shougi saikyou (japan) (rev 1).bin" size="262144" crc="a074bf7e" sha1="1c5a97aa3a09362c94fdd630456e5e59ae3af5fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -22789,7 +22789,7 @@ license:CC0
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="super mario land 2 - 6 golden coins (usa, europe) (rev a).bin" size="524288" crc="e6f886e5" sha1="96e3a314561fb394cdf51101f9178a32713c2313" />
+				<rom name="super mario land 2 - 6 golden coins (usa, europe) (rev 1).bin" size="524288" crc="e6f886e5" sha1="96e3a314561fb394cdf51101f9178a32713c2313" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -24533,7 +24533,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="toy story (usa) (rev a).bin" size="524288" crc="6f36b6ed" sha1="04227fcd3e049465f4499fefe6519322ee492a82" />
+				<rom name="toy story (usa) (rev 1).bin" size="524288" crc="6f36b6ed" sha1="04227fcd3e049465f4499fefe6519322ee492a82" />
 			</dataarea>
 		</part>
 	</software>
@@ -26470,7 +26470,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="zelda no densetsu - yume o miru shima (japan) (rev a).bin" size="524288" crc="ea20b82a" sha1="80f5d111c7e2d79d39f6c25a37b54c3196d2bd12" />
+				<rom name="zelda no densetsu - yume o miru shima (japan) (rev 1).bin" size="524288" crc="ea20b82a" sha1="80f5d111c7e2d79d39f6c25a37b54c3196d2bd12" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -27141,7 +27141,7 @@ patch the rom to 0x00 and 0x00....and at 0x0B3D also patch it to
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_camera" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket camera (japan) (rev a).bin" size="1048576" crc="73e8ef96" sha1="912205ea22e1dd735ed4f41d247039eebf39dddc" />
+				<rom name="pocket camera (japan) (rev 1).bin" size="1048576" crc="73e8ef96" sha1="912205ea22e1dd735ed4f41d247039eebf39dddc" />
 			</dataarea>
 			<dataarea name="nvram" size="131072">
 			</dataarea>

--- a/hash/gameboy.xml
+++ b/hash/gameboy.xml
@@ -4,24 +4,26 @@
 license:CC0
 
   To investigate:
-	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
-	- Was Gargoyle's Quest (Rev 1) released in the USA?
+	- Gargoyle's Quest - Ghosts'n Goblins (Rev 1)	<-	Unreleased in the USA?
+	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
 
   Known dumps not yet verified against retail cartridge:
 	- The Adventures of Rocky and Bullwinkle (USA)
 	- Fastest Lap (USA)
+	- Gargoyle's Quest - Ghosts'n Goblins (Rev 1)
 	- GI King! - Sanbiki no Yosouya (Japan)
 	- Hyper Lode Runner (Japan?)
 	- The Jetsons - Robot Panic (USA, Rev 1)
 	- Jungle Strike (USA)
 	- Kaseki Sousei Reborn (Japan, Rev 1)
+	- Kirby's Dream Land 2 (USA)
 	- Disney's Mulan (USA)
 	- Pac-In-Time (Europe, Rev 1)
 	- Pac-Man (Japan)
 	- Pang (UK)
 	- Suzuki Aguri no F-1 Super Driving (Japan)
 	- Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
-	- World Cup Striker (Europe, En / Fra / Ger)	<-	Unreleased?
+	- World Cup Striker (Europe, En / Fra / Ger)
 
   Undumped pirate carts:
 	- GOWIN carts (see below the list of known games)
@@ -273,7 +275,6 @@ license:CC0
 	</software>
 
 	<software name="rockybw">
-		<!--	In lot check as "dmgrye-0.647"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>The Adventures of Rocky and Bullwinkle (USA)</description>
 		<year>1992</year>
@@ -284,7 +285,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgrye-0.647" size="131072" crc="362c841c" sha1="0ce98889e5d9d6167338e91119394537318810da"/>
+				<rom name="dmg-rye-0.u1" size="131072" crc="362c841c" sha1="0ce98889e5d9d6167338e91119394537318810da"/>
 			</dataarea>
 		</part>
 	</software>
@@ -608,7 +609,7 @@ license:CC0
 	</software>
 
 	<software name="asbase99">
-		<!--	In lot check as "Dmgab9e0.e21", "KENSA\Dmgab9p0.1"	-->
+		<!--	Planned for release in Europe as "dmg-ab9p-0"	-->
 		<description>All-Star Baseball '99 (USA)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -617,7 +618,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="all-star baseball '99 (usa).bin" size="524288" crc="d51ee6d3" sha1="49d13eef514d26cee37b10ff602e21a92b87b69d" />
+				<rom name="dmg-ab9e-0.u1" size="524288" crc="d51ee6d3" sha1="49d13eef514d26cee37b10ff602e21a92b87b69d" />
 			</dataarea>
 		</part>
 	</software>
@@ -778,7 +779,6 @@ license:CC0
 	</software>
 
 	<software name="amoudan2a">
-		<!--	In lot check as "dmgauj-1.434"	-->
 		<description>America Oudan Ultra Quiz Part 2 (Japan, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Tomy</publisher>
@@ -788,7 +788,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgauj-1.434" size="262144" crc="739c26fc" sha1="cb3ed70f4d095405df2c322c528cab2a00d56557"/>
+				<rom name="dmg-auj-1.u1" size="262144" crc="739c26fc" sha1="cb3ed70f4d095405df2c322c528cab2a00d56557"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2486,7 +2486,7 @@ license:CC0
 	</software>
 
 	<software name="bokujomnp" cloneof="harvmoon">
-		<!--	In lot check as "KENSA\dmgbywj0.0"	-->
+		<!--	Planned for physical release?	-->
 		<description>Bokujou Monogatari GB (Japan, NP)</description>
 		<year>1997</year>
 		<publisher>Victor Interactive Software</publisher>
@@ -2497,7 +2497,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="dmgbywj0.0" size="524288" crc="0424df85" sha1="551df2021d0e433e7f07cf881c7b1d534f54f6ad"/>
+				<rom name="dmg-bywj-0.u1" size="524288" crc="0424df85" sha1="551df2021d0e433e7f07cf881c7b1d534f54f6ad"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2782,7 +2782,6 @@ license:CC0
 	</software>
 
 	<software name="boxxle" cloneof="boxxlea">
-		<!--	In lot check as "dmgsoe-0.020"	-->
 		<description>Boxxle (USA)</description>
 		<year>1990</year>
 		<publisher>FCI</publisher>
@@ -2791,7 +2790,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="32768">
-				<rom name="dmgsoe-0.020" size="32768" crc="24843867" sha1="3e169f1db16cc1c3ffbc8645aa7ce28194033d26"/>
+				<rom name="dmg-soe-0.u1" size="32768" crc="24843867" sha1="3e169f1db16cc1c3ffbc8645aa7ce28194033d26"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3212,7 +3211,7 @@ license:CC0
 	</software>
 
 	<software name="bam3dx">
-		<!--	In lot check as "Dmga3vp0.e84", "KENSA\DMGA3VE0.0"	-->
+		<!--	Planned for release in USA as "dmg-a3ve-0"	-->
 		<description>Bust-A-Move 3 DX (Europe)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
@@ -3220,7 +3219,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="bust-a-move 3 dx (europe).bin" size="131072" crc="e555c612" sha1="e89dc67087205c4113a4d152347eba38204e270b" />
+				<rom name="dmg-a3vp-0.u1" size="131072" crc="e555c612" sha1="e89dc67087205c4113a4d152347eba38204e270b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6271,7 +6270,6 @@ license:CC0
 	</software>
 
 	<software name="fastlapu">
-		<!--	In lot check as "dmgf2e-0.411"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Fastest Lap (USA)</description>
 		<year>1991</year>
@@ -6281,7 +6279,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgf2e-0.411" size="131072" crc="a9ba7875" sha1="25bf89b112c9b134b2e4d07354d1a762ab0d4e92"/>
+				<rom name="dmg-f2e-0.u1" size="131072" crc="a9ba7875" sha1="25bf89b112c9b134b2e4d07354d1a762ab0d4e92"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6413,7 +6411,7 @@ license:CC0
 	</software>
 
 	<software name="fifa98a" cloneof="fifa98">
-		<!--	In lot check as "DMGA8SP0.D75", "KENSA\DMGA8SE0.4"	-->
+		<!--	Planned for release in USA as "dmg-a8se-0"	-->
 		<description>FIFA Road to the World Cup '98 (Europe)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
@@ -7322,7 +7320,6 @@ license:CC0
 	</software>
 
 	<software name="gargoylea">
-		<!--	In lot check as "dmgrae-1.108"	-->
 		<!--	European release is a relabeled USA version	-->
 		<!--	Unreleased in USA?	-->
 		<description>Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev 1)</description>
@@ -7334,7 +7331,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgrae-1.108" size="131072" crc="b86ef7a5" sha1="21fbe39014ffed80d0de2092517522d3cb9b03f9"/>
+				<rom name="dmg-rae-1.u1" size="131072" crc="b86ef7a5" sha1="21fbe39014ffed80d0de2092517522d3cb9b03f9"/>
 			</dataarea>
 		</part>
 	</software>
@@ -7677,7 +7674,6 @@ license:CC0
 	</software>
 
 	<software name="giking">
-		<!--	In lot check as "dmggij-0.777"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>GI King! - Sanbiki no Yosouya (Japan)</description>
 		<year>1993</year>
@@ -7695,7 +7691,7 @@ license:CC0
 			<feature name="batt" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmggij-0.777" size="131072" crc="f0dff737" sha1="65265b1c28173a6df0fede8c025cce56e752b1fd"/>
+				<rom name="dmg-gij-0.u1" size="131072" crc="f0dff737" sha1="65265b1c28173a6df0fede8c025cce56e752b1fd"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -8023,7 +8019,6 @@ license:CC0
 	</software>
 
 	<software name="gbskjtatie">
-		<!--	In lot check as "dmgbq2j0.k33"	-->
 		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Japan, Alt)</description>
 		<year>2003</year>
 		<publisher>IE Institute</publisher>
@@ -8033,7 +8028,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgbq2j0.k33" size="1048576" crc="180d54a7" sha1="7dce0adcbac61f0caae33646847fd06ced8c8b67"/>
+				<rom name="dmg-bq2j-0.u1" size="1048576" crc="180d54a7" sha1="7dce0adcbac61f0caae33646847fd06ced8c8b67"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -8065,7 +8060,6 @@ license:CC0
 	</software>
 
 	<software name="gbskstatie">
-		<!--	In lot check as "dmgbc6j0.k32"	-->
 		<description>Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Keisan no Tatsujin (Japan, Alt)</description>
 		<year>2003</year>
 		<publisher>IE Institute</publisher>
@@ -8075,7 +8069,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="dmgbc6j0.k32" size="1048576" crc="04214f92" sha1="6b8726c69a31e674a4c5ab02631de073d42e7d52"/>
+				<rom name="dmg-bc6j-0.u1" size="1048576" crc="04214f92" sha1="6b8726c69a31e674a4c5ab02631de073d42e7d52"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -9462,7 +9456,6 @@ license:CC0
 	</software>
 
 	<software name="hyperloda">
-		<!--	In lot check as "dmghla-1.011"	-->
 		<!--	Region code "A"	-->
 		<description>Hyper Lode Runner (World, Rev 1)</description>
 		<year>1989</year>
@@ -9480,7 +9473,6 @@ license:CC0
 	</software>
 
 	<software name="hyperlod" cloneof="hyperloda">
-		<!--	In lot check as "dmghla-0.011"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<!--	Region code "A"	-->
 		<description>Hyper Lode Runner (Japan?)</description>
@@ -9492,7 +9484,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="32768">
-				<rom name="dmghla-0.011" size="32768" crc="3fc21b74" sha1="37d0f2cbac0f95af8b22dea0c882612681ec5cc8"/>
+				<rom name="dmg-hla-0.u1" size="32768" crc="3fc21b74" sha1="37d0f2cbac0f95af8b22dea0c882612681ec5cc8"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10097,7 +10089,7 @@ license:CC0
 	</software>
 
 	<software name="jellyboy">
-		<!--	In lot check as "DMGAJBP0.A52", "POOL\DMGAJBE0"	-->
+		<!--	Planned for release in USA as "dmg-ajbe-0"	-->
 		<description>Jelly Boy (Europe)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
@@ -10105,7 +10097,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="jelly boy (europe).bin" size="262144" crc="7e6598bb" sha1="579579d660cdc84af2428ccd1b30b40a2fb592fa" />
+				<rom name="dmg-ajbp-0.u1" size="262144" crc="7e6598bb" sha1="579579d660cdc84af2428ccd1b30b40a2fb592fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10124,7 +10116,7 @@ license:CC0
 	</software>
 
 	<software name="jeopardp">
-		<!--	In lot check as "DMGAJPE0.C68", "POOL\DMGAJPP0"	-->
+		<!--	Planned for release in Europe as "dmg-ajpp-0"	-->
 		<description>Jeopardy! - Platinum Edition (USA)</description>
 		<year>1996</year>
 		<publisher>GameTek</publisher>
@@ -10133,7 +10125,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="jeopardy - platinum edition (usa).bin" size="131072" crc="5206fd09" sha1="35934633a9b301d734a6fced7c56d55eba0385aa" />
+				<rom name="dmg-ajpe-0.u1" size="131072" crc="5206fd09" sha1="35934633a9b301d734a6fced7c56d55eba0385aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -10152,7 +10144,7 @@ license:CC0
 	</software>
 
 	<software name="jeopardt">
-		<!--	In lot check as "DMGAJQE0.C69", "POOL\DMGAJQP0"	-->
+		<!--	Planned for release in Europe as "dmg-ajqp-0"	-->
 		<description>Jeopardy! - Teen Tournament (USA)</description>
 		<year>1996</year>
 		<publisher>GameTek</publisher>
@@ -10161,13 +10153,12 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="jeopardy - teen tournament (usa).bin" size="131072" crc="cd3df0c1" sha1="20c71f434ef093fac9361fa1db9c2282c938dd71" />
+				<rom name="dmg-ajqe-0.u1" size="131072" crc="cd3df0c1" sha1="20c71f434ef093fac9361fa1db9c2282c938dd71" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="jetsonsa">
-		<!--	In lot check as "dmgjse-1.588"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>The Jetsons - Robot Panic (USA, Rev 1)</description>
 		<year>1992</year>
@@ -10177,7 +10168,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgjse-1.588" size="131072" crc="cc38cf0d" sha1="38b5ec2c74316696b7731cd88e56be4519084168"/>
+				<rom name="dmg-jse-1.u1" size="131072" crc="cc38cf0d" sha1="38b5ec2c74316696b7731cd88e56be4519084168"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10443,7 +10434,6 @@ license:CC0
 	</software>
 
 	<software name="jstrikeu" cloneof="jstrike">
-		<!--	In lot check as "dmgajge0.a85"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Jungle Strike (USA)</description>
 		<year>1995</year>
@@ -10453,7 +10443,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgajge0.a85" size="262144" crc="7a8cdbe8" sha1="ea8b7a5d8d16b4448a3d758fff1f91f27db60292"/>
+				<rom name="dmg-ajge-0.u1" size="262144" crc="7a8cdbe8" sha1="ea8b7a5d8d16b4448a3d758fff1f91f27db60292"/>
 			</dataarea>
 		</part>
 	</software>
@@ -10713,7 +10703,6 @@ license:CC0
 	</software>
 
 	<software name="kasekia">
-		<!--	In lot check as "dmgakrj1.e41"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Kaseki Sousei Reborn (Japan, Rev 1)</description>
 		<year>1998</year>
@@ -10725,7 +10714,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="dmgakrj1.e41" size="524288" crc="7c94197c" sha1="5759394e2e8bfd68ccf5519362572daaba003573"/>
+				<rom name="dmg-akrj-1.u1" size="524288" crc="7c94197c" sha1="5759394e2e8bfd68ccf5519362572daaba003573"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11104,7 +11093,6 @@ license:CC0
 	</software>
 
 	<software name="kininkoa">
-		<!--	In lot check as "dmgonj-1.153"	-->
 		<description>Kinin Koumaroku Oni (Japan, Rev 1)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
@@ -11114,7 +11102,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc2" />
 			<dataarea name="rom" size = "131072">
-				<rom name="dmgonj-1.153.gb" size="131072" crc="aaf6366c" sha1="298965bc2b99e49339618914114abfd0962560c1" offset="0"/>
+				<rom name="dmg-onj-1.u1" size="131072" crc="aaf6366c" sha1="298965bc2b99e49339618914114abfd0962560c1" offset="0"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11260,7 +11248,8 @@ license:CC0
 	</software>
 
 	<software name="kirby2">
-		<!--	In lot check as "DMGAKBE0.A66", "DMGAKBP0.A74", "POOL\DMGAKBP0"	-->
+		<!--	USA version released as "dmg-akbe-0"	-->
+		<!--	Retail cartridge of USA version not yet secured	-->
 		<description>Kirby's Dream Land 2 (Australia, Europe, USA)</description>
 		<year>1995</year>
 		<publisher>Nintendo</publisher>
@@ -11889,7 +11878,7 @@ license:CC0
 	</software>
 
 	<software name="rivkingu" cloneof="rivking">
-		<!--	In lot check as "Dmgafhe0.e42", "KENSA\Dmgafhp0.2"	-->
+		<!--	Planned for release in Europe as "dmg-afhp-0"	-->
 		<description>Legend of the River King GB (USA)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
@@ -11898,7 +11887,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="legend of the river king gb (usa).bin" size="524288" crc="a6e685dc" sha1="d2e8a9aceec8639b528f712532a38fe0c2b0edef" />
+				<rom name="dmg-afhe-0.u1" size="524288" crc="a6e685dc" sha1="d2e8a9aceec8639b528f712532a38fe0c2b0edef" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11906,7 +11895,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnk">
-		<!--	In lot check as "DMGZLE-2.858"	-->
 		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Europe, USA, Rev 2)</description>
 		<year>1993</year>
@@ -11924,7 +11912,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnka" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLE-1.858"	-->
 		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA, Rev 1)</description>
 		<year>1993</year>
@@ -11942,7 +11929,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkb" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLE-0.858"	-->
 		<!--	Region code "E" (USA)	-->
 		<description>The Legend of Zelda - Link's Awakening (Canada, Europe, USA)</description>
 		<year>1993</year>
@@ -11966,7 +11952,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkc" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZCF-0.888"	-->
 		<description>The Legend of Zelda - Link's Awakening (Canada, French)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
@@ -11989,7 +11974,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkf" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLF-0.872"	-->
 		<description>The Legend of Zelda - Link's Awakening (France)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
@@ -12012,7 +11996,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkg" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLD-0.873"	-->
 		<description>The Legend of Zelda - Link's Awakening (Germany)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
@@ -12092,7 +12075,7 @@ license:CC0
 	</software>
 
 	<software name="lemming2">
-		<!--	In lot check as "DMGAL2P0.@93", "POOL\DMGAL2E0"	-->
+		<!--	Planned for release in USA as "dmg-al2e-0"	-->
 		<description>Lemmings 2 - The Tribes (Europe)</description>
 		<year>1994</year>
 		<publisher>Psygnosis</publisher>
@@ -12100,7 +12083,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="lemmings 2 - the tribes (europe).bin" size="524288" crc="9800bd49" sha1="76ccf9ac82faebc7f9c4a4c8b5cd47ddea46c486" />
+				<rom name="dmg-al2p-0.u1" size="524288" crc="9800bd49" sha1="76ccf9ac82faebc7f9c4a4c8b5cd47ddea46c486" />
 			</dataarea>
 		</part>
 	</software>
@@ -12481,7 +12464,7 @@ license:CC0
 	</software>
 
 	<software name="madden97">
-		<!--	In lot check as "DMGA7ME0.C47", "POOL\DMGA7MP0"	-->
+		<!--	Planned for release in Europe as "dmg-a7mp-0"	-->
 		<description>Madden '97 (USA)</description>
 		<year>1995</year>
 		<publisher>Black Pearl</publisher>
@@ -12490,7 +12473,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="madden '97 (usa).bin" size="524288" crc="88a837a2" sha1="e1d92b6afdd7dc2254c895ad8a9a066262fb214b" />
+				<rom name="dmg-a7me-0.u1" size="524288" crc="88a837a2" sha1="e1d92b6afdd7dc2254c895ad8a9a066262fb214b" />
 			</dataarea>
 		</part>
 	</software>
@@ -12934,7 +12917,7 @@ license:CC0
 	</software>
 
 	<software name="mauimall">
-		<!--	In lot check as "Dmgamie0.e45", "KENSA\Dmgamip0.1"	-->
+		<!--	Planned for release in Europe as "dmg-amip-0"	-->
 		<description>Maui Mallard (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
@@ -12944,7 +12927,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="maui mallard (usa).bin" size="262144" crc="6f30a43a" sha1="eb401c5ddff1488013ff032918ed365e82104ae0" />
+				<rom name="dmg-amie-0.u1" size="262144" crc="6f30a43a" sha1="eb401c5ddff1488013ff032918ed365e82104ae0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13518,7 +13501,6 @@ license:CC0
 	</software>
 
 	<software name="mickey5" cloneof="mickeymw">
-		<!--	In lot check as "dmgi5j-0.933"	-->
 		<description>Mickey Mouse V (Japan)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
@@ -13535,7 +13517,6 @@ license:CC0
 	</software>
 
 	<software name="mickey5a" cloneof="mickeymw">
-		<!--	In lot check as "dmgi5j-1.933"	-->
 		<description>Mickey Mouse V (Japan, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Kemco</publisher>
@@ -13545,7 +13526,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgi5j-1.933" size="131072" crc="464eaa5d" sha1="095285ec078124e3a4cbbfa3ac0d7680ee491e2b"/>
+				<rom name="dmg-i5j-1.u1" size="131072" crc="464eaa5d" sha1="095285ec078124e3a4cbbfa3ac0d7680ee491e2b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -14581,7 +14562,7 @@ license:CC0
 	</software>
 
 	<software name="mrnutz">
-		<!--	In lot check as "DMGAN8P0.A12", "POOL\DMGAN8E0"	-->
+		<!--	Planned for release in USA as "dmg-an8e-0"	-->
 		<description>Mr Nutz (Europe)</description>
 		<year>1994</year>
 		<publisher>Ocean</publisher>
@@ -14589,7 +14570,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="mr nutz (europe).bin" size="262144" crc="03b64a35" sha1="c3dc8fa1aebc92b07eacd6c78aece7c6dd33429d" />
+				<rom name="dmg-an8p-0.u1" size="262144" crc="03b64a35" sha1="c3dc8fa1aebc92b07eacd6c78aece7c6dd33429d" />
 			</dataarea>
 		</part>
 	</software>
@@ -14715,7 +14696,6 @@ license:CC0
 	</software>
 
 	<software name="mulanu" cloneof="mulan">
-		<!--	In lot check as "dmgamle0.e74"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Disney's Mulan (USA)</description>
 		<year>1998</year>
@@ -14726,7 +14706,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="dmgamle0.e74" size="524288" crc="bfcf71a1" sha1="7832fcc373ff752e757550079519b39583665c82"/>
+				<rom name="dmg-amle-0.u1" size="524288" crc="bfcf71a1" sha1="7832fcc373ff752e757550079519b39583665c82"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15517,7 +15497,6 @@ license:CC0
 	</software>
 
 	<software name="wh2ja" cloneof="wh2">
-		<!--	In lot check as "dmgawjj1.a40"	-->
 		<description>Nettou World Heroes 2 Jet (Japan, Rev 1)</description>
 		<year>1995</year>
 		<publisher>Takara</publisher>
@@ -15528,7 +15507,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="dmgawjj1.a40" size="524288" crc="7c5ffe52" sha1="14bc507f479e814b0131febfab19f2ef30eb23a5"/>
+				<rom name="dmg-awjj-1.u1" size="524288" crc="7c5ffe52" sha1="14bc507f479e814b0131febfab19f2ef30eb23a5"/>
 			</dataarea>
 		</part>
 	</software>
@@ -16376,7 +16355,6 @@ license:CC0
 	</software>
 
 	<software name="pacintima">
-		<!--	In lot check as "dmgaptp1.a96"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Pac-In-Time (Europe, Rev 1)</description>
 		<year>1995</year>
@@ -16387,7 +16365,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgaptp1.a96" size="262144" crc="7ff79df9" sha1="f30108b8e422c4b9776c90c884710194508545ea"/>
+				<rom name="dmg-aptp-1.u1" size="262144" crc="7ff79df9" sha1="f30108b8e422c4b9776c90c884710194508545ea"/>
 			</dataarea>
 		</part>
 	</software>
@@ -16446,7 +16424,6 @@ license:CC0
 	</software>
 
 	<software name="pacman">
-		<!--	In lot check as "DMGPCX-0.412"	-->
 		<description>Pac-Man (Europe)</description>
 		<year>1991</year>
 		<publisher>Namco</publisher>
@@ -16464,8 +16441,6 @@ license:CC0
 	</software>
 
 	<software name="pacmanj" cloneof="pacman">
-		<!--	In lot check as "dmgpca-0.159"	-->
-		<!--	Lot check ROM is padded with FFs to twice its size, but correct size is 512kb (64KB) according to the official release spreadsheet	-->
 		<!--	Retail cartridge not yet secured	-->
 		<!--	Region code "A"	-->
 		<!-- Also released via the Nintendo Power service in 2000-03 -->
@@ -16484,7 +16459,6 @@ license:CC0
 	</software>
 
 	<software name="pacmanu" cloneof="pacman">
-		<!--	In lot check as "DMGPCE-0.264"	-->
 		<description>Pac-Man (USA)</description>
 		<year>1991</year>
 		<publisher>Namco</publisher>
@@ -16887,7 +16861,6 @@ license:CC0
 	</software>
 
 	<software name="pang">
-		<!--	In lot check as "dmgagx-0.897"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Pang (UK)</description>
 		<year>1993</year>
@@ -17468,7 +17441,7 @@ license:CC0
 	</software>
 
 	<software name="pockbman">
-		<!--	In lot check as "DMGAKOP0.D90", "KENSA\DMGAKOE0.0"	-->
+		<!--	Planned for release in USA as "dmg-akoe-0"	-->
 		<description>Pocket Bomberman (Europe)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
@@ -17477,7 +17450,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="pocket bomberman (europe).bin" size="524288" crc="0fd1ae54" sha1="34f377a6de2961fe16bfb854e0cebc7fdba7cf4b" />
+				<rom name="dmg-akop-0.u1" size="524288" crc="0fd1ae54" sha1="34f377a6de2961fe16bfb854e0cebc7fdba7cf4b" />
 			</dataarea>
 		</part>
 	</software>
@@ -17884,8 +17857,8 @@ license:CC0
 	</software>
 
 	<software name="poktpuyoa">
-		<!--	In lot check as "KENSA\dmgapyj1.0"	-->
 		<!-- NP only -->
+		<!--	Planned for physical release?	-->
 		<description>Pocket Puyo Puyo Tsuu (Japan, Rev 1, NP)</description>
 		<year>1996</year>
 		<publisher>Compile</publisher>
@@ -17896,7 +17869,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgapyj1.0" size="262144" crc="cae8a317" sha1="36b677b76af12287cdbdec9ae06ca3f9dbfc1e67"/>
+				<rom name="dmg-apyj-1.u1" size="262144" crc="cae8a317" sha1="36b677b76af12287cdbdec9ae06ca3f9dbfc1e67"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18383,7 +18356,6 @@ license:CC0
 	</software>
 
 	<software name="popeye2ja" cloneof="popeye2">
-		<!--	In lot check as "dmgpgj-1.403"	-->
 		<description>Popeye 2 (Japan, Rev 1)</description>
 		<year>1991</year>
 		<publisher>Sigma</publisher>
@@ -18393,7 +18365,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgpgj-1.403" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd"/>
+				<rom name="dmg-pgj-1.u1" size="131072" crc="8cd93719" sha1="7c4ac88e7a9f034da08ee84f299d9093e40213fd"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18814,8 +18786,8 @@ license:CC0
 	</software>
 
 	<software name="purikuraa">
-		<!--	In lot check as "KENSA\dmgappj1.0"	-->
 		<!-- NP only -->
+		<!--	Planned for physical release?	-->
 		<description>Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev 1, NP)</description>
 		<year>1997</year>
 		<publisher>Atlus</publisher>
@@ -18825,7 +18797,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
-				<rom name="dmgappj1.0" size="524288" crc="57e9c17d" sha1="90929296b16d89130969041271327bcaa2b6a73e"/>
+				<rom name="dmg-appj-1.u1" size="524288" crc="57e9c17d" sha1="90929296b16d89130969041271327bcaa2b6a73e"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19989,7 +19961,6 @@ license:CC0
 	</software>
 
 	<software name="mvpbba">
-		<!--	In lot check as "dmgvme-1.640"	-->
 		<description>Roger Clemens' MVP Baseball (USA, Rev 1)</description>
 		<year>1992</year>
 		<publisher>LJN</publisher>
@@ -19999,7 +19970,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgvme-1.640" size="262144" crc="fa955b39" sha1="678ea6ec765c467862be861d2c61fbb3a582c1f2"/>
+				<rom name="dmg-vme-1.u1" size="262144" crc="fa955b39" sha1="678ea6ec765c467862be861d2c61fbb3a582c1f2"/>
 			</dataarea>
 		</part>
 	</software>
@@ -23109,7 +23080,6 @@ license:CC0
 	</software>
 
 	<software name="suzukif1">
-		<!--	In lot check as "dmgfqj-0.803", "POOL\dmgfqj-0"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Suzuki Aguri no F-1 Super Driving (Japan)</description>
 		<year>1993</year>
@@ -23121,7 +23091,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgfqj-0.803" size="262144" crc="7fe42a7f" sha1="40f1280c87918307ebc2a3f2ec1ce9b66ff9a67b"/>
+				<rom name="dmg-fqj-0.u1" size="262144" crc="7fe42a7f" sha1="40f1280c87918307ebc2a3f2ec1ce9b66ff9a67b"/>
 			</dataarea>
 		</part>
 	</software>
@@ -23215,7 +23185,7 @@ license:CC0
 	</software>
 
 	<software name="swordho2">
-		<!--	In lot check as "DMGSIE0.C34", "POOL\DMGSIE-0.3", "POOL\DMGSIX-0.0"	-->
+		<!--	Planned for release in UK as "dmg-six-0"	-->
 		<description>The Sword of Hope II (USA)</description>
 		<year>1996</year>
 		<publisher>Kemco</publisher>
@@ -23223,7 +23193,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="sword of hope ii, the (usa).bin" size="262144" crc="5b7ff38c" sha1="3ccb37fd8e6e39a9e8421ee6f1ae199b4586afc1" />
+				<rom name="dmg-sie-0.u1" size="262144" crc="5b7ff38c" sha1="3ccb37fd8e6e39a9e8421ee6f1ae199b4586afc1" />
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -23549,7 +23519,7 @@ license:CC0
 	</software>
 
 	<software name="tazmani2u" cloneof="tazmania">
-		<!--	In lot check as "DMGATZE0.C83", "POOL\DMGATZP0"	-->
+		<!--	Planned for release in Europe as "dmg-atzp-0"	-->
 		<description>Taz-Mania 2 (USA, THQ)</description>
 		<year>1997</year>
 		<publisher>THQ</publisher>
@@ -23557,7 +23527,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="taz-mania 2 (usa).bin" size="131072" crc="4ccb65e0" sha1="60116a304e85f04209dc7eb64d9649dc41c963f6" />
+				<rom name="dmg-atze-0.u1" size="131072" crc="4ccb65e0" sha1="60116a304e85f04209dc7eb64d9649dc41c963f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -23637,7 +23607,6 @@ license:CC0
 	</software>
 
 	<software name="tmnt3a" cloneof="tmnt3">
-		<!--	In lot check as "dmgk8x-1.918"	-->
 		<!--	Retail cartridge not yet secured	-->
 		<description>Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)</description>
 		<year>1993</year>
@@ -23647,7 +23616,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgk8x-1.918" size="131072" crc="5b7c9a54" sha1="5f01016c06c7d52bb434540b9ca327abe5039936"/>
+				<rom name="dmg-k8x-1.u1" size="131072" crc="5b7c9a54" sha1="5f01016c06c7d52bb434540b9ca327abe5039936"/>
 			</dataarea>
 		</part>
 	</software>
@@ -23914,7 +23883,6 @@ license:CC0
 	</software>
 
 	<software name="tetris2a">
-		<!--	In lot check as "dmgehx-1.@08"	-->
 		<description>Tetris 2 (Europe, Rev 1)</description>
 		<year>1994</year>
 		<publisher>Nintendo</publisher>
@@ -23923,13 +23891,12 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgehx-1.@08" size="131072" crc="25c3100a" sha1="51bdceed8fc384b593444a5306b6a46a4672c96b"/>
+				<rom name="dmg-ehx-1.u1" size="131072" crc="25c3100a" sha1="51bdceed8fc384b593444a5306b6a46a4672c96b"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="tetris2" cloneof="tetris2a">
-		<!--	In lot check as "dmgehx-0.@08"	-->
 		<!--	USA rerelease is a relabeled European cartridge?	-->
 		<description>Tetris 2 (Europe, USA)</description>
 		<year>1994</year>
@@ -23949,7 +23916,6 @@ license:CC0
 	</software>
 
 	<software name="tetris2u" cloneof="tetris2a">
-		<!--	In lot check as "dmgehe-0.926"	-->
 		<!--	Original USA-only release	-->
 		<description>Tetris 2 (USA)</description>
 		<year>1994</year>
@@ -24078,7 +24044,6 @@ license:CC0
 	</software>
 
 	<software name="tintinx">
-		<!--	In lot check as "dmgat6x0.c13"	-->
 		<description>Tintin in Tibet (Europe, En / Es / It / Sv)</description>
 		<year>1994</year>
 		<publisher>Infogrames</publisher>
@@ -24088,7 +24053,7 @@ license:CC0
 			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="dmgat6x0.c13" size="262144" crc="7a7d820f" sha1="a69bee8c26a520b648a780c67e4a73d54e1bf812"/>
+				<rom name="dmg-at6x-0.u1" size="262144" crc="7a7d820f" sha1="a69bee8c26a520b648a780c67e4a73d54e1bf812"/>
 			</dataarea>
 		</part>
 	</software>
@@ -25479,7 +25444,7 @@ license:CC0
 	</software>
 
 	<software name="waterwrl">
-		<!--	In lot check as "DMGAWEP0.B72", "POOL\DMGAWEE0.1"	-->
+		<!--	Planned for release in USA as "dmg-awee-0"	-->
 		<description>Water World (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
@@ -25487,7 +25452,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="water world (europe).bin" size="262144" crc="4786fd6e" sha1="e669d47b124a1e12d73f4ac80d8b4c0f917cb058" />
+				<rom name="dmg-awep-0.u1" size="262144" crc="4786fd6e" sha1="e669d47b124a1e12d73f4ac80d8b4c0f917cb058" />
 			</dataarea>
 		</part>
 	</software>
@@ -25870,7 +25835,6 @@ license:CC0
 	</software>
 
 	<software name="wcstrikrx" cloneof="soccer">
-		<!--	In lot check as "dmgykx-0.999"	-->
 		<!--	Retail cartridge not yet secured, might be unreleased	-->
 		<description>World Cup Striker (Europe, En / Fra / Ger)</description>
 		<year>1994</year>
@@ -25880,7 +25844,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
-				<rom name="dmgykx-0.999" size="131072" crc="40418964" sha1="4c976fc98a85089cfae7e7af7de6baef31e39f92"/>
+				<rom name="dmg-ykx-0.u1" size="131072" crc="40418964" sha1="4c976fc98a85089cfae7e7af7de6baef31e39f92"/>
 			</dataarea>
 		</part>
 	</software>
@@ -25982,7 +25946,7 @@ license:CC0
 	</software>
 
 	<software name="worms">
-		<!--	In lot check as "DmGaw3P0.B96", "POOL\DMGAW3E0.0"	-->
+		<!--	Planned for release in USA as "dmg-aw3e-0"	-->
 		<description>Worms (Europe)</description>
 		<year>1995</year>
 		<publisher>Ocean</publisher>
@@ -25990,7 +25954,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="262144">
-				<rom name="worms (europe).bin" size="262144" crc="2ebc40c2" sha1="26137ca97b840c63a462bcf85677a5f3db67fadf" />
+				<rom name="dmg-aw3p-0.u1" size="262144" crc="2ebc40c2" sha1="26137ca97b840c63a462bcf85677a5f3db67fadf" />
 			</dataarea>
 		</part>
 	</software>
@@ -26475,7 +26439,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkj" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLJ-1.836"	-->
 		<description>Zelda no Densetsu - Yume o Miru Shima (China, Japan, Rev 1)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>
@@ -26493,7 +26456,6 @@ license:CC0
 	</software>
 
 	<software name="zeldalnkja" cloneof="zeldalnk">
-		<!--	In lot check as "DMGZLJ-0.836"	-->
 		<description>Zelda no Densetsu - Yume o Miru Shima (Japan)</description>
 		<year>1993</year>
 		<publisher>Nintendo</publisher>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -3,20 +3,39 @@
 <!--
 license:CC0
 
-To investigate:
-  - Shanghai Pocket by Sunsoft: are serial and release date correct or do they refer to the GB version?
+  To investigate:
+	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
 
-Undumped:
-- San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
+  Undumped:
+	- San Francisco Rush 2049 (Europe, fr/de/nl) [small pic]
+	
+  Known dumps not yet verified against retail cartridge:
+	- Alice in Wonderland (Europe)
+	- AMF Bowling (USA)
+	- Donkey Kong Country (USA, Not for resale)
+	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)	<- What is this version?
+	- Gakkyuu Ou Yamazaki (Japan)
+	- Jissen ni Yakudatsu Tsumego (Japan)
+	- Laura (Europe)
+	- Mission Impossible (Europe, Rev. 1)
+	- Monster Traveler (Japan)
+	- NBA In the Zone (USA)
+	- Pro Pool (USA)
+	- Sei Hai Densetsu (Japan)
+	- Super Mario Bros. Deluxe (USA, Rev. 2)	<- Was it released?
+	- Tsuri Sensei 2 (Japan, Rev. 1)
+	- Turok - Rage Wars (Australia)
+	- VR Sports Powerboat Racing (USA)
+	- Yakouchuu GB (Japan)
 
-Undumped GBC protos:
-  - Jet Force Gemini
+  Undumped GBC protos:
+	- Jet Force Gemini
 
-Unreleased (music source code exists, possibly no prototypes exist)
-- Crimson
-- Hard Truck
-- Katharsis
-- Hero's Quest
+  Unreleased (music source code exists, possibly no prototypes exist)
+	- Crimson
+	- Hard Truck
+	- Katharsis
+	- Hero's Quest
 
 
  Info on the PCB codes, based on Tauwasser's notes and research
@@ -49,7 +68,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="007twine">
 		<!-- Notes: GBC only -->
-		<description>007 - The World Is Not Enough (Euro, USA)</description>
+		<description>007 - The World Is Not Enough (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BO7E-USA, CGB-BO7P-EUR"/>
@@ -66,7 +85,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="10pinb">
 		<!-- Notes: GBC only -->
-		<description>10-Pin Bowling (Euro)</description>
+		<description>10-Pin Bowling (Europe)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-AXPP-UKV"/>
@@ -102,7 +121,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Euro, USA)</description>
+		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99E-USA, CGB-B99P-UKV"/>
@@ -119,7 +138,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="102dalmaf" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's Les 102 Dalmatiens à la Rescousse (Fra)</description>
+		<description>Disney's Les 102 Dalmatiens à la Rescousse (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99F-FRA"/>
@@ -133,7 +152,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="102dalmag" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatiner (Ger)</description>
+		<description>Disney's 102 Dalmatiner (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99D-NOE"/>
@@ -147,7 +166,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="102dalmas" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spa)</description>
+		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spain)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99S-ESP"/>
@@ -164,7 +183,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="1942">
 		<!-- Notes: GBC only -->
-		<description>1942 (Euro, USA)</description>
+		<description>1942 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AQ4E-USA, CGB-AQ4P-???"/>
@@ -202,10 +221,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="3dpool">
 		<!-- Notes: GBC only -->
-		<description>3D Pocket Pool (Euro)</description>
+		<description>3D Pocket Pool (Europe)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BVPP-EUR"/>
+		<info name="gold" value="20010215"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -215,7 +235,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="4x4world">
-		<description>4x4 World Trophy (Euro)</description>
+		<description>4x4 World Trophy (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AQ3P-EUR"/>
@@ -230,7 +250,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="720">
-		<description>720° (Euro, USA)</description>
+		<description>720° (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AA7E-USA, DMG-AA7P-EUR"/>
@@ -247,7 +267,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="actionmn">
 		<!-- Notes: GBC only -->
-		<description>Action Man - Search for Base X (Euro, USA)</description>
+		<description>Action Man - Search for Base X (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAXE-USA, CGB-BAXP-EUR"/>
@@ -260,7 +280,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="elmo">
-		<description>The Adventures of Elmo in Grouchland (Euro)</description>
+		<description>The Adventures of Elmo in Grouchland (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AELP-EUR"/>
@@ -290,7 +310,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smurfs">
 		<!-- Notes: GBC only -->
-		<description>The Adventures of the Smurfs (Euro)</description>
+		<description>The Adventures of the Smurfs (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSFP-FRA"/>
@@ -305,7 +325,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tintinpr">
-		<description>The Adventures of Tintin - Prisoners of the Sun (Euro)</description>
+		<description>The Adventures of Tintin - Prisoners of the Sun (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin - Prisoners of the Sun (Box?), Tintin - Le Temple du Soleil (French Box)"/>
@@ -320,7 +340,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="airforcdj" cloneof="deadlysk">
 		<!-- Notes: GBC only -->
-		<description>AirForce Delta (Jpn)</description>
+		<description>AirForce Delta (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLJ-JPN (RK223-J1)"/>
@@ -350,7 +370,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="aladdin">
 		<!-- Notes: GBC only -->
-		<description>Disney's Aladdin (Euro)</description>
+		<description>Disney's Aladdin (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BADP-EUR"/>
@@ -381,7 +401,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="alfred">
 		<!-- Notes: GBC only -->
-		<description>Alfred's Adventure (Euro)</description>
+		<description>Alfred's Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BAAP-EUR"/>
@@ -395,7 +415,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="alice">
 		<!-- Notes: GBC only -->
-		<description>Alice in Wonderland (Euro)</description>
+		<description>Alice in Wonderland (Europe)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AIWP-EUR"/>
@@ -411,10 +431,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="aliceu" cloneof="alice">
 		<!-- Notes: GBC only -->
-		<description>Alice in Wonderland (USA)</description>
+		<!--	Retail cartridge of European version not yet secured	-->
+		<description>Alice in Wonderland (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="CGB-AIWE-USA"/>
+		<info name="serial" value="CGB-AIWP-EUR, CGB-AIWE-USA"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -427,7 +448,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="aliens">
 		<!-- Notes: GBC only -->
-		<description>Aliens - Thanatos Encounter (Euro, USA)</description>
+		<description>Aliens - Thanatos Encounter (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAEE-USA, CGB-BAEP-EUR"/>
@@ -443,10 +464,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="astenn2k">
-		<description>All Star Tennis 2000 (Euro)</description>
+		<description>All Star Tennis 2000 (Europe)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AZTP-EUR"/>
+		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -465,7 +487,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="asbase2k">
 		<!-- Notes: GBC only -->
-		<description>All-Star Baseball 2000 (Euro, USA)</description>
+		<description>All-Star Baseball 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AATE-USA, CGB-AATP-EUR"/>
@@ -493,7 +515,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="aitdnn">
 		<!-- Notes: GBC only -->
-		<description>Alone in the Dark - The New Nightmare (Euro)</description>
+		<description>Alone in the Dark - The New Nightmare (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BIDP-UKV"/>
@@ -523,15 +545,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="amfbowli">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbafpe0.339"	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
+		<description>AMF Bowling (USA)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<info name="serial" value="CGB-AFPE-USA?"/>
+		<info name="gold" value="20000727"/>
+		<info name="alt_title" value="AMF Xtreme Bowling"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbafpe0.339" size="1048576" crc="392559ee" sha1="1dd7d94f320d119682fd4df80297c8df1b28141b"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="animalb3">
-		<!-- Notes: SGB enhanced -->
-		<description>Animal Breeder 3 (Jpn)</description>
+		<description>Animal Breeder 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AA3J-JPN"/>
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="あにまるぶりーだー3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="animal breeder 3 (japan).bin" size="4194304" crc="c62a4c30" sha1="f5e6e770a681bb6eba255e2584f9ed343e5d9f98"/>
@@ -543,7 +583,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="animalb4">
 		<!-- Notes: GBC only -->
-		<description>Animal Breeder 4 (Jpn)</description>
+		<description>Animal Breeder 4 (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A4AJ-JPN"/>
@@ -561,7 +601,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="animasta">
 		<!-- Notes: GBC only -->
-		<description>Animastar GB (Jpn)</description>
+		<description>Animastar GB (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BNMJ-JPN"/>
@@ -579,7 +619,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="animorph">
 		<!-- Notes: GBC only -->
-		<description>Animorphs (Euro)</description>
+		<description>Animorphs (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BAMP-EUR"/>
@@ -607,7 +647,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="anpfiff" cloneof="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Anpfiff - Der RTL Fussball-Manager (Ger)</description>
+		<description>Anpfiff - Der RTL Fussball-Manager (Germany)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBD-NOE"/>
@@ -628,7 +668,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="antz">
-		<description>Antz (Euro)</description>
+		<description>Antz (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ANXP-EUR"/>
@@ -658,7 +698,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="antzracn">
 		<!-- Notes: GBC only -->
-		<description>Antz Racing (Euro)</description>
+		<description>Antz Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BAZP-UKV"/>
@@ -692,7 +732,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="antzsprt">
 		<!-- Notes: GBC only -->
-		<description>Antz World Sportz (Euro)</description>
+		<description>Antz World Sportz (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BA7P-EUR"/>
@@ -705,14 +745,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="aqualife">
-		<!-- Notes: SGB enhanced -->
-		<description>Aqualife (Jpn)</description>
+		<description>Aqualife (Japan)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AALJ-JPN"/>
 		<info name="release" value="19991022"/>
 		<info name="alt_title" value="アクアライフ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="aqualife (japan).bin" size="1048576" crc="e243feb4" sha1="69eaf53eccdaf98cd7cc0d436209f511b558d761"/>
@@ -723,7 +763,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="arcadejd">
-		<description>Arcade Hits - Joust &amp; Defender (Euro, USA)</description>
+		<description>Arcade Hits - Joust &amp; Defender (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AADE-USA, DMG-AADP-EUR"/>
@@ -736,7 +776,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="arcadems">
-		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Euro, USA)</description>
+		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ADUE-USA, DMG-ADUP-???"/>
@@ -749,14 +789,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="arle">
-		<!-- Notes: SGB enhanced -->
-		<description>Arle no Bouken - Mahou no Jewel (Jpn)</description>
+		<description>Arle no Bouken - Mahou no Jewel (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-BRBJ-JPN"/>
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="アルルの冒険 まほうのジュエル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="arle no bouken - mahou no jewel (japan).bin" size="1048576" crc="8ee043ea" sha1="fb781637ddac30cebb1865ba939f49bb2b0b5146"/>
@@ -784,7 +824,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="armorine">
 		<!-- Notes: GBC only -->
-		<description>Armorines - Project S.W.A.R.M. (Euro, USA)</description>
+		<description>Armorines - Project S.W.A.R.M. (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AOXE-USA, CGB-AOXP-EUR"/>
@@ -801,7 +841,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="armymen">
 		<!-- Notes: GBC only -->
-		<description>Army Men (Euro, USA)</description>
+		<description>Army Men (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVCE-USA, CGB-AVCP-(NOE/UKV)"/>
@@ -818,7 +858,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="armymen2">
 		<!-- Notes: GBC only -->
-		<description>Army Men 2 (Euro, USA)</description>
+		<description>Army Men 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BA2E-USA, CGB-BA2P-EUR"/>
@@ -835,7 +875,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="amenairc">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Air Combat (Euro, USA)</description>
+		<description>Army Men - Air Combat (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BATE-USA, CGB-BATP-EUR"/>
@@ -852,7 +892,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="amensar2">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Sarge's Heroes 2 (Euro, USA)</description>
+		<description>Army Men - Sarge's Heroes 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BSHE-USA, CGB-BSHP-EUR"/>
@@ -883,7 +923,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="astobelx">
 		<!-- Notes: GBC only -->
-		<description>Astérix &amp; Obélix (Euro)</description>
+		<description>Astérix &amp; Obélix (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="??"/>
@@ -896,7 +936,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="astcesar">
-		<description>Astérix &amp; Obélix Contre César (Euro)</description>
+		<description>Astérix &amp; Obélix Contre César (Europe)</description>
 		<year>1999</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-BAOP-NOE"/>
@@ -913,7 +953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="astsearc">
 		<!-- Notes: GBC only -->
-		<description>Astérix - Search for Dogmatix (Euro)</description>
+		<description>Astérix - Search for Dogmatix (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AA6P-ESP"/>
@@ -926,7 +966,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="asteroid">
-		<description>Asteroids (Euro, USA)</description>
+		<description>Asteroids (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AARE-USA, DMG-AARP-UKV"/>
@@ -940,7 +980,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, English / Spanish / Italian)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, English / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABX-EUR"/>
@@ -957,7 +997,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="atlantisa" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, French / German / Dutch)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, French / German / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABY-EUU"/>
@@ -974,7 +1014,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="atlantisu" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Euro, USA)</description>
+		<description>Disney's Atlantis - The Lost Empire (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABE-USA, CGB-BABP-UKV"/>
@@ -988,7 +1028,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="poohadvj" cloneof="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Jpn)</description>
+		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BPUJ-JPN"/>
@@ -1006,7 +1046,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="apoweroh">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Oh, Behave! (Euro)</description>
+		<description>Austin Powers - Oh, Behave! (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BAPX-UKV"/>
@@ -1038,7 +1078,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="apowerul">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Welcome to my Underground Lair! (Euro)</description>
+		<description>Austin Powers - Welcome to my Underground Lair! (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BEAX-(EUR/UKV/EUU)"/>
@@ -1070,7 +1110,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="azarashi">
 		<!-- Notes: GBC only -->
-		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Jpn)</description>
+		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Japan)</description>
 		<year>2002</year>
 		<publisher>Omega Micott</publisher>
 		<info name="serial" value="CGB-BOAJ-JPN"/>
@@ -1087,7 +1127,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="azured">
-		<description>Azure Dreams (Euro)</description>
+		<description>Azure Dreams (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAYP-EUR"/>
@@ -1117,14 +1157,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bdaman">
-		<!-- Notes: SGB enhanced -->
-		<description>B-Daman Bakugaiden - Victory e no Michi (Jpn)</description>
+		<description>B-Daman Bakugaiden - Victory e no Michi (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOKJ-JPN"/>
 		<info name="release" value="19990129"/>
 		<info name="alt_title" value="Bビーダマン爆 外伝 ビクトリーへのみち"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [MX23C8003-20]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -1142,7 +1182,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bdamanv">
 		<!-- Notes: GBC only -->
-		<description>B-Daman Bakugaiden V - Final Mega Tune (Jpn)</description>
+		<description>B-Daman Bakugaiden V - Final Mega Tune (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-AIRJ-JPN"/>
@@ -1159,7 +1199,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="babe">
-		<description>Babe and Friends (Euro)</description>
+		<description>Babe and Friends (Europe)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AVAP-FAH"/>
@@ -1189,7 +1229,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="babyflix">
 		<!-- Notes: GBC only -->
-		<description>Baby Felix - Halloween (Euro)</description>
+		<description>Baby Felix - Halloween (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BFHP-EUR"/>
@@ -1202,7 +1242,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="backgamm">
-		<description>Backgammon (Euro)</description>
+		<description>Backgammon (Europe)</description>
 		<year>2000</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="DMG-AAKP-EUR"/>
@@ -1215,7 +1255,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="backgammj" cloneof="backgamm">
-		<description>Backgammon (Jpn)</description>
+		<description>Backgammon (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AAKJ-JPN"/>
@@ -1233,7 +1273,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="badbadtz">
 		<!-- Notes: GBC only -->
-		<description>Bad Badtz-Maru Robo Battle (Jpn)</description>
+		<description>Bad Badtz-Maru Robo Battle (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BBRJ-JPN"/>
@@ -1250,7 +1290,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bakukyuu">
-		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Jpn)</description>
+		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-A4RJ-JPN"/>
@@ -1268,7 +1308,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bakusodd">
 		<!-- Notes: GBC only -->
-		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Jpn)</description>
+		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Japan)</description>
 		<year>2000</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-BDBJ-JPN"/>
@@ -1285,12 +1325,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="metalwlkj" cloneof="metalwlk">
-		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Jpn)</description>
+		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AUEJ-JPN"/>
+		<info name="gold" value="19991104"/>
 		<info name="release" value="19991224"/>
-		<info name="alt_title" value="爆走戦記 メタルウォーカーGB 鋼鉄の友情"/>
+		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -1303,7 +1344,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bsbeybld">
 		<!-- Notes: GBC only -->
-		<description>Bakuten Shoot Beyblade (Jpn)</description>
+		<description>Bakuten Shoot Beyblade (Japan)</description>
 		<year>2001</year>
 		<publisher>Broccoli</publisher>
 		<info name="serial" value="CGB-BB3J-JPN"/>
@@ -1333,14 +1374,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="balonfgt">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
-		<description>Balloon Fight GB (Jpn, NP)</description>
+		<!-- Also released by NP in 2000-08 -->
+		<description>Balloon Fight GB (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BBKJ-JPN"/>
 		<info name="release" value="2000-07-31 / 20000801"/>
 		<info name="alt_title" value="BALLOON FIGHT GB バルーンファイトGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="balloon fight gb (japan) (np).bin" size="262144" crc="d2af64ce" sha1="dbaa1bf9061de0f052704d6a33892341a38f2152"/>
@@ -1351,7 +1393,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbiefp">
-		<description>Barbie - Fashion Pack Games (Euro, USA)</description>
+		<description>Barbie - Fashion Pack Games (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="DMG-BFPE-USA, DMG-BFPP-EUR"/>
@@ -1381,7 +1423,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbieoc">
-		<description>Barbie - Ocean Discovery (Euro)</description>
+		<description>Barbie - Ocean Discovery (Europe)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYP-UKV"/>
@@ -1410,7 +1452,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbieocf" cloneof="barbieoc">
-		<description>Barbie - Chasse au Trésor Sous-Marine (Fra)</description>
+		<description>Barbie - Chasse au Trésor Sous-Marine (France)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYF-FRA"/>
@@ -1423,7 +1465,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbieocg" cloneof="barbieoc">
-		<description>Barbie - Meeres Abenteuer (Ger)</description>
+		<description>Barbie - Meeres Abenteuer (Germany)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYD-NOE"/>
@@ -1436,7 +1478,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbieoci" cloneof="barbieoc">
-		<description>Barbie - Avventure nell'Oceano (Ita)</description>
+		<description>Barbie - Avventure nell'Oceano (Italia)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYI-ITA"/>
@@ -1452,7 +1494,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barbieocs" cloneof="barbieoc">
-		<description>Barbie - Aventura Submarina (Spa)</description>
+		<description>Barbie - Aventura Submarina (Spain)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYS-ESP"/>
@@ -1482,7 +1524,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="barbiept">
 		<!-- Notes: GBC only -->
-		<description>Barbie - Pet Rescue (Euro)</description>
+		<description>Barbie - Pet Rescue (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BPEP-EUR"/>
@@ -1510,7 +1552,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shellycl">
 		<!-- Notes: GBC only -->
-		<description>Shelly Club (Euro)</description>
+		<description>Shelly Club (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BKIP-EUR"/>
@@ -1526,14 +1568,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="barcode">
-		<!-- Notes: SGB enhanced -->
-		<description>Barcode Taisen Bardigun (Jpn)</description>
+		<description>Barcode Taisen Bardigun (Japan)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN"/>
+		<info name="gold" value="19981105"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="バーコード対戦 バーディガン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC3A [MBC3A]" />
@@ -1550,9 +1593,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="barcodea" cloneof="barcode">
+		<!--	In lot check as "dmgabej1.f26"	-->
+		<description>Barcode Taisen Bardigun (Japan, Rev. 1)</description>
+		<year>1998</year>
+		<publisher>Tamsoft</publisher>
+		<info name="serial" value="DMG-ABEJ-JPN-1"/>
+		<info name="gold" value="19990323"/>
+		<info name="alt_title" value="バーコード対戦 バーディガン"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgabej1.f26" size="1048576" crc="f6d291a9" sha1="21e386f60fcd3694c4a308de9e178762c5175b6c"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="barca2k" cloneof="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Barça Total 2000 (Euro)</description>
+		<description>Barça Total 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -1567,7 +1630,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bassmasc">
-		<description>Bass Masters Classic (Euro, USA)</description>
+		<description>Bass Masters Classic (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AQME-USA, DMG-AQMP-EUR"/>
@@ -1584,7 +1647,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="batmanbej" cloneof="batmanbe">
 		<!-- Notes: GBC only, NP only -->
-		<description>Batman Beyond - Return of the Joker (Jpn, NP)</description>
+		<description>Batman Beyond - Return of the Joker (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTKJ-JPN"/>
@@ -1614,7 +1677,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="batmanbe">
 		<!-- Notes: GBC only -->
-		<description>Batman of the Future - Return of the Joker (Euro)</description>
+		<description>Batman of the Future - Return of the Joker (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTKP-EUR"/>
@@ -1628,7 +1691,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="batlfish">
 		<!-- Notes: GBC only -->
-		<description>Battle Fishers (Jpn)</description>
+		<description>Battle Fishers (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BBAJ-JPN (RK198-J1)"/>
@@ -1645,7 +1708,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bship">
-		<description>Battleship (Euro, USA)</description>
+		<description>Battleship (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AIPE-USA, DMG-AIPP-EUR"/>
@@ -1662,7 +1725,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="btanx">
 		<!-- Notes: GBC only -->
-		<description>BattleTanx (Euro)</description>
+		<description>BattleTanx (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVNP-UKV"/>
@@ -1693,7 +1756,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="beachbal">
 		<!-- Notes: GBC only -->
-		<description>Beach'n Ball (Euro)</description>
+		<description>Beach'n Ball (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVBP-EUR"/>
@@ -1707,7 +1770,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bearblue">
 		<!-- Notes: GBC only -->
-		<description>Jim Henson's Bear in the Big Blue House (Euro)</description>
+		<description>Jim Henson's Bear in the Big Blue House (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBNP-EUR"/>
@@ -1737,14 +1800,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bmanigb">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
-		<description>Beatmania GB (Jpn)</description>
+		<!-- Also released by NP in 2000-05 -->
+		<description>Beatmania GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AOOJ-JPN (RK184-J1)"/>
 		<info name="release" value="19990311"/>
 		<info name="alt_title" value="ビートマニアGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb (japan).bin" size="1048576" crc="0d9cb195" sha1="640c4633fe8ec60b767c15a094c87ab7e113d555"/>
@@ -1754,7 +1818,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bmanigb3">
 		<!-- Notes: GBC only -->
-		<description>Beatmania GB - Gotcha Mix 2 (Jpn)</description>
+		<description>Beatmania GB - Gotcha Mix 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3GJ-JPN (RK220-J1)"/>
@@ -1769,14 +1833,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bmanigb2">
-		<!-- Notes: SGB enhanced -->
-		<description>Beatmania GB2 - Gotcha Mix (Jpn)</description>
+		<description>Beatmania GB2 - Gotcha Mix (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A2GJ-JPN (RK195-J1)"/>
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="ビートマニア GB2 ガチャミックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb2 - gotcha mix (japan).bin" size="1048576" crc="59beb372" sha1="b6273c434e880d6f9b5f4f6f53307bda9902fff1"/>
@@ -1785,7 +1849,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (Euro)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUP-EUR"/>
@@ -1806,7 +1870,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="beautyu" cloneof="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (USA, Aus)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (USA, Australia)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUE-USA, DMG-AVUU-AUS"/>
@@ -1822,7 +1886,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="benjamin">
 		<!-- Notes: GBC only -->
-		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Ger)</description>
+		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Germany)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BB5D-NOE"/>
@@ -1836,7 +1900,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="beyblade">
 		<!-- Notes: GBC only -->
-		<description>Beyblade - Fighting Tournament (Jpn)</description>
+		<description>Beyblade - Fighting Tournament (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BBVJ-JPN"/>
@@ -1854,7 +1918,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bibibloc">
 		<!-- Notes: GBC only -->
-		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Ger)</description>
+		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Germany)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BIBD-NOE"/>
@@ -1868,7 +1932,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bibitina">
 		<!-- Notes: GBC only -->
-		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Ger)</description>
+		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Germany)</description>
 		<year>2002</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BFED-NOE-1"/>
@@ -1884,14 +1948,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bikkuri">
-		<!-- Notes: SGB enhanced -->
-		<description>Bikkuriman 2000 - Charging Card GB (Jpn)</description>
+		<description>Bikkuriman 2000 - Charging Card GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BC2J-JPN"/>
 		<info name="release" value="20000610"/>
 		<info name="alt_title" value="ビックリマン2000 チャージングカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="bikkuriman 2000 - charging card gb (japan).bin" size="2097152" crc="5be2517c" sha1="c3c608f1b3581a070c9b7eb65b6fb6d1b72d98d3"/>
@@ -1903,7 +1967,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="billybob">
 		<!-- Notes: GBC only -->
-		<description>Billy Bob's Huntin' 'n' Fishin' (Euro, USA)</description>
+		<description>Billy Bob's Huntin' 'n' Fishin' (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AHZE-USA, CGB-AHZP-EUR"/>
@@ -1920,7 +1984,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="biohazg" cloneof="revilg">
 		<!-- Notes: GBC only -->
-		<description>BioHazard Gaiden (Jpn)</description>
+		<description>BioHazard Gaiden (Japan)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOJ-JPN"/>
@@ -1938,7 +2002,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bionicc">
 		<!-- Notes: GBC only -->
-		<description>Bionic Commando - Elite Forces (Aus, USA)</description>
+		<description>Bionic Commando - Elite Forces (Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AV4E-USA, CGB-AV4P-AUS"/>
@@ -1953,7 +2017,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="blackbas">
-		<description>Black Bass - Lure Fishing (Euro, USA)</description>
+		<description>Black Bass - Lure Fishing (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-ALFE-USA, DMG-ALFP-EUR"/>
@@ -1970,7 +2034,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="blckonyx">
 		<!-- Notes: GBC only -->
-		<description>The Black Onyx (Jpn)</description>
+		<description>The Black Onyx (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BBOJ-JPN"/>
@@ -1988,7 +2052,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="blade">
 		<!-- Notes: GBC only -->
-		<description>Blade (Euro, USA)</description>
+		<description>Blade (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLEE-USA, CGB-BLEP-EUR"/>
@@ -2004,7 +2068,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bmaster">
-		<description>Blaster Master - Enemy Below (Euro, USA)</description>
+		<description>Blaster Master - Enemy Below (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AEHE-USA, DMG-AEHP-EUR"/>
@@ -2022,6 +2086,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="CGB-BALE-USA"/>
+		<info name="gold" value="20000926"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2046,7 +2111,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bobbobet">
 		<!-- Notes: GBC only -->
-		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Euro)</description>
+		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBQP-FAH"/>
@@ -2063,7 +2128,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / French / German / Spanish / Dutch)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / French / German / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBP-UKV"/>
@@ -2077,7 +2142,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bobbuilda" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / French / Italian)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBY-EUR"/>
@@ -2094,7 +2159,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bobbuildb" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Euro, English / Swedish / Norwegian / Danish / Finnish)</description>
+		<description>Bob the Builder - Fix it Fun! (Europe, English / Swedish / Norwegian / Danish / Finnish)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBX-SCN"/>
@@ -2125,7 +2190,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bokucamp">
 		<!-- Notes: GBC only -->
-		<description>Boku no Camp-jou (Jpn)</description>
+		<description>Boku no Camp-jou (Japan)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="CGB-BDPJ-JPN"/>
@@ -2142,7 +2207,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bokujom2" cloneof="harvmon2">
-		<description>Bokujou Monogatari GB2 (Jpn)</description>
+		<description>Bokujou Monogatari GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-A37J-JPN"/>
@@ -2160,10 +2225,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bokujom3" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
+		<info name="gold" value="20000731"/>
 		<info name="release" value="20000929"/>
 		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2176,9 +2242,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="bokujom3a" cloneof="harvmon3">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbwaj1.350"	-->
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Victor Interactive Software</publisher>
+		<info name="serial" value="CGB-BWAJ-JPN"/>
+		<info name="gold" value="20001205"/>
+		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbwaj1.350" size="2097152" crc="75af0e84" sha1="acb2e549fb7d107d20507af88c36f40234f74958"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bombmmxa">
 		<!-- Notes: GBC only, this was the prize for a draw contest -->
-		<description>Bomberman Max - Ain Version (Jpn)</description>
+		<description>Bomberman Max - Ain Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -2215,7 +2300,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bombmmxh" cloneof="bombmmxb">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Hikari no Yuusha (Jpn)</description>
+		<description>Bomberman Max - Hikari no Yuusha (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A8BJ-JPN"/>
@@ -2255,7 +2340,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bombmmxy" cloneof="bombmmxr">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Yami no Senshi (Jpn)</description>
+		<description>Bomberman Max - Yami no Senshi (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A7BJ-JPN"/>
@@ -2272,7 +2357,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bombmqst">
-		<description>Bomberman Quest (Euro)</description>
+		<description>Bomberman Quest (Europe)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AQVP-EUR"/>
@@ -2287,14 +2372,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bombmqstj" cloneof="bombmqst">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
-		<description>Bomberman Quest (Jpn)</description>
+		<!-- Also released by NP in 2000-08 -->
+		<description>Bomberman Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AB5J-JPN"/>
 		<info name="release" value="19981224"/>
 		<info name="alt_title" value="ボンバーマンクエスト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-DFCN-20" /><!-- DMG-DECN? -->
 			<feature name="slot" value="rom_mbc1" />
@@ -2327,6 +2413,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2003</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-B2CK-KOR"/>
+		<info name="gold" value="20030409"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-M-BFAN-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -2338,9 +2425,10 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+
 	<software name="bouken">
 		<!-- Notes: GBC only -->
-		<description>Bouken! Dondoko-tou (Jpn)</description>
+		<description>Bouken! Dondoko-tou (Japan)</description>
 		<year>2002</year>
 		<publisher>Global A</publisher>
 		<info name="serial" value="CGB-BDVJ-JPN"/>
@@ -2358,7 +2446,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bravesag">
 		<!-- Notes: GBC only -->
-		<description>Brave Saga - Shinshou Astaria (Jpn)</description>
+		<description>Brave Saga - Shinshou Astaria (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BBSJ-JPN"/>
@@ -2376,7 +2464,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="buffy">
 		<!-- Notes: GBC only -->
-		<description>Buffy the Vampire Slayer (Euro, USA)</description>
+		<description>Buffy the Vampire Slayer (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BVSE-USA, CGB-BVSP-EUR"/>
@@ -2392,7 +2480,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bugslife">
-		<description>A Bug's Life (Euro)</description>
+		<description>A Bug's Life (Europe)</description>
 		<year>1998</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-APXP-EUU"/>
@@ -2418,7 +2506,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bugsblol">
-		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Euro)</description>
+		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Europe)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ABLP-FRA"/>
@@ -2432,7 +2520,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bugsbcc3">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny - Crazy Castle 3 (Euro, USA)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6E-USA, DMG-AB6P-EUR"/>
@@ -2448,7 +2536,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bugsbcc3j" cloneof="bugsbcc3">
-		<description>Bugs Bunny - Crazy Castle 3 (Jpn)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6J-JPN"/>
@@ -2464,7 +2552,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Euro)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4P-EUU-1"/>
@@ -2478,7 +2566,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bugsbcc4f" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny et le Château des Catastrophes (Fra)</description>
+		<description>Bugs Bunny et le Château des Catastrophes (France)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4F-FRA"/>
@@ -2495,7 +2583,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bugsbcc4j" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Jpn)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4J-JPN"/>
@@ -2524,7 +2612,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bundl2k1" cloneof="fa2001">
-		<description>Bundesliga Stars 2001 (Ger)</description>
+		<description>Bundesliga Stars 2001 (Germany)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -2538,7 +2626,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="buraicol" cloneof="spacemar">
 		<!-- Notes: GBC only -->
-		<description>Burai Senshi Color (Jpn)</description>
+		<description>Burai Senshi Color (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZYJ-JPN"/>
@@ -2553,14 +2641,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="burgerb">
-		<!-- Notes: SGB enhanced -->
-		<description>Burger Burger Pocket (Jpn)</description>
+		<description>Burger Burger Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-ABNJ-JPN"/>
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="バーガーバーガーポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="burger burger pocket (japan).bin" size="1048576" crc="1abcedbe" sha1="f4579d4bb3b39f572fdf033df01a84a925fb3f2e"/>
@@ -2570,7 +2658,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="burgerpi">
 		<!-- Notes: GBC only -->
-		<description>Burger Paradise International (Jpn)</description>
+		<description>Burger Paradise International (Japan)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="CGB-AEYJ-JPN"/>
@@ -2587,7 +2675,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bam4">
-		<description>Bust-A-Move 4 (Euro, USA)</description>
+		<description>Bust-A-Move 4 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AA4E-USA, DMG-AA4P-EUR"/>
@@ -2601,7 +2689,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="bammill">
 		<!-- Notes: GBC only -->
-		<description>Bust-A-Move Millennium (Euro, USA)</description>
+		<description>Bust-A-Move Millennium (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BANE-USA, CGB-BANP-EUR"/>
@@ -2615,7 +2703,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Buzz Lightyear of Star Command (Euro, USA)</description>
+		<description>Buzz Lightyear of Star Command (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZE-USA, CGB-BUZP-UKV"/>
@@ -2632,7 +2720,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="buzzlghtf" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Les Aventures de Buzz l'Eclair (Fra)</description>
+		<description>Les Aventures de Buzz l'Eclair (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZF-FRA"/>
@@ -2646,7 +2734,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="buzzlghtg" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Captain Buzz Lightyear - Star Command (Ger)</description>
+		<description>Captain Buzz Lightyear - Star Command (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZD-NOE"/>
@@ -2660,7 +2748,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="caesars2">
 		<!-- Notes: GBC only -->
-		<description>Caesars Palace II (Euro, USA)</description>
+		<description>Caesars Palace II (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AI2E-USA, CGB-AI2P-EUR"/>
@@ -2682,7 +2770,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="cfodder">
 		<!-- Notes: GBC only -->
-		<description>Cannon Fodder (Euro)</description>
+		<description>Cannon Fodder (Europe)</description>
 		<year>2000</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BCFP-EUR"/>
@@ -2732,7 +2820,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. B)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2748,7 +2836,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev b).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 2).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2756,7 +2844,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ccsakuita" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. A)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2766,7 +2854,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev a).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 1).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2774,7 +2862,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ccsakuitb" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2793,10 +2881,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ccsakuto">
 		<!-- Notes: GBC only -->
-		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Jpn)</description>
+		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BS7J-JPN"/>
+		<info name="gold" value="20000824"/>
 		<info name="release" value="20001006"/>
 		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2811,7 +2900,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="clewis2k">
 		<!-- Notes: GBC only -->
-		<description>Carl Lewis Athletics 2000 (Euro)</description>
+		<description>Carl Lewis Athletics 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCLP-EUR"/>
@@ -2827,10 +2916,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="carmgedd">
 		<!-- Notes: GBC only -->
-		<description>Carmageddon - Carpocalypse Now (Euro, USA)</description>
+		<!--	USA cartridges have the European sticker underneath.	-->
+		<description>Carmageddon - Carpocalypse Now (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
+		<info name="gold" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -2844,7 +2935,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="carmgeddg" cloneof="carmgedd">
 		<!-- Notes: GBC only -->
-		<description>Carmageddon - Carpocalypse Now (Ger)</description>
+		<description>Carmageddon - Carpocalypse Now (Germany)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-AKWD-NOE"/>
@@ -2858,10 +2949,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Euro, English / Spanish / Italian)</description>
+		<description>Casper (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9X-EUU"/>
+		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -2880,10 +2972,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="caspera" cloneof="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Euro, English / French / German)</description>
+		<description>Casper (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9P-EUR"/>
+		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2900,6 +2993,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9E-USA"/>
+		<info name="gold" value="20000404"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2911,7 +3005,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="caterpil">
-		<description>Caterpillar Construction Zone (Euro, USA)</description>
+		<description>Caterpillar Construction Zone (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AR4E-USA, DMG-AR4P-EUU?"/>
@@ -2925,10 +3019,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="catwoman">
 		<!-- Notes: GBC only -->
-		<description>Catwoman (Euro)</description>
+		<description>Catwoman (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CP-EUR"/>
+		<info name="gold" value="19991018"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2943,6 +3038,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CE-USA"/>
+		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2953,7 +3049,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="catz">
 		<!-- Notes: GBC only -->
-		<description>Catz - Your Virtual Petz Palz (Euro)</description>
+		<description>Catz - Your Virtual Petz Palz (Europe)</description>
 		<year>1999</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AZCP-EUR"/>
@@ -2984,7 +3080,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="centiped">
-		<description>Centipede (Euro)</description>
+		<description>Centipede (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AC5P-EUR"/>
@@ -3011,7 +3107,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="motox2k1">
 		<!-- Notes: GBC only -->
-		<description>Championship Motocross 2001 featuring Ricky Carmichael (Euro, USA)</description>
+		<description>Championship Motocross 2001 featuring Ricky Carmichael (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCME-USA, CGB-BCMP-EUR"/>
@@ -3027,7 +3123,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="chasehq">
-		<description>Chase H.Q. - Secret Police (Euro)</description>
+		<description>Chase H.Q. - Secret Police (Europe)</description>
 		<year>2000</year>
 		<publisher>Gaga</publisher>
 		<info name="serial" value="DMG-AH9P-EUR"/>
@@ -3053,7 +3149,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="checkmat">
-		<description>Checkmate (Jpn)</description>
+		<description>Checkmate (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ACZJ-JPN"/>
@@ -3071,7 +3167,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="cheechai">
 		<!-- Notes: GBC only -->
-		<description>Chee-Chai Alien (Jpn)</description>
+		<description>Chee-Chai Alien (Japan)</description>
 		<year>2001</year>
 		<publisher>Creatures</publisher>
 		<info name="serial" value="CGB-VCAJ-JPN"/>
@@ -3096,7 +3192,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="chessmst">
-		<description>Chessmaster (Euro, USA)</description>
+		<description>Chessmaster (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Mindascape</publisher>
 		<info name="serial" value="DMG-AC9E-USA, DMG-AC9P-EUR"/>
@@ -3110,7 +3206,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="chitoase">
 		<!-- Notes: GBC only -->
-		<description>Chi to Ase to Namida no Koukou Yakyuu (Jpn)</description>
+		<description>Chi to Ase to Namida no Koukou Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-BBJJ-JPN"/>
@@ -3128,7 +3224,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="chibim">
 		<!-- Notes: GBC only -->
-		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Jpn)</description>
+		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BCNJ-JPN"/>
@@ -3146,7 +3242,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="chickrun">
 		<!-- Notes: GBC only -->
-		<description>Chicken Run (Euro, USA)</description>
+		<description>Chicken Run (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCKE-USA, CGB-BCKP-EUR"/>
@@ -3163,7 +3259,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="chikirac" cloneof="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Chiki Chiki Machine Mou Race (Jpn)</description>
+		<description>Chiki Chiki Machine Mou Race (Japan)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-AW9J-JPN"/>
@@ -3178,14 +3274,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="choroq">
-		<!-- Notes: SGB enhanced -->
-		<description>Choro Q - Hyper Customable GB (Jpn)</description>
+		<description>Choro Q - Hyper Customable GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACQJ-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="チョロQ ハイパーカスタマブルGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="choro q - hyper customable gb (japan).bin" size="2097152" crc="65610ca4" sha1="8af215c632599aaab9bc4614194ac45802407bbc"/>
@@ -3196,7 +3292,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bublbobl">
-		<description>Classic Bubble Bobble (Euro)</description>
+		<description>Classic Bubble Bobble (Europe)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AVWP-EUR-1"/>
@@ -3223,7 +3319,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mcrae">
 		<!-- Notes: GBC only -->
-		<description>Colin McRae Rally (Euro)</description>
+		<description>Colin McRae Rally (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCOP-EUR"/>
@@ -3238,14 +3334,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="columns">
-		<!-- Notes: SGB enhanced -->
-		<description>Columns GB - Tezuka Osamu Characters (Jpn)</description>
+		<description>Columns GB - Tezuka Osamu Characters (Japan)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOYJ-JPN"/>
 		<info name="release" value="19991105"/>
 		<info name="alt_title" value="コラムスGB手塚治虫キャラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="columns gb - tezuka osamu characters (japan).bin" size="524288" crc="fbe5de37" sha1="a8d9a6631f1d203d99be38fb90135c10e5f0c880"/>
@@ -3257,7 +3353,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="commandm" supported="no">
 		<!-- Notes: GBC only.  The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Command Master (Jpn)</description>
+		<description>Command Master (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-KCEJ-JPN"/>
@@ -3280,7 +3376,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="commandk">
 		<!-- Notes: GBC only -->
-		<description>Commander Keen (Euro, USA)</description>
+		<description>Commander Keen (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BCBE-USA, CGB-BCBP-EUR"/>
@@ -3293,7 +3389,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="conker">
-		<description>Conker's Pocket Tales (Euro, USA)</description>
+		<description>Conker's Pocket Tales (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACRE-USA, DMG-ACRP-EUR"/>
@@ -3315,7 +3411,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="coolbric">
 		<!-- Notes: GBC only -->
-		<description>Cool Bricks (Euro)</description>
+		<description>Cool Bricks (Europe)</description>
 		<year>1999</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BOGP-EUR"/>
@@ -3328,7 +3424,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="coolhand">
-		<description>Cool Hand (Euro)</description>
+		<description>Cool Hand (Europe)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-ACWP-EUU"/>
@@ -3342,7 +3438,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="crazybik">
 		<!-- Notes: GBC only -->
-		<description>Crazy Bikers (Euro)</description>
+		<description>Crazy Bikers (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AMHP-EUR"/>
@@ -3358,7 +3454,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="croc">
 		<!-- Notes: GBC only -->
-		<description>Croc (Euro, USA)</description>
+		<description>Croc (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRCE-USA, CGB-BRCP-EUR"/>
@@ -3375,7 +3471,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="croc2">
 		<!-- Notes: GBC only -->
-		<description>Croc 2 (Euro, USA)</description>
+		<description>Croc 2 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BK2E-USA, CGB-BK2P-EUR"/>
@@ -3388,7 +3484,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="xcountry">
-		<description>Cross Country Racing (Euro)</description>
+		<description>Cross Country Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLP-EUR"/>
@@ -3402,7 +3498,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xhunterm">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Monster Hunter Version (Jpn)</description>
+		<description>Cross Hunter - Monster Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC8J-JPN"/>
@@ -3420,7 +3516,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xhuntert">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Treasure Hunter Version (Jpn)</description>
+		<description>Cross Hunter - Treasure Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC7J-JPN"/>
@@ -3444,7 +3540,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xhunterx">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - X Hunter Version (Jpn)</description>
+		<description>Cross Hunter - X Hunter Version (Japan)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC9J-JPN"/>
@@ -3462,6 +3558,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="crusnexo">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "CGBBXOE0.382", "KENSA\CGBBXOP0.0"	-->
 		<description>Cruis'n Exotica (USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
@@ -3506,7 +3603,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="cybertgr">
 		<!-- Notes: GBC only -->
-		<description>CyberTiger (Euro, USA)</description>
+		<description>CyberTiger (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BCTE-USA, CGB-BCTP-UKV"/>
@@ -3523,7 +3620,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="cyborgku">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan - Devil Fukkatsu (Jpn)</description>
+		<description>Cyborg Kuro-chan - Devil Fukkatsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSKJ-JPN (RK204-J1)"/>
@@ -3541,7 +3638,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="cyborgk2">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Jpn)</description>
+		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSBJ-JPN (RK219-J1)"/>
@@ -3559,7 +3656,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="daadaada">
 		<!-- Notes: GBC only -->
-		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Jpn)</description>
+		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Japan)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BDOJ-JPN"/>
@@ -3576,7 +3673,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="daffyfow">
-		<description>Daffy Duck - Fowl Play (Euro, USA)</description>
+		<description>Daffy Duck - Fowl Play (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7E-USA, DMG-AD7P-UKV"/>
@@ -3589,7 +3686,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="daffysub">
-		<description>Daffy Duck - Subette Koron de Ougane Mochi (Jpn)</description>
+		<description>Daffy Duck - Subette Koron de Ougane Mochi (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7J-JPN"/>
@@ -3604,14 +3701,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="miraclz2">
-		<!-- Notes: SGB enhanced -->
-		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Jpn)</description>
+		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AM6J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="大貝獣物語 ザ・ミラクル オブ ザ・ゾーンII"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC1A [HuC-1]" />
@@ -3629,10 +3726,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Euro, English / French / Italian)</description>
+		<description>Daikatana (Europe, English / French / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22X-EUR"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3645,10 +3743,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="daikatana" cloneof="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Euro, French / German / Spanish)</description>
+		<description>Daikatana (Europe, French / German / Spanish)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22Y-EUU"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3676,7 +3775,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="daikatanj" cloneof="daikatan">
 		<!-- Notes: GBC only, NP only -->
-		<description>Daikatana GB (Jpn, NP)</description>
+		<description>Daikatana GB (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22J-JPN"/>
@@ -3693,14 +3792,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="daikugen">
-		<!-- Notes: SGB enhanced -->
-		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Jpn)</description>
+		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Japan)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-BGNJ-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="大工の源さん 〜カチカチのトンカチガカチ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="daiku no gen-san - kachikachi no tonkachi ga kachi (japan).bin" size="1048576" crc="e2071293" sha1="2d961353e7242babce49dda8d017a459f4ef7609"/>
@@ -3712,7 +3811,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ddr">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB (Jpn)</description>
+		<description>Dance Dance Revolution GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDGJ-JPN (RK209-J1)"/>
@@ -3731,7 +3830,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ddrdisny">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB - Disney Mix (Jpn)</description>
+		<description>Dance Dance Revolution GB - Disney Mix (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD7J-JPN (RK237-J1)"/>
@@ -3749,7 +3848,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ddr2">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB2 (Jpn)</description>
+		<description>Dance Dance Revolution GB2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD2J-JPN (RK224-J1)"/>
@@ -3768,7 +3867,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ddr3">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB3 (Jpn)</description>
+		<description>Dance Dance Revolution GB3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BD6J-JPN (RK235-J1)"/>
@@ -3783,7 +3882,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dancefrb">
-		<description>Dancing Furby (Jpn)</description>
+		<description>Dancing Furby (Japan)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BFBJ-JPN"/>
@@ -3801,7 +3900,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dnyakyu">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu (Jpn)</description>
+		<description>Data-Navi Pro Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-A89J-JPN"/>
@@ -3819,7 +3918,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dnyakyu2">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu 2 (Jpn)</description>
+		<description>Data-Navi Pro Yakyuu 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-B8QJ-JPN"/>
@@ -3837,7 +3936,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mirrabmx">
 		<!-- Notes: GBC only -->
-		<description>Dave Mirra Freestyle BMX (Euro, USA)</description>
+		<description>Dave Mirra Freestyle BMX (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMXE-USA, CGB-BMXP-EUR"/>
@@ -3851,10 +3950,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="beckham">
 		<!-- Notes: GBC only -->
-		<description>David Beckham Soccer (Euro)</description>
+		<description>David Beckham Soccer (Europe)</description>
 		<year>2002</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BJ2P-EUR"/>
+		<info name="gold" value="20011127"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3866,7 +3966,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="deadlysk">
-		<description>Deadly Skies (Euro)</description>
+		<description>Deadly Skies (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLP-EUR"/>
@@ -3879,14 +3979,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="deardani">
-		<!-- Notes: SGB enhanced -->
-		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Jpn)</description>
+		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BSAJ-JPN"/>
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dear daniel no sweet adventure - kitty-chan o sagashite (japan).bin" size="1048576" crc="0fd34427" sha1="8598594285f0342b3d93c447b475fadd4722c6cb"/>
@@ -3912,7 +4012,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, English / French)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, English / French)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTX-EUR"/>
@@ -3928,7 +4028,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dejavua" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, French / German)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, French / German)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTY-EUU"/>
@@ -3944,7 +4044,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dejavuj" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Jpn)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTJ-JPN"/>
@@ -3977,7 +4077,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dejikomj">
-		<description>Dejiko no Mahjong Party (Jpn)</description>
+		<description>Dejiko no Mahjong Party (Japan)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQSJ-JPN (KIG-11)"/>
@@ -3995,10 +4095,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="denkiblk">
 		<!-- Notes: GBC only -->
-		<description>Denki Blocks! (Euro)</description>
+		<description>Denki Blocks! (Europe)</description>
 		<year>2001</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BD9P-EUR"/>
+		<info name="gold" value="20010830"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -4011,7 +4112,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dendego">
 		<!-- Notes: GBC only -->
-		<description>Densha de Go! (Jpn)</description>
+		<description>Densha de Go! (Japan)</description>
 		<year>1999</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-A72J-JPN"/>
@@ -4029,12 +4130,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dendego2">
 		<!-- Notes: GBC only -->
-		<description>Densha de Go! 2 (Jpn)</description>
+		<!--	In lot check as "cgbb82j0.538"	-->
+		<description>Densha de Go! 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-B82J-JPN"/>
+		<info name="gold" value="20001020"/>
 		<info name="release" value="20001208"/>
-		<info name="alt_title" value="電車でGO ! 2"/>
+		<info name="alt_title" value="電車でＧＯ！ ２"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A15-10" />
 			<feature name="u1" value="U1 32M MROM 02" />
@@ -4056,7 +4159,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dexterlb" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Dexter's Laboratory - Robot Rampage (Euro, USA)</description>
+		<description>Dexter's Laboratory - Robot Rampage (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BROE-USA, CGB-BROP-EUR"/>
@@ -4072,14 +4175,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dinobrd3">
-		<!-- Notes: SGB enhanced -->
-		<description>Dino Breeder 3 - Gaia Fukkatsu (Jpn)</description>
+		<description>Dino Breeder 3 - Gaia Fukkatsu (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A3DJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ディノブリーダー3 ガイア復活"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 3 - gaia fukkatsu (japan).bin" size="2097152" crc="d9f071bb" sha1="f571a591a2f4fc4f70897e380fdbe9011be75f8d"/>
@@ -4090,14 +4193,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dinobrd4">
-		<!-- Notes: SGB enhanced -->
-		<description>Dino Breeder 4 (Jpn)</description>
+		<description>Dino Breeder 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A4DJ-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="ディノブリーダー4"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 4 (japan).bin" size="2097152" crc="b0106777" sha1="b25681defda961837a28be1432076b65574fd1be"/>
@@ -4109,7 +4212,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dinosaur">
 		<!-- Notes: GBC only -->
-		<description>Dinosaur (Euro)</description>
+		<description>Dinosaur (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BDNP-EUR"/>
@@ -4156,7 +4259,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dinosrus">
 		<!-- Notes: GBC only -->
-		<description>Dinosaur'us (Euro)</description>
+		<!--	In lot check as "CGBBDSP0.602", "KENSA\CGBBDSE0.0"	-->
+		<description>Dinosaur'us (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BDSP-EUR"/>
@@ -4178,7 +4282,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Euro)</description>
+		<description>Diva Starz (Europe)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8P-EUR"/>
@@ -4195,7 +4299,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="divastarf" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Fra)</description>
+		<description>Diva Starz (France)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8F-FRA"/>
@@ -4212,7 +4316,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="divastarg" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Ger)</description>
+		<description>Diva Starz (Germany)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8D-NOE"/>
@@ -4243,7 +4347,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dogz">
 		<!-- Notes: GBC only -->
-		<description>Dogz - Your Virtual Petz Palz (Euro)</description>
+		<description>Dogz - Your Virtual Petz Palz (Europe)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AOZP-EUR"/>
@@ -4274,7 +4378,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dokapon">
-		<description>Dokapon! - Millennium Quest (Jpn)</description>
+		<description>Dokapon! - Millennium Quest (Japan)</description>
 		<year>2000</year>
 		<publisher>Asmik Ace</publisher>
 		<info name="serial" value="DMG-BDKJ-JPN"/>
@@ -4292,7 +4396,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dokixdok">
 		<!-- Notes: GBC only -->
-		<description>Doki x Doki Sasete!! (Jpn)</description>
+		<description>Doki x Doki Sasete!! (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BP6J-JPN"/>
@@ -4310,7 +4414,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dokidoki">
 		<!-- Notes: GBC only -->
-		<description>Dokidoki Densetsu - Mahoujin Guruguru (Jpn)</description>
+		<description>Dokidoki Densetsu - Mahoujin Guruguru (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-B96J-JPN"/>
@@ -4328,7 +4432,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's "Donald" @#Duck?*! (Euro)</description>
+		<description>Disney's "Donald" @#Duck?*! (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Disney's Donald Duck - &quot;Qu@ck &quot;Att@ck&quot;?*! (Box, Cart)"/>
@@ -4346,7 +4450,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="donalddj" cloneof="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's Donald Duck - Daisy o Sukue! (Jpn)</description>
+		<description>Disney's Donald Duck - Daisy o Sukue! (Japan)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUDJ-JPN"/>
@@ -4377,7 +4481,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dkong2k1" cloneof="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong 2001 (Jpn)</description>
+		<description>Donkey Kong 2001 (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDJ-JPN"/>
@@ -4395,7 +4499,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong Country (Euro, Aus, USA)</description>
+		<description>Donkey Kong Country (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDE-USA, CGB-BDDP-(EUR/AUS)"/>
@@ -4416,7 +4520,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dkongcs" cloneof="dkongc">
-		<description>Donkey Kong Country (Euro, USA, Sample)</description>
+		<description>Donkey Kong Country (Europe, USA, Sample)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -4429,9 +4533,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="dkongcd" cloneof="dkongc">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbdye0.326"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Donkey Kong Country (USA, Not for resale)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DIS-CGB-BDYE-USA"/>
+		<info name="gold" value="20000719"/>
+		<info name="alt_title" value="DONKEY KONG COUNTRY (DISPLAY)"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbdye0.326" size="4194304" crc="080605a3" sha1="38fedd71736d258e31d3062864d28449e7c3f1c5"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dkonggb">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Jpn)</description>
+		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AD3J-JPN"/>
@@ -4454,7 +4578,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="doralaby">
-		<description>Doraemon - Aruke Aruke Labyrinth (Jpn)</description>
+		<description>Doraemon - Aruke Aruke Labyrinth (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADAJ-JPN"/>
@@ -4471,7 +4595,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dorapetm">
-		<description>Doraemon - Kimi to Pet no Monogatari (Jpn)</description>
+		<description>Doraemon - Kimi to Pet no Monogatari (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BRDJ-JPN"/>
@@ -4488,14 +4612,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dorakrt2">
-		<!-- Notes: SGB enhanced -->
-		<description>Doraemon Kart 2 (Jpn)</description>
+		<description>Doraemon Kart 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADOJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="ドラえもんカート2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WW3]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -4512,7 +4636,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="doramemo">
-		<description>Doraemon Memories - Nobita no Omoide Daibouken (Jpn)</description>
+		<description>Doraemon Memories - Nobita no Omoide Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BDMJ-JPN"/>
@@ -4530,7 +4654,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Jpn, Rev. A)</description>
+		<description>Doraemon no Quiz Boy (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4554,7 +4678,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="doraqzba" cloneof="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Jpn)</description>
+		<description>Doraemon no Quiz Boy (Japan)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4572,7 +4696,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="doraqzb2">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy 2 (Jpn)</description>
+		<description>Doraemon no Quiz Boy 2 (Japan)</description>
 		<year>2002</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQ7J-JPN"/>
@@ -4596,7 +4720,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dorakang">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Jpn)</description>
+		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Japan)</description>
 		<year>2001</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BGKJ-JPN"/>
@@ -4614,7 +4738,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dorakany">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Jpn)</description>
+		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Japan)</description>
 		<year>2003</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BKYJ-JPN"/>
@@ -4632,7 +4756,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dorakuku">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kuku Game (Jpn)</description>
+		<description>Doraemon no Study Boy - Kuku Game (Japan)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQQJ-JPN"/>
@@ -4650,7 +4774,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Euro)</description>
+		<description>Disney's Doug's Big Game (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUP-EUR"/>
@@ -4667,7 +4791,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dougf" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug - La Grande Aventure (Fra)</description>
+		<description>Disney's Doug - La Grande Aventure (France)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUF-FRA"/>
@@ -4681,7 +4805,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dougg" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Ger)</description>
+		<description>Disney's Doug's Big Game (Germany)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUD-NOE"/>
@@ -4712,7 +4836,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="drrin">
 		<!-- Notes: GBC only -->
-		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Jpn)</description>
+		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BDFJ-JPN"/>
@@ -4736,7 +4860,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="draccraz">
 		<!-- Notes: GBC only -->
-		<description>Dracula - Crazy Vampire (Euro)</description>
+		<description>Dracula - Crazy Vampire (Europe)</description>
 		<year>2001</year>
 		<publisher>DreamCatcher Interactive</publisher>
 		<info name="serial" value="CGB-BUAP-EUR"/>
@@ -4764,7 +4888,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendary Super Warriors (Euro)</description>
+		<description>Dragon Ball Z - Legendary Super Warriors (Europe)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZP-UKV"/>
@@ -4780,7 +4904,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbzj" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Jpn)</description>
+		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Japan)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="CGB-BBZJ-JPN"/>
@@ -4798,7 +4922,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbzf" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Les Guerriers Légendaires (Fra)</description>
+		<description>Dragon Ball Z - Les Guerriers Légendaires (France)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZF-FRA"/>
@@ -4814,7 +4938,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbzg" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendäre Superkämpfer (Ger)</description>
+		<description>Dragon Ball Z - Legendäre Superkämpfer (Germany)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZD-NOE"/>
@@ -4836,7 +4960,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbzi" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Ita)</description>
+		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Italia)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZI-ITA"/>
@@ -4858,7 +4982,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dbzs" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Guerreros de Leyenda (Spa)</description>
+		<description>Dragon Ball Z - Guerreros de Leyenda (Spain)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZS-ESP"/>
@@ -4899,6 +5023,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-BDAE-USA"/>
+		<info name="gold" value="20000623"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
@@ -4908,14 +5033,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dquest12" cloneof="dwarr12">
-		<!-- Notes: SGB enhanced -->
-		<description>Dragon Quest I &amp; II (Jpn)</description>
+		<description>Dragon Quest I &amp; II (Japan)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-AEDJ-JPN"/>
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="ドラゴンクエストI・II"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -4933,7 +5058,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dquest3" cloneof="dwarr3">
 		<!-- Notes: GBC only -->
-		<description>Dragon Quest III - Soshite Densetsu e... (Jpn)</description>
+		<description>Dragon Quest III - Soshite Densetsu e... (Japan)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-BD3J-JPN"/>
@@ -4950,14 +5075,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<!-- Notes: SGB enhanced -->
-		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. A)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -4974,14 +5099,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqma" cloneof="dwm">
-		<!-- Notes: SGB enhanced -->
-		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn)</description>
+		<description>Dragon Quest Monsters - Terry no Wonderland (Japan)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -4998,7 +5123,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqmg" cloneof="dwm">
-		<description>Dragon Quest Monsters (Ger)</description>
+		<description>Dragon Quest Monsters (Germany)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQD-NOE"/>
@@ -5013,14 +5138,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm2i" cloneof="dwm2t">
-		<!-- Notes: SGB enhanced -->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Jpn)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQIJ-JPN"/>
+		<info name="gold" value="20001222"/>
 		<info name="release" value="20010412"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 イルの冒険"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dragon quest monsters 2 - maruta no fushigi na kagi - iru no bouken (japan).bin" size="4194304" crc="68ba18d7" sha1="9193778b28e2e4a6303e09cb4170ca00d0058ae5"/>
@@ -5031,14 +5157,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dqm2r" cloneof="dwm2c">
-		<!-- Notes: SGB enhanced -->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn)</description>
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
+		<info name="gold" value="20001208"/>
 		<info name="release" value="20010309"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5048,6 +5175,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dmg-bqlj-0.u1" size="4194304" crc="2c428a87" sha1="5d2daec53938805236328a0f8a614debffa34048"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dqm2ra" cloneof="dwm2c">
+		<!--	In lot check as "dmgbqlj1.j93"	-->
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev. 1)</description>
+		<year>2001</year>
+		<publisher>Enix</publisher>
+		<info name="serial" value="DMG-BQLJ-JPN"/>
+		<info name="gold" value="20001228"/>
+		<info name="release" value="20010309"/>
+		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dmgbqlj1.j93" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -5073,7 +5220,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dtalesdw">
 		<!-- Notes: GBC only -->
-		<description>Dragon Tales - Dragon Wings (Euro)</description>
+		<description>Dragon Tales - Dragon Wings (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDZP-EUR"/>
@@ -5135,7 +5282,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dwm">
-		<description>Dragon Warrior Monsters (Euro, USA)</description>
+		<description>Dragon Warrior Monsters (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQE-USA, DMG-AWQP-UKV"/>
@@ -5187,7 +5334,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dlair">
 		<!-- Notes: GBC only -->
-		<description>Dragon's Lair (Euro, USA)</description>
+		<description>Dragon's Lair (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BDXE-USA, CGB-BDXP-EUR"/>
@@ -5204,7 +5351,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="driver">
 		<!-- Notes: GBC only -->
-		<description>Driver (Euro)</description>
+		<description>Driver (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BDRP-EUR"/>
@@ -5235,7 +5382,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dropzone">
-		<description>Dropzone (Euro)</description>
+		<description>Dropzone (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AD4P-EUR"/>
@@ -5251,14 +5398,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dtlords">
-		<!-- Notes: SGB enhanced -->
-		<description>DT - Lords of Genomes (Jpn)</description>
+		<description>DT - Lords of Genomes (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-BBDJ-JPN"/>
 		<info name="release" value="20010525"/>
 		<info name="alt_title" value="DT ローズ・オブ・ゲノム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dt - lords of genomes (japan).bin" size="4194304" crc="42ceb854" sha1="66988a201f77cd4c33fb0a9b3981ff5831206c9d"/>
@@ -5270,7 +5417,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dukenuke">
 		<!-- Notes: GBC only -->
-		<description>Duke Nukem (Euro)</description>
+		<description>Duke Nukem (Europe)</description>
 		<year>1999</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="CGB-ADIP-EUR"/>
@@ -5302,7 +5449,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hazzard">
 		<!-- Notes: GBC only -->
-		<description>The Dukes of Hazzard - Racing for Home (Euro)</description>
+		<description>The Dukes of Hazzard - Racing for Home (Europe)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-BDCP-EUR"/>
@@ -5339,14 +5486,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dsavior">
-		<!-- Notes: SGB enhanced -->
-		<description>Dungeon Savior (Jpn)</description>
+		<description>Dungeon Savior (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-ADWJ-JPN"/>
+		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ダンジョンセイバー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dungeon savior (japan).bin" size="4194304" crc="2bcb5f78" sha1="766ab65d9420f361d8d9a4754ea8c6b692e34c36"/>
@@ -5358,7 +5506,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dxjinsei">
 		<!-- Notes: GBC only -->
-		<description>DX Jinsei Game (Jpn)</description>
+		<description>DX Jinsei Game (Japan)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BZGJ-JPN"/>
@@ -5375,14 +5523,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="dxmono">
-		<!-- Notes: SGB enhanced -->
-		<description>DX Monopoly GB (Jpn)</description>
+		<description>DX Monopoly GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-BMPJ-JPN"/>
 		<info name="release" value="20000421"/>
 		<info name="alt_title" value="デラックスモノポリーGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dx monopoly gb (japan).bin" size="1048576" crc="3f1e076c" sha1="524d9459d357e209d64a2ef17b4072478f290806"/>
@@ -5394,7 +5542,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dynamike">
 		<!-- Notes: GBC only -->
-		<description>DynaMike (Euro, Prototype)</description>
+		<description>DynaMike (Europe, Prototype)</description>
 		<year>19??</year>
 		<publisher>Engine Software</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -5409,7 +5557,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="etcg">
 		<!-- Notes: GBC only -->
-		<description>E.T. and the Cosmic Garden (Euro)</description>
+		<description>E.T. and the Cosmic Garden (Europe)</description>
 		<year>2002</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BEOP-EUR"/>
@@ -5447,6 +5595,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BETE-USA"/>
+		<info name="gold" value="20011015"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -5460,7 +5609,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="et">
 		<!-- Notes: GBC only -->
-		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Euro)</description>
+		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Europe)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BERP-EUR"/>
@@ -5492,7 +5641,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ejim">
 		<!-- Notes: GBC only -->
-		<description>Earthworm Jim - Menace 2 the Galaxy (Euro, USA)</description>
+		<description>Earthworm Jim - Menace 2 the Galaxy (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEBE-USA, DMG-AEBP-EUR"/>
@@ -5509,7 +5658,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ecwhard">
 		<!-- Notes: GBC only -->
-		<description>ECW Hardcore Revolution (Euro, USA)</description>
+		<description>ECW Hardcore Revolution (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BECE-USA, CGB-BECP-EUR"/>
@@ -5526,7 +5675,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Euro)</description>
+		<description>Elevator Action EX (Europe)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="alt_title" value="Elevator Action (Box)"/>
@@ -5541,7 +5690,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="elevatorj" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Jpn)</description>
+		<description>Elevator Action EX (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BEXJ-JPN"/>
@@ -5556,14 +5705,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="atelelie">
-		<!-- Notes: SGB enhanced -->
-		<description>Elie no Atelier GB (Jpn)</description>
+		<description>Elie no Atelier GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8EJ-JPN"/>
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="エリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5580,7 +5729,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="elmo123">
-		<description>Elmo's 123s (Euro)</description>
+		<description>Elmo's 123s (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AE3P-EUR"/>
@@ -5606,7 +5755,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="elmoabc">
-		<description>Elmo's ABCs (Euro)</description>
+		<description>Elmo's ABCs (Europe)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AEAP-EUR"/>
@@ -5634,9 +5783,10 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="emperor">
+	<software name="emperorunk" cloneof="emperor">
 		<!-- Notes: GBC only -->
-		<description>The Emperor's New Groove (Euro)</description>
+		<!-- Old dump of unknown origin -->
+		<description>The Emperor's New Groove (Europe, bad dump?)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
@@ -5650,12 +5800,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="emperor">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbenp0.641"	-->
+		<description>The Emperor's New Groove (Europe)</description>
+		<year>2001</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BENP-EUR"/>
+		<info name="gold" value="20010123"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbenp0.641" size="2097152" crc="eb29c584" sha1="2f53318aa7f1c82df95bf3da6b29701a2c563d13"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+
 	<software name="emperoru" cloneof="emperor">
 		<!-- Notes: GBC only -->
 		<description>The Emperor's New Groove (USA)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENE-USA"/>
+		<info name="gold" value="20010123"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5700,7 +5870,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="estpolis" cloneof="lufia">
 		<!-- Notes: GBC only -->
-		<description>Estpolis Denki - Yomigaeru Densetsu (Jpn)</description>
+		<description>Estpolis Denki - Yomigaeru Densetsu (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BLCJ-JPN"/>
@@ -5724,7 +5894,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="euroleag">
 		<!-- Notes: GBC only -->
-		<description>European Super League (Euro)</description>
+		<description>European Super League (Europe)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="??"/>
@@ -5739,7 +5909,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="evelkni">
-		<description>Evel Knievel (Euro)</description>
+		<description>Evel Knievel (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AEVP-EUR"/>
@@ -5769,7 +5939,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="exghostb">
 		<!-- Notes: GBC only -->
-		<description>Extreme Ghostbusters (Euro)</description>
+		<description>Extreme Ghostbusters (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BEBP-EUR"/>
@@ -5783,7 +5953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="extsport">
 		<!-- Notes: GBC only -->
-		<description>Extreme Sports with the Berenstain Bears (Euro, USA)</description>
+		<description>Extreme Sports with the Berenstain Bears (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Sound Source</publisher>
 		<info name="serial" value="CGB-BESE-USA, CGB-BESP-EUR"/>
@@ -5801,10 +5971,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1wgp">
 		<!-- Notes: GBC only -->
-		<description>F-1 World Grand Prix (Euro)</description>
+		<!--	In lot check as "cgbafip0.028", "KENSA\cgbafie0.0"	-->
+		<description>F-1 World Grand Prix (Europe)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-AFIP-EUR"/>
+		<info name="gold" value="19990526"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5817,7 +5989,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f18thund">
 		<!-- Notes: GBC only -->
-		<description>F-18 Thunder Strike (Euro, USA)</description>
+		<description>F-18 Thunder Strike (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-B18E-USA, CGB-B18P-NOE"/>
@@ -5834,10 +6006,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="fa2001">
 		<!-- Notes: GBC only -->
-		<description>The F.A. Premier League Stars 2001 (Euro)</description>
+		<description>The F.A. Premier League Stars 2001 (Europe)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BSJP-?"/>
+		<info name="gold" value="20010413"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -5848,10 +6021,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1chmp2k">
 		<!-- Notes: GBC only -->
-		<description>F1 Championship Season 2000 (Euro)</description>
+		<description>F1 Championship Season 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BFIP-?"/>
+		<info name="gold" value="20001117"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5860,16 +6034,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="f1chmp2kb" cloneof="f1chmp2k">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfib0.579"	-->
+		<description>F1 Championship Season 2000 (Bra)</description>
+		<year>2000</year>
+		<publisher>Electronic Arts</publisher>
+		<info name="serial" value="CGB-BFIB-?"/>
+		<info name="gold" value="20001107"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbfib0.579" size="2097152" crc="f4f5ed18" sha1="4731a7442bbff31c6d470b84938a3f148a4f1f6c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="f1racing">
 		<!-- Notes: GBC only -->
-		<description>F1 Racing Championship (Euro)</description>
+		<!--	In lot check as "cgbaeqp0.381"	-->
+		<description>F1 Racing Championship (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AEQP-EUR"/>
+		<info name="gold" value="20000829"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
+				<rom name="cgbaeqp0.381" size="4194304" crc="93a9789f" sha1="ea844051c0b5c6f9a6a8c472f4f67ee6b9b3d8e7"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5878,13 +6070,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1racingp" cloneof="f1racing">
 		<!-- Notes: GBC only -->
-		<description>F1 Racing Championship (Euro, Prototype)</description>
+		<description>F1 Racing Championship (Europe, Prototype)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta) (february, 2000).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="f1racingunk" cloneof="f1racing">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>F1 Racing Championship (Europe, bad dump?)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5893,7 +6101,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Euro)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Europe)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2P-EUR"/>
@@ -5909,7 +6117,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="f1wgp2j" cloneof="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Jpn)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Japan)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2J-JPN"/>
@@ -5948,17 +6156,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="fairykit">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. A)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (rev. a).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
+				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (Rev. 1).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -5966,14 +6175,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="fairykita" cloneof="fairykit">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan).bin" size="1048576" crc="b59a51c4" sha1="a27b498c6170b4136d2ca8a75c3d529dd6c06639"/>
@@ -5985,7 +6195,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ferret">
 		<!-- Notes: GBC only -->
-		<description>Ferret Monogatari (Jpn)</description>
+		<description>Ferret Monogatari (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BBIJ-JPN"/>
@@ -6002,7 +6212,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="fifa2k">
-		<description>FIFA 2000 (Euro, USA)</description>
+		<description>FIFA 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AFOE-USA, DMG-AFOP-UKV"/>
@@ -6019,7 +6229,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="fishfile">
 		<!-- Notes: GBC only -->
-		<description>The Fish Files (Euro)</description>
+		<description>The Fish Files (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BFQP-EUR"/>
@@ -6035,7 +6245,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="fixfoxi">
 		<!-- Notes: GBC only -->
-		<description>Fix &amp; Foxi - Episode 1: Lupo (Euro)</description>
+		<description>Fix &amp; Foxi - Episode 1: Lupo (Europe)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BFFP-EUR"/>
@@ -6049,7 +6259,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Euro)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6064,7 +6274,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 <!-- The header is wrong, can it be a bad dump? a beta? investigations are needed on this older dump -->
 	<software name="flintbba" cloneof="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Euro, Alt?)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Europe, Alt?)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6092,7 +6302,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="flipperl">
 		<!-- Notes: GBC only -->
-		<description>Flipper &amp; Lopaka (Euro)</description>
+		<description>Flipper &amp; Lopaka (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BFLP-EUR"/>
@@ -6136,7 +6346,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="fortboya">
 		<!-- Notes: GBC only -->
-		<description>Fort Boyard (Euro)</description>
+		<description>Fort Boyard (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BYDP-EUR"/>
@@ -6149,7 +6359,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="frogger">
-		<description>Frogger (Euro)</description>
+		<description>Frogger (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRP-EUR"/>
@@ -6162,7 +6372,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="froggeru" cloneof="frogger">
-		<description>Frogger (USA, Rev. B)</description>
+		<description>Frogger (USA, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-3"/>
@@ -6178,14 +6388,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="froggerua" cloneof="frogger">
-		<description>Frogger (USA, Rev. A)</description>
+		<description>Frogger (USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="frogger (usa) (rev a).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
+				<rom name="frogger (usa) (rev 1).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
 			</dataarea>
 		</part>
 	</software>
@@ -6209,6 +6419,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
+		<info name="gold" value="20000731"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6219,15 +6430,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="frogger2a" cloneof="frogger2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbh2e1.351"	-->
+		<description>Frogger 2 (USA, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Majesco</publisher>
+		<info name="serial" value="CGB-BH2E-USA"/>
+		<info name="gold" value="20000821"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbh2e1.351" size="1048576" crc="e3227b7d" sha1="0d5028ca6fcc10df46d11cd4b56e5add1dc5e63e"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="onepglin">
-		<!-- Notes: SGB enhanced -->
-		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Jpn)</description>
+		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BZOJ-JPN"/>
+		<info name="gold" value="20020510"/>
 		<info name="release" value="20020628"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 幻のグランドライン冒険記!"/>
+		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6244,14 +6474,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="onepyume">
-		<!-- Notes: SGB enhanced -->
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. A)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
+		<info name="gold" value="20010615"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
+		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C3203-12A2]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -6260,7 +6491,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="battery" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (rev. a).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
+				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (Rev. 1).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6268,14 +6499,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="onepyumea" cloneof="onepyume">
-		<!-- Notes: SGB enhanced -->
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn)</description>
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
+		<info name="gold" value="20010307"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
+		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6293,7 +6525,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="frontlin">
 		<!-- Notes: GBC only -->
-		<description>Front Line - The Next Mission (Jpn)</description>
+		<description>Front Line - The Next Mission (Japan)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFRJ-JPN"/>
@@ -6309,7 +6541,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="frontrow">
 		<!-- Notes: GBC only -->
-		<description>Front Row (Jpn)</description>
+		<description>Front Row (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZDJ-JPN"/>
@@ -6327,12 +6559,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="furaish2">
 		<!-- Notes: GBC only -->
-		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn)</description>
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-AFMJ-JPN"/>
+		<info name="gold" value="20010622"/>
 		<info name="release" value="20010719"/>
-		<info name="alt_title" value="不思議のダンジョン 風来のシレンGB2 砂漠の魔城"/>
+		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -6343,9 +6576,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="furaish2a" cloneof="furaish2">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfwj0.814"	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
+		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to feature the common retail release)	-->
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)</description>
+		<year>2001</year>
+		<publisher>ChinSoft</publisher>
+		<info name="serial" value="CGB-BFWJ-JPN?"/>
+		<info name="gold" value="20010703"/>
+		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbfwj0.814" size="4194304" crc="f3c20fbe" sha1="d9c490af97c08ac7053bbb9f7ae06d3501035127"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gaiamast">
 		<!-- Notes: GBC only -->
-		<description>Gaiamaster Duel - Card Attackers (Jpn)</description>
+		<description>Gaiamaster Duel - Card Attackers (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BGIJ-JPN"/>
@@ -6361,11 +6615,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="gakkyama">
-		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. A)</description>
+	<software name="gakkyamaa">
+		<description>Gakkyuu Ou Yamazaki (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
+		<info name="gold" value="19990428"/>
 		<info name="release" value="19990529"/>
 		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6378,6 +6633,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmg-aymj-1.u1" size="1048576" crc="ef2cfd99" sha1="3a2718efa3d1cac7345fbbcddb7c3f666fc6c70c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gakkyama" cloneof="gakkyamaa">
+		<!--	In lot check as "dmgaymj0.g22"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Gakkyuu Ou Yamazaki (Japan)</description>
+		<year>1999</year>
+		<publisher>Koei</publisher>
+		<info name="serial" value="DMG-AYMJ-JPN?"/>
+		<info name="gold" value="19990226"/>
+		<info name="release" value="19990529"/>
+		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaymj0.g22" size="1048576" crc="b8147b5c" sha1="132b872391565d418ccc9d0e1c643510d778c066"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6400,10 +6675,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gamblert">
 		<!-- Notes: GBC only -->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN"/>
+		<info name="gold" value="20001218"/>
 		<info name="release" value="20010209"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6416,8 +6692,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="gamblerta" cloneof="gamblert">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbgyj1.607"	-->
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev. 1)</description>
+		<year>2001</year>
+		<publisher>Athena</publisher>
+		<info name="serial" value="CGB-BGYJ-JPN?"/>
+		<info name="gold" value="20010307"/>
+		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbgyj1.607" size="1048576" crc="91739def" sha1="b62f8e56b995874c0e1a2533df5a37f6996df12e"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="gwatch2">
-		<description>Game &amp; Watch Gallery 2 (Euro, USA)</description>
+		<description>Game &amp; Watch Gallery 2 (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLE-USA, DMG-AGLP-EUR"/>
@@ -6432,7 +6727,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gwatch3">
-		<description>Game &amp; Watch Gallery 3 (Euro, USA)</description>
+		<description>Game &amp; Watch Gallery 3 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQE-USA, DMG-AGQP-EUR"/>
@@ -6448,7 +6743,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gbpromo">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Color Promotional Demo (Euro, USA)</description>
+		<description>Game Boy Color Promotional Demo (Europe, USA)</description>
 		<year>19??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6460,7 +6755,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbgall3" cloneof="gwatch2">
-		<description>Game Boy Gallery 3 (Aus)</description>
+		<description>Game Boy Gallery 3 (Australia)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLU-AUS"/>
@@ -6475,14 +6770,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbgall3j" cloneof="gwatch3">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Game Boy Gallery 3 (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Game Boy Gallery 3 (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQJ-JPN"/>
 		<info name="release" value="19990408"/>
 		<info name="alt_title" value="ゲームボーイギャラリー3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-Z02-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -6495,7 +6791,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbgall4" cloneof="gwatch3">
-		<description>Game Boy Gallery 4 (Aus)</description>
+		<description>Game Boy Gallery 4 (Australia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQU-AUS"/>
@@ -6516,14 +6812,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbwars2">
-		<!-- Notes: SGB enhanced -->
-		<description>Game Boy Wars 2 (Jpn)</description>
+		<description>Game Boy Wars 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AWOJ-JPN"/>
 		<info name="release" value="19981120"/>
 		<info name="alt_title" value="ゲームボーイウォーズ2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 			<!-- 2nd half is filled with 0xff, confirmed with the real cart -->
@@ -6536,7 +6832,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gbwars3">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Wars 3 (Jpn)</description>
+		<description>Game Boy Wars 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BWWJ-JPN"/>
@@ -6555,7 +6851,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gameconv">
-		<description>Game Conveni 21 (Jpn)</description>
+		<description>Game Conveni 21 (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BG2J-JPN"/>
@@ -6571,7 +6867,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gamefrnz">
 		<!-- Notes: GBC only -->
-		<description>Games Frenzy (Euro)</description>
+		<description>Games Frenzy (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BFGP-EUR"/>
@@ -6585,7 +6881,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ggoemdyn">
 		<!-- Notes: GBC only, also released by NP in 2001-07 -->
-		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Jpn)</description>
+		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BEKJ-JPN (RK234-J1)"/>
@@ -6602,14 +6898,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ggoemnab">
-		<!-- Notes: SGB enhanced -->
-		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Jpn)</description>
+		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AEFJ-JPN (RK192-J1)"/>
 		<info name="release" value="19991216"/>
 		<info name="alt_title" value="がんばれゴエモン もののけ道中飛び出せ鍋奉行!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="ganbare goemon - mononoke douchuu tobisuise nabebugyou (japan).bin" size="2097152" crc="73311cfa" sha1="4bc3928f3528a2c566b09613e538253dd128864c"/>
@@ -6620,8 +6916,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ggoemtng">
-		<!-- Notes: Also released by NP in 2000-05 -->
-		<description>Ganbare Goemon - Tengutou no Gyakushuu (Jpn)</description>
+		<!-- Also released by NP in 2000-05 -->
+		<description>Ganbare Goemon - Tengutou no Gyakushuu (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AGUJ-JPN (RK182-J1)"/>
@@ -6639,7 +6935,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="olymp2k" cloneof="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>Ganbare! Nippon! Olympic 2000 (Jpn)</description>
+		<description>Ganbare! Nippon! Olympic 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HJ-JPN (RK208-J1)"/>
@@ -6657,7 +6953,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="harobots">
 		<!-- Notes: GBC only -->
-		<description>GB Harobots (Jpn)</description>
+		<description>GB Harobots (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunrise Interactive</publisher>
 		<info name="serial" value="CGB-BHRJ-JPN"/>
@@ -6675,7 +6971,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gbmemory">
 		<!-- Notes: GBC only -->
-		<description>GB Memory Multi Menu (Jpn, NP)</description>
+		<description>GB Memory Multi Menu (Japan, NP)</description>
 		<year>20??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6688,7 +6984,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="happyhip">
 		<!-- Notes: GBC only -->
-		<description>Das Geheimnis der Happy Hippo-Insel (Ger)</description>
+		<description>Das Geheimnis der Happy Hippo-Insel (Germany)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BHOD-NOE"/>
@@ -6705,7 +7001,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="dangunrc">
 		<!-- Notes: GBC only -->
-		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Jpn)</description>
+		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BDJJ-JPN"/>
@@ -6722,14 +7018,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gemgem" cloneof="lilmonst">
-		<!-- Notes: SGB enhanced -->
-		<description>Gem Gem Monster (Jpn)</description>
+		<description>Gem Gem Monster (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AJYJ-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="ジェムジェムモンスター"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="gem gem monster (japan).bin" size="1048576" crc="de7505c0" sha1="8b1396cf9dbc77246b3443810282b8b9bcb65a67"/>
@@ -6741,7 +7037,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gmsayuki">
 		<!-- Notes: GBC only -->
-		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Jpn)</description>
+		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BGSJ-JPN"/>
@@ -6758,7 +7054,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="getchuu">
-		<description>Get Chuu Club - Minna no Konchuu Daizukan (Jpn)</description>
+		<description>Get Chuu Club - Minna no Konchuu Daizukan (Japan)</description>
 		<year>1999</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="DMG-VRKJ-JPN"/>
@@ -6783,7 +7079,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gex2">
-		<description>Gex - Enter the Gecko (Euro, USA)</description>
+		<description>Gex - Enter the Gecko (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEXE-USA, DMG-AEXP-EUR"/>
@@ -6797,7 +7093,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gex3">
 		<!-- Notes: GBC only -->
-		<description>Gex 3 - Deep Cover Gecko (Euro)</description>
+		<description>Gex 3 - Deep Cover Gecko (Europe)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="CGB-AXGP-EUR"/>
@@ -6824,7 +7120,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gng">
-		<description>Ghosts'n Goblins (Euro, USA)</description>
+		<description>Ghosts'n Goblins (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AG9E-USA, DMG-AG9P-EUR"/>
@@ -6840,7 +7136,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gifts" cloneof="gift">
-		<description>Gift (Euro, Sample)</description>
+		<description>Gift (Europe, Sample)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6853,10 +7149,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gift">
 		<!-- Notes: GBC only -->
-		<description>Gift (Euro)</description>
+		<description>Gift (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFP-EUR"/>
+		<info name="gold" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6867,10 +7164,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gifty" cloneof="gift">
 		<!-- Notes: GBC only -->
-		<description>Gifty (Ger)</description>
+		<description>Gifty (Germany)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BGFD-?"/>
+		<info name="gold" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6880,14 +7178,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="glochex" cloneof="hexcite">
-		<!-- Notes: SGB enhanced -->
-		<description>Glocal Hexcite (Jpn)</description>
+		<description>Glocal Hexcite (Japan)</description>
 		<year>1998</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="DMG-AICJ-JPN"/>
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="グローカルヘキサイト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="glocal hexcite (japan).bin" size="1048576" crc="f1908391" sha1="7d13220593c8d89af1b4cae955caacff7df3817a"/>
@@ -6912,7 +7210,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="godzilla">
-		<description>Godzilla - The Series (Euro)</description>
+		<description>Godzilla - The Series (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AZIP-EUR"/>
@@ -6939,7 +7237,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="godzmwar">
 		<!-- Notes: GBC only -->
-		<description>Godzilla - The Series - Monster Wars (Euro)</description>
+		<description>Godzilla - The Series - Monster Wars (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BGDP-EUR"/>
@@ -6970,7 +7268,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="goldglry">
 		<!-- Notes: GBC only -->
-		<description>Gold and Glory - The Road to El Dorado (Euro)</description>
+		<description>Gold and Glory - The Road to El Dorado (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BEDP-EUR"/>
@@ -6997,7 +7295,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="goldgoal">
-		<description>Golden Goal (Euro)</description>
+		<description>Golden Goal (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFX-EUR"/>
@@ -7018,7 +7316,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="goldgoalg" cloneof="goldgoal">
-		<description>Golden Goal (Ger)</description>
+		<description>Golden Goal (Germany)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFD-NOE"/>
@@ -7033,14 +7331,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="golfdai">
-		<!-- Notes: SGB enhanced -->
-		<description>Golf Daisuki! (Jpn)</description>
+		<description>Golf Daisuki! (Japan)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AAGJ-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ゴルフだいすき!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="golf daisuki (japan).bin" size="2097152" crc="80444a86" sha1="d245a267b1b1d056e0f5af4ba732c66c8deadde2"/>
@@ -7051,7 +7349,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="golfohas" cloneof="holein1">
-		<description>Golf de Ohasuta (Jpn)</description>
+		<description>Golf de Ohasuta (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOHJ-JPN"/>
@@ -7068,14 +7366,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="golfou">
-		<!-- Notes: SGB enhanced -->
-		<description>Golf Ou (Jpn)</description>
+		<description>Golf Ou (Japan)</description>
 		<year>1999</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-AZAJ-JPN"/>
+		<info name="gold" value="19990617"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="ゴルフ王"/>
+		<info name="alt_title" value="ゴルフ王 THE KING OF GOLF"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="golf ou (japan).bin" size="4194304" crc="634b2d43" sha1="d196af0aaf77ca67f9784d0ccd1ef4b25abed5c2"/>
@@ -7087,7 +7386,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gonta">
 		<!-- Notes: GBC only -->
-		<description>Gonta no Okiraku Daibouken (Jpn)</description>
+		<description>Gonta no Okiraku Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Lay-Up</publisher>
 		<info name="serial" value="CGB-B54J-JPN"/>
@@ -7104,7 +7403,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="goraku">
-		<description>Goraku Ou Tango! (Jpn)</description>
+		<description>Goraku Ou Tango! (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AOEJ-JPN"/>
@@ -7121,7 +7420,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gta">
-		<description>Grand Theft Auto (Euro)</description>
+		<description>Grand Theft Auto (Europe)</description>
 		<year>1999</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="DMG-AOAP-EUR"/>
@@ -7152,7 +7451,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gta2">
 		<!-- Notes: GBC only -->
-		<description>Grand Theft Auto 2 (Euro)</description>
+		<description>Grand Theft Auto 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BGTP-(EUR/UKV)"/>
@@ -7180,7 +7479,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="grandia">
 		<!-- Notes: GBC only -->
-		<description>Grandia - Parallel Trippers (Jpn)</description>
+		<description>Grandia - Parallel Trippers (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BGEJ-JPN"/>
@@ -7198,7 +7497,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="granduel">
 		<!-- Notes: GBC only -->
-		<description>Granduel - Shinki Dungeon no Hihou (Jpn)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-ADVJ-JPN"/>
@@ -7215,7 +7514,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="granduels" cloneof="granduel">
-		<description>Granduel - Shinki Dungeon no Hihou (Jpn, Sample)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Japan, Sample)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7227,14 +7526,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gbattlep">
-		<!-- Notes: SGB enhanced -->
-		<description>The Great Battle Pocket (Jpn)</description>
+		<description>The Great Battle Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AGVJ-JPN"/>
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="ザ・グレイトバトル ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -7247,7 +7546,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="gremlins">
 		<!-- Notes: GBC only -->
-		<description>Gremlins Unleashed (Euro)</description>
+		<description>Gremlins Unleashed (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BGPP-EUR"/>
@@ -7260,7 +7559,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gremlinsp" cloneof="gremlins">
-		<description>Gremlins Unleashed (Euro, Prototype)</description>
+		<description>Gremlins Unleashed (Europe, Prototype)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7273,7 +7572,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="grinch">
 		<!-- Notes: GBC only -->
-		<description>The Grinch (Euro)</description>
+		<description>The Grinch (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGHP-EUR"/>
@@ -7290,7 +7589,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="grinchj" cloneof="grinch">
 		<!-- Notes: GBC only -->
-		<description>Grinch (Jpn)</description>
+		<description>Grinch (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUGJ-JPN (RK221-J1)"/>
@@ -7327,14 +7626,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gurugugr">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
-		<description>Guruguru Garakutas (Jpn)</description>
+		<!-- Also released by NP in 2000-07 -->
+		<description>Guruguru Garakutas (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AUGJ-JPN"/>
 		<info name="release" value="19990910"/>
 		<info name="alt_title" value="ぐるぐるガラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="guruguru garakutas (japan).bin" size="1048576" crc="7eaeeeac" sha1="86fea7dd8d815a51c1b75b816125ab4ba731dba1"/>
@@ -7346,7 +7646,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="guruguth">
 		<!-- Notes: GBC only -->
-		<description>Guruguru Town Hanamaru-kun (Jpn)</description>
+		<description>Guruguru Town Hanamaru-kun (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BHJJ-JPN"/>
@@ -7361,7 +7661,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="gutequiz">
-		<description>Gute Zeiten Schlechte Zeiten Quiz (Ger)</description>
+		<description>Gute Zeiten Schlechte Zeiten Quiz (Germany)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="DMG-BGQD-NOE"/>
@@ -7375,7 +7675,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="docguy">
 		<!-- Notes: GBC only -->
-		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Jpn)</description>
+		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BB6J-JPN (RK266-J1) "/>
@@ -7393,7 +7693,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hallowen">
 		<!-- Notes: GBC only -->
-		<description>Halloween Racer (Euro)</description>
+		<description>Halloween Racer (Europe)</description>
 		<year>1999</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-AHIP-EUR"/>
@@ -7406,7 +7706,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hamstclb">
-		<description>Hamster Club (Jpn)</description>
+		<description>Hamster Club (Japan)</description>
 		<year>1999</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-AJNJ-JPN"/>
@@ -7423,7 +7723,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hamstcla">
-		<description>Hamster Club - Awasete Chuu (Jpn)</description>
+		<description>Hamster Club - Awasete Chuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJHJ-JPN"/>
@@ -7439,7 +7739,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstclo">
 		<!-- Notes: GBC only -->
-		<description>Hamster Club - Oshiema Chuu (Jpn)</description>
+		<description>Hamster Club - Oshiema Chuu (Japan)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJSJ-JPN"/>
@@ -7456,7 +7756,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hamstcl2">
-		<description>Hamster Club 2 (Jpn)</description>
+		<description>Hamster Club 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJNJ-JPN"/>
@@ -7480,7 +7780,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstmon">
 		<!-- Notes: GBC only -->
-		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Jpn)</description>
+		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Japan)</description>
 		<year>2002</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-B8MJ-JPN"/>
@@ -7503,14 +7803,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hamstpar">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
-		<description>Hamster Paradise (Jpn)</description>
+		<!-- Also released by NP in 2001-06 -->
+		<description>Hamster Paradise (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AHMJ-JPN"/>
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="ハムスターパラダイス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hamster paradise (japan).bin" size="1048576" crc="f520cb19" sha1="87ebc7e0cfb0803e6e14da7eec1b2fad51c83ba0"/>
@@ -7522,7 +7823,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Jpn, Rev. A)</description>
+		<description>Hamster Paradise 2 (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7531,7 +7832,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="hamster paradise 2 (japan) (rev a).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
+				<rom name="hamster paradise 2 (japan) (rev 1).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -7540,7 +7841,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstpa2a" cloneof="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Jpn)</description>
+		<description>Hamster Paradise 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7558,7 +7859,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstpa3">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 3 (Jpn)</description>
+		<description>Hamster Paradise 3 (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BH3J-JPN"/>
@@ -7576,7 +7877,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamstpa4">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 4 (Jpn)</description>
+		<description>Hamster Paradise 4 (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BCUJ-JPN"/>
@@ -7594,7 +7895,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Hamtaro - Ham-Hams Unite! (Euro)</description>
+		<description>Hamtaro - Ham-Hams Unite! (Europe)</description>
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86P-EUR"/>
@@ -7626,7 +7927,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hamunapt" cloneof="mummy">
 		<!-- Notes: GBC only -->
-		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Jpn)</description>
+		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUMJ-JPN (RK222-J1)"/>
@@ -7644,7 +7945,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hanayori">
 		<!-- Notes: GBC only -->
-		<description>Hana Yori Dango - Another Love Story (Jpn)</description>
+		<description>Hana Yori Dango - Another Love Story (Japan)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-B87J-JPN"/>
@@ -7667,14 +7968,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hanasaka">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-04 -->
-		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Jpn)</description>
+		<!-- Also released by NP in 2001-04 -->
+		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHTJ-JPN (RK186-J1)"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="花さか天使テンテンくんのBeat Breaker"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hanasaka tenshi tenten-kun no beat breaker (japan).bin" size="1048576" crc="6e988c07" sha1="791ea554de774de622bb4fb6bc2bf42955a201b3"/>
@@ -7686,7 +7988,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="handtime">
 		<!-- Notes: GBC only -->
-		<description>Hands of Time (Euro, USA)</description>
+		<description>Hands of Time (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BWCE-USA, CGB-BWCP-EUR"/>
@@ -7719,7 +8021,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hpotcsec">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Chamber of Secrets (Euro, USA)</description>
+		<description>Harry Potter and the Chamber of Secrets (Europe, USA)</description>
 		<year>2002</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BH6E-USA, CGB-BH6P-EUR"/>
@@ -7735,7 +8037,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Philosopher's Stone (Euro) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
+		<description>Harry Potter and the Philosopher's Stone (Europe) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BHVE-USA, CGB-BHVP-EUR"/>
@@ -7751,7 +8053,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hpotkenj" cloneof="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter to Kenja no Ishi (Jpn)</description>
+		<description>Harry Potter to Kenja no Ishi (Japan)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts Victor</publisher>
 		<info name="serial" value="CGB-BHVJ-JPN"/>
@@ -7768,7 +8070,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="harvmon2">
-		<description>Harvest Moon 2 GBC (Euro)</description>
+		<description>Harvest Moon 2 GBC (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2P-EUR"/>
@@ -7783,7 +8085,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="harvmon2g" cloneof="harvmon2">
-		<description>Harvest Moon 2 GBC (Ger)</description>
+		<description>Harvest Moon 2 GBC (Germany)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2D-NOE"/>
@@ -7829,7 +8131,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="harvmoon">
-		<description>Harvest Moon GB (Euro)</description>
+		<description>Harvest Moon GB (Europe)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXP-EUR"/>
@@ -7845,7 +8147,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="harvmoong" cloneof="harvmoon">
-		<description>Harvest Moon GB (Ger)</description>
+		<description>Harvest Moon GB (Germany)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXD-NOE"/>
@@ -7883,14 +8185,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hellokbf">
-		<!-- Notes: SGB enhanced -->
-		<description>Hello Kitty no Beads Factory (Jpn)</description>
+		<description>Hello Kitty no Beads Factory (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHBJ-JPN"/>
 		<info name="release" value="19990717"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのビーズ工房"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no beads factory (japan).bin" size="1048576" crc="12f74cd4" sha1="539ddbe7f73b33ffb886143dd14869d486f3fecf"/>
@@ -7902,7 +8204,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hellokhh">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty no Happy House (Jpn)</description>
+		<description>Hello Kitty no Happy House (Japan)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BK7J-JPN"/>
@@ -7919,14 +8221,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hellokmm">
-		<!-- Notes: SGB enhanced -->
-		<description>Hello Kitty no Magical Museum (Jpn)</description>
+		<description>Hello Kitty no Magical Museum (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHKJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのマジカルミュージアム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -7943,14 +8245,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="helloksa">
-		<!-- Notes: SGB enhanced -->
-		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Jpn)</description>
+		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BKTJ-JPN"/>
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no sweet adventure - daniel-kun ni aitai (japan).bin" size="1048576" crc="45f4159b" sha1="c290dbd29a6246eb001f35f973c0e664af2c97b1"/>
@@ -7962,7 +8264,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hellokdd">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty to Dear Daniel no Dream Adventure (Jpn)</description>
+		<description>Hello Kitty to Dear Daniel no Dream Adventure (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BK8J-JPN"/>
@@ -7983,6 +8285,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AF4E-USA"/>
+		<info name="gold" value="19991027"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7993,7 +8296,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hercules">
 		<!-- Notes: GBC only -->
-		<description>Hercules - The Legendary Journeys (Euro)</description>
+		<description>Hercules - The Legendary Journeys (Europe)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -8009,7 +8312,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="herohero">
 		<!-- Notes: GBC only -->
-		<description>Hero Hero Kun (Jpn)</description>
+		<description>Hero Hero Kun (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BH9J-JPN"/>
@@ -8027,10 +8330,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mightmag">
 		<!-- Notes: GBC only -->
-		<description>Heroes of Might and Magic (Euro)</description>
+		<description>Heroes of Might and Magic (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHP-EUR"/>
+		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8053,6 +8357,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHE-USA"/>
+		<info name="gold" value="20000508"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8080,7 +8385,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hexcite">
-		<description>Hexcite (Euro, USA)</description>
+		<!--	European cartridges have USA sticker underneath.	-->
+		<description>Hexcite (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AICE-USA, DMG-AICP-EUR"/>
@@ -8104,7 +8410,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hiryuken">
 		<!-- Notes: GBC only -->
-		<description>Hiryuu no Ken - Retsuden GB (Jpn)</description>
+		<description>Hiryuu no Ken - Retsuden GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BKEJ-JPN"/>
@@ -8120,7 +8426,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pachiboy">
 		<!-- Notes: GBC only -->
-		<description>Hissatsu Pachinko Boy - CR Monster House (Jpn)</description>
+		<description>Hissatsu Pachinko Boy - CR Monster House (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-BHPJ-JPN"/>
@@ -8158,7 +8464,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hollywpb">
-		<description>Hollywood Pinball (Euro)</description>
+		<description>Hollywood Pinball (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AHLP-EUR"/>
@@ -8171,7 +8477,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hollywpbj" cloneof="hollywpb">
-		<description>Hollywood Pinball (Jpn)</description>
+		<description>Hollywood Pinball (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AHNJ-JPN"/>
@@ -8186,7 +8492,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="holymagc">
-		<description>Holy Magic Century (Euro)</description>
+		<description>Holy Magic Century (Europe)</description>
 		<year>1999</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="DMG-AQTP-EUR"/>
@@ -8200,7 +8506,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="honkhana">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Honkaku Hanafuda GB (Jpn)</description>
+		<description>Honkaku Hanafuda GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-AH3J-JPN"/>
@@ -8217,14 +8523,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="honkshog">
-		<!-- Notes: SGB enhanced -->
-		<description>Honkaku Shougi - Shougi Ou (Jpn)</description>
+		<description>Honkaku Shougi - Shougi Ou (Japan)</description>
 		<year>1998</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AG8J-JPN"/>
 		<info name="release" value="19981113"/>
 		<info name="alt_title" value="本格将棋 将棋王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku shougi - shougi ou (japan).bin" size="1048576" crc="3a96e868" sha1="a0e5a6b00cc31670949f7d8cdeec2486d0ec986f"/>
@@ -8235,7 +8541,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="honktsho">
-		<description>Honkaku Taisen Shougi Ayumu (Jpn)</description>
+		<description>Honkaku Taisen Shougi Ayumu (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AIBJ-JPN"/>
@@ -8252,14 +8558,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="honkmj">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
-		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Jpn)</description>
+		<!-- Also released by NP in 2000-04 -->
+		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Japan)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AAAJ-JPN"/>
 		<info name="release" value="19990219"/>
 		<info name="alt_title" value="本格四人打麻雀 麻雀王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku yonin uchi mahjong - mahjong ou (japan).bin" size="1048576" crc="8ed4bbba" sha1="222487f14aaaa8f0bb536a09238e63ac95636208"/>
@@ -8270,7 +8577,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hotwheel">
-		<description>Hot Wheels - Stunt Track Driver (Euro, USA)</description>
+		<description>Hot Wheels - Stunt Track Driver (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AHEE-USA, DMG-AHEP-EUR"/>
@@ -8314,7 +8621,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hugobdf">
 		<!-- Notes: GBC only -->
-		<description>Hugo - Black Diamond Fever (Euro)</description>
+		<description>Hugo - Black Diamond Fever (Europe)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHUP-EUR"/>
@@ -8328,7 +8635,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hugoevmr">
 		<!-- Notes: GBC only -->
-		<description>Hugo - The Evil Mirror (Euro)</description>
+		<description>Hugo - The Evil Mirror (Europe)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHXP-EUR"/>
@@ -8344,7 +8651,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hugo2hlf">
-		<description>Hugo 2½ (Ger)</description>
+		<description>Hugo 2½ (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AHOP-NOE"/>
@@ -8358,7 +8665,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hxhhunke">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Hunter no Keifu (Jpn)</description>
+		<description>Hunter X Hunter - Hunter no Keifu (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHHJ-JPN (RK203-J1)"/>
@@ -8376,7 +8683,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hxhkindn">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Kindan no Hihou (Jpn)</description>
+		<description>Hunter X Hunter - Kindan no Hihou (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHKJ-JPN (RK236-J1)"/>
@@ -8394,10 +8701,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hype">
 		<!-- Notes: GBC only -->
-		<description>Hype - The Time Quest (Euro)</description>
+		<description>Hype - The Time Quest (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BHQP-EUR"/>
+		<info name="gold" value="20000707"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8406,9 +8714,25 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="hypeb" cloneof="hype">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpfe0.737"	-->
+		<description>Hype - The Time Quest (Bra)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BPFE-?"/>
+		<info name="gold" value="20010411"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpfe0.737" size="1048576" crc="cafb8035" sha1="7c7dca7c48dc478d0278c273ba37723b9e9dce5b"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="hyprol2k" cloneof="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Hyper Olympic - Winter 2000 (Jpn)</description>
+		<description>Hyper Olympic - Winter 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HJ-JPN (RK196-J1)"/>
@@ -8425,14 +8749,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hyperol" cloneof="itf">
-		<!-- Notes: SGB enhanced -->
-		<description>Hyper Olympic Series - Track &amp; Field GB (Jpn)</description>
+		<description>Hyper Olympic Series - Track &amp; Field GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDJ-JPN (RK183-J1)"/>
 		<info name="release" value="19990701"/>
 		<info name="alt_title" value="ハイパーオリンピックシリーズ トラック&amp;フィールドGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hyper olympic series - track &amp; field gb (japan).bin" size="1048576" crc="77f76ebc" sha1="6dabafe260b53e61a810cbae2f14287adafffd8e"/>
@@ -8444,7 +8768,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ideyumjk">
 		<!-- Notes: GBC only -->
-		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Jpn)</description>
+		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BIMJ-JPN"/>
@@ -8462,7 +8786,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="indyinfm">
 		<!-- Notes: GBC only -->
-		<description>Indiana Jones and the Infernal Machine (Euro, USA)</description>
+		<description>Indiana Jones and the Infernal Machine (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BIJE-USA, CGB-BIJP-EUR"/>
@@ -8479,7 +8803,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="inspgadg">
 		<!-- Notes: GBC only -->
-		<description>Inspector Gadget - Operation Madkactus (Euro)</description>
+		<description>Inspector Gadget - Operation Madkactus (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BIGP-EUR"/>
@@ -8507,7 +8831,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ik2000">
 		<!-- Notes: GBC only -->
-		<description>International Karate 2000 (Euro)</description>
+		<description>International Karate 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BIKP-EUU"/>
@@ -8536,12 +8860,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="iss99">
-		<!-- Notes: SGB enhanced -->
-		<description>International Superstar Soccer '99 (Euro)</description>
+		<description>International Superstar Soccer '99 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (europe).bin" size="1048576" crc="1b76d115" sha1="d9d9fffb463d4c35f8a1a753908cddfbe17fc671"/>
@@ -8552,12 +8876,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="iss99u" cloneof="iss99">
-		<!-- Notes: SGB enhanced -->
 		<description>International Superstar Soccer '99 (USA)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZE-USA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (usa).bin" size="1048576" crc="9d0290a7" sha1="6f491e6f919a677627090f949b8e69abb8bfd1db"/>
@@ -8569,7 +8893,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="iss2k">
 		<!-- Notes: GBC only -->
-		<description>International Superstar Soccer 2000 (Euro)</description>
+		<description>International Superstar Soccer 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSP-EUR"/>
@@ -8606,7 +8930,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="itf">
-		<description>International Track &amp; Field (Euro)</description>
+		<description>International Track &amp; Field (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDP-EUR"/>
@@ -8637,7 +8961,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>International Track &amp; Field - Summer Games (Euro)</description>
+		<description>International Track &amp; Field - Summer Games (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HP-EUR"/>
@@ -8652,14 +8976,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wldrally" cloneof="xcountry">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
-		<description>It's a World Rally (Jpn)</description>
+		<!-- Also released by NP in 2000-08 -->
+		<description>It's a World Rally (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLJ-JPN (RX187-J1)"/>
 		<info name="release" value="19990513"/>
 		<info name="alt_title" value="It's a ワールドラリー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="it's a world rally (japan).bin" size="1048576" crc="39e34650" sha1="31a289823468285ac786afe7de38201235983e35"/>
@@ -8671,7 +8996,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="itsudemo">
 		<!-- Notes: GBC only -->
-		<description>Itsudemo Pachinko GB - CR Monster House (Jpn)</description>
+		<description>Itsudemo Pachinko GB - CR Monster House (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BCRJ-JPN"/>
@@ -8689,7 +9014,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jlexcstg">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage GB (Jpn)</description>
+		<description>J.League Excite Stage GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AESJ-JPN"/>
@@ -8707,7 +9032,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jlexcstt">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage Tactics (Jpn)</description>
+		<description>J.League Excite Stage Tactics (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AJEJ-JPN"/>
@@ -8724,14 +9049,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jackdaib" cloneof="questrpg">
-		<!-- Notes: SGB enhanced -->
-		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Jpn)</description>
+		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AQJJ-JPN"/>
 		<info name="release" value="20000115"/>
 		<info name="alt_title" value="ジャックの大冒険 〜大魔王の逆襲〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="jack no daibouken - daimaou no gyakushuu (japan).bin" size="2097152" crc="cff5325a" sha1="c2d9548e845ed9a76a0e6dae81bb80023564a9f2"/>
@@ -8742,8 +9067,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jagainu">
-		<!-- Notes: Also released by NP in 2000-12 -->
-		<description>Jagainu-kun (Jpn)</description>
+		<!-- Also released by NP in 2000-12 -->
+		<description>Jagainu-kun (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-B39J-JPN"/>
@@ -8761,7 +9086,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jankyus">
 		<!-- Notes: GBC only -->
-		<description>Jankyuusei - Cosplay Paradise (Jpn)</description>
+		<description>Jankyuusei - Cosplay Paradise (Japan)</description>
 		<year>2001</year>
 		<publisher>Elf</publisher>
 		<info name="serial" value="CGB-BHGJ-JPN"/>
@@ -8779,7 +9104,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="janosch">
 		<!-- Notes: GBC only -->
-		<description>Janosch - Das grosse Panama-Spiel (Ger)</description>
+		<description>Janosch - Das grosse Panama-Spiel (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AJOD-NOE"/>
@@ -8793,7 +9118,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jayspiel">
 		<!-- Notes: GBC only -->
-		<description>Jay und die Spielzeugdiebe (Ger)</description>
+		<description>Jay und die Spielzeugdiebe (Germany)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BJYD-NOE"/>
@@ -8810,6 +9135,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AJZE-USA"/>
+		<info name="gold" value="19990930"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8820,10 +9146,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jmg2k">
 		<!-- Notes: GBC only -->
-		<description>Jeremy McGrath Supercross 2000 (Euro, USA)</description>
+		<description>Jeremy McGrath Supercross 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AJUE-USA, CGB-AJUP-EUR"/>
+		<info name="gold" value="20000218"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8837,7 +9164,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jetdego">
 		<!-- Notes: GBC only -->
-		<description>Jet de Go! (Jpn)</description>
+		<description>Jet de Go! (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BJEJ-JPN"/>
@@ -8855,10 +9182,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jimmywhi">
 		<!-- Notes: GBC only -->
-		<description>Jimmy White's Cueball (Euro)</description>
+		<description>Jimmy White's Cueball (Europe)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BJWP-EUR"/>
+		<info name="gold" value="20001019"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8868,14 +9196,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="jinsei">
-		<!-- Notes: SGB enhanced -->
-		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Jpn)</description>
+		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACJJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="人生ゲーム 友達たくさんつくろうよ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="jinsei game - tomodachi takusan tsukurou yo (japan).bin" size="1048576" crc="c8d46e99" sha1="d2c4ae3808d9a24cbd4c6c8e43184ca0ef2d8373"/>
@@ -8887,7 +9215,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jisedai">
 		<!-- Notes: GBC only -->
-		<description>Jisedai Begoma Battle Beyblade (Jpn)</description>
+		<description>Jisedai Begoma Battle Beyblade (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-AG5J-JPN"/>
@@ -8903,12 +9231,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="jissen">
+	<software name="jissena">
 		<!-- Notes: GBC only -->
-		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. A)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
+		<info name="gold" value="20000711"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="実戦に役立つ詰碁"/>
 		<part name="cart" interface="gameboy_cart">
@@ -8922,15 +9251,33 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="jissen" cloneof="jissena">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbjtj0.313"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Jissen ni Yakudatsu Tsumego (Japan)</description>
+		<year>2000</year>
+		<publisher>Pony Canyon</publisher>
+		<info name="serial" value="CGB-BJTJ-JPN?"/>
+		<info name="gold" value="20001004"/>
+		<info name="alt_title" value="実戦に役立つ詰碁"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="262144">
+				<rom name="cgbbjtj0.313" size="262144" crc="69c6dbef" sha1="f7ed6cdce7637a11d7fa7f5cb59b8f8ce131f9d1"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="joryujan">
-		<!-- Notes: SGB enhanced -->
-		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Jpn)</description>
+		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-A55J-JPN"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="女流雀士に挑戦GB 〜私達に挑戦してネ!〜 ~ Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene! (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="joryuu janshi ni chousen gb - watashi-tachi ni chousen shitene (japan).bin" size="1048576" crc="9fa5cdb5" sha1="a332817b9561dcab7d1f3dc0cf300e1656b253c3"/>
@@ -8956,7 +9303,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jungle">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Euro)</description>
+		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BJGP-EUR"/>
@@ -8984,7 +9331,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="jukosenk">
 		<!-- Notes: GBC only -->
-		<description>Juukou Senki Bullet Battlers (Jpn)</description>
+		<description>Juukou Senki Bullet Battlers (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AZXJ-JPN (RX173-J1)"/>
@@ -9002,7 +9349,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="koprobox">
 		<!-- Notes: GBC only -->
-		<description>K.O. - The Pro Boxing (Jpn)</description>
+		<description>K.O. - The Pro Boxing (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BKOJ-JPN"/>
@@ -9020,7 +9367,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kaptnblb">
 		<!-- Notes: GBC only -->
-		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Ger)</description>
+		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Germany)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BVRD-NOE"/>
@@ -9033,7 +9380,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kaiteide">
-		<description>Kaitei Densetsu!! Treasure World (Jpn)</description>
+		<description>Kaitei Densetsu!! Treasure World (Japan)</description>
 		<year>2000</year>
 		<publisher>Dazz</publisher>
 		<info name="serial" value="DMG-BDTJ-JPN"/>
@@ -9051,7 +9398,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kakurenb">
 		<!-- Notes: GBC only -->
-		<description>Kakurenbo Battle Monster Tactics (Jpn)</description>
+		<description>Kakurenbo Battle Monster Tactics (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BMFJ-JPN"/>
@@ -9074,14 +9421,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bistrokb">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-12 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Jpn)</description>
+		<!-- Also released by NP in 2000-12 -->
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A2WJ-JPN"/>
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 決闘★ビストガルム編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kakutou ryouri densetsu bistro recipe - kettou bistgarm hen (japan).bin" size="1048576" crc="4fbec464" sha1="c9fa1b1a24a0098eadd7e3fa4ee19f1b615a618f"/>
@@ -9092,14 +9440,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bistrogf">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-10 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Jpn)</description>
+		<!-- Also released by NP in 2000-10 -->
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AWRJ-JPN"/>
 		<info name="release" value="19991008"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 激闘★フードンバトル編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -9116,14 +9465,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanjiboy">
-		<!-- Notes: SGB enhanced -->
-		<description>Kanji Boy (Jpn)</description>
+		<description>Kanji Boy (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWKJ-JPN"/>
 		<info name="release" value="19990603"/>
 		<info name="alt_title" value="漢字BOY"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy (japan).bin" size="4194304" crc="18caa513" sha1="3876d5f64113e5365b42d30945f51f40b1d22d47"/>
@@ -9132,14 +9481,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanjibo2">
-		<!-- Notes: SGB enhanced -->
-		<description>Kanji Boy 2 (Jpn)</description>
+		<description>Kanji Boy 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2CJ-JPN"/>
 		<info name="release" value="20000630"/>
 		<info name="alt_title" value="漢字BOY2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy 2 (japan).bin" size="4194304" crc="81fd8918" sha1="4d382de7fd6912c0cd8ca15032e6f75409d0a97b"/>
@@ -9151,7 +9500,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kanjibo3">
 		<!-- Notes: GBC only -->
-		<description>Kanji Boy 3 (Jpn)</description>
+		<description>Kanji Boy 3 (Japan)</description>
 		<year>2003</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BK3J-JPN"/>
@@ -9168,7 +9517,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanjipzl">
-		<description>Kanji de Puzzle (Jpn)</description>
+		<description>Kanji de Puzzle (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BKAJ-JPN"/>
@@ -9183,8 +9532,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kanzumep">
-		<!-- Notes: Also released by NP in 2000-06 -->
-		<description>Kanzume Monsters Parfait (Jpn)</description>
+		<!-- Also released by NP in 2000-06 -->
+		<description>Kanzume Monsters Parfait (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AQPJ-JPN"/>
@@ -9201,14 +9550,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="karamuok">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Karamuchou wa Oosawagi! - Okawari! (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Karamuchou wa Oosawagi! - Okawari! (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BOOJ-JPN"/>
 		<info name="release" value="20000801"/>
 		<info name="alt_title" value="カラムー町は大さわぎ!おかわりっ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - okawari (japan) (np).bin" size="1048576" crc="6c568e06" sha1="9217169dc3f42562d71a7edabc3b42e36ec8304b"/>
@@ -9219,14 +9569,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="karamupl">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Japan)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AOPJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="カラムー町は大さわぎ! 〜ポリンキーズとおかしな仲間たち〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - polinkies to okashina nakama-tachi (japan).bin" size="1048576" crc="dd948071" sha1="cb6079dc290ace0daafdd40353e4477e4a37c8f7"/>
@@ -9238,7 +9589,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="karankor">
 		<!-- Notes: GBC only -->
-		<description>Karan Koron Gakuen - Hanafuda Mahjong (Jpn)</description>
+		<description>Karan Koron Gakuen - Hanafuda Mahjong (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AHFJ-JPN"/>
@@ -9253,14 +9604,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kaseki2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Kaseki Sousei Reborn II - Monster Digger (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Kaseki Sousei Reborn II - Monster Digger (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ARMJ-JPN"/>
 		<info name="release" value="19990212"/>
 		<info name="alt_title" value="化石創世リボーンII 〜モンスターディガー〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kaseki sousei reborn ii - monster digger (japan).bin" size="1048576" crc="bf80c897" sha1="857fb62dc310268e0b92e9383c6b6fd61aa33fa0"/>
@@ -9271,14 +9623,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="katohifu">
-		<!-- Notes: SGB enhanced -->
-		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Jpn)</description>
+		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AKHJ-JPN"/>
 		<info name="release" value="19990409"/>
 		<info name="alt_title" value="加藤一二三 九段の 将棋教室 "/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="katou hifumi kudan - shougi kyoushitsu (japan).bin" size="1048576" crc="a262269f" sha1="c3ba0d2b82d66ef1b5c0dee8813a5f965631ed75"/>
@@ -9287,14 +9639,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kawanus4" cloneof="rivking2">
-		<!-- Notes: SGB enhanced -->
-		<description>Kawa no Nushi Tsuri 4 (Jpn)</description>
+		<description>Kawa no Nushi Tsuri 4 (Japan)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-VUTJ-JPN"/>
+		<info name="gold" value="19990520"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="川のぬし釣り4"/>
+		<info name="alt_title" value="川のぬし釣り４"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A04-01" />
 			<feature name="u1" value="U1 4M/8M MROM [M438011E-57]" />
 			<feature name="u2" value="U2 MBC5 [BMC-5]" />
@@ -9313,14 +9666,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kawaipet">
-		<!-- Notes: SGB enhanced -->
-		<description>Kawaii Pet Shop Monogatari (Jpn)</description>
+		<description>Kawaii Pet Shop Monogatari (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AEIJ-JPN"/>
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="かわいいペットショップ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kawaii pet shop monogatari (japan).bin" size="1048576" crc="44767443" sha1="8392eccbac1d8ae23782c6d29d3ee604a03b5c05"/>
@@ -9330,11 +9683,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kawaipt2">
-		<description>Kawaii Pet Shop Monogatari 2 (Jpn)</description>
+	<software name="kawaipt2a">
+		<!--	In lot check as "dmgbmnj1.j90"	-->
+		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
+		<info name="gold" value="20010201"/>
+		<info name="alt_title" value="かわいいペットショップ物語2"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbmnj1.j90" size="2097152" crc="6fce1ad0" sha1="58ea410ebbee5edc18644c0467fe9ea03d179b1c"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kawaipt2" cloneof="kawaipt2a">
+		<description>Kawaii Pet Shop Monogatari 2 (Japan)</description>
+		<year>2000</year>
+		<publisher>Taito</publisher>
+		<info name="serial" value="DMG-BMNJ-JPN"/>
+		<info name="gold" value="20001107"/>
 		<info name="release" value="20001222"/>
 		<info name="alt_title" value="かわいいペットショップ物語2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9349,7 +9721,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="keepblnc">
 		<!-- Notes: GBC only -->
-		<description>Keep the Balance (Euro)</description>
+		<description>Keep the Balance (Europe)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment AG</publisher>
 		<info name="serial" value="CGB-BKNP-EUR"/>
@@ -9362,7 +9734,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="keibajou">
-		<description>Keibajou e Ikou! Wide (Jpn)</description>
+		<description>Keibajou e Ikou! Wide (Japan)</description>
 		<year>2000</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-ASCJ-JPN"/>
@@ -9381,7 +9753,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	<software name="telefngp">
 		<!-- Notes: This game uses an accessory called "Power Antenna", which is just a LED light connected
 		        to the GB accessories port. It is used ingame to simulate a mobile phone. -->
-		<description>Keitai Denjuu Telefang - Power Version (Jpn)</description>
+		<description>Keitai Denjuu Telefang - Power Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTXJ-JPN"/>
@@ -9405,7 +9777,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="telefngs">
-		<description>Keitai Denjuu Telefang - Speed Version (Jpn)</description>
+		<description>Keitai Denjuu Telefang - Speed Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTZJ-JPN"/>
@@ -9453,14 +9825,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kettoubw">
-		<!-- Notes: SGB enhanced -->
-		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Jpn)</description>
+		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Japan)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AB7J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="決闘トランスフォーマービーストウォーズ ビースト戦士最強決定戦 ~ Kettou Transformers Beast Wars - Beast Senshi Saikyou Ketteisen (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kettou beast wars - beast senshi saikyou ketteisen (japan).bin" size="1048576" crc="72895639" sha1="db690f46d37e0273c69f24badbb44588a363a84f"/>
@@ -9470,7 +9842,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nadesico">
 		<!-- Notes: GBC only -->
-		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Jpn)</description>
+		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQNJ-JPN (KIG-9)"/>
@@ -9488,7 +9860,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kikathom">
 		<!-- Notes: GBC only -->
-		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Jpn)</description>
+		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Japan)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BBWJ-JPN"/>
@@ -9505,14 +9877,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kindajik">
-		<!-- Notes: SGB enhanced -->
-		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Jpn)</description>
+		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BKSJ-JPN"/>
 		<info name="release" value="20001216"/>
 		<info name="alt_title" value="金田一少年の事件簿 〜10年目の招待状〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9525,14 +9897,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kinniban">
-		<!-- Notes: SGB enhanced -->
-		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Jpn)</description>
+		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A5KJ-JPN (RK197-J1)"/>
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="筋肉番付GB 〜挑戦者はキミだ!〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kinniku banzuke gb - chousensha wa kimida (japan).bin" size="1048576" crc="e2e4328b" sha1="75d7e35fea257d8da4c1efcdd6ebdca020c648a6"/>
@@ -9543,14 +9915,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kinnibn2">
-		<!-- Notes: SGB enhanced -->
-		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Jpn)</description>
+		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B6KJ-JPN (RK213-J1)"/>
 		<info name="release" value="20000810"/>
 		<info name="alt_title" value="筋肉番付GB2 〜目指せ!マッスルチャンピオン!〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9564,7 +9936,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kinnibn3">
 		<!-- Notes: GBC only -->
-		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Jpn)</description>
+		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B7KJ-JPN (RK233-J1)"/>
@@ -9582,6 +9954,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
+		<!--	In lot check as "CGBKTNE0.638", "KENSA\CGBKTNP0.0"	-->
 		<description>Kirby Tilt 'n' Tumble (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -9603,7 +9976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kiriku">
 		<!-- Notes: GBC only -->
-		<description>Kirikou (Euro)</description>
+		<description>Kirikou (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BKKP-EUR"/>
@@ -9617,7 +9990,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Jpn, Rev. A)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -9626,7 +9999,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="kisekae series 2 - oshare nikki (japan) (rev. a).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
+				<rom name="kisekae series 2 - oshare nikki (japan) (Rev. 1).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -9635,7 +10008,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kisekae2a" cloneof="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Jpn)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -9653,7 +10026,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kisekae3">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 3 - Kisekae Hamster (Jpn)</description>
+		<description>Kisekae Series 3 - Kisekae Hamster (Japan)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BKHJ-JPN"/>
@@ -9670,7 +10043,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="klustar">
-		<description>Klustar (Euro)</description>
+		<description>Klustar (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AKUP-EUR"/>
@@ -9684,7 +10057,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kokings">
 		<!-- Notes: GBC only -->
-		<description>Knockout Kings (Euro, USA)</description>
+		<description>Knockout Kings (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AXKE-USA, CGB-AXKP-EUR"/>
@@ -9701,7 +10074,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="klax">
 		<!-- Notes: GBC only -->
-		<description>Klax (Euro, USA)</description>
+		<description>Klax (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ALXE-USA, CGB-ALXP-EUR"/>
@@ -9730,8 +10103,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="kogurugu">
-		<!-- Notes: NP only -->
-		<description>Koguru Guruguru - Guruguru to Nakayoshi (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Koguru Guruguru - Guruguru to Nakayoshi (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Sting</publisher>
 		<info name="serial" value="DMG-BKGJ-JPN"/>
@@ -9748,7 +10121,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konamic1">
-		<description>Konami GB Collection Vol.1 (Euro)</description>
+		<description>Konami GB Collection Vol.1 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF5P-EUR"/>
@@ -9761,7 +10134,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konamic2">
-		<description>Konami GB Collection Vol.2 (Euro)</description>
+		<description>Konami GB Collection Vol.2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF6P-EUR"/>
@@ -9774,7 +10147,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konamic3">
-		<description>Konami GB Collection Vol.3 (Euro)</description>
+		<description>Konami GB Collection Vol.3 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF7P-EUR"/>
@@ -9787,7 +10160,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konamic4">
-		<description>Konami GB Collection Vol.4 (Euro)</description>
+		<description>Konami GB Collection Vol.4 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF8P-EUR"/>
@@ -9801,7 +10174,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Konami Winter Games (Euro)</description>
+		<description>Konami Winter Games (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HP-EUR"/>
@@ -9817,7 +10190,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="konchufg">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Fighters (Jpn)</description>
+		<description>Konchuu Fighters (Japan)</description>
 		<year>2002</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-BZZJ-JPN"/>
@@ -9834,14 +10207,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="konchuh2">
-		<!-- Notes: SGB enhanced -->
-		<description>Konchuu Hakase 2 (Jpn)</description>
+		<description>Konchuu Hakase 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2KJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="釣り先生2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="konchuu hakase 2 (japan).bin" size="2097152" crc="b6381744" sha1="e4bcfb94aa1c09a013a03f26f978b32e74f70d23"/>
@@ -9853,7 +10226,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="konchuh3">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Hakase 3 (Jpn)</description>
+		<description>Konchuu Hakase 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A3KJ-JPN"/>
@@ -9871,7 +10244,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="korokoro" cloneof="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Korokoro Kirby (Jpn)</description>
+		<description>Korokoro Kirby (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-KKKJ-JPN"/>
@@ -9894,7 +10267,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="kotobatt">
 		<!-- Notes: GBC only -->
-		<description>Koto Battle - Tengai no Moribito (Jpn)</description>
+		<description>Koto Battle - Tengai no Moribito (Japan)</description>
 		<year>2001</year>
 		<publisher>Alphadream</publisher>
 		<info name="serial" value="CGB-BAJJ-JPN"/>
@@ -9911,14 +10284,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="koshien">
-		<!-- Notes: SGB enhanced -->
-		<description>Koushien Pocket (Jpn)</description>
+		<description>Koushien Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AKSJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="甲子園ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="koushien pocket (japan).bin" size="1048576" crc="6910ff3a" sha1="a677bf07c67925ded32799d6a8eb63ec99c01bb7"/>
@@ -9930,7 +10303,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="landbtim">
 		<!-- Notes: GBC only -->
-		<description>The Land Before Time (Euro)</description>
+		<description>The Land Before Time (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BLBP-EUR"/>
@@ -9971,7 +10344,26 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="laura">
 		<!-- Notes: GBC only -->
-		<description>Laura (Euro)</description>
+		<!--	In lot check as "cgbbldp0.420"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Laura (Europe)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
+		<info name="serial" value="CGB-BLDP-EUR"/>
+		<info name="gold" value="20000913"/>
+		<info name="alt_title" value="Laura's Happy Adventures"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbldp0.420" size="1048576" crc="a58c8282" sha1="47e5c4c7fa447efc8a0abf019e8d2cd227c5e0e3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lauraunk" cloneof="laura">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Laura (Europe, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -10002,7 +10394,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lemans24">
 		<!-- Notes: GBC only -->
-		<description>Le Mans 24 Hours (Euro)</description>
+		<description>Le Mans 24 Hours (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-B24P-NOE"/>
@@ -10017,7 +10409,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rivking2">
-		<description>Legend of the River King 2 (Euro)</description>
+		<description>Legend of the River King 2 (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BRKP-EUR"/>
@@ -10047,7 +10439,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rivking">
-		<description>Legend of the River King GB (Euro)</description>
+		<description>Legend of the River King GB (Europe)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-ARKP-EUR"/>
@@ -10062,7 +10454,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rivkingg" cloneof="rivking">
-		<description>Legend of the River King GB (Ger)</description>
+		<description>Legend of the River King GB (Germany)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="??"/>
@@ -10092,14 +10484,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, Aus, USA, Rev. B)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, Australia, USA, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-(EUR/AUS)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev b).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 2).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10107,14 +10499,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev a).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 1).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10122,12 +10514,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxb" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced -->
-		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10144,7 +10536,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxf" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Fra, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (France, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10164,12 +10556,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxfa" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced -->
-		<description>The Legend of Zelda - Link's Awakening DX (Fra)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (France)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10186,7 +10578,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxg" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Ger, Rev. A)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Germany, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10206,7 +10598,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxga" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Ger)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Germany)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10222,7 +10614,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Euro)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8P-EUR"/>
@@ -10244,7 +10636,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldaageu" cloneof="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Aus, USA)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8U-AUS, CGB-AZ8E-USA"/>
@@ -10266,7 +10658,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Euro)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7P-EUR"/>
@@ -10288,7 +10680,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldaseau" cloneof="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Aus, USA)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7U-AUS, CGB-AZ7E-USA"/>
@@ -10310,7 +10702,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="legoatm">
 		<!-- Notes: GBC only -->
-		<description>LEGO Alpha Team (Euro)</description>
+		<description>LEGO Alpha Team (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLPP-(EUR/SCN)"/>
@@ -10342,7 +10734,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="legoisl2">
 		<!-- Notes: GBC only -->
-		<description>LEGO Island 2 - The Brickster's Revenge (Euro)</description>
+		<description>LEGO Island 2 - The Brickster's Revenge (Europe)</description>
 		<year>2001</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BL2P-EUR"/>
@@ -10374,7 +10766,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="legorace">
 		<!-- Notes: GBC only -->
-		<description>LEGO Racers (Euro)</description>
+		<description>LEGO Racers (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLRP-EUU"/>
@@ -10412,7 +10804,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="legostnt">
 		<!-- Notes: GBC only -->
-		<description>LEGO Stunt Rally (Euro)</description>
+		<description>LEGO Stunt Rally (Europe)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLYP-SCN"/>
@@ -10475,7 +10867,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lionking">
 		<!-- Notes: GBC only -->
-		<description>The Lion King - Simba's Mighty Adventure (Euro, USA)</description>
+		<description>The Lion King - Simba's Mighty Adventure (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKE-USA, CGB-BLKP-UKV"/>
@@ -10492,10 +10884,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lionkingf" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Le Roi Lion - Les Adventures de Simba (Fra)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
+		<info name="gold" value="20001113"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -10504,9 +10897,25 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="lionkingfa" cloneof="lionking">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbblkf1.573"	-->
+		<description>Le Roi Lion - Les Adventures de Simba (France, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Activision</publisher>
+		<info name="serial" value="CGB-BLKF-FRA"/>
+		<info name="gold" value="20010406"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbblkf1.573" size="1048576" crc="c7aae1b3" sha1="b8cc2f1d3a8d40c7588d5c535f28e2f80446a793"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="lionkingg" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Der König der Löwen - Simbas grosses Abenteuer (Ger)</description>
+		<description>Der König der Löwen - Simbas grosses Abenteuer (Germany)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKD-NOE"/>
@@ -10523,7 +10932,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lilmagic">
 		<!-- Notes: GBC only -->
-		<description>Little Magic (Jpn)</description>
+		<description>Little Magic (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-ALJJ-JPN"/>
@@ -10541,7 +10950,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mermaid2">
 		<!-- Notes: GBC only -->
-		<description>Disney's The Little Mermaid II - Pinball Frenzy (Euro)</description>
+		<description>Disney's The Little Mermaid II - Pinball Frenzy (Europe)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="CGB-BY2P-EUR"/>
@@ -10595,7 +11004,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lnf2001" cloneof="fa2001">
 		<!-- Notes: GBC only -->
-		<description>LNF Stars 2001 (Fra)</description>
+		<description>LNF Stars 2001 (France)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -10608,7 +11017,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ldrun">
-		<description>Lode Runner - Domudomu Dan no Yabou (Jpn)</description>
+		<description>Lode Runner - Domudomu Dan no Yabou (Japan)</description>
 		<year>2000</year>
 		<publisher>Xing Entertainment</publisher>
 		<info name="serial" value="DMG-BXLJ-JPN"/>
@@ -10625,14 +11034,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lodoss">
-		<!-- Notes: SGB enhanced -->
-		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Jpn)</description>
+		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Japan)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-ARAJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ロードス島戦記 英雄騎士伝 GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="lodoss-tou senki - eiyuu kishiden gb (japan).bin" size="1048576" crc="66e166bb" sha1="3431247ffae511b6c2a836759e5ed0545d11ba05"/>
@@ -10642,7 +11051,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="logical">
 		<!-- Notes: GBC only -->
-		<description>Logical (Euro)</description>
+		<description>Logical (Europe)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AOGP-EUR"/>
@@ -10670,7 +11079,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="looney">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes (Euro)</description>
+		<description>Looney Tunes (Europe)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALTP-(EUR/UKV)"/>
@@ -10743,7 +11152,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Alert! (Euro)</description>
+		<description>Looney Tunes Collector - Martian Alert! (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALMP-UKV"/>
@@ -10759,7 +11168,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="looneymaj" cloneof="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Quest! (Jpn)</description>
+		<description>Looney Tunes Collector - Martian Quest! (Japan)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-ALMJ-JPN"/>
@@ -10783,7 +11192,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="looneymr">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Revenge! (Euro)</description>
+		<description>Looney Tunes Collector - Martian Revenge! (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLAP-UKV"/>
@@ -10799,7 +11208,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="looneyrc">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Racing (Euro)</description>
+		<description>Looney Tunes Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLQP-EUR"/>
@@ -10836,17 +11245,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl2">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10854,14 +11264,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl2a" cloneof="hirapzl2">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (np).bin" size="262144" crc="29e193c5" sha1="8cc512784d323f7c0bfe36848c5f7fdc49257285"/>
@@ -10872,17 +11283,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl3">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10890,14 +11302,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzl3a" cloneof="hirapzl3">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (np).bin" size="262144" crc="e078d9f8" sha1="a7faa970e71d38c68948b646d3dcb9cbea1df995"/>
@@ -10908,17 +11321,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzls">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. A, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10926,14 +11340,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="hirapzlsa" cloneof="hirapzls">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (np).bin" size="262144" crc="c0287cf2" sha1="7425bd94790866bf716fd3c23886a5cdc06f1aad"/>
@@ -10943,33 +11358,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl2">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
+	<software name="kangpzl2a">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzl2a" cloneof="kangpzl2">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, NP)</description>
+	<software name="kangpzl2" cloneof="kangpzl2a">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (np).bin" size="262144" crc="d457cc6c" sha1="cb14866337caecd5458edc72f2d56f2c8c028411"/>
@@ -10979,33 +11396,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzl3">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
+	<software name="kangpzl3a">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzl3a" cloneof="kangpzl3">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, NP)</description>
+	<software name="kangpzl3" cloneof="kangpzl3a">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (np).bin" size="262144" crc="3ef25533" sha1="9822fecf183d3d0a6e9af80696463b09e1f31a60"/>
@@ -11015,33 +11434,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="kangpzls">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. A, NP)</description>
+	<software name="kangpzlsa">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzlsa" cloneof="kangpzls">
-		<!-- Notes: SGB enhanced, NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, NP)</description>
+	<software name="kangpzls" cloneof="kangpzlsa">
+		<!-- NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (np).bin" size="262144" crc="094ffd1e" sha1="5a476f79db61aa8c6f32bbabd82fade5cde811d2"/>
@@ -11053,7 +11474,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lovehpty">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Party (Jpn)</description>
+		<description>Love Hina Party (Japan)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BLHJ-JPN"/>
@@ -11077,10 +11498,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lovehina">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Pocket (Jpn)</description>
+		<description>Love Hina Pocket (Japan)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
+		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ラブひなポケット"/>
 		<part name="cart" interface="gameboy_cart">
@@ -11093,15 +11515,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="lovehinaa" cloneof="lovehina">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbphj1.290"	-->
+		<description>Love Hina Pocket (Japan, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Marvelous Entertainment</publisher>
+		<info name="serial" value="CGB-BPHJ-JPN"/>
+		<info name="gold" value="20000824"/>
+		<info name="alt_title" value="ラブひなポケット"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbphj1.290" size="4194304" crc="55dd0ba6" sha1="b29abee319ccb223e5d1a4f88982fb53e538d527"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="lucapuzl">
-		<!-- Notes: SGB enhanced -->
-		<description>Luca no Puzzle de Daibouken! (Jpn)</description>
+		<description>Luca no Puzzle de Daibouken! (Japan)</description>
 		<year>1999</year>
 		<publisher>Human Entertainment</publisher>
 		<info name="serial" value="DMG-ARCJ-JPN"/>
 		<info name="release" value="19990611"/>
 		<info name="alt_title" value="ルーカのぱずるで大冒険!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="luca no puzzle de daibouken (japan).bin" size="524288" crc="3aebfad8" sha1="3c06fe05909ad632b761c6a1c00bc69da81aa358"/>
@@ -11113,7 +11554,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="luckyluk">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke (Euro)</description>
+		<description>Lucky Luke (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALQP-EUR"/>
@@ -11144,7 +11585,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="luckyldt">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke - Desperado Train (Euro)</description>
+		<description>Lucky Luke - Desperado Train (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLLP-(FRA/NOE)"/>
@@ -11158,7 +11599,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="lufia">
 		<!-- Notes: GBC only -->
-		<description>Lufia - The Legend Returns (Euro)</description>
+		<description>Lufia - The Legend Returns (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLFP-EUR"/>
@@ -11190,7 +11631,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Euro)</description>
+		<description>M&amp;M's Minis Madness (Europe)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMIP-UKV"/>
@@ -11207,7 +11648,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mmsg" cloneof="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Ger)</description>
+		<description>M&amp;M's Minis Madness (Germany)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMID-NOE"/>
@@ -11250,7 +11691,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="macross7">
 		<!-- Notes: GBC only -->
-		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Jpn)</description>
+		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BM7J-JPN"/>
@@ -11267,7 +11708,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="madden2k">
-		<description>Madden NFL 2000 (Euro, USA)</description>
+		<description>Madden NFL 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AEME-USA, DMG-AEMP-EUR"/>
@@ -11312,10 +11753,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="maginatn">
 		<!-- Notes: GBC only -->
-		<description>Magi Nation (USA)</description>
+		<description>Magi-Nation (USA)</description>
 		<year>2001</year>
 		<publisher>Interactive Imagination</publisher>
 		<info name="serial" value="CGB-BNNE-USA"/>
+		<info name="gold" value="20010112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -11328,7 +11770,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="magchase">
 		<!-- Notes: GBC only -->
-		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Jpn)</description>
+		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="CGB-AIFJ-JPN"/>
@@ -11344,7 +11786,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="magdrop">
 		<!-- Notes: GBC only -->
-		<description>Magical Drop (Euro)</description>
+		<description>Magical Drop (Europe)</description>
 		<year>2000</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AXJP-EUR"/>
@@ -11372,14 +11814,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Euro, Rev. A)</description>
+		<description>Magical Tetris Challenge (Europe, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev a).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
+				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev 1).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11388,7 +11830,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mtetrisca" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Euro)</description>
+		<description>Magical Tetris Challenge (Europe)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
@@ -11419,14 +11861,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjjoo">
-		<!-- Notes: SGB enhanced -->
-		<description>Mahjong Joou (Jpn)</description>
+		<description>Mahjong Joou (Japan)</description>
 		<year>2000</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-A56J-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="麻雀女王"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong joou (japan).bin" size="1048576" crc="7d83a5e8" sha1="68f2326f7fa70d0ed0207bd087c6fe26ec6f9a53"/>
@@ -11437,14 +11879,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjquest">
-		<!-- Notes: SGB enhanced -->
-		<description>Mahjong Quest (Jpn)</description>
+		<description>Mahjong Quest (Japan)</description>
 		<year>1998</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AMJJ-JPN"/>
 		<info name="release" value="19981223"/>
 		<info name="alt_title" value="麻雀クエスト"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong quest (japan).bin" size="1048576" crc="c870b88f" sha1="3ab49ce8aa69013c1b2d9427926513e21d5efe1d"/>
@@ -11455,17 +11897,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="majomari">
-		<!-- Notes: SGB enhanced -->
-		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. A)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN-1"/>
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="majokko mari-chan no kisekae monogatari (japan) (rev. a).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
+				<rom name="majokko mari-chan no kisekae monogatari (japan) (Rev. 1).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11473,14 +11915,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="majomaria" cloneof="majomari">
-		<!-- Notes: SGB enhanced -->
-		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn)</description>
+		<description>Majokko Mari-chan no Kisekae Monogatari (Japan)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN"/>
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="majokko mari-chan no kisekae monogatari (japan).bin" size="2097152" crc="934f4b0a" sha1="8bdd3bd414da91c6ea05bc29435e09b0b72e3790"/>
@@ -11492,7 +11934,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="marble">
 		<!-- Notes: GBC only -->
-		<description>Marble Madness (Euro, USA)</description>
+		<description>Marble Madness (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ANNE-USA, CGB-ANNP-EUR"/>
@@ -11505,14 +11947,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="atelmari">
-		<!-- Notes: SGB enhanced -->
-		<description>Marie no Atelier GB (Jpn)</description>
+		<description>Marie no Atelier GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8MJ-JPN"/>
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="マリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -11530,7 +11972,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mariofam">
 		<!-- Notes: GBC only, bundled with Jaguar Sewing Machine (Nuotto Expansion)? -->
-		<description>Mario Family (Jpn)</description>
+		<description>Mario Family (Japan)</description>
 		<year>2001</year>
 		<publisher>Jaguar</publisher>
 		<info name="serial" value="CGB-BJMJ-JPN"/>
@@ -11548,7 +11990,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf (Euro)</description>
+		<description>Mario Golf (Europe)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXP-EUR"/>
@@ -11580,7 +12022,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="marioglfj" cloneof="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf GB (Jpn)</description>
+		<description>Mario Golf GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXJ-JPN"/>
@@ -11604,7 +12046,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis (Euro)</description>
+		<description>Mario Tennis (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8P-EUR"/>
@@ -11642,7 +12084,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mariotenj" cloneof="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis GB (Jpn)</description>
+		<description>Mario Tennis GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8J-JPN"/>
@@ -11676,7 +12118,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mnacrush">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Crush Course (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Crush Course (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BCVE-USA, CGB-BCVP-UKV"/>
@@ -11692,7 +12134,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mnaclue">
-		<description>Mary-Kate &amp; Ashley - Get a Clue! (Euro, USA)</description>
+		<description>Mary-Kate &amp; Ashley - Get a Clue! (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BXFE-USA, DMG-BXFP-EUR"/>
@@ -11708,7 +12150,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mnaplann">
-		<description>Mary-Kate and Ashley - Pocket Planner (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Pocket Planner (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BMAE-USA, DMG-BMAP-EUR"/>
@@ -11731,7 +12173,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mnacircl">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Winners Circle (Euro, USA)</description>
+		<description>Mary-Kate and Ashley - Winners Circle (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BHFE-USA, CGB-BHFP-EUR"/>
@@ -11748,7 +12190,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zorro">
 		<!-- Notes: GBC only -->
-		<description>The Mask of Zorro (Euro)</description>
+		<description>The Mask of Zorro (Europe)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AZRP-EUR"/>
@@ -11776,7 +12218,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="hoffbmx">
 		<!-- Notes: GBC only -->
-		<description>Mat Hoffman's Pro BMX (Euro, USA)</description>
+		<description>Mat Hoffman's Pro BMX (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-BM5P-EUR"/>
@@ -11790,7 +12232,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="matchbox">
 		<!-- Notes: GBC only -->
-		<description>Matchbox Emergency Patrol (Euro, USA)</description>
+		<description>Matchbox Emergency Patrol (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BEPE-USA, CGB-BEPP-EUR"/>
@@ -11807,7 +12249,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="maus">
 		<!-- Notes: GBC only -->
-		<description>Die Maus (Euro)</description>
+		<description>Die Maus (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ADXP-NOE"/>
@@ -11821,7 +12263,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mausvo">
 		<!-- Notes: GBC only -->
-		<description>Die Maus - Verrückte Olympiade (Ger)</description>
+		<description>Die Maus - Verrückte Olympiade (Germany)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVOD-NOE"/>
@@ -11837,7 +12279,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mayabeef">
-		<description>Maya the Bee &amp; Her Friends (Euro)</description>
+		<description>Maya the Bee &amp; Her Friends (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -11851,7 +12293,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mayabee">
 		<!-- Notes: GBC only -->
-		<description>Maya the Bee - Garden Adventures (Euro)</description>
+		<description>Maya the Bee - Garden Adventures (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMJP-EUR"/>
@@ -11865,7 +12307,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mcdonald">
 		<!-- Notes: GBC only -->
-		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Jpn)</description>
+		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Japan)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-BI9J-JPN"/>
@@ -11882,14 +12324,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2ka">
-		<!-- Notes: SGB enhanced -->
-		<description>Medarot 2 - Kabuto Version (Jpn)</description>
+		<description>Medarot 2 - Kabuto Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2MJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C1603-12 1]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -11905,14 +12347,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2ku">
-		<!-- Notes: SGB enhanced -->
-		<description>Medarot 2 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 2 - Kuwagata Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2NJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MTN]" />
 			<feature name="u2" value="U2 MBC-5 [MBC-5]" />
@@ -11928,14 +12370,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medar2cl">
-		<!-- Notes: SGB enhanced -->
-		<description>Medarot 2 - Parts Collection (Jpn)</description>
+		<description>Medarot 2 - Parts Collection (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A7CJ-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="メダロット2 パーツコレクション"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [R531614G-12]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -11953,7 +12395,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar3ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kabuto Version (Jpn)</description>
+		<description>Medarot 3 - Kabuto Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B32J-JPN"/>
@@ -11971,7 +12413,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar3ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 3 - Kuwagata Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B33J-JPN"/>
@@ -11989,7 +12431,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar3cl">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Jpn)</description>
+		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B3PJ-JPN"/>
@@ -12007,7 +12449,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar4ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kabuto Version (Jpn)</description>
+		<description>Medarot 4 - Kabuto Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4MJ-JPN"/>
@@ -12025,7 +12467,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar4ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kuwagata Version (Jpn)</description>
+		<description>Medarot 4 - Kuwagata Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4NJ-JPN"/>
@@ -12043,7 +12485,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar5ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Jpn)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5MJ-JPN"/>
@@ -12061,7 +12503,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="medar5ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Jpn)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5NJ-JPN"/>
@@ -12078,14 +12520,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medarcka">
-		<!-- Notes: SGB enhanced -->
-		<description>Medarot Cardrobottle - Kabuto Version (Jpn)</description>
+		<description>Medarot Cardrobottle - Kabuto Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8CJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kabuto version (japan).bin" size="2097152" crc="4f03d80a" sha1="b7a02cee93169f73675b562d09d10175684ec77f"/>
@@ -12096,14 +12538,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="medarcku">
-		<!-- Notes: SGB enhanced -->
-		<description>Medarot Cardrobottle - Kuwagata Version (Jpn)</description>
+		<description>Medarot Cardrobottle - Kuwagata Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A9CJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kuwagata version (japan).bin" size="2097152" crc="a3735f81" sha1="26b5516170ea0fa1669cafb9484e1aeb5d2cae6c"/>
@@ -12114,7 +12556,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="megamnx">
-		<description>Mega Man Xtreme (Euro, USA)</description>
+		<description>Mega Man Xtreme (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BM6E-USA, DMG-BM6P-EUR?"/>
@@ -12130,7 +12572,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Mega Man Xtreme 2 (Euro, USA)</description>
+		<description>Mega Man Xtreme 2 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-B2XP-EUR"/>
@@ -12151,14 +12593,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lastbibl" cloneof="revelat">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Megami Tensei Gaiden - Last Bible (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-ALBJ-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible (japan).bin" size="1048576" crc="bd9ba639" sha1="419c5afdbc9b59e05e7861de8cc59ee367cd29f0"/>
@@ -12169,14 +12612,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="lastbib2">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible II (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Megami Tensei Gaiden - Last Bible II (Japan)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-A2LJ-JPN"/>
 		<info name="release" value="19990416"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブルII"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible ii (japan).bin" size="1048576" crc="9caa00b5" sha1="84df9508bdd8b24dfb19a74744fec492fffee56d"/>
@@ -12187,14 +12631,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconankj">
-		<!-- Notes: SGB enhanced -->
-		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Jpn)</description>
+		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A4BJ-JPN"/>
 		<info name="release" value="20000224"/>
 		<info name="alt_title" value="名探偵コナン −からくり寺院殺人事件−"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WKH]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12211,14 +12655,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconankh">
-		<!-- Notes: SGB enhanced -->
-		<description>Meitantei Conan - Kigantou Hihou Densetsu (Jpn)</description>
+		<description>Meitantei Conan - Kigantou Hihou Densetsu (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A5BJ-JPN"/>
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="名探偵コナン 奇岩島秘宝伝説"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -12235,14 +12679,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mconannk">
-		<!-- Notes: SGB enhanced -->
-		<description>Meitantei Conan - Norowareta Kouro (Jpn)</description>
+		<description>Meitantei Conan - Norowareta Kouro (Japan)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BC3J-JPN"/>
 		<info name="release" value="20010601"/>
 		<info name="alt_title" value="名探偵コナン−呪われた航路−"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="meitantei conan - norowareta kouro (japan).bin" size="2097152" crc="cabdd802" sha1="0858a619d716b0191713734d506d9f113f0d1c62"/>
@@ -12253,7 +12697,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mib">
-		<description>Men in Black - The Series (Euro, USA)</description>
+		<description>Men in Black - The Series (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AMNE-USA, DMG-AMNP-EUR"/>
@@ -12270,7 +12714,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mib2">
 		<!-- Notes: GBC only -->
-		<description>Men in Black 2 - The Series (Euro)</description>
+		<description>Men in Black 2 - The Series (Europe)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BB2P-EUR"/>
@@ -12298,7 +12742,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="merlin">
 		<!-- Notes: GBC only -->
-		<description>Merlin (Euro)</description>
+		<!--	In lot check as "CGBBMBP0.603", "KENSA\CGBBMBE0.0"	-->
+		<description>Merlin (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BMBP-EUR"/>
@@ -12312,7 +12757,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="metafght">
 		<!-- Notes: GBC only -->
-		<description>Meta Fight EX (Jpn)</description>
+		<description>Meta Fight EX (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A5MJ-JPN"/>
@@ -12328,7 +12773,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mgsj" cloneof="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear - Ghost Babel (Jpn)</description>
+		<description>Metal Gear - Ghost Babel (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMGJ-JPN (RK202-J1)"/>
@@ -12346,7 +12791,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear Solid (Euro)</description>
+		<description>Metal Gear Solid (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMSP-EUR"/>
@@ -12399,7 +12844,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="metamode">
 		<!-- Notes: GBC only -->
-		<description>Metamode (Jpn)</description>
+		<description>Metamode (Japan)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BTMJ-JPN"/>
@@ -12439,7 +12884,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mickeyra">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Racing Adventure (Euro, USA)</description>
+		<description>Mickey's Racing Adventure (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-ARNE-USA, CGB-ARNP-EUR"/>
@@ -12455,7 +12900,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="micksped">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Speedway USA (Euro, USA)</description>
+		<description>Mickey's Speedway USA (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BSNE-USA, CGB-BSNP-EUR"/>
@@ -12477,7 +12922,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="microm12">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines 1 and 2 - Twin Turbo (Euro, USA)</description>
+		<description>Micro Machines 1 and 2 - Twin Turbo (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-AT8E-USA, CGB-AT8P-EUR"/>
@@ -12494,7 +12939,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="micromc3">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines V3 (Euro, USA)</description>
+		<description>Micro Machines V3 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BM3E-USA, CGB-BM3P-EUR"/>
@@ -12511,7 +12956,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="microman">
 		<!-- Notes: GBC only -->
-		<description>Micro Maniacs (Euro)</description>
+		<description>Micro Maniacs (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B3NP-EUR"/>
@@ -12525,7 +12970,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="msep">
 		<!-- Notes: GBC only -->
-		<description>Microsoft - The Best of Entertainment Pack (Euro)</description>
+		<description>Microsoft - The Best of Entertainment Pack (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BMZP-EUR"/>
@@ -12553,7 +12998,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mspinb">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Pinball Arcade (Euro)</description>
+		<description>Microsoft Pinball Arcade (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo Interactive</publisher>
 		<info name="serial" value="CGB-BMQP-EUR"/>
@@ -12587,7 +13032,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mspuzzle">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Puzzle Collection (Euro)</description>
+		<description>Microsoft Puzzle Collection (Europe)</description>
 		<year>2000</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="alt_title" value="Microsoft - The 6 in 1 Puzzle Collection Entertainment Pack (Box)"/>
@@ -12635,12 +13080,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="minnashg">
-		<description>Minna no Shougi - Shokyuu Hen (Jpn)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
+		<info name="gold" value="19991028"/>
 		<info name="release" value="19991210"/>
-		<info name="alt_title" value="みんなの将棋 初級編"/>
+		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -12651,9 +13097,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="minnashga" cloneof="minnashg">
+		<!--	In lot check as "dmga7yj1.i18"	-->
+		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev. 1)</description>
+		<year>1999</year>
+		<publisher>MTO</publisher>
+		<info name="serial" value="DMG-A7YJ-JPN"/>
+		<info name="gold" value="20000811"/>
+		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmga7yj1.i18" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="minnie">
 		<!-- Notes: GBC only -->
-		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Jpn)</description>
+		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BYKJ-JPN"/>
@@ -12677,7 +13142,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="missile">
 		<!-- Notes: GBC only -->
-		<description>Missile Command (Euro)</description>
+		<description>Missile Command (Europe)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ALCP-EUR"/>
@@ -12713,14 +13178,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="missimp">
 		<!-- Notes: GBC only -->
-		<description>Mission Impossible (Euro)</description>
+		<description>Mission Impossible (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-(NOE/UKV/FAH)"/>
+		<info name="gold" value="19991006"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mission impossible (europe) (en,fr,de,es,it).bin" size="1048576" crc="0af32baa" sha1="5eb8dad248ff23809016a2515657089116e8df33"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="missimpa" cloneof="missimp">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbaimp1.076"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Mission Impossible (Europe, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Infogrames</publisher>
+		<info name="serial" value="CGB-AIMP-?"/>
+		<info name="gold" value="19991227"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbaimp1.076" size="1048576" crc="9c51f4c7" sha1="f822bda01d881f34d1e17664465faf6a3ff64356"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -12733,6 +13218,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIME-USA"/>
+		<info name="gold" value="19991227"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -12745,7 +13231,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mizuki">
 		<!-- Notes: GBC only -->
-		<description>Mizuki Shigeru no Shin Youkaiden (Jpn)</description>
+		<description>Mizuki Shigeru no Shin Youkaiden (Japan)</description>
 		<year>2000</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BYPJ-JPN"/>
@@ -12762,7 +13248,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mobilglf">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		        This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		        for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		        There are different models depending on the target cellular phone:
@@ -12772,7 +13258,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		            * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		        Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		        manufactured by Mitsumi. -->
-		<description>Mobile Golf (Jpn)</description>
+		<description>Mobile Golf (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BGOJ-JPN"/>
@@ -12796,7 +13282,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<!-- when it checks for the connection, it checks for a value of 06 in C27D -->
 	<software name="mobiltrn" supported="partial">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		    This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		    for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		    There are different models depending on the target cellular phone:
@@ -12806,7 +13292,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		        * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		    Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		    manufactured by Mitsumi. -->
-		<description>Mobile Trainer (Jpn)</description>
+		<description>Mobile Trainer (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B9AJ-JPN"/>
@@ -12829,7 +13315,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="momo">
 		<!-- Notes: GBC only -->
-		<description>Momotarou Densetsu 1-2 (Jpn)</description>
+		<description>Momotarou Densetsu 1-2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BI2J-JPN"/>
@@ -12847,7 +13333,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="monkeyp">
 		<!-- Notes: GBC only -->
-		<description>Monkey Puncher (Euro)</description>
+		<description>Monkey Puncher (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-BSPP-EUR"/>
@@ -12862,14 +13348,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="monopolyj" cloneof="monopoly">
-		<!-- Notes: SGB enhanced -->
-		<description>Monopoly (Jpn)</description>
+		<description>Monopoly (Japan)</description>
 		<year>1998</year>
 		<publisher>Hasbro</publisher>
 		<info name="serial" value="DMG-AHAJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ゲームボーイモノポリー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="monopoly (japan).bin" size="1048576" crc="0503e567" sha1="3f42d9b423c15b4c1b997c7a2292ab2cba1ab23f"/>
@@ -12891,14 +13377,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mfarmbc" cloneof="mranchbc">
-		<!-- Notes: SGB enhanced -->
-		<description>Monster Farm Battle Card GB (Jpn)</description>
+		<description>Monster Farm Battle Card GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TJ-JPN"/>
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="モンスターファーム バトルカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster farm battle card gb (japan).bin" size="2097152" crc="69b88f1e" sha1="7e036e175c9e865572ab613ae0f8e6d3642ffb0e"/>
@@ -12909,14 +13395,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="monstrc2">
-		<!-- Notes: SGB enhanced -->
-		<description>Monster Race 2 (Jpn)</description>
+		<description>Monster Race 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AMWJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="もんすたあ★レース2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster race 2 (japan).bin" size="2097152" crc="b985f0d8" sha1="8d4a6b4cdaa37b9daaff5a05ac5926a407bacce3"/>
@@ -12927,12 +13413,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mranchbc">
-		<!-- Notes: SGB enhanced -->
 		<description>Monster Rancher Battle Card GB (USA)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TE-USA"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster rancher battle card gb (usa).bin" size="2097152" crc="50ddf120" sha1="f94dc1dbdf25d9ab7f7abd3d7878209d404b206d"/>
@@ -12958,25 +13444,48 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="monstrvl">
+	<software name="monstrvla">
 		<!-- Notes: GBC only -->
-		<description>Monster Traveler (Jpn, Rev. A)</description>
+		<description>Monster Traveler (Japan, Rev. 1)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
+		<info name="gold" value="20020207"/>
 		<info name="release" value="20020308"/>
-		<info name="alt_title" value="モン★スタートラベラー"/>
+		<info name="alt_title" value="モン☆スタートラベラー"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="monster traveler (japan) (rev a).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
+				<rom name="monster traveler (japan) (rev 1).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="monstrvl" cloneof="monstrvla">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbfvj0.949"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Monster Traveler (Japan)</description>
+		<year>2002</year>
+		<publisher>Taito</publisher>
+		<info name="serial" value="CGB-BFVJ-JPN"/>
+		<info name="gold" value="20020122"/>
+		<info name="alt_title" value="モン☆スタートラベラー"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="4194304">
+				<rom name="cgbbfvj0.949" size="4194304" crc="5d596cf6" sha1="5195f55ad6aaa302c0a0e11c0ec6ecad4efe0e27"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, Rev. A)</description>
+		<description>Monsters, Inc. (Europe, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QP-UKV"/>
@@ -12993,7 +13502,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="monstincu" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, USA)</description>
+		<description>Monsters, Inc. (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QE-USA, CGB-B4QP-UKV"/>
@@ -13010,7 +13519,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="monstinca" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, English / Spanish / Dutch)</description>
+		<description>Monsters, Inc. (Europe, English / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QX-EUR"/>
@@ -13027,7 +13536,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="monstincb" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Euro, English / French / Italian)</description>
+		<description>Monsters, Inc. (Europe, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QY-EUU"/>
@@ -13044,7 +13553,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="monstincg" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Die Monster AG (Ger)</description>
+		<description>Die Monster AG (Germany)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QD-NOE"/>
@@ -13057,7 +13566,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="montezum">
-		<description>Montezuma's Return! (Euro)</description>
+		<description>Montezuma's Return! (Europe)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AZMP-EUR"/>
@@ -13084,7 +13593,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moominj" cloneof="moomin">
 		<!-- Notes: GBC only -->
-		<description>Moomin no Daibouken (Jpn)</description>
+		<description>Moomin no Daibouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A36J-JPN"/>
@@ -13102,7 +13611,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moomin">
 		<!-- Notes: GBC only -->
-		<description>Moomin's Tale (Euro)</description>
+		<!--	In lot check as "CGBAM9P0.471", "KENSA\CGBAM9E0.0"	-->
+		<description>Moomin's Tale (Europe)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AM9P-EUR"/>
@@ -13116,7 +13626,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moorhun2">
 		<!-- Notes: GBC only -->
-		<description>Moorhuhn 2 - Die Jagd geht weiter (Ger)</description>
+		<description>Moorhuhn 2 - Die Jagd geht weiter (Germany)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BDED-NOE"/>
@@ -13138,7 +13648,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moorhen3">
 		<!-- Notes: GBC only -->
-		<description>Moorhen 3 - The Chicken Chase! (Euro)</description>
+		<description>Moorhen 3 - The Chicken Chase! (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Moorhuhn 3: ...Es Gibt Huhn! (Box)"/>
@@ -13160,7 +13670,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mk4">
-		<description>Mortal Kombat 4 (Euro, USA)</description>
+		<description>Mortal Kombat 4 (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KE-USA, DMG-A4KP-EUR"/>
@@ -13173,7 +13683,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mk4g" cloneof="mk4">
-		<description>Mortal Kombat 4 (Ger)</description>
+		<description>Mortal Kombat 4 (Germany)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KD-NOE"/>
@@ -13206,7 +13716,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mrnutz">
 		<!-- Notes: GBC only -->
-		<description>Mr Nutz (Euro)</description>
+		<description>Mr Nutz (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ANUP-(EUR/FAH/NOE)"/>
@@ -13237,7 +13747,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mrdrillr">
 		<!-- Notes: GBC only -->
-		<description>Mr. Driller (Euro)</description>
+		<description>Mr. Driller (Europe)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDP-EUR"/>
@@ -13252,18 +13762,38 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="mrdrillrj" cloneof="mrdrillr">
-		<!-- Notes: GBC only, also released by NP in 2001-06 -->
-		<description>Mr. Driller (Jpn)</description>
+	<software name="mrdrillrja" cloneof="mrdrillr">
+		<!-- Notes: GBC only -->
+		<description>Mr. Driller (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDJ-JPN"/>
+		<info name="gold" value="20000510"/>
 		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ミスタードリラーGB版"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mr. driller (japan).bin" size="1048576" crc="773729af" sha1="b0d725dacea717be7109bd6a81817e717641da86"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mrdrillrjnp" cloneof="mrdrillr">
+		<!-- Notes: GBC only, NP only -->
+		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
+		<description>Mr. Driller (Japan, NP)</description>
+		<year>2000</year>
+		<publisher>Namco</publisher>
+		<info name="serial" value="CGB-BV3J-JPN"/>
+		<info name="release" value="200106"/>
+		<info name="alt_title" value="ミスタードリラーGB版"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="524288">
+				<rom name="cgbbv3j0.0" size="524288" crc="35fd440d" sha1="fb64fa7da6a0fec3e358bb3357e66d68473ada67"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13300,7 +13830,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mspacman">
 		<!-- Notes: GBC only -->
-		<description>Ms. Pac-Man - Special Colour Edition (Euro)</description>
+		<description>Ms. Pac-Man - Special Colour Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AQCP-EUR"/>
@@ -13314,7 +13844,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mtvride">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Pure Ride (Euro, USA)</description>
+		<description>MTV Sports - Pure Ride (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BPVE-USA, CGB-BPVP-EUR"/>
@@ -13331,7 +13861,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mtvskate">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Euro, USA)</description>
+		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BMTE-USA, CGB-BMTP-EUR"/>
@@ -13348,7 +13878,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mtvbmx">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Euro, USA)</description>
+		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTVE-USA, CGB-BTVP-EUR"/>
@@ -13365,7 +13895,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mummyr">
 		<!-- Notes: GBC only -->
-		<description>The Mummy Returns (Euro)</description>
+		<description>The Mummy Returns (Europe)</description>
 		<year>2001</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-B2RP-EUR"/>
@@ -13396,7 +13926,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mummy">
 		<!-- Notes: GBC only -->
-		<description>The Mummy (Euro)</description>
+		<description>The Mummy (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMYP-EUR"/>
@@ -13424,7 +13954,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Euro, Black Cart)</description>
+		<description>The Muppets (Europe, Black Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="alt_title" value="Jim Henson's Puppets (Cart)"/>
@@ -13447,7 +13977,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="muppetsa" cloneof="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Euro, Transparent Cart)</description>
+		<description>The Muppets (Europe, Transparent Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AX9P-EUR"/>
@@ -13485,7 +14015,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="trizenon">
 		<!-- Notes: GBC only -->
-		<description>Muteki Ou Tri-Zenon (Jpn)</description>
+		<description>Muteki Ou Tri-Zenon (Japan)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BZNJ-JPN"/>
@@ -13503,7 +14033,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nyrace">
 		<!-- Notes: GBC only -->
-		<description>N.Y. Race (Euro)</description>
+		<description>N.Y. Race (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BNXP-EUR"/>
@@ -13517,7 +14047,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ncook1">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Jpn)</description>
+		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7CJ-JPN"/>
@@ -13535,7 +14065,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ncook2">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Jpn)</description>
+		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7PJ-JPN"/>
@@ -13553,7 +14083,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ncook3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Jpn)</description>
+		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7BJ-JPN"/>
@@ -13571,7 +14101,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ncook4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Jpn)</description>
+		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3DJ-JPN"/>
@@ -13595,12 +14125,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ncook5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Jpn)</description>
+		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3CJ-JPN"/>
+		<info name="gold" value="20020307"/>
 		<info name="release" value="20020405"/>
-		<info name="alt_title" value="なかよしクッキングシリーズ(5) こむぎちゃんのケーキをつくろう!"/>
+		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -13617,8 +14148,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+
 	<software name="nakapet1">
-		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Jpn)</description>
+		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7HJ-JPN"/>
@@ -13635,7 +14167,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nakapet2">
-		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Jpn)</description>
+		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7UJ-JPN"/>
@@ -13653,7 +14185,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nakapet3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Jpn)</description>
+		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7IJ-JPN"/>
@@ -13671,7 +14203,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nakapet4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Jpn)</description>
+		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7NJ-JPN"/>
@@ -13689,7 +14221,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nakapet5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Jpn)</description>
+		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Japan)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B2HJ-JPN"/>
@@ -13707,7 +14239,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="naminori" cloneof="ultsurf">
 		<!-- Notes: GBC only, NP only -->
-		<description>Naminori Yarou! (Jpn, NP)</description>
+		<description>Naminori Yarou! (Japan, NP)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BNYJ-JPN"/>
@@ -13725,7 +14257,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nascar2k">
 		<!-- Notes: GBC only -->
-		<description>NASCAR 2000 (Euro, USA)</description>
+		<description>NASCAR 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BN2E-USA, CGB-BN2P-EUR"/>
@@ -13790,7 +14322,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nations">
 		<!-- Notes: GBC only -->
-		<description>The Nations - Land of Legends (Euro)</description>
+		<description>The Nations - Land of Legends (Europe)</description>
 		<year>2002</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-BNLP-EUR"/>
@@ -13831,15 +14363,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="nbazone" cloneof="nbapro99">
-		<description>NBA In the Zone (USA, Rev. A)</description>
+	<software name="nbazonea" cloneof="nbapro99">
+		<description>NBA In the Zone (USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
+		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="nba in the zone (usa) (rev a).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
+				<rom name="nba in the zone (usa) (rev 1).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="nbazone" cloneof="nbapro99">
+		<!--	In lot check as "dmganze0.g29"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>NBA In the Zone (USA)</description>
+		<year>1999</year>
+		<publisher>Konami</publisher>
+		<info name="serial" value="DMG-ANZE-USA?"/>
+		<info name="gold" value="19990303"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmganze0.g29" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13848,10 +14400,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nbazon2k">
 		<!-- Notes: GBC only -->
-		<description>NBA In the Zone 2000 (Euro)</description>
+		<description>NBA In the Zone 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AJ7P-EUR"/>
+		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -13879,7 +14432,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nbajam99">
-		<description>NBA Jam '99 (Euro, USA)</description>
+		<description>NBA Jam '99 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AJME-USA, DMG-AJMP-EUR"/>
@@ -13896,7 +14449,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nbajm2k1">
 		<!-- Notes: GBC only -->
-		<description>NBA Jam 2001 (Euro, USA)</description>
+		<description>NBA Jam 2001 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BJAE-USA, CGB-BJAP-EUR"/>
@@ -13912,10 +14465,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nbapro99">
-		<description>NBA Pro '99 (Euro)</description>
+		<description>NBA Pro '99 (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZP-EUR"/>
+		<info name="gold" value="19990716"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13932,6 +14486,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AA5E-USA"/>
+		<info name="gold" value="19991124"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13942,7 +14497,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="netdeget">
 		<!-- Notes: GBC only -->
-		<description>Net de Get - Minigame @ 100 (Jpn)</description>
+		<description>Net de Get - Minigame @ 100 (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMVJ-JPN (RK215-J1)"/>
@@ -13968,7 +14523,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Alpha Version (Jpn)</description>
+		<description>Network Boukenki Bugsite - Alpha Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BAUJ-JPN"/>
@@ -13988,7 +14543,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Beta Version (Jpn)</description>
+		<description>Network Boukenki Bugsite - Beta Version (Japan)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BBUJ-JPN"/>
@@ -14012,10 +14567,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="newaddfm">
 		<!-- Notes: GBC only -->
-		<description>The New Addams Family Series (Euro)</description>
+		<description>The New Addams Family Series (Europe)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BAIP-EUR"/>
+		<info name="gold" value="20011108"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -14027,7 +14583,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="newmna">
-		<description>The New Adventures of Mary-Kate &amp; Ashley (Euro, USA)</description>
+		<description>The New Adventures of Mary-Kate &amp; Ashley (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AXFE-USA, DMG-AXFP-EUR"/>
@@ -14044,7 +14600,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="newbatmn">
 		<!-- Notes: GBC only -->
-		<description>The New Batman Adventures - Chaos in Gotham (Euro)</description>
+		<description>The New Batman Adventures - Chaos in Gotham (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBBP-EUR"/>
@@ -14071,7 +14627,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="blitz">
-		<description>NFL Blitz (Euro, USA, Rev. A)</description>
+		<description>NFL Blitz (Europe, USA, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ABZE-USA, DMG-ABZP-EUU"/>
@@ -14128,7 +14684,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nhl2k">
-		<description>NHL 2000 (Euro, USA)</description>
+		<description>NHL 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ANRE-USA, DMG-ANRP-EUR"/>
@@ -14188,7 +14744,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nintama">
 		<!-- Notes: GBC only -->
-		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Jpn)</description>
+		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Japan)</description>
 		<year>2001</year>
 		<publisher>ASK</publisher>
 		<info name="serial" value="CGB-BNAJ-JPN"/>
@@ -14206,7 +14762,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nisemon">
 		<!-- Notes: GBC only -->
-		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Jpn)</description>
+		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Japan)</description>
 		<year>2001</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BNPJ-JPN"/>
@@ -14224,7 +14780,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nofear">
 		<!-- Notes: GBC only -->
-		<description>No Fear - Downhill Mountain Biking (Euro)</description>
+		<description>No Fear - Downhill Mountain Biking (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BKFP-EUR"/>
@@ -14237,7 +14793,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="nobugb2">
-		<description>Nobunaga no Yabou - Game Boy Ban 2 (Jpn)</description>
+		<description>Nobunaga no Yabou - Game Boy Ban 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AGYJ-JPN"/>
@@ -14255,7 +14811,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="noddy">
 		<!-- Notes: GBC only -->
-		<description>Noddy and the Birthday Party (Euro)</description>
+		<description>Noddy and the Birthday Party (Europe)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-AZEP-UKV"/>
@@ -14285,7 +14841,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="nushiadv">
 		<!-- Notes: GBC only -->
-		<description>Nushi Tsuri Adventure - Kite no Bouken (Jpn)</description>
+		<description>Nushi Tsuri Adventure - Kite no Bouken (Japan)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-VVJJ-JPN"/>
@@ -14311,7 +14867,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="oleary">
 		<!-- Notes: GBC only -->
-		<description>O'Leary Manager 2000 (Euro)</description>
+		<description>O'Leary Manager 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -14326,7 +14882,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="oddworld">
-		<description>Oddworld Adventures II (Euro)</description>
+		<description>Oddworld Adventures II (Europe)</description>
 		<year>2000</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="DMG-AOWP-EUR"/>
@@ -14353,7 +14909,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ohasuddr">
 		<!-- Notes: GBC only -->
-		<description>Ohasuta Dance Dance Revolution GB (Jpn)</description>
+		<description>Ohasuta Dance Dance Revolution GB (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD5J-JPN (RK231-J1)"/>
@@ -14370,14 +14926,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ohasuynr">
-		<!-- Notes: SGB enhanced -->
-		<description>Ohasuta Yama-chan &amp; Raymond (Jpn)</description>
+		<description>Ohasuta Yama-chan &amp; Raymond (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOSJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="おはスタ やまちゃん&amp;レイモンド"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -14389,7 +14945,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="oiderasc">
 		<!-- Notes: GBC only -->
-		<description>Oide Rascal (Jpn)</description>
+		<description>Oide Rascal (Japan)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BLSJ-JPN"/>
@@ -14406,7 +14962,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ojarumam">
-		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Jpn)</description>
+		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Japan)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BOJJ-JPN"/>
@@ -14423,7 +14979,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ojarumat">
-		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Jpn)</description>
+		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Japan)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-BORJ-JPN"/>
@@ -14441,7 +14997,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="moorhun">
 		<!-- Notes: GBC only -->
-		<description>Die Original Moorhuhn Jagd (Ger)</description>
+		<description>Die Original Moorhuhn Jagd (Germany)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BOMD-NOE"/>
@@ -14457,7 +15013,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="othellom">
-		<description>Othello Millennium (Jpn)</description>
+		<description>Othello Millennium (Japan)</description>
 		<year>1999</year>
 		<publisher>Tsukuda Original</publisher>
 		<info name="serial" value="DMG-AO7J-JPN"/>
@@ -14474,14 +15030,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="azuredj" cloneof="azured">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
-		<description>Other Life - Azure Dreams GB (Jpn)</description>
+		<!-- Also released by NP in 2000-08 -->
+		<description>Other Life - Azure Dreams GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAZJ-JPN (RK179-J1)"/>
 		<info name="release" value="19990805"/>
 		<info name="alt_title" value="アザーライフ アザードリームGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="other life - azure dreams gb (japan).bin" size="1048576" crc="c6f1abd4" sha1="9e473df09e962a9accc3f6446140b0333f6a088e"/>
@@ -14493,7 +15050,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ottifant">
 		<!-- Notes: GBC only -->
-		<description>Ottifanten - Kommando Störtebeker (Ger)</description>
+		<description>Ottifanten - Kommando Störtebeker (Germany)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -14506,14 +15063,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="oudoroan">
-		<!-- Notes: SGB enhanced -->
-		<description>Ou Dorobou Jing - Angel Version (Jpn)</description>
+		<description>Ou Dorobou Jing - Angel Version (Japan)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZWJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン エンジェルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - angel version (japan).bin" size="1048576" crc="d47c0dcf" sha1="493e37dac6d8b037e44e64f9f31dba7f08a89e08"/>
@@ -14524,14 +15081,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="oudorodv">
-		<!-- Notes: SGB enhanced -->
-		<description>Ou Dorobou Jing - Devil Version (Jpn)</description>
+		<description>Ou Dorobou Jing - Devil Version (Japan)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZKJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン デビルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - devil version (japan).bin" size="1048576" crc="2a39a874" sha1="71797aa125b88614182ce3d0f8252d6ed8cfa08e"/>
@@ -14542,14 +15099,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="owarai">
-		<!-- Notes: SGB enhanced -->
-		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Jpn)</description>
+		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYIJ-JPN (RK194-J1)"/>
 		<info name="release" value="19991225"/>
 		<info name="alt_title" value="おわらいよゐこのげえむ道 〜おやじ探して3丁目〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="owarai yowiko no game-dou - oyaji sagashite sanchoume (japan).bin" size="1048576" crc="3f635a4f" sha1="21644c1ef67bdd6038686d8522e957e3de803237"/>
@@ -14573,7 +15130,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pacmansp">
-		<description>Pac-Man - Special Colour Edition (Euro)</description>
+		<description>Pac-Man - Special Colour Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AACP-EUR"/>
@@ -14586,7 +15143,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pachicrt">
-		<description>Pachinko CR Mouretsu Genshijin T (Jpn)</description>
+		<description>Pachinko CR Mouretsu Genshijin T (Japan)</description>
 		<year>1999</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-AXAJ-JPN"/>
@@ -14601,7 +15158,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pachihis">
-		<description>Pachinko Hisshou Guide - Data no Ousama (Jpn)</description>
+		<description>Pachinko Hisshou Guide - Data no Ousama (Japan)</description>
 		<year>1999</year>
 		<publisher>BOSS Communications</publisher>
 		<info name="serial" value="DMG-AYEJ-JPN"/>
@@ -14618,14 +15175,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pachislt">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-06 -->
-		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Jpn)</description>
+		<!-- Also released by NP in 2000-06 -->
+		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ANPJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パチパチ パチス郎〜ニューパルサー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pachipachi pachi-slot - new pulsar hen (japan).bin" size="1048576" crc="1e443d1b" sha1="969d5352c15e3e5daa891edcda91bd48a8380308"/>
@@ -14637,7 +15195,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="paperboy">
 		<!-- Notes: GBC only -->
-		<description>Paperboy (Euro, USA)</description>
+		<description>Paperboy (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AYPE-USA, CGB-AYPP-EUR"/>
@@ -14651,7 +15209,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="papyrus">
 		<!-- Notes: GBC only -->
-		<description>Papyrus (Euro)</description>
+		<description>Papyrus (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AY9P-EUR"/>
@@ -14665,7 +15223,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pchoroq">
 		<!-- Notes: GBC only -->
-		<description>Perfect Choro Q (Jpn)</description>
+		<description>Perfect Choro Q (Japan)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BPQJ-JPN"/>
@@ -14683,7 +15241,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pdark">
 		<!-- Notes: GBC only -->
-		<description>Perfect Dark (Euro, USA)</description>
+		<description>Perfect Dark (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VPDE-USA, CGB-VPDP-EUR"/>
@@ -14706,14 +15264,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="phantomz">
-		<!-- Notes: SGB enhanced -->
-		<description>Phantom Zona - Kaijin Zona (Jpn)</description>
+		<description>Phantom Zona - Kaijin Zona (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BKZJ-JPN"/>
 		<info name="release" value="20001021"/>
 		<info name="alt_title" value="怪人ゾナー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-Z03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -14731,7 +15289,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="picarro2">
 		<!-- Notes: GBC only -->
-		<description>Pia Carrot e Youkoso!! 2.2 (Jpn)</description>
+		<description>Pia Carrot e Youkoso!! 2.2 (Japan)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="CGB-B22J-JPN"/>
@@ -14748,7 +15306,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pitfall">
-		<description>Pitfall - Beyond the Jungle (Euro, USA)</description>
+		<description>Pitfall - Beyond the Jungle (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AFLE-USA, DMG-AFLP-EUR"/>
@@ -14764,7 +15322,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pitfallj" cloneof="pitfall">
-		<description>Pitfall GB (Jpn)</description>
+		<description>Pitfall GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AFLJ-JPN (PCPE-10003)"/>
@@ -14780,7 +15338,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="planapes">
 		<!-- Notes: GBC only -->
-		<description>Planet of the Apes (Euro)</description>
+		<description>Planet of the Apes (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BYNP-EUR"/>
@@ -14811,7 +15369,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Player Manager 2001 (Euro)</description>
+		<description>Player Manager 2001 (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBP-EUR"/>
@@ -14826,7 +15384,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockbill">
-		<description>Pocket Billiards - Funk the 9 Ball (Jpn)</description>
+		<description>Pocket Billiards - Funk the 9 Ball (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-A9BJ-JPN"/>
@@ -14843,7 +15401,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockbman">
-		<description>Pocket Bomberman (Euro, USA)</description>
+		<description>Pocket Bomberman (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AKQE-USA, DMG-AKQP-EUR"/>
@@ -14859,7 +15417,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockbwlj" cloneof="pockbwl">
-		<description>Pocket Bowling (Jpn)</description>
+		<description>Pocket Bowling (Japan)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AVBJ-JPN"/>
@@ -14890,7 +15448,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockcbil">
-		<description>Pocket Color Billiards (Jpn)</description>
+		<description>Pocket Color Billiards (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A3AJ-JPN"/>
@@ -14905,14 +15463,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockcblk" cloneof="ddance">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Color Block (Jpn)</description>
+		<description>Pocket Color Block (Japan)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-AC6J-JPN"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケットカラー ブロック"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="pocket color block (japan).bin" size="131072" crc="389cf56f" sha1="84d243c64f98731965ca78b75ad48f8787d3c907"/>
@@ -14921,7 +15479,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockcmj">
-		<description>Pocket Color Mahjong (Jpn)</description>
+		<description>Pocket Color Mahjong (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A2AJ-JPN"/>
@@ -14936,7 +15494,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockctrm">
-		<description>Pocket Color Trump (Jpn)</description>
+		<description>Pocket Color Trump (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A4CJ-JPN"/>
@@ -14952,7 +15510,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockcook">
 		<!-- Notes: GBC only -->
-		<description>Pocket Cooking (Jpn)</description>
+		<description>Pocket Cooking (Japan)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-APJJ-JPN"/>
@@ -14975,14 +15533,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockden2">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Densha 2 (Jpn)</description>
+		<description>Pocket Densha 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Coconuts Japan</publisher>
 		<info name="serial" value="DMG-AP8J-JPN"/>
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="ポケット電車2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket densha 2 (japan).bin" size="1048576" crc="4d26e880" sha1="859331f57a964197f271acafa7e8dc586e598cf5"/>
@@ -14991,9 +15549,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockfam2">
-		<!-- Notes: GBC only.
+		<!-- Notes: GBC only
 		    The game cart has an integrated speaker and a replaceable battery (CR2025). -->
-		<description>Pocket Family GB2 (Jpn)</description>
+		<description>Pocket Family GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-HF2J-JPN"/>
@@ -15017,14 +15575,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockgis">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket GI Stable (Jpn)</description>
+		<description>Pocket GI Stable (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-APUJ-JPN (RK156-J1)"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ポケットGIステイブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pocket gi stable (japan).bin" size="2097152" crc="c424874e" sha1="f818e6284d198f4b394f79cb8511c9b906d69f03"/>
@@ -15036,10 +15594,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockgt" cloneof="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket GT (Jpn)</description>
+		<description>Pocket GT (Japan)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-A7GJ-JPN"/>
+		<info name="gold" value="19990920"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="ポケット ジーティー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15053,7 +15612,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockgtp" cloneof="pockrace">
-		<description>Pocket GT (Eur, Prototype?)</description>
+		<description>Pocket GT (Europe, Prototype?)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -15068,7 +15627,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockhana">
 		<!-- Notes: GBC only -->
-		<description>Pocket Hanafuda (Jpn)</description>
+		<description>Pocket Hanafuda (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A6PJ-JPN"/>
@@ -15083,7 +15642,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pockking">
-		<description>Pocket King (Jpn)</description>
+		<description>Pocket King (Japan)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AV5J-JPN"/>
@@ -15101,7 +15660,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pocklure">
 		<!-- Notes: GBC only -->
-		<description>Pocket Lure Boy (Jpn)</description>
+		<description>Pocket Lure Boy (Japan)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQIJ-JPN (KIG-8)"/>
@@ -15152,14 +15711,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Monsters Gin (Jpn, Rev. A)</description>
+		<description>Pocket Monsters Gin (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-10" />
 			<feature name="u1" value="U1 PRG [M538011E-B9]" />
 			<feature name="u2" value="U2 MBC3A [MBC3 A]" />
@@ -15169,7 +15728,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters gin (japan) (rev a).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
+				<rom name="pocket monsters gin (japan) (rev 1).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15177,14 +15736,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegina" cloneof="pokesilv">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Monsters Gin (Jpn)</description>
+		<description>Pocket Monsters Gin (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15196,18 +15755,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Monsters Kin (Jpn, Rev. A)</description>
+		<description>Pocket Monsters Kin (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters kin (japan) (rev a).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
+				<rom name="pocket monsters kin (japan) (rev 1).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15215,14 +15774,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokekina" cloneof="pokegold">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Monsters Kin (Jpn)</description>
+		<description>Pocket Monsters Kin (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15235,10 +15794,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysj" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pocket Monsters - Crystal Version (Jpn)</description>
+		<description>Pocket Monsters - Crystal Version (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BXTJ-JPN"/>
+		<info name="gold" value="20001020"/>
 		<info name="release" value="20001214"/>
 		<info name="alt_title" value="ポケットモンスター クリスタルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15260,10 +15820,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockmus">
 		<!-- Notes: GBC only -->
-		<description>Pocket Music (Euro)</description>
+		<description>Pocket Music (Europe)</description>
 		<year>2002</year>
 		<publisher>Rage Software</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-BP9P-EUR?"/>
+		<info name="gold" value="20010925"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -15276,7 +15837,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pocknaka">
 		<!-- Notes: GBC only -->
-		<description>Pocket no Naka no Ookoku (Jpn, Prototype)</description>
+		<description>Pocket no Naka no Ookoku (Japan, Prototype)</description>
 		<year>2000</year>   <!-- scheduled to be released January 2001 (3/11/2000 Famitsu) -->
 		<publisher>Hector</publisher>
 		<info name="alt_title" value="ポケットの中の王国"/>
@@ -15292,7 +15853,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockprow">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Wrestling - Perfect Wrestler (Jpn)</description>
+		<description>Pocket Pro Wrestling - Perfect Wrestler (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AJVJ-JPN"/>
@@ -15308,7 +15869,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pockyak">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Yakyuu (Jpn)</description>
+		<description>Pocket Pro Yakyuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BPPJ-JPN"/>
@@ -15325,14 +15886,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="poktpuys">
-		<!-- Notes: SGB enhanced -->
-		<description>Pocket Puyo Puyo Sun (Jpn)</description>
+		<description>Pocket Puyo Puyo Sun (Japan)</description>
 		<year>1998</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AYSJ-JPN"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ぽけっとぷよぷよSUN"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket puyo puyo sun (japan).bin" size="1048576" crc="45661ec3" sha1="c2f72fad1a26ad765eb3036f0c9e9e8945133d3a"/>
@@ -15344,10 +15905,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="poktpuyn">
 		<!-- Notes: GBC only -->
-		<description>Pocket Puyo Puyo-n (Jpn)</description>
+		<description>Pocket Puyo Puyo-n (Japan)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="gold" value="20000721"/>
 		<info name="release" value="20000922"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15360,9 +15922,47 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="poktpuyna" cloneof="poktpuyn">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpyj1.327"	-->
+		<description>Pocket Puyo Puyo-n (Japan, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Compile</publisher>
+		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="gold" value="20010327"/>
+		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpyj1.327" size="1048576" crc="c884037a" sha1="3d52805f712e6d1ce22b88dfebfcac2a31743ff3"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="poktpuynb" cloneof="poktpuyn">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpyj2.327"	-->
+		<description>Pocket Puyo Puyo-n (Japan, Rev. 2)</description>
+		<year>2000</year>
+		<publisher>Compile</publisher>
+		<info name="serial" value="CGB-BPYJ-JPN"/>
+		<info name="gold" value="20010719"/>
+		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpyj2.327" size="1048576" crc="573613d7" sha1="09b217161ac326da63887693281b60751ca2dfcf"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket Racing (Euro)</description>
+		<description>Pocket Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BPKP-EUR"/>
@@ -15378,7 +15978,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pocksocr">
 		<!-- Notes: GBC only -->
-		<description>Pocket Soccer (Euro)</description>
+		<!--	In lot check as "CGBBPSP0.618", "KENSA\CGBBPSE0.0"	-->
+		<description>Pocket Soccer (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="GCB-BPSP-EUR"/>
@@ -15394,15 +15995,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Crystal Version (Euro, USA, Rev. A)</description>
+		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
+		<description>Pokémon - Crystal Version (Europe, USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
+		<info name="gold" value="20010807, 20010726"/>
+		<info name="release" value="?, 20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
-				<rom name="pokemon - crystal version (usa, europe) (rev a).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
+				<rom name="pokemon - crystal version (usa, europe) (rev 1).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15411,10 +16015,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysa" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Crystal Version (Euro, USA)</description>
+		<description>Pokémon - Crystal Version (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
+		<info name="gold" value="20010524, 20010101"/>
+		<info name="release" value="20010729, unreleased"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15428,10 +16034,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysf" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Version Cristal (Fra)</description>
+		<description>Pokémon - Version Cristal (France)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTF-FRA"/>
+		<info name="gold" value="20010817"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15445,10 +16053,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysg" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Kristall-Edition (Ger)</description>
+		<description>Pokémon - Kristall-Edition (Germany)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTD-NOE"/>
+		<info name="gold" value="20010726"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15462,10 +16072,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrysi" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Versione Cristallo (Ita)</description>
+		<description>Pokémon - Versione Cristallo (Italia)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTI-ITA"/>
+		<info name="gold" value="20010914"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-KGDU-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -15485,10 +16097,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecryss" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Edición Cristal (Spa)</description>
+		<description>Pokémon - Edición Cristal (Spain)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTS-ESP"/>
+		<info name="gold" value="20010830"/>
+		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -15500,8 +16114,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="pokecrysaus" cloneof="pokecrys">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbytu0.834"	-->
+		<description>Pokémon - Crystal Version (Australia)</description>
+		<year>2001</year>
+		<publisher>Nintendo</publisher>
+		<info name="gold" value="20010724"/>
+		<info name="release" value="20010930"/>
+		<info name="serial" value="CGB-BYTU-AUS"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbytu0.834" size="2097152" crc="bb6dd80c" sha1="a0fc810f1d4e124434f7be2c989ab5b5892ddf36"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pokegold">
-		<description>Pokémon - Gold Version (Euro, USA)</description>
+		<description>Pokémon - Gold Version (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUE-USA, DMG-AAUP-(EUR/EUR-1)"/>
@@ -15519,7 +16153,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegoldf" cloneof="pokegold">
-		<description>Pokémon - Version Or (Fra)</description>
+		<description>Pokémon - Version Or (France)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUF-FRA"/>
@@ -15535,7 +16169,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegoldg" cloneof="pokegold">
-		<description>Pokémon - Goldene Edition (Ger)</description>
+		<description>Pokémon - Goldene Edition (Germany)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUD-NOE"/>
@@ -15551,7 +16185,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegoldi" cloneof="pokegold">
-		<description>Pokémon - Versione Oro (Ita)</description>
+		<description>Pokémon - Versione Oro (Italia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AAUI-ITA"/>
@@ -15573,7 +16207,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokegolds" cloneof="pokegold">
-		<description>Pokémon - Edición Oro (Spa)</description>
+		<description>Pokémon - Edición Oro (Spain)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUS-ESP"/>
@@ -15595,7 +16229,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokesilv">
-		<description>Pokémon - Silver Version (Euro, Aus, USA)</description>
+		<description>Pokémon - Silver Version (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXE-USA, DMG-AAXP-(EUR/AUS)"/>
@@ -15611,7 +16245,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokesilvf" cloneof="pokesilv">
-		<description>Pokémon - Version Argent (Fra)</description>
+		<description>Pokémon - Version Argent (France)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXF-FRA"/>
@@ -15627,7 +16261,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokesilvg" cloneof="pokesilv">
-		<description>Pokémon - Silberne Edition (Ger)</description>
+		<description>Pokémon - Silberne Edition (Germany)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXD-NOE"/>
@@ -15649,7 +16283,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokesilvi" cloneof="pokesilv">
-		<description>Pokémon - Versione Argento (Ita)</description>
+		<description>Pokémon - Versione Argento (Italia)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXI-ITA"/>
@@ -15665,7 +16299,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokesilvs" cloneof="pokesilv">
-		<description>Pokémon - Edición Plata (Spa)</description>
+		<description>Pokémon - Edición Plata (Spain)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXS-ESP"/>
@@ -15681,15 +16315,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecardj" cloneof="pokecard">
-		<!-- Notes: SGB enhanced.
-		        This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
-		<description>Pokémon Card GB (Jpn)</description>
+		<!-- This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
+		<description>Pokémon Card GB (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACXJ-JPN"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケモンカードGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG [KM23C8000DG]" />
 			<feature name="u2" value="U2 HuC1A" />
@@ -15707,7 +16341,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokecrd2">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Card GB2 - GR Dan Sanjou! (Jpn)</description>
+		<description>Pokémon Card GB2 - GR Dan Sanjou! (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BP7J-JPN"/>
@@ -15725,7 +16359,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokepuzlj" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon de Panepon (Jpn)</description>
+		<description>Pokémon de Panepon (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNJ-JPN"/>
@@ -15742,7 +16376,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokepinb">
-		<description>Pokémon Pinball (Euro)</description>
+		<description>Pokémon Pinball (Europe)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHP-EUR"/>
@@ -15765,14 +16399,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokepinbj" cloneof="pokepinb">
-		<!-- Notes: SGB enhanced -->
-		<description>Pokémon Pinball (Jpn)</description>
+		<description>Pokémon Pinball (Japan)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHJ-JPN"/>
 		<info name="release" value="19990414"/>
 		<info name="alt_title" value="ポケモンピンボール"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<feature name="rumble" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15785,7 +16419,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokepinbu" cloneof="pokepinb">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Pinball (Aus, USA)</description>
+		<description>Pokémon Pinball (Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHE-USA, DMG-VPHU-AUS"/>
@@ -15802,7 +16436,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Puzzle Challenge (Euro)</description>
+		<description>Pokémon Puzzle Challenge (Europe)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNP-EUR"/>
@@ -15818,6 +16452,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pokepuzlu" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
+		<!-- Includes a limited version of Panel de Pon GB as an easter egg	-->
 		<description>Pokémon Puzzle Challenge (USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -15833,11 +16468,31 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pokecard">
-		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian)</description>
+		<!--	In lot check as "dmgaxqx1.j85"	-->
+		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AXQX-EUR-1"/>
+		<info name="gold" value="20001108"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgaxqx1.j85" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pokecardx" cloneof="pokecard">
+		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR"/>
+		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pokemon trading card game (europe) (en,es,it).bin" size="2097152" crc="966daef1" sha1="2138a422d135a13c49fce71229ae36bc1dc4fbb5"/>
@@ -15847,12 +16502,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="pokecarda" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Euro, English / French / German)</description>
+	<software name="pokecarde" cloneof="pokecard">
+		<description>Pokémon Trading Card Game (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE"/>
+		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -15868,12 +16525,31 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="pokecardaa" cloneof="pokecard">
+		<!--	In lot check as "dmgaxqp1.j84"	-->
+		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev. 1)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AXQP-NOE?"/>
+		<info name="gold" value="20001108"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgaxqp1.j84" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="pokecardu" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Aus, USA)</description>
+		<description>Pokémon Trading Card Game (Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQE-USA, DMG-AXQU-AUS"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pokemon trading card game (usa).bin" size="1048576" crc="81069d53" sha1="0f8670a583255cff3e5b7ca71b5d7454d928fc48"/>
@@ -15904,7 +16580,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pongtnl">
 		<!-- Notes: GBC only -->
-		<description>Pong - The Next Level (Euro, USA)</description>
+		<description>Pong - The Next Level (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-AOVE-USA, CGB-AOVP-EUR"/>
@@ -15918,7 +16594,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="poohhuns">
 		<!-- Notes: GBC only -->
-		<description>Pooh and Tigger's Hunny Safari (Euro)</description>
+		<description>Pooh and Tigger's Hunny Safari (Europe)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BP8P-EUR"/>
@@ -15949,7 +16625,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="popngb">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB (Jpn)</description>
+		<description>Pop'n Music GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPMJ-JPN (RK207-J1)"/>
@@ -15965,7 +16641,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="popngbam">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Animation Melody (Jpn)</description>
+		<description>Pop'n Music GB - Animation Melody (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPAJ-JPN (RK216-J1)"/>
@@ -15981,7 +16657,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="popngbdt">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Disney Tunes (Jpn)</description>
+		<description>Pop'n Music GB - Disney Tunes (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPDJ-JPN (RK218-J1)"/>
@@ -15997,7 +16673,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Euro)</description>
+		<description>Pop'n Pop (Europe)</description>
 		<year>2001</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="??"/>
@@ -16011,7 +16687,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="popnpopj" cloneof="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Jpn)</description>
+		<description>Pop'n Pop (Japan)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJPJ-JPN"/>
@@ -16040,17 +16716,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkp">
-		<!-- Notes: SGB enhanced -->
-		<description>Power Pro Kun Pocket (Jpn, Rev. A)</description>
+		<description>Power Pro Kun Pocket (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="power pro kun pocket (japan) (rev a).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
+				<rom name="power pro kun pocket (japan) (rev 1).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16058,14 +16734,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkpa" cloneof="powrpkp">
-		<!-- Notes: SGB enhanced -->
-		<description>Power Pro Kun Pocket (Jpn)</description>
+		<description>Power Pro Kun Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="power pro kun pocket (japan).bin" size="2097152" crc="145540d8" sha1="f796f9cb259646555f0d429b9337ac6b423755a3"/>
@@ -16076,14 +16752,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powrpkp2">
-		<!-- Notes: SGB enhanced -->
-		<description>Power Pro Kun Pocket 2 (Jpn)</description>
+		<description>Power Pro Kun Pocket 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BPWJ-JPN (RK205-J1)"/>
 		<info name="release" value="20000330"/>
 		<info name="alt_title" value="パワプロクンポケット2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC5 [MBC-5]" />
@@ -16100,7 +16776,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="powerqst">
-		<description>Power Quest (Euro)</description>
+		<description>Power Quest (Europe)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-APQP-EUR"/>
@@ -16130,7 +16806,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="prlr">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Lightspeed Rescue (Euro, USA)</description>
+		<description>Power Rangers - Lightspeed Rescue (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRSE-USA, CGB-BRSP-EUR"/>
@@ -16147,7 +16823,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="prtf">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Time Force (Euro, USA)</description>
+		<description>Power Rangers - Time Force (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4TE-USA, CGB-B4TP-EUR"/>
@@ -16178,7 +16854,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (Euro)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (Europe)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJP-UKV"/>
@@ -16200,7 +16876,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbmf" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (Fra)</description>
+		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (France)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJF-FRA"/>
@@ -16222,7 +16898,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbms" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - El Malvado Mojo Jojo (Spa)</description>
+		<description>Las Super Nenas - El Malvado Mojo Jojo (Spain)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJS-ESP"/>
@@ -16244,7 +16920,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbmu" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. B)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-2"/>
@@ -16262,7 +16938,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbmua" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-1"/>
@@ -16300,7 +16976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (Euro)</description>
+		<description>The Powerpuff Girls - Battle Him (Europe)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHP-EUR"/>
@@ -16322,7 +16998,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbhf" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bulle Contre Lui (Fra)</description>
+		<description>The Powerpuff Girls - Bulle Contre Lui (France)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHF-FRA"/>
@@ -16344,7 +17020,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbhs" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Lucha con Ese (Spa)</description>
+		<description>Las Super Nenas - Lucha con Ese (Spain)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHS-ESP"/>
@@ -16366,7 +17042,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfbhu" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Battle Him (USA, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHE-USA-1"/>
@@ -16399,7 +17075,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (Euro)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (Europe)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTP-(EUR, UKV)"/>
@@ -16421,7 +17097,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfpnf" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Panique a Townsville (Fra)</description>
+		<description>The Powerpuff Girls - Panique a Townsville (France)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTF-FRA"/>
@@ -16443,7 +17119,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfpns" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Pánico en Townsville (Spa)</description>
+		<description>Las Super Nenas - Pánico en Townsville (Spain)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTS-ESP"/>
@@ -16465,28 +17141,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="powrpfpnu" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. B)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 2)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-2?"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev b).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 2).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="powrpfpnua" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. A)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-1"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev a).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 1).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -16510,14 +17186,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="poyondr">
-		<!-- Notes: SGB enhanced -->
-		<description>Poyon no Dungeon Room (Jpn)</description>
+		<description>Poyon no Dungeon Room (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-ADZJ-JPN"/>
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="大貝獣物語 ポヨンのダンジョンルーム ~ Daikaijuu Monogatari - Poyon no Dungeon Room (Box)"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="daikaijuu monogatari - poyon no dungeon room (japan).bin" size="2097152" crc="2f368da6" sha1="0854b7ea4791a460c75ce9096583934b1af053e8"/>
@@ -16529,7 +17205,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="poyondr2">
 		<!-- Notes: GBC only -->
-		<description>Poyon no Dungeon Room 2 (Jpn)</description>
+		<description>Poyon no Dungeon Room 2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BP2J-JPN"/>
@@ -16547,7 +17223,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pnaseem">
 		<!-- Notes: GBC only -->
-		<description>Prince Naseem Boxing (Euro)</description>
+		<description>Prince Naseem Boxing (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNCP-EUR"/>
@@ -16562,10 +17238,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ppersia">
-		<description>Prince of Persia (Euro, USA)</description>
+		<description>Prince of Persia (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-ARIE-USA, DMG-ARIP-EUR"/>
+		<info name="gold" value="19990303, 19990525"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -16592,14 +17269,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjkiwam2">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
-		<description>Pro Mahjong Kiwame GB II (Jpn)</description>
+		<!-- Also released by NP in 2001-06 -->
+		<description>Pro Mahjong Kiwame GB II (Japan)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AA2J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="プロ麻雀 極II GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong kiwame gb ii (japan).bin" size="1048576" crc="14f91f86" sha1="2c9c2967400ab9bad95ffe104763b3190f28aa39"/>
@@ -16610,14 +17288,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="mjtsuwa">
-		<!-- Notes: SGB enhanced -->
-		<description>Pro Mahjong Tsuwamono GB (Jpn)</description>
+		<description>Pro Mahjong Tsuwamono GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AQDJ-JPN"/>
 		<info name="release" value="19990709"/>
 		<info name="alt_title" value="プロ麻雀 兵 GB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong tsuwamono gb (japan).bin" size="1048576" crc="1461d8d8" sha1="b9e7cd7e53fda3db329c57971a47d35255bd0b34"/>
@@ -16629,7 +17307,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="mjtsuwa2">
 		<!-- Notes: GBC only -->
-		<description>Pro Mahjong Tsuwamono GB2 (Jpn)</description>
+		<description>Pro Mahjong Tsuwamono GB2 (Japan)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BMWJ-JPN"/>
@@ -16646,7 +17324,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="profoot" cloneof="goldgoal">
-		<description>Pro:Foot (Fra)</description>
+		<description>Pro:Foot (France)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFF-FAH"/>
@@ -16662,10 +17340,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="propool">
 		<!-- Notes: GBC only -->
-		<description>Pro Pool (Euro)</description>
+		<description>Pro Pool (Europe)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLP-EUU"/>
+		<info name="gold" value="20000621"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -16684,7 +17363,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="propoolu" cloneof="propool">
 		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbple0.298"	-->
+		<!--	Retail cartridge not yet secured	-->
 		<description>Pro Pool (USA)</description>
+		<year>2000?</year>
+		<publisher>Codemasters</publisher>
+		<info name="serial" value="CGB-BPLE-USA?"/>
+		<info name="gold" value="20000621"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbple0.298" size="1048576" crc="2611fa3d" sha1="c85e514c24c82071907c6495243dae448b46c2b2"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="propooluunk" cloneof="propool">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Pro Pool (USA, bad dump?)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLE-USA"/>
@@ -16697,6 +17396,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+
 
 	<software name="projs11">
 		<!-- Notes: GBC only -->
@@ -16713,10 +17413,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puchicar">
-		<description>Puchi Carat (Euro)</description>
+		<description>Puchi Carat (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-AIQP-EUR"/>
+		<info name="gold" value="20000112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -16728,14 +17429,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puchicarj" cloneof="puchicar">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
-		<description>Puchi Carat (Jpn)</description>
+		<!-- Also released by NP in 2000-07 -->
+		<description>Puchi Carat (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-ACUJ-JPN"/>
+		<info name="gold" value="19990311"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="プチカラット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puchi carat (japan).bin" size="1048576" crc="f0d0c36d" sha1="25abda13f97140d412bb00e109baca8574d5af6e"/>
@@ -16747,7 +17450,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pumucklp">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer bei den Piraten (Ger)</description>
+		<description>Pumuckls Abenteuer bei den Piraten (Germany)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AVED-NOE"/>
@@ -16761,7 +17464,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pumucklg">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer im Geisterschloss (Ger)</description>
+		<description>Pumuckls Abenteuer im Geisterschloss (Germany)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BPCD-NOE"/>
@@ -16774,14 +17477,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puyopuyg">
-		<!-- Notes: SGB enhanced -->
-		<description>Puyo Puyo Gaiden - Puyo Wars (Jpn)</description>
+		<description>Puyo Puyo Gaiden - Puyo Wars (Japan)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AWYJ-JPN"/>
 		<info name="release" value="19990827"/>
 		<info name="alt_title" value="ぷよぷよ外伝 ぷよウォーズ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puyo puyo gaiden - puyo wars (japan).bin" size="1048576" crc="67350bc9" sha1="b1802797e892d09e4da53304d096bdf35bac1118"/>
@@ -16792,7 +17495,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puzzloop" cloneof="ballistc">
-		<description>Puzz Loop (Jpn)</description>
+		<description>Puzz Loop (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BPZJ-JPN"/>
@@ -16809,7 +17512,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="pbobble4" cloneof="bam4">
-		<description>Puzzle Bobble 4 (Jpn)</description>
+		<description>Puzzle Bobble 4 (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AA4J-JPN"/>
@@ -16825,7 +17528,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="pbobblem" cloneof="bammill">
 		<!-- Notes: GBC only -->
-		<description>Puzzle Bobble Millennium (Jpn)</description>
+		<description>Puzzle Bobble Millennium (Japan)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BP5J-JPN"/>
@@ -16840,7 +17543,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="puzlshou">
-		<description>Puzzle de Shoubuyo! Wootama-chan (Jpn)</description>
+		<description>Puzzle de Shoubuyo! Wootama-chan (Japan)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="DMG-BKUJ-JPN"/>
@@ -16871,7 +17574,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="puzzled">
 		<!-- Notes: GBC only -->
-		<description>Puzzled (Euro)</description>
+		<description>Puzzled (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AZWP-EUR"/>
@@ -16913,10 +17616,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="qixadv">
 		<!-- Notes: GBC only -->
-		<description>Qix Adventure (Euro)</description>
+		<description>Qix Adventure (Europe)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="CGB-AQYP-EUR"/>
+		<info name="gold" value="20001017"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -16929,7 +17633,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="qixadvj" cloneof="qixadv">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Qix Adventure (Jpn)</description>
+		<description>Qix Adventure (Japan)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-AQSJ-JPN"/>
@@ -16959,7 +17663,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="questcam">
-		<description>Quest for Camelot (Euro)</description>
+		<description>Quest for Camelot (Europe)</description>
 		<year>1998</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ACNP-EUR"/>
@@ -17005,7 +17709,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="quiqui">
-		<description>Qui Qui (Jpn)</description>
+		<description>Qui Qui (Japan)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AQUJ-JPN"/>
@@ -17022,7 +17726,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rtypedx">
-		<description>R-Type DX (Euro, Aus, USA)</description>
+		<description>R-Type DX (Europe, Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWHE-USA, DMG-AWHP-(AUS/EUR)"/>
@@ -17043,7 +17747,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rtypedxj" cloneof="rtypedx">
-		<description>R-Type DX (Jpn)</description>
+		<description>R-Type DX (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ARUJ-JPN"/>
@@ -17075,7 +17779,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="radikal">
 		<!-- Notes: GBC only -->
-		<description>Radikal Bikers (Euro, Prototype)</description>
+		<description>Radikal Bikers (Europe, Prototype)</description>
 		<year>1998?</year>
 		<publisher>Bit Managers</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -17090,7 +17794,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rbisland">
 		<!-- Notes: GBC only -->
-		<description>Rainbow Islands (Euro)</description>
+		<description>Rainbow Islands (Europe)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BISP-EUR"/>
@@ -17104,7 +17808,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rakuxcs">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Cut Shuu (Jpn)</description>
+		<description>Raku x Raku - Cut Shuu (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BELJ-JPN"/>
@@ -17121,7 +17825,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rakuxmis">
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Raku x Raku - Mishin (Jpn)</description>
+		<description>Raku x Raku - Mishin (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAJ-JPN"/>
@@ -17143,7 +17847,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rakuxmoj">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Moji (Jpn)</description>
+		<description>Raku x Raku - Moji (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BEMJ-JPN"/>
@@ -17159,7 +17863,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rampage">
-		<description>Rampage - World Tour (Euro, USA)</description>
+		<description>Rampage - World Tour (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ARPE-USA, DMG-ARPP-EUR"/>
@@ -17173,7 +17877,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rampage2">
 		<!-- Notes: GBC only -->
-		<description>Rampage 2 - Universal Tour (Euro, USA)</description>
+		<description>Rampage 2 - Universal Tour (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AUTE-USA, CGB-AUTP-EUR"/>
@@ -17217,7 +17921,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman (Euro)</description>
+		<description>Rayman (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AYQP-EUR"/>
@@ -17245,7 +17949,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="raymanj" cloneof="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman - Mister Dark no Wana (Jpn)</description>
+		<description>Rayman - Mister Dark no Wana (Japan)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BURJ-JPN"/>
@@ -17261,7 +17965,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rayman2">
 		<!-- Notes: GBC only -->
-		<description>Rayman 2 - The Great Escape (Euro)</description>
+		<description>Rayman 2 - The Great Escape (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BRYP-EUR"/>
@@ -17299,7 +18003,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="freestyl">
 		<!-- Notes: GBC only -->
-		<description>Freestyle Scooter (Euro)</description>
+		<description>Freestyle Scooter (Europe)</description>
 		<year>2001</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BRZP-EUR"/>
@@ -17330,7 +18034,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="r2rumble">
 		<!-- Notes: GBC only -->
-		<description>Ready 2 Rumble Boxing (Euro)</description>
+		<description>Ready 2 Rumble Boxing (Europe)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AQOP-EUR"/>
@@ -17362,14 +18066,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rpyakyuc">
-		<!-- Notes: SGB enhanced -->
-		<description>Real Pro Yakyuu! - Central League Hen (Jpn)</description>
+		<description>Real Pro Yakyuu! - Central League Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AECJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 セントラルリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - central league hen (japan).bin" size="524288" crc="afff6bb9" sha1="02c18d98a07b3af9a1d26d0c3003f8e75c81f4d9"/>
@@ -17380,14 +18084,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rpyakyup">
-		<!-- Notes: SGB enhanced -->
-		<description>Real Pro Yakyuu! - Pacific League Hen (Jpn)</description>
+		<description>Real Pro Yakyuu! - Pacific League Hen (Japan)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AEPJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 パシフィックリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - pacific league hen (japan).bin" size="524288" crc="16b81c36" sha1="a7a2cd7bbb4cae171b5f2c798293afefe2882afc"/>
@@ -17412,7 +18116,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="resrvrat">
-		<description>Reservoir Rat (Euro)</description>
+		<description>Reservoir Rat (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AVTP-EUR"/>
@@ -17456,7 +18160,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="revilg">
 		<!-- Notes: GBC only -->
-		<description>Resident Evil Gaiden (Euro)</description>
+		<description>Resident Evil Gaiden (Europe)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOP-EUR"/>
@@ -17488,7 +18192,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="retninja">
 		<!-- Notes: GBC only -->
-		<description>Return of the Ninja (Euro)</description>
+		<description>Return of the Ninja (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BNJP-EUR"/>
@@ -17531,7 +18235,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rhino">
 		<!-- Notes: GBC only -->
-		<description>Rhino Rumble (Euro, USA)</description>
+		<description>Rhino Rumble (Europe, USA)</description>
 		<year>2002</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-BRNE-USA, CGB-BRNP-EUR"/>
@@ -17544,7 +18248,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="riptide">
-		<description>Rip-Tide Racer (Euro)</description>
+		<description>Rip-Tide Racer (Europe)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-AXYP-EUR"/>
@@ -17558,7 +18262,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="roadchmp">
 		<!-- Notes: GBC only -->
-		<description>Road Champs - BXS Stunt Biking (Euro, USA)</description>
+		<description>Road Champs - BXS Stunt Biking (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXSE-USA, CGB-BXSP-EUR"/>
@@ -17575,7 +18279,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="roadrash">
 		<!-- Notes: GBC only -->
-		<description>Road Rash (Euro, USA)</description>
+		<description>Road Rash (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRRE-USA, CGB-BRRP-EUR"/>
@@ -17605,7 +18309,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="roadster">
-		<description>Roadsters Trophy (Euro)</description>
+		<description>Roadsters Trophy (Europe)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -17632,7 +18336,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="robin">
 		<!-- Notes: GBC only -->
-		<description>Robin Hood (Euro)</description>
+		<description>Robin Hood (Europe)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRHP-EUR"/>
@@ -17646,7 +18350,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="robocop">
 		<!-- Notes: GBC only -->
-		<description>RoboCop (Euro)</description>
+		<description>RoboCop (Europe)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BR9P-EUR"/>
@@ -17682,15 +18386,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopspc">
-		<!-- Notes: GBC only..
+		<!-- Notes: GBC only
 		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Jpn)</description>
-		<year>1999?</year>
+		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Japan)</description>
+		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H5UJ-JPN"/>
+		<info name="gold" value="19990618"/>
+		<info name="alt_title" value="ロボットポンコッツ ボンボンスペシャルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-10" />
@@ -17710,18 +18416,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopmon">
-		<!-- Notes: SGB enhanced.
-		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Moon Version (Jpn)</description>
+		<description>Robot Ponkottsu - Moon Version (Japan)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H3UJ-JPN"/>
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="ロボットポンコッツ月バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-10" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -17739,18 +18445,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopstr">
-		<!-- Notes: SGB enhanced.
-		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Star Version (Jpn)</description>
+		<description>Robot Ponkottsu - Star Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HRCJ-JPN"/>
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ星バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -17768,14 +18474,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="robopsunj" cloneof="robopsun">
-		<!-- Notes: SGB enhanced -->
-		<description>Robot Ponkottsu - Sun Version (Jpn)</description>
+		<description>Robot Ponkottsu - Sun Version (Japan)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HREJ-JPN"/>
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ太陽バージョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="slot" value="rom_huc3" />
@@ -17789,7 +18495,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="robowars">
 		<!-- Notes: GBC only -->
-		<description>Robot Wars - Metal Mayhem (Euro)</description>
+		<description>Robot Wars - Metal Mayhem (Europe)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-BRWP-UKV"/>
@@ -17805,7 +18511,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - Gettin' Air (Euro, USA)</description>
+		<description>Rocket Power - Gettin' Air (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRUP-EUR, CGB-BRUE-USA"/>
@@ -17822,7 +18528,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rcktpwf" cloneof="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - La Glisse de l'Extreme (Fra)</description>
+		<description>Rocket Power - La Glisse de l'Extreme (France)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="??"/>
@@ -17835,7 +18541,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rockmnx" cloneof="megamnx">
-		<description>Rockman X - Cyber Mission (Jpn)</description>
+		<description>Rockman X - Cyber Mission (Japan)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BRXJ-JPN"/>
@@ -17853,7 +18559,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rockmnx2" cloneof="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Rockman X2 - Soul Eraser (Jpn)</description>
+		<description>Rockman X2 - Soul Eraser (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BXRJ-JPN"/>
@@ -17885,7 +18591,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rokumon">
 		<!-- Notes: GBC only -->
-		<description>Rokumon Tengai Mon-Colle-Knight GB (Jpn)</description>
+		<description>Rokumon Tengai Mon-Colle-Knight GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Kadokawa Shoten</publisher>
 		<info name="serial" value="CGB-BKDJ-JPN"/>
@@ -17903,7 +18609,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rolandg">
 		<!-- Notes: GBC only -->
-		<description>Roland Garros French Open (Euro)</description>
+		<description>Roland Garros French Open (Europe)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BRGP-EUR"/>
@@ -17916,7 +18622,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ronaldov">
-		<description>Ronaldo V-Football (Euro)</description>
+		<description>Ronaldo V-Football (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AORP-(EUR/FAH)"/>
@@ -17947,7 +18653,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="roswell">
 		<!-- Notes: GBC only -->
-		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Euro)</description>
+		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCPP-EUR"/>
@@ -17974,7 +18680,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rox">
-		<description>Rox - 6=Six (Euro, USA)</description>
+		<description>Rox - 6=Six (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ARXE-USA, DMG-ARXP-EUR"/>
@@ -17991,7 +18697,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="roxj" cloneof="rox">
 		<!-- Notes: GBC only -->
-		<description>Rox - 6=Six (Jpn)</description>
+		<description>Rox - 6=Six (Japan)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ARXJ-JPN"/>
@@ -18009,12 +18715,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rpgtsuku">
 		<!-- Notes: GBC only -->
-		<description>RPG Tsukuru GB (Jpn)</description>
+		<description>RPG Tsukuru GB (Japan)</description>
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-A2QJ-JPN"/>
+		<info name="gold" value="20000209"/>
 		<info name="release" value="20000317"/>
-		<info name="alt_title" value="RPGツクールGB"/>
+		<info name="alt_title" value="ＲＰＧ ツクール ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -18026,7 +18733,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rugtimet">
-		<description>Rugrats - Time Travelers (Euro, USA)</description>
+		<description>Rugrats - Time Travelers (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AVME-USA, DMG-AVMP-EUR"/>
@@ -18042,7 +18749,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rugtimetf" cloneof="rugtimet">
-		<description>Les Razmoket - Voyage dans le Temps (Fra)</description>
+		<description>Les Razmoket - Voyage dans le Temps (France)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRTF-FRA"/>
@@ -18056,7 +18763,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugtotanf" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket - 100% Angelica (Fra)</description>
+		<description>Les Razmoket - 100% Angelica (France)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGF-FRA"/>
@@ -18070,7 +18777,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Totally Angelica (Euro, USA)</description>
+		<description>Rugrats - Totally Angelica (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGE-USA, CGB-BAGP-EUR"/>
@@ -18087,7 +18794,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugtotang" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Typisch Angelica (Ger)</description>
+		<description>Rugrats - Typisch Angelica (Germany)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGD-NOE"/>
@@ -18101,7 +18808,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Euro)</description>
+		<description>Rugrats in Paris - The Movie (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPX-ESP"/>
@@ -18115,7 +18822,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugparisa" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Euro, USA)</description>
+		<description>Rugrats in Paris - The Movie (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPE-USA, CGB-BRPP-EUR"/>
@@ -18132,7 +18839,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rugparisf" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket à Paris - Le Film (Fra)</description>
+		<description>Les Razmoket à Paris - Le Film (France)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPF-FRA"/>
@@ -18148,7 +18855,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="rugmovie">
-		<description>The Rugrats Movie (Euro)</description>
+		<description>The Rugrats Movie (Europe)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ARZP-(NOE/UKV)"/>
@@ -18178,7 +18885,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sabrinas">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Spooked! (Euro, USA)</description>
+		<description>Sabrina - The Animated Series - Spooked! (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-B4PE-USA, CGB-B4PP-UKV"/>
@@ -18195,7 +18902,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Euro)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Europe)</description>
 		<year>2000</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-BSGX-EUU"/>
@@ -18209,7 +18916,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sabrinazu" cloneof="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Euro, USA)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-BSGE-USA, CGB-BSGP-EUR"/>
@@ -18225,14 +18932,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sakata">
-		<!-- Notes: SGB enhanced -->
-		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Jpn)</description>
+		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AREJ-JPN"/>
 		<info name="release" value="19990625"/>
 		<info name="alt_title" value="坂田吾朗 九段の 連珠教室"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sakata gorou kudan no renju kyoushitsu (japan).bin" size="1048576" crc="b5412c6f" sha1="f2330533b10c22e98c140bb550827618985253cb"/>
@@ -18244,7 +18951,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only, 10 variant packs got released!
 		            This game is compatible with an external pedometer named "Pocket Sakura" (same hardware as the Pokémon Pikachu Color / Pokémon Pikachu 2 GS pedometer)
 		            wich connects to the GBC via the console's IR port -->
-		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Jpn)</description>
+		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BRJJ-JPN"/>
@@ -18268,7 +18975,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sakura2">
 		<!-- Notes: GBC only -->
-		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Jpn)</description>
+		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Japan)</description>
 		<year>2001</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="CGB-BQYJ-JPN (Limited Edition got serial HGB-0001)"/>
@@ -18286,7 +18993,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="samurai">
 		<!-- Notes: GBC only -->
-		<description>Samurai Kid (Jpn)</description>
+		<description>Samurai Kid (Japan)</description>
 		<year>2001</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BS5J-JPN"/>
@@ -18304,7 +19011,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sf2049">
 		<!-- Notes: GBC only -->
-		<description>San Francisco Rush 2049 (Euro, USA)</description>
+		<description>San Francisco Rush 2049 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ASXE-USA, CGB-ASXP-EUU, CGB-ASXP-EUR"/>
@@ -18320,14 +19027,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sangogb2">
-		<!-- Notes: SGB enhanced -->
-		<description>Sangokushi - Game Boy Ban 2 (Jpn)</description>
+		<description>Sangokushi - Game Boy Ban 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AS9J-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="三國志 ゲームボーイ版2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sangokushi - game boy ban 2 (japan).bin" size="1048576" crc="e787b44c" sha1="ec6089ff2cfcb17faf6a8ea9a4171869b3c7289b"/>
@@ -18338,14 +19045,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sanriotk">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Kako Hen (Jpn)</description>
+		<!-- Also released by NP in 2000-05 -->
+		<description>Sanrio Timenet - Kako Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
+		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 過去編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WNE]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -18361,15 +19070,37 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="sanriotka" cloneof="sanriotk">
+		<!--	In lot check as "dmgatpj1.f14"	-->
+		<description>Sanrio Timenet - Kako Hen (Japan, Rev. 1)</description>
+		<year>1998</year>
+		<publisher>Imagineer</publisher>
+		<info name="serial" value="DMG-ATPJ-JPN"/>
+		<info name="gold" value="19981130"/>
+		<info name="release" value="19981127"/>
+		<info name="alt_title" value="サンリオタイムネット 過去編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgatpj1.f14" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sanriotm">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Mirai Hen (Jpn)</description>
+		<!-- Also released by NP in 2000-05 -->
+		<description>Sanrio Timenet - Mirai Hen (Japan)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
+		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 未来編"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sanrio timenet - mirai hen (japan).bin" size="1048576" crc="efe51e17" sha1="65c4113401336784be4c53a51fe8d9b4b3d287da"/>
@@ -18379,8 +19110,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="sanriotma" cloneof="sanriotm">
+		<!--	In lot check as "dmgatfj1.f15"	-->
+		<description>Sanrio Timenet - Mirai Hen (Japan, Rev. 1)</description>
+		<year>1998</year>
+		<publisher>Imagineer</publisher>
+		<info name="serial" value="DMG-ATFJ-JPN"/>
+		<info name="gold" value="19981130"/>
+		<info name="release" value="19981127"/>
+		<info name="alt_title" value="サンリオタイムネット 未来編"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgatfj1.f15" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="santajr">
-		<description>Santa Claus Junior (Euro)</description>
+		<description>Santa Claus Junior (Europe)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-B3JP-EUR"/>
@@ -18393,14 +19144,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sarupnch" cloneof="monkeyp">
-		<!-- Notes: SGB enhanced -->
-		<description>Saru Puncher (Jpn)</description>
+		<description>Saru Puncher (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSPJ-JPN"/>
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="さるパンチャー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MYY]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -18418,7 +19169,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="scooby">
 		<!-- Notes: GBC only -->
-		<description>Scooby-Doo! - Classic Creep Capers (Euro, USA)</description>
+		<description>Scooby-Doo! - Classic Creep Capers (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCCE-USA, CGB-BCCP-EUR-1"/>
@@ -18435,7 +19186,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="scrabble">
 		<!-- Notes: GBC only -->
-		<description>Scrabble (Euro)</description>
+		<description>Scrabble (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B9QP-EUR"/>
@@ -18450,14 +19201,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sdhiryux">
-		<!-- Notes: SGB enhanced -->
-		<description>SD Hiryuu no Ken EX (Jpn)</description>
+		<description>SD Hiryuu no Ken EX (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AUXJ-JPN"/>
 		<info name="release" value="19990430"/>
 		<info name="alt_title" value="SD飛龍の拳EX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sd hiryuu no ken ex (japan).bin" size="1048576" crc="365bf43f" sha1="bed7b913a395ae4b62eac39ff8d6b3093529ed45"/>
@@ -18466,14 +19217,34 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="seihai">
-		<!-- Notes: SGB enhanced -->
-		<description>Sei Hai Densetsu (Jpn)</description>
+		<!--	In lot check as "dmgaeoj0.j01"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Sei Hai Densetsu (Japan)</description>
+		<year>2000</year>
+		<publisher>Gaps</publisher>
+		<info name="serial" value="DMG-AEOJ-JPN?"/>
+		<info name="gold" value="20000221"/>
+		<info name="release" value="20000414"/>
+		<info name="alt_title" value="聖牌伝説"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgaeoj0.j01" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="seihaiunk" cloneof="seihai">
+		<!-- Old dump of unknown origin -->
+		<description>Sei Hai Densetsu (Japan, bad dump?)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN"/>
 		<info name="release" value="20000414"/>
 		<info name="alt_title" value="聖牌伝説"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sei hai densetsu (japan).bin" size="1048576" crc="612f0529" sha1="1bada799254b220c1007a1dac6d13b1be4a04ff2"/>
@@ -18484,7 +19255,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="semecom">
-		<description>Seme COM Dungeon - Drururuaga (Jpn)</description>
+		<description>Seme COM Dungeon - Drururuaga (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-BV6J-JPN"/>
@@ -18501,14 +19272,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="senkai">
-		<!-- Notes: SGB enhanced -->
-		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Jpn)</description>
+		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Japan)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BHSJ-JPN"/>
 		<info name="release" value="20001124"/>
 		<info name="alt_title" value="仙界異聞録 準提大戦〜TVアニメーション「仙界伝封神演義」より〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="senkai ibunroku juntei taisen - tv animation senkaiden houshin engi yori (japan).bin" size="1048576" crc="23fa5f53" sha1="c10249ef96a1989c3532a48917862b4dd8bad12a"/>
@@ -18520,7 +19291,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sesamesp">
 		<!-- Notes: GBC only -->
-		<description>Sesame Street Sports (Euro)</description>
+		<description>Sesame Street Sports (Europe)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BSQP-???"/>
@@ -18561,7 +19332,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate Classic (Euro, USA, Rev. A)</description>
+		<description>Shadowgate Classic (Europe, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-EUR"/>
@@ -18582,7 +19353,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shadgatea" cloneof="shadgate">
-		<description>Shadowgate Classic (Aus, USA)</description>
+		<description>Shadowgate Classic (Australia, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-AUS"/>
@@ -18603,7 +19374,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shadgatej" cloneof="shadgate">
-		<description>Shadowgate Return (Jpn)</description>
+		<description>Shadowgate Return (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWJ-JPN"/>
@@ -18621,7 +19392,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shamcrdf">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Jpn)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQUJ-JPN (KIG-12)"/>
@@ -18639,7 +19410,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shamcrdm">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Jpn)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Japan)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQVJ-JPN (KIG-13)"/>
@@ -18656,7 +19427,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shamus">
-		<description>Shamus (Euro, USA)</description>
+		<description>Shamus (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="DMG-AVXE-USA, DMG-AVXP-EUR"/>
@@ -18672,27 +19443,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Euro, USA, Rev. A)</description>
+		<description>Shanghai Pocket (Europe, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-AHPE-USA, DMG-AHPP-(EUR/EUU)"/>
+		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
+		<info name="gold" value="19981222"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa, europe) (rev a).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
+				<rom name="shanghai pocket (europe) (rev 1).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="shanghaij" cloneof="shanghai">
-		<!-- Notes: SGB enhanced -->
-		<description>Shanghai Pocket (Jpn)</description>
+		<description>Shanghai Pocket (Japan)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ASEJ-JPN?"/>
-		<info name="release" value="19980806?"/>
+		<info name="gold" value="19980701"/>
+		<info name="release" value="19980806"/>
 		<info name="alt_title" value="上海 ポケット"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="shanghai pocket (japan).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
@@ -18700,15 +19473,32 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="shanghaie" cloneof="shanghai">
+		<description>Shanghai Pocket (Europe)</description>
+		<year>1998</year>
+		<publisher>Sunsoft</publisher>
+		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
+		<info name="gold" value="19981110"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="shanghai pocket (europe).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="shanghaiu" cloneof="shanghai">
+		<!--	In lot check as "dmgahpe0.f55"	-->
 		<description>Shanghai Pocket (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPE-USA"/>
+		<info name="gold" value="19981112"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
+				<rom name="shanghai pocket (usa).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
 			</dataarea>
 		</part>
 	</software>
@@ -18731,7 +19521,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shaunsnw">
 		<!-- Notes: GBC only -->
-		<description>Shaun Palmer's Pro Snowboarder (Aus, USA)</description>
+		<description>Shaun Palmer's Pro Snowboarder (Australia, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3SE-USA, CGB-B3SP-AUS"/>
@@ -18743,15 +19533,36 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="shinmta">
-		<!-- Notes: SGB enhanced -->
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn)</description>
+	<software name="shinmtaa">
+		<!--	In lot check as "dmgbhnj1.j70"	-->
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbhnj1.j70" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shinmta" cloneof="shinmtaa">
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan)</description>
+		<year>2000</year>
+		<publisher>Atlus</publisher>
+		<info name="serial" value="DMG-BHNJ-JPN"/>
+		<info name="gold" value="20000912"/>
+		<info name="release" value="20001117"/>
+		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -18767,15 +19578,36 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="shinmtk">
-		<!-- Notes: SGB enhanced -->
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn)</description>
+	<software name="shinmtka">
+		<!--	In lot check as "dmgbhej1.j69"	-->
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgbhej1.j69" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="shinmtk" cloneof="shinmtka">
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan)</description>
+		<year>2000</year>
+		<publisher>Atlus</publisher>
+		<info name="serial" value="DMG-BHEJ-JPN"/>
+		<info name="gold" value="20000912"/>
+		<info name="release" value="20001117"/>
+		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -18793,10 +19625,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shinmts">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Jpn)</description>
+		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHWJ-JPN"/>
+		<info name="gold" value="20010608"/>
 		<info name="release" value="20010727"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 白の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -18817,7 +19650,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shinmtcd">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Trading Card - Card Summoner (Jpn)</description>
+		<description>Shin Megami Tensei Trading Card - Card Summoner (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-BT8J-JPN"/>
@@ -18841,7 +19674,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="evangeln">
 		<!-- Notes: GBC only -->
-		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Jpn)</description>
+		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Japan)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQRJ-JPN (KIG-10)"/>
@@ -18858,8 +19691,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shougi2">
-		<!-- Notes: Also released by NP in 2000-04 -->
-		<description>Shougi 2 (Jpn)</description>
+		<!-- Also released by NP in 2000-04 -->
+		<description>Shougi 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AS8J-JPN (PCPE-10002)"/>
@@ -18874,7 +19707,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shougi3">
-		<description>Shougi 3 (Jpn)</description>
+		<description>Shougi 3 (Japan)</description>
 		<year>2001</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-B9SJ-JPN (PCPE-1000?)"/>
@@ -18890,7 +19723,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="shrek">
 		<!-- Notes: GBC only -->
-		<description>Shrek - Fairy Tale Freakdown (Euro, USA)</description>
+		<description>Shrek - Fairy Tale Freakdown (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BFUE-USA, CGB-BFUP-EUR"/>
@@ -18906,14 +19739,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="shutoku">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
-		<description>The Shutokou Racing (Jpn)</description>
+		<!-- Also released by NP in 2000-04 -->
+		<description>The Shutokou Racing (Japan)</description>
 		<year>1998</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-ASUJ-JPN (PCPE-10001)"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ザ・首都高レーシング"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
 			<dataarea name="rom" size="131072">
 				<rom name="shutokou racing, the (japan).bin" size="131072" crc="36e781cd" sha1="0f29818190ea9ce8c242b648ba64d50cc5408e5a"/>
@@ -18925,7 +19759,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="simpsons">
 		<!-- Notes: GBC only -->
-		<description>The Simpsons - Night of the Living Treehouse of Horror (Euro, USA)</description>
+		<description>The Simpsons - Night of the Living Treehouse of Horror (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNOE-USA, CGB-BNOP-EUR"/>
@@ -18946,6 +19780,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAE-USA"/>
+		<info name="gold" value="20000921"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -18956,9 +19791,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="sewingose" cloneof="sewingos">
+		<!--	In lot check as "dmgbraz0.k25"	-->
+		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
+		<description>Sewing Machine Operation Software (Europe)</description>
+		<year>2000</year>
+		<publisher>Natsume</publisher>
+		<info name="serial" value="DMG-BRAZ-EUU"/>
+		<info name="gold" value="20010920"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgbraz0.k25" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="smurfnig">
 		<!-- Notes: GBC only -->
-		<description>The Smurfs Nightmare (Euro)</description>
+		<description>The Smurfs Nightmare (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ASNP-EUR"/>
@@ -18989,7 +19843,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="snobochm">
 		<!-- Notes: GBC only -->
-		<description>Snobow Champion (Jpn)</description>
+		<description>Snobow Champion (Japan)</description>
 		<year>2000</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-B5CJ-JPN"/>
@@ -19005,7 +19859,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Euro)</description>
+		<description>Snoopy Tennis (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9P-NOE"/>
@@ -19022,7 +19876,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="snoopytnj" cloneof="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Jpn)</description>
+		<description>Snoopy Tennis (Japan)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9J-JPN"/>
@@ -19052,7 +19906,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="snowhite">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's Snow White and the Seven Dwarfs (Euro)</description>
+		<description>Walt Disney's Snow White and the Seven Dwarfs (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B7DP-EUR"/>
@@ -19083,7 +19937,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="snowcros">
 		<!-- Notes: GBC only -->
-		<description>SnowCross (Euro)</description>
+		<description>SnowCross (Europe)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-B3OP-EUR"/>
@@ -19097,7 +19951,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="socmanag">
 		<!-- Notes: GBC only -->
-		<description>Soccer Manager (Euro)</description>
+		<description>Soccer Manager (Europe)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BSMP-EUR"/>
@@ -19113,7 +19967,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="solomon" cloneof="mranchex">
 		<!-- Notes: GBC only -->
-		<description>Solomon (Jpn)</description>
+		<description>Solomon (Japan)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="CGB-BSOJ-JPN"/>
@@ -19131,7 +19985,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="anpan5to">
 		<!-- Notes: GBC only -->
-		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Jpn)</description>
+		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Japan)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BS2J-JPN"/>
@@ -19148,14 +20002,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="anpanfna">
-		<!-- Notes: SGB enhanced -->
-		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Jpn)</description>
+		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Japan)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AANJ-JPN"/>
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="それいけ!!アンパンマン 不思議なにこにこアルバム"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="soreike anpanman - fushigi na nikoniko album (japan).bin" size="1048576" crc="a80eeead" sha1="fe75b7b7a904ce76130d65b67d24e291ba3c2693"/>
@@ -19166,7 +20020,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sokoban">
-		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Jpn)</description>
+		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWIJ-JPN"/>
@@ -19183,7 +20037,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="soulget">
-		<description>Soul Getter - Houkago Bouken RPG (Jpn)</description>
+		<description>Soul Getter - Houkago Bouken RPG (Japan)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="DMG-AL9J-JPN"/>
@@ -19200,7 +20054,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="spaceinv">
-		<description>Space Invaders (Euro, USA)</description>
+		<description>Space Invaders (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AIVE-USA, DMG-AIVP-(EUR/NOE)"/>
@@ -19213,7 +20067,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="spaceinvx" cloneof="spaceinv">
-		<description>Space Invaders X (Jpn)</description>
+		<description>Space Invaders X (Japan)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSIJ-JPN"/>
@@ -19243,7 +20097,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spacentb">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Blue (Jpn)</description>
+		<description>Space-Net - Cosmo Blue (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BNBJ-JPN"/>
@@ -19261,7 +20115,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spacentr">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Red (Jpn)</description>
+		<description>Space-Net - Cosmo Red (Japan)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BREJ-JPN"/>
@@ -19278,7 +20132,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="silicon">
-		<description>Spacestation Silicon Valley (Euro)</description>
+		<description>Spacestation Silicon Valley (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AV2P-EUR"/>
@@ -19307,7 +20161,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="speedy">
-		<description>Speedy Gonzales - Aztec Adventure (Euro, USA)</description>
+		<description>Speedy Gonzales - Aztec Adventure (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALZE-USA, DMG-ALZP-(NOE/UKV)"/>
@@ -19324,7 +20178,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Euro, USA)</description>
+		<description>Spider-Man (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEE-USA, CGB-BSEP-EUR"/>
@@ -19338,7 +20192,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spidermnf" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Fra)</description>
+		<description>Spider-Man (France)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEF-FRA"/>
@@ -19352,7 +20206,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spidermnj" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Jpn)</description>
+		<description>Spider-Man (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BSEJ-JPN"/>
@@ -19368,7 +20222,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spiderm2">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man 2 - The Sinister Six (Euro, USA)</description>
+		<description>Spider-Man 2 - The Sinister Six (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2SE-USA, CGB-B2SP-EUR"/>
@@ -19385,7 +20239,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spirou">
 		<!-- Notes: GBC only -->
-		<description>Spirou Robbedoes - The Robot Invasion (Euro)</description>
+		<description>Spirou Robbedoes - The Robot Invasion (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSCP-EUR"/>
@@ -19399,7 +20253,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spongebb">
 		<!-- Notes: GBC only -->
-		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Euro, USA)</description>
+		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BQPE-USA, CGB-BQPP-EUR"/>
@@ -19416,10 +20270,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spyvsspy">
 		<!-- Notes: GBC only -->
-		<description>Spy vs. Spy (Euro)</description>
+		<description>Spy vs. Spy (Europe)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6P-EUR"/>
+		<info name="gold" value="19990506"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19430,10 +20285,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="spyvsspyj" cloneof="spyvsspy">
 		<!-- Notes: GBC only, also released by NP in 2001-05 -->
-		<description>Spy vs. Spy (Jpn)</description>
+		<description>Spy vs. Spy (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6J-JPN"/>
+		<info name="gold" value="19990615"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="スパイ アンド スパイ"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19444,12 +20300,28 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="spyvsspyjanp" cloneof="spyvsspy">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
+		<!--	Never released as physical cartridge	-->
+		<description>Spy vs. Spy (Japan, Rev. 1, NP)</description>
+		<year>1999</year>
+		<publisher>Kemco</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbas6j1.0" size="1048576" crc="eb47d63b" sha1="9e203f04857cd84ec49b0e6c6d4917b1a5cc199e"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="spyvsspyu" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<description>Spy vs. Spy (USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6E-USA"/>
+		<info name="gold" value="19990512"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19459,7 +20331,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="starocbs">
-		<description>Star Ocean - Blue Sphere (Jpn)</description>
+		<description>Star Ocean - Blue Sphere (Japan)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BO2J-JPN"/>
@@ -19477,7 +20349,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="swep1obi">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Obi-Wan's Adventures (Euro)</description>
+		<description>Star Wars Episode I - Obi-Wan's Adventures (Europe)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BOWP-EUR"/>
@@ -19505,7 +20377,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="swracer">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Racer (Euro, USA)</description>
+		<description>Star Wars Episode I - Racer (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VYHE-USA, CGB-VYHP-EUR"/>
@@ -19528,7 +20400,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="stranded">
-		<description>Stranded Kids (Euro)</description>
+		<description>Stranded Kids (Europe)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKP-EUR"/>
@@ -19544,10 +20416,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Euro)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Europe)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-AFZP-EUR"/>
+		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19558,10 +20431,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sfaj" cloneof="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Jpn)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BFZJ-JPN"/>
+		<info name="gold" value="20010206"/>
 		<info name="release" value="20010330"/>
 		<info name="alt_title" value="ストリートファイター アルファ WARRIORS' DREAMS"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19578,6 +20452,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AFZE-USA"/>
+		<info name="gold" value="20000120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19588,7 +20463,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Euro, USA)</description>
+		<description>Stuart Little - The Journey Home (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIE-USA, CGB-BJIP-UKV"/>
@@ -19605,7 +20480,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="stuartla" cloneof="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Euro)</description>
+		<description>Stuart Little - The Journey Home (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIX-EUR"/>
@@ -19622,7 +20497,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sblkbass">
 		<!-- Notes: GBC only -->
-		<description>Super Black Bass - Real Fight (Jpn)</description>
+		<description>Super Black Bass - Real Fight (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-VRFJ-JPN"/>
@@ -19647,14 +20522,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sblkbap3" cloneof="tnnofc">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Super Black Bass Pocket 3 (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Super Black Bass Pocket 3 (Japan)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ABQJ-JPN"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="スーパーブラックバス ポケット3"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super black bass pocket 3 (japan).bin" size="1048576" crc="ae466545" sha1="b416f8fe1d229bd4e90259f2e6a7d78dd1f7bf3e"/>
@@ -19665,14 +20541,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sbomblis">
-		<!-- Notes: SGB enhanced -->
-		<description>Super Bombliss DX (Jpn)</description>
+		<description>Super Bombliss DX (Japan)</description>
 		<year>1999</year>
 		<publisher>Bullet-Proof Software</publisher>
 		<info name="serial" value="DMG-A2OJ-JPN"/>
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="スーパーボンブリス デラックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="super bombliss dx (japan).bin" size="262144" crc="34c8a4a5" sha1="44070e77eb2b56b67f979e444d404e56b67edbb0"/>
@@ -19681,7 +20557,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sbrkout">
-		<description>Super Breakout! (Euro)</description>
+		<description>Super Breakout! (Europe)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AOTP-EUR"/>
@@ -19708,7 +20584,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="supchinf">
 		<!-- Notes: GBC only -->
-		<description>Super Chinese Fighter EX (Jpn)</description>
+		<description>Super Chinese Fighter EX (Japan)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-A66J-JPN"/>
@@ -19726,7 +20602,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sdoll">
 		<!-- Notes: GBC only -->
-		<description>Super Doll Licca-chan - Kisekae Daisakusen (Jpn)</description>
+		<description>Super Doll Licca-chan - Kisekae Daisakusen (Japan)</description>
 		<year>2000</year>
 		<publisher>VR1 Japan</publisher>
 		<info name="serial" value="CGB-BSLJ-JPN"/>
@@ -19744,7 +20620,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sgals">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran (Jpn)</description>
+		<description>Super Gals! Kotobuki Ran (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGLJ-JPN (RK251-J1)"/>
@@ -19768,7 +20644,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sgals2">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Jpn)</description>
+		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Japan)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGUJ-JPN (RK283-J1)"/>
@@ -19786,7 +20662,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdxj" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
-		<description>Super Mario Bros. Deluxe (Jpn, NP)</description>
+		<!--	In lot check as "POOL\cgbahyj0.0"	-->
+		<description>Super Mario Bros. Deluxe (Japan, NP)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -19802,16 +20679,37 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="smbdxja" cloneof="smbdx">
+		<!-- Notes: GBC only, NP only -->
+		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
+		<description>Super Mario Bros. Deluxe (Japan, NP, Rev. 1)</description>
+		<year>1999</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="CGB-AHYJ-JPN"/>
+		<info name="release" value="20000301"/>
+		<info name="alt_title" value="スーパーマリオブラザーズデラックス"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbahyj1.0" size="1048576" crc="f4e91f63" sha1="e61d564e1ff19eb4b7c62a6cd96214f2bca4b01d"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. B)</description>
+		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
+		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 2)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev b).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev 2).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19820,14 +20718,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdxa" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. A)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev a).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev 1).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -19836,7 +20734,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smbdxb" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Euro, USA)</description>
+		<description>Super Mario Bros. Deluxe (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -19852,7 +20750,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="smemail">
 		<!-- Notes: GBC only -->
-		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Jpn)</description>
+		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHAJ-JPN"/>
@@ -19870,7 +20768,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="srfish">
 		<!-- Notes: GBC only -->
-		<description>Super Real Fishing (Jpn)</description>
+		<description>Super Real Fishing (Japan)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-VPFJ-JPN"/>
@@ -19890,7 +20788,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="srobopin">
 		<!-- Notes: GBC only -->
-		<description>Super Robot Pinball (Jpn)</description>
+		<description>Super Robot Pinball (Japan)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BSUJ-JPN"/>
@@ -19907,14 +20805,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="srobotlb">
-		<!-- Notes: SGB enhanced -->
-		<description>Super Robot Taisen - Link Battler (Jpn)</description>
+		<description>Super Robot Taisen - Link Battler (Japan)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AL6J-JPN"/>
 		<info name="release" value="19991001"/>
 		<info name="alt_title" value="スーパーロボット大戦 リンクバトラー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super robot taisen - link battler (japan).bin" size="1048576" crc="d24e592d" sha1="e6c715042adc4c1b52a7295e082953ada79cf95e"/>
@@ -19926,7 +20824,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="superx">
 		<!-- Notes: GBC only -->
-		<description>Supercross Freestyle (Euro)</description>
+		<description>Supercross Freestyle (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSXP-EUR"/>
@@ -19942,7 +20840,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="supreme">
 		<!-- Notes: GBC only -->
-		<description>Supreme Snowboarding (Euro)</description>
+		<description>Supreme Snowboarding (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AXWP-NOE"/>
@@ -19970,14 +20868,35 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="survkidsj" cloneof="stranded">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
-		<description>Survival Kids - Kotou no Boukensha (Jpn)</description>
+		<!-- Also released by NP in 2001-02 -->
+		<!--	In lot check as "dmgavkj0.g64"	-->
+		<description>Survival Kids - Kotou no Boukensha (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKJ-JPN (RK189-J1)"/>
+		<info name="gold" value="19990423"/>
 		<info name="release" value="19990617"/>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="dmgavkj0.g64" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="survkidsjunk" cloneof="stranded">
+		<!-- Also released by NP in 2001-02 -->
+		<!-- Old dump of unknown origin -->
+		<description>Survival Kids - Kotou no Boukensha (Japan, bad dump?)</description>
+		<year>1999</year>
+		<publisher>Konami</publisher>
+		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids - kotou no boukensha (japan).bin" size="1048576" crc="19c2bd07" sha1="091afc2743425e1846cfe356cf8cb0f3c4e14ed7"/>
@@ -19988,14 +20907,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="survkid2">
-		<!-- Notes: SGB enhanced -->
-		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Jpn)</description>
+		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B2VJ-JPN (RK210-J1)"/>
+		<info name="gold" value="20000606"/>
 		<info name="release" value="20000719"/>
-		<info name="alt_title" value="サバイバルキッズ2 脱出!双子島!"/>
+		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids 2 - dasshutsu futago shima (japan).bin" size="1048576" crc="ab8b25d8" sha1="8fd720d5b035939b553910a3ec45c1bd052484eb"/>
@@ -20007,10 +20927,12 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="suzuki">
 		<!-- Notes: GBC only -->
-		<description>Suzuki Alstare Extreme Racing (Euro)</description>
+		<description>Suzuki Alstare Extreme Racing (Europe)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="??"/>
+		<info name="serial" value="CGB-AXRP-EUR?"/>
+		<info name="gold" value="19991001"/>
+		<info name="release" value="20000719"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
@@ -20020,14 +20942,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sweetang">
-		<!-- Notes: SGB enhanced -->
-		<description>Sweet Ange (Jpn)</description>
+		<description>Sweet Ange (Japan)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AUBJ-JPN"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="スウィートアンジェ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sweet ange (japan).bin" size="1048576" crc="4be9b159" sha1="5b6f268d945bcdb070195459582f01b434c01495"/>
@@ -20039,7 +20961,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="swing">
 		<!-- Notes: GBC only -->
-		<description>Swing (Ger)</description>
+		<description>Swing (Germany)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="CGB-BSWD-NOE"/>
@@ -20055,7 +20977,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="swiv">
 		<!-- Notes: GBC only -->
-		<description>SWIV (Euro)</description>
+		<description>SWIV (Europe)</description>
 		<year>2001</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BSVP-EUR"/>
@@ -20068,14 +20990,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sylvan">
-		<!-- Notes: SGB enhanced -->
-		<description>Sylvanian Families - Otogi no Kuni no Pendant (Jpn)</description>
+		<description>Sylvanian Families - Otogi no Kuni no Pendant (Japan)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ALVJ-JPN"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="シルバニアファミリー 〜おとぎの国のペンダント〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -20092,12 +21014,13 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sylvan2">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Jpn)</description>
+		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BLVJ-JPN"/>
+		<info name="gold" value="20001117"/>
 		<info name="release" value="20001222"/>
-		<info name="alt_title" value="シルバニアファミリー2 色づく森のファンタジー"/>
+		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -20110,7 +21033,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="sylvan3">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Jpn)</description>
+		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Japan)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BL3J-JPN"/>
@@ -20127,14 +21050,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sylvmel">
-		<!-- Notes: SGB enhanced -->
-		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Jpn)</description>
+		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Japan)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BMKJ-JPN"/>
 		<info name="release" value="20000317"/>
 		<info name="alt_title" value="シルバニアメロディー 森のなかまと踊りましょ!"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sylvanian melodies - mori no nakama to odori mashi (japan).bin" size="1048576" crc="6dd8ac91" sha1="55230e865958f7301076a4354b6b8b083a494bae"/>
@@ -20145,7 +21068,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="sylvestr">
-		<description>Sylvester and Tweety - Breakfast on the Run (Euro)</description>
+		<description>Sylvester and Tweety - Breakfast on the Run (Europe)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AYRP-NOE, DMG-AYRP-UKV, DMG-AYRP-EUR)"/>
@@ -20159,7 +21082,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tabaluga">
 		<!-- Notes: GBC only -->
-		<description>Tabaluga (Ger)</description>
+		<description>Tabaluga (Germany)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ALUP-NOE"/>
@@ -20172,8 +21095,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="ttshogi">
-		<!-- Notes: NP only -->
-		<description>Taisen Tsumeshougi (Jpn, NP)</description>
+		<!-- NP only -->
+		<description>Taisen Tsumeshougi (Japan, NP)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-BTSJ-JPN"/>
@@ -20188,14 +21111,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="bublboblj" cloneof="bublbobl">
-		<!-- Notes: SGB enhanced -->
-		<description>Taito Memorial - Bubble Bobble (Jpn)</description>
+		<description>Taito Memorial - Bubble Bobble (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJBJ-JPN"/>
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル バブルボブル"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - bubble bobble (japan).bin" size="1048576" crc="388c6760" sha1="6a30d328417e085dcd10588d0a5af90ff4bfa40d"/>
@@ -20204,14 +21127,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="chasehqj" cloneof="chasehq">
-		<!-- Notes: SGB enhanced -->
-		<description>Taito Memorial - Chase H.Q. - Secret Police (Jpn)</description>
+		<description>Taito Memorial - Chase H.Q. - Secret Police (Japan)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJCJ-JPN"/>
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル チェイス・エイチ・キュー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - chase h.q. - secret police (japan).bin" size="1048576" crc="6a0c272d" sha1="d6d90667ebf295016f01b4604ab03ab5b1876d00"/>
@@ -20220,14 +21143,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tophant">
-		<!-- Notes: SGB enhanced -->
-		<description>Tales of Phantasia - Narikiri Dungeon (Jpn)</description>
+		<description>Tales of Phantasia - Narikiri Dungeon (Japan)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AN6J-JPN"/>
 		<info name="release" value="20001110"/>
 		<info name="alt_title" value="テイルズオブファンタジア なりきりダンジョン"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tales of phantasia - narikiri dungeon (japan).bin" size="2097152" crc="725cf31c" sha1="ef322f4160ceebd8da67758ebd73225190af6d23"/>
@@ -20238,14 +21161,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="donqix">
-		<!-- Notes: SGB enhanced -->
-		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Jpn)</description>
+		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Japan)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BDHJ-JPN"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="谷村ひとし流パチンコ攻略大作戦 ドン・キホーテが行く"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tanimura hitoshi ryuu pachinko kouryaku daisakusen - don quijote ga iku (japan).bin" size="2097152" crc="ce8ae58c" sha1="f752e96602274a29006425a06086d8ab45e1075c"/>
@@ -20257,7 +21180,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Euro, USA)</description>
+		<description>Disney's Tarzan (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHE-USA, CGB-ATHP-UKV"/>
@@ -20271,7 +21194,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tarzanf" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Fra)</description>
+		<description>Disney's Tarzan (France)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHF-FRA"/>
@@ -20288,7 +21211,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tarzang" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Ger)</description>
+		<description>Disney's Tarzan (Germany)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHD-NOE"/>
@@ -20302,7 +21225,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tarzanj" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Jpn)</description>
+		<description>Disney's Tarzan (Japan)</description>
 		<year>2000</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-BTHJ-JPN"/>
@@ -20317,10 +21240,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="taxi2">
-		<description>Taxi 2 (Fra)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<description>Taxi 2 (France)</description>
+		<year>2000</year>
+		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BT2F-FRA"/>
+		<info name="gold" value="20000323"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20330,7 +21254,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="taxi3">
-		<description>Taxi 3 (Fra)</description>
+		<description>Taxi 3 (France)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BXIF-FRA"/>
@@ -20346,7 +21270,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tazmandv">
-		<description>Tazmanian Devil - Munching Madness (Euro)</description>
+		<description>Tazmanian Devil - Munching Madness (Europe)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AVZP-UKV"/>
@@ -20373,7 +21297,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="techdeck">
 		<!-- Notes: GBC only -->
-		<description>Tech Deck Skateboarding (Euro, USA)</description>
+		<description>Tech Deck Skateboarding (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTUE-USA, CGB-BTUP-EUR"/>
@@ -20402,7 +21326,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="td6a" cloneof="td6">
-		<description>Test Drive 6 (Euro, Sample 'Destinations Toutes Sensations')</description>
+		<description>Test Drive 6 (Europe, Sample 'Destinations Toutes Sensations')</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -20416,7 +21340,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="td6">
-		<description>Test Drive 6 (Euro)</description>
+		<description>Test Drive 6 (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AW6P-EUR"/>
@@ -20502,10 +21426,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tetrisad" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN"/>
+		<info name="gold" value="19991004"/>
 		<info name="release" value="19991112"/>
 		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20518,8 +21443,27 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="tetrisada" cloneof="mtetrisc">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbat7j1.070"	-->
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev. 1)</description>
+		<year>1999</year>
+		<publisher>Capcom</publisher>
+		<info name="serial" value="CGB-AT7J-JPN?"/>
+		<info name="gold" value="20000623"/>
+		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbat7j1.070" size="1048576" crc="b7c0831f" sha1="a8842e85f2c6de4db40b47c9640dad59ae9d1c51"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="tetrisdx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-09 -->
+		<!-- Also released by NP in 2000-09 -->
 		<description>Tetris DX (World)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -20527,6 +21471,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<info name="release" value="19981021 (JPN)"/>
 		<info name="alt_title" value="テトリスデラックス"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="tetris dx (world).bin" size="524288" crc="69989152" sha1="7183bcb54dd35f3a07d8fe63339b768f13b8168d"/>
@@ -20538,10 +21483,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tgrall2a" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>TG Rally 2 (Euro)</description>
+		<description>TG Rally 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33X-UKV"/>
+		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -20559,7 +21505,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="3lions" cloneof="goldgoal">
-		<description>Three Lions (Euro)</description>
+		<description>Three Lions (Europe)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFP-UKV"/>
@@ -20575,7 +21521,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Euro, English / French / German / Italian / Spanish)</description>
+		<description>Thunderbirds (Europe, English / French / German / Italian / Spanish)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNX-EUR"/>
@@ -20592,7 +21538,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tbirdsa" cloneof="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Euro)</description>
+		<description>Thunderbirds (Europe)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNP-UKV"/>
@@ -20605,7 +21551,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="twoods2k">
-		<description>Tiger Woods PGA Tour 2000 (Euro, USA)</description>
+		<description>Tiger Woods PGA Tour 2000 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYGE-USA, DMG-AYGP-EUR"/>
@@ -20622,7 +21568,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tintin">
 		<!-- Notes: GBC only -->
-		<description>Tintin in Tibet (Euro)</description>
+		<description>Tintin in Tibet (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin au Tibet (Box)"/>
@@ -20637,7 +21583,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ttoonbsd">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Buster Saves the Day (Euro)</description>
+		<description>Tiny Toon Adventures - Buster Saves the Day (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BUSP-EUR"/>
@@ -20665,10 +21611,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ttoondiz">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Euro)</description>
+		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Europe)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BDQP-EUR"/>
+		<info name="gold" value="20010529"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20679,7 +21626,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="titi" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Titi - Le Tour du Monde en 80 Chats (Fra)</description>
+		<description>Titi - Le Tour du Monde en 80 Chats (France)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWF-FRA"/>
@@ -20694,7 +21641,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="titus">
-		<description>Titus the Fox to Marrakech and Back (Euro)</description>
+		<description>Titus the Fox to Marrakech and Back (Europe)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-BFXP-EUR"/>
@@ -20724,6 +21671,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AFCE-USA"/>
+		<info name="gold" value="19990917"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20736,7 +21684,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="toca">
 		<!-- Notes: GBC only -->
-		<description>TOCA Touring Car Championship (Euro, USA)</description>
+		<description>TOCA Touring Car Championship (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTCE-USA, CGB-BTCP-EUR"/>
@@ -20750,7 +21698,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tokitori">
 		<!-- Notes: GBC only -->
-		<description>Toki Tori (Euro, USA)</description>
+		<description>Toki Tori (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2TE-USA, CGB-B2TP-EUR"/>
@@ -20765,14 +21713,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tokimclt">
-		<!-- Notes: SGB enhanced -->
-		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Jpn)</description>
+		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AC7J-JPN (RK172-J1)"/>
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET カルチャー編 〜木漏れ日のメロディ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - culture hen - komorebi no melody (japan).bin" size="4194304" crc="4be4a8ed" sha1="0f64c4afe74b6cfd693b6c65f0168dcb26224443"/>
@@ -20783,14 +21731,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tokimspt">
-		<!-- Notes: SGB enhanced -->
-		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Jpn)</description>
+		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AS7J-JPN (RK171-J1)"/>
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET スポーツ編 〜桜庭のフォトグラフ〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - sport hen - koutei no photograph (japan).bin" size="4194304" crc="78e14fa9" sha1="ce39fcf903bb3b0529205cab4a412bfa0e8a2ebf"/>
@@ -20801,7 +21749,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tokoro">
-		<description>Tokoro-san no Setagaya C.C. (Jpn)</description>
+		<description>Tokoro-san no Setagaya C.C. (Japan)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BGBJ-JPN"/>
@@ -20821,7 +21769,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tomjerry">
 		<!-- Notes: GBC only -->
-		<description>Tom &amp; Jerry (Euro, USA)</description>
+		<description>Tom &amp; Jerry (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-ATXE-USA, CGB-ATXP-EUR"/>
@@ -20838,14 +21786,31 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tomjermh">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry - Mousehunt (Euro)</description>
+		<description>Tom and Jerry - Mousehunt (Europe)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
+		<info name="gold" value="20000928"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="tom and jerry - mousehunt (europe) (en,fr,de,es,it).bin" size="1048576" crc="3e17d04a" sha1="6f837075d7493adcbd5b18ba1e27386b6fc31e62"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tomjermha" cloneof="tomjermh">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbtjp1.487"	-->
+		<description>Tom and Jerry - Mousehunt (Europe, Rev. 1)</description>
+		<year>2001</year>
+		<publisher>Conspiracy Entertainment</publisher>
+		<info name="serial" value="CGB-BTJP-EUR"/>
+		<info name="gold" value="20010223"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbtjp1.487" size="1048576" crc="4b4553e0" sha1="bf5faf4c5c2aabe9636f8f5afbbf526aba59e21d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20864,9 +21829,25 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="tomjermhua" cloneof="tomjermh">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbtqe1.541"	-->
+		<description>Tom and Jerry - Mousehunt (USA, Rev. 1)</description>
+		<year>2001</year>
+		<publisher>Conspiracy Entertainment</publisher>
+		<info name="serial" value="CGB-BTJE-USA?"/>
+		<info name="gold" value="20010129"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbbtqe1.541" size="2097152" crc="ce4ca7b1" sha1="89374d81045a3bedf24e42b58ce403b0a5fbcddb"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="tomjerma">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry in Mouse Attacks! (Euro)</description>
+		<description>Tom and Jerry in Mouse Attacks! (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTQP-EUR"/>
@@ -20884,6 +21865,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BTQE-USA"/>
+		<info name="gold" value="20001020"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -20894,7 +21876,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rainbow6">
 		<!-- Notes: GBC only -->
-		<description>Tom Clancy's Rainbow Six (Euro, USA)</description>
+		<description>Tom Clancy's Rainbow Six (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-AR6E-USA, CGB-AR6P-EUR"/>
@@ -20916,7 +21898,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="traid">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider (Euro, USA)</description>
+		<description>Tomb Raider (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="alt_title" value="Tomb Raider Starring Lara Croft (US Box)"/>
@@ -20938,7 +21920,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="traidp" cloneof="traid">
-		<description>Tomb Raider (Euro, USA, Prototype)</description>
+		<description>Tomb Raider (Europe, USA, Prototype)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -20953,7 +21935,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="traid2">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider - Curse of the Sword (Euro, USA)</description>
+		<description>Tomb Raider - Curse of the Sword (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="alt_title" value="Lara Croft - Tomb Raider - Curse of the Sword (Box)"/>
@@ -20976,7 +21958,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tonictr">
 		<!-- Notes: GBC only -->
-		<description>Tonic Trouble (Euro)</description>
+		<description>Tonic Trouble (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AXTP-EUR"/>
@@ -20994,6 +21976,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BCZE-USA"/>
+		<info name="gold" value="20020411"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21004,7 +21987,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tonkarac">
 		<!-- Notes: GBC only -->
-		<description>Tonka Raceway (Euro)</description>
+		<description>Tonka Raceway (Europe)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ATQP-EUR"/>
@@ -21054,10 +22037,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="thps">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTFE-USA-1, CGB-BTFP-EUR"/>
+		<info name="gold" value="20000201"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -21071,7 +22055,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="thps2">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 2 (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater 2 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTGE-USA, CGB-BTGE-USA-1, CGB-BTGP-EUR"/>
@@ -21088,7 +22072,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="thps3">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 3 (Euro, USA)</description>
+		<description>Tony Hawk's Pro Skater 3 (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3TE-USA, CGB-B3TP-EUR"/>
@@ -21124,7 +22108,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="toonsylv">
 		<!-- Notes: GBC only -->
-		<description>Toonsylvania (Euro)</description>
+		<description>Toonsylvania (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSYP-EUR"/>
@@ -21152,7 +22136,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tootuff">
 		<!-- Notes: GBC only -->
-		<description>Tootuff (Euro)</description>
+		<description>Tootuff (Europe)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BT9P-UKV"/>
@@ -21166,7 +22150,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="topgearj" cloneof="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket (Jpn)</description>
+		<description>Top Gear Pocket (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRJ-JPN"/>
@@ -21202,10 +22186,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="topgear2j" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket 2 (Jpn)</description>
+		<description>Top Gear Pocket 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-V33J-JPN"/>
+		<info name="gold" value="19991028"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="トップギア・ポケット2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -21223,8 +22208,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- Notes: GBC only -->
 		<description>Top Gear Pocket 2 (USA)</description>
 		<year>2000</year>
-		<publisher>Kemco</publisher>
+		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-A33E-USA"/>
+		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21235,9 +22221,10 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+
 	<software name="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally (Euro)</description>
+		<description>Top Gear Rally (Europe)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRP-(NOE/UKV)"/>
@@ -21252,10 +22239,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally 2 (Euro)</description>
+		<description>Top Gear Rally 2 (Europe)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33P-(EUR/FRA)"/>
+		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21268,7 +22256,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="topgunfs">
 		<!-- Notes: GBC only -->
-		<description>Top Gun - Fire Storm (Euro, USA)</description>
+		<description>Top Gun - Fire Storm (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BICE-USA, CGB-BICP-EUR"/>
@@ -21285,7 +22273,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Total Soccer 2000 (Euro)</description>
+		<description>Total Soccer 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="David O'Leary's Total Soccer 2000 (Box)"/>
@@ -21301,14 +22289,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="totsuge">
-		<!-- Notes: SGB enhanced -->
-		<description>Totsugeki! Papparatai (Jpn)</description>
+		<description>Totsugeki! Papparatai (Japan)</description>
 		<year>2000</year>
 		<publisher>J-WIng</publisher>
 		<info name="serial" value="DMG-APHJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="突撃!パッパラ隊"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="totsugeki papparatai (japan).bin" size="4194304" crc="0aeae8fb" sha1="4c98beab325cd058445102c85d30b3724325f2ce"/>
@@ -21320,7 +22308,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn, Rev. A)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -21336,7 +22324,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev a).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
+				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev 1).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -21345,7 +22333,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tottokha" cloneof="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -21364,7 +22352,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tottokh2" cloneof="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Jpn)</description>
+		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86J-JPN"/>
@@ -21382,7 +22370,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="towers">
 		<!-- Notes: GBC only -->
-		<description>Towers - Lord Baniff's Deceit (Euro, USA)</description>
+		<description>Towers - Lord Baniff's Deceit (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-ALHE-USA, CGB-ALHP-EUR"/>
@@ -21397,7 +22385,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="toystor2">
-		<description>Toy Story 2 (Euro, USA)</description>
+		<description>Toy Story 2 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AOQE-USA, DMG-AOQP-(FRA/UKV)"/>
@@ -21414,7 +22402,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Euro)</description>
+		<description>Toy Story Racer (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5X-EUU"/>
@@ -21428,7 +22416,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="toystracu" cloneof="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Euro, USA)</description>
+		<description>Toy Story Racer (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5E-USA, CGB-BT5P-EUR"/>
@@ -21443,15 +22431,37 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-	<software name="tradebat">
-		<!-- Notes: SGB enhanced -->
-		<description>Trade &amp; Battle Card Hero (Jpn)</description>
+	<software name="tradebata">
+		<!--	Never released as physical cartridge	-->
+		<!--	Released on the 3DS Virtual Console	-->
+		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
+		<description>Trade &amp; Battle Card Hero (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
+		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc3" />
+			<feature name="rtc" value="yes" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmgahhj1.1" size="2097152" crc="d98a877d" sha1="c6c1e0365166b53d25a1f84bc380948a9661df30"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tradebat" cloneof="tradebata">
+		<description>Trade &amp; Battle Card Hero (Japan)</description>
+		<year>2000</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="DMG-AHHJ-JPN"/>
+		<info name="gold" value="20000111"/>
 		<info name="release" value="20000221"/>
 		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
@@ -21464,7 +22474,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="trickbrd">
 		<!-- Notes: GBC only -->
-		<description>Trick Boarder (Euro)</description>
+		<description>Trick Boarder (Europe)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BTBP-EUR"/>
@@ -21495,7 +22505,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="trickbrdj" cloneof="trickbrd">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Trickboarder GP (Jpn)</description>
+		<description>Trickboarder GP (Japan)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BTBJ-JPN"/>
@@ -21511,7 +22521,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tplay2k1">
 		<!-- Notes: GBC only -->
-		<description>Triple Play 2001 (Euro, USA)</description>
+		<description>Triple Play 2001 (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTPE-USA, CGB-BTPP-EUR"/>
@@ -21541,14 +22551,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="tsurisn2">
-		<!-- Notes: SGB enhanced -->
-		<description>Tsuri Sensei 2 (Jpn)</description>
+		<description>Tsuri Sensei 2 (Japan)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN"/>
+		<info name="gold" value="19990624"/>
 		<info name="release" value="19990723"/>
-		<info name="alt_title" value="昆虫博士2"/>
+		<info name="alt_title" value="昆虫博士 ２"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -21559,10 +22570,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 			</dataarea>
 		</part>
 	</software>
+	
+	<software name="tsurisn2a" cloneof="tsurisn2">
+		<!--	In lot check as "dmga2kj1.g93"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Tsuri Sensei 2 (Japan, Rev. 1)</description>
+		<year>1999</year>
+		<publisher>J-Wing</publisher>
+		<info name="serial" value="DMG-AF2J-JPN?"/>
+		<info name="gold" value="19990908"/>
+		<info name="alt_title" value="昆虫博士 ２"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="dmga2kj1.g93" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
+			</dataarea>
+			<dataarea name="nvram" size="32768">
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="tsuriiko">
 		<!-- Notes: GBC only -->
-		<description>Tsuriiko!! (Jpn)</description>
+		<description>Tsuriiko!! (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BAFJ-JPN"/>
@@ -21579,7 +22610,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="turok2">
-		<description>Turok 2 - Seeds of Evil (Euro, USA)</description>
+		<description>Turok 2 - Seeds of Evil (Europe, USA)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-A2TE-USA, DMG-A2TP-EUR"/>
@@ -21595,7 +22626,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="turok2j" cloneof="turok2">
-		<description>Turok 2 - Seeds of Evil (Jpn)</description>
+		<description>Turok 2 - Seeds of Evil (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-A2TJ-JPN"/>
@@ -21611,7 +22642,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="turok3">
 		<!-- Notes: GBC only -->
-		<description>Turok 3 - Shadow of Oblivion (Euro, USA)</description>
+		<description>Turok 3 - Shadow of Oblivion (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BT3E-USA, CGB-BT3P-EUR"/>
@@ -21628,7 +22659,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="turokrag">
 		<!-- Notes: GBC only -->
-		<description>Turok - Rage Wars (Euro, Aus, USA)</description>
+		<!--	Retail cartridge of Australian version not yet secured, does it exist?	-->
+		<description>Turok - Rage Wars (Europe, Australia, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AR7E-USA, CGB-AR7P-(EUR/AUS)"/>
@@ -21645,7 +22677,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Euro, English / German / Spanish / Italian)</description>
+		<description>Tweenies - Doodles' Bones (Europe, English / German / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZP-UKV"/>
@@ -21659,7 +22691,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tweeniesds" cloneof="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Euro, English / Dutch / Swedish / Norwegian / Danish)</description>
+		<description>Tweenies - Doodles' Bones (Europe, English / Dutch / Swedish / Norwegian / Danish)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZX-HOL"/>
@@ -21676,7 +22708,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tweetyj" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Jpn)</description>
+		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Japan)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWJ-JPN"/>
@@ -21694,7 +22726,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Euro, English / Spanish / Italian)</description>
+		<description>Tweety's High-Flying Adventure (Europe, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWY-EUU-1"/>
@@ -21716,7 +22748,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="tweetya" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Euro, English / French / German)</description>
+		<description>Tweety's High-Flying Adventure (Europe, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWX-UKV-1"/>
@@ -21784,7 +22816,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="rpgtsuk2">
 		<!-- Notes: GBC only -->
-		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Jpn)</description>
+		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Japan)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-B3QJ-JPN"/>
@@ -21802,7 +22834,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="uefa2k">
 		<!-- Notes: GBC only -->
-		<description>UEFA 2000 (Euro)</description>
+		<description>UEFA 2000 (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BUEP-(EUR/NOE/FRA/UKV)"/>
@@ -21818,7 +22850,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ufc">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Fighting Championship (Euro)</description>
+		<description>Ultimate Fighting Championship (Europe)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUCP-EUR-1"/>
@@ -21849,7 +22881,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ultpaint">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Paint Ball (Euro, USA)</description>
+		<description>Ultimate Paint Ball (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BUPE-USA, CGB-BUPP-EUR"/>
@@ -21863,7 +22895,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="ultsurf">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Surfing (Euro)</description>
+		<description>Ultimate Surfing (Europe)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BSUP-EUR"/>
@@ -21893,7 +22925,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="uno">
-		<description>Uno (Euro)</description>
+		<description>Uno (Europe)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AUNP-EUR"/>
@@ -21920,7 +22952,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Euro)</description>
+		<description>V-Rally - Championship Edition (Europe)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AVYP-NOE"/>
@@ -21934,7 +22966,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="vrallyj" cloneof="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Jpn)</description>
+		<description>V-Rally - Championship Edition (Japan)</description>
 		<year>1999</year>
 		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-AVJJ-JPN"/>
@@ -21965,10 +22997,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="vegas">
 		<!-- Notes: GBC only -->
-		<description>Vegas Games (Euro)</description>
+		<description>Vegas Games (Europe)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFP-EUR"/>
+		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21983,6 +23016,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFE-USA"/>
+		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22014,7 +23048,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<!-- The US box of V.I.P usually contains the european cart. This was also shown on a youtube unboxing video with a sealed copy. Therefore the dump is labeled USA + Europe.
 		But recently it was discovered some boxes also contain a real US shaped cart (see vipu below). -->
 		<!-- Notes: GBC only -->
-		<description>VIP (Euro, USA)</description>
+		<description>VIP (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BVIE-USA, CGB-BVIP-EUR"/>
@@ -22044,7 +23078,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="visiteur">
-		<description>Les Visiteurs (Fra)</description>
+		<description>Les Visiteurs (France)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AVGF-FRA"/>
@@ -22056,12 +23090,30 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+	<software name="vrspower">
+		<!-- Notes: GBC only -->
+		<!--	In lot check as "cgbbpbe0.340"	-->
+		<!--	Retail cartridge not yet secured, might be unreleased	-->
+		<description>VR Sports Powerboat Racing (USA)</description>
+		<year>2000</year>
+		<publisher>Vatical Entertainment</publisher>
+		<info name="serial" value="CGB-BPBE-USA?"/>
+		<info name="gold" value="20000727"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="1048576">
+				<rom name="cgbbpbe0.340" size="1048576" crc="cff671f1" sha1="1c77f032cdd373bfa108ea82c463f8f9f6874c71"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="vslemmin" cloneof="lemmings">
 		<!-- Notes: GBC only -->
-		<description>VS Lemmings (Jpn)</description>
+		<description>VS Lemmings (Japan)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-ALEJ-JPN"/>
+		<info name="gold" value="20000225"/>
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="VSレミングス"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22076,7 +23128,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Wacky Races (Euro)</description>
+		<description>Wacky Races (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AW9P-(NOE/UKV)"/>
@@ -22104,7 +23156,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Euro, USA)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDE-USA, CGB-BWDP-UKV"/>
@@ -22121,7 +23173,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="magraceta" cloneof="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Euro)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Europe)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDX-EUR"/>
@@ -22138,7 +23190,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="warauinu">
 		<!-- Notes: GBC only -->
-		<description>Warau Inu no Bouken - Silly Go Lucky! (Jpn)</description>
+		<description>Warau Inu no Bouken - Silly Go Lucky! (Japan)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BWBJ-JPN"/>
@@ -22161,14 +23213,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wario2j" cloneof="wario2">
-		<!-- Notes: SGB enhanced -->
-		<description>Wario Land 2 (Jpn)</description>
+		<description>Wario Land 2 (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AW2J-JPN"/>
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="ワリオランド2ワリオランド2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="wario land 2 (japan).bin" size="2097152" crc="b30fdbf5" sha1="cd6266e48df816219fb38d223b0ec6760259616d"/>
@@ -22204,7 +23256,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wario2">
 		<!-- Notes: GBC only -->
-		<description>Wario Land II (Euro, USA)</description>
+		<description>Wario Land II (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWLE-USA, DMG-AWLP-EUR"/>
@@ -22258,7 +23310,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Jpn, Rev. A)</description>
+		<description>Watashi no Kitchen (Japan, Rev. 1)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -22267,7 +23319,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="watashi no kitchen (japan) (rev a).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
+				<rom name="watashi no kitchen (japan) (rev 1).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -22276,7 +23328,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="watashika" cloneof="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Jpn)</description>
+		<description>Watashi no Kitchen (Japan)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -22300,10 +23352,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="watashir">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Restaurant (Jpn)</description>
+		<description>Watashi no Restaurant (Japan)</description>
 		<year>2002</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BWNJ-JPN"/>
+		<info name="gold" value="20020322"/>
 		<info name="release" value="20020426"/>
 		<info name="alt_title" value="わたしのレストラン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22318,7 +23371,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wcwmayhm">
 		<!-- Notes: GBC only -->
-		<description>WCW Mayhem (Euro, USA)</description>
+		<description>WCW Mayhem (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AYHE-USA, CGB-AYHP-NOE"/>
@@ -22335,7 +23388,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wendy">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Every Witch Way (Euro, USA)</description>
+		<description>Wendy - Every Witch Way (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWGE-USA, CGB-BWGP-EUR"/>
@@ -22352,10 +23405,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wendydta">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Der Traum von Arizona (Ger)</description>
+		<description>Wendy - Der Traum von Arizona (Germany)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWYD-NOE"/>
+		<info name="gold" value="20021120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -22366,7 +23420,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wetrix">
 		<!-- Notes: GBC only -->
-		<description>Wetrix GB (Euro)</description>
+		<description>Wetrix GB (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Wetrix (Box)"/>
@@ -22380,14 +23434,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wetrixj" cloneof="wetrix">
-		<!-- Notes: SGB enhanced -->
-		<description>Wetrix GB (Jpn)</description>
+		<description>Wetrix GB (Japan)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AW5J-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ウエットリスGB"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="wetrix gb (japan).bin" size="1048576" crc="6215c5b3" sha1="92944052b6e4448abf0103f085998662e0140825"/>
@@ -22424,7 +23478,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wingfury">
-		<description>Wings of Fury (Euro)</description>
+		<description>Wings of Fury (Europe)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-AFXP-EUR"/>
@@ -22451,7 +23505,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Euro)</description>
+		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Europe)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BPOP-EUR-1"/>
@@ -22483,7 +23537,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Jpn, Rev. A)</description>
+		<description>Wizardry Empire (Japan, Rev. 1)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -22492,7 +23546,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="wizardry empire (japan) (rev a).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
+				<rom name="wizardry empire (japan) (rev 1).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -22501,7 +23555,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizardema" cloneof="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Jpn)</description>
+		<description>Wizardry Empire (Japan)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -22519,7 +23573,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizarde2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire - Fukkatsu no Tsue (Jpn)</description>
+		<description>Wizardry Empire - Fukkatsu no Tsue (Japan)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-BFTJ-JPN"/>
@@ -22537,7 +23591,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizardry">
 		<!-- Notes: GBC only -->
-		<description>Wizardry I - Proving Grounds of the Mad Overlord (Jpn)</description>
+		<description>Wizardry I - Proving Grounds of the Mad Overlord (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BWIJ-JPN"/>
@@ -22555,7 +23609,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizardr2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry II - Llylgamyn no Isan (Jpn)</description>
+		<description>Wizardry II - Llylgamyn no Isan (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW2J-JPN"/>
@@ -22573,7 +23627,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wizardr3">
 		<!-- Notes: GBC only -->
-		<description>Wizardry III - Diamond no Kishi (Jpn)</description>
+		<description>Wizardry III - Diamond no Kishi (Japan)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW3J-JPN"/>
@@ -22591,7 +23645,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="woody">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker (Euro)</description>
+		<description>Woody Woodpecker (Europe)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BWPP-EUR"/>
@@ -22619,7 +23673,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker Racing (Euro)</description>
+		<description>Woody Woodpecker Racing (Europe)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRP-EUR"/>
@@ -22641,7 +23695,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="woodyracj" cloneof="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker no Go! Go! Racing (Jpn)</description>
+		<description>Woody Woodpecker no Go! Go! Racing (Japan)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRJ-JPN (RK225-J1)"/>
@@ -22689,7 +23743,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wsoccr2k" cloneof="iss2k">
 		<!-- Notes: GBC only -->
-		<description>World Soccer GB 2000 (Jpn)</description>
+		<description>World Soccer GB 2000 (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSJ-JPN (RK200-J1)"/>
@@ -22706,14 +23760,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wsoccer2" cloneof="iss99">
-		<!-- Notes: SGB enhanced -->
-		<description>World Soccer GB2 (Jpn)</description>
+		<description>World Soccer GB2 (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZJ-JPN (RK176-J1)"/>
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ワールドサッカーGB2"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="world soccer gb2 (japan).bin" size="1048576" crc="dd18db5f" sha1="b58c969510aab4930a1846d857f58d57ed342592"/>
@@ -22725,7 +23779,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wormsarm">
 		<!-- Notes: GBC only -->
-		<description>Worms Armageddon (Euro)</description>
+		<description>Worms Armageddon (Europe)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AWUP-(UKV/NOE)"/>
@@ -22756,7 +23810,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wwfattit">
 		<!-- Notes: GBC only -->
-		<description>WWF Attitude (Euro, USA)</description>
+		<description>WWF Attitude (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AWTE-USA, CGB-AWTP-EUR"/>
@@ -22773,7 +23827,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wwfbtray">
 		<!-- Notes: GBC only -->
-		<description>WWF Betrayal (Euro, USA)</description>
+		<description>WWF Betrayal (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BWFE-USA, CGB-BWFP-EUR"/>
@@ -22789,7 +23843,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="wmania2k">
-		<description>WWF WrestleMania 2000 (Euro, USA)</description>
+		<description>WWF WrestleMania 2000 (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AUWE-USA, DMG-AUWP-EUR"/>
@@ -22806,7 +23860,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Euro, USA, Rev. A)</description>
+		<description>X-Men - Mutant Academy (Europe, USA, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-NOE"/>
@@ -22823,7 +23877,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xmenma1" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Euro, USA)</description>
+		<description>X-Men - Mutant Academy (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-UKV"/>
@@ -22840,7 +23894,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xmenmaj" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Jpn)</description>
+		<description>X-Men - Mutant Academy (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BXAJ-JPN"/>
@@ -22856,7 +23910,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xmenmw">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Wars (Euro, USA)</description>
+		<description>X-Men - Mutant Wars (Europe, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXME-USA, CGB-BXMP-EUR"/>
@@ -22873,7 +23927,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="wolvrage">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Wolverine's Rage (Euro)</description>
+		<description>X-Men - Wolverine's Rage (Europe)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWOP-EUR"/>
@@ -22904,7 +23958,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xena">
 		<!-- Notes: GBC only -->
-		<description>Xena - Warrior Princess (Euro, USA)</description>
+		<description>Xena - Warrior Princess (Europe, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BXWE-USA, CGB-BXWP-EUR"/>
@@ -22936,10 +23990,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="xtremew">
 		<!-- Notes: GBC only -->
-		<description>Xtreme Wheels (Euro)</description>
+		<description>Xtreme Wheels (Europe)</description>
 		<year>2001</year>
-		<publisher>BAM! Entertainment</publisher>
+		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-BXCP-EUR"/>
+		<info name="gold" value="20000922"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22956,6 +24011,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BXCE-USA"/>
+		<info name="gold" value="20010307"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22968,7 +24024,29 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yakouchu">
 		<!-- Notes: GBC only -->
-		<description>Yakouchuu GB (Jpn)</description>
+		<!--	In lot check as "cgbaytj0.066"	-->
+		<!--	Retail cartridge not yet secured	-->
+		<description>Yakouchuu GB (Japan)</description>
+		<year>1999</year>
+		<publisher>Athena</publisher>
+		<info name="serial" value="CGB-AYTJ-JPN"/>
+		<info name="gold" value="19990924"/>
+		<info name="release" value="19991022"/>
+		<info name="alt_title" value="夜光虫GB"/>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
+			<dataarea name="rom" size="2097152">
+				<rom name="cgbaytj0.066" size="2097152" crc="e0a06018" sha1="a7efd41d0ad17892132788bd90cdfb9df6806a78"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="yakouchuunk" cloneof="yakouchu">
+		<!-- Notes: GBC only -->
+		<!-- Old dump of unknown origin -->
+		<description>Yakouchuu GB (Japan, bad dump?)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
@@ -22984,8 +24062,9 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
+
 	<software name="yarsrev">
-		<description>Yars' Revenge (Euro, USA)</description>
+		<description>Yars' Revenge (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="DMG-AYVE-USA, DMG-AYVP-EUR"/>
@@ -22998,7 +24077,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="yodastor">
-		<description>Yoda Stories (Euro, USA)</description>
+		<description>Yoda Stories (Europe, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYDE-USA, DMG-AYDP-EUR"/>
@@ -23026,10 +24105,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Dark Duel Stories (Euro)</description>
+		<description>Yu-Gi-Oh! - Dark Duel Stories (Europe)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3P-EUR"/>
+		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -23048,10 +24128,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugiddsf" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duel des Tenebres (Fra)</description>
+		<description>Yu-Gi-Oh! - Duel des Tenebres (France)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3F-FRA-1"/>
+		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23070,10 +24151,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugiddsg" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Das Dunkle Duell (Ger)</description>
+		<description>Yu-Gi-Oh! - Das Dunkle Duell (Germany)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3D-NOE"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23092,10 +24174,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugiddsi" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Racconti Oscuri (Ita)</description>
+		<description>Yu-Gi-Oh! - Racconti Oscuri (Italia)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3I-ITA"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23114,10 +24197,11 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugiddss" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spa)</description>
+		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spain)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3S-ESP"/>
+		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -23140,6 +24224,8 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3E-USA"/>
+		<info name="gold" value="20011217"/>
+		<info name="alt_title" value="Yu-Gi-Oh! Duel Monsters: Dark Duel Stories"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -23151,14 +24237,16 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="yugimcap">
-		<!-- Notes: SGB enhanced, also released by NP in 2001-02-01 -->
-		<description>Yu-Gi-Oh! - Monster Capsule GB (Jpn)</description>
+		<!-- Also released by NP in 2001-02-01 -->
+		<description>Yu-Gi-Oh! - Monster Capsule GB (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYCJ-JPN (RK206-J1)"/>
+		<info name="gold" value="20000217"/>
 		<info name="release" value="20000413"/>
-		<info name="alt_title" value="遊戯王 モンスターカプセルGB"/>
+		<info name="alt_title" value="遊戯王 モンスターカプセル ＧＢ"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="yu-gi-oh - monster capsule gb (japan).bin" size="1048576" crc="1371e872" sha1="4ed5607dd83ebe7975c492b08d36870f8dd6e302"/>
@@ -23170,7 +24258,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugidm4j">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY6J-JPN (RK228-J1)"/>
@@ -23194,7 +24282,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugidm4k">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY5J-JPN (RK229-J1)"/>
@@ -23212,7 +24300,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugidm4y">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY4J-JPN (RK227-J1)"/>
@@ -23235,14 +24323,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="yugidm2">
-		<!-- Notes: SGB enhanced -->
-		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Japan)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYKJ-JPN (RK188-J1)"/>
 		<info name="release" value="19990708"/>
 		<info name="alt_title" value="遊戯王デュエルモンスターズII 闇界決闘記"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -23259,7 +24347,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="yugidm3" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Jpn)</description>
+		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Japan)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3J-JPN (RK211-J1)"/>
@@ -23302,7 +24390,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldadai">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Jpn)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7J-JPN"/>
@@ -23320,7 +24408,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zeldajik">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Jpn)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Japan)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8J-JPN"/>
@@ -23337,14 +24425,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. B)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 2)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -23361,17 +24450,18 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. A)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 1)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev a).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
+				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev 1).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -23379,14 +24469,15 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zeldaldxjb" cloneof="zeldaldx">
-		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn)</description>
+		<!-- Also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="zelda no densetsu - yume o miru shima dx (japan).bin" size="1048576" crc="d974abea" sha1="b810925bf9d9f4f6cd97c5e46c94c1a9dd61a113"/>
@@ -23398,7 +24489,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="znsst">
 		<!-- Notes: GBC only -->
-		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Jpn)</description>
+		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Japan)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BJFJ-JPN"/>
@@ -23416,7 +24507,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zidane">
 		<!-- Notes: GBC only -->
-		<description>Zidane Football Generation (Euro)</description>
+		<description>Zidane Football Generation (Europe)</description>
 		<year>2002</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BZSP-EUR"/>
@@ -23445,17 +24536,17 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zoidsjas">
-		<!-- Notes: SGB enhanced -->
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. A)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan, Rev. 1)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev a).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
+				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev 1).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -23463,14 +24554,14 @@ Unreleased (music source code exists, possibly no prototypes exist)
 	</software>
 
 	<software name="zoidsjasa" cloneof="zoidsjas">
-		<!-- Notes: SGB enhanced -->
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn)</description>
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="zoids - jashin fukkatsu genobreaker hen (japan).bin" size="2097152" crc="f36c874d" sha1="4ddb1d66d909d453374bd195a4a7dbe328ed41be"/>
@@ -23482,7 +24573,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 
 	<software name="zoidsshi">
 		<!-- Notes: GBC only -->
-		<description>Zoids - Shirogane no Juukishin Liger Zero (Jpn)</description>
+		<description>Zoids - Shirogane no Juukishin Liger Zero (Japan)</description>
 		<year>2001</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BZ2J-JPN"/>
@@ -23511,7 +24602,7 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		    It has a Fujitsu MB89135L (undumped), four leds, a speaker and an IR emitter.
 		    It connects with the Game Boy using the console IR, but just one way (device to console).
 		    The peripheral device is named "Furu Changer". -->
-		<description>Zok Zok Heroes (Jpn)</description>
+		<description>Zok Zok Heroes (Japan)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BZHJ-JPN"/>
@@ -23533,21 +24624,19 @@ Unreleased (music source code exists, possibly no prototypes exist)
 		</part>
 	</software>
 
-
-
 <!--
-List of pirate cartridges
+	List of pirate cartridges
 -->
 
 <!--
-Rocket Games
+	Rocket Games
 
-These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
+	These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Euro)</description>
+		<description>ATV Racing &amp; Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23563,7 +24652,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="atvrackja" cloneof="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Euro, Alt)</description>
+		<description>ATV Racing &amp; Karate Joe (Europe, Alt)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23578,7 +24667,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="atvracin">
-		<description>ATV Racing (Euro)</description>
+		<description>ATV Racing (Europe)</description>
 		<year>2001</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23594,7 +24683,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="fullhang" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Full Time Soccer &amp; Hang Time Basketball (Euro)</description>
+		<description>Full Time Soccer &amp; Hang Time Basketball (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23609,7 +24698,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="fulltime">
-		<description>Full Time Soccer (Euro)</description>
+		<description>Full Time Soccer (Europe)</description>
 		<year>2000</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23625,7 +24714,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="hangtime">
 		<!-- Notes: GBC only -->
-		<description>Hang Time Basketball (Euro)</description>
+		<description>Hang Time Basketball (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23641,7 +24730,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="pocksmrt" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out &amp; Race Time (Euro)</description>
+		<description>Pocket Smash Out &amp; Race Time (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23655,7 +24744,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="pocksm" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out (Euro)</description>
+		<description>Pocket Smash Out (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23671,7 +24760,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="karatej" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Karate Joe (Euro)</description>
+		<description>Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23684,7 +24773,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="painter">
-		<description>Painter (Euro)</description>
+		<description>Painter (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23698,7 +24787,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="racetime">
 		<!-- Notes: GBC only -->
-		<description>Race Time (Euro)</description>
+		<description>Race Time (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23712,7 +24801,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="sinkj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Karate Joe (Euro)</description>
+		<description>Space Invasion &amp; Karate Joe (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23728,7 +24817,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="sinpntr" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Painter (Euro)</description>
+		<description>Space Invasion &amp; Painter (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23744,7 +24833,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="sinvasn" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion (Euro)</description>
+		<description>Space Invasion (Europe)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -23762,7 +24851,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 <!-- Sachen games -->
 
 	<software name="beastfgt">
-		<description>Beast Fighter (Tw)</description>
+		<description>Beast Fighter (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-001"/>
@@ -23775,7 +24864,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="beastfgth" cloneof="beastfgt">
-		<description>Beast Fighter (Tw, Hacked?)</description>
+		<description>Beast Fighter (Taiwan, Hacked?)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="EB-001?"/>
@@ -23814,8 +24903,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 
-	<!-- also data from ThunderBlast Man -->
 	<software name="jboy2a" cloneof="jboy2">
+	<!-- also data from ThunderBlast Man -->
 		<description>Jurassic Boy II</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
@@ -23828,7 +24917,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="rocmanx" supported="no">
-		<description>Rocman-X (Tw)</description>
+		<description>Rocman-X (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -23840,7 +24929,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shero" supported="no">
-		<description>Street Hero (Tw)</description>
+		<description>Street Hero (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-004" />
@@ -23853,7 +24942,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="thundbmna" cloneof="thundbmn" supported="no">
-		<description>Thunder Blast Man (Euro)</description>
+		<description>Thunder Blast Man (Europe)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="SA-114" />
@@ -23866,7 +24955,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mc_8in1">
-		<description>8 in 1 (Tw)</description>
+		<description>8 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="??"/>
@@ -23930,7 +25019,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mc_6in1">
-		<description>Super 6 in 1 (Tw)</description>
+		<description>Super 6 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="6B-001" />
@@ -23943,7 +25032,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mc_16in1">
-		<description>Super 16 in 1 (Tw)</description>
+		<description>Super 16 in 1 (Taiwan)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -23955,7 +25044,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mc_31t" cloneof="mc_31" supported="no">
-		<description>31 in 1 Mighty Mix (Tw)</description>
+		<description>31 in 1 Mighty Mix (Taiwan)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -23967,7 +25056,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mc_31" supported="no">
-		<description>31-in-1 Mighty Mix (Aus)</description>
+		<description>31-in-1 Mighty Mix (Australia)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -23987,9 +25076,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 -->
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="leinujs" supported="no">
-		<description>Lei Nu Ji Shen (Tw)</description>
+	<!-- This version should be the real dump, protected as the original cart -->
+		<description>Lei Nu Ji Shen (Taiwan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24004,10 +25093,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="leinujsh" cloneof="leinujs">
-		<description>Lei Nu Ji Shen (Tw, Hacked)</description>
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+		 the real card, so it can be removed once we properly emulate the parent -->
+		<description>Lei Nu Ji Shen (Taiwan, Hacked)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24023,7 +25112,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="magicmnk">
-		<description>Magic Monkey (Tw)</description>
+		<description>Magic Monkey (Taiwan)</description>
 		<year>200?</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24036,7 +25125,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="binmnst3">
-		<description>Binary Monster III (Tw)</description>
+		<description>Binary Monster III (Taiwan)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24049,7 +25138,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="amaznrob">
-		<description>Amazing Robot (Tw)</description>
+		<description>Amazing Robot (Taiwan)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24062,7 +25151,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="magiclmpjp" cloneof="magiclmp" supported="no">
-		<description>Magic Lamp (Jpn)</description>
+		<description>Magic Lamp (Japan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24075,7 +25164,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="magiclmp" supported="no">
-		<description>Magic Lamp (US)</description>
+		<description>Magic Lamp (USA)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24088,7 +25177,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="binmnst2" supported="no">
-		<description>Binary Monster 2 - Adventure of Hell(TW)</description>
+		<description>Binary Monster 2 - Adventure of Hell (Taiwan)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -24135,7 +25224,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="emochndx" supported="partial">
-		<description>Emo Cheng DX (Chi)</description>
+		<description>Emo Cheng DX (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24149,7 +25238,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shuihusslc" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (Chi, Li Cheng)</description>
+		<description>Shui Hu Shen Shou (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA010"/>
@@ -24165,7 +25254,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbl3lc" cloneof="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi, Li Cheng)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA011"/>
@@ -24181,7 +25270,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="digid3">
-		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (Chi)</description>
+		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA012"/>
@@ -24197,7 +25286,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="emochen2">
-		<description>Emo Cheng 2 - Fengyun Pian (Chi)</description>
+		<description>Emo Cheng 2 - Fengyun Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA033"/>
@@ -24212,9 +25301,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- AKA Digimon D-4 published by SKOB -->
 	<software name="mingzhu2">
-		<description>Ming Zhu Kou Dai Guai Shou II (Chi)</description>
+	<!-- AKA Digimon D-4 published by SKOB -->
+		<description>Ming Zhu Kou Dai Guai Shou II (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA060"/>
@@ -24230,7 +25319,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="taikonzs">
-		<description>Taikong Zhan Shi - Jing Dian Ban (Chi)</description>
+		<description>Taikong Zhan Shi - Jing Dian Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA063"/>
@@ -24246,7 +25335,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="gangdanw">
-		<description>Gang Dan Wu Yu II (Chi)</description>
+		<description>Gang Dan Wu Yu II (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA064"/>
@@ -24262,7 +25351,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mingzhu3">
-		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (Chi)</description>
+		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA065"/>
@@ -24278,7 +25367,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shuihujd">
-		<description>Shui Hu Zhuan - Jing Dian Ban (Chi)</description>
+		<description>Shui Hu Zhuan - Jing Dian Ban (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA073"/>
@@ -24294,7 +25383,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="yingxj2">
-		<description>Ying Xiong Jian 2 (Chi)</description>
+		<description>Ying Xiong Jian 2 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA075"/>
@@ -24310,7 +25399,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="xiyouji">
-		<description>Xi You Ji (Chi)</description>
+		<description>Xi You Ji (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA076"/>
@@ -24324,7 +25413,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbldnp">
-		<description>Shu Ma Bao Long - Dian Nao Pian (Chi)</description>
+		<description>Shu Ma Bao Long - Dian Nao Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA078"/>
@@ -24340,7 +25429,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="yxtx">
-		<description>Ying Xiong Tian Xia (Chi)</description>
+		<description>Ying Xiong Tian Xia (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA079"/>
@@ -24354,7 +25443,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sanguowd">
-		<description>San Guo Zhi Wu Dai (Chi)</description>
+		<description>San Guo Zhi Wu Dai (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA080"/>
@@ -24370,7 +25459,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="taikonglc" cloneof="firmbaby">
-		<description>Tai Kong Bao Bei (Chi, Li Cheng)</description>
+		<description>Tai Kong Bao Bei (China, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA083"/>
@@ -24386,7 +25475,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbbhjbt">
-		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (Chi)</description>
+		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA085"/>
@@ -24402,7 +25491,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbbcmm">
-		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (Chi)</description>
+		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA086"/>
@@ -24418,7 +25507,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbbhzs">
-		<description>Shu Ma Bao Bei - Hai Zhi Shen (Chi)</description>
+		<description>Shu Ma Bao Bei - Hai Zhi Shen (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA087"/>
@@ -24434,7 +25523,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mojie3">
-		<description>Mo Jie 3 - Bu Wanme De Shijie (Chi)</description>
+		<description>Mo Jie 3 - Bu Wanme De Shijie (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA089"/>
@@ -24450,7 +25539,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="xinshdyx">
-		<description>Xin Shediao Ying Xiong Chuan (Chi)</description>
+		<description>Xin Shediao Ying Xiong Chuan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng / Sintax</publisher>
 		<info name="serial" value="CBA090"/>
@@ -24465,9 +25554,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
 	<software name="lkrdx6">
-		<description>Luo Ke Ren DX6 (Chi)</description>
+	<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
+		<description>Luo Ke Ren DX6 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA091"/>
@@ -24483,7 +25572,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="xinguam2">
-		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (Chi)</description>
+		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA095"/>
@@ -24499,7 +25588,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbbdx6">
-		<description>Shu Ma Bao Bei - DX6 (Chi)</description>
+		<description>Shu Ma Bao Bei - DX6 (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA097"/>
@@ -24515,8 +25604,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="teshu2k1" cloneof="mslug2k1">
-		<!-- probably developed by BDD -->
-		<description>Teshu Budui 2001 (Chi, Li Cheng)</description>
+	<!-- probably developed by BDD -->
+		<description>Teshu Budui 2001 (China, Li Cheng)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA100"/>
@@ -24532,7 +25621,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="taikond3">
-		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (Chi)</description>
+		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA145"/>
@@ -24547,9 +25636,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
 	<software name="terr911">
-		<description>Teshu Budui 2 - Jidi (Chi)</description>
+	<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
+		<description>Teshu Budui 2 - Jidi (China)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA146"/>
@@ -24565,7 +25654,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shimianm">
-		<description>Shi Mian Maifu - Feng Yun Pian (Chi)</description>
+		<description>Shi Mian Maifu - Feng Yun Pian (China)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA147"/>
@@ -24609,8 +25698,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="hpotter">
-		<!-- probably developed by BDD -->
-		<description>Harry Potter (Chi)</description>
+	<!-- probably developed by BDD -->
+		<description>Harry Potter (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24624,7 +25713,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="iceage">
-		<description>Ice Age (Chi)</description>
+		<description>Ice Age (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24638,7 +25727,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="iceage2a" cloneof="iceage2">
-		<description>Ice Age II (Chi)</description>
+		<description>Ice Age II (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24653,7 +25742,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="zhwsj">
-		<description>Zuizhong Huanxiang - Wujin Sha Jia (Chi)</description>
+		<description>Zuizhong Huanxiang - Wujin Sha Jia (China)</description>
 		<year>2002?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="最終幻想 無盡沙加 (Final Fantasy Endless Saga), Crystal Age (Official English Name by Sintax)"/>
@@ -24668,7 +25757,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="zzqb">
-		<description>Zhong Zhuan Qi Bing (Chi)</description>
+		<description>Zhong Zhuan Qi Bing (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="重裝機兵 , Metal Max (Official English Name by Sintax)"/>
@@ -24685,8 +25774,22 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 <!-- Other Asian Pirate dumps to sort -->
 
+	<software name="188in1" supported="partial">
+	<!--	This dump comes from the "GBCK003" board that's soldered inside some GB Boy Colour units	-->
+		<description>Color GameBoy 188 in 1 (Hong Kong)</description>
+		<year>199?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gameboy_cart">
+			<feature name="pcb" value="GBCK003" />
+			<feature name="slot" value="rom_188in1" />
+			<dataarea name="rom" size="8388608">
+				<rom name="m29w640ft.u2" size="8388608" crc="e4068d7d" sha1="e61ee50ed39fd5b5cc8bdcb96fe1c3cccdcfc76f" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="digicrs2" cloneof="pokesaph">
-		<description>Digimon Crystal II (Chi)</description>
+		<description>Digimon Crystal II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24700,7 +25803,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="laofuzi">
-		<description>Lao Fuzi Chuanqi (Chi)</description>
+		<description>Lao Fuzi Chuanqi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="老夫子傳奇"/>
@@ -24715,7 +25818,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="yuenanzx">
-		<description>Yuenan Zhanyi X - Shenru Dihou (Chi)</description>
+		<description>Yuenan Zhanyi X - Shenru Dihou (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役X-深入敵後"/>
@@ -24730,7 +25833,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="dballadv">
-		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (Chi)</description>
+		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="七龍珠Z3"/>
@@ -24744,9 +25847,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- World WarCraft? -->
 	<software name="moshosj">
-		<description>Mo Shou Shi Ji - Zhan Shen (Chi)</description>
+	<!-- World WarCraft? -->
+		<description>Mo Shou Shi Ji - Zhan Shen (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="魔獸世紀-戰神"/>
@@ -24761,7 +25864,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="fengzg2">
-		<description>Feng Zhi Gou II (Chi)</description>
+		<description>Feng Zhi Gou II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="风之谷II"/>
@@ -24776,7 +25879,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="digigdb">
-		<description>2003 Shu Ma Bao Long - Ge Dou Ban (Chi)</description>
+		<description>2003 Shu Ma Bao Long - Ge Dou Ban (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003数码暴龙 格斗版"/>
@@ -24791,7 +25894,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="lkrx5">
-		<description>Luo Ke Ren X5 (Chi)</description>
+		<description>Luo Ke Ren X5 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="洛克人X5, 络克英雄EXE5 ~ Luo Ke Ying Xiong EXE5 (Cart)"/>
@@ -24806,7 +25909,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="crash2c" cloneof="crash2">
-		<description>2003 Gu Huo Lang II - The Huge Adventure (Chi)</description>
+		<description>2003 Gu Huo Lang II - The Huge Adventure (China)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 古惑狼II (Cart)"/>
@@ -24821,7 +25924,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="iceage2">
-		<description>Bing Yuan Li Xian Ji II (Chi)</description>
+		<description>Bing Yuan Li Xian Ji II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="冰原歷險記II"/>
@@ -24835,9 +25938,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Pokemon Platinum? -->
 	<software name="pokeplat">
-		<description>Kou Dai Yao Guai - Bai Jin Ban (Chi)</description>
+	<!-- Pokemon Platinum? -->
+		<description>Kou Dai Yao Guai - Bai Jin Ban (China)</description>
 		<year>2005</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋妖怪-白金版"/>
@@ -24851,9 +25954,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Metal Slug 3? -->
 	<software name="ynzy3">
-		<description>Yue Nan Zhan Yi 3 (Chi)</description>
+	<!-- Metal Slug 3? -->
+		<description>Yue Nan Zhan Yi 3 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役3"/>
@@ -24867,9 +25970,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- TODO: study the menu and writes of this cart! -->
 	<software name="m_digi10" supported="no">
-		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (Chi)</description>
+	<!-- TODO: study the menu and writes of this cart! -->
+		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (China)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="數碼暴龍專集 10 in 1"/>
@@ -24881,9 +25984,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This got ripped by m_digi10 -->
 	<software name="digid3h" cloneof="digid3">
-		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (Chi, Ripped from 10 in 1 multicart)</description>
+	<!-- This got ripped by m_digi10 -->
+		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (China, Ripped from 10 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="超進化 數碼寶貝D-3"/>
@@ -24898,7 +26001,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="fkdfw">
-		<description>Feng Kuang Da Fu Weng (Chi, Ripped from multicart)</description>
+		<description>Feng Kuang Da Fu Weng (China, Ripped from multicart)</description>
 		<year>200?</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="疯狂大富翁"/>
@@ -24913,7 +26016,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="onimush2">
-		<description>Gui Wu Zhe 2 (Chi)</description>
+		<description>Gui Wu Zhe 2 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="鬼武者2"/>
@@ -24927,10 +26030,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
-<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
 	<software name="hjtaiyou">
-		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (Chi)</description>
+	<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
+	<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
+		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="篇外章 黃金太陽-封印的遠古煉金術 ~ Pian Wai Zhang Huang Jin Tai Yang - Feng Yin De Yuan Gu Lian Jin Shu"/>
@@ -24944,9 +26047,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
 	<software name="dquest8">
-		<description>Yong Zhe Dou E Long VIII (Chi)</description>
+	<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
+		<description>Yong Zhe Dou E Long VIII (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="勇者鬥惡龍VIII"/>
@@ -24961,7 +26064,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mgear2">
-		<description>He Jin Zhuang Bei II (Chi)</description>
+		<description>He Jin Zhuang Bei II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="合金裝備II"/>
@@ -24976,7 +26079,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shaolin">
-		<description>Fantasic ShaoLin Kungfu (Chi)</description>
+		<description>Fantasic ShaoLin Kungfu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Shaoling Legend - Hero, the saver (Cart)"/>
@@ -24991,7 +26094,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shaolinc" cloneof="shaolin">
-		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (Chi)</description>
+		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="少林十三棍-英雄救主"/>
@@ -25006,7 +26109,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="digiyjad">
-		<description>Digimon Yellow Jade (Chi)</description>
+		<description>Digimon Yellow Jade (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25020,7 +26123,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="hpottr2c">
-		<description>Xiao Shi Mi Shi (Chi)</description>
+		<description>Xiao Shi Mi Shi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003哈利波特2-消失的密室 ~ 2003 Harry Potter 2 - Xiao Shi De Mi Shi"/>
@@ -25035,7 +26138,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="hpotter4" cloneof="hpottr2c">
-		<description>Harry Xiao Zi IV (Chi)</description>
+		<description>Harry Xiao Zi IV (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子IV, 2003哈利小子IV ~ 2003 Ha Li Xiao Zi IV (Cart)"/>
@@ -25050,7 +26153,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="emodao">
-		<description>E Mo Dao (Chi, Ripped from 8 in 1 multicart)</description>
+		<description>E Mo Dao (China, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>Vast Fame</publisher>
 		<info name="alt_title" value="惡魔島"/>
@@ -25065,7 +26168,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="qtdsheng" cloneof="xiyouji">
-		<description>Qi Tian Da Sheng - Sun Wu Kong (Chi, Ripped from 8 in 1 multicart)</description>
+		<description>Qi Tian Da Sheng - Sun Wu Kong (China, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="齊天大聖 - 孫悟空"/>
@@ -25078,7 +26181,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sswy">
-		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="聖獸物語 - 神龍傳說"/>
@@ -25094,7 +26197,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="pokeruby">
 	<!-- 4MB rom with crc 4a68fd38 is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Ruby (Chi)</description>
+		<description>Pocket Monster Ruby (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Pocket Monster Carbuncle (Cart)"/>
@@ -25110,7 +26213,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="pokesaph">
 	<!-- 4MB rom with crc 81d1e6ff is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Saphire (Chi)</description>
+		<description>Pocket Monster Saphire (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Pokémon - Sapphire Version (Cart)"/>
@@ -25124,10 +26227,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<software name="pokesaphc" cloneof="pokesaph">
+	<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<!-- 4MB rom with crc 3a08c8eb is taizou's cracked version running on base MBC5 -->
-		<description>Kou Dai Guai Shou - Lan Bao Shi (Chi)</description>
+		<description>Kou Dai Guai Shou - Lan Bao Shi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋怪獸 - 藍寶石, 2003 口袋怪獸-藍寶石 (Cart)"/>
@@ -25143,7 +26246,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="shuiji2" cloneof="pokesaph">
 	<!-- 4MB rom with crc 5f2472ad is taizou's cracked version running on base MBC5 -->
-		<description>Shu Ma Bao Long - Shui Jing Ban II (Chi)</description>
+		<description>Shu Ma Bao Long - Shui Jing Ban II (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="數碼暴龍 - 水晶版II"/>
@@ -25159,7 +26262,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="firmbaby">
 	<!-- 4MB rom with crc 66539153 is taizou's cracked version running on base MBC5 -->
-		<description>The Firmament Baby (Chi)</description>
+		<description>The Firmament Baby (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Space Baby (Cart)"/>
@@ -25175,7 +26278,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="taikong" cloneof="firmbaby">
 	<!-- 4MB rom with crc 5b49af92 is taizou's cracked version running on base MBC5 -->
-		<description>Tai Kong Bao Bei (Chi, Sintax)</description>
+		<description>Tai Kong Bao Bei (China, Sintax)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="太空寶貝"/>
@@ -25191,7 +26294,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="taichi">
 	<!-- 4MB rom with crc fab140ab is taizou's cracked version running on base MBC5 -->
-		<description>Xiao Taichi - Shen Hua Li Xian (Chi)</description>
+		<description>Xiao Taichi - Shen Hua Li Xian (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="小太极 - 神话历险"/>
@@ -25207,7 +26310,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="crash2">
 	<!-- 4MB rom with crc 0af243bf is taizou's cracked version running on base MBC5 -->
-		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (Chi)</description>
+		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Crash II Advance (Cart)"/>
@@ -25223,7 +26326,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="bwarr5" cloneof="dballadv">
 	<!-- 4MB rom with crc 9d332731 is taizou's cracked version running on base MBC5 -->
-		<description>Bynasty Warriors Advance 5 (Chi)</description>
+		<description>Bynasty Warriors Advance 5 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="叁國無雙5 ~ San Guo Wu Shang 5 (Cart)"/>
@@ -25239,7 +26342,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="cjjqx">
 	<!-- 4MB rom with crc 378b182d is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -25255,7 +26358,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="cjjqx1" cloneof="cjjqx">
 	<!-- 4MB rom with crc 0cea6b33 is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi, Alt)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (China, Alt)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -25271,7 +26374,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="jinglw3">
 	<!-- rom with crc 15a4b4ec is taizou's cracked version running on base MBC5 -->
-		<description>Jing Ling Wang III (Chi)</description>
+		<description>Jing Ling Wang III (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="精靈王III"/>
@@ -25287,7 +26390,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="qbtx">
 	<!-- rom with crc 5bcf90fa is taizou's cracked version running on base MBC5 -->
-		<description>Quan Ba Tian Xia (Chi)</description>
+		<description>Quan Ba Tian Xia (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="拳霸天下"/>
@@ -25303,7 +26406,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="zhihuanw">
 	<!-- 4MB rom with crc 49e77dd9 is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Huan Wang - Shou Bu Qu (Chi)</description>
+		<description>Zhi Huan Wang - Shou Bu Qu (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="指环王 - 首部曲"/>
@@ -25319,7 +26422,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="xqdz2">
 	<!-- 4MB rom with crc e8fd000f is taizou's cracked version running on base MBC5 -->
-		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (Chi)</description>
+		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="星球大战2 - 克隆人战役"/>
@@ -25335,7 +26438,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="mishidem">
 	<!-- 4MB rom with crc 88a86ff4 is taizou's cracked version running on base MBC5 -->
-		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (Chi)</description>
+		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子第二部 - 密室的秘"/>
@@ -25351,7 +26454,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="hzqibing">
 	<!-- 4MB rom with crc bb78f17e is taizou's cracked version running on base MBC5 -->
-		<description>Hai Zhan Qi Bing (Chi)</description>
+		<description>Hai Zhan Qi Bing (China)</description>
 		<year>200?</year>
 		<publisher>Jump Technology ~ Sintax</publisher>
 		<info name="alt_title" value="海戰奇兵"/>
@@ -25367,7 +26470,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="3gokum2">
 	<!-- 4MB rom with crc 8de5f8d5 is taizou's cracked version running on base MBC5 -->
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -25382,7 +26485,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="3gokum2a" cloneof="3gokum2">
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi, Pirate)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China, Pirate)</description>
 		<year>200?</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -25397,7 +26500,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="spiderm3">
-		<description>Spider-Man 3 (Chi)</description>
+		<description>Spider-Man 3 (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Movie Version Spider-Man 3 (Cart)"/>
@@ -25413,7 +26516,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="chuanshu" cloneof="spiderm3">
 	<!-- Same game as spiderm3 but alt sprite (still uses spider-man in status bar!) -->
-		<description>Chuan Shuo (Chi)</description>
+		<description>Chuan Shuo (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="傳說"/>
@@ -25429,7 +26532,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="zzx3" cloneof="spiderm3">
 	<!-- 4MB rom with crc 66442e7d is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Zhu Xia III (Chi)</description>
+		<description>Zhi Zhu Xia III (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="蜘蛛侠3-电影版 ~ Zhi Zhu Xia 3 - Dian Ying Ban (Spider-Man 3 Movie Version)"/>
@@ -25444,7 +26547,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="xfsb">
-		<description>Xin Feng Shen Bang (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Xin Feng Shen Bang (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="新封神榜"/>
@@ -25460,7 +26563,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="digisaph">
 	<!-- 4MB rom with crc 88da70ac is taizou's cracked version running on base MBC5 -->
-		<description>2003 Digitmon Sapphire (Chi)</description>
+		<description>2003 Digitmon Sapphire (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="2003 Digimom Sapphii (Cart)"/>
@@ -25475,7 +26578,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="數碼暴龍3-水晶版"/>
@@ -25490,7 +26593,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smbl9">
-		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (Chi)</description>
+		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="CK019-1"/>
@@ -25505,14 +26608,14 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<software name="chongwu">
+	<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<!-- at 0x1e0 starts a routine which (at 0x1ec) reads from $41c3, then compares
 	     the value with 0x5d. if comparison fails, the code enters a routine at 0x780
 	     where it gets stuck. if comparison works, then the code goes to 0x150 as the
 	     patched version does (because the single modified byte replaces the jump to
 	     0x1e0 with the jump to 0x150). Not sure yet if current workaround is correct... -->
-		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (Chi)</description>
+		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="宠物小精灵 结金塔之王"/>
@@ -25527,7 +26630,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="jyqxc2">
-		<description>Jin Yong Qun Xia Chuan II (Chi)</description>
+		<description>Jin Yong Qun Xia Chuan II (China)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="金庸群侠传II"/>
@@ -25542,7 +26645,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="soulfalc">
-		<description>Soul Falchion - Ge Dou Jian Shen (Chi)</description>
+		<description>Soul Falchion - Ge Dou Jian Shen (China)</description>
 		<year>2002</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="格鬥劍神"/>
@@ -25557,7 +26660,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="capf2k3" cloneof="soulfalc">
-		<description>Capcom Fight 2003 (Chi)</description>
+		<description>Capcom Fight 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25571,7 +26674,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="heroswrd">
-		<description>Heroic Sword (Chi)</description>
+		<description>Heroic Sword (China)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="英雄剑"/>
@@ -25586,7 +26689,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25600,7 +26703,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="crzyric2a" cloneof="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi, Alt)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25614,7 +26717,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="ffantx">
-		<description>Final Fantasy X: Fantasy War (Chi)</description>
+		<description>Final Fantasy X: Fantasy War (China)</description>
 		<year>20??</year>
 		<publisher>SKOB ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25627,9 +26730,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of the undumped 'Zook Hero 2' -->
 	<software name="rockmnx3">
-		<description>Rockman X3 (Chi)</description>
+	<!-- This is a title hack of the undumped 'Zook Hero 2' -->
+		<description>Rockman X3 (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -25644,7 +26747,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="rockmnx3a" cloneof="rockmnx3">
-		<description>Rockman X3 (Chi, Alt)</description>
+		<description>Rockman X3 (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -25658,9 +26761,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of the undumped 'Super Fighter S' -->
 	<software name="sf99">
-		<description>Super Fighters '99 (Chi)</description>
+	<!-- This is a title hack of the undumped 'Super Fighter S' -->
+		<description>Super Fighters '99 (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25672,7 +26775,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="garou">
-		<description>Garou - Mark of the Wolves (Chi)</description>
+		<description>Garou - Mark of the Wolves (China)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25686,7 +26789,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="garou2k3" cloneof="garou">
-		<description>Garou 2003 - Mark of the Wolfs (Chi)</description>
+		<description>Garou 2003 - Mark of the Wolfs (China)</description>
 		<year>2003?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25700,7 +26803,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="fighthot">
-		<description>E' Fighter HOT (Chi)</description>
+		<description>E' Fighter HOT (China)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25713,9 +26816,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped Dragon Ball fighting game -->
 	<software name="dbf2005">
-		<description>Dragonball Fight 2005 (Chi)</description>
+	<!-- This is a title hack of an undumped Dragon Ball fighting game -->
+		<description>Dragonball Fight 2005 (China)</description>
 		<year>2005?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25740,9 +26843,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
 	<software name="hpotter3c" cloneof="hpotter2">
-		<description>Harry Potter 3 2003 (Chi)</description>
+	<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
+		<description>Harry Potter 3 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>V.Fame?</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25756,7 +26859,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="skxs">
-		<description>Shi Kong Xing Shou (Chi, Ripped from 12 in 1 multicart)</description>
+		<description>Shi Kong Xing Shou (China, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="時空星獸"/>
@@ -25771,7 +26874,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shjmlwc">
-		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (Chi)</description>
+		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (China)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<info name="alt_title" value="聖火降魔錄外傳 - 光與暗的輪迴, 聖火降魔錄 (Box)"/>
@@ -25786,7 +26889,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="xgmyha" cloneof="shjmlwc">
-		<description>Xin Guang Ming Yu Hei An (Chi)</description>
+		<description>Xin Guang Ming Yu Hei An (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="新光明与黑暗"/>
@@ -25801,8 +26904,8 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="mszb3" cloneof="shjmlwc">
-		<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
-		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (Chi)</description>
+	<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
+		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25816,7 +26919,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shuihuss">
-		<description>Shui Hu Shen Shou (Chi)</description>
+		<description>Shui Hu Shen Shou (China)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -25831,7 +26934,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="shuihussa" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (Chi, Alt)</description>
+		<description>Shui Hu Shen Shou (China, Alt)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -25845,9 +26948,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- Title hack of the above, with VF logo removed -->
 	<software name="shuihuz" cloneof="shuihuss">
-		<description>Shui Hu Zhuan (Chi)</description>
+	<!-- Title hack of the above, with VF logo removed -->
+		<description>Shui Hu Zhuan (China)</description>
 		<year>2002</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="水滸傳"/>
@@ -25861,9 +26964,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
 	<software name="kof2003">
-		<description>Ge Dou Zhi Zun 2003 (Chi)</description>
+	<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
+		<description>Ge Dou Zhi Zun 2003 (China)</description>
 		<year>2003?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="格斗至尊2003"/>
@@ -25878,7 +26981,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (Chi)</description>
+		<description>Super Robot Taisen Final Vol.1 (China)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25893,7 +26996,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="srobotf1a" cloneof="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (Chi, Alt)</description>
+		<description>Super Robot Taisen Final Vol.1 (China, Alt)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25908,7 +27011,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (China)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -25923,7 +27026,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sanguoasa" cloneof="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -25937,9 +27040,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
 	<software name="sanguoasb" cloneof="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt Bad?)</description>
+	<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
+		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt Bad?)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -25953,12 +27056,12 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
 	<software name="cbzz">
-		<!-- Alt. Title: 吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs) -->
-		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (Chi)</description>
+	<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
+		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -25970,10 +27073,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smmftu">
-		<!-- Alt. Title: 十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter) -->
-		<description>Shi Mian Mai Fu - Tu Long Pian (Chi)</description>
+		<description>Shi Mian Mai Fu - Tu Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -25985,10 +27088,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="smmftian">
-		<!-- Alt. Title: 十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter) -->
-		<description>Shi Mian Mai Fu - Tian Long Pian (Chi)</description>
+		<description>Shi Mian Mai Fu - Tian Long Pian (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -26000,7 +27103,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="unk01" supported="no">
-		<description>Unknown RPG - Digimon? Zelda? (Chi, Encrypted?)</description>
+		<description>Unknown RPG - Digimon? Zelda? (China, Encrypted?)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26014,7 +27117,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="pokedmnda" cloneof="telefngp">
-		<description>Pocket Monsters Diamond (Chi)</description>
+		<description>Pocket Monsters Diamond (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26029,7 +27132,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="pokedmnd" cloneof="telefngp">
-		<description>Pokémon Diamond (Chi)</description>
+		<description>Pokémon Diamond (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26044,10 +27147,10 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="yxcs" supported="no">
-		<description>Ying Xiong Chuan Shuo (Chi)</description>
+		<description>Ying Xiong Chuan Shuo (China)</description>
 		<year>20??</year>
 		<publisher>Waixing</publisher>
-		<info name="alt_title" value="英雄传说 (Legend of Heroes) "/>
+		<info name="alt_title" value="英雄传说 (Legend of Heroes)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_digimon" />
 			<dataarea name="rom" size="1048576">
@@ -26059,11 +27162,11 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="sqsd">
-		<!-- Alt. Title: 石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King) -->
-		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (Chi)</description>
+		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (China)</description>
 		<year>20??</year>
 		<publisher>GOWIN</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
+		<info name="alt_title" value="石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_yong" />
 			<dataarea name="rom" size="4194304">
@@ -26075,7 +27178,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="dquest4">
-		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (Chi)</description>
+		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="勇者斗恶龙4"/>
@@ -26089,11 +27192,11 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-	<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
-	(apparently it got sent to US by a Vietnamese guy back in the 2000)
-	it can be seen on youtube. -->
 	<software name="pokecrysb" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
+		<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
+		(apparently it got sent to US by a Vietnamese guy back in the 2000)
+		it can be seen on youtube. -->
 		<description>Pocket Monsters - Crystal Version (Bootleg)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -26108,9 +27211,9 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-	<!-- Notes: GBC only -->
 	<software name="pikangtm" cloneof="smurfnig">
-		<description>The Pikachu Nightmare (Chi)</description>
+		<!-- Notes: GBC only -->
+		<description>The Pikachu Nightmare (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26122,7 +27225,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="pokegogo" cloneof="smurfnig">
-		<description>Pocket Monsters GO!GO! GO!! (Chi)</description>
+		<description>Pocket Monsters GO!GO! GO!! (China)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26136,7 +27239,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 <!-- These are basically the same game as Sonic 3D Blast 5, always by Yong Yong (see gameboy.xml) -->
 	<software name="sonicad7">
 		<!-- Alt. Title: Sonic 7, Sonic Adventure 7 -->
-		<description>Sonic Adventure (Chi)</description>
+		<description>Sonic Adventure (China)</description>
 		<year>1999</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26148,7 +27251,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="pokeadv">
-		<description>Pokémon Adventure (Chi)</description>
+		<description>Pokémon Adventure (China)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26160,7 +27263,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 	</software>
 
 	<software name="dkong5">
-		<description>Donkey Kong 5 (Chi, Bad?)</description>
+		<description>Donkey Kong 5 (China, Bad?)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26173,7 +27276,7 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 
 	<software name="dkong5ts">
 	<!-- 4MB rom with crc f27a687e is taizou's cracked version running on base MBC5 -->
-		<description>Donkey Kong 5 - The Journey of Over Time and Space (Chi)</description>
+		<description>Donkey Kong 5 - The Journey of Over Time and Space (China)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26186,17 +27289,17 @@ These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 		</part>
 	</software>
 
-<!--
-There are various dumps of this:
-2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
-256KB version (CRC 791f8c86) which contains the first half of the rom used here
-
-taizou dumped the game also from a multicart and got a 1MB dump containing the rom
-used here repeated twice. we need to redump the standalone cart to confirm the size
-but the 256KB version is definitely underdumped and misses sprite data
--->
 	<software name="sm3sp" supported="no">
-		<description>Super Mario 3 Special (Chi)</description>
+	<!--
+	There are various dumps of this:
+	2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
+	256KB version (CRC 791f8c86) which contains the first half of the rom used here
+
+	taizou dumped the game also from a multicart and got a 1MB dump containing the rom
+	used here repeated twice. we need to redump the standalone cart to confirm the size
+	but the 256KB version is definitely underdumped and misses sprite data
+	-->
+		<description>Super Mario 3 Special (China)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26207,9 +27310,9 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn2" supported="no">
-		<description>Digimon 2 (Chi)</description>
+	<!-- This version should be the real dump, protected as the original cart -->
+		<description>Digimon 2 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26222,10 +27325,10 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="digimn2h" cloneof="digimn2">
-		<description>Digimon 2 (Chi, Hacked)</description>
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+     the real card, so it can be removed once we properly emulate the parent -->
+		<description>Digimon 2 (China, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26239,7 +27342,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 	<software name="digimn3c">
-		<description>Digimon 3 Crystal (Chi)</description>
+		<description>Digimon 3 Crystal (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26252,9 +27355,9 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn4" supported="no">
-		<description>Digimon 02 4 (Chi)</description>
+	<!-- This version should be the real dump, protected as the original cart -->
+		<description>Digimon 02 4 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26267,10 +27370,10 @@ but the 256KB version is definitely underdumped and misses sprite data
 		</part>
 	</software>
 
-<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="digimn4h" cloneof="digimn4">
-		<description>Digimon 02 4 (Chi, Hacked)</description>
+	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+     the real card, so it can be removed once we properly emulate the parent -->
+		<description>Digimon 02 4 (China, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26284,7 +27387,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 	<software name="digijade" cloneof="digimn4">
-		<description>Digimon 02 Jade (Chi)</description>
+		<description>Digimon 02 Jade (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26298,7 +27401,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 	<software name="digimn5">
-		<description>Digimon 02 5 (Chi)</description>
+		<description>Digimon 02 5 (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26312,7 +27415,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 	<software name="digimn5c" cloneof="digimn5">
-		<description>Digimon 02 5 Crystal (Chi)</description>
+		<description>Digimon 02 5 Crystal (China)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26329,7 +27432,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 <!-- Once sorted out what is good and what not, the entry should be moved among the Sintax games above! -->
 	<software name="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi)</description>
+		<description>Metal Slug 2001 (China)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26344,7 +27447,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 
 	<software name="mslug2k1a" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi, Alt 1)</description>
+		<description>Metal Slug 2001 (China, Alt 1)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26359,7 +27462,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 
 	<software name="mslug2k1b" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (Chi, Alt 2)</description>
+		<description>Metal Slug 2001 (China, Alt 2)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26373,7 +27476,7 @@ but the 256KB version is definitely underdumped and misses sprite data
 	</software>
 
 <!--
-List of unclassified roms
+	List of unclassified roms
 -->
 
 
@@ -26381,10 +27484,11 @@ List of unclassified roms
 
 	<software name="ar" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Action Replay Online BIOS (Euro)</description>
+		<description>Action Replay Online BIOS (Europe)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="131072">
 				<rom name="action replay online bios (europe) (unl).bin" size="131072" crc="04c8c858" sha1="fa441c5e376b54b3503596fe8177b3a9ad79a9a8"/>
 			</dataarea>
@@ -26397,10 +27501,10 @@ List of unclassified roms
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
+			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="81920">
 				<rom name="gameshark online bios (usa) (unl).bin" size="81920" crc="c37d21d9" sha1="22f00e604acb827a48d4c9e109ba622f59a9d0a9"/>
 			</dataarea>
 		</part>
 	</software>
-
 </softwarelist>

--- a/hash/gbcolor.xml
+++ b/hash/gbcolor.xml
@@ -3,39 +3,20 @@
 <!--
 license:CC0
 
-  To investigate:
-	- Check for duplicates in lot check folders and cross-check with official spreadsheets, to look for additional regional releases with shared ROM contents.
+To investigate:
+  - Shanghai Pocket by Sunsoft: are serial and release date correct or do they refer to the GB version?
 
-  Undumped:
-	- San Francisco Rush 2049 (Europe, fr/de/nl) [small pic]
-	
-  Known dumps not yet verified against retail cartridge:
-	- Alice in Wonderland (Europe)
-	- AMF Bowling (USA)
-	- Donkey Kong Country (USA, Not for resale)
-	- Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)	<- What is this version?
-	- Gakkyuu Ou Yamazaki (Japan)
-	- Jissen ni Yakudatsu Tsumego (Japan)
-	- Laura (Europe)
-	- Mission Impossible (Europe, Rev. 1)
-	- Monster Traveler (Japan)
-	- NBA In the Zone (USA)
-	- Pro Pool (USA)
-	- Sei Hai Densetsu (Japan)
-	- Super Mario Bros. Deluxe (USA, Rev. 2)	<- Was it released?
-	- Tsuri Sensei 2 (Japan, Rev. 1)
-	- Turok - Rage Wars (Australia)
-	- VR Sports Powerboat Racing (USA)
-	- Yakouchuu GB (Japan)
+Undumped:
+- San Francisco Rush 2049 (Euro, fr/de/nl) [small pic]
 
-  Undumped GBC protos:
-	- Jet Force Gemini
+Undumped GBC protos:
+  - Jet Force Gemini
 
-  Unreleased (music source code exists, possibly no prototypes exist)
-	- Crimson
-	- Hard Truck
-	- Katharsis
-	- Hero's Quest
+Unreleased (music source code exists, possibly no prototypes exist)
+- Crimson
+- Hard Truck
+- Katharsis
+- Hero's Quest
 
 
  Info on the PCB codes, based on Tauwasser's notes and research
@@ -68,7 +49,7 @@ license:CC0
 
 	<software name="007twine">
 		<!-- Notes: GBC only -->
-		<description>007 - The World Is Not Enough (Europe, USA)</description>
+		<description>007 - The World Is Not Enough (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BO7E-USA, CGB-BO7P-EUR"/>
@@ -85,7 +66,7 @@ license:CC0
 
 	<software name="10pinb">
 		<!-- Notes: GBC only -->
-		<description>10-Pin Bowling (Europe)</description>
+		<description>10-Pin Bowling (Euro)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-AXPP-UKV"/>
@@ -121,7 +102,7 @@ license:CC0
 
 	<software name="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Europe, USA)</description>
+		<description>Disney's 102 Dalmatians - Puppies to the Rescue (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99E-USA, CGB-B99P-UKV"/>
@@ -138,7 +119,7 @@ license:CC0
 
 	<software name="102dalmaf" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's Les 102 Dalmatiens à la Rescousse (France)</description>
+		<description>Disney's Les 102 Dalmatiens à la Rescousse (Fra)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99F-FRA"/>
@@ -152,7 +133,7 @@ license:CC0
 
 	<software name="102dalmag" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>Disney's 102 Dalmatiner (Germany)</description>
+		<description>Disney's 102 Dalmatiner (Ger)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99D-NOE"/>
@@ -166,7 +147,7 @@ license:CC0
 
 	<software name="102dalmas" cloneof="102dalma">
 		<!-- Notes: GBC only -->
-		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spain)</description>
+		<description>102 Dálmatas de Disney: Cachorros al Rescate (Spa)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B99S-ESP"/>
@@ -183,7 +164,7 @@ license:CC0
 
 	<software name="1942">
 		<!-- Notes: GBC only -->
-		<description>1942 (Europe, USA)</description>
+		<description>1942 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AQ4E-USA, CGB-AQ4P-???"/>
@@ -221,11 +202,10 @@ license:CC0
 
 	<software name="3dpool">
 		<!-- Notes: GBC only -->
-		<description>3D Pocket Pool (Europe)</description>
+		<description>3D Pocket Pool (Euro)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BVPP-EUR"/>
-		<info name="gold" value="20010215"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -235,7 +215,7 @@ license:CC0
 	</software>
 
 	<software name="4x4world">
-		<description>4x4 World Trophy (Europe)</description>
+		<description>4x4 World Trophy (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AQ3P-EUR"/>
@@ -250,7 +230,7 @@ license:CC0
 	</software>
 
 	<software name="720">
-		<description>720° (Europe, USA)</description>
+		<description>720° (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AA7E-USA, DMG-AA7P-EUR"/>
@@ -267,7 +247,7 @@ license:CC0
 
 	<software name="actionmn">
 		<!-- Notes: GBC only -->
-		<description>Action Man - Search for Base X (Europe, USA)</description>
+		<description>Action Man - Search for Base X (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAXE-USA, CGB-BAXP-EUR"/>
@@ -280,7 +260,7 @@ license:CC0
 	</software>
 
 	<software name="elmo">
-		<description>The Adventures of Elmo in Grouchland (Europe)</description>
+		<description>The Adventures of Elmo in Grouchland (Euro)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AELP-EUR"/>
@@ -310,7 +290,7 @@ license:CC0
 
 	<software name="smurfs">
 		<!-- Notes: GBC only -->
-		<description>The Adventures of the Smurfs (Europe)</description>
+		<description>The Adventures of the Smurfs (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSFP-FRA"/>
@@ -325,7 +305,7 @@ license:CC0
 	</software>
 
 	<software name="tintinpr">
-		<description>The Adventures of Tintin - Prisoners of the Sun (Europe)</description>
+		<description>The Adventures of Tintin - Prisoners of the Sun (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin - Prisoners of the Sun (Box?), Tintin - Le Temple du Soleil (French Box)"/>
@@ -340,7 +320,7 @@ license:CC0
 
 	<software name="airforcdj" cloneof="deadlysk">
 		<!-- Notes: GBC only -->
-		<description>AirForce Delta (Japan)</description>
+		<description>AirForce Delta (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLJ-JPN (RK223-J1)"/>
@@ -370,7 +350,7 @@ license:CC0
 
 	<software name="aladdin">
 		<!-- Notes: GBC only -->
-		<description>Disney's Aladdin (Europe)</description>
+		<description>Disney's Aladdin (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BADP-EUR"/>
@@ -401,7 +381,7 @@ license:CC0
 
 	<software name="alfred">
 		<!-- Notes: GBC only -->
-		<description>Alfred's Adventure (Europe)</description>
+		<description>Alfred's Adventure (Euro)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BAAP-EUR"/>
@@ -415,7 +395,7 @@ license:CC0
 
 	<software name="alice">
 		<!-- Notes: GBC only -->
-		<description>Alice in Wonderland (Europe)</description>
+		<description>Alice in Wonderland (Euro)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AIWP-EUR"/>
@@ -431,11 +411,10 @@ license:CC0
 
 	<software name="aliceu" cloneof="alice">
 		<!-- Notes: GBC only -->
-		<!--	Retail cartridge of European version not yet secured	-->
-		<description>Alice in Wonderland (Europe, USA)</description>
+		<description>Alice in Wonderland (USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
-		<info name="serial" value="CGB-AIWP-EUR, CGB-AIWE-USA"/>
+		<info name="serial" value="CGB-AIWE-USA"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -448,7 +427,7 @@ license:CC0
 
 	<software name="aliens">
 		<!-- Notes: GBC only -->
-		<description>Aliens - Thanatos Encounter (Europe, USA)</description>
+		<description>Aliens - Thanatos Encounter (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAEE-USA, CGB-BAEP-EUR"/>
@@ -464,11 +443,10 @@ license:CC0
 	</software>
 
 	<software name="astenn2k">
-		<description>All Star Tennis 2000 (Europe)</description>
+		<description>All Star Tennis 2000 (Euro)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AZTP-EUR"/>
-		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -487,7 +465,7 @@ license:CC0
 
 	<software name="asbase2k">
 		<!-- Notes: GBC only -->
-		<description>All-Star Baseball 2000 (Europe, USA)</description>
+		<description>All-Star Baseball 2000 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AATE-USA, CGB-AATP-EUR"/>
@@ -515,7 +493,7 @@ license:CC0
 
 	<software name="aitdnn">
 		<!-- Notes: GBC only -->
-		<description>Alone in the Dark - The New Nightmare (Europe)</description>
+		<description>Alone in the Dark - The New Nightmare (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BIDP-UKV"/>
@@ -545,33 +523,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="amfbowli">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbafpe0.339"	-->
-		<!--	Retail cartridge not yet secured, might be unreleased	-->
-		<description>AMF Bowling (USA)</description>
-		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
-		<info name="serial" value="CGB-AFPE-USA?"/>
-		<info name="gold" value="20000727"/>
-		<info name="alt_title" value="AMF Xtreme Bowling"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbafpe0.339" size="1048576" crc="392559ee" sha1="1dd7d94f320d119682fd4df80297c8df1b28141b"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="animalb3">
-		<description>Animal Breeder 3 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Animal Breeder 3 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AA3J-JPN"/>
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="あにまるぶりーだー3"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="animal breeder 3 (japan).bin" size="4194304" crc="c62a4c30" sha1="f5e6e770a681bb6eba255e2584f9ed343e5d9f98"/>
@@ -583,7 +543,7 @@ license:CC0
 
 	<software name="animalb4">
 		<!-- Notes: GBC only -->
-		<description>Animal Breeder 4 (Japan)</description>
+		<description>Animal Breeder 4 (Jpn)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A4AJ-JPN"/>
@@ -601,7 +561,7 @@ license:CC0
 
 	<software name="animasta">
 		<!-- Notes: GBC only -->
-		<description>Animastar GB (Japan)</description>
+		<description>Animastar GB (Jpn)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BNMJ-JPN"/>
@@ -619,7 +579,7 @@ license:CC0
 
 	<software name="animorph">
 		<!-- Notes: GBC only -->
-		<description>Animorphs (Europe)</description>
+		<description>Animorphs (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BAMP-EUR"/>
@@ -647,7 +607,7 @@ license:CC0
 
 	<software name="anpfiff" cloneof="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Anpfiff - Der RTL Fussball-Manager (Germany)</description>
+		<description>Anpfiff - Der RTL Fussball-Manager (Ger)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBD-NOE"/>
@@ -668,7 +628,7 @@ license:CC0
 	</software>
 
 	<software name="antz">
-		<description>Antz (Europe)</description>
+		<description>Antz (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ANXP-EUR"/>
@@ -698,7 +658,7 @@ license:CC0
 
 	<software name="antzracn">
 		<!-- Notes: GBC only -->
-		<description>Antz Racing (Europe)</description>
+		<description>Antz Racing (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BAZP-UKV"/>
@@ -732,7 +692,7 @@ license:CC0
 
 	<software name="antzsprt">
 		<!-- Notes: GBC only -->
-		<description>Antz World Sportz (Europe)</description>
+		<description>Antz World Sportz (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BA7P-EUR"/>
@@ -745,14 +705,14 @@ license:CC0
 	</software>
 
 	<software name="aqualife">
-		<description>Aqualife (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Aqualife (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AALJ-JPN"/>
 		<info name="release" value="19991022"/>
 		<info name="alt_title" value="アクアライフ"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="aqualife (japan).bin" size="1048576" crc="e243feb4" sha1="69eaf53eccdaf98cd7cc0d436209f511b558d761"/>
@@ -763,7 +723,7 @@ license:CC0
 	</software>
 
 	<software name="arcadejd">
-		<description>Arcade Hits - Joust &amp; Defender (Europe, USA)</description>
+		<description>Arcade Hits - Joust &amp; Defender (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-AADE-USA, DMG-AADP-EUR"/>
@@ -776,7 +736,7 @@ license:CC0
 	</software>
 
 	<software name="arcadems">
-		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Europe, USA)</description>
+		<description>Arcade Hits - Moon Patrol &amp; Spy Hunter (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ADUE-USA, DMG-ADUP-???"/>
@@ -789,14 +749,14 @@ license:CC0
 	</software>
 
 	<software name="arle">
-		<description>Arle no Bouken - Mahou no Jewel (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Arle no Bouken - Mahou no Jewel (Jpn)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-BRBJ-JPN"/>
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="アルルの冒険 まほうのジュエル"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="arle no bouken - mahou no jewel (japan).bin" size="1048576" crc="8ee043ea" sha1="fb781637ddac30cebb1865ba939f49bb2b0b5146"/>
@@ -824,7 +784,7 @@ license:CC0
 
 	<software name="armorine">
 		<!-- Notes: GBC only -->
-		<description>Armorines - Project S.W.A.R.M. (Europe, USA)</description>
+		<description>Armorines - Project S.W.A.R.M. (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AOXE-USA, CGB-AOXP-EUR"/>
@@ -841,7 +801,7 @@ license:CC0
 
 	<software name="armymen">
 		<!-- Notes: GBC only -->
-		<description>Army Men (Europe, USA)</description>
+		<description>Army Men (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVCE-USA, CGB-AVCP-(NOE/UKV)"/>
@@ -858,7 +818,7 @@ license:CC0
 
 	<software name="armymen2">
 		<!-- Notes: GBC only -->
-		<description>Army Men 2 (Europe, USA)</description>
+		<description>Army Men 2 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BA2E-USA, CGB-BA2P-EUR"/>
@@ -875,7 +835,7 @@ license:CC0
 
 	<software name="amenairc">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Air Combat (Europe, USA)</description>
+		<description>Army Men - Air Combat (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BATE-USA, CGB-BATP-EUR"/>
@@ -892,7 +852,7 @@ license:CC0
 
 	<software name="amensar2">
 		<!-- Notes: GBC only -->
-		<description>Army Men - Sarge's Heroes 2 (Europe, USA)</description>
+		<description>Army Men - Sarge's Heroes 2 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BSHE-USA, CGB-BSHP-EUR"/>
@@ -923,7 +883,7 @@ license:CC0
 
 	<software name="astobelx">
 		<!-- Notes: GBC only -->
-		<description>Astérix &amp; Obélix (Europe)</description>
+		<description>Astérix &amp; Obélix (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="??"/>
@@ -936,7 +896,7 @@ license:CC0
 	</software>
 
 	<software name="astcesar">
-		<description>Astérix &amp; Obélix Contre César (Europe)</description>
+		<description>Astérix &amp; Obélix Contre César (Euro)</description>
 		<year>1999</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-BAOP-NOE"/>
@@ -953,7 +913,7 @@ license:CC0
 
 	<software name="astsearc">
 		<!-- Notes: GBC only -->
-		<description>Astérix - Search for Dogmatix (Europe)</description>
+		<description>Astérix - Search for Dogmatix (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AA6P-ESP"/>
@@ -966,7 +926,7 @@ license:CC0
 	</software>
 
 	<software name="asteroid">
-		<description>Asteroids (Europe, USA)</description>
+		<description>Asteroids (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AARE-USA, DMG-AARP-UKV"/>
@@ -980,7 +940,7 @@ license:CC0
 
 	<software name="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Europe, English / Spanish / Italian)</description>
+		<description>Disney's Atlantis - The Lost Empire (Euro, English / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABX-EUR"/>
@@ -997,7 +957,7 @@ license:CC0
 
 	<software name="atlantisa" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Europe, French / German / Dutch)</description>
+		<description>Disney's Atlantis - The Lost Empire (Euro, French / German / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABY-EUU"/>
@@ -1014,7 +974,7 @@ license:CC0
 
 	<software name="atlantisu" cloneof="atlantis">
 		<!-- Notes: GBC only -->
-		<description>Disney's Atlantis - The Lost Empire (Europe, USA)</description>
+		<description>Disney's Atlantis - The Lost Empire (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BABE-USA, CGB-BABP-UKV"/>
@@ -1028,7 +988,7 @@ license:CC0
 
 	<software name="poohadvj" cloneof="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Japan)</description>
+		<description>Atsumete Asobu Kuma no Pooh-san - Mori no Takaramono (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BPUJ-JPN"/>
@@ -1046,7 +1006,7 @@ license:CC0
 
 	<software name="apoweroh">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Oh, Behave! (Europe)</description>
+		<description>Austin Powers - Oh, Behave! (Euro)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BAPX-UKV"/>
@@ -1078,7 +1038,7 @@ license:CC0
 
 	<software name="apowerul">
 		<!-- Notes: GBC only -->
-		<description>Austin Powers - Welcome to my Underground Lair! (Europe)</description>
+		<description>Austin Powers - Welcome to my Underground Lair! (Euro)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BEAX-(EUR/UKV/EUU)"/>
@@ -1110,7 +1070,7 @@ license:CC0
 
 	<software name="azarashi">
 		<!-- Notes: GBC only -->
-		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Japan)</description>
+		<description>Azarashi Sentai Inazuma - Dokidoki Daisakusen! (Jpn)</description>
 		<year>2002</year>
 		<publisher>Omega Micott</publisher>
 		<info name="serial" value="CGB-BOAJ-JPN"/>
@@ -1127,7 +1087,7 @@ license:CC0
 	</software>
 
 	<software name="azured">
-		<description>Azure Dreams (Europe)</description>
+		<description>Azure Dreams (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAYP-EUR"/>
@@ -1157,14 +1117,14 @@ license:CC0
 	</software>
 
 	<software name="bdaman">
-		<description>B-Daman Bakugaiden - Victory e no Michi (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>B-Daman Bakugaiden - Victory e no Michi (Jpn)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOKJ-JPN"/>
 		<info name="release" value="19990129"/>
 		<info name="alt_title" value="Bビーダマン爆 外伝 ビクトリーへのみち"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [MX23C8003-20]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -1182,7 +1142,7 @@ license:CC0
 
 	<software name="bdamanv">
 		<!-- Notes: GBC only -->
-		<description>B-Daman Bakugaiden V - Final Mega Tune (Japan)</description>
+		<description>B-Daman Bakugaiden V - Final Mega Tune (Jpn)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-AIRJ-JPN"/>
@@ -1199,7 +1159,7 @@ license:CC0
 	</software>
 
 	<software name="babe">
-		<description>Babe and Friends (Europe)</description>
+		<description>Babe and Friends (Euro)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AVAP-FAH"/>
@@ -1229,7 +1189,7 @@ license:CC0
 
 	<software name="babyflix">
 		<!-- Notes: GBC only -->
-		<description>Baby Felix - Halloween (Europe)</description>
+		<description>Baby Felix - Halloween (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BFHP-EUR"/>
@@ -1242,7 +1202,7 @@ license:CC0
 	</software>
 
 	<software name="backgamm">
-		<description>Backgammon (Europe)</description>
+		<description>Backgammon (Euro)</description>
 		<year>2000</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="DMG-AAKP-EUR"/>
@@ -1255,7 +1215,7 @@ license:CC0
 	</software>
 
 	<software name="backgammj" cloneof="backgamm">
-		<description>Backgammon (Japan)</description>
+		<description>Backgammon (Jpn)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AAKJ-JPN"/>
@@ -1273,7 +1233,7 @@ license:CC0
 
 	<software name="badbadtz">
 		<!-- Notes: GBC only -->
-		<description>Bad Badtz-Maru Robo Battle (Japan)</description>
+		<description>Bad Badtz-Maru Robo Battle (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BBRJ-JPN"/>
@@ -1290,7 +1250,7 @@ license:CC0
 	</software>
 
 	<software name="bakukyuu">
-		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Japan)</description>
+		<description>Bakukyuu Renpatsu!! Super B-Daman - Gekitan! Rising Valkyrie!! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-A4RJ-JPN"/>
@@ -1308,7 +1268,7 @@ license:CC0
 
 	<software name="bakusodd">
 		<!-- Notes: GBC only -->
-		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Japan)</description>
+		<description>Bakusou Dekotora Densetsu GB Special - Otoko Dokyou no Tenka Touitsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-BDBJ-JPN"/>
@@ -1325,13 +1285,12 @@ license:CC0
 	</software>
 
 	<software name="metalwlkj" cloneof="metalwlk">
-		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Japan)</description>
+		<description>Bakusou Senki Metal Walker GB - Koutetsu no Yuujou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AUEJ-JPN"/>
-		<info name="gold" value="19991104"/>
 		<info name="release" value="19991224"/>
-		<info name="alt_title" value="爆走戦記 メタルウォーカーＧＢ ～鋼鉄の友情～"/>
+		<info name="alt_title" value="爆走戦記 メタルウォーカーGB 鋼鉄の友情"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -1344,7 +1303,7 @@ license:CC0
 
 	<software name="bsbeybld">
 		<!-- Notes: GBC only -->
-		<description>Bakuten Shoot Beyblade (Japan)</description>
+		<description>Bakuten Shoot Beyblade (Jpn)</description>
 		<year>2001</year>
 		<publisher>Broccoli</publisher>
 		<info name="serial" value="CGB-BB3J-JPN"/>
@@ -1374,15 +1333,14 @@ license:CC0
 	</software>
 
 	<software name="balonfgt">
-		<!-- Also released by NP in 2000-08 -->
-		<description>Balloon Fight GB (Japan, NP)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<description>Balloon Fight GB (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BBKJ-JPN"/>
 		<info name="release" value="2000-07-31 / 20000801"/>
 		<info name="alt_title" value="BALLOON FIGHT GB バルーンファイトGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="balloon fight gb (japan) (np).bin" size="262144" crc="d2af64ce" sha1="dbaa1bf9061de0f052704d6a33892341a38f2152"/>
@@ -1393,7 +1351,7 @@ license:CC0
 	</software>
 
 	<software name="barbiefp">
-		<description>Barbie - Fashion Pack Games (Europe, USA)</description>
+		<description>Barbie - Fashion Pack Games (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="DMG-BFPE-USA, DMG-BFPP-EUR"/>
@@ -1423,7 +1381,7 @@ license:CC0
 	</software>
 
 	<software name="barbieoc">
-		<description>Barbie - Ocean Discovery (Europe)</description>
+		<description>Barbie - Ocean Discovery (Euro)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYP-UKV"/>
@@ -1452,7 +1410,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocf" cloneof="barbieoc">
-		<description>Barbie - Chasse au Trésor Sous-Marine (France)</description>
+		<description>Barbie - Chasse au Trésor Sous-Marine (Fra)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYF-FRA"/>
@@ -1465,7 +1423,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocg" cloneof="barbieoc">
-		<description>Barbie - Meeres Abenteuer (Germany)</description>
+		<description>Barbie - Meeres Abenteuer (Ger)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYD-NOE"/>
@@ -1478,7 +1436,7 @@ license:CC0
 	</software>
 
 	<software name="barbieoci" cloneof="barbieoc">
-		<description>Barbie - Avventure nell'Oceano (Italia)</description>
+		<description>Barbie - Avventure nell'Oceano (Ita)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYI-ITA"/>
@@ -1494,7 +1452,7 @@ license:CC0
 	</software>
 
 	<software name="barbieocs" cloneof="barbieoc">
-		<description>Barbie - Aventura Submarina (Spain)</description>
+		<description>Barbie - Aventura Submarina (Spa)</description>
 		<year>1999</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-ADYS-ESP"/>
@@ -1524,7 +1482,7 @@ license:CC0
 
 	<software name="barbiept">
 		<!-- Notes: GBC only -->
-		<description>Barbie - Pet Rescue (Europe)</description>
+		<description>Barbie - Pet Rescue (Euro)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BPEP-EUR"/>
@@ -1552,7 +1510,7 @@ license:CC0
 
 	<software name="shellycl">
 		<!-- Notes: GBC only -->
-		<description>Shelly Club (Europe)</description>
+		<description>Shelly Club (Euro)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BKIP-EUR"/>
@@ -1568,15 +1526,14 @@ license:CC0
 	</software>
 
 	<software name="barcode">
-		<description>Barcode Taisen Bardigun (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Barcode Taisen Bardigun (Jpn)</description>
 		<year>1998</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-ABEJ-JPN"/>
-		<info name="gold" value="19981105"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="バーコード対戦 バーディガン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 MBC3A [MBC3A]" />
@@ -1593,29 +1550,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="barcodea" cloneof="barcode">
-		<!--	In lot check as "dmgabej1.f26"	-->
-		<description>Barcode Taisen Bardigun (Japan, Rev. 1)</description>
-		<year>1998</year>
-		<publisher>Tamsoft</publisher>
-		<info name="serial" value="DMG-ABEJ-JPN-1"/>
-		<info name="gold" value="19990323"/>
-		<info name="alt_title" value="バーコード対戦 バーディガン"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc3" />
-			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgabej1.f26" size="1048576" crc="f6d291a9" sha1="21e386f60fcd3694c4a308de9e178762c5175b6c"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="barca2k" cloneof="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Barça Total 2000 (Europe)</description>
+		<description>Barça Total 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -1630,7 +1567,7 @@ license:CC0
 	</software>
 
 	<software name="bassmasc">
-		<description>Bass Masters Classic (Europe, USA)</description>
+		<description>Bass Masters Classic (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AQME-USA, DMG-AQMP-EUR"/>
@@ -1647,7 +1584,7 @@ license:CC0
 
 	<software name="batmanbej" cloneof="batmanbe">
 		<!-- Notes: GBC only, NP only -->
-		<description>Batman Beyond - Return of the Joker (Japan, NP)</description>
+		<description>Batman Beyond - Return of the Joker (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTKJ-JPN"/>
@@ -1677,7 +1614,7 @@ license:CC0
 
 	<software name="batmanbe">
 		<!-- Notes: GBC only -->
-		<description>Batman of the Future - Return of the Joker (Europe)</description>
+		<description>Batman of the Future - Return of the Joker (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTKP-EUR"/>
@@ -1691,7 +1628,7 @@ license:CC0
 
 	<software name="batlfish">
 		<!-- Notes: GBC only -->
-		<description>Battle Fishers (Japan)</description>
+		<description>Battle Fishers (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BBAJ-JPN (RK198-J1)"/>
@@ -1708,7 +1645,7 @@ license:CC0
 	</software>
 
 	<software name="bship">
-		<description>Battleship (Europe, USA)</description>
+		<description>Battleship (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AIPE-USA, DMG-AIPP-EUR"/>
@@ -1725,7 +1662,7 @@ license:CC0
 
 	<software name="btanx">
 		<!-- Notes: GBC only -->
-		<description>BattleTanx (Europe)</description>
+		<description>BattleTanx (Euro)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVNP-UKV"/>
@@ -1756,7 +1693,7 @@ license:CC0
 
 	<software name="beachbal">
 		<!-- Notes: GBC only -->
-		<description>Beach'n Ball (Europe)</description>
+		<description>Beach'n Ball (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVBP-EUR"/>
@@ -1770,7 +1707,7 @@ license:CC0
 
 	<software name="bearblue">
 		<!-- Notes: GBC only -->
-		<description>Jim Henson's Bear in the Big Blue House (Europe)</description>
+		<description>Jim Henson's Bear in the Big Blue House (Euro)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBNP-EUR"/>
@@ -1800,15 +1737,14 @@ license:CC0
 	</software>
 
 	<software name="bmanigb">
-		<!-- Also released by NP in 2000-05 -->
-		<description>Beatmania GB (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<description>Beatmania GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AOOJ-JPN (RK184-J1)"/>
 		<info name="release" value="19990311"/>
 		<info name="alt_title" value="ビートマニアGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb (japan).bin" size="1048576" crc="0d9cb195" sha1="640c4633fe8ec60b767c15a094c87ab7e113d555"/>
@@ -1818,7 +1754,7 @@ license:CC0
 
 	<software name="bmanigb3">
 		<!-- Notes: GBC only -->
-		<description>Beatmania GB - Gotcha Mix 2 (Japan)</description>
+		<description>Beatmania GB - Gotcha Mix 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3GJ-JPN (RK220-J1)"/>
@@ -1833,14 +1769,14 @@ license:CC0
 	</software>
 
 	<software name="bmanigb2">
-		<description>Beatmania GB2 - Gotcha Mix (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Beatmania GB2 - Gotcha Mix (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A2GJ-JPN (RK195-J1)"/>
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="ビートマニア GB2 ガチャミックス"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="beatmania gb2 - gotcha mix (japan).bin" size="1048576" crc="59beb372" sha1="b6273c434e880d6f9b5f4f6f53307bda9902fff1"/>
@@ -1849,7 +1785,7 @@ license:CC0
 	</software>
 
 	<software name="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (Europe)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (Euro)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUP-EUR"/>
@@ -1870,7 +1806,7 @@ license:CC0
 	</software>
 
 	<software name="beautyu" cloneof="beauty">
-		<description>Beauty and the Beast - A Board Game Adventure (USA, Australia)</description>
+		<description>Beauty and the Beast - A Board Game Adventure (USA, Aus)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="DMG-AVUE-USA, DMG-AVUU-AUS"/>
@@ -1886,7 +1822,7 @@ license:CC0
 
 	<software name="benjamin">
 		<!-- Notes: GBC only -->
-		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Germany)</description>
+		<description>Benjamin Blümchen - Ein verrückter Tag im Zoo (Ger)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BB5D-NOE"/>
@@ -1900,7 +1836,7 @@ license:CC0
 
 	<software name="beyblade">
 		<!-- Notes: GBC only -->
-		<description>Beyblade - Fighting Tournament (Japan)</description>
+		<description>Beyblade - Fighting Tournament (Jpn)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BBVJ-JPN"/>
@@ -1918,7 +1854,7 @@ license:CC0
 
 	<software name="bibibloc">
 		<!-- Notes: GBC only -->
-		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Germany)</description>
+		<description>Bibi Blocksberg - Im Bann der Hexenkugel (Ger)</description>
 		<year>2001</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BIBD-NOE"/>
@@ -1932,7 +1868,7 @@ license:CC0
 
 	<software name="bibitina">
 		<!-- Notes: GBC only -->
-		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Germany)</description>
+		<description>Bibi und Tina - Fohlen "Felix" in Gefahr (Ger)</description>
 		<year>2002</year>
 		<publisher>Kiddinx</publisher>
 		<info name="serial" value="CGB-BFED-NOE-1"/>
@@ -1948,14 +1884,14 @@ license:CC0
 	</software>
 
 	<software name="bikkuri">
-		<description>Bikkuriman 2000 - Charging Card GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Bikkuriman 2000 - Charging Card GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BC2J-JPN"/>
 		<info name="release" value="20000610"/>
 		<info name="alt_title" value="ビックリマン2000 チャージングカードGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="bikkuriman 2000 - charging card gb (japan).bin" size="2097152" crc="5be2517c" sha1="c3c608f1b3581a070c9b7eb65b6fb6d1b72d98d3"/>
@@ -1967,7 +1903,7 @@ license:CC0
 
 	<software name="billybob">
 		<!-- Notes: GBC only -->
-		<description>Billy Bob's Huntin' 'n' Fishin' (Europe, USA)</description>
+		<description>Billy Bob's Huntin' 'n' Fishin' (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AHZE-USA, CGB-AHZP-EUR"/>
@@ -1984,7 +1920,7 @@ license:CC0
 
 	<software name="biohazg" cloneof="revilg">
 		<!-- Notes: GBC only -->
-		<description>BioHazard Gaiden (Japan)</description>
+		<description>BioHazard Gaiden (Jpn)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOJ-JPN"/>
@@ -2002,7 +1938,7 @@ license:CC0
 
 	<software name="bionicc">
 		<!-- Notes: GBC only -->
-		<description>Bionic Commando - Elite Forces (Australia, USA)</description>
+		<description>Bionic Commando - Elite Forces (Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AV4E-USA, CGB-AV4P-AUS"/>
@@ -2017,7 +1953,7 @@ license:CC0
 	</software>
 
 	<software name="blackbas">
-		<description>Black Bass - Lure Fishing (Europe, USA)</description>
+		<description>Black Bass - Lure Fishing (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-ALFE-USA, DMG-ALFP-EUR"/>
@@ -2034,7 +1970,7 @@ license:CC0
 
 	<software name="blckonyx">
 		<!-- Notes: GBC only -->
-		<description>The Black Onyx (Japan)</description>
+		<description>The Black Onyx (Jpn)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BBOJ-JPN"/>
@@ -2052,7 +1988,7 @@ license:CC0
 
 	<software name="blade">
 		<!-- Notes: GBC only -->
-		<description>Blade (Europe, USA)</description>
+		<description>Blade (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLEE-USA, CGB-BLEP-EUR"/>
@@ -2068,7 +2004,7 @@ license:CC0
 	</software>
 
 	<software name="bmaster">
-		<description>Blaster Master - Enemy Below (Europe, USA)</description>
+		<description>Blaster Master - Enemy Below (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AEHE-USA, DMG-AEHP-EUR"/>
@@ -2086,7 +2022,6 @@ license:CC0
 		<year>2001</year>
 		<publisher>Mattel Interactive</publisher>
 		<info name="serial" value="CGB-BALE-USA"/>
-		<info name="gold" value="20000926"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2111,7 +2046,7 @@ license:CC0
 
 	<software name="bobbobet">
 		<!-- Notes: GBC only -->
-		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Europe)</description>
+		<description>Bob et Bobette - Les Dompteurs du Temps ~ Suske en Wiske - De Tijdtemmers (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBQP-FAH"/>
@@ -2128,7 +2063,7 @@ license:CC0
 
 	<software name="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Europe, English / French / German / Spanish / Dutch)</description>
+		<description>Bob the Builder - Fix it Fun! (Euro, English / French / German / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBP-UKV"/>
@@ -2142,7 +2077,7 @@ license:CC0
 
 	<software name="bobbuilda" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Europe, English / French / Italian)</description>
+		<description>Bob the Builder - Fix it Fun! (Euro, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBY-EUR"/>
@@ -2159,7 +2094,7 @@ license:CC0
 
 	<software name="bobbuildb" cloneof="bobbuild">
 		<!-- Notes: GBC only -->
-		<description>Bob the Builder - Fix it Fun! (Europe, English / Swedish / Norwegian / Danish / Finnish)</description>
+		<description>Bob the Builder - Fix it Fun! (Euro, English / Swedish / Norwegian / Danish / Finnish)</description>
 		<year>2001</year>
 		<publisher>BBC Worldwide</publisher>
 		<info name="serial" value="CGB-BOBX-SCN"/>
@@ -2190,7 +2125,7 @@ license:CC0
 
 	<software name="bokucamp">
 		<!-- Notes: GBC only -->
-		<description>Boku no Camp-jou (Japan)</description>
+		<description>Boku no Camp-jou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="CGB-BDPJ-JPN"/>
@@ -2207,7 +2142,7 @@ license:CC0
 	</software>
 
 	<software name="bokujom2" cloneof="harvmon2">
-		<description>Bokujou Monogatari GB2 (Japan)</description>
+		<description>Bokujou Monogatari GB2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-A37J-JPN"/>
@@ -2225,11 +2160,10 @@ license:CC0
 
 	<software name="bokujom3" cloneof="harvmon3">
 		<!-- Notes: GBC only -->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan)</description>
+		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Jpn)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BWAJ-JPN"/>
-		<info name="gold" value="20000731"/>
 		<info name="release" value="20000929"/>
 		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2242,28 +2176,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="bokujom3a" cloneof="harvmon3">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbwaj1.350"	-->
-		<description>Bokujou Monogatari GB3 - Boy Meets Girl (Japan, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Victor Interactive Software</publisher>
-		<info name="serial" value="CGB-BWAJ-JPN"/>
-		<info name="gold" value="20001205"/>
-		<info name="alt_title" value="牧場物語GB3 ボーイ・ミーツ・ガール"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbwaj1.350" size="2097152" crc="75af0e84" sha1="acb2e549fb7d107d20507af88c36f40234f74958"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="bombmmxa">
 		<!-- Notes: GBC only, this was the prize for a draw contest -->
-		<description>Bomberman Max - Ain Version (Japan)</description>
+		<description>Bomberman Max - Ain Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -2300,7 +2215,7 @@ license:CC0
 
 	<software name="bombmmxh" cloneof="bombmmxb">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Hikari no Yuusha (Japan)</description>
+		<description>Bomberman Max - Hikari no Yuusha (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A8BJ-JPN"/>
@@ -2340,7 +2255,7 @@ license:CC0
 
 	<software name="bombmmxy" cloneof="bombmmxr">
 		<!-- Notes: GBC only -->
-		<description>Bomberman Max - Yami no Senshi (Japan)</description>
+		<description>Bomberman Max - Yami no Senshi (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-A7BJ-JPN"/>
@@ -2357,7 +2272,7 @@ license:CC0
 	</software>
 
 	<software name="bombmqst">
-		<description>Bomberman Quest (Europe)</description>
+		<description>Bomberman Quest (Euro)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AQVP-EUR"/>
@@ -2372,15 +2287,14 @@ license:CC0
 	</software>
 
 	<software name="bombmqstj" cloneof="bombmqst">
-		<!-- Also released by NP in 2000-08 -->
-		<description>Bomberman Quest (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<description>Bomberman Quest (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AB5J-JPN"/>
 		<info name="release" value="19981224"/>
 		<info name="alt_title" value="ボンバーマンクエスト"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-DFCN-20" /><!-- DMG-DECN? -->
 			<feature name="slot" value="rom_mbc1" />
@@ -2413,7 +2327,6 @@ license:CC0
 		<year>2003</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-B2CK-KOR"/>
-		<info name="gold" value="20030409"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-M-BFAN-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -2425,10 +2338,9 @@ license:CC0
 		</part>
 	</software>
 
-
 	<software name="bouken">
 		<!-- Notes: GBC only -->
-		<description>Bouken! Dondoko-tou (Japan)</description>
+		<description>Bouken! Dondoko-tou (Jpn)</description>
 		<year>2002</year>
 		<publisher>Global A</publisher>
 		<info name="serial" value="CGB-BDVJ-JPN"/>
@@ -2446,7 +2358,7 @@ license:CC0
 
 	<software name="bravesag">
 		<!-- Notes: GBC only -->
-		<description>Brave Saga - Shinshou Astaria (Japan)</description>
+		<description>Brave Saga - Shinshou Astaria (Jpn)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BBSJ-JPN"/>
@@ -2464,7 +2376,7 @@ license:CC0
 
 	<software name="buffy">
 		<!-- Notes: GBC only -->
-		<description>Buffy the Vampire Slayer (Europe, USA)</description>
+		<description>Buffy the Vampire Slayer (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BVSE-USA, CGB-BVSP-EUR"/>
@@ -2480,7 +2392,7 @@ license:CC0
 	</software>
 
 	<software name="bugslife">
-		<description>A Bug's Life (Europe)</description>
+		<description>A Bug's Life (Euro)</description>
 		<year>1998</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-APXP-EUU"/>
@@ -2506,7 +2418,7 @@ license:CC0
 	</software>
 
 	<software name="bugsblol">
-		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Europe)</description>
+		<description>Bugs Bunny &amp; Lola Bunny - Operation Carrots (Euro)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ABLP-FRA"/>
@@ -2520,7 +2432,7 @@ license:CC0
 
 	<software name="bugsbcc3">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny - Crazy Castle 3 (Europe, USA)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6E-USA, DMG-AB6P-EUR"/>
@@ -2536,7 +2448,7 @@ license:CC0
 	</software>
 
 	<software name="bugsbcc3j" cloneof="bugsbcc3">
-		<description>Bugs Bunny - Crazy Castle 3 (Japan)</description>
+		<description>Bugs Bunny - Crazy Castle 3 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-AB6J-JPN"/>
@@ -2552,7 +2464,7 @@ license:CC0
 
 	<software name="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Europe)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Euro)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4P-EUU-1"/>
@@ -2566,7 +2478,7 @@ license:CC0
 
 	<software name="bugsbcc4f" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny et le Château des Catastrophes (France)</description>
+		<description>Bugs Bunny et le Château des Catastrophes (Fra)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4F-FRA"/>
@@ -2583,7 +2495,7 @@ license:CC0
 
 	<software name="bugsbcc4j" cloneof="bugsbcc4">
 		<!-- Notes: GBC only -->
-		<description>Bugs Bunny in Crazy Castle 4 (Japan)</description>
+		<description>Bugs Bunny in Crazy Castle 4 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AO4J-JPN"/>
@@ -2612,7 +2524,7 @@ license:CC0
 	</software>
 
 	<software name="bundl2k1" cloneof="fa2001">
-		<description>Bundesliga Stars 2001 (Germany)</description>
+		<description>Bundesliga Stars 2001 (Ger)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -2626,7 +2538,7 @@ license:CC0
 
 	<software name="buraicol" cloneof="spacemar">
 		<!-- Notes: GBC only -->
-		<description>Burai Senshi Color (Japan)</description>
+		<description>Burai Senshi Color (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZYJ-JPN"/>
@@ -2641,14 +2553,14 @@ license:CC0
 	</software>
 
 	<software name="burgerb">
-		<description>Burger Burger Pocket (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Burger Burger Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-ABNJ-JPN"/>
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="バーガーバーガーポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="burger burger pocket (japan).bin" size="1048576" crc="1abcedbe" sha1="f4579d4bb3b39f572fdf033df01a84a925fb3f2e"/>
@@ -2658,7 +2570,7 @@ license:CC0
 
 	<software name="burgerpi">
 		<!-- Notes: GBC only -->
-		<description>Burger Paradise International (Japan)</description>
+		<description>Burger Paradise International (Jpn)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="CGB-AEYJ-JPN"/>
@@ -2675,7 +2587,7 @@ license:CC0
 	</software>
 
 	<software name="bam4">
-		<description>Bust-A-Move 4 (Europe, USA)</description>
+		<description>Bust-A-Move 4 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AA4E-USA, DMG-AA4P-EUR"/>
@@ -2689,7 +2601,7 @@ license:CC0
 
 	<software name="bammill">
 		<!-- Notes: GBC only -->
-		<description>Bust-A-Move Millennium (Europe, USA)</description>
+		<description>Bust-A-Move Millennium (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BANE-USA, CGB-BANP-EUR"/>
@@ -2703,7 +2615,7 @@ license:CC0
 
 	<software name="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Buzz Lightyear of Star Command (Europe, USA)</description>
+		<description>Buzz Lightyear of Star Command (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZE-USA, CGB-BUZP-UKV"/>
@@ -2720,7 +2632,7 @@ license:CC0
 
 	<software name="buzzlghtf" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Les Aventures de Buzz l'Eclair (France)</description>
+		<description>Les Aventures de Buzz l'Eclair (Fra)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZF-FRA"/>
@@ -2734,7 +2646,7 @@ license:CC0
 
 	<software name="buzzlghtg" cloneof="buzzlght">
 		<!-- Notes: GBC only -->
-		<description>Captain Buzz Lightyear - Star Command (Germany)</description>
+		<description>Captain Buzz Lightyear - Star Command (Ger)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BUZD-NOE"/>
@@ -2748,7 +2660,7 @@ license:CC0
 
 	<software name="caesars2">
 		<!-- Notes: GBC only -->
-		<description>Caesars Palace II (Europe, USA)</description>
+		<description>Caesars Palace II (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AI2E-USA, CGB-AI2P-EUR"/>
@@ -2770,7 +2682,7 @@ license:CC0
 
 	<software name="cfodder">
 		<!-- Notes: GBC only -->
-		<description>Cannon Fodder (Europe)</description>
+		<description>Cannon Fodder (Euro)</description>
 		<year>2000</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BCFP-EUR"/>
@@ -2820,7 +2732,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 2)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. B)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2836,7 +2748,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 2).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev b).bin" size="524288" crc="7243e258" sha1="a53e7f8d95375aea144e870977b0966cc1fd4b94"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2844,7 +2756,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuita" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan, Rev. 1)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2854,7 +2766,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="524288">
-				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev 1).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
+				<rom name="cardcaptor sakura - itsumo sakura-chan to issho (japan) (rev a).bin" size="524288" crc="43f28e22" sha1="b3926ac213b9f88f570b0587fae89e3151018d63"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -2862,7 +2774,7 @@ license:CC0
 	</software>
 
 	<software name="ccsakuitb" cloneof="ccsakuit">
-		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Japan)</description>
+		<description>Cardcaptor Sakura - Itsumo Sakura-chan to Issho (Jpn)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-AM7J-JPN"/>
@@ -2881,11 +2793,10 @@ license:CC0
 
 	<software name="ccsakuto">
 		<!-- Notes: GBC only -->
-		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Japan)</description>
+		<description>Cardcaptor Sakura - Tomoeda Shougakkou Daiundoukai (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BS7J-JPN"/>
-		<info name="gold" value="20000824"/>
 		<info name="release" value="20001006"/>
 		<info name="alt_title" value="カードキャプターさくら 〜友枝小学校大運動会〜"/>
 		<part name="cart" interface="gameboy_cart">
@@ -2900,7 +2811,7 @@ license:CC0
 
 	<software name="clewis2k">
 		<!-- Notes: GBC only -->
-		<description>Carl Lewis Athletics 2000 (Europe)</description>
+		<description>Carl Lewis Athletics 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCLP-EUR"/>
@@ -2916,12 +2827,10 @@ license:CC0
 
 	<software name="carmgedd">
 		<!-- Notes: GBC only -->
-		<!--	USA cartridges have the European sticker underneath.	-->
-		<description>Carmageddon - Carpocalypse Now (Europe, USA)</description>
+		<description>Carmageddon - Carpocalypse Now (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
-		<info name="gold" value="CGB-AKWE-USA, CGB-AKWP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A09-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -2935,7 +2844,7 @@ license:CC0
 
 	<software name="carmgeddg" cloneof="carmgedd">
 		<!-- Notes: GBC only -->
-		<description>Carmageddon - Carpocalypse Now (Germany)</description>
+		<description>Carmageddon - Carpocalypse Now (Ger)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-AKWD-NOE"/>
@@ -2949,11 +2858,10 @@ license:CC0
 
 	<software name="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Europe, English / Spanish / Italian)</description>
+		<description>Casper (Euro, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9X-EUU"/>
-		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -2972,11 +2880,10 @@ license:CC0
 
 	<software name="caspera" cloneof="casper">
 		<!-- Notes: GBC only -->
-		<description>Casper (Europe, English / French / German)</description>
+		<description>Casper (Euro, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9P-EUR"/>
-		<info name="gold" value="20000831"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -2993,7 +2900,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Interplay</publisher>
 		<info name="serial" value="CGB-AF9E-USA"/>
-		<info name="gold" value="20000404"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3005,7 +2911,7 @@ license:CC0
 	</software>
 
 	<software name="caterpil">
-		<description>Caterpillar Construction Zone (Europe, USA)</description>
+		<description>Caterpillar Construction Zone (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AR4E-USA, DMG-AR4P-EUU?"/>
@@ -3019,11 +2925,10 @@ license:CC0
 
 	<software name="catwoman">
 		<!-- Notes: GBC only -->
-		<description>Catwoman (Europe)</description>
+		<description>Catwoman (Euro)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CP-EUR"/>
-		<info name="gold" value="19991018"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3038,7 +2943,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A3CE-USA"/>
-		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3049,7 +2953,7 @@ license:CC0
 
 	<software name="catz">
 		<!-- Notes: GBC only -->
-		<description>Catz - Your Virtual Petz Palz (Europe)</description>
+		<description>Catz - Your Virtual Petz Palz (Euro)</description>
 		<year>1999</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AZCP-EUR"/>
@@ -3080,7 +2984,7 @@ license:CC0
 	</software>
 
 	<software name="centiped">
-		<description>Centipede (Europe)</description>
+		<description>Centipede (Euro)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AC5P-EUR"/>
@@ -3107,7 +3011,7 @@ license:CC0
 
 	<software name="motox2k1">
 		<!-- Notes: GBC only -->
-		<description>Championship Motocross 2001 featuring Ricky Carmichael (Europe, USA)</description>
+		<description>Championship Motocross 2001 featuring Ricky Carmichael (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCME-USA, CGB-BCMP-EUR"/>
@@ -3123,7 +3027,7 @@ license:CC0
 	</software>
 
 	<software name="chasehq">
-		<description>Chase H.Q. - Secret Police (Europe)</description>
+		<description>Chase H.Q. - Secret Police (Euro)</description>
 		<year>2000</year>
 		<publisher>Gaga</publisher>
 		<info name="serial" value="DMG-AH9P-EUR"/>
@@ -3149,7 +3053,7 @@ license:CC0
 	</software>
 
 	<software name="checkmat">
-		<description>Checkmate (Japan)</description>
+		<description>Checkmate (Jpn)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ACZJ-JPN"/>
@@ -3167,7 +3071,7 @@ license:CC0
 
 	<software name="cheechai">
 		<!-- Notes: GBC only -->
-		<description>Chee-Chai Alien (Japan)</description>
+		<description>Chee-Chai Alien (Jpn)</description>
 		<year>2001</year>
 		<publisher>Creatures</publisher>
 		<info name="serial" value="CGB-VCAJ-JPN"/>
@@ -3192,7 +3096,7 @@ license:CC0
 	</software>
 
 	<software name="chessmst">
-		<description>Chessmaster (Europe, USA)</description>
+		<description>Chessmaster (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Mindascape</publisher>
 		<info name="serial" value="DMG-AC9E-USA, DMG-AC9P-EUR"/>
@@ -3206,7 +3110,7 @@ license:CC0
 
 	<software name="chitoase">
 		<!-- Notes: GBC only -->
-		<description>Chi to Ase to Namida no Koukou Yakyuu (Japan)</description>
+		<description>Chi to Ase to Namida no Koukou Yakyuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-BBJJ-JPN"/>
@@ -3224,7 +3128,7 @@ license:CC0
 
 	<software name="chibim">
 		<!-- Notes: GBC only -->
-		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Japan)</description>
+		<description>Chibi Maruko-chan - Go Chounai Minna de Game Da yo! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BCNJ-JPN"/>
@@ -3242,7 +3146,7 @@ license:CC0
 
 	<software name="chickrun">
 		<!-- Notes: GBC only -->
-		<description>Chicken Run (Europe, USA)</description>
+		<description>Chicken Run (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCKE-USA, CGB-BCKP-EUR"/>
@@ -3259,7 +3163,7 @@ license:CC0
 
 	<software name="chikirac" cloneof="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Chiki Chiki Machine Mou Race (Japan)</description>
+		<description>Chiki Chiki Machine Mou Race (Jpn)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-AW9J-JPN"/>
@@ -3274,14 +3178,14 @@ license:CC0
 	</software>
 
 	<software name="choroq">
-		<description>Choro Q - Hyper Customable GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Choro Q - Hyper Customable GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACQJ-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="チョロQ ハイパーカスタマブルGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="choro q - hyper customable gb (japan).bin" size="2097152" crc="65610ca4" sha1="8af215c632599aaab9bc4614194ac45802407bbc"/>
@@ -3292,7 +3196,7 @@ license:CC0
 	</software>
 
 	<software name="bublbobl">
-		<description>Classic Bubble Bobble (Europe)</description>
+		<description>Classic Bubble Bobble (Euro)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AVWP-EUR-1"/>
@@ -3319,7 +3223,7 @@ license:CC0
 
 	<software name="mcrae">
 		<!-- Notes: GBC only -->
-		<description>Colin McRae Rally (Europe)</description>
+		<description>Colin McRae Rally (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCOP-EUR"/>
@@ -3334,14 +3238,14 @@ license:CC0
 	</software>
 
 	<software name="columns">
-		<description>Columns GB - Tezuka Osamu Characters (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Columns GB - Tezuka Osamu Characters (Jpn)</description>
 		<year>1999</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-AOYJ-JPN"/>
 		<info name="release" value="19991105"/>
 		<info name="alt_title" value="コラムスGB手塚治虫キャラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="columns gb - tezuka osamu characters (japan).bin" size="524288" crc="fbe5de37" sha1="a8d9a6631f1d203d99be38fb90135c10e5f0c880"/>
@@ -3353,7 +3257,7 @@ license:CC0
 
 	<software name="commandm" supported="no">
 		<!-- Notes: GBC only.  The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Command Master (Japan)</description>
+		<description>Command Master (Jpn)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-KCEJ-JPN"/>
@@ -3376,7 +3280,7 @@ license:CC0
 
 	<software name="commandk">
 		<!-- Notes: GBC only -->
-		<description>Commander Keen (Europe, USA)</description>
+		<description>Commander Keen (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BCBE-USA, CGB-BCBP-EUR"/>
@@ -3389,7 +3293,7 @@ license:CC0
 	</software>
 
 	<software name="conker">
-		<description>Conker's Pocket Tales (Europe, USA)</description>
+		<description>Conker's Pocket Tales (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACRE-USA, DMG-ACRP-EUR"/>
@@ -3411,7 +3315,7 @@ license:CC0
 
 	<software name="coolbric">
 		<!-- Notes: GBC only -->
-		<description>Cool Bricks (Europe)</description>
+		<description>Cool Bricks (Euro)</description>
 		<year>1999</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BOGP-EUR"/>
@@ -3424,7 +3328,7 @@ license:CC0
 	</software>
 
 	<software name="coolhand">
-		<description>Cool Hand (Europe)</description>
+		<description>Cool Hand (Euro)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-ACWP-EUU"/>
@@ -3438,7 +3342,7 @@ license:CC0
 
 	<software name="crazybik">
 		<!-- Notes: GBC only -->
-		<description>Crazy Bikers (Europe)</description>
+		<description>Crazy Bikers (Euro)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AMHP-EUR"/>
@@ -3454,7 +3358,7 @@ license:CC0
 
 	<software name="croc">
 		<!-- Notes: GBC only -->
-		<description>Croc (Europe, USA)</description>
+		<description>Croc (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRCE-USA, CGB-BRCP-EUR"/>
@@ -3471,7 +3375,7 @@ license:CC0
 
 	<software name="croc2">
 		<!-- Notes: GBC only -->
-		<description>Croc 2 (Europe, USA)</description>
+		<description>Croc 2 (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BK2E-USA, CGB-BK2P-EUR"/>
@@ -3484,7 +3388,7 @@ license:CC0
 	</software>
 
 	<software name="xcountry">
-		<description>Cross Country Racing (Europe)</description>
+		<description>Cross Country Racing (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLP-EUR"/>
@@ -3498,7 +3402,7 @@ license:CC0
 
 	<software name="xhunterm">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Monster Hunter Version (Japan)</description>
+		<description>Cross Hunter - Monster Hunter Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC8J-JPN"/>
@@ -3516,7 +3420,7 @@ license:CC0
 
 	<software name="xhuntert">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - Treasure Hunter Version (Japan)</description>
+		<description>Cross Hunter - Treasure Hunter Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC7J-JPN"/>
@@ -3540,7 +3444,7 @@ license:CC0
 
 	<software name="xhunterx">
 		<!-- Notes: GBC only -->
-		<description>Cross Hunter - X Hunter Version (Japan)</description>
+		<description>Cross Hunter - X Hunter Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>NetVillage</publisher>
 		<info name="serial" value="CGB-BC9J-JPN"/>
@@ -3558,7 +3462,6 @@ license:CC0
 
 	<software name="crusnexo">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBXOE0.382", "KENSA\CGBBXOP0.0"	-->
 		<description>Cruis'n Exotica (USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
@@ -3603,7 +3506,7 @@ license:CC0
 
 	<software name="cybertgr">
 		<!-- Notes: GBC only -->
-		<description>CyberTiger (Europe, USA)</description>
+		<description>CyberTiger (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BCTE-USA, CGB-BCTP-UKV"/>
@@ -3620,7 +3523,7 @@ license:CC0
 
 	<software name="cyborgku">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan - Devil Fukkatsu (Japan)</description>
+		<description>Cyborg Kuro-chan - Devil Fukkatsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSKJ-JPN (RK204-J1)"/>
@@ -3638,7 +3541,7 @@ license:CC0
 
 	<software name="cyborgk2">
 		<!-- Notes: GBC only -->
-		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Japan)</description>
+		<description>Cyborg Kuro-chan 2 - White Woods no Gyakushuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BSBJ-JPN (RK219-J1)"/>
@@ -3656,7 +3559,7 @@ license:CC0
 
 	<software name="daadaada">
 		<!-- Notes: GBC only -->
-		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Japan)</description>
+		<description>Daa! Daa! Daa! - Totsuzen Card de Battle de Uranai de! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BDOJ-JPN"/>
@@ -3673,7 +3576,7 @@ license:CC0
 	</software>
 
 	<software name="daffyfow">
-		<description>Daffy Duck - Fowl Play (Europe, USA)</description>
+		<description>Daffy Duck - Fowl Play (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7E-USA, DMG-AD7P-UKV"/>
@@ -3686,7 +3589,7 @@ license:CC0
 	</software>
 
 	<software name="daffysub">
-		<description>Daffy Duck - Subette Koron de Ougane Mochi (Japan)</description>
+		<description>Daffy Duck - Subette Koron de Ougane Mochi (Jpn)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AD7J-JPN"/>
@@ -3701,14 +3604,14 @@ license:CC0
 	</software>
 
 	<software name="miraclz2">
-		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Daikaijuu Monogatari - The Miracle of the Zone II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AM6J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="大貝獣物語 ザ・ミラクル オブ ザ・ゾーンII"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC1A [HuC-1]" />
@@ -3726,11 +3629,10 @@ license:CC0
 
 	<software name="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Europe, English / French / Italian)</description>
+		<description>Daikatana (Euro, English / French / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22X-EUR"/>
-		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3743,11 +3645,10 @@ license:CC0
 
 	<software name="daikatana" cloneof="daikatan">
 		<!-- Notes: GBC only -->
-		<description>Daikatana (Europe, French / German / Spanish)</description>
+		<description>Daikatana (Euro, French / German / Spanish)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22Y-EUU"/>
-		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3775,7 +3676,7 @@ license:CC0
 
 	<software name="daikatanj" cloneof="daikatan">
 		<!-- Notes: GBC only, NP only -->
-		<description>Daikatana GB (Japan, NP)</description>
+		<description>Daikatana GB (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A22J-JPN"/>
@@ -3792,14 +3693,14 @@ license:CC0
 	</software>
 
 	<software name="daikugen">
-		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Daiku no Gen-san - Kachikachi no Tonkachi ga Kachi (Jpn)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-BGNJ-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="大工の源さん 〜カチカチのトンカチガカチ〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="daiku no gen-san - kachikachi no tonkachi ga kachi (japan).bin" size="1048576" crc="e2071293" sha1="2d961353e7242babce49dda8d017a459f4ef7609"/>
@@ -3811,7 +3712,7 @@ license:CC0
 
 	<software name="ddr">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB (Japan)</description>
+		<description>Dance Dance Revolution GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDGJ-JPN (RK209-J1)"/>
@@ -3830,7 +3731,7 @@ license:CC0
 
 	<software name="ddrdisny">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB - Disney Mix (Japan)</description>
+		<description>Dance Dance Revolution GB - Disney Mix (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD7J-JPN (RK237-J1)"/>
@@ -3848,7 +3749,7 @@ license:CC0
 
 	<software name="ddr2">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB2 (Japan)</description>
+		<description>Dance Dance Revolution GB2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD2J-JPN (RK224-J1)"/>
@@ -3867,7 +3768,7 @@ license:CC0
 
 	<software name="ddr3">
 		<!-- Notes: GBC only -->
-		<description>Dance Dance Revolution GB3 (Japan)</description>
+		<description>Dance Dance Revolution GB3 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BD6J-JPN (RK235-J1)"/>
@@ -3882,7 +3783,7 @@ license:CC0
 	</software>
 
 	<software name="dancefrb">
-		<description>Dancing Furby (Japan)</description>
+		<description>Dancing Furby (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BFBJ-JPN"/>
@@ -3900,7 +3801,7 @@ license:CC0
 
 	<software name="dnyakyu">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu (Japan)</description>
+		<description>Data-Navi Pro Yakyuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-A89J-JPN"/>
@@ -3918,7 +3819,7 @@ license:CC0
 
 	<software name="dnyakyu2">
 		<!-- Notes: GBC only -->
-		<description>Data-Navi Pro Yakyuu 2 (Japan)</description>
+		<description>Data-Navi Pro Yakyuu 2 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Now Production</publisher>
 		<info name="serial" value="CGB-B8QJ-JPN"/>
@@ -3936,7 +3837,7 @@ license:CC0
 
 	<software name="mirrabmx">
 		<!-- Notes: GBC only -->
-		<description>Dave Mirra Freestyle BMX (Europe, USA)</description>
+		<description>Dave Mirra Freestyle BMX (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMXE-USA, CGB-BMXP-EUR"/>
@@ -3950,11 +3851,10 @@ license:CC0
 
 	<software name="beckham">
 		<!-- Notes: GBC only -->
-		<description>David Beckham Soccer (Europe)</description>
+		<description>David Beckham Soccer (Euro)</description>
 		<year>2002</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BJ2P-EUR"/>
-		<info name="gold" value="20011127"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -3966,7 +3866,7 @@ license:CC0
 	</software>
 
 	<software name="deadlysk">
-		<description>Deadly Skies (Europe)</description>
+		<description>Deadly Skies (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BDLP-EUR"/>
@@ -3979,14 +3879,14 @@ license:CC0
 	</software>
 
 	<software name="deardani">
-		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dear Daniel no Sweet Adventure - Kitty-chan o Sagashite (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BSAJ-JPN"/>
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dear daniel no sweet adventure - kitty-chan o sagashite (japan).bin" size="1048576" crc="0fd34427" sha1="8598594285f0342b3d93c447b475fadd4722c6cb"/>
@@ -4012,7 +3912,7 @@ license:CC0
 
 	<software name="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, English / French)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, English / French)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTX-EUR"/>
@@ -4028,7 +3928,7 @@ license:CC0
 
 	<software name="dejavua" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Europe, French / German)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Euro, French / German)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTY-EUU"/>
@@ -4044,7 +3944,7 @@ license:CC0
 
 	<software name="dejavuj" cloneof="dejavu">
 		<!-- Notes: GBC only -->
-		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Japan)</description>
+		<description>Deja Vu I &amp; II - The Casebooks of Ace Harding (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-ADTJ-JPN"/>
@@ -4077,7 +3977,7 @@ license:CC0
 	</software>
 
 	<software name="dejikomj">
-		<description>Dejiko no Mahjong Party (Japan)</description>
+		<description>Dejiko no Mahjong Party (Jpn)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQSJ-JPN (KIG-11)"/>
@@ -4095,11 +3995,10 @@ license:CC0
 
 	<software name="denkiblk">
 		<!-- Notes: GBC only -->
-		<description>Denki Blocks! (Europe)</description>
+		<description>Denki Blocks! (Euro)</description>
 		<year>2001</year>
 		<publisher>Rage Software</publisher>
 		<info name="serial" value="CGB-BD9P-EUR"/>
-		<info name="gold" value="20010830"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -4112,7 +4011,7 @@ license:CC0
 
 	<software name="dendego">
 		<!-- Notes: GBC only -->
-		<description>Densha de Go! (Japan)</description>
+		<description>Densha de Go! (Jpn)</description>
 		<year>1999</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-A72J-JPN"/>
@@ -4130,14 +4029,12 @@ license:CC0
 
 	<software name="dendego2">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbb82j0.538"	-->
-		<description>Densha de Go! 2 (Japan)</description>
+		<description>Densha de Go! 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>CyberFront</publisher>
 		<info name="serial" value="CGB-B82J-JPN"/>
-		<info name="gold" value="20001020"/>
 		<info name="release" value="20001208"/>
-		<info name="alt_title" value="電車でＧＯ！ ２"/>
+		<info name="alt_title" value="電車でGO ! 2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A15-10" />
 			<feature name="u1" value="U1 32M MROM 02" />
@@ -4159,7 +4056,7 @@ license:CC0
 
 	<software name="dexterlb" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Dexter's Laboratory - Robot Rampage (Europe, USA)</description>
+		<description>Dexter's Laboratory - Robot Rampage (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BROE-USA, CGB-BROP-EUR"/>
@@ -4175,14 +4072,14 @@ license:CC0
 	</software>
 
 	<software name="dinobrd3">
-		<description>Dino Breeder 3 - Gaia Fukkatsu (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dino Breeder 3 - Gaia Fukkatsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A3DJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ディノブリーダー3 ガイア復活"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 3 - gaia fukkatsu (japan).bin" size="2097152" crc="d9f071bb" sha1="f571a591a2f4fc4f70897e380fdbe9011be75f8d"/>
@@ -4193,14 +4090,14 @@ license:CC0
 	</software>
 
 	<software name="dinobrd4">
-		<description>Dino Breeder 4 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dino Breeder 4 (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A4DJ-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="ディノブリーダー4"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dino breeder 4 (japan).bin" size="2097152" crc="b0106777" sha1="b25681defda961837a28be1432076b65574fd1be"/>
@@ -4212,7 +4109,7 @@ license:CC0
 
 	<software name="dinosaur">
 		<!-- Notes: GBC only -->
-		<description>Dinosaur (Europe)</description>
+		<description>Dinosaur (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BDNP-EUR"/>
@@ -4259,8 +4156,7 @@ license:CC0
 
 	<software name="dinosrus">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBDSP0.602", "KENSA\CGBBDSE0.0"	-->
-		<description>Dinosaur'us (Europe)</description>
+		<description>Dinosaur'us (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BDSP-EUR"/>
@@ -4282,7 +4178,7 @@ license:CC0
 
 	<software name="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Europe)</description>
+		<description>Diva Starz (Euro)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8P-EUR"/>
@@ -4299,7 +4195,7 @@ license:CC0
 
 	<software name="divastarf" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (France)</description>
+		<description>Diva Starz (Fra)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8F-FRA"/>
@@ -4316,7 +4212,7 @@ license:CC0
 
 	<software name="divastarg" cloneof="divastar">
 		<!-- Notes: GBC only -->
-		<description>Diva Starz (Germany)</description>
+		<description>Diva Starz (Ger)</description>
 		<year>2001</year>
 		<publisher>Vivendi Universal</publisher>
 		<info name="serial" value="CGB-BD8D-NOE"/>
@@ -4347,7 +4243,7 @@ license:CC0
 
 	<software name="dogz">
 		<!-- Notes: GBC only -->
-		<description>Dogz - Your Virtual Petz Palz (Europe)</description>
+		<description>Dogz - Your Virtual Petz Palz (Euro)</description>
 		<year>2000</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="CGB-AOZP-EUR"/>
@@ -4378,7 +4274,7 @@ license:CC0
 	</software>
 
 	<software name="dokapon">
-		<description>Dokapon! - Millennium Quest (Japan)</description>
+		<description>Dokapon! - Millennium Quest (Jpn)</description>
 		<year>2000</year>
 		<publisher>Asmik Ace</publisher>
 		<info name="serial" value="DMG-BDKJ-JPN"/>
@@ -4396,7 +4292,7 @@ license:CC0
 
 	<software name="dokixdok">
 		<!-- Notes: GBC only -->
-		<description>Doki x Doki Sasete!! (Japan)</description>
+		<description>Doki x Doki Sasete!! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BP6J-JPN"/>
@@ -4414,7 +4310,7 @@ license:CC0
 
 	<software name="dokidoki">
 		<!-- Notes: GBC only -->
-		<description>Dokidoki Densetsu - Mahoujin Guruguru (Japan)</description>
+		<description>Dokidoki Densetsu - Mahoujin Guruguru (Jpn)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-B96J-JPN"/>
@@ -4432,7 +4328,7 @@ license:CC0
 
 	<software name="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's "Donald" @#Duck?*! (Europe)</description>
+		<description>Disney's "Donald" @#Duck?*! (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Disney's Donald Duck - &quot;Qu@ck &quot;Att@ck&quot;?*! (Box, Cart)"/>
@@ -4450,7 +4346,7 @@ license:CC0
 
 	<software name="donalddj" cloneof="donaldd">
 		<!-- Notes: GBC only -->
-		<description>Disney's Donald Duck - Daisy o Sukue! (Japan)</description>
+		<description>Disney's Donald Duck - Daisy o Sukue! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUDJ-JPN"/>
@@ -4481,7 +4377,7 @@ license:CC0
 
 	<software name="dkong2k1" cloneof="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong 2001 (Japan)</description>
+		<description>Donkey Kong 2001 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDJ-JPN"/>
@@ -4499,7 +4395,7 @@ license:CC0
 
 	<software name="dkongc">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong Country (Europe, Australia, USA)</description>
+		<description>Donkey Kong Country (Euro, Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BDDE-USA, CGB-BDDP-(EUR/AUS)"/>
@@ -4520,7 +4416,7 @@ license:CC0
 	</software>
 
 	<software name="dkongcs" cloneof="dkongc">
-		<description>Donkey Kong Country (Europe, USA, Sample)</description>
+		<description>Donkey Kong Country (Euro, USA, Sample)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -4533,29 +4429,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="dkongcd" cloneof="dkongc">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbdye0.326"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Donkey Kong Country (USA, Not for resale)</description>
-		<year>2000</year>
-		<publisher>Nintendo</publisher>
-		<info name="serial" value="DIS-CGB-BDYE-USA"/>
-		<info name="gold" value="20000719"/>
-		<info name="alt_title" value="DONKEY KONG COUNTRY (DISPLAY)"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbbdye0.326" size="4194304" crc="080605a3" sha1="38fedd71736d258e31d3062864d28449e7c3f1c5"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="dkonggb">
 		<!-- Notes: GBC only -->
-		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Japan)</description>
+		<description>Donkey Kong GB - Dinky Kong &amp; Dixie Kong (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AD3J-JPN"/>
@@ -4578,7 +4454,7 @@ license:CC0
 	</software>
 
 	<software name="doralaby">
-		<description>Doraemon - Aruke Aruke Labyrinth (Japan)</description>
+		<description>Doraemon - Aruke Aruke Labyrinth (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADAJ-JPN"/>
@@ -4595,7 +4471,7 @@ license:CC0
 	</software>
 
 	<software name="dorapetm">
-		<description>Doraemon - Kimi to Pet no Monogatari (Japan)</description>
+		<description>Doraemon - Kimi to Pet no Monogatari (Jpn)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BRDJ-JPN"/>
@@ -4612,14 +4488,14 @@ license:CC0
 	</software>
 
 	<software name="dorakrt2">
-		<description>Doraemon Kart 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Doraemon Kart 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ADOJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="ドラえもんカート2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WW3]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -4636,7 +4512,7 @@ license:CC0
 	</software>
 
 	<software name="doramemo">
-		<description>Doraemon Memories - Nobita no Omoide Daibouken (Japan)</description>
+		<description>Doraemon Memories - Nobita no Omoide Daibouken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BDMJ-JPN"/>
@@ -4654,7 +4530,7 @@ license:CC0
 
 	<software name="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Japan, Rev. 1)</description>
+		<description>Doraemon no Quiz Boy (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4678,7 +4554,7 @@ license:CC0
 
 	<software name="doraqzba" cloneof="doraqzb">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy (Japan)</description>
+		<description>Doraemon no Quiz Boy (Jpn)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQBJ-JPN"/>
@@ -4696,7 +4572,7 @@ license:CC0
 
 	<software name="doraqzb2">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Quiz Boy 2 (Japan)</description>
+		<description>Doraemon no Quiz Boy 2 (Jpn)</description>
 		<year>2002</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQ7J-JPN"/>
@@ -4720,7 +4596,7 @@ license:CC0
 
 	<software name="dorakang">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Japan)</description>
+		<description>Doraemon no Study Boy - Gakushuu Kanji Game (Jpn)</description>
 		<year>2001</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BGKJ-JPN"/>
@@ -4738,7 +4614,7 @@ license:CC0
 
 	<software name="dorakany">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Japan)</description>
+		<description>Doraemon no Study Boy - Kanji Yomikaki Master (Jpn)</description>
 		<year>2003</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BKYJ-JPN"/>
@@ -4756,7 +4632,7 @@ license:CC0
 
 	<software name="dorakuku">
 		<!-- Notes: GBC only -->
-		<description>Doraemon no Study Boy - Kuku Game (Japan)</description>
+		<description>Doraemon no Study Boy - Kuku Game (Jpn)</description>
 		<year>2000</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="CGB-BQQJ-JPN"/>
@@ -4774,7 +4650,7 @@ license:CC0
 
 	<software name="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Europe)</description>
+		<description>Disney's Doug's Big Game (Euro)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUP-EUR"/>
@@ -4791,7 +4667,7 @@ license:CC0
 
 	<software name="dougf" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug - La Grande Aventure (France)</description>
+		<description>Disney's Doug - La Grande Aventure (Fra)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUF-FRA"/>
@@ -4805,7 +4681,7 @@ license:CC0
 
 	<software name="dougg" cloneof="doug">
 		<!-- Notes: GBC only -->
-		<description>Disney's Doug's Big Game (Germany)</description>
+		<description>Disney's Doug's Big Game (Ger)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDUD-NOE"/>
@@ -4836,7 +4712,7 @@ license:CC0
 
 	<software name="drrin">
 		<!-- Notes: GBC only -->
-		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Japan)</description>
+		<description>Dr. Rin ni Kiitemite! - Koi no Rin Fuusui (Jpn)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BDFJ-JPN"/>
@@ -4860,7 +4736,7 @@ license:CC0
 
 	<software name="draccraz">
 		<!-- Notes: GBC only -->
-		<description>Dracula - Crazy Vampire (Europe)</description>
+		<description>Dracula - Crazy Vampire (Euro)</description>
 		<year>2001</year>
 		<publisher>DreamCatcher Interactive</publisher>
 		<info name="serial" value="CGB-BUAP-EUR"/>
@@ -4888,7 +4764,7 @@ license:CC0
 
 	<software name="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendary Super Warriors (Europe)</description>
+		<description>Dragon Ball Z - Legendary Super Warriors (Euro)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZP-UKV"/>
@@ -4904,7 +4780,7 @@ license:CC0
 
 	<software name="dbzj" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Japan)</description>
+		<description>Dragon Ball Z - Densetsu no Chou Senshi-tachi (Jpn)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="CGB-BBZJ-JPN"/>
@@ -4922,7 +4798,7 @@ license:CC0
 
 	<software name="dbzf" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Les Guerriers Légendaires (France)</description>
+		<description>Dragon Ball Z - Les Guerriers Légendaires (Fra)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZF-FRA"/>
@@ -4938,7 +4814,7 @@ license:CC0
 
 	<software name="dbzg" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Legendäre Superkämpfer (Germany)</description>
+		<description>Dragon Ball Z - Legendäre Superkämpfer (Ger)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZD-NOE"/>
@@ -4960,7 +4836,7 @@ license:CC0
 
 	<software name="dbzi" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Italia)</description>
+		<description>Dragon Ball Z - I Leggendari Super Guerrieri (Ita)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZI-ITA"/>
@@ -4982,7 +4858,7 @@ license:CC0
 
 	<software name="dbzs" cloneof="dbz">
 		<!-- Notes: GBC only -->
-		<description>Dragon Ball Z - Guerreros de Leyenda (Spain)</description>
+		<description>Dragon Ball Z - Guerreros de Leyenda (Spa)</description>
 		<year>2002</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BBZS-ESP"/>
@@ -5023,7 +4899,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-BDAE-USA"/>
-		<info name="gold" value="20000623"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
@@ -5033,14 +4908,14 @@ license:CC0
 	</software>
 
 	<software name="dquest12" cloneof="dwarr12">
-		<description>Dragon Quest I &amp; II (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dragon Quest I &amp; II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-AEDJ-JPN"/>
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="ドラゴンクエストI・II"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5058,7 +4933,7 @@ license:CC0
 
 	<software name="dquest3" cloneof="dwarr3">
 		<!-- Notes: GBC only -->
-		<description>Dragon Quest III - Soshite Densetsu e... (Japan)</description>
+		<description>Dragon Quest III - Soshite Densetsu e... (Jpn)</description>
 		<year>2000</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="CGB-BD3J-JPN"/>
@@ -5075,14 +4950,14 @@ license:CC0
 	</software>
 
 	<software name="dqm" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -5099,14 +4974,14 @@ license:CC0
 	</software>
 
 	<software name="dqma" cloneof="dwm">
-		<description>Dragon Quest Monsters - Terry no Wonderland (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dragon Quest Monsters - Terry no Wonderland (Jpn)</description>
 		<year>1998</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-ADQJ-JPN"/>
 		<info name="release" value="19980925"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ テリーのワンダーランド"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-DGCU-01" />
 			<feature name="u1" value="U1 16M MROM" />
 			<feature name="u2" value="U2 MBC1 [MBC1-B]" />
@@ -5123,7 +4998,7 @@ license:CC0
 	</software>
 
 	<software name="dqmg" cloneof="dwm">
-		<description>Dragon Quest Monsters (Germany)</description>
+		<description>Dragon Quest Monsters (Ger)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQD-NOE"/>
@@ -5138,15 +5013,14 @@ license:CC0
 	</software>
 
 	<software name="dqm2i" cloneof="dwm2t">
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Iru no Bouken (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQIJ-JPN"/>
-		<info name="gold" value="20001222"/>
 		<info name="release" value="20010412"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 イルの冒険"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dragon quest monsters 2 - maruta no fushigi na kagi - iru no bouken (japan).bin" size="4194304" crc="68ba18d7" sha1="9193778b28e2e4a6303e09cb4170ca00d0058ae5"/>
@@ -5157,15 +5031,14 @@ license:CC0
 	</software>
 
 	<software name="dqm2r" cloneof="dwm2c">
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BQLJ-JPN"/>
-		<info name="gold" value="20001208"/>
 		<info name="release" value="20010309"/>
 		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5175,26 +5048,6 @@ license:CC0
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dmg-bqlj-0.u1" size="4194304" crc="2c428a87" sha1="5d2daec53938805236328a0f8a614debffa34048"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dqm2ra" cloneof="dwm2c">
-		<!--	In lot check as "dmgbqlj1.j93"	-->
-		<description>Dragon Quest Monsters 2 - Maruta no Fushigi na Kagi - Ruka no Tabidachi (Japan, Rev. 1)</description>
-		<year>2001</year>
-		<publisher>Enix</publisher>
-		<info name="serial" value="DMG-BQLJ-JPN"/>
-		<info name="gold" value="20001228"/>
-		<info name="release" value="20010309"/>
-		<info name="alt_title" value="ドラゴンクエストモンスターズ2 マルタのふしぎな鍵 ルカの旅立ち"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dmgbqlj1.j93" size="4194304" crc="649e8d97" sha1="217faaf8e7d60545bd07f818a3b3373843e6318d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -5220,7 +5073,7 @@ license:CC0
 
 	<software name="dtalesdw">
 		<!-- Notes: GBC only -->
-		<description>Dragon Tales - Dragon Wings (Europe)</description>
+		<description>Dragon Tales - Dragon Wings (Euro)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BDZP-EUR"/>
@@ -5282,7 +5135,7 @@ license:CC0
 	</software>
 
 	<software name="dwm">
-		<description>Dragon Warrior Monsters (Europe, USA)</description>
+		<description>Dragon Warrior Monsters (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="DMG-AWQE-USA, DMG-AWQP-UKV"/>
@@ -5334,7 +5187,7 @@ license:CC0
 
 	<software name="dlair">
 		<!-- Notes: GBC only -->
-		<description>Dragon's Lair (Europe, USA)</description>
+		<description>Dragon's Lair (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BDXE-USA, CGB-BDXP-EUR"/>
@@ -5351,7 +5204,7 @@ license:CC0
 
 	<software name="driver">
 		<!-- Notes: GBC only -->
-		<description>Driver (Europe)</description>
+		<description>Driver (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BDRP-EUR"/>
@@ -5382,7 +5235,7 @@ license:CC0
 	</software>
 
 	<software name="dropzone">
-		<description>Dropzone (Europe)</description>
+		<description>Dropzone (Euro)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AD4P-EUR"/>
@@ -5398,14 +5251,14 @@ license:CC0
 	</software>
 
 	<software name="dtlords">
-		<description>DT - Lords of Genomes (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>DT - Lords of Genomes (Jpn)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="DMG-BBDJ-JPN"/>
 		<info name="release" value="20010525"/>
 		<info name="alt_title" value="DT ローズ・オブ・ゲノム"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dt - lords of genomes (japan).bin" size="4194304" crc="42ceb854" sha1="66988a201f77cd4c33fb0a9b3981ff5831206c9d"/>
@@ -5417,7 +5270,7 @@ license:CC0
 
 	<software name="dukenuke">
 		<!-- Notes: GBC only -->
-		<description>Duke Nukem (Europe)</description>
+		<description>Duke Nukem (Euro)</description>
 		<year>1999</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="CGB-ADIP-EUR"/>
@@ -5449,7 +5302,7 @@ license:CC0
 
 	<software name="hazzard">
 		<!-- Notes: GBC only -->
-		<description>The Dukes of Hazzard - Racing for Home (Europe)</description>
+		<description>The Dukes of Hazzard - Racing for Home (Euro)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-BDCP-EUR"/>
@@ -5486,15 +5339,14 @@ license:CC0
 	</software>
 
 	<software name="dsavior">
-		<description>Dungeon Savior (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Dungeon Savior (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-ADWJ-JPN"/>
-		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ダンジョンセイバー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="dungeon savior (japan).bin" size="4194304" crc="2bcb5f78" sha1="766ab65d9420f361d8d9a4754ea8c6b692e34c36"/>
@@ -5506,7 +5358,7 @@ license:CC0
 
 	<software name="dxjinsei">
 		<!-- Notes: GBC only -->
-		<description>DX Jinsei Game (Japan)</description>
+		<description>DX Jinsei Game (Jpn)</description>
 		<year>2001</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BZGJ-JPN"/>
@@ -5523,14 +5375,14 @@ license:CC0
 	</software>
 
 	<software name="dxmono">
-		<description>DX Monopoly GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>DX Monopoly GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-BMPJ-JPN"/>
 		<info name="release" value="20000421"/>
 		<info name="alt_title" value="デラックスモノポリーGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dx monopoly gb (japan).bin" size="1048576" crc="3f1e076c" sha1="524d9459d357e209d64a2ef17b4072478f290806"/>
@@ -5542,7 +5394,7 @@ license:CC0
 
 	<software name="dynamike">
 		<!-- Notes: GBC only -->
-		<description>DynaMike (Europe, Prototype)</description>
+		<description>DynaMike (Euro, Prototype)</description>
 		<year>19??</year>
 		<publisher>Engine Software</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -5557,7 +5409,7 @@ license:CC0
 
 	<software name="etcg">
 		<!-- Notes: GBC only -->
-		<description>E.T. and the Cosmic Garden (Europe)</description>
+		<description>E.T. and the Cosmic Garden (Euro)</description>
 		<year>2002</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BEOP-EUR"/>
@@ -5595,7 +5447,6 @@ license:CC0
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BETE-USA"/>
-		<info name="gold" value="20011015"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -5609,7 +5460,7 @@ license:CC0
 
 	<software name="et">
 		<!-- Notes: GBC only -->
-		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Europe)</description>
+		<description>E.T. The Extra Terrestrial - Escape from Planet Earth (Euro)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BERP-EUR"/>
@@ -5641,7 +5492,7 @@ license:CC0
 
 	<software name="ejim">
 		<!-- Notes: GBC only -->
-		<description>Earthworm Jim - Menace 2 the Galaxy (Europe, USA)</description>
+		<description>Earthworm Jim - Menace 2 the Galaxy (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEBE-USA, DMG-AEBP-EUR"/>
@@ -5658,7 +5509,7 @@ license:CC0
 
 	<software name="ecwhard">
 		<!-- Notes: GBC only -->
-		<description>ECW Hardcore Revolution (Europe, USA)</description>
+		<description>ECW Hardcore Revolution (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BECE-USA, CGB-BECP-EUR"/>
@@ -5675,7 +5526,7 @@ license:CC0
 
 	<software name="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Europe)</description>
+		<description>Elevator Action EX (Euro)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="alt_title" value="Elevator Action (Box)"/>
@@ -5690,7 +5541,7 @@ license:CC0
 
 	<software name="elevatorj" cloneof="elevator">
 		<!-- Notes: GBC only -->
-		<description>Elevator Action EX (Japan)</description>
+		<description>Elevator Action EX (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BEXJ-JPN"/>
@@ -5705,14 +5556,14 @@ license:CC0
 	</software>
 
 	<software name="atelelie">
-		<description>Elie no Atelier GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Elie no Atelier GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8EJ-JPN"/>
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="エリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -5729,7 +5580,7 @@ license:CC0
 	</software>
 
 	<software name="elmo123">
-		<description>Elmo's 123s (Europe)</description>
+		<description>Elmo's 123s (Euro)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AE3P-EUR"/>
@@ -5755,7 +5606,7 @@ license:CC0
 	</software>
 
 	<software name="elmoabc">
-		<description>Elmo's ABCs (Europe)</description>
+		<description>Elmo's ABCs (Euro)</description>
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AEAP-EUR"/>
@@ -5783,10 +5634,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="emperorunk" cloneof="emperor">
+	<software name="emperor">
 		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>The Emperor's New Groove (Europe, bad dump?)</description>
+		<description>The Emperor's New Groove (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENP-EUR"/>
@@ -5800,32 +5650,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="emperor">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbenp0.641"	-->
-		<description>The Emperor's New Groove (Europe)</description>
-		<year>2001</year>
-		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="CGB-BENP-EUR"/>
-		<info name="gold" value="20010123"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbenp0.641" size="2097152" crc="eb29c584" sha1="2f53318aa7f1c82df95bf3da6b29701a2c563d13"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-
 	<software name="emperoru" cloneof="emperor">
 		<!-- Notes: GBC only -->
 		<description>The Emperor's New Groove (USA)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BENE-USA"/>
-		<info name="gold" value="20010123"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5870,7 +5700,7 @@ license:CC0
 
 	<software name="estpolis" cloneof="lufia">
 		<!-- Notes: GBC only -->
-		<description>Estpolis Denki - Yomigaeru Densetsu (Japan)</description>
+		<description>Estpolis Denki - Yomigaeru Densetsu (Jpn)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BLCJ-JPN"/>
@@ -5894,7 +5724,7 @@ license:CC0
 
 	<software name="euroleag">
 		<!-- Notes: GBC only -->
-		<description>European Super League (Europe)</description>
+		<description>European Super League (Euro)</description>
 		<year>2001</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="??"/>
@@ -5909,7 +5739,7 @@ license:CC0
 	</software>
 
 	<software name="evelkni">
-		<description>Evel Knievel (Europe)</description>
+		<description>Evel Knievel (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AEVP-EUR"/>
@@ -5939,7 +5769,7 @@ license:CC0
 
 	<software name="exghostb">
 		<!-- Notes: GBC only -->
-		<description>Extreme Ghostbusters (Europe)</description>
+		<description>Extreme Ghostbusters (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BEBP-EUR"/>
@@ -5953,7 +5783,7 @@ license:CC0
 
 	<software name="extsport">
 		<!-- Notes: GBC only -->
-		<description>Extreme Sports with the Berenstain Bears (Europe, USA)</description>
+		<description>Extreme Sports with the Berenstain Bears (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Sound Source</publisher>
 		<info name="serial" value="CGB-BESE-USA, CGB-BESP-EUR"/>
@@ -5971,12 +5801,10 @@ license:CC0
 
 	<software name="f1wgp">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbafip0.028", "KENSA\cgbafie0.0"	-->
-		<description>F-1 World Grand Prix (Europe)</description>
+		<description>F-1 World Grand Prix (Euro)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-AFIP-EUR"/>
-		<info name="gold" value="19990526"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -5989,7 +5817,7 @@ license:CC0
 
 	<software name="f18thund">
 		<!-- Notes: GBC only -->
-		<description>F-18 Thunder Strike (Europe, USA)</description>
+		<description>F-18 Thunder Strike (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-B18E-USA, CGB-B18P-NOE"/>
@@ -6006,11 +5834,10 @@ license:CC0
 
 	<software name="fa2001">
 		<!-- Notes: GBC only -->
-		<description>The F.A. Premier League Stars 2001 (Europe)</description>
+		<description>The F.A. Premier League Stars 2001 (Euro)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="CGB-BSJP-?"/>
-		<info name="gold" value="20010413"/>
+		<info name="serial" value="??"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6021,11 +5848,10 @@ license:CC0
 
 	<software name="f1chmp2k">
 		<!-- Notes: GBC only -->
-		<description>F1 Championship Season 2000 (Europe)</description>
+		<description>F1 Championship Season 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="CGB-BFIP-?"/>
-		<info name="gold" value="20001117"/>
+		<info name="serial" value="??"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -6034,34 +5860,16 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="f1chmp2kb" cloneof="f1chmp2k">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfib0.579"	-->
-		<description>F1 Championship Season 2000 (Bra)</description>
-		<year>2000</year>
-		<publisher>Electronic Arts</publisher>
-		<info name="serial" value="CGB-BFIB-?"/>
-		<info name="gold" value="20001107"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbfib0.579" size="2097152" crc="f4f5ed18" sha1="4731a7442bbff31c6d470b84938a3f148a4f1f6c"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="f1racing">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaeqp0.381"	-->
-		<description>F1 Racing Championship (Europe)</description>
+		<description>F1 Racing Championship (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AEQP-EUR"/>
-		<info name="gold" value="20000829"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="cgbaeqp0.381" size="4194304" crc="93a9789f" sha1="ea844051c0b5c6f9a6a8c472f4f67ee6b9b3d8e7"/>
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6070,29 +5878,13 @@ license:CC0
 
 	<software name="f1racingp" cloneof="f1racing">
 		<!-- Notes: GBC only -->
-		<description>F1 Racing Championship (Europe, Prototype)</description>
+		<description>F1 Racing Championship (Euro, Prototype)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta) (february, 2000).bin" size="4194304" crc="e115ddb1" sha1="e9616a53ab9474c0bb85451ff19b62bed9e7f1a4"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="f1racingunk" cloneof="f1racing">
-		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>F1 Racing Championship (Europe, bad dump?)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it) (beta).bin" size="4194304" crc="fc537719" sha1="3c10fe93521a604f1e312253328cd977236eae07"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6101,7 +5893,7 @@ license:CC0
 
 	<software name="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Europe)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Euro)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2P-EUR"/>
@@ -6117,7 +5909,7 @@ license:CC0
 
 	<software name="f1wgp2j" cloneof="f1wgp2">
 		<!-- Notes: GBC only -->
-		<description>F1 World Grand Prix II for Game Boy Color (Japan)</description>
+		<description>F1 World Grand Prix II for Game Boy Color (Jpn)</description>
 		<year>2000</year>
 		<publisher>Video System</publisher>
 		<info name="serial" value="CGB-BF2J-JPN"/>
@@ -6156,18 +5948,17 @@ license:CC0
 	</software>
 
 	<software name="fairykit">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (Rev. 1).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
+				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan) (rev. a).bin" size="1048576" crc="c4d3628f" sha1="d07b600cc9af8cadc2581a6ac19aadea79313d69"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6175,15 +5966,14 @@ license:CC0
 	</software>
 
 	<software name="fairykita" cloneof="fairykit">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Fairy Kitty no Kaiun Jiten - Yousei no Kuni no Uranai Shugyou (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AFUJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="フェアリーキティの開運辞典 妖精の国の占い修行"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="fairy kitty no kaiun jiten - yousei no kuni no uranai shugyou (japan).bin" size="1048576" crc="b59a51c4" sha1="a27b498c6170b4136d2ca8a75c3d529dd6c06639"/>
@@ -6195,7 +5985,7 @@ license:CC0
 
 	<software name="ferret">
 		<!-- Notes: GBC only -->
-		<description>Ferret Monogatari (Japan)</description>
+		<description>Ferret Monogatari (Jpn)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BBIJ-JPN"/>
@@ -6212,7 +6002,7 @@ license:CC0
 	</software>
 
 	<software name="fifa2k">
-		<description>FIFA 2000 (Europe, USA)</description>
+		<description>FIFA 2000 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AFOE-USA, DMG-AFOP-UKV"/>
@@ -6229,7 +6019,7 @@ license:CC0
 
 	<software name="fishfile">
 		<!-- Notes: GBC only -->
-		<description>The Fish Files (Europe)</description>
+		<description>The Fish Files (Euro)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BFQP-EUR"/>
@@ -6245,7 +6035,7 @@ license:CC0
 
 	<software name="fixfoxi">
 		<!-- Notes: GBC only -->
-		<description>Fix &amp; Foxi - Episode 1: Lupo (Europe)</description>
+		<description>Fix &amp; Foxi - Episode 1: Lupo (Euro)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BFFP-EUR"/>
@@ -6259,7 +6049,7 @@ license:CC0
 
 	<software name="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Europe)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Euro)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6274,7 +6064,7 @@ license:CC0
 <!-- The header is wrong, can it be a bad dump? a beta? investigations are needed on this older dump -->
 	<software name="flintbba" cloneof="flintbb">
 		<!-- Notes: GBC only -->
-		<description>The Flintstones - Burgertime in Bedrock (Europe, Alt?)</description>
+		<description>The Flintstones - Burgertime in Bedrock (Euro, Alt?)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BFSP-EUR"/>
@@ -6302,7 +6092,7 @@ license:CC0
 
 	<software name="flipperl">
 		<!-- Notes: GBC only -->
-		<description>Flipper &amp; Lopaka (Europe)</description>
+		<description>Flipper &amp; Lopaka (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BFLP-EUR"/>
@@ -6346,7 +6136,7 @@ license:CC0
 
 	<software name="fortboya">
 		<!-- Notes: GBC only -->
-		<description>Fort Boyard (Europe)</description>
+		<description>Fort Boyard (Euro)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BYDP-EUR"/>
@@ -6359,7 +6149,7 @@ license:CC0
 	</software>
 
 	<software name="frogger">
-		<description>Frogger (Europe)</description>
+		<description>Frogger (Euro)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRP-EUR"/>
@@ -6372,7 +6162,7 @@ license:CC0
 	</software>
 
 	<software name="froggeru" cloneof="frogger">
-		<description>Frogger (USA, Rev. 2)</description>
+		<description>Frogger (USA, Rev. B)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-3"/>
@@ -6388,14 +6178,14 @@ license:CC0
 	</software>
 
 	<software name="froggerua" cloneof="frogger">
-		<description>Frogger (USA, Rev. 1)</description>
+		<description>Frogger (USA, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AFRE-USA-2"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="frogger (usa) (rev 1).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
+				<rom name="frogger (usa) (rev a).bin" size="1048576" crc="ba907064" sha1="db3d21977c17a505936d1e2fc3626a0b43addf16"/>
 			</dataarea>
 		</part>
 	</software>
@@ -6419,7 +6209,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BH2E-USA"/>
-		<info name="gold" value="20000731"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -6430,34 +6219,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="frogger2a" cloneof="frogger2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbh2e1.351"	-->
-		<description>Frogger 2 (USA, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Majesco</publisher>
-		<info name="serial" value="CGB-BH2E-USA"/>
-		<info name="gold" value="20000821"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbh2e1.351" size="1048576" crc="e3227b7d" sha1="0d5028ca6fcc10df46d11cd4b56e5add1dc5e63e"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="onepglin">
-		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>From TV Animation One Piece - Maboroshi no Grand Line Boukenki! (Jpn)</description>
 		<year>2002</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BZOJ-JPN"/>
-		<info name="gold" value="20020510"/>
 		<info name="release" value="20020628"/>
-		<info name="alt_title" value="From TV animation ＯＮＥ ＰＩＥＣＥ　幻のグランドライン冒険記！"/>
+		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 幻のグランドライン冒険記!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6474,15 +6244,14 @@ license:CC0
 	</software>
 
 	<software name="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
-		<info name="gold" value="20010615"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
+		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C3203-12A2]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -6491,7 +6260,7 @@ license:CC0
 			<feature name="battery" value="Batt CR1616" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (Rev. 1).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
+				<rom name="from tv animation one piece - yume no luffy kaizokudan tanjou (japan) (rev. a).bin" size="4194304" crc="a4dde805" sha1="53da28b16a4bf0efab1f65c21f7931ce4948865b"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6499,15 +6268,14 @@ license:CC0
 	</software>
 
 	<software name="onepyumea" cloneof="onepyume">
-		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>From TV Animation One Piece - Yume no Luffy Kaizokudan Tanjou! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BLUJ-JPN"/>
-		<info name="gold" value="20010307"/>
 		<info name="release" value="20010427"/>
-		<info name="alt_title" value="FROM TV ANIMATION　ＯＮＥ ＰＩＥＣＥ　夢のルフィ海賊団誕生！"/>
+		<info name="alt_title" value="フロム・テレビ・アニメーション・ワンピース 夢のルフィ海賊団誕生!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -6525,7 +6293,7 @@ license:CC0
 
 	<software name="frontlin">
 		<!-- Notes: GBC only -->
-		<description>Front Line - The Next Mission (Japan)</description>
+		<description>Front Line - The Next Mission (Jpn)</description>
 		<year>2001</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFRJ-JPN"/>
@@ -6541,7 +6309,7 @@ license:CC0
 
 	<software name="frontrow">
 		<!-- Notes: GBC only -->
-		<description>Front Row (Japan)</description>
+		<description>Front Row (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="CGB-AZDJ-JPN"/>
@@ -6559,13 +6327,12 @@ license:CC0
 
 	<software name="furaish2">
 		<!-- Notes: GBC only -->
-		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan)</description>
+		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Jpn)</description>
 		<year>2001</year>
 		<publisher>ChinSoft</publisher>
 		<info name="serial" value="CGB-AFMJ-JPN"/>
-		<info name="gold" value="20010622"/>
 		<info name="release" value="20010719"/>
-		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
+		<info name="alt_title" value="不思議のダンジョン 風来のシレンGB2 砂漠の魔城"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -6576,30 +6343,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="furaish2a" cloneof="furaish2">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfwj0.814"	-->
-		<!--	Retail cartridge not yet secured, might be unreleased	-->
-		<!--	Alternate version with a different serial code, purpose unknown (limited edition seems to feature the common retail release)	-->
-		<description>Fushigi no Dungeon - Fuurai no Shiren GB2 - Sabaku no Majou (Japan, Alt)</description>
-		<year>2001</year>
-		<publisher>ChinSoft</publisher>
-		<info name="serial" value="CGB-BFWJ-JPN?"/>
-		<info name="gold" value="20010703"/>
-		<info name="alt_title" value="不思議のダンジョン　風来のシレンＧＢ２　砂漠の魔城"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbbfwj0.814" size="4194304" crc="f3c20fbe" sha1="d9c490af97c08ac7053bbb9f7ae06d3501035127"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="gaiamast">
 		<!-- Notes: GBC only -->
-		<description>Gaiamaster Duel - Card Attackers (Japan)</description>
+		<description>Gaiamaster Duel - Card Attackers (Jpn)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BGIJ-JPN"/>
@@ -6615,12 +6361,11 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="gakkyamaa">
-		<description>Gakkyuu Ou Yamazaki (Japan, Rev. 1)</description>
+	<software name="gakkyama">
+		<description>Gakkyuu Ou Yamazaki (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AYMJ-JPN"/>
-		<info name="gold" value="19990428"/>
 		<info name="release" value="19990529"/>
 		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6633,26 +6378,6 @@ license:CC0
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="dmg-aymj-1.u1" size="1048576" crc="ef2cfd99" sha1="3a2718efa3d1cac7345fbbcddb7c3f666fc6c70c"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="gakkyama" cloneof="gakkyamaa">
-		<!--	In lot check as "dmgaymj0.g22"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Gakkyuu Ou Yamazaki (Japan)</description>
-		<year>1999</year>
-		<publisher>Koei</publisher>
-		<info name="serial" value="DMG-AYMJ-JPN?"/>
-		<info name="gold" value="19990226"/>
-		<info name="release" value="19990529"/>
-		<info name="alt_title" value="学級王ヤマザキ ゲームボーイ版"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaymj0.g22" size="1048576" crc="b8147b5c" sha1="132b872391565d418ccc9d0e1c643510d778c066"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -6675,11 +6400,10 @@ license:CC0
 
 	<software name="gamblert">
 		<!-- Notes: GBC only -->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan)</description>
+		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Jpn)</description>
 		<year>2001</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BGYJ-JPN"/>
-		<info name="gold" value="20001218"/>
 		<info name="release" value="20010209"/>
 		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
 		<part name="cart" interface="gameboy_cart">
@@ -6692,27 +6416,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="gamblerta" cloneof="gamblert">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbgyj1.607"	-->
-		<description>Gambler Densetsu Tetsuya - Shinjuku Tenun Hen (Japan, Rev. 1)</description>
-		<year>2001</year>
-		<publisher>Athena</publisher>
-		<info name="serial" value="CGB-BGYJ-JPN?"/>
-		<info name="gold" value="20010307"/>
-		<info name="alt_title" value="勝負師伝説 哲也 新宿天運編"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbgyj1.607" size="1048576" crc="91739def" sha1="b62f8e56b995874c0e1a2533df5a37f6996df12e"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="gwatch2">
-		<description>Game &amp; Watch Gallery 2 (Europe, USA)</description>
+		<description>Game &amp; Watch Gallery 2 (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLE-USA, DMG-AGLP-EUR"/>
@@ -6727,7 +6432,7 @@ license:CC0
 	</software>
 
 	<software name="gwatch3">
-		<description>Game &amp; Watch Gallery 3 (Europe, USA)</description>
+		<description>Game &amp; Watch Gallery 3 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQE-USA, DMG-AGQP-EUR"/>
@@ -6743,7 +6448,7 @@ license:CC0
 
 	<software name="gbpromo">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Color Promotional Demo (Europe, USA)</description>
+		<description>Game Boy Color Promotional Demo (Euro, USA)</description>
 		<year>19??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6755,7 +6460,7 @@ license:CC0
 	</software>
 
 	<software name="gbgall3" cloneof="gwatch2">
-		<description>Game Boy Gallery 3 (Australia)</description>
+		<description>Game Boy Gallery 3 (Aus)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGLU-AUS"/>
@@ -6770,15 +6475,14 @@ license:CC0
 	</software>
 
 	<software name="gbgall3j" cloneof="gwatch3">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Game Boy Gallery 3 (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Game Boy Gallery 3 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQJ-JPN"/>
 		<info name="release" value="19990408"/>
 		<info name="alt_title" value="ゲームボーイギャラリー3"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-Z02-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -6791,7 +6495,7 @@ license:CC0
 	</software>
 
 	<software name="gbgall4" cloneof="gwatch3">
-		<description>Game Boy Gallery 4 (Australia)</description>
+		<description>Game Boy Gallery 4 (Aus)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AGQU-AUS"/>
@@ -6812,14 +6516,14 @@ license:CC0
 	</software>
 
 	<software name="gbwars2">
-		<description>Game Boy Wars 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Game Boy Wars 2 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-AWOJ-JPN"/>
 		<info name="release" value="19981120"/>
 		<info name="alt_title" value="ゲームボーイウォーズ2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 			<!-- 2nd half is filled with 0xff, confirmed with the real cart -->
@@ -6832,7 +6536,7 @@ license:CC0
 
 	<software name="gbwars3">
 		<!-- Notes: GBC only -->
-		<description>Game Boy Wars 3 (Japan)</description>
+		<description>Game Boy Wars 3 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BWWJ-JPN"/>
@@ -6851,7 +6555,7 @@ license:CC0
 	</software>
 
 	<software name="gameconv">
-		<description>Game Conveni 21 (Japan)</description>
+		<description>Game Conveni 21 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BG2J-JPN"/>
@@ -6867,7 +6571,7 @@ license:CC0
 
 	<software name="gamefrnz">
 		<!-- Notes: GBC only -->
-		<description>Games Frenzy (Europe)</description>
+		<description>Games Frenzy (Euro)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-BFGP-EUR"/>
@@ -6881,7 +6585,7 @@ license:CC0
 
 	<software name="ggoemdyn">
 		<!-- Notes: GBC only, also released by NP in 2001-07 -->
-		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Japan)</description>
+		<description>Ganbare Goemon - Seikuushi Dynamites Arawaru!! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BEKJ-JPN (RK234-J1)"/>
@@ -6898,14 +6602,14 @@ license:CC0
 	</software>
 
 	<software name="ggoemnab">
-		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Ganbare Goemon - Mononoke Douchuu Tobidase Nabebugyou! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AEFJ-JPN (RK192-J1)"/>
 		<info name="release" value="19991216"/>
 		<info name="alt_title" value="がんばれゴエモン もののけ道中飛び出せ鍋奉行!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="ganbare goemon - mononoke douchuu tobisuise nabebugyou (japan).bin" size="2097152" crc="73311cfa" sha1="4bc3928f3528a2c566b09613e538253dd128864c"/>
@@ -6916,8 +6620,8 @@ license:CC0
 	</software>
 
 	<software name="ggoemtng">
-		<!-- Also released by NP in 2000-05 -->
-		<description>Ganbare Goemon - Tengutou no Gyakushuu (Japan)</description>
+		<!-- Notes: Also released by NP in 2000-05 -->
+		<description>Ganbare Goemon - Tengutou no Gyakushuu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AGUJ-JPN (RK182-J1)"/>
@@ -6935,7 +6639,7 @@ license:CC0
 
 	<software name="olymp2k" cloneof="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>Ganbare! Nippon! Olympic 2000 (Japan)</description>
+		<description>Ganbare! Nippon! Olympic 2000 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HJ-JPN (RK208-J1)"/>
@@ -6953,7 +6657,7 @@ license:CC0
 
 	<software name="harobots">
 		<!-- Notes: GBC only -->
-		<description>GB Harobots (Japan)</description>
+		<description>GB Harobots (Jpn)</description>
 		<year>2000</year>
 		<publisher>Sunrise Interactive</publisher>
 		<info name="serial" value="CGB-BHRJ-JPN"/>
@@ -6971,7 +6675,7 @@ license:CC0
 
 	<software name="gbmemory">
 		<!-- Notes: GBC only -->
-		<description>GB Memory Multi Menu (Japan, NP)</description>
+		<description>GB Memory Multi Menu (Jpn, NP)</description>
 		<year>20??</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -6984,7 +6688,7 @@ license:CC0
 
 	<software name="happyhip">
 		<!-- Notes: GBC only -->
-		<description>Das Geheimnis der Happy Hippo-Insel (Germany)</description>
+		<description>Das Geheimnis der Happy Hippo-Insel (Ger)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BHOD-NOE"/>
@@ -7001,7 +6705,7 @@ license:CC0
 
 	<software name="dangunrc">
 		<!-- Notes: GBC only -->
-		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Japan)</description>
+		<description>Gekisou Dangun Racer - Onsoku Buster Dangun Dan (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BDJJ-JPN"/>
@@ -7018,14 +6722,14 @@ license:CC0
 	</software>
 
 	<software name="gemgem" cloneof="lilmonst">
-		<description>Gem Gem Monster (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Gem Gem Monster (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AJYJ-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="ジェムジェムモンスター"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="gem gem monster (japan).bin" size="1048576" crc="de7505c0" sha1="8b1396cf9dbc77246b3443810282b8b9bcb65a67"/>
@@ -7037,7 +6741,7 @@ license:CC0
 
 	<software name="gmsayuki">
 		<!-- Notes: GBC only -->
-		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Japan)</description>
+		<description>Gensou Maden Saiyuuki - Sabaku no Shishin (Jpn)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BGSJ-JPN"/>
@@ -7054,7 +6758,7 @@ license:CC0
 	</software>
 
 	<software name="getchuu">
-		<description>Get Chuu Club - Minna no Konchuu Daizukan (Japan)</description>
+		<description>Get Chuu Club - Minna no Konchuu Daizukan (Jpn)</description>
 		<year>1999</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="DMG-VRKJ-JPN"/>
@@ -7079,7 +6783,7 @@ license:CC0
 	</software>
 
 	<software name="gex2">
-		<description>Gex - Enter the Gecko (Europe, USA)</description>
+		<description>Gex - Enter the Gecko (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AEXE-USA, DMG-AEXP-EUR"/>
@@ -7093,7 +6797,7 @@ license:CC0
 
 	<software name="gex3">
 		<!-- Notes: GBC only -->
-		<description>Gex 3 - Deep Cover Gecko (Europe)</description>
+		<description>Gex 3 - Deep Cover Gecko (Euro)</description>
 		<year>1999</year>
 		<publisher>Eidos</publisher>
 		<info name="serial" value="CGB-AXGP-EUR"/>
@@ -7120,7 +6824,7 @@ license:CC0
 	</software>
 
 	<software name="gng">
-		<description>Ghosts'n Goblins (Europe, USA)</description>
+		<description>Ghosts'n Goblins (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-AG9E-USA, DMG-AG9P-EUR"/>
@@ -7136,7 +6840,7 @@ license:CC0
 	</software>
 
 	<software name="gifts" cloneof="gift">
-		<description>Gift (Europe, Sample)</description>
+		<description>Gift (Euro, Sample)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7149,11 +6853,10 @@ license:CC0
 
 	<software name="gift">
 		<!-- Notes: GBC only -->
-		<description>Gift (Europe)</description>
+		<description>Gift (Euro)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BGFP-EUR"/>
-		<info name="gold" value="20001026"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7164,11 +6867,10 @@ license:CC0
 
 	<software name="gifty" cloneof="gift">
 		<!-- Notes: GBC only -->
-		<description>Gifty (Germany)</description>
+		<description>Gifty (Ger)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
-		<info name="serial" value="CGB-BGFD-?"/>
-		<info name="gold" value="20001026"/>
+		<info name="serial" value="??"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -7178,14 +6880,14 @@ license:CC0
 	</software>
 
 	<software name="glochex" cloneof="hexcite">
-		<description>Glocal Hexcite (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Glocal Hexcite (Jpn)</description>
 		<year>1998</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="DMG-AICJ-JPN"/>
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="グローカルヘキサイト"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="glocal hexcite (japan).bin" size="1048576" crc="f1908391" sha1="7d13220593c8d89af1b4cae955caacff7df3817a"/>
@@ -7210,7 +6912,7 @@ license:CC0
 	</software>
 
 	<software name="godzilla">
-		<description>Godzilla - The Series (Europe)</description>
+		<description>Godzilla - The Series (Euro)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AZIP-EUR"/>
@@ -7237,7 +6939,7 @@ license:CC0
 
 	<software name="godzmwar">
 		<!-- Notes: GBC only -->
-		<description>Godzilla - The Series - Monster Wars (Europe)</description>
+		<description>Godzilla - The Series - Monster Wars (Euro)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BGDP-EUR"/>
@@ -7268,7 +6970,7 @@ license:CC0
 
 	<software name="goldglry">
 		<!-- Notes: GBC only -->
-		<description>Gold and Glory - The Road to El Dorado (Europe)</description>
+		<description>Gold and Glory - The Road to El Dorado (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BEDP-EUR"/>
@@ -7295,7 +6997,7 @@ license:CC0
 	</software>
 
 	<software name="goldgoal">
-		<description>Golden Goal (Europe)</description>
+		<description>Golden Goal (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFX-EUR"/>
@@ -7316,7 +7018,7 @@ license:CC0
 	</software>
 
 	<software name="goldgoalg" cloneof="goldgoal">
-		<description>Golden Goal (Germany)</description>
+		<description>Golden Goal (Ger)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFD-NOE"/>
@@ -7331,14 +7033,14 @@ license:CC0
 	</software>
 
 	<software name="golfdai">
-		<description>Golf Daisuki! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Golf Daisuki! (Jpn)</description>
 		<year>1999</year>
 		<publisher>KID</publisher>
 		<info name="serial" value="DMG-AAGJ-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ゴルフだいすき!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="golf daisuki (japan).bin" size="2097152" crc="80444a86" sha1="d245a267b1b1d056e0f5af4ba732c66c8deadde2"/>
@@ -7349,7 +7051,7 @@ license:CC0
 	</software>
 
 	<software name="golfohas" cloneof="holein1">
-		<description>Golf de Ohasuta (Japan)</description>
+		<description>Golf de Ohasuta (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOHJ-JPN"/>
@@ -7366,15 +7068,14 @@ license:CC0
 	</software>
 
 	<software name="golfou">
-		<description>Golf Ou (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Golf Ou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-AZAJ-JPN"/>
-		<info name="gold" value="19990617"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="ゴルフ王 THE KING OF GOLF"/>
+		<info name="alt_title" value="ゴルフ王"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="golf ou (japan).bin" size="4194304" crc="634b2d43" sha1="d196af0aaf77ca67f9784d0ccd1ef4b25abed5c2"/>
@@ -7386,7 +7087,7 @@ license:CC0
 
 	<software name="gonta">
 		<!-- Notes: GBC only -->
-		<description>Gonta no Okiraku Daibouken (Japan)</description>
+		<description>Gonta no Okiraku Daibouken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Lay-Up</publisher>
 		<info name="serial" value="CGB-B54J-JPN"/>
@@ -7403,7 +7104,7 @@ license:CC0
 	</software>
 
 	<software name="goraku">
-		<description>Goraku Ou Tango! (Japan)</description>
+		<description>Goraku Ou Tango! (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AOEJ-JPN"/>
@@ -7420,7 +7121,7 @@ license:CC0
 	</software>
 
 	<software name="gta">
-		<description>Grand Theft Auto (Europe)</description>
+		<description>Grand Theft Auto (Euro)</description>
 		<year>1999</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="DMG-AOAP-EUR"/>
@@ -7451,7 +7152,7 @@ license:CC0
 
 	<software name="gta2">
 		<!-- Notes: GBC only -->
-		<description>Grand Theft Auto 2 (Europe)</description>
+		<description>Grand Theft Auto 2 (Euro)</description>
 		<year>2000</year>
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="CGB-BGTP-(EUR/UKV)"/>
@@ -7479,7 +7180,7 @@ license:CC0
 
 	<software name="grandia">
 		<!-- Notes: GBC only -->
-		<description>Grandia - Parallel Trippers (Japan)</description>
+		<description>Grandia - Parallel Trippers (Jpn)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BGEJ-JPN"/>
@@ -7497,7 +7198,7 @@ license:CC0
 
 	<software name="granduel">
 		<!-- Notes: GBC only -->
-		<description>Granduel - Shinki Dungeon no Hihou (Japan)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-ADVJ-JPN"/>
@@ -7514,7 +7215,7 @@ license:CC0
 	</software>
 
 	<software name="granduels" cloneof="granduel">
-		<description>Granduel - Shinki Dungeon no Hihou (Japan, Sample)</description>
+		<description>Granduel - Shinki Dungeon no Hihou (Jpn, Sample)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7526,14 +7227,14 @@ license:CC0
 	</software>
 
 	<software name="gbattlep">
-		<description>The Great Battle Pocket (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>The Great Battle Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AGVJ-JPN"/>
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="ザ・グレイトバトル ポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -7546,7 +7247,7 @@ license:CC0
 
 	<software name="gremlins">
 		<!-- Notes: GBC only -->
-		<description>Gremlins Unleashed (Europe)</description>
+		<description>Gremlins Unleashed (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<info name="serial" value="CGB-BGPP-EUR"/>
@@ -7559,7 +7260,7 @@ license:CC0
 	</software>
 
 	<software name="gremlinsp" cloneof="gremlins">
-		<description>Gremlins Unleashed (Europe, Prototype)</description>
+		<description>Gremlins Unleashed (Euro, Prototype)</description>
 		<year>2001</year>
 		<publisher>L.S.P.</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -7572,7 +7273,7 @@ license:CC0
 
 	<software name="grinch">
 		<!-- Notes: GBC only -->
-		<description>The Grinch (Europe)</description>
+		<description>The Grinch (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGHP-EUR"/>
@@ -7589,7 +7290,7 @@ license:CC0
 
 	<software name="grinchj" cloneof="grinch">
 		<!-- Notes: GBC only -->
-		<description>Grinch (Japan)</description>
+		<description>Grinch (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUGJ-JPN (RK221-J1)"/>
@@ -7626,15 +7327,14 @@ license:CC0
 	</software>
 
 	<software name="gurugugr">
-		<!-- Also released by NP in 2000-07 -->
-		<description>Guruguru Garakutas (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
+		<description>Guruguru Garakutas (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AUGJ-JPN"/>
 		<info name="release" value="19990910"/>
 		<info name="alt_title" value="ぐるぐるガラクターズ"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="guruguru garakutas (japan).bin" size="1048576" crc="7eaeeeac" sha1="86fea7dd8d815a51c1b75b816125ab4ba731dba1"/>
@@ -7646,7 +7346,7 @@ license:CC0
 
 	<software name="guruguth">
 		<!-- Notes: GBC only -->
-		<description>Guruguru Town Hanamaru-kun (Japan)</description>
+		<description>Guruguru Town Hanamaru-kun (Jpn)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BHJJ-JPN"/>
@@ -7661,7 +7361,7 @@ license:CC0
 	</software>
 
 	<software name="gutequiz">
-		<description>Gute Zeiten Schlechte Zeiten Quiz (Germany)</description>
+		<description>Gute Zeiten Schlechte Zeiten Quiz (Ger)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="DMG-BGQD-NOE"/>
@@ -7675,7 +7375,7 @@ license:CC0
 
 	<software name="docguy">
 		<!-- Notes: GBC only -->
-		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Japan)</description>
+		<description>Gyouten Ningen Batseelor - Doctor Guy no Yabou (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BB6J-JPN (RK266-J1) "/>
@@ -7693,7 +7393,7 @@ license:CC0
 
 	<software name="hallowen">
 		<!-- Notes: GBC only -->
-		<description>Halloween Racer (Europe)</description>
+		<description>Halloween Racer (Euro)</description>
 		<year>1999</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-AHIP-EUR"/>
@@ -7706,7 +7406,7 @@ license:CC0
 	</software>
 
 	<software name="hamstclb">
-		<description>Hamster Club (Japan)</description>
+		<description>Hamster Club (Jpn)</description>
 		<year>1999</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-AJNJ-JPN"/>
@@ -7723,7 +7423,7 @@ license:CC0
 	</software>
 
 	<software name="hamstcla">
-		<description>Hamster Club - Awasete Chuu (Japan)</description>
+		<description>Hamster Club - Awasete Chuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJHJ-JPN"/>
@@ -7739,7 +7439,7 @@ license:CC0
 
 	<software name="hamstclo">
 		<!-- Notes: GBC only -->
-		<description>Hamster Club - Oshiema Chuu (Japan)</description>
+		<description>Hamster Club - Oshiema Chuu (Jpn)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJSJ-JPN"/>
@@ -7756,7 +7456,7 @@ license:CC0
 	</software>
 
 	<software name="hamstcl2">
-		<description>Hamster Club 2 (Japan)</description>
+		<description>Hamster Club 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJNJ-JPN"/>
@@ -7780,7 +7480,7 @@ license:CC0
 
 	<software name="hamstmon">
 		<!-- Notes: GBC only -->
-		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Japan)</description>
+		<description>Hamster Monogatari GB + Magi Ham no Mahou Shoujo (Jpn)</description>
 		<year>2002</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-B8MJ-JPN"/>
@@ -7803,15 +7503,14 @@ license:CC0
 	</software>
 
 	<software name="hamstpar">
-		<!-- Also released by NP in 2001-06 -->
-		<description>Hamster Paradise (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
+		<description>Hamster Paradise (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-AHMJ-JPN"/>
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="ハムスターパラダイス"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hamster paradise (japan).bin" size="1048576" crc="f520cb19" sha1="87ebc7e0cfb0803e6e14da7eec1b2fad51c83ba0"/>
@@ -7823,7 +7522,7 @@ license:CC0
 
 	<software name="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Japan, Rev. 1)</description>
+		<description>Hamster Paradise 2 (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7832,7 +7531,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="hamster paradise 2 (japan) (rev 1).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
+				<rom name="hamster paradise 2 (japan) (rev a).bin" size="2097152" crc="b9e1f3b0" sha1="140100d96d165ee399f5cd18f5aec962fde714b6"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -7841,7 +7540,7 @@ license:CC0
 
 	<software name="hamstpa2a" cloneof="hamstpa2">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 2 (Japan)</description>
+		<description>Hamster Paradise 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHMJ-JPN"/>
@@ -7859,7 +7558,7 @@ license:CC0
 
 	<software name="hamstpa3">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 3 (Japan)</description>
+		<description>Hamster Paradise 3 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BH3J-JPN"/>
@@ -7877,7 +7576,7 @@ license:CC0
 
 	<software name="hamstpa4">
 		<!-- Notes: GBC only -->
-		<description>Hamster Paradise 4 (Japan)</description>
+		<description>Hamster Paradise 4 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BCUJ-JPN"/>
@@ -7895,7 +7594,7 @@ license:CC0
 
 	<software name="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Hamtaro - Ham-Hams Unite! (Europe)</description>
+		<description>Hamtaro - Ham-Hams Unite! (Euro)</description>
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86P-EUR"/>
@@ -7927,7 +7626,7 @@ license:CC0
 
 	<software name="hamunapt" cloneof="mummy">
 		<!-- Notes: GBC only -->
-		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Japan)</description>
+		<description>Hamunaptra - Ushinawareta Sabaku no Miyako (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BUMJ-JPN (RK222-J1)"/>
@@ -7945,7 +7644,7 @@ license:CC0
 
 	<software name="hanayori">
 		<!-- Notes: GBC only -->
-		<description>Hana Yori Dango - Another Love Story (Japan)</description>
+		<description>Hana Yori Dango - Another Love Story (Jpn)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-B87J-JPN"/>
@@ -7968,15 +7667,14 @@ license:CC0
 	</software>
 
 	<software name="hanasaka">
-		<!-- Also released by NP in 2001-04 -->
-		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2001-04 -->
+		<description>Hanasaka Tenshi Tenten-kun no Beat Breaker (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHTJ-JPN (RK186-J1)"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="花さか天使テンテンくんのBeat Breaker"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hanasaka tenshi tenten-kun no beat breaker (japan).bin" size="1048576" crc="6e988c07" sha1="791ea554de774de622bb4fb6bc2bf42955a201b3"/>
@@ -7988,7 +7686,7 @@ license:CC0
 
 	<software name="handtime">
 		<!-- Notes: GBC only -->
-		<description>Hands of Time (Europe, USA)</description>
+		<description>Hands of Time (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BWCE-USA, CGB-BWCP-EUR"/>
@@ -8021,7 +7719,7 @@ license:CC0
 
 	<software name="hpotcsec">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Chamber of Secrets (Europe, USA)</description>
+		<description>Harry Potter and the Chamber of Secrets (Euro, USA)</description>
 		<year>2002</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BH6E-USA, CGB-BH6P-EUR"/>
@@ -8037,7 +7735,7 @@ license:CC0
 
 	<software name="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter and the Philosopher's Stone (Europe) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
+		<description>Harry Potter and the Philosopher's Stone (Euro) ~ Harry Potter and the Sorcerer's Stone (USA)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BHVE-USA, CGB-BHVP-EUR"/>
@@ -8053,7 +7751,7 @@ license:CC0
 
 	<software name="hpotkenj" cloneof="hpotphil">
 		<!-- Notes: GBC only -->
-		<description>Harry Potter to Kenja no Ishi (Japan)</description>
+		<description>Harry Potter to Kenja no Ishi (Jpn)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts Victor</publisher>
 		<info name="serial" value="CGB-BHVJ-JPN"/>
@@ -8070,7 +7768,7 @@ license:CC0
 	</software>
 
 	<software name="harvmon2">
-		<description>Harvest Moon 2 GBC (Europe)</description>
+		<description>Harvest Moon 2 GBC (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2P-EUR"/>
@@ -8085,7 +7783,7 @@ license:CC0
 	</software>
 
 	<software name="harvmon2g" cloneof="harvmon2">
-		<description>Harvest Moon 2 GBC (Germany)</description>
+		<description>Harvest Moon 2 GBC (Ger)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BM2D-NOE"/>
@@ -8131,7 +7829,7 @@ license:CC0
 	</software>
 
 	<software name="harvmoon">
-		<description>Harvest Moon GB (Europe)</description>
+		<description>Harvest Moon GB (Euro)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXP-EUR"/>
@@ -8147,7 +7845,7 @@ license:CC0
 	</software>
 
 	<software name="harvmoong" cloneof="harvmoon">
-		<description>Harvest Moon GB (Germany)</description>
+		<description>Harvest Moon GB (Ger)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AYXD-NOE"/>
@@ -8185,14 +7883,14 @@ license:CC0
 	</software>
 
 	<software name="hellokbf">
-		<description>Hello Kitty no Beads Factory (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Hello Kitty no Beads Factory (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHBJ-JPN"/>
 		<info name="release" value="19990717"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのビーズ工房"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no beads factory (japan).bin" size="1048576" crc="12f74cd4" sha1="539ddbe7f73b33ffb886143dd14869d486f3fecf"/>
@@ -8204,7 +7902,7 @@ license:CC0
 
 	<software name="hellokhh">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty no Happy House (Japan)</description>
+		<description>Hello Kitty no Happy House (Jpn)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-BK7J-JPN"/>
@@ -8221,14 +7919,14 @@ license:CC0
 	</software>
 
 	<software name="hellokmm">
-		<description>Hello Kitty no Magical Museum (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Hello Kitty no Magical Museum (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AHKJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パズルコレクション ハローキティのマジカルミュージアム"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -8245,14 +7943,14 @@ license:CC0
 	</software>
 
 	<software name="helloksa">
-		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Hello Kitty no Sweet Adventure - Daniel-kun ni Aitai (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-BKTJ-JPN"/>
 		<info name="release" value="20000719"/>
 		<info name="alt_title" value="ハローキティのスウィートアドベンチャー 〜ダニエルくんにあいたい〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hello kitty no sweet adventure - daniel-kun ni aitai (japan).bin" size="1048576" crc="45f4159b" sha1="c290dbd29a6246eb001f35f973c0e664af2c97b1"/>
@@ -8264,7 +7962,7 @@ license:CC0
 
 	<software name="hellokdd">
 		<!-- Notes: GBC only -->
-		<description>Hello Kitty to Dear Daniel no Dream Adventure (Japan)</description>
+		<description>Hello Kitty to Dear Daniel no Dream Adventure (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BK8J-JPN"/>
@@ -8285,7 +7983,6 @@ license:CC0
 		<year>1999</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="DMG-AF4E-USA"/>
-		<info name="gold" value="19991027"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8296,7 +7993,7 @@ license:CC0
 
 	<software name="hercules">
 		<!-- Notes: GBC only -->
-		<description>Hercules - The Legendary Journeys (Europe)</description>
+		<description>Hercules - The Legendary Journeys (Euro)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -8312,7 +8009,7 @@ license:CC0
 
 	<software name="herohero">
 		<!-- Notes: GBC only -->
-		<description>Hero Hero Kun (Japan)</description>
+		<description>Hero Hero Kun (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BH9J-JPN"/>
@@ -8330,11 +8027,10 @@ license:CC0
 
 	<software name="mightmag">
 		<!-- Notes: GBC only -->
-		<description>Heroes of Might and Magic (Europe)</description>
+		<description>Heroes of Might and Magic (Euro)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHP-EUR"/>
-		<info name="gold" value="20000727"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -8357,7 +8053,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AUHE-USA"/>
-		<info name="gold" value="20000508"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8385,8 +8080,7 @@ license:CC0
 	</software>
 
 	<software name="hexcite">
-		<!--	European cartridges have USA sticker underneath.	-->
-		<description>Hexcite (Europe, USA)</description>
+		<description>Hexcite (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AICE-USA, DMG-AICP-EUR"/>
@@ -8410,7 +8104,7 @@ license:CC0
 
 	<software name="hiryuken">
 		<!-- Notes: GBC only -->
-		<description>Hiryuu no Ken - Retsuden GB (Japan)</description>
+		<description>Hiryuu no Ken - Retsuden GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BKEJ-JPN"/>
@@ -8426,7 +8120,7 @@ license:CC0
 
 	<software name="pachiboy">
 		<!-- Notes: GBC only -->
-		<description>Hissatsu Pachinko Boy - CR Monster House (Japan)</description>
+		<description>Hissatsu Pachinko Boy - CR Monster House (Jpn)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-BHPJ-JPN"/>
@@ -8464,7 +8158,7 @@ license:CC0
 	</software>
 
 	<software name="hollywpb">
-		<description>Hollywood Pinball (Europe)</description>
+		<description>Hollywood Pinball (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AHLP-EUR"/>
@@ -8477,7 +8171,7 @@ license:CC0
 	</software>
 
 	<software name="hollywpbj" cloneof="hollywpb">
-		<description>Hollywood Pinball (Japan)</description>
+		<description>Hollywood Pinball (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AHNJ-JPN"/>
@@ -8492,7 +8186,7 @@ license:CC0
 	</software>
 
 	<software name="holymagc">
-		<description>Holy Magic Century (Europe)</description>
+		<description>Holy Magic Century (Euro)</description>
 		<year>1999</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="DMG-AQTP-EUR"/>
@@ -8506,7 +8200,7 @@ license:CC0
 
 	<software name="honkhana">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Honkaku Hanafuda GB (Japan)</description>
+		<description>Honkaku Hanafuda GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-AH3J-JPN"/>
@@ -8523,14 +8217,14 @@ license:CC0
 	</software>
 
 	<software name="honkshog">
-		<description>Honkaku Shougi - Shougi Ou (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Honkaku Shougi - Shougi Ou (Jpn)</description>
 		<year>1998</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AG8J-JPN"/>
 		<info name="release" value="19981113"/>
 		<info name="alt_title" value="本格将棋 将棋王"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku shougi - shougi ou (japan).bin" size="1048576" crc="3a96e868" sha1="a0e5a6b00cc31670949f7d8cdeec2486d0ec986f"/>
@@ -8541,7 +8235,7 @@ license:CC0
 	</software>
 
 	<software name="honktsho">
-		<description>Honkaku Taisen Shougi Ayumu (Japan)</description>
+		<description>Honkaku Taisen Shougi Ayumu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AIBJ-JPN"/>
@@ -8558,15 +8252,14 @@ license:CC0
 	</software>
 
 	<software name="honkmj">
-		<!-- Also released by NP in 2000-04 -->
-		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
+		<description>Honkaku Yonin Uchi Mahjong - Mahjong Ou (Jpn)</description>
 		<year>1999</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-AAAJ-JPN"/>
 		<info name="release" value="19990219"/>
 		<info name="alt_title" value="本格四人打麻雀 麻雀王"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="honkaku yonin uchi mahjong - mahjong ou (japan).bin" size="1048576" crc="8ed4bbba" sha1="222487f14aaaa8f0bb536a09238e63ac95636208"/>
@@ -8577,7 +8270,7 @@ license:CC0
 	</software>
 
 	<software name="hotwheel">
-		<description>Hot Wheels - Stunt Track Driver (Europe, USA)</description>
+		<description>Hot Wheels - Stunt Track Driver (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AHEE-USA, DMG-AHEP-EUR"/>
@@ -8621,7 +8314,7 @@ license:CC0
 
 	<software name="hugobdf">
 		<!-- Notes: GBC only -->
-		<description>Hugo - Black Diamond Fever (Europe)</description>
+		<description>Hugo - Black Diamond Fever (Euro)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHUP-EUR"/>
@@ -8635,7 +8328,7 @@ license:CC0
 
 	<software name="hugoevmr">
 		<!-- Notes: GBC only -->
-		<description>Hugo - The Evil Mirror (Europe)</description>
+		<description>Hugo - The Evil Mirror (Euro)</description>
 		<year>2001</year>
 		<publisher>ITE Media</publisher>
 		<info name="serial" value="CGB-BHXP-EUR"/>
@@ -8651,7 +8344,7 @@ license:CC0
 	</software>
 
 	<software name="hugo2hlf">
-		<description>Hugo 2½ (Germany)</description>
+		<description>Hugo 2½ (Ger)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AHOP-NOE"/>
@@ -8665,7 +8358,7 @@ license:CC0
 
 	<software name="hxhhunke">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Hunter no Keifu (Japan)</description>
+		<description>Hunter X Hunter - Hunter no Keifu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHHJ-JPN (RK203-J1)"/>
@@ -8683,7 +8376,7 @@ license:CC0
 
 	<software name="hxhkindn">
 		<!-- Notes: GBC only -->
-		<description>Hunter X Hunter - Kindan no Hihou (Japan)</description>
+		<description>Hunter X Hunter - Kindan no Hihou (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHKJ-JPN (RK236-J1)"/>
@@ -8701,11 +8394,10 @@ license:CC0
 
 	<software name="hype">
 		<!-- Notes: GBC only -->
-		<description>Hype - The Time Quest (Europe)</description>
+		<description>Hype - The Time Quest (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BHQP-EUR"/>
-		<info name="gold" value="20000707"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -8714,25 +8406,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="hypeb" cloneof="hype">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpfe0.737"	-->
-		<description>Hype - The Time Quest (Bra)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="CGB-BPFE-?"/>
-		<info name="gold" value="20010411"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpfe0.737" size="1048576" crc="cafb8035" sha1="7c7dca7c48dc478d0278c273ba37723b9e9dce5b"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="hyprol2k" cloneof="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Hyper Olympic - Winter 2000 (Japan)</description>
+		<description>Hyper Olympic - Winter 2000 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HJ-JPN (RK196-J1)"/>
@@ -8749,14 +8425,14 @@ license:CC0
 	</software>
 
 	<software name="hyperol" cloneof="itf">
-		<description>Hyper Olympic Series - Track &amp; Field GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Hyper Olympic Series - Track &amp; Field GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDJ-JPN (RK183-J1)"/>
 		<info name="release" value="19990701"/>
 		<info name="alt_title" value="ハイパーオリンピックシリーズ トラック&amp;フィールドGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="hyper olympic series - track &amp; field gb (japan).bin" size="1048576" crc="77f76ebc" sha1="6dabafe260b53e61a810cbae2f14287adafffd8e"/>
@@ -8768,7 +8444,7 @@ license:CC0
 
 	<software name="ideyumjk">
 		<!-- Notes: GBC only -->
-		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Japan)</description>
+		<description>Ide Yousuke no Mahjong Kyoushitsu GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BIMJ-JPN"/>
@@ -8786,7 +8462,7 @@ license:CC0
 
 	<software name="indyinfm">
 		<!-- Notes: GBC only -->
-		<description>Indiana Jones and the Infernal Machine (Europe, USA)</description>
+		<description>Indiana Jones and the Infernal Machine (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BIJE-USA, CGB-BIJP-EUR"/>
@@ -8803,7 +8479,7 @@ license:CC0
 
 	<software name="inspgadg">
 		<!-- Notes: GBC only -->
-		<description>Inspector Gadget - Operation Madkactus (Europe)</description>
+		<description>Inspector Gadget - Operation Madkactus (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BIGP-EUR"/>
@@ -8831,7 +8507,7 @@ license:CC0
 
 	<software name="ik2000">
 		<!-- Notes: GBC only -->
-		<description>International Karate 2000 (Europe)</description>
+		<description>International Karate 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BIKP-EUU"/>
@@ -8860,12 +8536,12 @@ license:CC0
 	</software>
 
 	<software name="iss99">
-		<description>International Superstar Soccer '99 (Europe)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>International Superstar Soccer '99 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (europe).bin" size="1048576" crc="1b76d115" sha1="d9d9fffb463d4c35f8a1a753908cddfbe17fc671"/>
@@ -8876,12 +8552,12 @@ license:CC0
 	</software>
 
 	<software name="iss99u" cloneof="iss99">
+		<!-- Notes: SGB enhanced -->
 		<description>International Superstar Soccer '99 (USA)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZE-USA"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="international superstar soccer '99 (usa).bin" size="1048576" crc="9d0290a7" sha1="6f491e6f919a677627090f949b8e69abb8bfd1db"/>
@@ -8893,7 +8569,7 @@ license:CC0
 
 	<software name="iss2k">
 		<!-- Notes: GBC only -->
-		<description>International Superstar Soccer 2000 (Europe)</description>
+		<description>International Superstar Soccer 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSP-EUR"/>
@@ -8930,7 +8606,7 @@ license:CC0
 	</software>
 
 	<software name="itf">
-		<description>International Track &amp; Field (Europe)</description>
+		<description>International Track &amp; Field (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AHDP-EUR"/>
@@ -8961,7 +8637,7 @@ license:CC0
 
 	<software name="itfsummr">
 		<!-- Notes: GBC only -->
-		<description>International Track &amp; Field - Summer Games (Europe)</description>
+		<description>International Track &amp; Field - Summer Games (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B3HP-EUR"/>
@@ -8976,15 +8652,14 @@ license:CC0
 	</software>
 
 	<software name="wldrally" cloneof="xcountry">
-		<!-- Also released by NP in 2000-08 -->
-		<description>It's a World Rally (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<description>It's a World Rally (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ARLJ-JPN (RX187-J1)"/>
 		<info name="release" value="19990513"/>
 		<info name="alt_title" value="It's a ワールドラリー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="it's a world rally (japan).bin" size="1048576" crc="39e34650" sha1="31a289823468285ac786afe7de38201235983e35"/>
@@ -8996,7 +8671,7 @@ license:CC0
 
 	<software name="itsudemo">
 		<!-- Notes: GBC only -->
-		<description>Itsudemo Pachinko GB - CR Monster House (Japan)</description>
+		<description>Itsudemo Pachinko GB - CR Monster House (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BCRJ-JPN"/>
@@ -9014,7 +8689,7 @@ license:CC0
 
 	<software name="jlexcstg">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage GB (Japan)</description>
+		<description>J.League Excite Stage GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AESJ-JPN"/>
@@ -9032,7 +8707,7 @@ license:CC0
 
 	<software name="jlexcstt">
 		<!-- Notes: GBC only -->
-		<description>J.League Excite Stage Tactics (Japan)</description>
+		<description>J.League Excite Stage Tactics (Jpn)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-AJEJ-JPN"/>
@@ -9049,14 +8724,14 @@ license:CC0
 	</software>
 
 	<software name="jackdaib" cloneof="questrpg">
-		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Elemental Tale - Jack no Daibouken - Daimaou no Gyakushuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AQJJ-JPN"/>
 		<info name="release" value="20000115"/>
 		<info name="alt_title" value="ジャックの大冒険 〜大魔王の逆襲〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="jack no daibouken - daimaou no gyakushuu (japan).bin" size="2097152" crc="cff5325a" sha1="c2d9548e845ed9a76a0e6dae81bb80023564a9f2"/>
@@ -9067,8 +8742,8 @@ license:CC0
 	</software>
 
 	<software name="jagainu">
-		<!-- Also released by NP in 2000-12 -->
-		<description>Jagainu-kun (Japan)</description>
+		<!-- Notes: Also released by NP in 2000-12 -->
+		<description>Jagainu-kun (Jpn)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-B39J-JPN"/>
@@ -9086,7 +8761,7 @@ license:CC0
 
 	<software name="jankyus">
 		<!-- Notes: GBC only -->
-		<description>Jankyuusei - Cosplay Paradise (Japan)</description>
+		<description>Jankyuusei - Cosplay Paradise (Jpn)</description>
 		<year>2001</year>
 		<publisher>Elf</publisher>
 		<info name="serial" value="CGB-BHGJ-JPN"/>
@@ -9104,7 +8779,7 @@ license:CC0
 
 	<software name="janosch">
 		<!-- Notes: GBC only -->
-		<description>Janosch - Das grosse Panama-Spiel (Germany)</description>
+		<description>Janosch - Das grosse Panama-Spiel (Ger)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AJOD-NOE"/>
@@ -9118,7 +8793,7 @@ license:CC0
 
 	<software name="jayspiel">
 		<!-- Notes: GBC only -->
-		<description>Jay und die Spielzeugdiebe (Germany)</description>
+		<description>Jay und die Spielzeugdiebe (Ger)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BJYD-NOE"/>
@@ -9135,7 +8810,6 @@ license:CC0
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AJZE-USA"/>
-		<info name="gold" value="19990930"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -9146,11 +8820,10 @@ license:CC0
 
 	<software name="jmg2k">
 		<!-- Notes: GBC only -->
-		<description>Jeremy McGrath Supercross 2000 (Europe, USA)</description>
+		<description>Jeremy McGrath Supercross 2000 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AJUE-USA, CGB-AJUP-EUR"/>
-		<info name="gold" value="20000218"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -9164,7 +8837,7 @@ license:CC0
 
 	<software name="jetdego">
 		<!-- Notes: GBC only -->
-		<description>Jet de Go! (Japan)</description>
+		<description>Jet de Go! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BJEJ-JPN"/>
@@ -9182,11 +8855,10 @@ license:CC0
 
 	<software name="jimmywhi">
 		<!-- Notes: GBC only -->
-		<description>Jimmy White's Cueball (Europe)</description>
+		<description>Jimmy White's Cueball (Euro)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="CGB-BJWP-EUR"/>
-		<info name="gold" value="20001019"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -9196,14 +8868,14 @@ license:CC0
 	</software>
 
 	<software name="jinsei">
-		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Jinsei Game - Tomodachi Takusan Tsukurou yo! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-ACJJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="人生ゲーム 友達たくさんつくろうよ!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="jinsei game - tomodachi takusan tsukurou yo (japan).bin" size="1048576" crc="c8d46e99" sha1="d2c4ae3808d9a24cbd4c6c8e43184ca0ef2d8373"/>
@@ -9215,7 +8887,7 @@ license:CC0
 
 	<software name="jisedai">
 		<!-- Notes: GBC only -->
-		<description>Jisedai Begoma Battle Beyblade (Japan)</description>
+		<description>Jisedai Begoma Battle Beyblade (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-AG5J-JPN"/>
@@ -9231,13 +8903,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="jissena">
+	<software name="jissen">
 		<!-- Notes: GBC only -->
-		<description>Jissen ni Yakudatsu Tsumego (Japan, Rev. 1)</description>
+		<description>Jissen ni Yakudatsu Tsumego (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="CGB-BJTJ-JPN (PCPE-10004)"/>
-		<info name="gold" value="20000711"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="実戦に役立つ詰碁"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9251,33 +8922,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="jissen" cloneof="jissena">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbjtj0.313"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Jissen ni Yakudatsu Tsumego (Japan)</description>
-		<year>2000</year>
-		<publisher>Pony Canyon</publisher>
-		<info name="serial" value="CGB-BJTJ-JPN?"/>
-		<info name="gold" value="20001004"/>
-		<info name="alt_title" value="実戦に役立つ詰碁"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="262144">
-				<rom name="cgbbjtj0.313" size="262144" crc="69c6dbef" sha1="f7ed6cdce7637a11d7fa7f5cb59b8f8ce131f9d1"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="joryujan">
-		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-A55J-JPN"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="女流雀士に挑戦GB 〜私達に挑戦してネ!〜 ~ Joryuu Janshi ni Chousen GB - Watashi-tachi ni Chousen Shitene! (Box)"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="joryuu janshi ni chousen gb - watashi-tachi ni chousen shitene (japan).bin" size="1048576" crc="9fa5cdb5" sha1="a332817b9561dcab7d1f3dc0cf300e1656b253c3"/>
@@ -9303,7 +8956,7 @@ license:CC0
 
 	<software name="jungle">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Europe)</description>
+		<description>Walt Disney's The Jungle Book - Mowgli's Wild Adventure (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BJGP-EUR"/>
@@ -9331,7 +8984,7 @@ license:CC0
 
 	<software name="jukosenk">
 		<!-- Notes: GBC only -->
-		<description>Juukou Senki Bullet Battlers (Japan)</description>
+		<description>Juukou Senki Bullet Battlers (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AZXJ-JPN (RX173-J1)"/>
@@ -9349,7 +9002,7 @@ license:CC0
 
 	<software name="koprobox">
 		<!-- Notes: GBC only -->
-		<description>K.O. - The Pro Boxing (Japan)</description>
+		<description>K.O. - The Pro Boxing (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BKOJ-JPN"/>
@@ -9367,7 +9020,7 @@ license:CC0
 
 	<software name="kaptnblb">
 		<!-- Notes: GBC only -->
-		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Germany)</description>
+		<description>Käpt'n Blaubär - Die verrückte Schatzsuche (Ger)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BVRD-NOE"/>
@@ -9380,7 +9033,7 @@ license:CC0
 	</software>
 
 	<software name="kaiteide">
-		<description>Kaitei Densetsu!! Treasure World (Japan)</description>
+		<description>Kaitei Densetsu!! Treasure World (Jpn)</description>
 		<year>2000</year>
 		<publisher>Dazz</publisher>
 		<info name="serial" value="DMG-BDTJ-JPN"/>
@@ -9398,7 +9051,7 @@ license:CC0
 
 	<software name="kakurenb">
 		<!-- Notes: GBC only -->
-		<description>Kakurenbo Battle Monster Tactics (Japan)</description>
+		<description>Kakurenbo Battle Monster Tactics (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BMFJ-JPN"/>
@@ -9421,15 +9074,14 @@ license:CC0
 	</software>
 
 	<software name="bistrokb">
-		<!-- Also released by NP in 2000-12 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-12 -->
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Kettou Bistgarm Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A2WJ-JPN"/>
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 決闘★ビストガルム編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kakutou ryouri densetsu bistro recipe - kettou bistgarm hen (japan).bin" size="1048576" crc="4fbec464" sha1="c9fa1b1a24a0098eadd7e3fa4ee19f1b615a618f"/>
@@ -9440,15 +9092,14 @@ license:CC0
 	</software>
 
 	<software name="bistrogf">
-		<!-- Also released by NP in 2000-10 -->
-		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-10 -->
+		<description>Kakutou Ryouri Densetsu Bistro Recipe - Gekitou Foodon Battle Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AWRJ-JPN"/>
 		<info name="release" value="19991008"/>
 		<info name="alt_title" value="格闘料理伝説ビストロレシピ 激闘★フードンバトル編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -9465,14 +9116,14 @@ license:CC0
 	</software>
 
 	<software name="kanjiboy">
-		<description>Kanji Boy (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kanji Boy (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWKJ-JPN"/>
 		<info name="release" value="19990603"/>
 		<info name="alt_title" value="漢字BOY"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy (japan).bin" size="4194304" crc="18caa513" sha1="3876d5f64113e5365b42d30945f51f40b1d22d47"/>
@@ -9481,14 +9132,14 @@ license:CC0
 	</software>
 
 	<software name="kanjibo2">
-		<description>Kanji Boy 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kanji Boy 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2CJ-JPN"/>
 		<info name="release" value="20000630"/>
 		<info name="alt_title" value="漢字BOY2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="kanji boy 2 (japan).bin" size="4194304" crc="81fd8918" sha1="4d382de7fd6912c0cd8ca15032e6f75409d0a97b"/>
@@ -9500,7 +9151,7 @@ license:CC0
 
 	<software name="kanjibo3">
 		<!-- Notes: GBC only -->
-		<description>Kanji Boy 3 (Japan)</description>
+		<description>Kanji Boy 3 (Jpn)</description>
 		<year>2003</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-BK3J-JPN"/>
@@ -9517,7 +9168,7 @@ license:CC0
 	</software>
 
 	<software name="kanjipzl">
-		<description>Kanji de Puzzle (Japan)</description>
+		<description>Kanji de Puzzle (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BKAJ-JPN"/>
@@ -9532,8 +9183,8 @@ license:CC0
 	</software>
 
 	<software name="kanzumep">
-		<!-- Also released by NP in 2000-06 -->
-		<description>Kanzume Monsters Parfait (Japan)</description>
+		<!-- Notes: Also released by NP in 2000-06 -->
+		<description>Kanzume Monsters Parfait (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AQPJ-JPN"/>
@@ -9550,15 +9201,14 @@ license:CC0
 	</software>
 
 	<software name="karamuok">
-		<!-- NP only -->
-		<description>Karamuchou wa Oosawagi! - Okawari! (Japan, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Karamuchou wa Oosawagi! - Okawari! (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-BOOJ-JPN"/>
 		<info name="release" value="20000801"/>
 		<info name="alt_title" value="カラムー町は大さわぎ!おかわりっ!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - okawari (japan) (np).bin" size="1048576" crc="6c568e06" sha1="9217169dc3f42562d71a7edabc3b42e36ec8304b"/>
@@ -9569,15 +9219,14 @@ license:CC0
 	</software>
 
 	<software name="karamupl">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Karamuchou wa Oosawagi! - Polinkies to Okashina Nakama-tachi (Jpn)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-AOPJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="カラムー町は大さわぎ! 〜ポリンキーズとおかしな仲間たち〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="karamuchou wa oosawagi - polinkies to okashina nakama-tachi (japan).bin" size="1048576" crc="dd948071" sha1="cb6079dc290ace0daafdd40353e4477e4a37c8f7"/>
@@ -9589,7 +9238,7 @@ license:CC0
 
 	<software name="karankor">
 		<!-- Notes: GBC only -->
-		<description>Karan Koron Gakuen - Hanafuda Mahjong (Japan)</description>
+		<description>Karan Koron Gakuen - Hanafuda Mahjong (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AHFJ-JPN"/>
@@ -9604,15 +9253,14 @@ license:CC0
 	</software>
 
 	<software name="kaseki2">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Kaseki Sousei Reborn II - Monster Digger (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Kaseki Sousei Reborn II - Monster Digger (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ARMJ-JPN"/>
 		<info name="release" value="19990212"/>
 		<info name="alt_title" value="化石創世リボーンII 〜モンスターディガー〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kaseki sousei reborn ii - monster digger (japan).bin" size="1048576" crc="bf80c897" sha1="857fb62dc310268e0b92e9383c6b6fd61aa33fa0"/>
@@ -9623,14 +9271,14 @@ license:CC0
 	</software>
 
 	<software name="katohifu">
-		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Katou Hifumi Kudan - Shougi Kyoushitsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AKHJ-JPN"/>
 		<info name="release" value="19990409"/>
 		<info name="alt_title" value="加藤一二三 九段の 将棋教室 "/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="katou hifumi kudan - shougi kyoushitsu (japan).bin" size="1048576" crc="a262269f" sha1="c3ba0d2b82d66ef1b5c0dee8813a5f965631ed75"/>
@@ -9639,15 +9287,14 @@ license:CC0
 	</software>
 
 	<software name="kawanus4" cloneof="rivking2">
-		<description>Kawa no Nushi Tsuri 4 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kawa no Nushi Tsuri 4 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-VUTJ-JPN"/>
-		<info name="gold" value="19990520"/>
 		<info name="release" value="19990716"/>
-		<info name="alt_title" value="川のぬし釣り４"/>
+		<info name="alt_title" value="川のぬし釣り4"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A04-01" />
 			<feature name="u1" value="U1 4M/8M MROM [M438011E-57]" />
 			<feature name="u2" value="U2 MBC5 [BMC-5]" />
@@ -9666,14 +9313,14 @@ license:CC0
 	</software>
 
 	<software name="kawaipet">
-		<description>Kawaii Pet Shop Monogatari (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kawaii Pet Shop Monogatari (Jpn)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-AEIJ-JPN"/>
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="かわいいペットショップ物語"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kawaii pet shop monogatari (japan).bin" size="1048576" crc="44767443" sha1="8392eccbac1d8ae23782c6d29d3ee604a03b5c05"/>
@@ -9683,30 +9330,11 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kawaipt2a">
-		<!--	In lot check as "dmgbmnj1.j90"	-->
-		<description>Kawaii Pet Shop Monogatari 2 (Japan, Rev. 1)</description>
+	<software name="kawaipt2">
+		<description>Kawaii Pet Shop Monogatari 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BMNJ-JPN"/>
-		<info name="gold" value="20010201"/>
-		<info name="alt_title" value="かわいいペットショップ物語2"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgbmnj1.j90" size="2097152" crc="6fce1ad0" sha1="58ea410ebbee5edc18644c0467fe9ea03d179b1c"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="kawaipt2" cloneof="kawaipt2a">
-		<description>Kawaii Pet Shop Monogatari 2 (Japan)</description>
-		<year>2000</year>
-		<publisher>Taito</publisher>
-		<info name="serial" value="DMG-BMNJ-JPN"/>
-		<info name="gold" value="20001107"/>
 		<info name="release" value="20001222"/>
 		<info name="alt_title" value="かわいいペットショップ物語2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -9721,7 +9349,7 @@ license:CC0
 
 	<software name="keepblnc">
 		<!-- Notes: GBC only -->
-		<description>Keep the Balance (Europe)</description>
+		<description>Keep the Balance (Euro)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment AG</publisher>
 		<info name="serial" value="CGB-BKNP-EUR"/>
@@ -9734,7 +9362,7 @@ license:CC0
 	</software>
 
 	<software name="keibajou">
-		<description>Keibajou e Ikou! Wide (Japan)</description>
+		<description>Keibajou e Ikou! Wide (Jpn)</description>
 		<year>2000</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-ASCJ-JPN"/>
@@ -9753,7 +9381,7 @@ license:CC0
 	<software name="telefngp">
 		<!-- Notes: This game uses an accessory called "Power Antenna", which is just a LED light connected
 		        to the GB accessories port. It is used ingame to simulate a mobile phone. -->
-		<description>Keitai Denjuu Telefang - Power Version (Japan)</description>
+		<description>Keitai Denjuu Telefang - Power Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTXJ-JPN"/>
@@ -9777,7 +9405,7 @@ license:CC0
 	</software>
 
 	<software name="telefngs">
-		<description>Keitai Denjuu Telefang - Speed Version (Japan)</description>
+		<description>Keitai Denjuu Telefang - Speed Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BTZJ-JPN"/>
@@ -9825,14 +9453,14 @@ license:CC0
 	</software>
 
 	<software name="kettoubw">
-		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kettou Beast Wars - Beast Senshi Saikyou Ketteisen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="DMG-AB7J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="決闘トランスフォーマービーストウォーズ ビースト戦士最強決定戦 ~ Kettou Transformers Beast Wars - Beast Senshi Saikyou Ketteisen (Box)"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kettou beast wars - beast senshi saikyou ketteisen (japan).bin" size="1048576" crc="72895639" sha1="db690f46d37e0273c69f24badbb44588a363a84f"/>
@@ -9842,7 +9470,7 @@ license:CC0
 
 	<software name="nadesico">
 		<!-- Notes: GBC only -->
-		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Japan)</description>
+		<description>Kidou Senkan Nadesico - Ruri Ruri Mahjong (Jpn)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQNJ-JPN (KIG-9)"/>
@@ -9860,7 +9488,7 @@ license:CC0
 
 	<software name="kikathom">
 		<!-- Notes: GBC only -->
-		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Japan)</description>
+		<description>Kikansha Thomas - Sodor-tou no Nakama-tachi (Jpn)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BBWJ-JPN"/>
@@ -9877,14 +9505,14 @@ license:CC0
 	</software>
 
 	<software name="kindajik">
-		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kindaichi Shounen no Jikenbo - 10nenme no Shoutaijou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BKSJ-JPN"/>
 		<info name="release" value="20001216"/>
 		<info name="alt_title" value="金田一少年の事件簿 〜10年目の招待状〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9897,14 +9525,14 @@ license:CC0
 	</software>
 
 	<software name="kinniban">
-		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kinniku Banzuke GB - Chousensha wa Kimida! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-A5KJ-JPN (RK197-J1)"/>
 		<info name="release" value="19991125"/>
 		<info name="alt_title" value="筋肉番付GB 〜挑戦者はキミだ!〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="kinniku banzuke gb - chousensha wa kimida (japan).bin" size="1048576" crc="e2e4328b" sha1="75d7e35fea257d8da4c1efcdd6ebdca020c648a6"/>
@@ -9915,14 +9543,14 @@ license:CC0
 	</software>
 
 	<software name="kinnibn2">
-		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Kinniku Banzuke GB2 - Mezase! Muscle Champion (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B6KJ-JPN (RK213-J1)"/>
 		<info name="release" value="20000810"/>
 		<info name="alt_title" value="筋肉番付GB2 〜目指せ!マッスルチャンピオン!〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -9936,7 +9564,7 @@ license:CC0
 
 	<software name="kinnibn3">
 		<!-- Notes: GBC only -->
-		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Japan)</description>
+		<description>Kinniku Banzuke GB3 - Shinseiki Survival Retsuden! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-B7KJ-JPN (RK233-J1)"/>
@@ -9954,7 +9582,6 @@ license:CC0
 
 	<software name="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<!--	In lot check as "CGBKTNE0.638", "KENSA\CGBKTNP0.0"	-->
 		<description>Kirby Tilt 'n' Tumble (USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
@@ -9976,7 +9603,7 @@ license:CC0
 
 	<software name="kiriku">
 		<!-- Notes: GBC only -->
-		<description>Kirikou (Europe)</description>
+		<description>Kirikou (Euro)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BKKP-EUR"/>
@@ -9990,7 +9617,7 @@ license:CC0
 
 	<software name="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Japan, Rev. 1)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Jpn, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -9999,7 +9626,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="kisekae series 2 - oshare nikki (japan) (Rev. 1).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
+				<rom name="kisekae series 2 - oshare nikki (japan) (rev. a).bin" size="2097152" crc="e915337c" sha1="1896ec1aa7edb56774afa5d8b93e941aa1e838eb"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -10008,7 +9635,7 @@ license:CC0
 
 	<software name="kisekae2a" cloneof="kisekae2">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 2 - Oshare Nikki (Japan)</description>
+		<description>Kisekae Series 2 - Oshare Nikki (Jpn)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-B23J-JPN"/>
@@ -10026,7 +9653,7 @@ license:CC0
 
 	<software name="kisekae3">
 		<!-- Notes: GBC only -->
-		<description>Kisekae Series 3 - Kisekae Hamster (Japan)</description>
+		<description>Kisekae Series 3 - Kisekae Hamster (Jpn)</description>
 		<year>2001</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-BKHJ-JPN"/>
@@ -10043,7 +9670,7 @@ license:CC0
 	</software>
 
 	<software name="klustar">
-		<description>Klustar (Europe)</description>
+		<description>Klustar (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AKUP-EUR"/>
@@ -10057,7 +9684,7 @@ license:CC0
 
 	<software name="kokings">
 		<!-- Notes: GBC only -->
-		<description>Knockout Kings (Europe, USA)</description>
+		<description>Knockout Kings (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AXKE-USA, CGB-AXKP-EUR"/>
@@ -10074,7 +9701,7 @@ license:CC0
 
 	<software name="klax">
 		<!-- Notes: GBC only -->
-		<description>Klax (Europe, USA)</description>
+		<description>Klax (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ALXE-USA, CGB-ALXP-EUR"/>
@@ -10103,8 +9730,8 @@ license:CC0
 	</software>
 
 	<software name="kogurugu">
-		<!-- NP only -->
-		<description>Koguru Guruguru - Guruguru to Nakayoshi (Japan, NP)</description>
+		<!-- Notes: NP only -->
+		<description>Koguru Guruguru - Guruguru to Nakayoshi (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Sting</publisher>
 		<info name="serial" value="DMG-BKGJ-JPN"/>
@@ -10121,7 +9748,7 @@ license:CC0
 	</software>
 
 	<software name="konamic1">
-		<description>Konami GB Collection Vol.1 (Europe)</description>
+		<description>Konami GB Collection Vol.1 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF5P-EUR"/>
@@ -10134,7 +9761,7 @@ license:CC0
 	</software>
 
 	<software name="konamic2">
-		<description>Konami GB Collection Vol.2 (Europe)</description>
+		<description>Konami GB Collection Vol.2 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF6P-EUR"/>
@@ -10147,7 +9774,7 @@ license:CC0
 	</software>
 
 	<software name="konamic3">
-		<description>Konami GB Collection Vol.3 (Europe)</description>
+		<description>Konami GB Collection Vol.3 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF7P-EUR"/>
@@ -10160,7 +9787,7 @@ license:CC0
 	</software>
 
 	<software name="konamic4">
-		<description>Konami GB Collection Vol.4 (Europe)</description>
+		<description>Konami GB Collection Vol.4 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AF8P-EUR"/>
@@ -10174,7 +9801,7 @@ license:CC0
 
 	<software name="konamiwg">
 		<!-- Notes: GBC only -->
-		<description>Konami Winter Games (Europe)</description>
+		<description>Konami Winter Games (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-A3HP-EUR"/>
@@ -10190,7 +9817,7 @@ license:CC0
 
 	<software name="konchufg">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Fighters (Japan)</description>
+		<description>Konchuu Fighters (Jpn)</description>
 		<year>2002</year>
 		<publisher>Digital Kids</publisher>
 		<info name="serial" value="CGB-BZZJ-JPN"/>
@@ -10207,14 +9834,14 @@ license:CC0
 	</software>
 
 	<software name="konchuh2">
-		<description>Konchuu Hakase 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Konchuu Hakase 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-A2KJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="釣り先生2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="konchuu hakase 2 (japan).bin" size="2097152" crc="b6381744" sha1="e4bcfb94aa1c09a013a03f26f978b32e74f70d23"/>
@@ -10226,7 +9853,7 @@ license:CC0
 
 	<software name="konchuh3">
 		<!-- Notes: GBC only -->
-		<description>Konchuu Hakase 3 (Japan)</description>
+		<description>Konchuu Hakase 3 (Jpn)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-A3KJ-JPN"/>
@@ -10244,7 +9871,7 @@ license:CC0
 
 	<software name="korokoro" cloneof="kirbytlt" supported="no">
 		<!-- Notes: GBC only. The game cart includes a motion-sensor (U4) for controlling the game by moving and shaking the console. -->
-		<description>Korokoro Kirby (Japan)</description>
+		<description>Korokoro Kirby (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-KKKJ-JPN"/>
@@ -10267,7 +9894,7 @@ license:CC0
 
 	<software name="kotobatt">
 		<!-- Notes: GBC only -->
-		<description>Koto Battle - Tengai no Moribito (Japan)</description>
+		<description>Koto Battle - Tengai no Moribito (Jpn)</description>
 		<year>2001</year>
 		<publisher>Alphadream</publisher>
 		<info name="serial" value="CGB-BAJJ-JPN"/>
@@ -10284,14 +9911,14 @@ license:CC0
 	</software>
 
 	<software name="koshien">
-		<description>Koushien Pocket (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Koushien Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AKSJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="甲子園ポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="koushien pocket (japan).bin" size="1048576" crc="6910ff3a" sha1="a677bf07c67925ded32799d6a8eb63ec99c01bb7"/>
@@ -10303,7 +9930,7 @@ license:CC0
 
 	<software name="landbtim">
 		<!-- Notes: GBC only -->
-		<description>The Land Before Time (Europe)</description>
+		<description>The Land Before Time (Euro)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BLBP-EUR"/>
@@ -10344,26 +9971,7 @@ license:CC0
 
 	<software name="laura">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbldp0.420"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Laura (Europe)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="CGB-BLDP-EUR"/>
-		<info name="gold" value="20000913"/>
-		<info name="alt_title" value="Laura's Happy Adventures"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbldp0.420" size="1048576" crc="a58c8282" sha1="47e5c4c7fa447efc8a0abf019e8d2cd227c5e0e3"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="lauraunk" cloneof="laura">
-		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>Laura (Europe, bad dump?)</description>
+		<description>Laura (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLDP-EUR"/>
@@ -10394,7 +10002,7 @@ license:CC0
 
 	<software name="lemans24">
 		<!-- Notes: GBC only -->
-		<description>Le Mans 24 Hours (Europe)</description>
+		<description>Le Mans 24 Hours (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-B24P-NOE"/>
@@ -10409,7 +10017,7 @@ license:CC0
 	</software>
 
 	<software name="rivking2">
-		<description>Legend of the River King 2 (Europe)</description>
+		<description>Legend of the River King 2 (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-BRKP-EUR"/>
@@ -10439,7 +10047,7 @@ license:CC0
 	</software>
 
 	<software name="rivking">
-		<description>Legend of the River King GB (Europe)</description>
+		<description>Legend of the River King GB (Euro)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="DMG-ARKP-EUR"/>
@@ -10454,7 +10062,7 @@ license:CC0
 	</software>
 
 	<software name="rivkingg" cloneof="rivking">
-		<description>Legend of the River King GB (Germany)</description>
+		<description>Legend of the River King GB (Ger)</description>
 		<year>1999</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="??"/>
@@ -10484,14 +10092,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Europe, Australia, USA, Rev. 2)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Euro, Aus, USA, Rev. B)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-(EUR/AUS)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 2).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev b).bin" size="1048576" crc="06887a34" sha1="1c091225688d966928cc74336dbef2e07d12a47c"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10499,14 +10107,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev 1).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
+				<rom name="legend of zelda, the - link's awakening dx (usa, europe) (rev a).bin" size="1048576" crc="b38eb9de" sha1="363d184d9b1e9faa5a2facd80897b7e118446164"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -10514,12 +10122,12 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxb" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Europe, USA)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>The Legend of Zelda - Link's Awakening DX (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLE-USA, DMG-AZLP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10536,7 +10144,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxf" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (France, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Fra, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
@@ -10556,12 +10164,12 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxfa" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (France)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>The Legend of Zelda - Link's Awakening DX (Fra)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLF-FRA"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -10578,7 +10186,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxg" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Germany, Rev. 1)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Ger, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10598,7 +10206,7 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxga" cloneof="zeldaldx">
-		<description>The Legend of Zelda - Link's Awakening DX (Germany)</description>
+		<description>The Legend of Zelda - Link's Awakening DX (Ger)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLD-NOE"/>
@@ -10614,7 +10222,7 @@ license:CC0
 
 	<software name="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Europe)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8P-EUR"/>
@@ -10636,7 +10244,7 @@ license:CC0
 
 	<software name="zeldaageu" cloneof="zeldaage">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Ages (Australia, USA)</description>
+		<description>The Legend of Zelda - Oracle of Ages (Aus, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8U-AUS, CGB-AZ8E-USA"/>
@@ -10658,7 +10266,7 @@ license:CC0
 
 	<software name="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Europe)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7P-EUR"/>
@@ -10680,7 +10288,7 @@ license:CC0
 
 	<software name="zeldaseau" cloneof="zeldasea">
 		<!-- Notes: GBC only -->
-		<description>The Legend of Zelda - Oracle of Seasons (Australia, USA)</description>
+		<description>The Legend of Zelda - Oracle of Seasons (Aus, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7U-AUS, CGB-AZ7E-USA"/>
@@ -10702,7 +10310,7 @@ license:CC0
 
 	<software name="legoatm">
 		<!-- Notes: GBC only -->
-		<description>LEGO Alpha Team (Europe)</description>
+		<description>LEGO Alpha Team (Euro)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLPP-(EUR/SCN)"/>
@@ -10734,7 +10342,7 @@ license:CC0
 
 	<software name="legoisl2">
 		<!-- Notes: GBC only -->
-		<description>LEGO Island 2 - The Brickster's Revenge (Europe)</description>
+		<description>LEGO Island 2 - The Brickster's Revenge (Euro)</description>
 		<year>2001</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BL2P-EUR"/>
@@ -10766,7 +10374,7 @@ license:CC0
 
 	<software name="legorace">
 		<!-- Notes: GBC only -->
-		<description>LEGO Racers (Europe)</description>
+		<description>LEGO Racers (Euro)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLRP-EUU"/>
@@ -10804,7 +10412,7 @@ license:CC0
 
 	<software name="legostnt">
 		<!-- Notes: GBC only -->
-		<description>LEGO Stunt Rally (Europe)</description>
+		<description>LEGO Stunt Rally (Euro)</description>
 		<year>2000</year>
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="CGB-BLYP-SCN"/>
@@ -10867,7 +10475,7 @@ license:CC0
 
 	<software name="lionking">
 		<!-- Notes: GBC only -->
-		<description>The Lion King - Simba's Mighty Adventure (Europe, USA)</description>
+		<description>The Lion King - Simba's Mighty Adventure (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKE-USA, CGB-BLKP-UKV"/>
@@ -10884,11 +10492,10 @@ license:CC0
 
 	<software name="lionkingf" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Le Roi Lion - Les Adventures de Simba (France)</description>
+		<description>Le Roi Lion - Les Adventures de Simba (Fra)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKF-FRA"/>
-		<info name="gold" value="20001113"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -10897,25 +10504,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lionkingfa" cloneof="lionking">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbblkf1.573"	-->
-		<description>Le Roi Lion - Les Adventures de Simba (France, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Activision</publisher>
-		<info name="serial" value="CGB-BLKF-FRA"/>
-		<info name="gold" value="20010406"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbblkf1.573" size="1048576" crc="c7aae1b3" sha1="b8cc2f1d3a8d40c7588d5c535f28e2f80446a793"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="lionkingg" cloneof="lionking">
 		<!-- Notes: GBC only -->
-		<description>Der König der Löwen - Simbas grosses Abenteuer (Germany)</description>
+		<description>Der König der Löwen - Simbas grosses Abenteuer (Ger)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BLKD-NOE"/>
@@ -10932,7 +10523,7 @@ license:CC0
 
 	<software name="lilmagic">
 		<!-- Notes: GBC only -->
-		<description>Little Magic (Japan)</description>
+		<description>Little Magic (Jpn)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-ALJJ-JPN"/>
@@ -10950,7 +10541,7 @@ license:CC0
 
 	<software name="mermaid2">
 		<!-- Notes: GBC only -->
-		<description>Disney's The Little Mermaid II - Pinball Frenzy (Europe)</description>
+		<description>Disney's The Little Mermaid II - Pinball Frenzy (Euro)</description>
 		<year>2000</year>
 		<publisher>Disney Interactive</publisher>
 		<info name="serial" value="CGB-BY2P-EUR"/>
@@ -11004,7 +10595,7 @@ license:CC0
 
 	<software name="lnf2001" cloneof="fa2001">
 		<!-- Notes: GBC only -->
-		<description>LNF Stars 2001 (France)</description>
+		<description>LNF Stars 2001 (Fra)</description>
 		<year>2001</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="??"/>
@@ -11017,7 +10608,7 @@ license:CC0
 	</software>
 
 	<software name="ldrun">
-		<description>Lode Runner - Domudomu Dan no Yabou (Japan)</description>
+		<description>Lode Runner - Domudomu Dan no Yabou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Xing Entertainment</publisher>
 		<info name="serial" value="DMG-BXLJ-JPN"/>
@@ -11034,14 +10625,14 @@ license:CC0
 	</software>
 
 	<software name="lodoss">
-		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Lodoss-tou Senki - Eiyuu Kishiden GB (Jpn)</description>
 		<year>1998</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-ARAJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ロードス島戦記 英雄騎士伝 GB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="lodoss-tou senki - eiyuu kishiden gb (japan).bin" size="1048576" crc="66e166bb" sha1="3431247ffae511b6c2a836759e5ed0545d11ba05"/>
@@ -11051,7 +10642,7 @@ license:CC0
 
 	<software name="logical">
 		<!-- Notes: GBC only -->
-		<description>Logical (Europe)</description>
+		<description>Logical (Euro)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AOGP-EUR"/>
@@ -11079,7 +10670,7 @@ license:CC0
 
 	<software name="looney">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes (Europe)</description>
+		<description>Looney Tunes (Euro)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALTP-(EUR/UKV)"/>
@@ -11152,7 +10743,7 @@ license:CC0
 
 	<software name="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Alert! (Europe)</description>
+		<description>Looney Tunes Collector - Martian Alert! (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALMP-UKV"/>
@@ -11168,7 +10759,7 @@ license:CC0
 
 	<software name="looneymaj" cloneof="looneyma">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Quest! (Japan)</description>
+		<description>Looney Tunes Collector - Martian Quest! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-ALMJ-JPN"/>
@@ -11192,7 +10783,7 @@ license:CC0
 
 	<software name="looneymr">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Collector - Martian Revenge! (Europe)</description>
+		<description>Looney Tunes Collector - Martian Revenge! (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLAP-UKV"/>
@@ -11208,7 +10799,7 @@ license:CC0
 
 	<software name="looneyrc">
 		<!-- Notes: GBC only -->
-		<description>Looney Tunes Racing (Europe)</description>
+		<description>Looney Tunes Racing (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLQP-EUR"/>
@@ -11245,18 +10836,17 @@ license:CC0
 	</software>
 
 	<software name="hirapzl2">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="d54d5836" sha1="c88ae04f7adbec5ad40edec650198cbe58a561bd"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11264,15 +10854,14 @@ license:CC0
 	</software>
 
 	<software name="hirapzl2a" cloneof="hirapzl2">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Japan, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-2-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B52J-JPN"/>
 		<info name="release" value="20011101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-2-gou (japan) (np).bin" size="262144" crc="29e193c5" sha1="8cc512784d323f7c0bfe36848c5f7fdc49257285"/>
@@ -11283,18 +10872,17 @@ license:CC0
 	</software>
 
 	<software name="hirapzl3">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="065a3bf5" sha1="42721b99b427e51f7e815c852bf53e807c52dd65"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11302,15 +10890,14 @@ license:CC0
 	</software>
 
 	<software name="hirapzl3a" cloneof="hirapzl3">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Japan, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Dai-3-gou (Jpn, NP)</description>
 		<year>2002</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B53J-JPN"/>
 		<info name="release" value="20020101"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle dai-3-gou (japan) (np).bin" size="262144" crc="e078d9f8" sha1="a7faa970e71d38c68948b646d3dcb9cbea1df995"/>
@@ -11321,18 +10908,17 @@ license:CC0
 	</software>
 
 	<software name="hirapzls">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, Rev. 1, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
+				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="267b5253" sha1="f977d3dd6395066bbea729ea547c7a81e1c4464d"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -11340,15 +10926,14 @@ license:CC0
 	</software>
 
 	<software name="hirapzlsa" cloneof="hirapzls">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Japan, NP)</description>
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Hirameku Puzzle Soukangou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B51J-JPN"/>
 		<info name="release" value="20010901"/>
 		<info name="alt_title" value="ロッピー パズルマガジン ひらめくパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - hirameku puzzle soukangou (japan) (np).bin" size="262144" crc="c0287cf2" sha1="7425bd94790866bf716fd3c23886a5cdc06f1aad"/>
@@ -11358,35 +10943,33 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kangpzl2a">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, Rev. 1, NP)</description>
+	<software name="kangpzl2">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev 1) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (rev a) (np).bin" size="262144" crc="a30ad68d" sha1="bbb3c1b9d0dcfabc177f443ea11efa6b6e3112e1"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzl2" cloneof="kangpzl2a">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Japan, NP)</description>
+	<software name="kangpzl2a" cloneof="kangpzl2">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-2-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B62J-JPN"/>
 		<info name="release" value="20011001"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第2号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-2-gou (japan) (np).bin" size="262144" crc="d457cc6c" sha1="cb14866337caecd5458edc72f2d56f2c8c028411"/>
@@ -11396,35 +10979,33 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kangpzl3a">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, Rev. 1, NP)</description>
+	<software name="kangpzl3">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev 1) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (rev a) (np).bin" size="262144" crc="9c932f0d" sha1="1d0dbac5283d6e7459afb0e4b4a194bbe79a798b"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzl3" cloneof="kangpzl3a">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Japan, NP)</description>
+	<software name="kangpzl3a" cloneof="kangpzl3">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Dai-3-gou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B63J-JPN"/>
 		<info name="release" value="20011201"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 第3号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle dai-3-gou (japan) (np).bin" size="262144" crc="3ef25533" sha1="9822fecf183d3d0a6e9af80696463b09e1f31a60"/>
@@ -11434,35 +11015,33 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kangpzlsa">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, Rev. 1, NP)</description>
+	<software name="kangpzls">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, Rev. A, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
-				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev 1) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
+				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (rev a) (np).bin" size="262144" crc="8019c6f5" sha1="4a9d7a35bc073399cbe852d356afa3772c5a7788"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
 		</part>
 	</software>
 
-	<software name="kangpzls" cloneof="kangpzlsa">
-		<!-- NP only -->
-		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Japan, NP)</description>
+	<software name="kangpzlsa" cloneof="kangpzls">
+		<!-- Notes: SGB enhanced, NP only -->
+		<description>Loppi Puzzle Magazine - Kangaeru Puzzle Soukangou (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-B61J-JPN"/>
 		<info name="release" value="20010801"/>
 		<info name="alt_title" value="ロッピー パズルマガジン かんがえるパズル 創刊号"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="loppi puzzle magazine - kangaeru puzzle soukangou (japan) (np).bin" size="262144" crc="094ffd1e" sha1="5a476f79db61aa8c6f32bbabd82fade5cde811d2"/>
@@ -11474,7 +11053,7 @@ license:CC0
 
 	<software name="lovehpty">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Party (Japan)</description>
+		<description>Love Hina Party (Jpn)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BLHJ-JPN"/>
@@ -11498,11 +11077,10 @@ license:CC0
 
 	<software name="lovehina">
 		<!-- Notes: GBC only -->
-		<description>Love Hina Pocket (Japan)</description>
+		<description>Love Hina Pocket (Jpn)</description>
 		<year>2000</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BPHJ-JPN"/>
-		<info name="gold" value="20000616"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ラブひなポケット"/>
 		<part name="cart" interface="gameboy_cart">
@@ -11515,34 +11093,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="lovehinaa" cloneof="lovehina">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbphj1.290"	-->
-		<description>Love Hina Pocket (Japan, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Marvelous Entertainment</publisher>
-		<info name="serial" value="CGB-BPHJ-JPN"/>
-		<info name="gold" value="20000824"/>
-		<info name="alt_title" value="ラブひなポケット"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbbphj1.290" size="4194304" crc="55dd0ba6" sha1="b29abee319ccb223e5d1a4f88982fb53e538d527"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="lucapuzl">
-		<description>Luca no Puzzle de Daibouken! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Luca no Puzzle de Daibouken! (Jpn)</description>
 		<year>1999</year>
 		<publisher>Human Entertainment</publisher>
 		<info name="serial" value="DMG-ARCJ-JPN"/>
 		<info name="release" value="19990611"/>
 		<info name="alt_title" value="ルーカのぱずるで大冒険!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="luca no puzzle de daibouken (japan).bin" size="524288" crc="3aebfad8" sha1="3c06fe05909ad632b761c6a1c00bc69da81aa358"/>
@@ -11554,7 +11113,7 @@ license:CC0
 
 	<software name="luckyluk">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke (Europe)</description>
+		<description>Lucky Luke (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ALQP-EUR"/>
@@ -11585,7 +11144,7 @@ license:CC0
 
 	<software name="luckyldt">
 		<!-- Notes: GBC only -->
-		<description>Lucky Luke - Desperado Train (Europe)</description>
+		<description>Lucky Luke - Desperado Train (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BLLP-(FRA/NOE)"/>
@@ -11599,7 +11158,7 @@ license:CC0
 
 	<software name="lufia">
 		<!-- Notes: GBC only -->
-		<description>Lufia - The Legend Returns (Europe)</description>
+		<description>Lufia - The Legend Returns (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BLFP-EUR"/>
@@ -11631,7 +11190,7 @@ license:CC0
 
 	<software name="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Europe)</description>
+		<description>M&amp;M's Minis Madness (Euro)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMIP-UKV"/>
@@ -11648,7 +11207,7 @@ license:CC0
 
 	<software name="mmsg" cloneof="mms">
 		<!-- Notes: GBC only -->
-		<description>M&amp;M's Minis Madness (Germany)</description>
+		<description>M&amp;M's Minis Madness (Ger)</description>
 		<year>2001</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BMID-NOE"/>
@@ -11691,7 +11250,7 @@ license:CC0
 
 	<software name="macross7">
 		<!-- Notes: GBC only -->
-		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Japan)</description>
+		<description>Macross 7 - Ginga no Heart o Furuwasero!! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BM7J-JPN"/>
@@ -11708,7 +11267,7 @@ license:CC0
 	</software>
 
 	<software name="madden2k">
-		<description>Madden NFL 2000 (Europe, USA)</description>
+		<description>Madden NFL 2000 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AEME-USA, DMG-AEMP-EUR"/>
@@ -11753,11 +11312,10 @@ license:CC0
 
 	<software name="maginatn">
 		<!-- Notes: GBC only -->
-		<description>Magi-Nation (USA)</description>
+		<description>Magi Nation (USA)</description>
 		<year>2001</year>
 		<publisher>Interactive Imagination</publisher>
 		<info name="serial" value="CGB-BNNE-USA"/>
-		<info name="gold" value="20010112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -11770,7 +11328,7 @@ license:CC0
 
 	<software name="magchase">
 		<!-- Notes: GBC only -->
-		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Japan)</description>
+		<description>Magical Chase GB - Minarai Mahoutsukai Kenja no Tani e (Jpn)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="CGB-AIFJ-JPN"/>
@@ -11786,7 +11344,7 @@ license:CC0
 
 	<software name="magdrop">
 		<!-- Notes: GBC only -->
-		<description>Magical Drop (Europe)</description>
+		<description>Magical Drop (Euro)</description>
 		<year>2000</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AXJP-EUR"/>
@@ -11814,14 +11372,14 @@ license:CC0
 
 	<software name="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Europe, Rev. 1)</description>
+		<description>Magical Tetris Challenge (Euro, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev 1).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
+				<rom name="magical tetris challenge (europe) (en,fr,de,es,it,nl,sv) (rev a).bin" size="1048576" crc="c82be2f4" sha1="950b30b267b0f0b79d7e85e91b8536b096b6a1b2"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11830,7 +11388,7 @@ license:CC0
 
 	<software name="mtetrisca" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Magical Tetris Challenge (Europe)</description>
+		<description>Magical Tetris Challenge (Euro)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-AXCP-EUR"/>
@@ -11861,14 +11419,14 @@ license:CC0
 	</software>
 
 	<software name="mjjoo">
-		<description>Mahjong Joou (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Mahjong Joou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Warashi</publisher>
 		<info name="serial" value="DMG-A56J-JPN"/>
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="麻雀女王"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong joou (japan).bin" size="1048576" crc="7d83a5e8" sha1="68f2326f7fa70d0ed0207bd087c6fe26ec6f9a53"/>
@@ -11879,14 +11437,14 @@ license:CC0
 	</software>
 
 	<software name="mjquest">
-		<description>Mahjong Quest (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Mahjong Quest (Jpn)</description>
 		<year>1998</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AMJJ-JPN"/>
 		<info name="release" value="19981223"/>
 		<info name="alt_title" value="麻雀クエスト"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mahjong quest (japan).bin" size="1048576" crc="c870b88f" sha1="3ab49ce8aa69013c1b2d9427926513e21d5efe1d"/>
@@ -11897,17 +11455,17 @@ license:CC0
 	</software>
 
 	<software name="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN-1"/>
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="majokko mari-chan no kisekae monogatari (japan) (Rev. 1).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
+				<rom name="majokko mari-chan no kisekae monogatari (japan) (rev. a).bin" size="2097152" crc="0d16a545" sha1="a56e2a42d4a0b21e656bc928e4451cf0623486cf"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -11915,14 +11473,14 @@ license:CC0
 	</software>
 
 	<software name="majomaria" cloneof="majomari">
-		<description>Majokko Mari-chan no Kisekae Monogatari (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Majokko Mari-chan no Kisekae Monogatari (Jpn)</description>
 		<year>1999</year>
 		<publisher>Pack In Soft</publisher>
 		<info name="serial" value="DMG-A23J-JPN"/>
 		<info name="release" value="19990903"/>
 		<info name="alt_title" value="まじょっコマリちゃんのきせかえ物語"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="majokko mari-chan no kisekae monogatari (japan).bin" size="2097152" crc="934f4b0a" sha1="8bdd3bd414da91c6ea05bc29435e09b0b72e3790"/>
@@ -11934,7 +11492,7 @@ license:CC0
 
 	<software name="marble">
 		<!-- Notes: GBC only -->
-		<description>Marble Madness (Europe, USA)</description>
+		<description>Marble Madness (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ANNE-USA, CGB-ANNP-EUR"/>
@@ -11947,14 +11505,14 @@ license:CC0
 	</software>
 
 	<software name="atelmari">
-		<description>Marie no Atelier GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Marie no Atelier GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8MJ-JPN"/>
 		<info name="release" value="20000108"/>
 		<info name="alt_title" value="マリーのアトリエGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -11972,7 +11530,7 @@ license:CC0
 
 	<software name="mariofam">
 		<!-- Notes: GBC only, bundled with Jaguar Sewing Machine (Nuotto Expansion)? -->
-		<description>Mario Family (Japan)</description>
+		<description>Mario Family (Jpn)</description>
 		<year>2001</year>
 		<publisher>Jaguar</publisher>
 		<info name="serial" value="CGB-BJMJ-JPN"/>
@@ -11990,7 +11548,7 @@ license:CC0
 
 	<software name="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf (Europe)</description>
+		<description>Mario Golf (Euro)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXP-EUR"/>
@@ -12022,7 +11580,7 @@ license:CC0
 
 	<software name="marioglfj" cloneof="marioglf">
 		<!-- Notes: GBC only -->
-		<description>Mario Golf GB (Japan)</description>
+		<description>Mario Golf GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AWXJ-JPN"/>
@@ -12046,7 +11604,7 @@ license:CC0
 
 	<software name="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis (Europe)</description>
+		<description>Mario Tennis (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8P-EUR"/>
@@ -12084,7 +11642,7 @@ license:CC0
 
 	<software name="mariotenj" cloneof="marioten">
 		<!-- Notes: GBC only -->
-		<description>Mario Tennis GB (Japan)</description>
+		<description>Mario Tennis GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BM8J-JPN"/>
@@ -12118,7 +11676,7 @@ license:CC0
 
 	<software name="mnacrush">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Crush Course (Europe, USA)</description>
+		<description>Mary-Kate and Ashley - Crush Course (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BCVE-USA, CGB-BCVP-UKV"/>
@@ -12134,7 +11692,7 @@ license:CC0
 	</software>
 
 	<software name="mnaclue">
-		<description>Mary-Kate &amp; Ashley - Get a Clue! (Europe, USA)</description>
+		<description>Mary-Kate &amp; Ashley - Get a Clue! (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BXFE-USA, DMG-BXFP-EUR"/>
@@ -12150,7 +11708,7 @@ license:CC0
 	</software>
 
 	<software name="mnaplann">
-		<description>Mary-Kate and Ashley - Pocket Planner (Europe, USA)</description>
+		<description>Mary-Kate and Ashley - Pocket Planner (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-BMAE-USA, DMG-BMAP-EUR"/>
@@ -12173,7 +11731,7 @@ license:CC0
 
 	<software name="mnacircl">
 		<!-- Notes: GBC only -->
-		<description>Mary-Kate and Ashley - Winners Circle (Europe, USA)</description>
+		<description>Mary-Kate and Ashley - Winners Circle (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BHFE-USA, CGB-BHFP-EUR"/>
@@ -12190,7 +11748,7 @@ license:CC0
 
 	<software name="zorro">
 		<!-- Notes: GBC only -->
-		<description>The Mask of Zorro (Europe)</description>
+		<description>The Mask of Zorro (Euro)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AZRP-EUR"/>
@@ -12218,7 +11776,7 @@ license:CC0
 
 	<software name="hoffbmx">
 		<!-- Notes: GBC only -->
-		<description>Mat Hoffman's Pro BMX (Europe, USA)</description>
+		<description>Mat Hoffman's Pro BMX (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-BM5P-EUR"/>
@@ -12232,7 +11790,7 @@ license:CC0
 
 	<software name="matchbox">
 		<!-- Notes: GBC only -->
-		<description>Matchbox Emergency Patrol (Europe, USA)</description>
+		<description>Matchbox Emergency Patrol (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BEPE-USA, CGB-BEPP-EUR"/>
@@ -12249,7 +11807,7 @@ license:CC0
 
 	<software name="maus">
 		<!-- Notes: GBC only -->
-		<description>Die Maus (Europe)</description>
+		<description>Die Maus (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ADXP-NOE"/>
@@ -12263,7 +11821,7 @@ license:CC0
 
 	<software name="mausvo">
 		<!-- Notes: GBC only -->
-		<description>Die Maus - Verrückte Olympiade (Germany)</description>
+		<description>Die Maus - Verrückte Olympiade (Ger)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BVOD-NOE"/>
@@ -12279,7 +11837,7 @@ license:CC0
 	</software>
 
 	<software name="mayabeef">
-		<description>Maya the Bee &amp; Her Friends (Europe)</description>
+		<description>Maya the Bee &amp; Her Friends (Euro)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -12293,7 +11851,7 @@ license:CC0
 
 	<software name="mayabee">
 		<!-- Notes: GBC only -->
-		<description>Maya the Bee - Garden Adventures (Europe)</description>
+		<description>Maya the Bee - Garden Adventures (Euro)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BMJP-EUR"/>
@@ -12307,7 +11865,7 @@ license:CC0
 
 	<software name="mcdonald">
 		<!-- Notes: GBC only -->
-		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Japan)</description>
+		<description>McDonald's Monogatari - Honobono Tenchou Ikusei Game (Jpn)</description>
 		<year>2001</year>
 		<publisher>TDK Core</publisher>
 		<info name="serial" value="CGB-BI9J-JPN"/>
@@ -12324,14 +11882,14 @@ license:CC0
 	</software>
 
 	<software name="medar2ka">
-		<description>Medarot 2 - Kabuto Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Medarot 2 - Kabuto Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2MJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [MX23C1603-12 1]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12347,14 +11905,14 @@ license:CC0
 	</software>
 
 	<software name="medar2ku">
-		<description>Medarot 2 - Kuwagata Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Medarot 2 - Kuwagata Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A2NJ-JPN"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="メダロット2 クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MTN]" />
 			<feature name="u2" value="U2 MBC-5 [MBC-5]" />
@@ -12370,14 +11928,14 @@ license:CC0
 	</software>
 
 	<software name="medar2cl">
-		<description>Medarot 2 - Parts Collection (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Medarot 2 - Parts Collection (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A7CJ-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="メダロット2 パーツコレクション"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [R531614G-12]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12395,7 +11953,7 @@ license:CC0
 
 	<software name="medar3ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kabuto Version (Japan)</description>
+		<description>Medarot 3 - Kabuto Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B32J-JPN"/>
@@ -12413,7 +11971,7 @@ license:CC0
 
 	<software name="medar3ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Kuwagata Version (Japan)</description>
+		<description>Medarot 3 - Kuwagata Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B33J-JPN"/>
@@ -12431,7 +11989,7 @@ license:CC0
 
 	<software name="medar3cl">
 		<!-- Notes: GBC only -->
-		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Japan)</description>
+		<description>Medarot 3 - Parts Collection - Z Kara no Chousenjou (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B3PJ-JPN"/>
@@ -12449,7 +12007,7 @@ license:CC0
 
 	<software name="medar4ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kabuto Version (Japan)</description>
+		<description>Medarot 4 - Kabuto Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4MJ-JPN"/>
@@ -12467,7 +12025,7 @@ license:CC0
 
 	<software name="medar4ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 4 - Kuwagata Version (Japan)</description>
+		<description>Medarot 4 - Kuwagata Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B4NJ-JPN"/>
@@ -12485,7 +12043,7 @@ license:CC0
 
 	<software name="medar5ka">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Japan)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kabuto Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5MJ-JPN"/>
@@ -12503,7 +12061,7 @@ license:CC0
 
 	<software name="medar5ku">
 		<!-- Notes: GBC only -->
-		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Japan)</description>
+		<description>Medarot 5 - Susutake Mura no Tenkousei - Kuwagata Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-B5NJ-JPN"/>
@@ -12520,14 +12078,14 @@ license:CC0
 	</software>
 
 	<software name="medarcka">
-		<description>Medarot Cardrobottle - Kabuto Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Medarot Cardrobottle - Kabuto Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A8CJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル カブトバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kabuto version (japan).bin" size="2097152" crc="4f03d80a" sha1="b7a02cee93169f73675b562d09d10175684ec77f"/>
@@ -12538,14 +12096,14 @@ license:CC0
 	</software>
 
 	<software name="medarcku">
-		<description>Medarot Cardrobottle - Kuwagata Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Medarot Cardrobottle - Kuwagata Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-A9CJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="メダロット カードロボトル クワガタバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="medarot cardrobottle - kuwagata version (japan).bin" size="2097152" crc="a3735f81" sha1="26b5516170ea0fa1669cafb9484e1aeb5d2cae6c"/>
@@ -12556,7 +12114,7 @@ license:CC0
 	</software>
 
 	<software name="megamnx">
-		<description>Mega Man Xtreme (Europe, USA)</description>
+		<description>Mega Man Xtreme (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BM6E-USA, DMG-BM6P-EUR?"/>
@@ -12572,7 +12130,7 @@ license:CC0
 
 	<software name="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Mega Man Xtreme 2 (Europe, USA)</description>
+		<description>Mega Man Xtreme 2 (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2XE-USA, CGB-B2XP-EUR"/>
@@ -12593,15 +12151,14 @@ license:CC0
 	</software>
 
 	<software name="lastbibl" cloneof="revelat">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Megami Tensei Gaiden - Last Bible (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-ALBJ-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブル"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible (japan).bin" size="1048576" crc="bd9ba639" sha1="419c5afdbc9b59e05e7861de8cc59ee367cd29f0"/>
@@ -12612,15 +12169,14 @@ license:CC0
 	</software>
 
 	<software name="lastbib2">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Megami Tensei Gaiden - Last Bible II (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Megami Tensei Gaiden - Last Bible II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-A2LJ-JPN"/>
 		<info name="release" value="19990416"/>
 		<info name="alt_title" value="女神転生外伝ラストバイブルII"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="megami tensei gaiden - last bible ii (japan).bin" size="1048576" crc="9caa00b5" sha1="84df9508bdd8b24dfb19a74744fec492fffee56d"/>
@@ -12631,14 +12187,14 @@ license:CC0
 	</software>
 
 	<software name="mconankj">
-		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Meitantei Conan - Karakuri Jiin Satsujin Jiken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A4BJ-JPN"/>
 		<info name="release" value="20000224"/>
 		<info name="alt_title" value="名探偵コナン −からくり寺院殺人事件−"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WKH]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -12655,14 +12211,14 @@ license:CC0
 	</software>
 
 	<software name="mconankh">
-		<description>Meitantei Conan - Kigantou Hihou Densetsu (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Meitantei Conan - Kigantou Hihou Densetsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-A5BJ-JPN"/>
 		<info name="release" value="20000331"/>
 		<info name="alt_title" value="名探偵コナン 奇岩島秘宝伝説"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -12679,14 +12235,14 @@ license:CC0
 	</software>
 
 	<software name="mconannk">
-		<description>Meitantei Conan - Norowareta Kouro (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Meitantei Conan - Norowareta Kouro (Jpn)</description>
 		<year>2001</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BC3J-JPN"/>
 		<info name="release" value="20010601"/>
 		<info name="alt_title" value="名探偵コナン−呪われた航路−"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="meitantei conan - norowareta kouro (japan).bin" size="2097152" crc="cabdd802" sha1="0858a619d716b0191713734d506d9f113f0d1c62"/>
@@ -12697,7 +12253,7 @@ license:CC0
 	</software>
 
 	<software name="mib">
-		<description>Men in Black - The Series (Europe, USA)</description>
+		<description>Men in Black - The Series (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AMNE-USA, DMG-AMNP-EUR"/>
@@ -12714,7 +12270,7 @@ license:CC0
 
 	<software name="mib2">
 		<!-- Notes: GBC only -->
-		<description>Men in Black 2 - The Series (Europe)</description>
+		<description>Men in Black 2 - The Series (Euro)</description>
 		<year>2000</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BB2P-EUR"/>
@@ -12742,8 +12298,7 @@ license:CC0
 
 	<software name="merlin">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBMBP0.603", "KENSA\CGBBMBE0.0"	-->
-		<description>Merlin (Europe)</description>
+		<description>Merlin (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BMBP-EUR"/>
@@ -12757,7 +12312,7 @@ license:CC0
 
 	<software name="metafght">
 		<!-- Notes: GBC only -->
-		<description>Meta Fight EX (Japan)</description>
+		<description>Meta Fight EX (Jpn)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A5MJ-JPN"/>
@@ -12773,7 +12328,7 @@ license:CC0
 
 	<software name="mgsj" cloneof="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear - Ghost Babel (Japan)</description>
+		<description>Metal Gear - Ghost Babel (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMGJ-JPN (RK202-J1)"/>
@@ -12791,7 +12346,7 @@ license:CC0
 
 	<software name="mgs">
 		<!-- Notes: GBC only -->
-		<description>Metal Gear Solid (Europe)</description>
+		<description>Metal Gear Solid (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMSP-EUR"/>
@@ -12844,7 +12399,7 @@ license:CC0
 
 	<software name="metamode">
 		<!-- Notes: GBC only -->
-		<description>Metamode (Japan)</description>
+		<description>Metamode (Jpn)</description>
 		<year>2000</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BTMJ-JPN"/>
@@ -12884,7 +12439,7 @@ license:CC0
 
 	<software name="mickeyra">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Racing Adventure (Europe, USA)</description>
+		<description>Mickey's Racing Adventure (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-ARNE-USA, CGB-ARNP-EUR"/>
@@ -12900,7 +12455,7 @@ license:CC0
 
 	<software name="micksped">
 		<!-- Notes: GBC only -->
-		<description>Mickey's Speedway USA (Europe, USA)</description>
+		<description>Mickey's Speedway USA (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BSNE-USA, CGB-BSNP-EUR"/>
@@ -12922,7 +12477,7 @@ license:CC0
 
 	<software name="microm12">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines 1 and 2 - Twin Turbo (Europe, USA)</description>
+		<description>Micro Machines 1 and 2 - Twin Turbo (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-AT8E-USA, CGB-AT8P-EUR"/>
@@ -12939,7 +12494,7 @@ license:CC0
 
 	<software name="micromc3">
 		<!-- Notes: GBC only -->
-		<description>Micro Machines V3 (Europe, USA)</description>
+		<description>Micro Machines V3 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BM3E-USA, CGB-BM3P-EUR"/>
@@ -12956,7 +12511,7 @@ license:CC0
 
 	<software name="microman">
 		<!-- Notes: GBC only -->
-		<description>Micro Maniacs (Europe)</description>
+		<description>Micro Maniacs (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B3NP-EUR"/>
@@ -12970,7 +12525,7 @@ license:CC0
 
 	<software name="msep">
 		<!-- Notes: GBC only -->
-		<description>Microsoft - The Best of Entertainment Pack (Europe)</description>
+		<description>Microsoft - The Best of Entertainment Pack (Euro)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BMZP-EUR"/>
@@ -12998,7 +12553,7 @@ license:CC0
 
 	<software name="mspinb">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Pinball Arcade (Europe)</description>
+		<description>Microsoft Pinball Arcade (Euro)</description>
 		<year>2001</year>
 		<publisher>Cryo Interactive</publisher>
 		<info name="serial" value="CGB-BMQP-EUR"/>
@@ -13032,7 +12587,7 @@ license:CC0
 
 	<software name="mspuzzle">
 		<!-- Notes: GBC only -->
-		<description>Microsoft Puzzle Collection (Europe)</description>
+		<description>Microsoft Puzzle Collection (Euro)</description>
 		<year>2000</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="alt_title" value="Microsoft - The 6 in 1 Puzzle Collection Entertainment Pack (Box)"/>
@@ -13080,13 +12635,12 @@ license:CC0
 	</software>
 
 	<software name="minnashg">
-		<description>Minna no Shougi - Shokyuu Hen (Japan)</description>
+		<description>Minna no Shougi - Shokyuu Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-A7YJ-JPN"/>
-		<info name="gold" value="19991028"/>
 		<info name="release" value="19991210"/>
-		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
+		<info name="alt_title" value="みんなの将棋 初級編"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13097,28 +12651,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="minnashga" cloneof="minnashg">
-		<!--	In lot check as "dmga7yj1.i18"	-->
-		<description>Minna no Shougi - Shokyuu Hen (Japan, Rev. 1)</description>
-		<year>1999</year>
-		<publisher>MTO</publisher>
-		<info name="serial" value="DMG-A7YJ-JPN"/>
-		<info name="gold" value="20000811"/>
-		<info name="alt_title" value="みんなの将棋 ～初級編～"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmga7yj1.i18" size="1048576" crc="f766015a" sha1="948d2015c29342fdb6052940a5d65e771b0a81d0"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="minnie">
 		<!-- Notes: GBC only -->
-		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Japan)</description>
+		<description>Minnie &amp; Friends - Yume no Kuni o Sagashite (Jpn)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BYKJ-JPN"/>
@@ -13142,7 +12677,7 @@ license:CC0
 
 	<software name="missile">
 		<!-- Notes: GBC only -->
-		<description>Missile Command (Europe)</description>
+		<description>Missile Command (Euro)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ALCP-EUR"/>
@@ -13178,34 +12713,14 @@ license:CC0
 
 	<software name="missimp">
 		<!-- Notes: GBC only -->
-		<description>Mission Impossible (Europe)</description>
+		<description>Mission Impossible (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIMP-(NOE/UKV/FAH)"/>
-		<info name="gold" value="19991006"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mission impossible (europe) (en,fr,de,es,it).bin" size="1048576" crc="0af32baa" sha1="5eb8dad248ff23809016a2515657089116e8df33"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="missimpa" cloneof="missimp">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaimp1.076"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Mission Impossible (Europe, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Infogrames</publisher>
-		<info name="serial" value="CGB-AIMP-?"/>
-		<info name="gold" value="19991227"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbaimp1.076" size="1048576" crc="9c51f4c7" sha1="f822bda01d881f34d1e17664465faf6a3ff64356"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -13218,7 +12733,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AIME-USA"/>
-		<info name="gold" value="19991227"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -13231,7 +12745,7 @@ license:CC0
 
 	<software name="mizuki">
 		<!-- Notes: GBC only -->
-		<description>Mizuki Shigeru no Shin Youkaiden (Japan)</description>
+		<description>Mizuki Shigeru no Shin Youkaiden (Jpn)</description>
 		<year>2000</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BYPJ-JPN"/>
@@ -13248,7 +12762,7 @@ license:CC0
 	</software>
 
 	<software name="mobilglf">
-		<!-- Notes: GBC only
+		<!-- Notes: GBC only.
 		        This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		        for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		        There are different models depending on the target cellular phone:
@@ -13258,7 +12772,7 @@ license:CC0
 		            * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		        Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		        manufactured by Mitsumi. -->
-		<description>Mobile Golf (Japan)</description>
+		<description>Mobile Golf (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BGOJ-JPN"/>
@@ -13282,7 +12796,7 @@ license:CC0
 
 	<!-- when it checks for the connection, it checks for a value of 06 in C27D -->
 	<software name="mobiltrn" supported="partial">
-		<!-- Notes: GBC only
+		<!-- Notes: GBC only.
 		    This game is compatible with the "Mobile System GB", a connected gaming system which uses an external adaptor
 		    for connecting to a mobile phone (named "Mobile Adaptor GB" [CGB-005]) and then to an external server.
 		    There are different models depending on the target cellular phone:
@@ -13292,7 +12806,7 @@ license:CC0
 		        * Green adapter (unreleased) can be used by the PHS (Astel, NTT DoCoMo).
 		    Internally, the "Mobile Adaptor GB" features a ML7060-01P ARM (internal ROM, if any, is undumped), and was
 		    manufactured by Mitsumi. -->
-		<description>Mobile Trainer (Japan)</description>
+		<description>Mobile Trainer (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B9AJ-JPN"/>
@@ -13315,7 +12829,7 @@ license:CC0
 
 	<software name="momo">
 		<!-- Notes: GBC only -->
-		<description>Momotarou Densetsu 1-2 (Japan)</description>
+		<description>Momotarou Densetsu 1-2 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BI2J-JPN"/>
@@ -13333,7 +12847,7 @@ license:CC0
 
 	<software name="monkeyp">
 		<!-- Notes: GBC only -->
-		<description>Monkey Puncher (Europe)</description>
+		<description>Monkey Puncher (Euro)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-BSPP-EUR"/>
@@ -13348,14 +12862,14 @@ license:CC0
 	</software>
 
 	<software name="monopolyj" cloneof="monopoly">
-		<description>Monopoly (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Monopoly (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hasbro</publisher>
 		<info name="serial" value="DMG-AHAJ-JPN"/>
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ゲームボーイモノポリー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="monopoly (japan).bin" size="1048576" crc="0503e567" sha1="3f42d9b423c15b4c1b997c7a2292ab2cba1ab23f"/>
@@ -13377,14 +12891,14 @@ license:CC0
 	</software>
 
 	<software name="mfarmbc" cloneof="mranchbc">
-		<description>Monster Farm Battle Card GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Monster Farm Battle Card GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TJ-JPN"/>
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="モンスターファーム バトルカードGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster farm battle card gb (japan).bin" size="2097152" crc="69b88f1e" sha1="7e036e175c9e865572ab613ae0f8e6d3642ffb0e"/>
@@ -13395,14 +12909,14 @@ license:CC0
 	</software>
 
 	<software name="monstrc2">
-		<description>Monster Race 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Monster Race 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AMWJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="もんすたあ★レース2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster race 2 (japan).bin" size="2097152" crc="b985f0d8" sha1="8d4a6b4cdaa37b9daaff5a05ac5926a407bacce3"/>
@@ -13413,12 +12927,12 @@ license:CC0
 	</software>
 
 	<software name="mranchbc">
+		<!-- Notes: SGB enhanced -->
 		<description>Monster Rancher Battle Card GB (USA)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="DMG-A6TE-USA"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="monster rancher battle card gb (usa).bin" size="2097152" crc="50ddf120" sha1="f94dc1dbdf25d9ab7f7abd3d7878209d404b206d"/>
@@ -13444,48 +12958,25 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="monstrvla">
+	<software name="monstrvl">
 		<!-- Notes: GBC only -->
-		<description>Monster Traveler (Japan, Rev. 1)</description>
+		<description>Monster Traveler (Jpn, Rev. A)</description>
 		<year>2002</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-BFVJ-JPN"/>
-		<info name="gold" value="20020207"/>
 		<info name="release" value="20020308"/>
-		<info name="alt_title" value="モン☆スタートラベラー"/>
+		<info name="alt_title" value="モン★スタートラベラー"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
-				<rom name="monster traveler (japan) (rev 1).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="monstrvl" cloneof="monstrvla">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbfvj0.949"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Monster Traveler (Japan)</description>
-		<year>2002</year>
-		<publisher>Taito</publisher>
-		<info name="serial" value="CGB-BFVJ-JPN"/>
-		<info name="gold" value="20020122"/>
-		<info name="alt_title" value="モン☆スタートラベラー"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="4194304">
-				<rom name="cgbbfvj0.949" size="4194304" crc="5d596cf6" sha1="5195f55ad6aaa302c0a0e11c0ec6ecad4efe0e27"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
+				<rom name="monster traveler (japan) (rev a).bin" size="4194304" crc="f60a376e" sha1="23842b7ad88a051b14c1676b1f561b933177f150"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Europe, Rev. 1)</description>
+		<description>Monsters, Inc. (Euro, Rev. A)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QP-UKV"/>
@@ -13502,7 +12993,7 @@ license:CC0
 
 	<software name="monstincu" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Europe, USA)</description>
+		<description>Monsters, Inc. (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QE-USA, CGB-B4QP-UKV"/>
@@ -13519,7 +13010,7 @@ license:CC0
 
 	<software name="monstinca" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Europe, English / Spanish / Dutch)</description>
+		<description>Monsters, Inc. (Euro, English / Spanish / Dutch)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QX-EUR"/>
@@ -13536,7 +13027,7 @@ license:CC0
 
 	<software name="monstincb" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Monsters, Inc. (Europe, English / French / Italian)</description>
+		<description>Monsters, Inc. (Euro, English / French / Italian)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QY-EUU"/>
@@ -13553,7 +13044,7 @@ license:CC0
 
 	<software name="monstincg" cloneof="monstinc">
 		<!-- Notes: GBC only -->
-		<description>Die Monster AG (Germany)</description>
+		<description>Die Monster AG (Ger)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4QD-NOE"/>
@@ -13566,7 +13057,7 @@ license:CC0
 	</software>
 
 	<software name="montezum">
-		<description>Montezuma's Return! (Europe)</description>
+		<description>Montezuma's Return! (Euro)</description>
 		<year>1998</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AZMP-EUR"/>
@@ -13593,7 +13084,7 @@ license:CC0
 
 	<software name="moominj" cloneof="moomin">
 		<!-- Notes: GBC only -->
-		<description>Moomin no Daibouken (Japan)</description>
+		<description>Moomin no Daibouken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-A36J-JPN"/>
@@ -13611,8 +13102,7 @@ license:CC0
 
 	<software name="moomin">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBAM9P0.471", "KENSA\CGBAM9E0.0"	-->
-		<description>Moomin's Tale (Europe)</description>
+		<description>Moomin's Tale (Euro)</description>
 		<year>2000</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="CGB-AM9P-EUR"/>
@@ -13626,7 +13116,7 @@ license:CC0
 
 	<software name="moorhun2">
 		<!-- Notes: GBC only -->
-		<description>Moorhuhn 2 - Die Jagd geht weiter (Germany)</description>
+		<description>Moorhuhn 2 - Die Jagd geht weiter (Ger)</description>
 		<year>2001</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BDED-NOE"/>
@@ -13648,7 +13138,7 @@ license:CC0
 
 	<software name="moorhen3">
 		<!-- Notes: GBC only -->
-		<description>Moorhen 3 - The Chicken Chase! (Europe)</description>
+		<description>Moorhen 3 - The Chicken Chase! (Euro)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="Moorhuhn 3: ...Es Gibt Huhn! (Box)"/>
@@ -13670,7 +13160,7 @@ license:CC0
 	</software>
 
 	<software name="mk4">
-		<description>Mortal Kombat 4 (Europe, USA)</description>
+		<description>Mortal Kombat 4 (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KE-USA, DMG-A4KP-EUR"/>
@@ -13683,7 +13173,7 @@ license:CC0
 	</software>
 
 	<software name="mk4g" cloneof="mk4">
-		<description>Mortal Kombat 4 (Germany)</description>
+		<description>Mortal Kombat 4 (Ger)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-A4KD-NOE"/>
@@ -13716,7 +13206,7 @@ license:CC0
 
 	<software name="mrnutz">
 		<!-- Notes: GBC only -->
-		<description>Mr Nutz (Europe)</description>
+		<description>Mr Nutz (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ANUP-(EUR/FAH/NOE)"/>
@@ -13747,7 +13237,7 @@ license:CC0
 
 	<software name="mrdrillr">
 		<!-- Notes: GBC only -->
-		<description>Mr. Driller (Europe)</description>
+		<description>Mr. Driller (Euro)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDP-EUR"/>
@@ -13762,38 +13252,18 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="mrdrillrja" cloneof="mrdrillr">
-		<!-- Notes: GBC only -->
-		<description>Mr. Driller (Japan)</description>
+	<software name="mrdrillrj" cloneof="mrdrillr">
+		<!-- Notes: GBC only, also released by NP in 2001-06 -->
+		<description>Mr. Driller (Jpn)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="CGB-BMDJ-JPN"/>
-		<info name="gold" value="20000510"/>
 		<info name="release" value="20000629"/>
 		<info name="alt_title" value="ミスタードリラーGB版"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="mr. driller (japan).bin" size="1048576" crc="773729af" sha1="b0d725dacea717be7109bd6a81817e717641da86"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="mrdrillrjnp" cloneof="mrdrillr">
-		<!-- Notes: GBC only, NP only -->
-		<!--	In lot check as "KENSA\cgbbv3j0.0"	-->
-		<description>Mr. Driller (Japan, NP)</description>
-		<year>2000</year>
-		<publisher>Namco</publisher>
-		<info name="serial" value="CGB-BV3J-JPN"/>
-		<info name="release" value="200106"/>
-		<info name="alt_title" value="ミスタードリラーGB版"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="524288">
-				<rom name="cgbbv3j0.0" size="524288" crc="35fd440d" sha1="fb64fa7da6a0fec3e358bb3357e66d68473ada67"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -13830,7 +13300,7 @@ license:CC0
 
 	<software name="mspacman">
 		<!-- Notes: GBC only -->
-		<description>Ms. Pac-Man - Special Colour Edition (Europe)</description>
+		<description>Ms. Pac-Man - Special Colour Edition (Euro)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AQCP-EUR"/>
@@ -13844,7 +13314,7 @@ license:CC0
 
 	<software name="mtvride">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Pure Ride (Europe, USA)</description>
+		<description>MTV Sports - Pure Ride (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BPVE-USA, CGB-BPVP-EUR"/>
@@ -13861,7 +13331,7 @@ license:CC0
 
 	<software name="mtvskate">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Europe, USA)</description>
+		<description>MTV Sports - Skateboarding featuring Andy MacDonald (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BMTE-USA, CGB-BMTP-EUR"/>
@@ -13878,7 +13348,7 @@ license:CC0
 
 	<software name="mtvbmx">
 		<!-- Notes: GBC only -->
-		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Europe, USA)</description>
+		<description>MTV Sports - T.J. Lavin's Ultimate BMX (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTVE-USA, CGB-BTVP-EUR"/>
@@ -13895,7 +13365,7 @@ license:CC0
 
 	<software name="mummyr">
 		<!-- Notes: GBC only -->
-		<description>The Mummy Returns (Europe)</description>
+		<description>The Mummy Returns (Euro)</description>
 		<year>2001</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-B2RP-EUR"/>
@@ -13926,7 +13396,7 @@ license:CC0
 
 	<software name="mummy">
 		<!-- Notes: GBC only -->
-		<description>The Mummy (Europe)</description>
+		<description>The Mummy (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMYP-EUR"/>
@@ -13954,7 +13424,7 @@ license:CC0
 
 	<software name="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Europe, Black Cart)</description>
+		<description>The Muppets (Euro, Black Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="alt_title" value="Jim Henson's Puppets (Cart)"/>
@@ -13977,7 +13447,7 @@ license:CC0
 
 	<software name="muppetsa" cloneof="muppets">
 		<!-- Notes: GBC only -->
-		<description>The Muppets (Europe, Transparent Cart)</description>
+		<description>The Muppets (Euro, Transparent Cart)</description>
 		<year>2000</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AX9P-EUR"/>
@@ -14015,7 +13485,7 @@ license:CC0
 
 	<software name="trizenon">
 		<!-- Notes: GBC only -->
-		<description>Muteki Ou Tri-Zenon (Japan)</description>
+		<description>Muteki Ou Tri-Zenon (Jpn)</description>
 		<year>2001</year>
 		<publisher>Marvelous Entertainment</publisher>
 		<info name="serial" value="CGB-BZNJ-JPN"/>
@@ -14033,7 +13503,7 @@ license:CC0
 
 	<software name="nyrace">
 		<!-- Notes: GBC only -->
-		<description>N.Y. Race (Europe)</description>
+		<description>N.Y. Race (Euro)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-BNXP-EUR"/>
@@ -14047,7 +13517,7 @@ license:CC0
 
 	<software name="ncook1">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Japan)</description>
+		<description>Nakayoshi Cooking Series 1 - Oishii Cake-ya-san (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7CJ-JPN"/>
@@ -14065,7 +13535,7 @@ license:CC0
 
 	<software name="ncook2">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Japan)</description>
+		<description>Nakayoshi Cooking Series 2 - Oishii Panya-san (Jpn)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7PJ-JPN"/>
@@ -14083,7 +13553,7 @@ license:CC0
 
 	<software name="ncook3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Japan)</description>
+		<description>Nakayoshi Cooking Series 3 - Tanoshii Obentou (Jpn)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7BJ-JPN"/>
@@ -14101,7 +13571,7 @@ license:CC0
 
 	<software name="ncook4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Japan)</description>
+		<description>Nakayoshi Cooking Series 4 - Tanoshii Dessert (Jpn)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3DJ-JPN"/>
@@ -14125,13 +13595,12 @@ license:CC0
 
 	<software name="ncook5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Japan)</description>
+		<description>Nakayoshi Cooking Series 5 - Cake o Tsukurou (Jpn)</description>
 		<year>2002</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B3CJ-JPN"/>
-		<info name="gold" value="20020307"/>
 		<info name="release" value="20020405"/>
-		<info name="alt_title" value="なかよしクッキングシリーズ⑤　こむぎちゃんのケーキをつくろう！"/>
+		<info name="alt_title" value="なかよしクッキングシリーズ(5) こむぎちゃんのケーキをつくろう!"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -14148,9 +13617,8 @@ license:CC0
 		</part>
 	</software>
 
-
 	<software name="nakapet1">
-		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Japan)</description>
+		<description>Nakayoshi Pet Series 1 - Kawaii Hamster (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7HJ-JPN"/>
@@ -14167,7 +13635,7 @@ license:CC0
 	</software>
 
 	<software name="nakapet2">
-		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Japan)</description>
+		<description>Nakayoshi Pet Series 2 - Kawaii Usagi (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-B7UJ-JPN"/>
@@ -14185,7 +13653,7 @@ license:CC0
 
 	<software name="nakapet3">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Japan)</description>
+		<description>Nakayoshi Pet Series 3 - Kawaii Koinu (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7IJ-JPN"/>
@@ -14203,7 +13671,7 @@ license:CC0
 
 	<software name="nakapet4">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Japan)</description>
+		<description>Nakayoshi Pet Series 4 - Kawaii Koneko (Jpn)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B7NJ-JPN"/>
@@ -14221,7 +13689,7 @@ license:CC0
 
 	<software name="nakapet5">
 		<!-- Notes: GBC only -->
-		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Japan)</description>
+		<description>Nakayoshi Pet Series 5 - Kawaii Hamster 2 (Jpn)</description>
 		<year>2001</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-B2HJ-JPN"/>
@@ -14239,7 +13707,7 @@ license:CC0
 
 	<software name="naminori" cloneof="ultsurf">
 		<!-- Notes: GBC only, NP only -->
-		<description>Naminori Yarou! (Japan, NP)</description>
+		<description>Naminori Yarou! (Jpn, NP)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BNYJ-JPN"/>
@@ -14257,7 +13725,7 @@ license:CC0
 
 	<software name="nascar2k">
 		<!-- Notes: GBC only -->
-		<description>NASCAR 2000 (Europe, USA)</description>
+		<description>NASCAR 2000 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BN2E-USA, CGB-BN2P-EUR"/>
@@ -14322,7 +13790,7 @@ license:CC0
 
 	<software name="nations">
 		<!-- Notes: GBC only -->
-		<description>The Nations - Land of Legends (Europe)</description>
+		<description>The Nations - Land of Legends (Euro)</description>
 		<year>2002</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-BNLP-EUR"/>
@@ -14363,35 +13831,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="nbazonea" cloneof="nbapro99">
-		<description>NBA In the Zone (USA, Rev. 1)</description>
+	<software name="nbazone" cloneof="nbapro99">
+		<description>NBA In the Zone (USA, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZE-USA"/>
-		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="nba in the zone (usa) (rev 1).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="nbazone" cloneof="nbapro99">
-		<!--	In lot check as "dmganze0.g29"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>NBA In the Zone (USA)</description>
-		<year>1999</year>
-		<publisher>Konami</publisher>
-		<info name="serial" value="DMG-ANZE-USA?"/>
-		<info name="gold" value="19990303"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmganze0.g29" size="1048576" crc="f6bae9a0" sha1="7f0d5a37956ae58077656a42b26629784c203038"/>
+				<rom name="nba in the zone (usa) (rev a).bin" size="1048576" crc="be949f74" sha1="f4ba926ad640d7b3e9d175fb58c90347dafcbef4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -14400,11 +13848,10 @@ license:CC0
 
 	<software name="nbazon2k">
 		<!-- Notes: GBC only -->
-		<description>NBA In the Zone 2000 (Europe)</description>
+		<description>NBA In the Zone 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-AJ7P-EUR"/>
-		<info name="gold" value="19990311"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -14432,7 +13879,7 @@ license:CC0
 	</software>
 
 	<software name="nbajam99">
-		<description>NBA Jam '99 (Europe, USA)</description>
+		<description>NBA Jam '99 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AJME-USA, DMG-AJMP-EUR"/>
@@ -14449,7 +13896,7 @@ license:CC0
 
 	<software name="nbajm2k1">
 		<!-- Notes: GBC only -->
-		<description>NBA Jam 2001 (Europe, USA)</description>
+		<description>NBA Jam 2001 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BJAE-USA, CGB-BJAP-EUR"/>
@@ -14465,11 +13912,10 @@ license:CC0
 	</software>
 
 	<software name="nbapro99">
-		<description>NBA Pro '99 (Europe)</description>
+		<description>NBA Pro '99 (Euro)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-ANZP-EUR"/>
-		<info name="gold" value="19990716"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14486,7 +13932,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AA5E-USA"/>
-		<info name="gold" value="19991124"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -14497,7 +13942,7 @@ license:CC0
 
 	<software name="netdeget">
 		<!-- Notes: GBC only -->
-		<description>Net de Get - Minigame @ 100 (Japan)</description>
+		<description>Net de Get - Minigame @ 100 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BMVJ-JPN (RK215-J1)"/>
@@ -14523,7 +13968,7 @@ license:CC0
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Alpha Version (Japan)</description>
+		<description>Network Boukenki Bugsite - Alpha Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BAUJ-JPN"/>
@@ -14543,7 +13988,7 @@ license:CC0
 		<!-- Notes: GBC only
 		        This game uses an accessory (same hardware as the Telefang "Power Antenna" but on differently shaped plastic case),
 		        which is just a LED light connected to the GB accessories port. -->
-		<description>Network Boukenki Bugsite - Beta Version (Japan)</description>
+		<description>Network Boukenki Bugsite - Beta Version (Jpn)</description>
 		<year>2001</year>
 		<publisher>Smilesoft</publisher>
 		<info name="serial" value="CGB-BBUJ-JPN"/>
@@ -14567,11 +14012,10 @@ license:CC0
 
 	<software name="newaddfm">
 		<!-- Notes: GBC only -->
-		<description>The New Addams Family Series (Europe)</description>
+		<description>The New Addams Family Series (Euro)</description>
 		<year>2001</year>
 		<publisher>Microids</publisher>
 		<info name="serial" value="CGB-BAIP-EUR"/>
-		<info name="gold" value="20011108"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -14583,7 +14027,7 @@ license:CC0
 	</software>
 
 	<software name="newmna">
-		<description>The New Adventures of Mary-Kate &amp; Ashley (Europe, USA)</description>
+		<description>The New Adventures of Mary-Kate &amp; Ashley (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AXFE-USA, DMG-AXFP-EUR"/>
@@ -14600,7 +14044,7 @@ license:CC0
 
 	<software name="newbatmn">
 		<!-- Notes: GBC only -->
-		<description>The New Batman Adventures - Chaos in Gotham (Europe)</description>
+		<description>The New Batman Adventures - Chaos in Gotham (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BBBP-EUR"/>
@@ -14627,7 +14071,7 @@ license:CC0
 	</software>
 
 	<software name="blitz">
-		<description>NFL Blitz (Europe, USA, Rev. 1)</description>
+		<description>NFL Blitz (Euro, USA, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ABZE-USA, DMG-ABZP-EUU"/>
@@ -14684,7 +14128,7 @@ license:CC0
 	</software>
 
 	<software name="nhl2k">
-		<description>NHL 2000 (Europe, USA)</description>
+		<description>NHL 2000 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ANRE-USA, DMG-ANRP-EUR"/>
@@ -14744,7 +14188,7 @@ license:CC0
 
 	<software name="nintama">
 		<!-- Notes: GBC only -->
-		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Japan)</description>
+		<description>Nintama Rantarou - Ninjutsu Gakuen ni Nyuugaku Shiyou no Dan (Jpn)</description>
 		<year>2001</year>
 		<publisher>ASK</publisher>
 		<info name="serial" value="CGB-BNAJ-JPN"/>
@@ -14762,7 +14206,7 @@ license:CC0
 
 	<software name="nisemon">
 		<!-- Notes: GBC only -->
-		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Japan)</description>
+		<description>Nisemon Puzzle da Mon! - Feromon Kyuushutsu Daisakusen! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Prime System</publisher>
 		<info name="serial" value="CGB-BNPJ-JPN"/>
@@ -14780,7 +14224,7 @@ license:CC0
 
 	<software name="nofear">
 		<!-- Notes: GBC only -->
-		<description>No Fear - Downhill Mountain Biking (Europe)</description>
+		<description>No Fear - Downhill Mountain Biking (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BKFP-EUR"/>
@@ -14793,7 +14237,7 @@ license:CC0
 	</software>
 
 	<software name="nobugb2">
-		<description>Nobunaga no Yabou - Game Boy Ban 2 (Japan)</description>
+		<description>Nobunaga no Yabou - Game Boy Ban 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AGYJ-JPN"/>
@@ -14811,7 +14255,7 @@ license:CC0
 
 	<software name="noddy">
 		<!-- Notes: GBC only -->
-		<description>Noddy and the Birthday Party (Europe)</description>
+		<description>Noddy and the Birthday Party (Euro)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-AZEP-UKV"/>
@@ -14841,7 +14285,7 @@ license:CC0
 
 	<software name="nushiadv">
 		<!-- Notes: GBC only -->
-		<description>Nushi Tsuri Adventure - Kite no Bouken (Japan)</description>
+		<description>Nushi Tsuri Adventure - Kite no Bouken (Jpn)</description>
 		<year>2000</year>
 		<publisher>Victor Interactive Software</publisher>
 		<info name="serial" value="CGB-VVJJ-JPN"/>
@@ -14867,7 +14311,7 @@ license:CC0
 
 	<software name="oleary">
 		<!-- Notes: GBC only -->
-		<description>O'Leary Manager 2000 (Europe)</description>
+		<description>O'Leary Manager 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="??"/>
@@ -14882,7 +14326,7 @@ license:CC0
 	</software>
 
 	<software name="oddworld">
-		<description>Oddworld Adventures II (Europe)</description>
+		<description>Oddworld Adventures II (Euro)</description>
 		<year>2000</year>
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="DMG-AOWP-EUR"/>
@@ -14909,7 +14353,7 @@ license:CC0
 
 	<software name="ohasuddr">
 		<!-- Notes: GBC only -->
-		<description>Ohasuta Dance Dance Revolution GB (Japan)</description>
+		<description>Ohasuta Dance Dance Revolution GB (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BD5J-JPN (RK231-J1)"/>
@@ -14926,14 +14370,14 @@ license:CC0
 	</software>
 
 	<software name="ohasuynr">
-		<description>Ohasuta Yama-chan &amp; Raymond (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Ohasuta Yama-chan &amp; Raymond (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-AOSJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="おはスタ やまちゃん&amp;レイモンド"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -14945,7 +14389,7 @@ license:CC0
 
 	<software name="oiderasc">
 		<!-- Notes: GBC only -->
-		<description>Oide Rascal (Japan)</description>
+		<description>Oide Rascal (Jpn)</description>
 		<year>2001</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BLSJ-JPN"/>
@@ -14962,7 +14406,7 @@ license:CC0
 	</software>
 
 	<software name="ojarumam">
-		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Japan)</description>
+		<description>Ojarumaru - Mangan Jinja no Ennichi de Ojaru! (Jpn)</description>
 		<year>2000</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="DMG-BOJJ-JPN"/>
@@ -14979,7 +14423,7 @@ license:CC0
 	</software>
 
 	<software name="ojarumat">
-		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Japan)</description>
+		<description>Ojarumaru - Tsukiyo ga Ike no Takaramono (Jpn)</description>
 		<year>2000</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="DMG-BORJ-JPN"/>
@@ -14997,7 +14441,7 @@ license:CC0
 
 	<software name="moorhun">
 		<!-- Notes: GBC only -->
-		<description>Die Original Moorhuhn Jagd (Germany)</description>
+		<description>Die Original Moorhuhn Jagd (Ger)</description>
 		<year>2000</year>
 		<publisher>Ravensburger Interactive</publisher>
 		<info name="serial" value="CGB-BOMD-NOE"/>
@@ -15013,7 +14457,7 @@ license:CC0
 	</software>
 
 	<software name="othellom">
-		<description>Othello Millennium (Japan)</description>
+		<description>Othello Millennium (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tsukuda Original</publisher>
 		<info name="serial" value="DMG-AO7J-JPN"/>
@@ -15030,15 +14474,14 @@ license:CC0
 	</software>
 
 	<software name="azuredj" cloneof="azured">
-		<!-- Also released by NP in 2000-08 -->
-		<description>Other Life - Azure Dreams GB (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-08 -->
+		<description>Other Life - Azure Dreams GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AAZJ-JPN (RK179-J1)"/>
 		<info name="release" value="19990805"/>
 		<info name="alt_title" value="アザーライフ アザードリームGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="other life - azure dreams gb (japan).bin" size="1048576" crc="c6f1abd4" sha1="9e473df09e962a9accc3f6446140b0333f6a088e"/>
@@ -15050,7 +14493,7 @@ license:CC0
 
 	<software name="ottifant">
 		<!-- Notes: GBC only -->
-		<description>Ottifanten - Kommando Störtebeker (Germany)</description>
+		<description>Ottifanten - Kommando Störtebeker (Ger)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="??"/>
@@ -15063,14 +14506,14 @@ license:CC0
 	</software>
 
 	<software name="oudoroan">
-		<description>Ou Dorobou Jing - Angel Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Ou Dorobou Jing - Angel Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZWJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン エンジェルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - angel version (japan).bin" size="1048576" crc="d47c0dcf" sha1="493e37dac6d8b037e44e64f9f31dba7f08a89e08"/>
@@ -15081,14 +14524,14 @@ license:CC0
 	</software>
 
 	<software name="oudorodv">
-		<description>Ou Dorobou Jing - Devil Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Ou Dorobou Jing - Devil Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>NCS</publisher>
 		<info name="serial" value="DMG-AZKJ-JPN"/>
 		<info name="release" value="19990312"/>
 		<info name="alt_title" value="王ドロボウジン デビルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="ou dorobou jing - devil version (japan).bin" size="1048576" crc="2a39a874" sha1="71797aa125b88614182ce3d0f8252d6ed8cfa08e"/>
@@ -15099,14 +14542,14 @@ license:CC0
 	</software>
 
 	<software name="owarai">
-		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Owarai Yoiko no Geemumichi - Oyaji Sagashite 3-Choume (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYIJ-JPN (RK194-J1)"/>
 		<info name="release" value="19991225"/>
 		<info name="alt_title" value="おわらいよゐこのげえむ道 〜おやじ探して3丁目〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="owarai yowiko no game-dou - oyaji sagashite sanchoume (japan).bin" size="1048576" crc="3f635a4f" sha1="21644c1ef67bdd6038686d8522e957e3de803237"/>
@@ -15130,7 +14573,7 @@ license:CC0
 	</software>
 
 	<software name="pacmansp">
-		<description>Pac-Man - Special Colour Edition (Europe)</description>
+		<description>Pac-Man - Special Colour Edition (Euro)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-AACP-EUR"/>
@@ -15143,7 +14586,7 @@ license:CC0
 	</software>
 
 	<software name="pachicrt">
-		<description>Pachinko CR Mouretsu Genshijin T (Japan)</description>
+		<description>Pachinko CR Mouretsu Genshijin T (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hector</publisher>
 		<info name="serial" value="DMG-AXAJ-JPN"/>
@@ -15158,7 +14601,7 @@ license:CC0
 	</software>
 
 	<software name="pachihis">
-		<description>Pachinko Hisshou Guide - Data no Ousama (Japan)</description>
+		<description>Pachinko Hisshou Guide - Data no Ousama (Jpn)</description>
 		<year>1999</year>
 		<publisher>BOSS Communications</publisher>
 		<info name="serial" value="DMG-AYEJ-JPN"/>
@@ -15175,15 +14618,14 @@ license:CC0
 	</software>
 
 	<software name="pachislt">
-		<!-- Also released by NP in 2000-06 -->
-		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-06 -->
+		<description>Pachipachi Pachi-Slot - New Pulsar Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ANPJ-JPN"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="パチパチ パチス郎〜ニューパルサー編〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pachipachi pachi-slot - new pulsar hen (japan).bin" size="1048576" crc="1e443d1b" sha1="969d5352c15e3e5daa891edcda91bd48a8380308"/>
@@ -15195,7 +14637,7 @@ license:CC0
 
 	<software name="paperboy">
 		<!-- Notes: GBC only -->
-		<description>Paperboy (Europe, USA)</description>
+		<description>Paperboy (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AYPE-USA, CGB-AYPP-EUR"/>
@@ -15209,7 +14651,7 @@ license:CC0
 
 	<software name="papyrus">
 		<!-- Notes: GBC only -->
-		<description>Papyrus (Europe)</description>
+		<description>Papyrus (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AY9P-EUR"/>
@@ -15223,7 +14665,7 @@ license:CC0
 
 	<software name="pchoroq">
 		<!-- Notes: GBC only -->
-		<description>Perfect Choro Q (Japan)</description>
+		<description>Perfect Choro Q (Jpn)</description>
 		<year>2000</year>
 		<publisher>Takara</publisher>
 		<info name="serial" value="CGB-BPQJ-JPN"/>
@@ -15241,7 +14683,7 @@ license:CC0
 
 	<software name="pdark">
 		<!-- Notes: GBC only -->
-		<description>Perfect Dark (Europe, USA)</description>
+		<description>Perfect Dark (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VPDE-USA, CGB-VPDP-EUR"/>
@@ -15264,14 +14706,14 @@ license:CC0
 	</software>
 
 	<software name="phantomz">
-		<description>Phantom Zona - Kaijin Zona (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Phantom Zona - Kaijin Zona (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BKZJ-JPN"/>
 		<info name="release" value="20001021"/>
 		<info name="alt_title" value="怪人ゾナー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-Z03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -15289,7 +14731,7 @@ license:CC0
 
 	<software name="picarro2">
 		<!-- Notes: GBC only -->
-		<description>Pia Carrot e Youkoso!! 2.2 (Japan)</description>
+		<description>Pia Carrot e Youkoso!! 2.2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>NEC Interchannel</publisher>
 		<info name="serial" value="CGB-B22J-JPN"/>
@@ -15306,7 +14748,7 @@ license:CC0
 	</software>
 
 	<software name="pitfall">
-		<description>Pitfall - Beyond the Jungle (Europe, USA)</description>
+		<description>Pitfall - Beyond the Jungle (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="DMG-AFLE-USA, DMG-AFLP-EUR"/>
@@ -15322,7 +14764,7 @@ license:CC0
 	</software>
 
 	<software name="pitfallj" cloneof="pitfall">
-		<description>Pitfall GB (Japan)</description>
+		<description>Pitfall GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AFLJ-JPN (PCPE-10003)"/>
@@ -15338,7 +14780,7 @@ license:CC0
 
 	<software name="planapes">
 		<!-- Notes: GBC only -->
-		<description>Planet of the Apes (Europe)</description>
+		<description>Planet of the Apes (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BYNP-EUR"/>
@@ -15369,7 +14811,7 @@ license:CC0
 
 	<software name="pmang2k1">
 		<!-- Notes: GBC only -->
-		<description>Player Manager 2001 (Europe)</description>
+		<description>Player Manager 2001 (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BFBP-EUR"/>
@@ -15384,7 +14826,7 @@ license:CC0
 	</software>
 
 	<software name="pockbill">
-		<description>Pocket Billiards - Funk the 9 Ball (Japan)</description>
+		<description>Pocket Billiards - Funk the 9 Ball (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-A9BJ-JPN"/>
@@ -15401,7 +14843,7 @@ license:CC0
 	</software>
 
 	<software name="pockbman">
-		<description>Pocket Bomberman (Europe, USA)</description>
+		<description>Pocket Bomberman (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AKQE-USA, DMG-AKQP-EUR"/>
@@ -15417,7 +14859,7 @@ license:CC0
 	</software>
 
 	<software name="pockbwlj" cloneof="pockbwl">
-		<description>Pocket Bowling (Japan)</description>
+		<description>Pocket Bowling (Jpn)</description>
 		<year>1998</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AVBJ-JPN"/>
@@ -15448,7 +14890,7 @@ license:CC0
 	</software>
 
 	<software name="pockcbil">
-		<description>Pocket Color Billiards (Japan)</description>
+		<description>Pocket Color Billiards (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A3AJ-JPN"/>
@@ -15463,14 +14905,14 @@ license:CC0
 	</software>
 
 	<software name="pockcblk" cloneof="ddance">
-		<description>Pocket Color Block (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Color Block (Jpn)</description>
 		<year>1998</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-AC6J-JPN"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケットカラー ブロック"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="131072">
 				<rom name="pocket color block (japan).bin" size="131072" crc="389cf56f" sha1="84d243c64f98731965ca78b75ad48f8787d3c907"/>
@@ -15479,7 +14921,7 @@ license:CC0
 	</software>
 
 	<software name="pockcmj">
-		<description>Pocket Color Mahjong (Japan)</description>
+		<description>Pocket Color Mahjong (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A2AJ-JPN"/>
@@ -15494,7 +14936,7 @@ license:CC0
 	</software>
 
 	<software name="pockctrm">
-		<description>Pocket Color Trump (Japan)</description>
+		<description>Pocket Color Trump (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="DMG-A4CJ-JPN"/>
@@ -15510,7 +14952,7 @@ license:CC0
 
 	<software name="pockcook">
 		<!-- Notes: GBC only -->
-		<description>Pocket Cooking (Japan)</description>
+		<description>Pocket Cooking (Jpn)</description>
 		<year>2001</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-APJJ-JPN"/>
@@ -15533,14 +14975,14 @@ license:CC0
 	</software>
 
 	<software name="pockden2">
-		<description>Pocket Densha 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Densha 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Coconuts Japan</publisher>
 		<info name="serial" value="DMG-AP8J-JPN"/>
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="ポケット電車2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket densha 2 (japan).bin" size="1048576" crc="4d26e880" sha1="859331f57a964197f271acafa7e8dc586e598cf5"/>
@@ -15549,9 +14991,9 @@ license:CC0
 	</software>
 
 	<software name="pockfam2">
-		<!-- Notes: GBC only
+		<!-- Notes: GBC only.
 		    The game cart has an integrated speaker and a replaceable battery (CR2025). -->
-		<description>Pocket Family GB2 (Japan)</description>
+		<description>Pocket Family GB2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-HF2J-JPN"/>
@@ -15575,14 +15017,14 @@ license:CC0
 	</software>
 
 	<software name="pockgis">
-		<description>Pocket GI Stable (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket GI Stable (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-APUJ-JPN (RK156-J1)"/>
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="ポケットGIステイブル"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pocket gi stable (japan).bin" size="2097152" crc="c424874e" sha1="f818e6284d198f4b394f79cb8511c9b906d69f03"/>
@@ -15594,11 +15036,10 @@ license:CC0
 
 	<software name="pockgt" cloneof="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket GT (Japan)</description>
+		<description>Pocket GT (Jpn)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<info name="serial" value="CGB-A7GJ-JPN"/>
-		<info name="gold" value="19990920"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="ポケット ジーティー"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15612,7 +15053,7 @@ license:CC0
 	</software>
 
 	<software name="pockgtp" cloneof="pockrace">
-		<description>Pocket GT (Europe, Prototype?)</description>
+		<description>Pocket GT (Eur, Prototype?)</description>
 		<year>1999</year>
 		<publisher>MTO</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -15627,7 +15068,7 @@ license:CC0
 
 	<software name="pockhana">
 		<!-- Notes: GBC only -->
-		<description>Pocket Hanafuda (Japan)</description>
+		<description>Pocket Hanafuda (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-A6PJ-JPN"/>
@@ -15642,7 +15083,7 @@ license:CC0
 	</software>
 
 	<software name="pockking">
-		<description>Pocket King (Japan)</description>
+		<description>Pocket King (Jpn)</description>
 		<year>2001</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AV5J-JPN"/>
@@ -15660,7 +15101,7 @@ license:CC0
 
 	<software name="pocklure">
 		<!-- Notes: GBC only -->
-		<description>Pocket Lure Boy (Japan)</description>
+		<description>Pocket Lure Boy (Jpn)</description>
 		<year>1999</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-AQIJ-JPN (KIG-8)"/>
@@ -15711,14 +15152,14 @@ license:CC0
 	</software>
 
 	<software name="pokegin" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Monsters Gin (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-KFDN-10" />
 			<feature name="u1" value="U1 PRG [M538011E-B9]" />
 			<feature name="u2" value="U2 MBC3A [MBC3 A]" />
@@ -15728,7 +15169,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters gin (japan) (rev 1).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
+				<rom name="pocket monsters gin (japan) (rev a).bin" size="1048576" crc="0aea5383" sha1="a11d5ddc26eb826086593f82370b15d16404d33e"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15736,14 +15177,14 @@ license:CC0
 	</software>
 
 	<software name="pokegina" cloneof="pokesilv">
-		<description>Pocket Monsters Gin (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Monsters Gin (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター銀"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15755,18 +15196,18 @@ license:CC0
 	</software>
 
 	<software name="pokekin" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Monsters Kin (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="pocket monsters kin (japan) (rev 1).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
+				<rom name="pocket monsters kin (japan) (rev a).bin" size="1048576" crc="4ef7f2a5" sha1="a222402235d484ee8e39f3f31bae57cf13daf585"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -15774,14 +15215,14 @@ license:CC0
 	</software>
 
 	<software name="pokekina" cloneof="pokegold">
-		<description>Pocket Monsters Kin (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Monsters Kin (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUJ-JPN"/>
 		<info name="release" value="19991121"/>
 		<info name="alt_title" value="ポケットモンスター金"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -15794,11 +15235,10 @@ license:CC0
 
 	<software name="pokecrysj" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pocket Monsters - Crystal Version (Japan)</description>
+		<description>Pocket Monsters - Crystal Version (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BXTJ-JPN"/>
-		<info name="gold" value="20001020"/>
 		<info name="release" value="20001214"/>
 		<info name="alt_title" value="ポケットモンスター クリスタルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15820,11 +15260,10 @@ license:CC0
 
 	<software name="pockmus">
 		<!-- Notes: GBC only -->
-		<description>Pocket Music (Europe)</description>
+		<description>Pocket Music (Euro)</description>
 		<year>2002</year>
 		<publisher>Rage Software</publisher>
-		<info name="serial" value="CGB-BP9P-EUR?"/>
-		<info name="gold" value="20010925"/>
+		<info name="serial" value="??"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -15837,7 +15276,7 @@ license:CC0
 
 	<software name="pocknaka">
 		<!-- Notes: GBC only -->
-		<description>Pocket no Naka no Ookoku (Japan, Prototype)</description>
+		<description>Pocket no Naka no Ookoku (Jpn, Prototype)</description>
 		<year>2000</year>   <!-- scheduled to be released January 2001 (3/11/2000 Famitsu) -->
 		<publisher>Hector</publisher>
 		<info name="alt_title" value="ポケットの中の王国"/>
@@ -15853,7 +15292,7 @@ license:CC0
 
 	<software name="pockprow">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Wrestling - Perfect Wrestler (Japan)</description>
+		<description>Pocket Pro Wrestling - Perfect Wrestler (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-AJVJ-JPN"/>
@@ -15869,7 +15308,7 @@ license:CC0
 
 	<software name="pockyak">
 		<!-- Notes: GBC only -->
-		<description>Pocket Pro Yakyuu (Japan)</description>
+		<description>Pocket Pro Yakyuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BPPJ-JPN"/>
@@ -15886,14 +15325,14 @@ license:CC0
 	</software>
 
 	<software name="poktpuys">
-		<description>Pocket Puyo Puyo Sun (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pocket Puyo Puyo Sun (Jpn)</description>
 		<year>1998</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AYSJ-JPN"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ぽけっとぷよぷよSUN"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pocket puyo puyo sun (japan).bin" size="1048576" crc="45661ec3" sha1="c2f72fad1a26ad765eb3036f0c9e9e8945133d3a"/>
@@ -15905,11 +15344,10 @@ license:CC0
 
 	<software name="poktpuyn">
 		<!-- Notes: GBC only -->
-		<description>Pocket Puyo Puyo-n (Japan)</description>
+		<description>Pocket Puyo Puyo-n (Jpn)</description>
 		<year>2000</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="gold" value="20000721"/>
 		<info name="release" value="20000922"/>
 		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
 		<part name="cart" interface="gameboy_cart">
@@ -15922,47 +15360,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="poktpuyna" cloneof="poktpuyn">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpyj1.327"	-->
-		<description>Pocket Puyo Puyo-n (Japan, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Compile</publisher>
-		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="gold" value="20010327"/>
-		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpyj1.327" size="1048576" crc="c884037a" sha1="3d52805f712e6d1ce22b88dfebfcac2a31743ff3"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="poktpuynb" cloneof="poktpuyn">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpyj2.327"	-->
-		<description>Pocket Puyo Puyo-n (Japan, Rev. 2)</description>
-		<year>2000</year>
-		<publisher>Compile</publisher>
-		<info name="serial" value="CGB-BPYJ-JPN"/>
-		<info name="gold" value="20010719"/>
-		<info name="alt_title" value="ぽけっとぷよぷよ〜ん"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpyj2.327" size="1048576" crc="573613d7" sha1="09b217161ac326da63887693281b60751ca2dfcf"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="pockrace">
 		<!-- Notes: GBC only -->
-		<description>Pocket Racing (Europe)</description>
+		<description>Pocket Racing (Euro)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-BPKP-EUR"/>
@@ -15978,8 +15378,7 @@ license:CC0
 
 	<software name="pocksocr">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "CGBBPSP0.618", "KENSA\CGBBPSE0.0"	-->
-		<description>Pocket Soccer (Europe)</description>
+		<description>Pocket Soccer (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="GCB-BPSP-EUR"/>
@@ -15995,18 +15394,15 @@ license:CC0
 
 	<software name="pokecrys">
 		<!-- Notes: GBC only -->
-		<!--	European version 0 never released (marked as "生産中止" in lot check)	-->
-		<description>Pokémon - Crystal Version (Europe, USA, Rev. 1)</description>
+		<description>Pokémon - Crystal Version (Euro, USA, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
-		<info name="gold" value="20010807, 20010726"/>
-		<info name="release" value="?, 20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
-				<rom name="pokemon - crystal version (usa, europe) (rev 1).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
+				<rom name="pokemon - crystal version (usa, europe) (rev a).bin" size="2097152" crc="3358e30a" sha1="f2f52230b536214ef7c9924f483392993e226cfb"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16015,12 +15411,10 @@ license:CC0
 
 	<software name="pokecrysa" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Crystal Version (USA)</description>
+		<description>Pokémon - Crystal Version (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTE-USA, CGB-BYTP-EUR"/>
-		<info name="gold" value="20010524, 20010101"/>
-		<info name="release" value="20010729, unreleased"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -16034,12 +15428,10 @@ license:CC0
 
 	<software name="pokecrysf" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Version Cristal (France)</description>
+		<description>Pokémon - Version Cristal (Fra)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTF-FRA"/>
-		<info name="gold" value="20010817"/>
-		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -16053,12 +15445,10 @@ license:CC0
 
 	<software name="pokecrysg" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Kristall-Edition (Germany)</description>
+		<description>Pokémon - Kristall-Edition (Ger)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTD-NOE"/>
-		<info name="gold" value="20010726"/>
-		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -16072,12 +15462,10 @@ license:CC0
 
 	<software name="pokecrysi" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Versione Cristallo (Italia)</description>
+		<description>Pokémon - Versione Cristallo (Ita)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTI-ITA"/>
-		<info name="gold" value="20010914"/>
-		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-KGDU-10" />
 			<feature name="u1" value="U1 PRG" />
@@ -16097,12 +15485,10 @@ license:CC0
 
 	<software name="pokecryss" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<description>Pokémon - Edición Cristal (Spain)</description>
+		<description>Pokémon - Edición Cristal (Spa)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BYTS-ESP"/>
-		<info name="gold" value="20010830"/>
-		<info name="release" value="20011102"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
@@ -16114,28 +15500,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pokecrysaus" cloneof="pokecrys">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbytu0.834"	-->
-		<description>Pokémon - Crystal Version (Australia)</description>
-		<year>2001</year>
-		<publisher>Nintendo</publisher>
-		<info name="gold" value="20010724"/>
-		<info name="release" value="20010930"/>
-		<info name="serial" value="CGB-BYTU-AUS"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc3" />
-			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbytu0.834" size="2097152" crc="bb6dd80c" sha1="a0fc810f1d4e124434f7be2c989ab5b5892ddf36"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="pokegold">
-		<description>Pokémon - Gold Version (Europe, USA)</description>
+		<description>Pokémon - Gold Version (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUE-USA, DMG-AAUP-(EUR/EUR-1)"/>
@@ -16153,7 +15519,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldf" cloneof="pokegold">
-		<description>Pokémon - Version Or (France)</description>
+		<description>Pokémon - Version Or (Fra)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUF-FRA"/>
@@ -16169,7 +15535,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldg" cloneof="pokegold">
-		<description>Pokémon - Goldene Edition (Germany)</description>
+		<description>Pokémon - Goldene Edition (Ger)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUD-NOE"/>
@@ -16185,7 +15551,7 @@ license:CC0
 	</software>
 
 	<software name="pokegoldi" cloneof="pokegold">
-		<description>Pokémon - Versione Oro (Italia)</description>
+		<description>Pokémon - Versione Oro (Ita)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AAUI-ITA"/>
@@ -16207,7 +15573,7 @@ license:CC0
 	</software>
 
 	<software name="pokegolds" cloneof="pokegold">
-		<description>Pokémon - Edición Oro (Spain)</description>
+		<description>Pokémon - Edición Oro (Spa)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAUS-ESP"/>
@@ -16229,7 +15595,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilv">
-		<description>Pokémon - Silver Version (Europe, Australia, USA)</description>
+		<description>Pokémon - Silver Version (Euro, Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXE-USA, DMG-AAXP-(EUR/AUS)"/>
@@ -16245,7 +15611,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvf" cloneof="pokesilv">
-		<description>Pokémon - Version Argent (France)</description>
+		<description>Pokémon - Version Argent (Fra)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXF-FRA"/>
@@ -16261,7 +15627,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvg" cloneof="pokesilv">
-		<description>Pokémon - Silberne Edition (Germany)</description>
+		<description>Pokémon - Silberne Edition (Ger)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXD-NOE"/>
@@ -16283,7 +15649,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvi" cloneof="pokesilv">
-		<description>Pokémon - Versione Argento (Italia)</description>
+		<description>Pokémon - Versione Argento (Ita)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXI-ITA"/>
@@ -16299,7 +15665,7 @@ license:CC0
 	</software>
 
 	<software name="pokesilvs" cloneof="pokesilv">
-		<description>Pokémon - Edición Plata (Spain)</description>
+		<description>Pokémon - Edición Plata (Spa)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AAXS-ESP"/>
@@ -16315,15 +15681,15 @@ license:CC0
 	</software>
 
 	<software name="pokecardj" cloneof="pokecard">
-		<!-- This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
-		<description>Pokémon Card GB (Japan)</description>
+		<!-- Notes: SGB enhanced.
+		        This game uses an integrated (on-cart) IR port por connected multiplayer gameplay. -->
+		<description>Pokémon Card GB (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-ACXJ-JPN"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ポケモンカードGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-TFDN-01" />
 			<feature name="u1" value="U1 PRG [KM23C8000DG]" />
 			<feature name="u2" value="U2 HuC1A" />
@@ -16341,7 +15707,7 @@ license:CC0
 
 	<software name="pokecrd2">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Card GB2 - GR Dan Sanjou! (Japan)</description>
+		<description>Pokémon Card GB2 - GR Dan Sanjou! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BP7J-JPN"/>
@@ -16359,7 +15725,7 @@ license:CC0
 
 	<software name="pokepuzlj" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon de Panepon (Japan)</description>
+		<description>Pokémon de Panepon (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNJ-JPN"/>
@@ -16376,7 +15742,7 @@ license:CC0
 	</software>
 
 	<software name="pokepinb">
-		<description>Pokémon Pinball (Europe)</description>
+		<description>Pokémon Pinball (Euro)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHP-EUR"/>
@@ -16399,14 +15765,14 @@ license:CC0
 	</software>
 
 	<software name="pokepinbj" cloneof="pokepinb">
-		<description>Pokémon Pinball (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pokémon Pinball (Jpn)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHJ-JPN"/>
 		<info name="release" value="19990414"/>
 		<info name="alt_title" value="ポケモンピンボール"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<feature name="rumble" value="yes" />
 			<dataarea name="rom" size="1048576">
@@ -16419,7 +15785,7 @@ license:CC0
 
 	<software name="pokepinbu" cloneof="pokepinb">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Pinball (Australia, USA)</description>
+		<description>Pokémon Pinball (Aus, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-VPHE-USA, DMG-VPHU-AUS"/>
@@ -16436,7 +15802,7 @@ license:CC0
 
 	<software name="pokepuzl">
 		<!-- Notes: GBC only -->
-		<description>Pokémon Puzzle Challenge (Europe)</description>
+		<description>Pokémon Puzzle Challenge (Euro)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-BPNP-EUR"/>
@@ -16452,7 +15818,6 @@ license:CC0
 
 	<software name="pokepuzlu" cloneof="pokepuzl">
 		<!-- Notes: GBC only -->
-		<!-- Includes a limited version of Panel de Pon GB as an easter egg	-->
 		<description>Pokémon Puzzle Challenge (USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
@@ -16468,31 +15833,11 @@ license:CC0
 	</software>
 
 	<software name="pokecard">
-		<!--	In lot check as "dmgaxqx1.j85"	-->
-		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Nintendo</publisher>
-		<info name="serial" value="DMG-AXQX-EUR-1"/>
-		<info name="gold" value="20001108"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgaxqx1.j85" size="2097152" crc="3f1d7e58" sha1="c54b81e638b0c45d3569f9f5f0345df9e95ce975"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="pokecardx" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Europe, English / Spanish / Italian)</description>
+		<description>Pokémon Trading Card Game (Euro, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQX-EUR"/>
-		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="pokemon trading card game (europe) (en,es,it).bin" size="2097152" crc="966daef1" sha1="2138a422d135a13c49fce71229ae36bc1dc4fbb5"/>
@@ -16502,14 +15847,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pokecarde" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Europe, English / French / German)</description>
+	<software name="pokecarda" cloneof="pokecard">
+		<description>Pokémon Trading Card Game (Euro, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQP-NOE"/>
-		<info name="gold" value="20001013"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -16525,31 +15868,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pokecardaa" cloneof="pokecard">
-		<!--	In lot check as "dmgaxqp1.j84"	-->
-		<description>Pokémon Trading Card Game (Europe, English / French / German, Rev. 1)</description>
-		<year>2000</year>
-		<publisher>Nintendo</publisher>
-		<info name="serial" value="DMG-AXQP-NOE?"/>
-		<info name="gold" value="20001108"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgaxqp1.j84" size="2097152" crc="942d0b7f" sha1="dffc15f3063a4c2df84c6361406b41aec1696d3e"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="pokecardu" cloneof="pokecard">
-		<description>Pokémon Trading Card Game (Australia, USA)</description>
+		<description>Pokémon Trading Card Game (Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AXQE-USA, DMG-AXQU-AUS"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pokemon trading card game (usa).bin" size="1048576" crc="81069d53" sha1="0f8670a583255cff3e5b7ca71b5d7454d928fc48"/>
@@ -16580,7 +15904,7 @@ license:CC0
 
 	<software name="pongtnl">
 		<!-- Notes: GBC only -->
-		<description>Pong - The Next Level (Europe, USA)</description>
+		<description>Pong - The Next Level (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-AOVE-USA, CGB-AOVP-EUR"/>
@@ -16594,7 +15918,7 @@ license:CC0
 
 	<software name="poohhuns">
 		<!-- Notes: GBC only -->
-		<description>Pooh and Tigger's Hunny Safari (Europe)</description>
+		<description>Pooh and Tigger's Hunny Safari (Euro)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BP8P-EUR"/>
@@ -16625,7 +15949,7 @@ license:CC0
 
 	<software name="popngb">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB (Japan)</description>
+		<description>Pop'n Music GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPMJ-JPN (RK207-J1)"/>
@@ -16641,7 +15965,7 @@ license:CC0
 
 	<software name="popngbam">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Animation Melody (Japan)</description>
+		<description>Pop'n Music GB - Animation Melody (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPAJ-JPN (RK216-J1)"/>
@@ -16657,7 +15981,7 @@ license:CC0
 
 	<software name="popngbdt">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Music GB - Disney Tunes (Japan)</description>
+		<description>Pop'n Music GB - Disney Tunes (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BPDJ-JPN (RK218-J1)"/>
@@ -16673,7 +15997,7 @@ license:CC0
 
 	<software name="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Europe)</description>
+		<description>Pop'n Pop (Euro)</description>
 		<year>2001</year>
 		<publisher>JVC</publisher>
 		<info name="serial" value="??"/>
@@ -16687,7 +16011,7 @@ license:CC0
 
 	<software name="popnpopj" cloneof="popnpop">
 		<!-- Notes: GBC only -->
-		<description>Pop'n Pop (Japan)</description>
+		<description>Pop'n Pop (Jpn)</description>
 		<year>2001</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="CGB-BJPJ-JPN"/>
@@ -16716,17 +16040,17 @@ license:CC0
 	</software>
 
 	<software name="powrpkp">
-		<description>Power Pro Kun Pocket (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Power Pro Kun Pocket (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="power pro kun pocket (japan) (rev 1).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
+				<rom name="power pro kun pocket (japan) (rev a).bin" size="2097152" crc="894d88f2" sha1="ae145f2de0d53c19b973c71baaf3f2cca2ca395a"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -16734,14 +16058,14 @@ license:CC0
 	</software>
 
 	<software name="powrpkpa" cloneof="powrpkp">
-		<description>Power Pro Kun Pocket (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Power Pro Kun Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVVJ-JPN (RK178-J1)"/>
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="パワプロクンポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="power pro kun pocket (japan).bin" size="2097152" crc="145540d8" sha1="f796f9cb259646555f0d429b9337ac6b423755a3"/>
@@ -16752,14 +16076,14 @@ license:CC0
 	</software>
 
 	<software name="powrpkp2">
-		<description>Power Pro Kun Pocket 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Power Pro Kun Pocket 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-BPWJ-JPN (RK205-J1)"/>
 		<info name="release" value="20000330"/>
 		<info name="alt_title" value="パワプロクンポケット2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC5 [MBC-5]" />
@@ -16776,7 +16100,7 @@ license:CC0
 	</software>
 
 	<software name="powerqst">
-		<description>Power Quest (Europe)</description>
+		<description>Power Quest (Euro)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-APQP-EUR"/>
@@ -16806,7 +16130,7 @@ license:CC0
 
 	<software name="prlr">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Lightspeed Rescue (Europe, USA)</description>
+		<description>Power Rangers - Lightspeed Rescue (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRSE-USA, CGB-BRSP-EUR"/>
@@ -16823,7 +16147,7 @@ license:CC0
 
 	<software name="prtf">
 		<!-- Notes: GBC only -->
-		<description>Power Rangers - Time Force (Europe, USA)</description>
+		<description>Power Rangers - Time Force (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-B4TE-USA, CGB-B4TP-EUR"/>
@@ -16854,7 +16178,7 @@ license:CC0
 
 	<software name="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (Europe)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (Euro)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJP-UKV"/>
@@ -16876,7 +16200,7 @@ license:CC0
 
 	<software name="powrpfbmf" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (France)</description>
+		<description>The Powerpuff Girls - L'Affreux Mojo Jojo (Fra)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJF-FRA"/>
@@ -16898,7 +16222,7 @@ license:CC0
 
 	<software name="powrpfbms" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - El Malvado Mojo Jojo (Spain)</description>
+		<description>Las Super Nenas - El Malvado Mojo Jojo (Spa)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJS-ESP"/>
@@ -16920,7 +16244,7 @@ license:CC0
 
 	<software name="powrpfbmu" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 2)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. B)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-2"/>
@@ -16938,7 +16262,7 @@ license:CC0
 
 	<software name="powrpfbmua" cloneof="powrpfbm">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Bad Mojo Jojo (USA, Rev. A)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BJJE-USA-1"/>
@@ -16976,7 +16300,7 @@ license:CC0
 
 	<software name="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (Europe)</description>
+		<description>The Powerpuff Girls - Battle Him (Euro)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHP-EUR"/>
@@ -16998,7 +16322,7 @@ license:CC0
 
 	<software name="powrpfbhf" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Bulle Contre Lui (France)</description>
+		<description>The Powerpuff Girls - Bulle Contre Lui (Fra)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHF-FRA"/>
@@ -17020,7 +16344,7 @@ license:CC0
 
 	<software name="powrpfbhs" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Lucha con Ese (Spain)</description>
+		<description>Las Super Nenas - Lucha con Ese (Spa)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHS-ESP"/>
@@ -17042,7 +16366,7 @@ license:CC0
 
 	<software name="powrpfbhu" cloneof="powrpfbh">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Battle Him (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Battle Him (USA, Rev. A)</description>
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BBHE-USA-1"/>
@@ -17075,7 +16399,7 @@ license:CC0
 
 	<software name="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (Europe)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (Euro)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTP-(EUR, UKV)"/>
@@ -17097,7 +16421,7 @@ license:CC0
 
 	<software name="powrpfpnf" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Panique a Townsville (France)</description>
+		<description>The Powerpuff Girls - Panique a Townsville (Fra)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTF-FRA"/>
@@ -17119,7 +16443,7 @@ license:CC0
 
 	<software name="powrpfpns" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>Las Super Nenas - Pánico en Townsville (Spain)</description>
+		<description>Las Super Nenas - Pánico en Townsville (Spa)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTS-ESP"/>
@@ -17141,28 +16465,28 @@ license:CC0
 
 	<software name="powrpfpnu" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 2)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. B)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-2?"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 2).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev b).bin" size="2097152" crc="443367ae" sha1="ef93e793067bbb3748aac17d661c8c8b68ccee9b"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="powrpfpnua" cloneof="powrpfpn">
 		<!-- Notes: GBC only -->
-		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. 1)</description>
+		<description>The Powerpuff Girls - Paint the Townsville Green (USA, Rev. A)</description>
 		<year>2000</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BPTE-USA-1"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev 1).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
+				<rom name="powerpuff girls, the - paint the townsville green (usa) (rev a).bin" size="2097152" crc="295b3646" sha1="023d4d9374e7fe9844f970dd0004c5d7eefd2d38"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -17186,14 +16510,14 @@ license:CC0
 	</software>
 
 	<software name="poyondr">
-		<description>Poyon no Dungeon Room (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Poyon no Dungeon Room (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-ADZJ-JPN"/>
 		<info name="release" value="19990226"/>
 		<info name="alt_title" value="大貝獣物語 ポヨンのダンジョンルーム ~ Daikaijuu Monogatari - Poyon no Dungeon Room (Box)"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="daikaijuu monogatari - poyon no dungeon room (japan).bin" size="2097152" crc="2f368da6" sha1="0854b7ea4791a460c75ce9096583934b1af053e8"/>
@@ -17205,7 +16529,7 @@ license:CC0
 
 	<software name="poyondr2">
 		<!-- Notes: GBC only -->
-		<description>Poyon no Dungeon Room 2 (Japan)</description>
+		<description>Poyon no Dungeon Room 2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="CGB-BP2J-JPN"/>
@@ -17223,7 +16547,7 @@ license:CC0
 
 	<software name="pnaseem">
 		<!-- Notes: GBC only -->
-		<description>Prince Naseem Boxing (Europe)</description>
+		<description>Prince Naseem Boxing (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNCP-EUR"/>
@@ -17238,11 +16562,10 @@ license:CC0
 	</software>
 
 	<software name="ppersia">
-		<description>Prince of Persia (Europe, USA)</description>
+		<description>Prince of Persia (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-ARIE-USA, DMG-ARIP-EUR"/>
-		<info name="gold" value="19990303, 19990525"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -17269,15 +16592,14 @@ license:CC0
 	</software>
 
 	<software name="mjkiwam2">
-		<!-- Also released by NP in 2001-06 -->
-		<description>Pro Mahjong Kiwame GB II (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2001-06 -->
+		<description>Pro Mahjong Kiwame GB II (Jpn)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-AA2J-JPN"/>
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="プロ麻雀 極II GB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong kiwame gb ii (japan).bin" size="1048576" crc="14f91f86" sha1="2c9c2967400ab9bad95ffe104763b3190f28aa39"/>
@@ -17288,14 +16610,14 @@ license:CC0
 	</software>
 
 	<software name="mjtsuwa">
-		<description>Pro Mahjong Tsuwamono GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Pro Mahjong Tsuwamono GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AQDJ-JPN"/>
 		<info name="release" value="19990709"/>
 		<info name="alt_title" value="プロ麻雀 兵 GB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="pro mahjong tsuwamono gb (japan).bin" size="1048576" crc="1461d8d8" sha1="b9e7cd7e53fda3db329c57971a47d35255bd0b34"/>
@@ -17307,7 +16629,7 @@ license:CC0
 
 	<software name="mjtsuwa2">
 		<!-- Notes: GBC only -->
-		<description>Pro Mahjong Tsuwamono GB2 (Japan)</description>
+		<description>Pro Mahjong Tsuwamono GB2 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-BMWJ-JPN"/>
@@ -17324,7 +16646,7 @@ license:CC0
 	</software>
 
 	<software name="profoot" cloneof="goldgoal">
-		<description>Pro:Foot (France)</description>
+		<description>Pro:Foot (Fra)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFF-FAH"/>
@@ -17340,11 +16662,10 @@ license:CC0
 
 	<software name="propool">
 		<!-- Notes: GBC only -->
-		<description>Pro Pool (Europe)</description>
+		<description>Pro Pool (Euro)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLP-EUU"/>
-		<info name="gold" value="20000621"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -17363,27 +16684,7 @@ license:CC0
 
 	<software name="propoolu" cloneof="propool">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbple0.298"	-->
-		<!--	Retail cartridge not yet secured	-->
 		<description>Pro Pool (USA)</description>
-		<year>2000?</year>
-		<publisher>Codemasters</publisher>
-		<info name="serial" value="CGB-BPLE-USA?"/>
-		<info name="gold" value="20000621"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbple0.298" size="1048576" crc="2611fa3d" sha1="c85e514c24c82071907c6495243dae448b46c2b2"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="propooluunk" cloneof="propool">
-		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>Pro Pool (USA, bad dump?)</description>
 		<year>2002</year>
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="CGB-BPLE-USA"/>
@@ -17396,7 +16697,6 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
-
 
 	<software name="projs11">
 		<!-- Notes: GBC only -->
@@ -17413,11 +16713,10 @@ license:CC0
 	</software>
 
 	<software name="puchicar">
-		<description>Puchi Carat (Europe)</description>
+		<description>Puchi Carat (Euro)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="DMG-AIQP-EUR"/>
-		<info name="gold" value="20000112"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -17429,16 +16728,14 @@ license:CC0
 	</software>
 
 	<software name="puchicarj" cloneof="puchicar">
-		<!-- Also released by NP in 2000-07 -->
-		<description>Puchi Carat (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-07 -->
+		<description>Puchi Carat (Jpn)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-ACUJ-JPN"/>
-		<info name="gold" value="19990311"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="プチカラット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puchi carat (japan).bin" size="1048576" crc="f0d0c36d" sha1="25abda13f97140d412bb00e109baca8574d5af6e"/>
@@ -17450,7 +16747,7 @@ license:CC0
 
 	<software name="pumucklp">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer bei den Piraten (Germany)</description>
+		<description>Pumuckls Abenteuer bei den Piraten (Ger)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AVED-NOE"/>
@@ -17464,7 +16761,7 @@ license:CC0
 
 	<software name="pumucklg">
 		<!-- Notes: GBC only -->
-		<description>Pumuckls Abenteuer im Geisterschloss (Germany)</description>
+		<description>Pumuckls Abenteuer im Geisterschloss (Ger)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BPCD-NOE"/>
@@ -17477,14 +16774,14 @@ license:CC0
 	</software>
 
 	<software name="puyopuyg">
-		<description>Puyo Puyo Gaiden - Puyo Wars (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Puyo Puyo Gaiden - Puyo Wars (Jpn)</description>
 		<year>1999</year>
 		<publisher>Compile</publisher>
 		<info name="serial" value="DMG-AWYJ-JPN"/>
 		<info name="release" value="19990827"/>
 		<info name="alt_title" value="ぷよぷよ外伝 ぷよウォーズ"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="puyo puyo gaiden - puyo wars (japan).bin" size="1048576" crc="67350bc9" sha1="b1802797e892d09e4da53304d096bdf35bac1118"/>
@@ -17495,7 +16792,7 @@ license:CC0
 	</software>
 
 	<software name="puzzloop" cloneof="ballistc">
-		<description>Puzz Loop (Japan)</description>
+		<description>Puzz Loop (Jpn)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BPZJ-JPN"/>
@@ -17512,7 +16809,7 @@ license:CC0
 	</software>
 
 	<software name="pbobble4" cloneof="bam4">
-		<description>Puzzle Bobble 4 (Japan)</description>
+		<description>Puzzle Bobble 4 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-AA4J-JPN"/>
@@ -17528,7 +16825,7 @@ license:CC0
 
 	<software name="pbobblem" cloneof="bammill">
 		<!-- Notes: GBC only -->
-		<description>Puzzle Bobble Millennium (Japan)</description>
+		<description>Puzzle Bobble Millennium (Jpn)</description>
 		<year>2000</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="CGB-BP5J-JPN"/>
@@ -17543,7 +16840,7 @@ license:CC0
 	</software>
 
 	<software name="puzlshou">
-		<description>Puzzle de Shoubuyo! Wootama-chan (Japan)</description>
+		<description>Puzzle de Shoubuyo! Wootama-chan (Jpn)</description>
 		<year>2000</year>
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="DMG-BKUJ-JPN"/>
@@ -17574,7 +16871,7 @@ license:CC0
 
 	<software name="puzzled">
 		<!-- Notes: GBC only -->
-		<description>Puzzled (Europe)</description>
+		<description>Puzzled (Euro)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-AZWP-EUR"/>
@@ -17616,11 +16913,10 @@ license:CC0
 
 	<software name="qixadv">
 		<!-- Notes: GBC only -->
-		<description>Qix Adventure (Europe)</description>
+		<description>Qix Adventure (Euro)</description>
 		<year>2000</year>
 		<publisher>Event Horizon Software</publisher>
 		<info name="serial" value="CGB-AQYP-EUR"/>
-		<info name="gold" value="20001017"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -17633,7 +16929,7 @@ license:CC0
 
 	<software name="qixadvj" cloneof="qixadv">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Qix Adventure (Japan)</description>
+		<description>Qix Adventure (Jpn)</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="CGB-AQSJ-JPN"/>
@@ -17663,7 +16959,7 @@ license:CC0
 	</software>
 
 	<software name="questcam">
-		<description>Quest for Camelot (Europe)</description>
+		<description>Quest for Camelot (Euro)</description>
 		<year>1998</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ACNP-EUR"/>
@@ -17709,7 +17005,7 @@ license:CC0
 	</software>
 
 	<software name="quiqui">
-		<description>Qui Qui (Japan)</description>
+		<description>Qui Qui (Jpn)</description>
 		<year>1999</year>
 		<publisher>Magical</publisher>
 		<info name="serial" value="DMG-AQUJ-JPN"/>
@@ -17726,7 +17022,7 @@ license:CC0
 	</software>
 
 	<software name="rtypedx">
-		<description>R-Type DX (Europe, Australia, USA)</description>
+		<description>R-Type DX (Euro, Aus, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWHE-USA, DMG-AWHP-(AUS/EUR)"/>
@@ -17747,7 +17043,7 @@ license:CC0
 	</software>
 
 	<software name="rtypedxj" cloneof="rtypedx">
-		<description>R-Type DX (Japan)</description>
+		<description>R-Type DX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ARUJ-JPN"/>
@@ -17779,7 +17075,7 @@ license:CC0
 
 	<software name="radikal">
 		<!-- Notes: GBC only -->
-		<description>Radikal Bikers (Europe, Prototype)</description>
+		<description>Radikal Bikers (Euro, Prototype)</description>
 		<year>1998?</year>
 		<publisher>Bit Managers</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -17794,7 +17090,7 @@ license:CC0
 
 	<software name="rbisland">
 		<!-- Notes: GBC only -->
-		<description>Rainbow Islands (Europe)</description>
+		<description>Rainbow Islands (Euro)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BISP-EUR"/>
@@ -17808,7 +17104,7 @@ license:CC0
 
 	<software name="rakuxcs">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Cut Shuu (Japan)</description>
+		<description>Raku x Raku - Cut Shuu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BELJ-JPN"/>
@@ -17825,7 +17121,7 @@ license:CC0
 
 	<software name="rakuxmis">
 		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Raku x Raku - Mishin (Japan)</description>
+		<description>Raku x Raku - Mishin (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAJ-JPN"/>
@@ -17847,7 +17143,7 @@ license:CC0
 
 	<software name="rakuxmoj">
 		<!-- Notes: GBC only, for use with Jaguar Sewing Machine (Nuotto Expansion) Model EM-2000 -->
-		<description>Raku x Raku - Moji (Japan)</description>
+		<description>Raku x Raku - Moji (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BEMJ-JPN"/>
@@ -17863,7 +17159,7 @@ license:CC0
 	</software>
 
 	<software name="rampage">
-		<description>Rampage - World Tour (Europe, USA)</description>
+		<description>Rampage - World Tour (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="DMG-ARPE-USA, DMG-ARPP-EUR"/>
@@ -17877,7 +17173,7 @@ license:CC0
 
 	<software name="rampage2">
 		<!-- Notes: GBC only -->
-		<description>Rampage 2 - Universal Tour (Europe, USA)</description>
+		<description>Rampage 2 - Universal Tour (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AUTE-USA, CGB-AUTP-EUR"/>
@@ -17921,7 +17217,7 @@ license:CC0
 
 	<software name="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman (Europe)</description>
+		<description>Rayman (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AYQP-EUR"/>
@@ -17949,7 +17245,7 @@ license:CC0
 
 	<software name="raymanj" cloneof="rayman">
 		<!-- Notes: GBC only -->
-		<description>Rayman - Mister Dark no Wana (Japan)</description>
+		<description>Rayman - Mister Dark no Wana (Jpn)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BURJ-JPN"/>
@@ -17965,7 +17261,7 @@ license:CC0
 
 	<software name="rayman2">
 		<!-- Notes: GBC only -->
-		<description>Rayman 2 - The Great Escape (Europe)</description>
+		<description>Rayman 2 - The Great Escape (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BRYP-EUR"/>
@@ -18003,7 +17299,7 @@ license:CC0
 
 	<software name="freestyl">
 		<!-- Notes: GBC only -->
-		<description>Freestyle Scooter (Europe)</description>
+		<description>Freestyle Scooter (Euro)</description>
 		<year>2001</year>
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="CGB-BRZP-EUR"/>
@@ -18034,7 +17330,7 @@ license:CC0
 
 	<software name="r2rumble">
 		<!-- Notes: GBC only -->
-		<description>Ready 2 Rumble Boxing (Europe)</description>
+		<description>Ready 2 Rumble Boxing (Euro)</description>
 		<year>1999</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-AQOP-EUR"/>
@@ -18066,14 +17362,14 @@ license:CC0
 	</software>
 
 	<software name="rpyakyuc">
-		<description>Real Pro Yakyuu! - Central League Hen (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Real Pro Yakyuu! - Central League Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AECJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 セントラルリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - central league hen (japan).bin" size="524288" crc="afff6bb9" sha1="02c18d98a07b3af9a1d26d0c3003f8e75c81f4d9"/>
@@ -18084,14 +17380,14 @@ license:CC0
 	</software>
 
 	<software name="rpyakyup">
-		<description>Real Pro Yakyuu! - Pacific League Hen (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Real Pro Yakyuu! - Pacific League Hen (Jpn)</description>
 		<year>1999</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-AEPJ-JPN"/>
 		<info name="release" value="19990423"/>
 		<info name="alt_title" value="リアルプロ野球 パシフィックリーグ編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
 				<rom name="real pro yakyuu - pacific league hen (japan).bin" size="524288" crc="16b81c36" sha1="a7a2cd7bbb4cae171b5f2c798293afefe2882afc"/>
@@ -18116,7 +17412,7 @@ license:CC0
 	</software>
 
 	<software name="resrvrat">
-		<description>Reservoir Rat (Europe)</description>
+		<description>Reservoir Rat (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AVTP-EUR"/>
@@ -18160,7 +17456,7 @@ license:CC0
 
 	<software name="revilg">
 		<!-- Notes: GBC only -->
-		<description>Resident Evil Gaiden (Europe)</description>
+		<description>Resident Evil Gaiden (Euro)</description>
 		<year>2002</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BIOP-EUR"/>
@@ -18192,7 +17488,7 @@ license:CC0
 
 	<software name="retninja">
 		<!-- Notes: GBC only -->
-		<description>Return of the Ninja (Europe)</description>
+		<description>Return of the Ninja (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BNJP-EUR"/>
@@ -18235,7 +17531,7 @@ license:CC0
 
 	<software name="rhino">
 		<!-- Notes: GBC only -->
-		<description>Rhino Rumble (Europe, USA)</description>
+		<description>Rhino Rumble (Euro, USA)</description>
 		<year>2002</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-BRNE-USA, CGB-BRNP-EUR"/>
@@ -18248,7 +17544,7 @@ license:CC0
 	</software>
 
 	<software name="riptide">
-		<description>Rip-Tide Racer (Europe)</description>
+		<description>Rip-Tide Racer (Euro)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="DMG-AXYP-EUR"/>
@@ -18262,7 +17558,7 @@ license:CC0
 
 	<software name="roadchmp">
 		<!-- Notes: GBC only -->
-		<description>Road Champs - BXS Stunt Biking (Europe, USA)</description>
+		<description>Road Champs - BXS Stunt Biking (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXSE-USA, CGB-BXSP-EUR"/>
@@ -18279,7 +17575,7 @@ license:CC0
 
 	<software name="roadrash">
 		<!-- Notes: GBC only -->
-		<description>Road Rash (Europe, USA)</description>
+		<description>Road Rash (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRRE-USA, CGB-BRRP-EUR"/>
@@ -18309,7 +17605,7 @@ license:CC0
 	</software>
 
 	<software name="roadster">
-		<description>Roadsters Trophy (Europe)</description>
+		<description>Roadsters Trophy (Euro)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="??"/>
@@ -18336,7 +17632,7 @@ license:CC0
 
 	<software name="robin">
 		<!-- Notes: GBC only -->
-		<description>Robin Hood (Europe)</description>
+		<description>Robin Hood (Euro)</description>
 		<year>2001</year>
 		<publisher>L.S.P. ~ Electronic Arts</publisher>
 		<info name="serial" value="CGB-BRHP-EUR"/>
@@ -18350,7 +17646,7 @@ license:CC0
 
 	<software name="robocop">
 		<!-- Notes: GBC only -->
-		<description>RoboCop (Europe)</description>
+		<description>RoboCop (Euro)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BR9P-EUR"/>
@@ -18386,17 +17682,15 @@ license:CC0
 	</software>
 
 	<software name="robopspc">
-		<!-- Notes: GBC only
+		<!-- Notes: GBC only..
 		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Japan)</description>
-		<year>1999</year>
+		<description>Robot Ponkottsu - Comic Bom Bom Special Version (Jpn)</description>
+		<year>1999?</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H5UJ-JPN"/>
-		<info name="gold" value="19990618"/>
-		<info name="alt_title" value="ロボットポンコッツ ボンボンスペシャルバージョン"/>
 		<part name="cart" interface="gameboy_cart">
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-10" />
@@ -18416,18 +17710,18 @@ license:CC0
 	</software>
 
 	<software name="robopmon">
-		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Notes: SGB enhanced.
+		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Moon Version (Japan)</description>
+		<description>Robot Ponkottsu - Moon Version (Jpn)</description>
 		<year>1999</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-H3UJ-JPN"/>
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="ロボットポンコッツ月バージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-10" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -18445,18 +17739,18 @@ license:CC0
 	</software>
 
 	<software name="robopstr">
-		<!-- Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
+		<!-- Notes: SGB enhanced.
+		    Supports "GBKiss". "GBKiss" is an integrated infrared port for cart-to-cart
 		    multiplayer play, but also for PC connection with the "GBKISS LINK" (Hudson Soft model No. HC-749), a parallel
 		    port (DB25) modem/adaptor for PC-DOS for transfering files between the game and a computer.
 		    The cart also has an integrated speaker (conns PE1 and PE2 on the PCB). -->
-		<description>Robot Ponkottsu - Star Version (Japan)</description>
+		<description>Robot Ponkottsu - Star Version (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HRCJ-JPN"/>
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ星バージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="u1" value="U1 PRG" />
 			<feature name="u2" value="U2 HuC3 [HuC-3]" />
@@ -18474,14 +17768,14 @@ license:CC0
 	</software>
 
 	<software name="robopsunj" cloneof="robopsun">
-		<description>Robot Ponkottsu - Sun Version (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Robot Ponkottsu - Sun Version (Jpn)</description>
 		<year>1998</year>
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="DMG-HREJ-JPN"/>
 		<info name="release" value="19981204"/>
 		<info name="alt_title" value="ロボットポンコッツ太陽バージョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-UFDT-01" />
 			<feature name="slot" value="rom_huc3" />
@@ -18495,7 +17789,7 @@ license:CC0
 
 	<software name="robowars">
 		<!-- Notes: GBC only -->
-		<description>Robot Wars - Metal Mayhem (Europe)</description>
+		<description>Robot Wars - Metal Mayhem (Euro)</description>
 		<year>2000</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-BRWP-UKV"/>
@@ -18511,7 +17805,7 @@ license:CC0
 
 	<software name="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - Gettin' Air (Europe, USA)</description>
+		<description>Rocket Power - Gettin' Air (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRUP-EUR, CGB-BRUE-USA"/>
@@ -18528,7 +17822,7 @@ license:CC0
 
 	<software name="rcktpwf" cloneof="rcktpw">
 		<!-- Notes: GBC only -->
-		<description>Rocket Power - La Glisse de l'Extreme (France)</description>
+		<description>Rocket Power - La Glisse de l'Extreme (Fra)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="??"/>
@@ -18541,7 +17835,7 @@ license:CC0
 	</software>
 
 	<software name="rockmnx" cloneof="megamnx">
-		<description>Rockman X - Cyber Mission (Japan)</description>
+		<description>Rockman X - Cyber Mission (Jpn)</description>
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="DMG-BRXJ-JPN"/>
@@ -18559,7 +17853,7 @@ license:CC0
 
 	<software name="rockmnx2" cloneof="megamnx2">
 		<!-- Notes: GBC only -->
-		<description>Rockman X2 - Soul Eraser (Japan)</description>
+		<description>Rockman X2 - Soul Eraser (Jpn)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BXRJ-JPN"/>
@@ -18591,7 +17885,7 @@ license:CC0
 
 	<software name="rokumon">
 		<!-- Notes: GBC only -->
-		<description>Rokumon Tengai Mon-Colle-Knight GB (Japan)</description>
+		<description>Rokumon Tengai Mon-Colle-Knight GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Kadokawa Shoten</publisher>
 		<info name="serial" value="CGB-BKDJ-JPN"/>
@@ -18609,7 +17903,7 @@ license:CC0
 
 	<software name="rolandg">
 		<!-- Notes: GBC only -->
-		<description>Roland Garros French Open (Europe)</description>
+		<description>Roland Garros French Open (Euro)</description>
 		<year>2000</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BRGP-EUR"/>
@@ -18622,7 +17916,7 @@ license:CC0
 	</software>
 
 	<software name="ronaldov">
-		<description>Ronaldo V-Football (Europe)</description>
+		<description>Ronaldo V-Football (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AORP-(EUR/FAH)"/>
@@ -18653,7 +17947,7 @@ license:CC0
 
 	<software name="roswell">
 		<!-- Notes: GBC only -->
-		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Europe)</description>
+		<description>Roswell Conspiracies - Aliens, Myths &amp; Legends (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BCPP-EUR"/>
@@ -18680,7 +17974,7 @@ license:CC0
 	</software>
 
 	<software name="rox">
-		<description>Rox - 6=Six (Europe, USA)</description>
+		<description>Rox - 6=Six (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-ARXE-USA, DMG-ARXP-EUR"/>
@@ -18697,7 +17991,7 @@ license:CC0
 
 	<software name="roxj" cloneof="rox">
 		<!-- Notes: GBC only -->
-		<description>Rox - 6=Six (Japan)</description>
+		<description>Rox - 6=Six (Jpn)</description>
 		<year>1999</year>
 		<publisher>Altron</publisher>
 		<info name="serial" value="DMG-ARXJ-JPN"/>
@@ -18715,13 +18009,12 @@ license:CC0
 
 	<software name="rpgtsuku">
 		<!-- Notes: GBC only -->
-		<description>RPG Tsukuru GB (Japan)</description>
+		<description>RPG Tsukuru GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-A2QJ-JPN"/>
-		<info name="gold" value="20000209"/>
 		<info name="release" value="20000317"/>
-		<info name="alt_title" value="ＲＰＧ ツクール ＧＢ"/>
+		<info name="alt_title" value="RPGツクールGB"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -18733,7 +18026,7 @@ license:CC0
 	</software>
 
 	<software name="rugtimet">
-		<description>Rugrats - Time Travelers (Europe, USA)</description>
+		<description>Rugrats - Time Travelers (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AVME-USA, DMG-AVMP-EUR"/>
@@ -18749,7 +18042,7 @@ license:CC0
 	</software>
 
 	<software name="rugtimetf" cloneof="rugtimet">
-		<description>Les Razmoket - Voyage dans le Temps (France)</description>
+		<description>Les Razmoket - Voyage dans le Temps (Fra)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRTF-FRA"/>
@@ -18763,7 +18056,7 @@ license:CC0
 
 	<software name="rugtotanf" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket - 100% Angelica (France)</description>
+		<description>Les Razmoket - 100% Angelica (Fra)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGF-FRA"/>
@@ -18777,7 +18070,7 @@ license:CC0
 
 	<software name="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Totally Angelica (Europe, USA)</description>
+		<description>Rugrats - Totally Angelica (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGE-USA, CGB-BAGP-EUR"/>
@@ -18794,7 +18087,7 @@ license:CC0
 
 	<software name="rugtotang" cloneof="rugtotan">
 		<!-- Notes: GBC only -->
-		<description>Rugrats - Typisch Angelica (Germany)</description>
+		<description>Rugrats - Typisch Angelica (Ger)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BAGD-NOE"/>
@@ -18808,7 +18101,7 @@ license:CC0
 
 	<software name="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Europe)</description>
+		<description>Rugrats in Paris - The Movie (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPX-ESP"/>
@@ -18822,7 +18115,7 @@ license:CC0
 
 	<software name="rugparisa" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Rugrats in Paris - The Movie (Europe, USA)</description>
+		<description>Rugrats in Paris - The Movie (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPE-USA, CGB-BRPP-EUR"/>
@@ -18839,7 +18132,7 @@ license:CC0
 
 	<software name="rugparisf" cloneof="rugparis">
 		<!-- Notes: GBC only -->
-		<description>Les Razmoket à Paris - Le Film (France)</description>
+		<description>Les Razmoket à Paris - Le Film (Fra)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BRPF-FRA"/>
@@ -18855,7 +18148,7 @@ license:CC0
 	</software>
 
 	<software name="rugmovie">
-		<description>The Rugrats Movie (Europe)</description>
+		<description>The Rugrats Movie (Euro)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-ARZP-(NOE/UKV)"/>
@@ -18885,7 +18178,7 @@ license:CC0
 
 	<software name="sabrinas">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Spooked! (Europe, USA)</description>
+		<description>Sabrina - The Animated Series - Spooked! (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-B4PE-USA, CGB-B4PP-UKV"/>
@@ -18902,7 +18195,7 @@ license:CC0
 
 	<software name="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Europe)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Euro)</description>
 		<year>2000</year>
 		<publisher>Havas Interactive</publisher>
 		<info name="serial" value="CGB-BSGX-EUU"/>
@@ -18916,7 +18209,7 @@ license:CC0
 
 	<software name="sabrinazu" cloneof="sabrinaz">
 		<!-- Notes: GBC only -->
-		<description>Sabrina - The Animated Series - Zapped! (Europe, USA)</description>
+		<description>Sabrina - The Animated Series - Zapped! (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Simon &amp; Schuster</publisher>
 		<info name="serial" value="CGB-BSGE-USA, CGB-BSGP-EUR"/>
@@ -18932,14 +18225,14 @@ license:CC0
 	</software>
 
 	<software name="sakata">
-		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sakata Gorou Kudan no Renju Kyoushitsu (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AREJ-JPN"/>
 		<info name="release" value="19990625"/>
 		<info name="alt_title" value="坂田吾朗 九段の 連珠教室"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sakata gorou kudan no renju kyoushitsu (japan).bin" size="1048576" crc="b5412c6f" sha1="f2330533b10c22e98c140bb550827618985253cb"/>
@@ -18951,7 +18244,7 @@ license:CC0
 		<!-- Notes: GBC only, 10 variant packs got released!
 		            This game is compatible with an external pedometer named "Pocket Sakura" (same hardware as the Pokémon Pikachu Color / Pokémon Pikachu 2 GS pedometer)
 		            wich connects to the GBC via the console's IR port -->
-		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Japan)</description>
+		<description>Sakura Taisen GB - Geki Hana Gumi Nyuutai! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BRJJ-JPN"/>
@@ -18975,7 +18268,7 @@ license:CC0
 
 	<software name="sakura2">
 		<!-- Notes: GBC only -->
-		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Japan)</description>
+		<description>Sakura Taisen GB2 - Thunderbolt Sakusen (Jpn)</description>
 		<year>2001</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="CGB-BQYJ-JPN (Limited Edition got serial HGB-0001)"/>
@@ -18993,7 +18286,7 @@ license:CC0
 
 	<software name="samurai">
 		<!-- Notes: GBC only -->
-		<description>Samurai Kid (Japan)</description>
+		<description>Samurai Kid (Jpn)</description>
 		<year>2001</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="CGB-BS5J-JPN"/>
@@ -19011,7 +18304,7 @@ license:CC0
 
 	<software name="sf2049">
 		<!-- Notes: GBC only -->
-		<description>San Francisco Rush 2049 (Europe, USA)</description>
+		<description>San Francisco Rush 2049 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Midway</publisher>
 		<info name="serial" value="CGB-ASXE-USA, CGB-ASXP-EUU, CGB-ASXP-EUR"/>
@@ -19027,14 +18320,14 @@ license:CC0
 	</software>
 
 	<software name="sangogb2">
-		<description>Sangokushi - Game Boy Ban 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sangokushi - Game Boy Ban 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AS9J-JPN"/>
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="三國志 ゲームボーイ版2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sangokushi - game boy ban 2 (japan).bin" size="1048576" crc="e787b44c" sha1="ec6089ff2cfcb17faf6a8ea9a4171869b3c7289b"/>
@@ -19045,16 +18338,14 @@ license:CC0
 	</software>
 
 	<software name="sanriotk">
-		<!-- Also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Kako Hen (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<description>Sanrio Timenet - Kako Hen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATPJ-JPN"/>
-		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 過去編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM [LH538WNE]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -19070,37 +18361,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sanriotka" cloneof="sanriotk">
-		<!--	In lot check as "dmgatpj1.f14"	-->
-		<description>Sanrio Timenet - Kako Hen (Japan, Rev. 1)</description>
-		<year>1998</year>
-		<publisher>Imagineer</publisher>
-		<info name="serial" value="DMG-ATPJ-JPN"/>
-		<info name="gold" value="19981130"/>
-		<info name="release" value="19981127"/>
-		<info name="alt_title" value="サンリオタイムネット 過去編"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgatpj1.f14" size="1048576" crc="6555b740" sha1="b3b80b4a48faec9cc71d80a6b08b12b3541b4c1b"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="sanriotm">
-		<!-- Also released by NP in 2000-05 -->
-		<description>Sanrio Timenet - Mirai Hen (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-05 -->
+		<description>Sanrio Timenet - Mirai Hen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-ATFJ-JPN"/>
-		<info name="gold" value="19981027"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="サンリオタイムネット 未来編"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sanrio timenet - mirai hen (japan).bin" size="1048576" crc="efe51e17" sha1="65c4113401336784be4c53a51fe8d9b4b3d287da"/>
@@ -19110,28 +18379,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sanriotma" cloneof="sanriotm">
-		<!--	In lot check as "dmgatfj1.f15"	-->
-		<description>Sanrio Timenet - Mirai Hen (Japan, Rev. 1)</description>
-		<year>1998</year>
-		<publisher>Imagineer</publisher>
-		<info name="serial" value="DMG-ATFJ-JPN"/>
-		<info name="gold" value="19981130"/>
-		<info name="release" value="19981127"/>
-		<info name="alt_title" value="サンリオタイムネット 未来編"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgatfj1.f15" size="1048576" crc="179da7f3" sha1="5ccaf8450862dab90b45b06ab2df291d72ea6033"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="santajr">
-		<description>Santa Claus Junior (Europe)</description>
+		<description>Santa Claus Junior (Euro)</description>
 		<year>2001</year>
 		<publisher>JoWooD Entertainment</publisher>
 		<info name="serial" value="CGB-B3JP-EUR"/>
@@ -19144,14 +18393,14 @@ license:CC0
 	</software>
 
 	<software name="sarupnch" cloneof="monkeyp">
-		<description>Saru Puncher (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Saru Puncher (Jpn)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSPJ-JPN"/>
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="さるパンチャー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM [LH537MYY]" />
 			<feature name="u2" value="U2 MBC-5 [MBC5]" />
@@ -19169,7 +18418,7 @@ license:CC0
 
 	<software name="scooby">
 		<!-- Notes: GBC only -->
-		<description>Scooby-Doo! - Classic Creep Capers (Europe, USA)</description>
+		<description>Scooby-Doo! - Classic Creep Capers (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BCCE-USA, CGB-BCCP-EUR-1"/>
@@ -19186,7 +18435,7 @@ license:CC0
 
 	<software name="scrabble">
 		<!-- Notes: GBC only -->
-		<description>Scrabble (Europe)</description>
+		<description>Scrabble (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B9QP-EUR"/>
@@ -19201,14 +18450,14 @@ license:CC0
 	</software>
 
 	<software name="sdhiryux">
-		<description>SD Hiryuu no Ken EX (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>SD Hiryuu no Ken EX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="DMG-AUXJ-JPN"/>
 		<info name="release" value="19990430"/>
 		<info name="alt_title" value="SD飛龍の拳EX"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sd hiryuu no ken ex (japan).bin" size="1048576" crc="365bf43f" sha1="bed7b913a395ae4b62eac39ff8d6b3093529ed45"/>
@@ -19217,34 +18466,14 @@ license:CC0
 	</software>
 
 	<software name="seihai">
-		<!--	In lot check as "dmgaeoj0.j01"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Sei Hai Densetsu (Japan)</description>
-		<year>2000</year>
-		<publisher>Gaps</publisher>
-		<info name="serial" value="DMG-AEOJ-JPN?"/>
-		<info name="gold" value="20000221"/>
-		<info name="release" value="20000414"/>
-		<info name="alt_title" value="聖牌伝説"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgaeoj0.j01" size="1048576" crc="8804f856" sha1="0840846bd0a3956fc49b5c7aec598ade93e3ff77"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="seihaiunk" cloneof="seihai">
-		<!-- Old dump of unknown origin -->
-		<description>Sei Hai Densetsu (Japan, bad dump?)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sei Hai Densetsu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Gaps</publisher>
 		<info name="serial" value="DMG-AEOJ-JPN"/>
 		<info name="release" value="20000414"/>
 		<info name="alt_title" value="聖牌伝説"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sei hai densetsu (japan).bin" size="1048576" crc="612f0529" sha1="1bada799254b220c1007a1dac6d13b1be4a04ff2"/>
@@ -19255,7 +18484,7 @@ license:CC0
 	</software>
 
 	<software name="semecom">
-		<description>Seme COM Dungeon - Drururuaga (Japan)</description>
+		<description>Seme COM Dungeon - Drururuaga (Jpn)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-BV6J-JPN"/>
@@ -19272,14 +18501,14 @@ license:CC0
 	</software>
 
 	<software name="senkai">
-		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Senkai Ibunroku Juntei Taisen - TV Animation Senkaiden Houshin Engi Yori (Jpn)</description>
 		<year>2000</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-BHSJ-JPN"/>
 		<info name="release" value="20001124"/>
 		<info name="alt_title" value="仙界異聞録 準提大戦〜TVアニメーション「仙界伝封神演義」より〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="senkai ibunroku juntei taisen - tv animation senkaiden houshin engi yori (japan).bin" size="1048576" crc="23fa5f53" sha1="c10249ef96a1989c3532a48917862b4dd8bad12a"/>
@@ -19291,7 +18520,7 @@ license:CC0
 
 	<software name="sesamesp">
 		<!-- Notes: GBC only -->
-		<description>Sesame Street Sports (Europe)</description>
+		<description>Sesame Street Sports (Euro)</description>
 		<year>2001</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BSQP-???"/>
@@ -19332,7 +18561,7 @@ license:CC0
 	</software>
 
 	<software name="shadgate">
-		<description>Shadowgate Classic (Europe, USA, Rev. 1)</description>
+		<description>Shadowgate Classic (Euro, USA, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-EUR"/>
@@ -19353,7 +18582,7 @@ license:CC0
 	</software>
 
 	<software name="shadgatea" cloneof="shadgate">
-		<description>Shadowgate Classic (Australia, USA)</description>
+		<description>Shadowgate Classic (Aus, USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWE-USA, DMG-ASWP-AUS"/>
@@ -19374,7 +18603,7 @@ license:CC0
 	</software>
 
 	<software name="shadgatej" cloneof="shadgate">
-		<description>Shadowgate Return (Japan)</description>
+		<description>Shadowgate Return (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="DMG-ASWJ-JPN"/>
@@ -19392,7 +18621,7 @@ license:CC0
 
 	<software name="shamcrdf">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Japan)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Funbari Hen (Jpn)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQUJ-JPN (KIG-12)"/>
@@ -19410,7 +18639,7 @@ license:CC0
 
 	<software name="shamcrdm">
 		<!-- Notes: GBC only -->
-		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Japan)</description>
+		<description>Shaman King Card Game - Chou Senjiryakketsu - Meramera Hen (Jpn)</description>
 		<year>2001</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQVJ-JPN (KIG-13)"/>
@@ -19427,7 +18656,7 @@ license:CC0
 	</software>
 
 	<software name="shamus">
-		<description>Shamus (Europe, USA)</description>
+		<description>Shamus (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<info name="serial" value="DMG-AVXE-USA, DMG-AVXP-EUR"/>
@@ -19443,29 +18672,27 @@ license:CC0
 	</software>
 
 	<software name="shanghai">
-		<description>Shanghai Pocket (Europe, Rev. 1)</description>
+		<description>Shanghai Pocket (Euro, USA, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
-		<info name="gold" value="19981222"/>
+		<info name="serial" value="DMG-AHPE-USA, DMG-AHPP-(EUR/EUU)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (europe) (rev 1).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
+				<rom name="shanghai pocket (usa, europe) (rev a).bin" size="1048576" crc="d8fac36c" sha1="adbf1a18dea69e46c3dbccec03e09668912f12a7"/>
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="shanghaij" cloneof="shanghai">
-		<description>Shanghai Pocket (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Shanghai Pocket (Jpn)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ASEJ-JPN?"/>
-		<info name="gold" value="19980701"/>
-		<info name="release" value="19980806"/>
+		<info name="release" value="19980806?"/>
 		<info name="alt_title" value="上海 ポケット"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="shanghai pocket (japan).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
@@ -19473,32 +18700,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="shanghaie" cloneof="shanghai">
-		<description>Shanghai Pocket (Europe)</description>
-		<year>1998</year>
-		<publisher>Sunsoft</publisher>
-		<info name="serial" value="DMG-AHPP-(EUR/EUU)?"/>
-		<info name="gold" value="19981110"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (europe).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="shanghaiu" cloneof="shanghai">
-		<!--	In lot check as "dmgahpe0.f55"	-->
 		<description>Shanghai Pocket (USA)</description>
 		<year>1998</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AHPE-USA"/>
-		<info name="gold" value="19981112"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="shanghai pocket (usa).bin" size="1048576" crc="a5e3ece9" sha1="2058964274d8bd596bb81bc24e9cfe306411c803"/>
+				<rom name="shanghai pocket (usa).bin" size="1048576" crc="9401ba47" sha1="6436b152924a8612d7cd28fef09f10a81ec91ad7"/>
 			</dataarea>
 		</part>
 	</software>
@@ -19521,7 +18731,7 @@ license:CC0
 
 	<software name="shaunsnw">
 		<!-- Notes: GBC only -->
-		<description>Shaun Palmer's Pro Snowboarder (Australia, USA)</description>
+		<description>Shaun Palmer's Pro Snowboarder (Aus, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3SE-USA, CGB-B3SP-AUS"/>
@@ -19533,36 +18743,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="shinmtaa">
-		<!--	In lot check as "dmgbhnj1.j70"	-->
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan, Rev. 1)</description>
+	<software name="shinmta">
+		<!-- Notes: SGB enhanced -->
+		<description>Shin Megami Tensei Devil Children - Aka no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHNJ-JPN"/>
-		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgbhnj1.j70" size="2097152" crc="c1e27556" sha1="e9a3edd28503ee94db8ec4ea48832dc2ba0264d9"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shinmta" cloneof="shinmtaa">
-		<description>Shin Megami Tensei Devil Children - Aka no Sho (Japan)</description>
-		<year>2000</year>
-		<publisher>Atlus</publisher>
-		<info name="serial" value="DMG-BHNJ-JPN"/>
-		<info name="gold" value="20000912"/>
-		<info name="release" value="20001117"/>
-		<info name="alt_title" value="真・女神転生 デビルチルドレン 赤の書"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -19578,36 +18767,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="shinmtka">
-		<!--	In lot check as "dmgbhej1.j69"	-->
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan, Rev. 1)</description>
+	<software name="shinmtk">
+		<!-- Notes: SGB enhanced -->
+		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="DMG-BHEJ-JPN"/>
-		<info name="gold" value="20010608"/>
 		<info name="release" value="20001117"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgbhej1.j69" size="2097152" crc="3d4ae536" sha1="421d20bf556e28d07801d808ecfef45daf86a974"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="shinmtk" cloneof="shinmtka">
-		<description>Shin Megami Tensei Devil Children - Kuro no Sho (Japan)</description>
-		<year>2000</year>
-		<publisher>Atlus</publisher>
-		<info name="serial" value="DMG-BHEJ-JPN"/>
-		<info name="gold" value="20000912"/>
-		<info name="release" value="20001117"/>
-		<info name="alt_title" value="真・女神転生 デビルチルドレン 黒の書"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A03-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -19625,11 +18793,10 @@ license:CC0
 
 	<software name="shinmts">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Japan)</description>
+		<description>Shin Megami Tensei Devil Children - Shiro no Sho (Jpn)</description>
 		<year>2001</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BHWJ-JPN"/>
-		<info name="gold" value="20010608"/>
 		<info name="release" value="20010727"/>
 		<info name="alt_title" value="真・女神転生 デビルチルドレン 白の書"/>
 		<part name="cart" interface="gameboy_cart">
@@ -19650,7 +18817,7 @@ license:CC0
 
 	<software name="shinmtcd">
 		<!-- Notes: GBC only -->
-		<description>Shin Megami Tensei Trading Card - Card Summoner (Japan)</description>
+		<description>Shin Megami Tensei Trading Card - Card Summoner (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-BT8J-JPN"/>
@@ -19674,7 +18841,7 @@ license:CC0
 
 	<software name="evangeln">
 		<!-- Notes: GBC only -->
-		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Japan)</description>
+		<description>Shinseiki Evangelion - Mahjong Hokan Keikaku (Jpn)</description>
 		<year>2000</year>
 		<publisher>King Records</publisher>
 		<info name="serial" value="CGB-BQRJ-JPN (KIG-10)"/>
@@ -19691,8 +18858,8 @@ license:CC0
 	</software>
 
 	<software name="shougi2">
-		<!-- Also released by NP in 2000-04 -->
-		<description>Shougi 2 (Japan)</description>
+		<!-- Notes: Also released by NP in 2000-04 -->
+		<description>Shougi 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-AS8J-JPN (PCPE-10002)"/>
@@ -19707,7 +18874,7 @@ license:CC0
 	</software>
 
 	<software name="shougi3">
-		<description>Shougi 3 (Japan)</description>
+		<description>Shougi 3 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-B9SJ-JPN (PCPE-1000?)"/>
@@ -19723,7 +18890,7 @@ license:CC0
 
 	<software name="shrek">
 		<!-- Notes: GBC only -->
-		<description>Shrek - Fairy Tale Freakdown (Europe, USA)</description>
+		<description>Shrek - Fairy Tale Freakdown (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BFUE-USA, CGB-BFUP-EUR"/>
@@ -19739,15 +18906,14 @@ license:CC0
 	</software>
 
 	<software name="shutoku">
-		<!-- Also released by NP in 2000-04 -->
-		<description>The Shutokou Racing (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-04 -->
+		<description>The Shutokou Racing (Jpn)</description>
 		<year>1998</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="DMG-ASUJ-JPN (PCPE-10001)"/>
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="ザ・首都高レーシング"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc2" />
 			<dataarea name="rom" size="131072">
 				<rom name="shutokou racing, the (japan).bin" size="131072" crc="36e781cd" sha1="0f29818190ea9ce8c242b648ba64d50cc5408e5a"/>
@@ -19759,7 +18925,7 @@ license:CC0
 
 	<software name="simpsons">
 		<!-- Notes: GBC only -->
-		<description>The Simpsons - Night of the Living Treehouse of Horror (Europe, USA)</description>
+		<description>The Simpsons - Night of the Living Treehouse of Horror (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BNOE-USA, CGB-BNOP-EUR"/>
@@ -19780,7 +18946,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BRAE-USA"/>
-		<info name="gold" value="20000921"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -19791,28 +18956,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sewingose" cloneof="sewingos">
-		<!--	In lot check as "dmgbraz0.k25"	-->
-		<!-- Notes: For use with Jaguar Sewing Machine (Nuotto Expansion) -->
-		<description>Sewing Machine Operation Software (Europe)</description>
-		<year>2000</year>
-		<publisher>Natsume</publisher>
-		<info name="serial" value="DMG-BRAZ-EUU"/>
-		<info name="gold" value="20010920"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgbraz0.k25" size="1048576" crc="d8433dee" sha1="4b12589fb14932381afa8433130d684120c5e3cd"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="smurfnig">
 		<!-- Notes: GBC only -->
-		<description>The Smurfs Nightmare (Europe)</description>
+		<description>The Smurfs Nightmare (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-ASNP-EUR"/>
@@ -19843,7 +18989,7 @@ license:CC0
 
 	<software name="snobochm">
 		<!-- Notes: GBC only -->
-		<description>Snobow Champion (Japan)</description>
+		<description>Snobow Champion (Jpn)</description>
 		<year>2000</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-B5CJ-JPN"/>
@@ -19859,7 +19005,7 @@ license:CC0
 
 	<software name="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Europe)</description>
+		<description>Snoopy Tennis (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9P-NOE"/>
@@ -19876,7 +19022,7 @@ license:CC0
 
 	<software name="snoopytnj" cloneof="snoopytn">
 		<!-- Notes: GBC only -->
-		<description>Snoopy Tennis (Japan)</description>
+		<description>Snoopy Tennis (Jpn)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BS9J-JPN"/>
@@ -19906,7 +19052,7 @@ license:CC0
 
 	<software name="snowhite">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney's Snow White and the Seven Dwarfs (Europe)</description>
+		<description>Walt Disney's Snow White and the Seven Dwarfs (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-B7DP-EUR"/>
@@ -19937,7 +19083,7 @@ license:CC0
 
 	<software name="snowcros">
 		<!-- Notes: GBC only -->
-		<description>SnowCross (Europe)</description>
+		<description>SnowCross (Euro)</description>
 		<year>2001</year>
 		<publisher>Wanadoo</publisher>
 		<info name="serial" value="CGB-B3OP-EUR"/>
@@ -19951,7 +19097,7 @@ license:CC0
 
 	<software name="socmanag">
 		<!-- Notes: GBC only -->
-		<description>Soccer Manager (Europe)</description>
+		<description>Soccer Manager (Euro)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BSMP-EUR"/>
@@ -19967,7 +19113,7 @@ license:CC0
 
 	<software name="solomon" cloneof="mranchex">
 		<!-- Notes: GBC only -->
-		<description>Solomon (Japan)</description>
+		<description>Solomon (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tecmo</publisher>
 		<info name="serial" value="CGB-BSOJ-JPN"/>
@@ -19985,7 +19131,7 @@ license:CC0
 
 	<software name="anpan5to">
 		<!-- Notes: GBC only -->
-		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Japan)</description>
+		<description>Soreike! Anpanman - 5-tsu no Tou no Ousama (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="CGB-BS2J-JPN"/>
@@ -20002,14 +19148,14 @@ license:CC0
 	</software>
 
 	<software name="anpanfna">
-		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Soreike! Anpanman - Fushigi na Nikoniko Album (Jpn)</description>
 		<year>1999</year>
 		<publisher>Tamsoft</publisher>
 		<info name="serial" value="DMG-AANJ-JPN"/>
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="それいけ!!アンパンマン 不思議なにこにこアルバム"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="soreike anpanman - fushigi na nikoniko album (japan).bin" size="1048576" crc="a80eeead" sha1="fe75b7b7a904ce76130d65b67d24e291ba3c2693"/>
@@ -20020,7 +19166,7 @@ license:CC0
 	</software>
 
 	<software name="sokoban">
-		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Japan)</description>
+		<description>Soukoban Densetsu - Hikari to Yami no Kuni (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AWIJ-JPN"/>
@@ -20037,7 +19183,7 @@ license:CC0
 	</software>
 
 	<software name="soulget">
-		<description>Soul Getter - Houkago Bouken RPG (Japan)</description>
+		<description>Soul Getter - Houkago Bouken RPG (Jpn)</description>
 		<year>2000</year>
 		<publisher>Micro Cabin</publisher>
 		<info name="serial" value="DMG-AL9J-JPN"/>
@@ -20054,7 +19200,7 @@ license:CC0
 	</software>
 
 	<software name="spaceinv">
-		<description>Space Invaders (Europe, USA)</description>
+		<description>Space Invaders (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="DMG-AIVE-USA, DMG-AIVP-(EUR/NOE)"/>
@@ -20067,7 +19213,7 @@ license:CC0
 	</software>
 
 	<software name="spaceinvx" cloneof="spaceinv">
-		<description>Space Invaders X (Japan)</description>
+		<description>Space Invaders X (Jpn)</description>
 		<year>2000</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="DMG-BSIJ-JPN"/>
@@ -20097,7 +19243,7 @@ license:CC0
 
 	<software name="spacentb">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Blue (Japan)</description>
+		<description>Space-Net - Cosmo Blue (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BNBJ-JPN"/>
@@ -20115,7 +19261,7 @@ license:CC0
 
 	<software name="spacentr">
 		<!-- Notes: GBC only -->
-		<description>Space-Net - Cosmo Red (Japan)</description>
+		<description>Space-Net - Cosmo Red (Jpn)</description>
 		<year>2001</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="CGB-BREJ-JPN"/>
@@ -20132,7 +19278,7 @@ license:CC0
 	</software>
 
 	<software name="silicon">
-		<description>Spacestation Silicon Valley (Europe)</description>
+		<description>Spacestation Silicon Valley (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AV2P-EUR"/>
@@ -20161,7 +19307,7 @@ license:CC0
 	</software>
 
 	<software name="speedy">
-		<description>Speedy Gonzales - Aztec Adventure (Europe, USA)</description>
+		<description>Speedy Gonzales - Aztec Adventure (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-ALZE-USA, DMG-ALZP-(NOE/UKV)"/>
@@ -20178,7 +19324,7 @@ license:CC0
 
 	<software name="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Europe, USA)</description>
+		<description>Spider-Man (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEE-USA, CGB-BSEP-EUR"/>
@@ -20192,7 +19338,7 @@ license:CC0
 
 	<software name="spidermnf" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (France)</description>
+		<description>Spider-Man (Fra)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BSEF-FRA"/>
@@ -20206,7 +19352,7 @@ license:CC0
 
 	<software name="spidermnj" cloneof="spidermn">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man (Japan)</description>
+		<description>Spider-Man (Jpn)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BSEJ-JPN"/>
@@ -20222,7 +19368,7 @@ license:CC0
 
 	<software name="spiderm2">
 		<!-- Notes: GBC only -->
-		<description>Spider-Man 2 - The Sinister Six (Europe, USA)</description>
+		<description>Spider-Man 2 - The Sinister Six (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B2SE-USA, CGB-B2SP-EUR"/>
@@ -20239,7 +19385,7 @@ license:CC0
 
 	<software name="spirou">
 		<!-- Notes: GBC only -->
-		<description>Spirou Robbedoes - The Robot Invasion (Europe)</description>
+		<description>Spirou Robbedoes - The Robot Invasion (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSCP-EUR"/>
@@ -20253,7 +19399,7 @@ license:CC0
 
 	<software name="spongebb">
 		<!-- Notes: GBC only -->
-		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Europe, USA)</description>
+		<description>SpongeBob SquarePants - Legend of the Lost Spatula (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BQPE-USA, CGB-BQPP-EUR"/>
@@ -20270,11 +19416,10 @@ license:CC0
 
 	<software name="spyvsspy">
 		<!-- Notes: GBC only -->
-		<description>Spy vs. Spy (Europe)</description>
+		<description>Spy vs. Spy (Euro)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6P-EUR"/>
-		<info name="gold" value="19990506"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20285,11 +19430,10 @@ license:CC0
 
 	<software name="spyvsspyj" cloneof="spyvsspy">
 		<!-- Notes: GBC only, also released by NP in 2001-05 -->
-		<description>Spy vs. Spy (Japan)</description>
+		<description>Spy vs. Spy (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6J-JPN"/>
-		<info name="gold" value="19990615"/>
 		<info name="release" value="19990723"/>
 		<info name="alt_title" value="スパイ アンド スパイ"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20300,28 +19444,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="spyvsspyjanp" cloneof="spyvsspy">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "KENSA\cgbas6j1.0"	-->
-		<!--	Never released as physical cartridge	-->
-		<description>Spy vs. Spy (Japan, Rev. 1, NP)</description>
-		<year>1999</year>
-		<publisher>Kemco</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbas6j1.0" size="1048576" crc="eb47d63b" sha1="9e203f04857cd84ec49b0e6c6d4917b1a5cc199e"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="spyvsspyu" cloneof="spyvsspy">
 		<!-- Notes: GBC only -->
 		<description>Spy vs. Spy (USA)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-AS6E-USA"/>
-		<info name="gold" value="19990512"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20331,7 +19459,7 @@ license:CC0
 	</software>
 
 	<software name="starocbs">
-		<description>Star Ocean - Blue Sphere (Japan)</description>
+		<description>Star Ocean - Blue Sphere (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enix</publisher>
 		<info name="serial" value="DMG-BO2J-JPN"/>
@@ -20349,7 +19477,7 @@ license:CC0
 
 	<software name="swep1obi">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Obi-Wan's Adventures (Europe)</description>
+		<description>Star Wars Episode I - Obi-Wan's Adventures (Euro)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BOWP-EUR"/>
@@ -20377,7 +19505,7 @@ license:CC0
 
 	<software name="swracer">
 		<!-- Notes: GBC only -->
-		<description>Star Wars Episode I - Racer (Europe, USA)</description>
+		<description>Star Wars Episode I - Racer (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-VYHE-USA, CGB-VYHP-EUR"/>
@@ -20400,7 +19528,7 @@ license:CC0
 	</software>
 
 	<software name="stranded">
-		<description>Stranded Kids (Europe)</description>
+		<description>Stranded Kids (Euro)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKP-EUR"/>
@@ -20416,11 +19544,10 @@ license:CC0
 
 	<software name="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Europe)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Euro)</description>
 		<year>2000</year>
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="CGB-AFZP-EUR"/>
-		<info name="gold" value="19991101"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20431,11 +19558,10 @@ license:CC0
 
 	<software name="sfaj" cloneof="sfa">
 		<!-- Notes: GBC only -->
-		<description>Street Fighter Alpha - Warriors' Dreams (Japan)</description>
+		<description>Street Fighter Alpha - Warriors' Dreams (Jpn)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BFZJ-JPN"/>
-		<info name="gold" value="20010206"/>
 		<info name="release" value="20010330"/>
 		<info name="alt_title" value="ストリートファイター アルファ WARRIORS' DREAMS"/>
 		<part name="cart" interface="gameboy_cart">
@@ -20452,7 +19578,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AFZE-USA"/>
-		<info name="gold" value="20000120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -20463,7 +19588,7 @@ license:CC0
 
 	<software name="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Europe, USA)</description>
+		<description>Stuart Little - The Journey Home (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIE-USA, CGB-BJIP-UKV"/>
@@ -20480,7 +19605,7 @@ license:CC0
 
 	<software name="stuartla" cloneof="stuartl">
 		<!-- Notes: GBC only -->
-		<description>Stuart Little - The Journey Home (Europe)</description>
+		<description>Stuart Little - The Journey Home (Euro)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BJIX-EUR"/>
@@ -20497,7 +19622,7 @@ license:CC0
 
 	<software name="sblkbass">
 		<!-- Notes: GBC only -->
-		<description>Super Black Bass - Real Fight (Japan)</description>
+		<description>Super Black Bass - Real Fight (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-VRFJ-JPN"/>
@@ -20522,15 +19647,14 @@ license:CC0
 	</software>
 
 	<software name="sblkbap3" cloneof="tnnofc">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Super Black Bass Pocket 3 (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Super Black Bass Pocket 3 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-ABQJ-JPN"/>
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="スーパーブラックバス ポケット3"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super black bass pocket 3 (japan).bin" size="1048576" crc="ae466545" sha1="b416f8fe1d229bd4e90259f2e6a7d78dd1f7bf3e"/>
@@ -20541,14 +19665,14 @@ license:CC0
 	</software>
 
 	<software name="sbomblis">
-		<description>Super Bombliss DX (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Super Bombliss DX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bullet-Proof Software</publisher>
 		<info name="serial" value="DMG-A2OJ-JPN"/>
 		<info name="release" value="19991210"/>
 		<info name="alt_title" value="スーパーボンブリス デラックス"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="262144">
 				<rom name="super bombliss dx (japan).bin" size="262144" crc="34c8a4a5" sha1="44070e77eb2b56b67f979e444d404e56b67edbb0"/>
@@ -20557,7 +19681,7 @@ license:CC0
 	</software>
 
 	<software name="sbrkout">
-		<description>Super Breakout! (Europe)</description>
+		<description>Super Breakout! (Euro)</description>
 		<year>1998</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="DMG-AOTP-EUR"/>
@@ -20584,7 +19708,7 @@ license:CC0
 
 	<software name="supchinf">
 		<!-- Notes: GBC only -->
-		<description>Super Chinese Fighter EX (Japan)</description>
+		<description>Super Chinese Fighter EX (Jpn)</description>
 		<year>1999</year>
 		<publisher>Culture Brain</publisher>
 		<info name="serial" value="CGB-A66J-JPN"/>
@@ -20602,7 +19726,7 @@ license:CC0
 
 	<software name="sdoll">
 		<!-- Notes: GBC only -->
-		<description>Super Doll Licca-chan - Kisekae Daisakusen (Japan)</description>
+		<description>Super Doll Licca-chan - Kisekae Daisakusen (Jpn)</description>
 		<year>2000</year>
 		<publisher>VR1 Japan</publisher>
 		<info name="serial" value="CGB-BSLJ-JPN"/>
@@ -20620,7 +19744,7 @@ license:CC0
 
 	<software name="sgals">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran (Japan)</description>
+		<description>Super Gals! Kotobuki Ran (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGLJ-JPN (RK251-J1)"/>
@@ -20644,7 +19768,7 @@ license:CC0
 
 	<software name="sgals2">
 		<!-- Notes: GBC only -->
-		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Japan)</description>
+		<description>Super Gals! Kotobuki Ran 2 - Miracle → Getting (Jpn)</description>
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BGUJ-JPN (RK283-J1)"/>
@@ -20662,8 +19786,7 @@ license:CC0
 
 	<software name="smbdxj" cloneof="smbdx">
 		<!-- Notes: GBC only, NP only -->
-		<!--	In lot check as "POOL\cgbahyj0.0"	-->
-		<description>Super Mario Bros. Deluxe (Japan, NP)</description>
+		<description>Super Mario Bros. Deluxe (Jpn, NP)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYJ-JPN"/>
@@ -20679,37 +19802,16 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="smbdxja" cloneof="smbdx">
-		<!-- Notes: GBC only, NP only -->
-		<!--	In lot check as "KENSA\cgbahyj1.0"	-->
-		<description>Super Mario Bros. Deluxe (Japan, NP, Rev. 1)</description>
-		<year>1999</year>
-		<publisher>Nintendo</publisher>
-		<info name="serial" value="CGB-AHYJ-JPN"/>
-		<info name="release" value="20000301"/>
-		<info name="alt_title" value="スーパーマリオブラザーズデラックス"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbahyj1.0" size="1048576" crc="f4e91f63" sha1="e61d564e1ff19eb4b7c62a6cd96214f2bca4b01d"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="smbdx">
 		<!-- Notes: GBC only -->
-		<!--	Retail cartridge of USA version not yet secured, might be unreleased	-->
-		<!--	In lot check as "cgbahyp2.013", "KENSA\cgbahye2.0"	-->
-		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 2)</description>
+		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. B)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev 2).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev b).bin" size="1048576" crc="62bbae83" sha1="254f2254e9d54e2501e3e4ebe09491e03573a6a4"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20718,14 +19820,14 @@ license:CC0
 
 	<software name="smbdxa" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Europe, USA, Rev. 1)</description>
+		<description>Super Mario Bros. Deluxe (Euro, USA, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="super mario bros. deluxe (usa, europe) (rev 1).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
+				<rom name="super mario bros. deluxe (usa, europe) (rev a).bin" size="1048576" crc="90ab047b" sha1="07295cd60ae44183ebecb013930727e0404169d5"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -20734,7 +19836,7 @@ license:CC0
 
 	<software name="smbdxb" cloneof="smbdx">
 		<!-- Notes: GBC only -->
-		<description>Super Mario Bros. Deluxe (Europe, USA)</description>
+		<description>Super Mario Bros. Deluxe (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AHYE-USA, CGB-AHYP-EUR"/>
@@ -20750,7 +19852,7 @@ license:CC0
 
 	<software name="smemail">
 		<!-- Notes: GBC only -->
-		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Japan)</description>
+		<description>Super Me-Mail GB - Me-Mail Bear no Happy Mail Town (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BHAJ-JPN"/>
@@ -20768,7 +19870,7 @@ license:CC0
 
 	<software name="srfish">
 		<!-- Notes: GBC only -->
-		<description>Super Real Fishing (Japan)</description>
+		<description>Super Real Fishing (Jpn)</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
 		<info name="serial" value="CGB-VPFJ-JPN"/>
@@ -20788,7 +19890,7 @@ license:CC0
 
 	<software name="srobopin">
 		<!-- Notes: GBC only -->
-		<description>Super Robot Pinball (Japan)</description>
+		<description>Super Robot Pinball (Jpn)</description>
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BSUJ-JPN"/>
@@ -20805,14 +19907,14 @@ license:CC0
 	</software>
 
 	<software name="srobotlb">
-		<description>Super Robot Taisen - Link Battler (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Super Robot Taisen - Link Battler (Jpn)</description>
 		<year>1999</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="DMG-AL6J-JPN"/>
 		<info name="release" value="19991001"/>
 		<info name="alt_title" value="スーパーロボット大戦 リンクバトラー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="super robot taisen - link battler (japan).bin" size="1048576" crc="d24e592d" sha1="e6c715042adc4c1b52a7295e082953ada79cf95e"/>
@@ -20824,7 +19926,7 @@ license:CC0
 
 	<software name="superx">
 		<!-- Notes: GBC only -->
-		<description>Supercross Freestyle (Europe)</description>
+		<description>Supercross Freestyle (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BSXP-EUR"/>
@@ -20840,7 +19942,7 @@ license:CC0
 
 	<software name="supreme">
 		<!-- Notes: GBC only -->
-		<description>Supreme Snowboarding (Europe)</description>
+		<description>Supreme Snowboarding (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AXWP-NOE"/>
@@ -20868,35 +19970,14 @@ license:CC0
 	</software>
 
 	<software name="survkidsj" cloneof="stranded">
-		<!-- Also released by NP in 2001-02 -->
-		<!--	In lot check as "dmgavkj0.g64"	-->
-		<description>Survival Kids - Kotou no Boukensha (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2001-02 -->
+		<description>Survival Kids - Kotou no Boukensha (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AVKJ-JPN (RK189-J1)"/>
-		<info name="gold" value="19990423"/>
 		<info name="release" value="19990617"/>
 		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="dmgavkj0.g64" size="1048576" crc="61fa675c" sha1="f80abbeaa2cf0631c1cdf812c13f13f1fea41f18"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="survkidsjunk" cloneof="stranded">
-		<!-- Also released by NP in 2001-02 -->
-		<!-- Old dump of unknown origin -->
-		<description>Survival Kids - Kotou no Boukensha (Japan, bad dump?)</description>
-		<year>1999</year>
-		<publisher>Konami</publisher>
-		<info name="alt_title" value="サバイバルキッズ 孤島の冒険者"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids - kotou no boukensha (japan).bin" size="1048576" crc="19c2bd07" sha1="091afc2743425e1846cfe356cf8cb0f3c4e14ed7"/>
@@ -20907,15 +19988,14 @@ license:CC0
 	</software>
 
 	<software name="survkid2">
-		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Survival Kids 2 - Dasshutsu!! Futagojima! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-B2VJ-JPN (RK210-J1)"/>
-		<info name="gold" value="20000606"/>
 		<info name="release" value="20000719"/>
-		<info name="alt_title" value="サバイバルキッズ ２ ～脱出！！双子島！～"/>
+		<info name="alt_title" value="サバイバルキッズ2 脱出!双子島!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="survival kids 2 - dasshutsu futago shima (japan).bin" size="1048576" crc="ab8b25d8" sha1="8fd720d5b035939b553910a3ec45c1bd052484eb"/>
@@ -20927,12 +20007,10 @@ license:CC0
 
 	<software name="suzuki">
 		<!-- Notes: GBC only -->
-		<description>Suzuki Alstare Extreme Racing (Europe)</description>
+		<description>Suzuki Alstare Extreme Racing (Euro)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
-		<info name="serial" value="CGB-AXRP-EUR?"/>
-		<info name="gold" value="19991001"/>
-		<info name="release" value="20000719"/>
+		<info name="serial" value="??"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="524288">
@@ -20942,14 +20020,14 @@ license:CC0
 	</software>
 
 	<software name="sweetang">
-		<description>Sweet Ange (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sweet Ange (Jpn)</description>
 		<year>1999</year>
 		<publisher>Koei</publisher>
 		<info name="serial" value="DMG-AUBJ-JPN"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="スウィートアンジェ"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sweet ange (japan).bin" size="1048576" crc="4be9b159" sha1="5b6f268d945bcdb070195459582f01b434c01495"/>
@@ -20961,7 +20039,7 @@ license:CC0
 
 	<software name="swing">
 		<!-- Notes: GBC only -->
-		<description>Swing (Germany)</description>
+		<description>Swing (Ger)</description>
 		<year>2000</year>
 		<publisher>Software 2000</publisher>
 		<info name="serial" value="CGB-BSWD-NOE"/>
@@ -20977,7 +20055,7 @@ license:CC0
 
 	<software name="swiv">
 		<!-- Notes: GBC only -->
-		<description>SWIV (Europe)</description>
+		<description>SWIV (Euro)</description>
 		<year>2001</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BSVP-EUR"/>
@@ -20990,14 +20068,14 @@ license:CC0
 	</software>
 
 	<software name="sylvan">
-		<description>Sylvanian Families - Otogi no Kuni no Pendant (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sylvanian Families - Otogi no Kuni no Pendant (Jpn)</description>
 		<year>1999</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-ALVJ-JPN"/>
 		<info name="release" value="19991015"/>
 		<info name="alt_title" value="シルバニアファミリー 〜おとぎの国のペンダント〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -21014,13 +20092,12 @@ license:CC0
 
 	<software name="sylvan2">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Japan)</description>
+		<description>Sylvanian Families 2 - Irozuku Mori no Fantasy (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BLVJ-JPN"/>
-		<info name="gold" value="20001117"/>
 		<info name="release" value="20001222"/>
-		<info name="alt_title" value="シルバニアファミリー２ ～色づく森のファンタジー～"/>
+		<info name="alt_title" value="シルバニアファミリー2 色づく森のファンタジー"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -21033,7 +20110,7 @@ license:CC0
 
 	<software name="sylvan3">
 		<!-- Notes: GBC only -->
-		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Japan)</description>
+		<description>Sylvanian Families 3 - Hoshi Furu Yoru no Sunadokei (Jpn)</description>
 		<year>2001</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="CGB-BL3J-JPN"/>
@@ -21050,14 +20127,14 @@ license:CC0
 	</software>
 
 	<software name="sylvmel">
-		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Sylvanian Melodies - Mori no Nakama to Odori Masho! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Epoch</publisher>
 		<info name="serial" value="DMG-BMKJ-JPN"/>
 		<info name="release" value="20000317"/>
 		<info name="alt_title" value="シルバニアメロディー 森のなかまと踊りましょ!"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="sylvanian melodies - mori no nakama to odori mashi (japan).bin" size="1048576" crc="6dd8ac91" sha1="55230e865958f7301076a4354b6b8b083a494bae"/>
@@ -21068,7 +20145,7 @@ license:CC0
 	</software>
 
 	<software name="sylvestr">
-		<description>Sylvester and Tweety - Breakfast on the Run (Europe)</description>
+		<description>Sylvester and Tweety - Breakfast on the Run (Euro)</description>
 		<year>1998</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AYRP-NOE, DMG-AYRP-UKV, DMG-AYRP-EUR)"/>
@@ -21082,7 +20159,7 @@ license:CC0
 
 	<software name="tabaluga">
 		<!-- Notes: GBC only -->
-		<description>Tabaluga (Germany)</description>
+		<description>Tabaluga (Ger)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-ALUP-NOE"/>
@@ -21095,8 +20172,8 @@ license:CC0
 	</software>
 
 	<software name="ttshogi">
-		<!-- NP only -->
-		<description>Taisen Tsumeshougi (Japan, NP)</description>
+		<!-- Notes: NP only -->
+		<description>Taisen Tsumeshougi (Jpn, NP)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="DMG-BTSJ-JPN"/>
@@ -21111,14 +20188,14 @@ license:CC0
 	</software>
 
 	<software name="bublboblj" cloneof="bublbobl">
-		<description>Taito Memorial - Bubble Bobble (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Taito Memorial - Bubble Bobble (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJBJ-JPN"/>
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル バブルボブル"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - bubble bobble (japan).bin" size="1048576" crc="388c6760" sha1="6a30d328417e085dcd10588d0a5af90ff4bfa40d"/>
@@ -21127,14 +20204,14 @@ license:CC0
 	</software>
 
 	<software name="chasehqj" cloneof="chasehq">
-		<description>Taito Memorial - Chase H.Q. - Secret Police (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Taito Memorial - Chase H.Q. - Secret Police (Jpn)</description>
 		<year>2000</year>
 		<publisher>Jorudan</publisher>
 		<info name="serial" value="DMG-BJCJ-JPN"/>
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="タイトーメモリアル チェイス・エイチ・キュー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="taito memorial - chase h.q. - secret police (japan).bin" size="1048576" crc="6a0c272d" sha1="d6d90667ebf295016f01b4604ab03ab5b1876d00"/>
@@ -21143,14 +20220,14 @@ license:CC0
 	</software>
 
 	<software name="tophant">
-		<description>Tales of Phantasia - Narikiri Dungeon (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Tales of Phantasia - Narikiri Dungeon (Jpn)</description>
 		<year>2000</year>
 		<publisher>Namco</publisher>
 		<info name="serial" value="DMG-AN6J-JPN"/>
 		<info name="release" value="20001110"/>
 		<info name="alt_title" value="テイルズオブファンタジア なりきりダンジョン"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tales of phantasia - narikiri dungeon (japan).bin" size="2097152" crc="725cf31c" sha1="ef322f4160ceebd8da67758ebd73225190af6d23"/>
@@ -21161,14 +20238,14 @@ license:CC0
 	</software>
 
 	<software name="donqix">
-		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Tanimura Hitoshi Ryuu Pachinko Kouryaku Daisakusen - Don Quijote ga Iku (Jpn)</description>
 		<year>2000</year>
 		<publisher>Atlus</publisher>
 		<info name="serial" value="CGB-BDHJ-JPN"/>
 		<info name="release" value="20000811"/>
 		<info name="alt_title" value="谷村ひとし流パチンコ攻略大作戦 ドン・キホーテが行く"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="tanimura hitoshi ryuu pachinko kouryaku daisakusen - don quijote ga iku (japan).bin" size="2097152" crc="ce8ae58c" sha1="f752e96602274a29006425a06086d8ab45e1075c"/>
@@ -21180,7 +20257,7 @@ license:CC0
 
 	<software name="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Europe, USA)</description>
+		<description>Disney's Tarzan (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHE-USA, CGB-ATHP-UKV"/>
@@ -21194,7 +20271,7 @@ license:CC0
 
 	<software name="tarzanf" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (France)</description>
+		<description>Disney's Tarzan (Fra)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHF-FRA"/>
@@ -21211,7 +20288,7 @@ license:CC0
 
 	<software name="tarzang" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Germany)</description>
+		<description>Disney's Tarzan (Ger)</description>
 		<year>1999</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-ATHD-NOE"/>
@@ -21225,7 +20302,7 @@ license:CC0
 
 	<software name="tarzanj" cloneof="tarzan">
 		<!-- Notes: GBC only -->
-		<description>Disney's Tarzan (Japan)</description>
+		<description>Disney's Tarzan (Jpn)</description>
 		<year>2000</year>
 		<publisher>Syscom</publisher>
 		<info name="serial" value="CGB-BTHJ-JPN"/>
@@ -21240,11 +20317,10 @@ license:CC0
 	</software>
 
 	<software name="taxi2">
-		<description>Taxi 2 (France)</description>
-		<year>2000</year>
-		<publisher>Ubi Soft</publisher>
+		<description>Taxi 2 (Fra)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="CGB-BT2F-FRA"/>
-		<info name="gold" value="20000323"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21254,7 +20330,7 @@ license:CC0
 	</software>
 
 	<software name="taxi3">
-		<description>Taxi 3 (France)</description>
+		<description>Taxi 3 (Fra)</description>
 		<year>2002</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BXIF-FRA"/>
@@ -21270,7 +20346,7 @@ license:CC0
 	</software>
 
 	<software name="tazmandv">
-		<description>Tazmanian Devil - Munching Madness (Europe)</description>
+		<description>Tazmanian Devil - Munching Madness (Euro)</description>
 		<year>1999</year>
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="DMG-AVZP-UKV"/>
@@ -21297,7 +20373,7 @@ license:CC0
 
 	<software name="techdeck">
 		<!-- Notes: GBC only -->
-		<description>Tech Deck Skateboarding (Europe, USA)</description>
+		<description>Tech Deck Skateboarding (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTUE-USA, CGB-BTUP-EUR"/>
@@ -21326,7 +20402,7 @@ license:CC0
 	</software>
 
 	<software name="td6a" cloneof="td6">
-		<description>Test Drive 6 (Europe, Sample 'Destinations Toutes Sensations')</description>
+		<description>Test Drive 6 (Euro, Sample 'Destinations Toutes Sensations')</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -21340,7 +20416,7 @@ license:CC0
 	</software>
 
 	<software name="td6">
-		<description>Test Drive 6 (Europe)</description>
+		<description>Test Drive 6 (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="DMG-AW6P-EUR"/>
@@ -21426,11 +20502,10 @@ license:CC0
 
 	<software name="tetrisad" cloneof="mtetrisc">
 		<!-- Notes: GBC only -->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan)</description>
+		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Jpn)</description>
 		<year>1999</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-AT7J-JPN"/>
-		<info name="gold" value="19991004"/>
 		<info name="release" value="19991112"/>
 		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
 		<part name="cart" interface="gameboy_cart">
@@ -21443,27 +20518,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tetrisada" cloneof="mtetrisc">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbat7j1.070"	-->
-		<description>Tetris Adventure - Susume Mickey to Nakama-tachi (Japan, Rev. 1)</description>
-		<year>1999</year>
-		<publisher>Capcom</publisher>
-		<info name="serial" value="CGB-AT7J-JPN?"/>
-		<info name="gold" value="20000623"/>
-		<info name="alt_title" value="テトリスアドベンチャー すすめミッキーとなかまたち"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbat7j1.070" size="1048576" crc="b7c0831f" sha1="a8842e85f2c6de4db40b47c9640dad59ae9d1c51"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="tetrisdx">
-		<!-- Also released by NP in 2000-09 -->
+		<!-- Notes: SGB enhanced, also released by NP in 2000-09 -->
 		<description>Tetris DX (World)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
@@ -21471,7 +20527,6 @@ license:CC0
 		<info name="release" value="19981021 (JPN)"/>
 		<info name="alt_title" value="テトリスデラックス"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc1" />
 			<dataarea name="rom" size="524288">
 				<rom name="tetris dx (world).bin" size="524288" crc="69989152" sha1="7183bcb54dd35f3a07d8fe63339b768f13b8168d"/>
@@ -21483,11 +20538,10 @@ license:CC0
 
 	<software name="tgrall2a" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>TG Rally 2 (Europe)</description>
+		<description>TG Rally 2 (Euro)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33X-UKV"/>
-		<info name="gold" value="20000223"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A06-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -21505,7 +20559,7 @@ license:CC0
 	</software>
 
 	<software name="3lions" cloneof="goldgoal">
-		<description>Three Lions (Europe)</description>
+		<description>Three Lions (Euro)</description>
 		<year>1999</year>
 		<publisher>Take-Two Interactive</publisher>
 		<info name="serial" value="DMG-AAFP-UKV"/>
@@ -21521,7 +20575,7 @@ license:CC0
 
 	<software name="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Europe, English / French / German / Italian / Spanish)</description>
+		<description>Thunderbirds (Euro, English / French / German / Italian / Spanish)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNX-EUR"/>
@@ -21538,7 +20592,7 @@ license:CC0
 
 	<software name="tbirdsa" cloneof="tbirds">
 		<!-- Notes: GBC only -->
-		<description>Thunderbirds (Europe)</description>
+		<description>Thunderbirds (Euro)</description>
 		<year>2000</year>
 		<publisher>SCI</publisher>
 		<info name="serial" value="CGB-BTNP-UKV"/>
@@ -21551,7 +20605,7 @@ license:CC0
 	</software>
 
 	<software name="twoods2k">
-		<description>Tiger Woods PGA Tour 2000 (Europe, USA)</description>
+		<description>Tiger Woods PGA Tour 2000 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYGE-USA, DMG-AYGP-EUR"/>
@@ -21568,7 +20622,7 @@ license:CC0
 
 	<software name="tintin">
 		<!-- Notes: GBC only -->
-		<description>Tintin in Tibet (Europe)</description>
+		<description>Tintin in Tibet (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Tintin au Tibet (Box)"/>
@@ -21583,7 +20637,7 @@ license:CC0
 
 	<software name="ttoonbsd">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Buster Saves the Day (Europe)</description>
+		<description>Tiny Toon Adventures - Buster Saves the Day (Euro)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BUSP-EUR"/>
@@ -21611,11 +20665,10 @@ license:CC0
 
 	<software name="ttoondiz">
 		<!-- Notes: GBC only -->
-		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Europe)</description>
+		<description>Tiny Toon Adventures - Dizzy's Candy Quest (Euro)</description>
 		<year>2001</year>
 		<publisher>Swing! Entertainment Media</publisher>
 		<info name="serial" value="CGB-BDQP-EUR"/>
-		<info name="gold" value="20010529"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21626,7 +20679,7 @@ license:CC0
 
 	<software name="titi" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Titi - Le Tour du Monde en 80 Chats (France)</description>
+		<description>Titi - Le Tour du Monde en 80 Chats (Fra)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWF-FRA"/>
@@ -21641,7 +20694,7 @@ license:CC0
 	</software>
 
 	<software name="titus">
-		<description>Titus the Fox to Marrakech and Back (Europe)</description>
+		<description>Titus the Fox to Marrakech and Back (Euro)</description>
 		<year>2000</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="DMG-BFXP-EUR"/>
@@ -21671,7 +20724,6 @@ license:CC0
 		<year>1999</year>
 		<publisher>ASC Games</publisher>
 		<info name="serial" value="DMG-AFCE-USA"/>
-		<info name="gold" value="19990917"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21684,7 +20736,7 @@ license:CC0
 
 	<software name="toca">
 		<!-- Notes: GBC only -->
-		<description>TOCA Touring Car Championship (Europe, USA)</description>
+		<description>TOCA Touring Car Championship (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTCE-USA, CGB-BTCP-EUR"/>
@@ -21698,7 +20750,7 @@ license:CC0
 
 	<software name="tokitori">
 		<!-- Notes: GBC only -->
-		<description>Toki Tori (Europe, USA)</description>
+		<description>Toki Tori (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-B2TE-USA, CGB-B2TP-EUR"/>
@@ -21713,14 +20765,14 @@ license:CC0
 	</software>
 
 	<software name="tokimclt">
-		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Tokimeki Memorial Pocket - Culture Hen - Komorebi no Melody (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AC7J-JPN (RK172-J1)"/>
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET カルチャー編 〜木漏れ日のメロディ〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - culture hen - komorebi no melody (japan).bin" size="4194304" crc="4be4a8ed" sha1="0f64c4afe74b6cfd693b6c65f0168dcb26224443"/>
@@ -21731,14 +20783,14 @@ license:CC0
 	</software>
 
 	<software name="tokimspt">
-		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Tokimeki Memorial Pocket - Sport Hen - Koutei no Photograph (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AS7J-JPN (RK171-J1)"/>
 		<info name="release" value="19990211"/>
 		<info name="alt_title" value="ときめきメモリアルPOCKET スポーツ編 〜桜庭のフォトグラフ〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="tokimeki memorial pocket - sport hen - koutei no photograph (japan).bin" size="4194304" crc="78e14fa9" sha1="ce39fcf903bb3b0529205cab4a412bfa0e8a2ebf"/>
@@ -21749,7 +20801,7 @@ license:CC0
 	</software>
 
 	<software name="tokoro">
-		<description>Tokoro-san no Setagaya C.C. (Japan)</description>
+		<description>Tokoro-san no Setagaya C.C. (Jpn)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="DMG-BGBJ-JPN"/>
@@ -21769,7 +20821,7 @@ license:CC0
 
 	<software name="tomjerry">
 		<!-- Notes: GBC only -->
-		<description>Tom &amp; Jerry (Europe, USA)</description>
+		<description>Tom &amp; Jerry (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-ATXE-USA, CGB-ATXP-EUR"/>
@@ -21786,31 +20838,14 @@ license:CC0
 
 	<software name="tomjermh">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry - Mousehunt (Europe)</description>
+		<description>Tom and Jerry - Mousehunt (Euro)</description>
 		<year>2001</year>
 		<publisher>Conspiracy Entertainment</publisher>
 		<info name="serial" value="CGB-BTJP-EUR"/>
-		<info name="gold" value="20000928"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="tom and jerry - mousehunt (europe) (en,fr,de,es,it).bin" size="1048576" crc="3e17d04a" sha1="6f837075d7493adcbd5b18ba1e27386b6fc31e62"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tomjermha" cloneof="tomjermh">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbtjp1.487"	-->
-		<description>Tom and Jerry - Mousehunt (Europe, Rev. 1)</description>
-		<year>2001</year>
-		<publisher>Conspiracy Entertainment</publisher>
-		<info name="serial" value="CGB-BTJP-EUR"/>
-		<info name="gold" value="20010223"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbtjp1.487" size="1048576" crc="4b4553e0" sha1="bf5faf4c5c2aabe9636f8f5afbbf526aba59e21d"/>
 			</dataarea>
 		</part>
 	</software>
@@ -21829,25 +20864,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tomjermhua" cloneof="tomjermh">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbtqe1.541"	-->
-		<description>Tom and Jerry - Mousehunt (USA, Rev. 1)</description>
-		<year>2001</year>
-		<publisher>Conspiracy Entertainment</publisher>
-		<info name="serial" value="CGB-BTJE-USA?"/>
-		<info name="gold" value="20010129"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbbtqe1.541" size="2097152" crc="ce4ca7b1" sha1="89374d81045a3bedf24e42b58ce403b0a5fbcddb"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="tomjerma">
 		<!-- Notes: GBC only -->
-		<description>Tom and Jerry in Mouse Attacks! (Europe)</description>
+		<description>Tom and Jerry in Mouse Attacks! (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BTQP-EUR"/>
@@ -21865,7 +20884,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BTQE-USA"/>
-		<info name="gold" value="20001020"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -21876,7 +20894,7 @@ license:CC0
 
 	<software name="rainbow6">
 		<!-- Notes: GBC only -->
-		<description>Tom Clancy's Rainbow Six (Europe, USA)</description>
+		<description>Tom Clancy's Rainbow Six (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>SouthPeak Games</publisher>
 		<info name="serial" value="CGB-AR6E-USA, CGB-AR6P-EUR"/>
@@ -21898,7 +20916,7 @@ license:CC0
 
 	<software name="traid">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider (Europe, USA)</description>
+		<description>Tomb Raider (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<info name="alt_title" value="Tomb Raider Starring Lara Croft (US Box)"/>
@@ -21920,7 +20938,7 @@ license:CC0
 	</software>
 
 	<software name="traidp" cloneof="traid">
-		<description>Tomb Raider (Europe, USA, Prototype)</description>
+		<description>Tomb Raider (Euro, USA, Prototype)</description>
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -21935,7 +20953,7 @@ license:CC0
 
 	<software name="traid2">
 		<!-- Notes: GBC only -->
-		<description>Tomb Raider - Curse of the Sword (Europe, USA)</description>
+		<description>Tomb Raider - Curse of the Sword (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="alt_title" value="Lara Croft - Tomb Raider - Curse of the Sword (Box)"/>
@@ -21958,7 +20976,7 @@ license:CC0
 
 	<software name="tonictr">
 		<!-- Notes: GBC only -->
-		<description>Tonic Trouble (Europe)</description>
+		<description>Tonic Trouble (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-AXTP-EUR"/>
@@ -21976,7 +20994,6 @@ license:CC0
 		<year>2002</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BCZE-USA"/>
-		<info name="gold" value="20020411"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -21987,7 +21004,7 @@ license:CC0
 
 	<software name="tonkarac">
 		<!-- Notes: GBC only -->
-		<description>Tonka Raceway (Europe)</description>
+		<description>Tonka Raceway (Euro)</description>
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<info name="serial" value="CGB-ATQP-EUR"/>
@@ -22037,11 +21054,10 @@ license:CC0
 
 	<software name="thps">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater (Europe, USA)</description>
+		<description>Tony Hawk's Pro Skater (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTFE-USA-1, CGB-BTFP-EUR"/>
-		<info name="gold" value="20000201"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A07-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -22055,7 +21071,7 @@ license:CC0
 
 	<software name="thps2">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 2 (Europe, USA)</description>
+		<description>Tony Hawk's Pro Skater 2 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BTGE-USA, CGB-BTGE-USA-1, CGB-BTGP-EUR"/>
@@ -22072,7 +21088,7 @@ license:CC0
 
 	<software name="thps3">
 		<!-- Notes: GBC only -->
-		<description>Tony Hawk's Pro Skater 3 (Europe, USA)</description>
+		<description>Tony Hawk's Pro Skater 3 (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-B3TE-USA, CGB-B3TP-EUR"/>
@@ -22108,7 +21124,7 @@ license:CC0
 
 	<software name="toonsylv">
 		<!-- Notes: GBC only -->
-		<description>Toonsylvania (Europe)</description>
+		<description>Toonsylvania (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BSYP-EUR"/>
@@ -22136,7 +21152,7 @@ license:CC0
 
 	<software name="tootuff">
 		<!-- Notes: GBC only -->
-		<description>Tootuff (Europe)</description>
+		<description>Tootuff (Euro)</description>
 		<year>2001</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BT9P-UKV"/>
@@ -22150,7 +21166,7 @@ license:CC0
 
 	<software name="topgearj" cloneof="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket (Japan)</description>
+		<description>Top Gear Pocket (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRJ-JPN"/>
@@ -22186,11 +21202,10 @@ license:CC0
 
 	<software name="topgear2j" cloneof="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Pocket 2 (Japan)</description>
+		<description>Top Gear Pocket 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-V33J-JPN"/>
-		<info name="gold" value="19991028"/>
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="トップギア・ポケット2"/>
 		<part name="cart" interface="gameboy_cart">
@@ -22208,9 +21223,8 @@ license:CC0
 		<!-- Notes: GBC only -->
 		<description>Top Gear Pocket 2 (USA)</description>
 		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
+		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33E-USA"/>
-		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22221,10 +21235,9 @@ license:CC0
 		</part>
 	</software>
 
-
 	<software name="tgrally">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally (Europe)</description>
+		<description>Top Gear Rally (Euro)</description>
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-VGRP-(NOE/UKV)"/>
@@ -22239,11 +21252,10 @@ license:CC0
 
 	<software name="tgrally2">
 		<!-- Notes: GBC only -->
-		<description>Top Gear Rally 2 (Europe)</description>
+		<description>Top Gear Rally 2 (Euro)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-A33P-(EUR/FRA)"/>
-		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -22256,7 +21268,7 @@ license:CC0
 
 	<software name="topgunfs">
 		<!-- Notes: GBC only -->
-		<description>Top Gun - Fire Storm (Europe, USA)</description>
+		<description>Top Gun - Fire Storm (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BICE-USA, CGB-BICP-EUR"/>
@@ -22273,7 +21285,7 @@ license:CC0
 
 	<software name="totalscr">
 		<!-- Notes: GBC only -->
-		<description>Total Soccer 2000 (Europe)</description>
+		<description>Total Soccer 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="alt_title" value="David O'Leary's Total Soccer 2000 (Box)"/>
@@ -22289,14 +21301,14 @@ license:CC0
 	</software>
 
 	<software name="totsuge">
-		<description>Totsugeki! Papparatai (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Totsugeki! Papparatai (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-WIng</publisher>
 		<info name="serial" value="DMG-APHJ-JPN"/>
 		<info name="release" value="20000310"/>
 		<info name="alt_title" value="突撃!パッパラ隊"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
 				<rom name="totsugeki papparatai (japan).bin" size="4194304" crc="0aeae8fb" sha1="4c98beab325cd058445102c85d30b3724325f2ce"/>
@@ -22308,7 +21320,7 @@ license:CC0
 
 	<software name="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan, Rev. 1)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22324,7 +21336,7 @@ license:CC0
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="1048576">
-				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev 1).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
+				<rom name="tottoko hamutarou - tomodachi daisakusen dechu (japan) (rev a).bin" size="1048576" crc="d549e074" sha1="369f53d1a8bc7e6f2d1ccd101e648c2744c39fc5"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -22333,7 +21345,7 @@ license:CC0
 
 	<software name="tottokha" cloneof="tottokh">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Japan)</description>
+		<description>Tottoko Hamutarou - Tomodachi Daisakusen Dechu (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-BHTJ-JPN"/>
@@ -22352,7 +21364,7 @@ license:CC0
 
 	<software name="tottokh2" cloneof="hamtaro">
 		<!-- Notes: GBC only -->
-		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Japan)</description>
+		<description>Tottoko Hamutarou 2 - Hamu-chan Zu Daishuugou Dechu (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-B86J-JPN"/>
@@ -22370,7 +21382,7 @@ license:CC0
 
 	<software name="towers">
 		<!-- Notes: GBC only -->
-		<description>Towers - Lord Baniff's Deceit (Europe, USA)</description>
+		<description>Towers - Lord Baniff's Deceit (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="CGB-ALHE-USA, CGB-ALHP-EUR"/>
@@ -22385,7 +21397,7 @@ license:CC0
 	</software>
 
 	<software name="toystor2">
-		<description>Toy Story 2 (Europe, USA)</description>
+		<description>Toy Story 2 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AOQE-USA, DMG-AOQP-(FRA/UKV)"/>
@@ -22402,7 +21414,7 @@ license:CC0
 
 	<software name="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Europe)</description>
+		<description>Toy Story Racer (Euro)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5X-EUU"/>
@@ -22416,7 +21428,7 @@ license:CC0
 
 	<software name="toystracu" cloneof="toystrac">
 		<!-- Notes: GBC only -->
-		<description>Toy Story Racer (Europe, USA)</description>
+		<description>Toy Story Racer (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BT5E-USA, CGB-BT5P-EUR"/>
@@ -22431,37 +21443,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="tradebata">
-		<!--	Never released as physical cartridge	-->
-		<!--	Released on the 3DS Virtual Console	-->
-		<!--	In lot check as "KENSA\dmgahhj1.1"	-->
-		<description>Trade &amp; Battle Card Hero (Japan, Rev. 1)</description>
+	<software name="tradebat">
+		<!-- Notes: SGB enhanced -->
+		<description>Trade &amp; Battle Card Hero (Jpn)</description>
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AHHJ-JPN"/>
-		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc3" />
-			<feature name="rtc" value="yes" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmgahhj1.1" size="2097152" crc="d98a877d" sha1="c6c1e0365166b53d25a1f84bc380948a9661df30"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="tradebat" cloneof="tradebata">
-		<description>Trade &amp; Battle Card Hero (Japan)</description>
-		<year>2000</year>
-		<publisher>Nintendo</publisher>
-		<info name="serial" value="DMG-AHHJ-JPN"/>
-		<info name="gold" value="20000111"/>
 		<info name="release" value="20000221"/>
 		<info name="alt_title" value="トレード&amp;バトル カードヒーロー"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc3" />
 			<feature name="rtc" value="yes" />
 			<dataarea name="rom" size="2097152">
@@ -22474,7 +21464,7 @@ license:CC0
 
 	<software name="trickbrd">
 		<!-- Notes: GBC only -->
-		<description>Trick Boarder (Europe)</description>
+		<description>Trick Boarder (Euro)</description>
 		<year>2000</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BTBP-EUR"/>
@@ -22505,7 +21495,7 @@ license:CC0
 
 	<software name="trickbrdj" cloneof="trickbrd">
 		<!-- Notes: GBC only, also released by NP in 2000-12 -->
-		<description>Trickboarder GP (Japan)</description>
+		<description>Trickboarder GP (Jpn)</description>
 		<year>2000</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-BTBJ-JPN"/>
@@ -22521,7 +21511,7 @@ license:CC0
 
 	<software name="tplay2k1">
 		<!-- Notes: GBC only -->
-		<description>Triple Play 2001 (Europe, USA)</description>
+		<description>Triple Play 2001 (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BTPE-USA, CGB-BTPP-EUR"/>
@@ -22551,15 +21541,14 @@ license:CC0
 	</software>
 
 	<software name="tsurisn2">
-		<description>Tsuri Sensei 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Tsuri Sensei 2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="DMG-AF2J-JPN"/>
-		<info name="gold" value="19990624"/>
 		<info name="release" value="19990723"/>
-		<info name="alt_title" value="昆虫博士 ２"/>
+		<info name="alt_title" value="昆虫博士2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<!-- PCB documentation incomplete, based on bad pics or written docs -->
 			<feature name="pcb" value="DMG-A03-01" />
 			<feature name="slot" value="rom_mbc5" />
@@ -22570,30 +21559,10 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
-	
-	<software name="tsurisn2a" cloneof="tsurisn2">
-		<!--	In lot check as "dmga2kj1.g93"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Tsuri Sensei 2 (Japan, Rev. 1)</description>
-		<year>1999</year>
-		<publisher>J-Wing</publisher>
-		<info name="serial" value="DMG-AF2J-JPN?"/>
-		<info name="gold" value="19990908"/>
-		<info name="alt_title" value="昆虫博士 ２"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="dmga2kj1.g93" size="2097152" crc="d390430e" sha1="59fa1707247f12b0c48eeb2e8fec274b9231d968"/>
-			</dataarea>
-			<dataarea name="nvram" size="32768">
-			</dataarea>
-		</part>
-	</software>
 
 	<software name="tsuriiko">
 		<!-- Notes: GBC only -->
-		<description>Tsuriiko!! (Japan)</description>
+		<description>Tsuriiko!! (Jpn)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BAFJ-JPN"/>
@@ -22610,7 +21579,7 @@ license:CC0
 	</software>
 
 	<software name="turok2">
-		<description>Turok 2 - Seeds of Evil (Europe, USA)</description>
+		<description>Turok 2 - Seeds of Evil (Euro, USA)</description>
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="DMG-A2TE-USA, DMG-A2TP-EUR"/>
@@ -22626,7 +21595,7 @@ license:CC0
 	</software>
 
 	<software name="turok2j" cloneof="turok2">
-		<description>Turok 2 - Seeds of Evil (Japan)</description>
+		<description>Turok 2 - Seeds of Evil (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="DMG-A2TJ-JPN"/>
@@ -22642,7 +21611,7 @@ license:CC0
 
 	<software name="turok3">
 		<!-- Notes: GBC only -->
-		<description>Turok 3 - Shadow of Oblivion (Europe, USA)</description>
+		<description>Turok 3 - Shadow of Oblivion (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-BT3E-USA, CGB-BT3P-EUR"/>
@@ -22659,8 +21628,7 @@ license:CC0
 
 	<software name="turokrag">
 		<!-- Notes: GBC only -->
-		<!--	Retail cartridge of Australian version not yet secured, does it exist?	-->
-		<description>Turok - Rage Wars (Europe, Australia, USA)</description>
+		<description>Turok - Rage Wars (Euro, Aus, USA)</description>
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AR7E-USA, CGB-AR7P-(EUR/AUS)"/>
@@ -22677,7 +21645,7 @@ license:CC0
 
 	<software name="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Europe, English / German / Spanish / Italian)</description>
+		<description>Tweenies - Doodles' Bones (Euro, English / German / Spanish / Italian)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZP-UKV"/>
@@ -22691,7 +21659,7 @@ license:CC0
 
 	<software name="tweeniesds" cloneof="tweenies">
 		<!-- Notes: GBC only -->
-		<description>Tweenies - Doodles' Bones (Europe, English / Dutch / Swedish / Norwegian / Danish)</description>
+		<description>Tweenies - Doodles' Bones (Euro, English / Dutch / Swedish / Norwegian / Danish)</description>
 		<year>2001</year>
 		<publisher>BBC Multimedia</publisher>
 		<info name="serial" value="CGB-B2ZX-HOL"/>
@@ -22708,7 +21676,7 @@ license:CC0
 
 	<software name="tweetyj" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Japan)</description>
+		<description>Tweety Sekaiisshuu - 80 Hiki no Neko o Sagase! (Jpn)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWJ-JPN"/>
@@ -22726,7 +21694,7 @@ license:CC0
 
 	<software name="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Europe, English / Spanish / Italian)</description>
+		<description>Tweety's High-Flying Adventure (Euro, English / Spanish / Italian)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWY-EUU-1"/>
@@ -22748,7 +21716,7 @@ license:CC0
 
 	<software name="tweetya" cloneof="tweety">
 		<!-- Notes: GBC only -->
-		<description>Tweety's High-Flying Adventure (Europe, English / French / German)</description>
+		<description>Tweety's High-Flying Adventure (Euro, English / French / German)</description>
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<info name="serial" value="CGB-BTWX-UKV-1"/>
@@ -22816,7 +21784,7 @@ license:CC0
 
 	<software name="rpgtsuk2">
 		<!-- Notes: GBC only -->
-		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Japan)</description>
+		<description>Uchuujin Tanaka Tarou de RPG Tsukuru GB2 (Jpn)</description>
 		<year>2001</year>
 		<publisher>Enterbrain</publisher>
 		<info name="serial" value="CGB-B3QJ-JPN"/>
@@ -22834,7 +21802,7 @@ license:CC0
 
 	<software name="uefa2k">
 		<!-- Notes: GBC only -->
-		<description>UEFA 2000 (Europe)</description>
+		<description>UEFA 2000 (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-BUEP-(EUR/NOE/FRA/UKV)"/>
@@ -22850,7 +21818,7 @@ license:CC0
 
 	<software name="ufc">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Fighting Championship (Europe)</description>
+		<description>Ultimate Fighting Championship (Euro)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BUCP-EUR-1"/>
@@ -22881,7 +21849,7 @@ license:CC0
 
 	<software name="ultpaint">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Paint Ball (Europe, USA)</description>
+		<description>Ultimate Paint Ball (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Majesco</publisher>
 		<info name="serial" value="CGB-BUPE-USA, CGB-BUPP-EUR"/>
@@ -22895,7 +21863,7 @@ license:CC0
 
 	<software name="ultsurf">
 		<!-- Notes: GBC only -->
-		<description>Ultimate Surfing (Europe)</description>
+		<description>Ultimate Surfing (Euro)</description>
 		<year>2001</year>
 		<publisher>Natsume</publisher>
 		<info name="serial" value="CGB-BSUP-EUR"/>
@@ -22925,7 +21893,7 @@ license:CC0
 	</software>
 
 	<software name="uno">
-		<description>Uno (Europe)</description>
+		<description>Uno (Euro)</description>
 		<year>2000</year>
 		<publisher>Mattel Media</publisher>
 		<info name="serial" value="DMG-AUNP-EUR"/>
@@ -22952,7 +21920,7 @@ license:CC0
 
 	<software name="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Europe)</description>
+		<description>V-Rally - Championship Edition (Euro)</description>
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AVYP-NOE"/>
@@ -22966,7 +21934,7 @@ license:CC0
 
 	<software name="vrallyj" cloneof="vrally">
 		<!-- Notes: GBC only -->
-		<description>V-Rally - Championship Edition (Japan)</description>
+		<description>V-Rally - Championship Edition (Jpn)</description>
 		<year>1999</year>
 		<publisher>Spike</publisher>
 		<info name="serial" value="CGB-AVJJ-JPN"/>
@@ -22997,11 +21965,10 @@ license:CC0
 
 	<software name="vegas">
 		<!-- Notes: GBC only -->
-		<description>Vegas Games (Europe)</description>
+		<description>Vegas Games (Euro)</description>
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFP-EUR"/>
-		<info name="gold" value="20000221"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -23016,7 +21983,6 @@ license:CC0
 		<year>2000</year>
 		<publisher>3DO</publisher>
 		<info name="serial" value="CGB-AVFE-USA"/>
-		<info name="gold" value="19991203"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -23048,7 +22014,7 @@ license:CC0
 		<!-- The US box of V.I.P usually contains the european cart. This was also shown on a youtube unboxing video with a sealed copy. Therefore the dump is labeled USA + Europe.
 		But recently it was discovered some boxes also contain a real US shaped cart (see vipu below). -->
 		<!-- Notes: GBC only -->
-		<description>VIP (Europe, USA)</description>
+		<description>VIP (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="CGB-BVIE-USA, CGB-BVIP-EUR"/>
@@ -23078,7 +22044,7 @@ license:CC0
 	</software>
 
 	<software name="visiteur">
-		<description>Les Visiteurs (France)</description>
+		<description>Les Visiteurs (Fra)</description>
 		<year>1999</year>
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="DMG-AVGF-FRA"/>
@@ -23090,30 +22056,12 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="vrspower">
-		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbbpbe0.340"	-->
-		<!--	Retail cartridge not yet secured, might be unreleased	-->
-		<description>VR Sports Powerboat Racing (USA)</description>
-		<year>2000</year>
-		<publisher>Vatical Entertainment</publisher>
-		<info name="serial" value="CGB-BPBE-USA?"/>
-		<info name="gold" value="20000727"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="1048576">
-				<rom name="cgbbpbe0.340" size="1048576" crc="cff671f1" sha1="1c77f032cdd373bfa108ea82c463f8f9f6874c71"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="vslemmin" cloneof="lemmings">
 		<!-- Notes: GBC only -->
-		<description>VS Lemmings (Japan)</description>
+		<description>VS Lemmings (Jpn)</description>
 		<year>2000</year>
 		<publisher>J-Wing</publisher>
 		<info name="serial" value="CGB-ALEJ-JPN"/>
-		<info name="gold" value="20000225"/>
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="VSレミングス"/>
 		<part name="cart" interface="gameboy_cart">
@@ -23128,7 +22076,7 @@ license:CC0
 
 	<software name="wackyrac">
 		<!-- Notes: GBC only -->
-		<description>Wacky Races (Europe)</description>
+		<description>Wacky Races (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AW9P-(NOE/UKV)"/>
@@ -23156,7 +22104,7 @@ license:CC0
 
 	<software name="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Europe, USA)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDE-USA, CGB-BWDP-UKV"/>
@@ -23173,7 +22121,7 @@ license:CC0
 
 	<software name="magraceta" cloneof="magracet">
 		<!-- Notes: GBC only -->
-		<description>Walt Disney World Quest - Magical Racing Tour (Europe)</description>
+		<description>Walt Disney World Quest - Magical Racing Tour (Euro)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWDX-EUR"/>
@@ -23190,7 +22138,7 @@ license:CC0
 
 	<software name="warauinu">
 		<!-- Notes: GBC only -->
-		<description>Warau Inu no Bouken - Silly Go Lucky! (Japan)</description>
+		<description>Warau Inu no Bouken - Silly Go Lucky! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CGB-BWBJ-JPN"/>
@@ -23213,14 +22161,14 @@ license:CC0
 	</software>
 
 	<software name="wario2j" cloneof="wario2">
-		<description>Wario Land 2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Wario Land 2 (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AW2J-JPN"/>
 		<info name="release" value="19981021"/>
 		<info name="alt_title" value="ワリオランド2ワリオランド2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="wario land 2 (japan).bin" size="2097152" crc="b30fdbf5" sha1="cd6266e48df816219fb38d223b0ec6760259616d"/>
@@ -23256,7 +22204,7 @@ license:CC0
 
 	<software name="wario2">
 		<!-- Notes: GBC only -->
-		<description>Wario Land II (Europe, USA)</description>
+		<description>Wario Land II (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AWLE-USA, DMG-AWLP-EUR"/>
@@ -23310,7 +22258,7 @@ license:CC0
 
 	<software name="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Japan, Rev. 1)</description>
+		<description>Watashi no Kitchen (Jpn, Rev. A)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23319,7 +22267,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="watashi no kitchen (japan) (rev 1).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
+				<rom name="watashi no kitchen (japan) (rev a).bin" size="1048576" crc="584669e4" sha1="effd0d198bac35abee1a8a6481382a1f2b14ead3"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -23328,7 +22276,7 @@ license:CC0
 
 	<software name="watashika" cloneof="watashik">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Kitchen (Japan)</description>
+		<description>Watashi no Kitchen (Jpn)</description>
 		<year>2001</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BKRJ-JPN"/>
@@ -23352,11 +22300,10 @@ license:CC0
 
 	<software name="watashir">
 		<!-- Notes: GBC only -->
-		<description>Watashi no Restaurant (Japan)</description>
+		<description>Watashi no Restaurant (Jpn)</description>
 		<year>2002</year>
 		<publisher>Kirat</publisher>
 		<info name="serial" value="CGB-BWNJ-JPN"/>
-		<info name="gold" value="20020322"/>
 		<info name="release" value="20020426"/>
 		<info name="alt_title" value="わたしのレストラン"/>
 		<part name="cart" interface="gameboy_cart">
@@ -23371,7 +22318,7 @@ license:CC0
 
 	<software name="wcwmayhm">
 		<!-- Notes: GBC only -->
-		<description>WCW Mayhem (Europe, USA)</description>
+		<description>WCW Mayhem (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="CGB-AYHE-USA, CGB-AYHP-NOE"/>
@@ -23388,7 +22335,7 @@ license:CC0
 
 	<software name="wendy">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Every Witch Way (Europe, USA)</description>
+		<description>Wendy - Every Witch Way (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWGE-USA, CGB-BWGP-EUR"/>
@@ -23405,11 +22352,10 @@ license:CC0
 
 	<software name="wendydta">
 		<!-- Notes: GBC only -->
-		<description>Wendy - Der Traum von Arizona (Germany)</description>
+		<description>Wendy - Der Traum von Arizona (Ger)</description>
 		<year>2000</year>
 		<publisher>TDK Mediactive</publisher>
 		<info name="serial" value="CGB-BWYD-NOE"/>
-		<info name="gold" value="20021120"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -23420,7 +22366,7 @@ license:CC0
 
 	<software name="wetrix">
 		<!-- Notes: GBC only -->
-		<description>Wetrix GB (Europe)</description>
+		<description>Wetrix GB (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="alt_title" value="Wetrix (Box)"/>
@@ -23434,14 +22380,14 @@ license:CC0
 	</software>
 
 	<software name="wetrixj" cloneof="wetrix">
-		<description>Wetrix GB (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Wetrix GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Imagineer</publisher>
 		<info name="serial" value="DMG-AW5J-JPN"/>
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="ウエットリスGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="wetrix gb (japan).bin" size="1048576" crc="6215c5b3" sha1="92944052b6e4448abf0103f085998662e0140825"/>
@@ -23478,7 +22424,7 @@ license:CC0
 	</software>
 
 	<software name="wingfury">
-		<description>Wings of Fury (Europe)</description>
+		<description>Wings of Fury (Euro)</description>
 		<year>1999</year>
 		<publisher>Red Orb Entertainment</publisher>
 		<info name="serial" value="DMG-AFXP-EUR"/>
@@ -23505,7 +22451,7 @@ license:CC0
 
 	<software name="poohadv">
 		<!-- Notes: GBC only -->
-		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Europe)</description>
+		<description>Winnie the Pooh - Adventures in the 100 Acre Wood (Euro)</description>
 		<year>2000</year>
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="CGB-BPOP-EUR-1"/>
@@ -23537,7 +22483,7 @@ license:CC0
 
 	<software name="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Japan, Rev. 1)</description>
+		<description>Wizardry Empire (Jpn, Rev. A)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23546,7 +22492,7 @@ license:CC0
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="wizardry empire (japan) (rev 1).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
+				<rom name="wizardry empire (japan) (rev a).bin" size="1048576" crc="fa82620f" sha1="f5f4e8bead0fe45075141133a530a0eb116ea78c"/>
 			</dataarea>
 			<dataarea name="nvram" size="8192">
 			</dataarea>
@@ -23555,7 +22501,7 @@ license:CC0
 
 	<software name="wizardema" cloneof="wizardem">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire (Japan)</description>
+		<description>Wizardry Empire (Jpn)</description>
 		<year>1999</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-AEWJ-JPN"/>
@@ -23573,7 +22519,7 @@ license:CC0
 
 	<software name="wizarde2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry Empire - Fukkatsu no Tsue (Japan)</description>
+		<description>Wizardry Empire - Fukkatsu no Tsue (Jpn)</description>
 		<year>2000</year>
 		<publisher>Starfish</publisher>
 		<info name="serial" value="CGB-BFTJ-JPN"/>
@@ -23591,7 +22537,7 @@ license:CC0
 
 	<software name="wizardry">
 		<!-- Notes: GBC only -->
-		<description>Wizardry I - Proving Grounds of the Mad Overlord (Japan)</description>
+		<description>Wizardry I - Proving Grounds of the Mad Overlord (Jpn)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BWIJ-JPN"/>
@@ -23609,7 +22555,7 @@ license:CC0
 
 	<software name="wizardr2">
 		<!-- Notes: GBC only -->
-		<description>Wizardry II - Llylgamyn no Isan (Japan)</description>
+		<description>Wizardry II - Llylgamyn no Isan (Jpn)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW2J-JPN"/>
@@ -23627,7 +22573,7 @@ license:CC0
 
 	<software name="wizardr3">
 		<!-- Notes: GBC only -->
-		<description>Wizardry III - Diamond no Kishi (Japan)</description>
+		<description>Wizardry III - Diamond no Kishi (Jpn)</description>
 		<year>2001</year>
 		<publisher>ASCII</publisher>
 		<info name="serial" value="CGB-BW3J-JPN"/>
@@ -23645,7 +22591,7 @@ license:CC0
 
 	<software name="woody">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker (Europe)</description>
+		<description>Woody Woodpecker (Euro)</description>
 		<year>2001</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BWPP-EUR"/>
@@ -23673,7 +22619,7 @@ license:CC0
 
 	<software name="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker Racing (Europe)</description>
+		<description>Woody Woodpecker Racing (Euro)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRP-EUR"/>
@@ -23695,7 +22641,7 @@ license:CC0
 
 	<software name="woodyracj" cloneof="woodyrac">
 		<!-- Notes: GBC only -->
-		<description>Woody Woodpecker no Go! Go! Racing (Japan)</description>
+		<description>Woody Woodpecker no Go! Go! Racing (Jpn)</description>
 		<year>2001</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWRJ-JPN (RK225-J1)"/>
@@ -23743,7 +22689,7 @@ license:CC0
 
 	<software name="wsoccr2k" cloneof="iss2k">
 		<!-- Notes: GBC only -->
-		<description>World Soccer GB 2000 (Japan)</description>
+		<description>World Soccer GB 2000 (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BWSJ-JPN (RK200-J1)"/>
@@ -23760,14 +22706,14 @@ license:CC0
 	</software>
 
 	<software name="wsoccer2" cloneof="iss99">
-		<description>World Soccer GB2 (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>World Soccer GB2 (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AWZJ-JPN (RK176-J1)"/>
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ワールドサッカーGB2"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="world soccer gb2 (japan).bin" size="1048576" crc="dd18db5f" sha1="b58c969510aab4930a1846d857f58d57ed342592"/>
@@ -23779,7 +22725,7 @@ license:CC0
 
 	<software name="wormsarm">
 		<!-- Notes: GBC only -->
-		<description>Worms Armageddon (Europe)</description>
+		<description>Worms Armageddon (Euro)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="CGB-AWUP-(UKV/NOE)"/>
@@ -23810,7 +22756,7 @@ license:CC0
 
 	<software name="wwfattit">
 		<!-- Notes: GBC only -->
-		<description>WWF Attitude (Europe, USA)</description>
+		<description>WWF Attitude (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="CGB-AWTE-USA, CGB-AWTP-EUR"/>
@@ -23827,7 +22773,7 @@ license:CC0
 
 	<software name="wwfbtray">
 		<!-- Notes: GBC only -->
-		<description>WWF Betrayal (Europe, USA)</description>
+		<description>WWF Betrayal (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="CGB-BWFE-USA, CGB-BWFP-EUR"/>
@@ -23843,7 +22789,7 @@ license:CC0
 	</software>
 
 	<software name="wmania2k">
-		<description>WWF WrestleMania 2000 (Europe, USA)</description>
+		<description>WWF WrestleMania 2000 (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AUWE-USA, DMG-AUWP-EUR"/>
@@ -23860,7 +22806,7 @@ license:CC0
 
 	<software name="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Europe, USA, Rev. 1)</description>
+		<description>X-Men - Mutant Academy (Euro, USA, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-NOE"/>
@@ -23877,7 +22823,7 @@ license:CC0
 
 	<software name="xmenma1" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Europe, USA)</description>
+		<description>X-Men - Mutant Academy (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXAE-USA, CGB-BXAP-UKV"/>
@@ -23894,7 +22840,7 @@ license:CC0
 
 	<software name="xmenmaj" cloneof="xmenma">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Academy (Japan)</description>
+		<description>X-Men - Mutant Academy (Jpn)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BXAJ-JPN"/>
@@ -23910,7 +22856,7 @@ license:CC0
 
 	<software name="xmenmw">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Mutant Wars (Europe, USA)</description>
+		<description>X-Men - Mutant Wars (Euro, USA)</description>
 		<year>2000</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BXME-USA, CGB-BXMP-EUR"/>
@@ -23927,7 +22873,7 @@ license:CC0
 
 	<software name="wolvrage">
 		<!-- Notes: GBC only -->
-		<description>X-Men - Wolverine's Rage (Europe)</description>
+		<description>X-Men - Wolverine's Rage (Euro)</description>
 		<year>2001</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CGB-BWOP-EUR"/>
@@ -23958,7 +22904,7 @@ license:CC0
 
 	<software name="xena">
 		<!-- Notes: GBC only -->
-		<description>Xena - Warrior Princess (Europe, USA)</description>
+		<description>Xena - Warrior Princess (Euro, USA)</description>
 		<year>2001</year>
 		<publisher>Titus</publisher>
 		<info name="serial" value="CGB-BXWE-USA, CGB-BXWP-EUR"/>
@@ -23990,11 +22936,10 @@ license:CC0
 
 	<software name="xtremew">
 		<!-- Notes: GBC only -->
-		<description>Xtreme Wheels (Europe)</description>
+		<description>Xtreme Wheels (Euro)</description>
 		<year>2001</year>
-		<publisher>Spike</publisher>
+		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BXCP-EUR"/>
-		<info name="gold" value="20000922"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -24011,7 +22956,6 @@ license:CC0
 		<year>2001</year>
 		<publisher>BAM! Entertainment</publisher>
 		<info name="serial" value="CGB-BXCE-USA"/>
-		<info name="gold" value="20010307"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -24024,29 +22968,7 @@ license:CC0
 
 	<software name="yakouchu">
 		<!-- Notes: GBC only -->
-		<!--	In lot check as "cgbaytj0.066"	-->
-		<!--	Retail cartridge not yet secured	-->
-		<description>Yakouchuu GB (Japan)</description>
-		<year>1999</year>
-		<publisher>Athena</publisher>
-		<info name="serial" value="CGB-AYTJ-JPN"/>
-		<info name="gold" value="19990924"/>
-		<info name="release" value="19991022"/>
-		<info name="alt_title" value="夜光虫GB"/>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
-			<dataarea name="rom" size="2097152">
-				<rom name="cgbaytj0.066" size="2097152" crc="e0a06018" sha1="a7efd41d0ad17892132788bd90cdfb9df6806a78"/>
-			</dataarea>
-			<dataarea name="nvram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="yakouchuunk" cloneof="yakouchu">
-		<!-- Notes: GBC only -->
-		<!-- Old dump of unknown origin -->
-		<description>Yakouchuu GB (Japan, bad dump?)</description>
+		<description>Yakouchuu GB (Jpn)</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
 		<info name="serial" value="CGB-AYTJ-JPN"/>
@@ -24062,9 +22984,8 @@ license:CC0
 		</part>
 	</software>
 
-
 	<software name="yarsrev">
-		<description>Yars' Revenge (Europe, USA)</description>
+		<description>Yars' Revenge (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>Telegames</publisher>
 		<info name="serial" value="DMG-AYVE-USA, DMG-AYVP-EUR"/>
@@ -24077,7 +22998,7 @@ license:CC0
 	</software>
 
 	<software name="yodastor">
-		<description>Yoda Stories (Europe, USA)</description>
+		<description>Yoda Stories (Euro, USA)</description>
 		<year>1999</year>
 		<publisher>THQ</publisher>
 		<info name="serial" value="DMG-AYDE-USA, DMG-AYDP-EUR"/>
@@ -24105,11 +23026,10 @@ license:CC0
 
 	<software name="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Dark Duel Stories (Europe)</description>
+		<description>Yu-Gi-Oh! - Dark Duel Stories (Euro)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3P-EUR"/>
-		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
@@ -24128,11 +23048,10 @@ license:CC0
 
 	<software name="yugiddsf" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duel des Tenebres (France)</description>
+		<description>Yu-Gi-Oh! - Duel des Tenebres (Fra)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3F-FRA-1"/>
-		<info name="gold" value="20020906"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24151,11 +23070,10 @@ license:CC0
 
 	<software name="yugiddsg" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Das Dunkle Duell (Germany)</description>
+		<description>Yu-Gi-Oh! - Das Dunkle Duell (Ger)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3D-NOE"/>
-		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24174,11 +23092,10 @@ license:CC0
 
 	<software name="yugiddsi" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Racconti Oscuri (Italia)</description>
+		<description>Yu-Gi-Oh! - Racconti Oscuri (Ita)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3I-ITA"/>
-		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24197,11 +23114,10 @@ license:CC0
 
 	<software name="yugiddss" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spain)</description>
+		<description>Yu-Gi-Oh! - Duelo en las Tinieblas (Spa)</description>
 		<year>2003</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3S-ESP"/>
-		<info name="gold" value="20030116"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="pcb" value="DMG-A08-10" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
@@ -24224,8 +23140,6 @@ license:CC0
 		<year>2002</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3E-USA"/>
-		<info name="gold" value="20011217"/>
-		<info name="alt_title" value="Yu-Gi-Oh! Duel Monsters: Dark Duel Stories"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="4194304">
@@ -24237,16 +23151,14 @@ license:CC0
 	</software>
 
 	<software name="yugimcap">
-		<!-- Also released by NP in 2001-02-01 -->
-		<description>Yu-Gi-Oh! - Monster Capsule GB (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2001-02-01 -->
+		<description>Yu-Gi-Oh! - Monster Capsule GB (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYCJ-JPN (RK206-J1)"/>
-		<info name="gold" value="20000217"/>
 		<info name="release" value="20000413"/>
-		<info name="alt_title" value="遊戯王 モンスターカプセル ＧＢ"/>
+		<info name="alt_title" value="遊戯王 モンスターカプセルGB"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="yu-gi-oh - monster capsule gb (japan).bin" size="1048576" crc="1371e872" sha1="4ed5607dd83ebe7975c492b08d36870f8dd6e302"/>
@@ -24258,7 +23170,7 @@ license:CC0
 
 	<software name="yugidm4j">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Japan)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Jounouchi Deck (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY6J-JPN (RK228-J1)"/>
@@ -24282,7 +23194,7 @@ license:CC0
 
 	<software name="yugidm4k">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Japan)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Kaiba Deck (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY5J-JPN (RK229-J1)"/>
@@ -24300,7 +23212,7 @@ license:CC0
 
 	<software name="yugidm4y">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Japan)</description>
+		<description>Yu-Gi-Oh! Duel Monsters 4 - Saikyou Kettousha Senki - Yugi Deck (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY4J-JPN (RK227-J1)"/>
@@ -24323,14 +23235,14 @@ license:CC0
 	</software>
 
 	<software name="yugidm2">
-		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Yu-Gi-Oh! Duel Monsters II - Yamikai Kettouki - Dark Duel Stories (Jpn)</description>
 		<year>1999</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="DMG-AYKJ-JPN (RK188-J1)"/>
 		<info name="release" value="19990708"/>
 		<info name="alt_title" value="遊戯王デュエルモンスターズII 闇界決闘記"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A08-01" />
 			<feature name="u1" value="U1 16M/32M/64M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -24347,7 +23259,7 @@ license:CC0
 
 	<software name="yugidm3" cloneof="yugidds">
 		<!-- Notes: GBC only -->
-		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Japan)</description>
+		<description>Yu-Gi-Oh! Duel Monsters III - Sanseisenshin Kourin (Jpn)</description>
 		<year>2000</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="CGB-BY3J-JPN (RK211-J1)"/>
@@ -24390,7 +23302,7 @@ license:CC0
 
 	<software name="zeldadai">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Japan)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Daichi no Shou (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ7J-JPN"/>
@@ -24408,7 +23320,7 @@ license:CC0
 
 	<software name="zeldajik">
 		<!-- Notes: GBC only -->
-		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Japan)</description>
+		<description>Zelda no Densetsu - Fushigi no Kinomi - Jikuu no Shou (Jpn)</description>
 		<year>2001</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="CGB-AZ8J-JPN"/>
@@ -24425,15 +23337,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxj" cloneof="zeldaldx">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 2)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. B)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="pcb" value="DMG-A02-01" />
 			<feature name="u1" value="U1 2M/4M/8M MROM" />
 			<feature name="u2" value="U2 MBC-5" />
@@ -24450,18 +23361,17 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxja" cloneof="zeldaldx">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn, Rev. A)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
-				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev 1).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
+				<rom name="zelda no densetsu - yume o miru shima dx (japan) (rev a).bin" size="1048576" crc="bd8a1041" sha1="d3de302d44bdb240bcf55a5dc70f491f5456d721"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -24469,15 +23379,14 @@ license:CC0
 	</software>
 
 	<software name="zeldaldxjb" cloneof="zeldaldx">
-		<!-- Also released by NP in 2000-03 -->
-		<description>Zelda no Densetsu - Yume o Miru Shima DX (Japan)</description>
+		<!-- Notes: SGB enhanced, also released by NP in 2000-03 -->
+		<description>Zelda no Densetsu - Yume o Miru Shima DX (Jpn)</description>
 		<year>1998</year>
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DMG-AZLJ-JPN"/>
 		<info name="release" value="19981212"/>
 		<info name="alt_title" value="ゼルダの伝説 夢をみる島DX"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
 				<rom name="zelda no densetsu - yume o miru shima dx (japan).bin" size="1048576" crc="d974abea" sha1="b810925bf9d9f4f6cd97c5e46c94c1a9dd61a113"/>
@@ -24489,7 +23398,7 @@ license:CC0
 
 	<software name="znsst">
 		<!-- Notes: GBC only -->
-		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Japan)</description>
+		<description>Zen-Nihon Shounen Soccer Taikai - Mezase Nihon Ichi! (Jpn)</description>
 		<year>2001</year>
 		<publisher>Success</publisher>
 		<info name="serial" value="CGB-BJFJ-JPN"/>
@@ -24507,7 +23416,7 @@ license:CC0
 
 	<software name="zidane">
 		<!-- Notes: GBC only -->
-		<description>Zidane Football Generation (Europe)</description>
+		<description>Zidane Football Generation (Euro)</description>
 		<year>2002</year>
 		<publisher>Cryo</publisher>
 		<info name="serial" value="CGB-BZSP-EUR"/>
@@ -24536,17 +23445,17 @@ license:CC0
 	</software>
 
 	<software name="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan, Rev. 1)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn, Rev. A)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
-				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev 1).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
+				<rom name="zoids - jashin fukkatsu genobreaker hen (japan) (rev a).bin" size="2097152" crc="96461918" sha1="bfe8cdb8a8da37d5c8d9db57e8a5eeedee24d4cc"/>
 			</dataarea>
 			<dataarea name="nvram" size="32768">
 			</dataarea>
@@ -24554,14 +23463,14 @@ license:CC0
 	</software>
 
 	<software name="zoidsjasa" cloneof="zoidsjas">
-		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Japan)</description>
+		<!-- Notes: SGB enhanced -->
+		<description>Zoids - Jashin Fukkatsu! Genobreaker Hen (Jpn)</description>
 		<year>2000</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="DMG-BGZJ-JPN"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ゾイド 邪神復活! 〜ジェノブレイカー編〜"/>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="enhancement" value="sgb" />
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
 				<rom name="zoids - jashin fukkatsu genobreaker hen (japan).bin" size="2097152" crc="f36c874d" sha1="4ddb1d66d909d453374bd195a4a7dbe328ed41be"/>
@@ -24573,7 +23482,7 @@ license:CC0
 
 	<software name="zoidsshi">
 		<!-- Notes: GBC only -->
-		<description>Zoids - Shirogane no Juukishin Liger Zero (Japan)</description>
+		<description>Zoids - Shirogane no Juukishin Liger Zero (Jpn)</description>
 		<year>2001</year>
 		<publisher>Tomy</publisher>
 		<info name="serial" value="CGB-BZ2J-JPN"/>
@@ -24602,7 +23511,7 @@ license:CC0
 		    It has a Fujitsu MB89135L (undumped), four leds, a speaker and an IR emitter.
 		    It connects with the Game Boy using the console IR, but just one way (device to console).
 		    The peripheral device is named "Furu Changer". -->
-		<description>Zok Zok Heroes (Japan)</description>
+		<description>Zok Zok Heroes (Jpn)</description>
 		<year>2000</year>
 		<publisher>Media Factory</publisher>
 		<info name="serial" value="CGB-BZHJ-JPN"/>
@@ -24624,19 +23533,21 @@ license:CC0
 		</part>
 	</software>
 
+
+
 <!--
-	List of pirate cartridges
+List of pirate cartridges
 -->
 
 <!--
-	Rocket Games
+Rocket Games
 
-	These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
+These were produced between 2000 and 2001 by Rocket Games, run by Datel Design
 -->
 
 	<software name="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Europe)</description>
+		<description>ATV Racing &amp; Karate Joe (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24652,7 +23563,7 @@ license:CC0
 
 	<software name="atvrackja" cloneof="atvrackj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>ATV Racing &amp; Karate Joe (Europe, Alt)</description>
+		<description>ATV Racing &amp; Karate Joe (Euro, Alt)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24667,7 +23578,7 @@ license:CC0
 	</software>
 
 	<software name="atvracin">
-		<description>ATV Racing (Europe)</description>
+		<description>ATV Racing (Euro)</description>
 		<year>2001</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24683,7 +23594,7 @@ license:CC0
 
 	<software name="fullhang" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Full Time Soccer &amp; Hang Time Basketball (Europe)</description>
+		<description>Full Time Soccer &amp; Hang Time Basketball (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24698,7 +23609,7 @@ license:CC0
 	</software>
 
 	<software name="fulltime">
-		<description>Full Time Soccer (Europe)</description>
+		<description>Full Time Soccer (Euro)</description>
 		<year>2000</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24714,7 +23625,7 @@ license:CC0
 
 	<software name="hangtime">
 		<!-- Notes: GBC only -->
-		<description>Hang Time Basketball (Europe)</description>
+		<description>Hang Time Basketball (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24730,7 +23641,7 @@ license:CC0
 
 	<software name="pocksmrt" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out &amp; Race Time (Europe)</description>
+		<description>Pocket Smash Out &amp; Race Time (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24744,7 +23655,7 @@ license:CC0
 
 	<software name="pocksm" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Pocket Smash Out (Europe)</description>
+		<description>Pocket Smash Out (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24760,7 +23671,7 @@ license:CC0
 
 	<software name="karatej" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Karate Joe (Europe)</description>
+		<description>Karate Joe (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24773,7 +23684,7 @@ license:CC0
 	</software>
 
 	<software name="painter">
-		<description>Painter (Europe)</description>
+		<description>Painter (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24787,7 +23698,7 @@ license:CC0
 
 	<software name="racetime">
 		<!-- Notes: GBC only -->
-		<description>Race Time (Europe)</description>
+		<description>Race Time (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24801,7 +23712,7 @@ license:CC0
 
 	<software name="sinkj" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Karate Joe (Europe)</description>
+		<description>Space Invasion &amp; Karate Joe (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24817,7 +23728,7 @@ license:CC0
 
 	<software name="sinpntr" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion &amp; Painter (Europe)</description>
+		<description>Space Invasion &amp; Painter (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24833,7 +23744,7 @@ license:CC0
 
 	<software name="sinvasn" supported="partial">
 		<!-- Notes: GBC only -->
-		<description>Space Invasion (Europe)</description>
+		<description>Space Invasion (Euro)</description>
 		<year>200?</year>
 		<publisher>Rocket Games</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -24851,7 +23762,7 @@ license:CC0
 <!-- Sachen games -->
 
 	<software name="beastfgt">
-		<description>Beast Fighter (Taiwan)</description>
+		<description>Beast Fighter (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-001"/>
@@ -24864,7 +23775,7 @@ license:CC0
 	</software>
 
 	<software name="beastfgth" cloneof="beastfgt">
-		<description>Beast Fighter (Taiwan, Hacked?)</description>
+		<description>Beast Fighter (Tw, Hacked?)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="EB-001?"/>
@@ -24903,8 +23814,8 @@ license:CC0
 	</software>
 
 
-	<software name="jboy2a" cloneof="jboy2">
 	<!-- also data from ThunderBlast Man -->
+	<software name="jboy2a" cloneof="jboy2">
 		<description>Jurassic Boy II</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
@@ -24917,7 +23828,7 @@ license:CC0
 	</software>
 
 	<software name="rocmanx" supported="no">
-		<description>Rocman-X (Taiwan)</description>
+		<description>Rocman-X (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -24929,7 +23840,7 @@ license:CC0
 	</software>
 
 	<software name="shero" supported="no">
-		<description>Street Hero (Taiwan)</description>
+		<description>Street Hero (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="1B-004" />
@@ -24942,7 +23853,7 @@ license:CC0
 	</software>
 
 	<software name="thundbmna" cloneof="thundbmn" supported="no">
-		<description>Thunder Blast Man (Europe)</description>
+		<description>Thunder Blast Man (Euro)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="SA-114" />
@@ -24955,7 +23866,7 @@ license:CC0
 	</software>
 
 	<software name="mc_8in1">
-		<description>8 in 1 (Taiwan)</description>
+		<description>8 in 1 (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="??"/>
@@ -25019,7 +23930,7 @@ license:CC0
 	</software>
 
 	<software name="mc_6in1">
-		<description>Super 6 in 1 (Taiwan)</description>
+		<description>Super 6 in 1 (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<info name="serial" value="6B-001" />
@@ -25032,7 +23943,7 @@ license:CC0
 	</software>
 
 	<software name="mc_16in1">
-		<description>Super 16 in 1 (Taiwan)</description>
+		<description>Super 16 in 1 (Tw)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25044,7 +23955,7 @@ license:CC0
 	</software>
 
 	<software name="mc_31t" cloneof="mc_31" supported="no">
-		<description>31 in 1 Mighty Mix (Taiwan)</description>
+		<description>31 in 1 Mighty Mix (Tw)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25056,7 +23967,7 @@ license:CC0
 	</software>
 
 	<software name="mc_31" supported="no">
-		<description>31-in-1 Mighty Mix (Australia)</description>
+		<description>31-in-1 Mighty Mix (Aus)</description>
 		<year>19??</year>
 		<publisher>Sachen</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25076,9 +23987,9 @@ license:CC0
 
 -->
 
+<!-- This version should be the real dump, protected as the original cart -->
 	<software name="leinujs" supported="no">
-	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Lei Nu Ji Shen (Taiwan)</description>
+		<description>Lei Nu Ji Shen (Tw)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25093,10 +24004,10 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+     the real card, so it can be removed once we properly emulate the parent -->
 	<software name="leinujsh" cloneof="leinujs">
-	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
-		 the real card, so it can be removed once we properly emulate the parent -->
-		<description>Lei Nu Ji Shen (Taiwan, Hacked)</description>
+		<description>Lei Nu Ji Shen (Tw, Hacked)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25112,7 +24023,7 @@ license:CC0
 	</software>
 
 	<software name="magicmnk">
-		<description>Magic Monkey (Taiwan)</description>
+		<description>Magic Monkey (Tw)</description>
 		<year>200?</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25125,7 +24036,7 @@ license:CC0
 	</software>
 
 	<software name="binmnst3">
-		<description>Binary Monster III (Taiwan)</description>
+		<description>Binary Monster III (Tw)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25138,7 +24049,7 @@ license:CC0
 	</software>
 
 	<software name="amaznrob">
-		<description>Amazing Robot (Taiwan)</description>
+		<description>Amazing Robot (Tw)</description>
 		<year>2001</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25151,7 +24062,7 @@ license:CC0
 	</software>
 
 	<software name="magiclmpjp" cloneof="magiclmp" supported="no">
-		<description>Magic Lamp (Japan)</description>
+		<description>Magic Lamp (Jpn)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25164,7 +24075,7 @@ license:CC0
 	</software>
 
 	<software name="magiclmp" supported="no">
-		<description>Magic Lamp (USA)</description>
+		<description>Magic Lamp (US)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25177,7 +24088,7 @@ license:CC0
 	</software>
 
 	<software name="binmnst2" supported="no">
-		<description>Binary Monster 2 - Adventure of Hell (Taiwan)</description>
+		<description>Binary Monster 2 - Adventure of Hell(TW)</description>
 		<year>2000</year>
 		<publisher>GOWIN</publisher>
 		<info name="serial" value="GS-??"/>
@@ -25224,7 +24135,7 @@ license:CC0
 -->
 
 	<software name="emochndx" supported="partial">
-		<description>Emo Cheng DX (China)</description>
+		<description>Emo Cheng DX (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25238,7 +24149,7 @@ license:CC0
 	</software>
 
 	<software name="shuihusslc" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (China, Li Cheng)</description>
+		<description>Shui Hu Shen Shou (Chi, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA010"/>
@@ -25254,7 +24165,7 @@ license:CC0
 	</software>
 
 	<software name="smbl3lc" cloneof="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China, Li Cheng)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA011"/>
@@ -25270,7 +24181,7 @@ license:CC0
 	</software>
 
 	<software name="digid3">
-		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (China)</description>
+		<description>Chao Jin Hua - Shu Ma Bao Long - Zuan Shi Ban (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA012"/>
@@ -25286,7 +24197,7 @@ license:CC0
 	</software>
 
 	<software name="emochen2">
-		<description>Emo Cheng 2 - Fengyun Pian (China)</description>
+		<description>Emo Cheng 2 - Fengyun Pian (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA033"/>
@@ -25301,9 +24212,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- AKA Digimon D-4 published by SKOB -->
 	<software name="mingzhu2">
-	<!-- AKA Digimon D-4 published by SKOB -->
-		<description>Ming Zhu Kou Dai Guai Shou II (China)</description>
+		<description>Ming Zhu Kou Dai Guai Shou II (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA060"/>
@@ -25319,7 +24230,7 @@ license:CC0
 	</software>
 
 	<software name="taikonzs">
-		<description>Taikong Zhan Shi - Jing Dian Ban (China)</description>
+		<description>Taikong Zhan Shi - Jing Dian Ban (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA063"/>
@@ -25335,7 +24246,7 @@ license:CC0
 	</software>
 
 	<software name="gangdanw">
-		<description>Gang Dan Wu Yu II (China)</description>
+		<description>Gang Dan Wu Yu II (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA064"/>
@@ -25351,7 +24262,7 @@ license:CC0
 	</software>
 
 	<software name="mingzhu3">
-		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (China)</description>
+		<description>Ming Zhu Kou Dai Guai Shou III ~ Digimon Fight ~ El Monstruo (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA065"/>
@@ -25367,7 +24278,7 @@ license:CC0
 	</software>
 
 	<software name="shuihujd">
-		<description>Shui Hu Zhuan - Jing Dian Ban (China)</description>
+		<description>Shui Hu Zhuan - Jing Dian Ban (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA073"/>
@@ -25383,7 +24294,7 @@ license:CC0
 	</software>
 
 	<software name="yingxj2">
-		<description>Ying Xiong Jian 2 (China)</description>
+		<description>Ying Xiong Jian 2 (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA075"/>
@@ -25399,7 +24310,7 @@ license:CC0
 	</software>
 
 	<software name="xiyouji">
-		<description>Xi You Ji (China)</description>
+		<description>Xi You Ji (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA076"/>
@@ -25413,7 +24324,7 @@ license:CC0
 	</software>
 
 	<software name="smbldnp">
-		<description>Shu Ma Bao Long - Dian Nao Pian (China)</description>
+		<description>Shu Ma Bao Long - Dian Nao Pian (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA078"/>
@@ -25429,7 +24340,7 @@ license:CC0
 	</software>
 
 	<software name="yxtx">
-		<description>Ying Xiong Tian Xia (China)</description>
+		<description>Ying Xiong Tian Xia (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA079"/>
@@ -25443,7 +24354,7 @@ license:CC0
 	</software>
 
 	<software name="sanguowd">
-		<description>San Guo Zhi Wu Dai (China)</description>
+		<description>San Guo Zhi Wu Dai (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA080"/>
@@ -25459,7 +24370,7 @@ license:CC0
 	</software>
 
 	<software name="taikonglc" cloneof="firmbaby">
-		<description>Tai Kong Bao Bei (China, Li Cheng)</description>
+		<description>Tai Kong Bao Bei (Chi, Li Cheng)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA083"/>
@@ -25475,7 +24386,7 @@ license:CC0
 	</software>
 
 	<software name="smbbhjbt">
-		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (China)</description>
+		<description>Shu Ma Bao Bei - Huo Jian Bing Tuan (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA085"/>
@@ -25491,7 +24402,7 @@ license:CC0
 	</software>
 
 	<software name="smbbcmm">
-		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (China)</description>
+		<description>Shu Ma Bao Bei - Chao Meng Meng Fan Ji Zhan (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA086"/>
@@ -25507,7 +24418,7 @@ license:CC0
 	</software>
 
 	<software name="smbbhzs">
-		<description>Shu Ma Bao Bei - Hai Zhi Shen (China)</description>
+		<description>Shu Ma Bao Bei - Hai Zhi Shen (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA087"/>
@@ -25523,7 +24434,7 @@ license:CC0
 	</software>
 
 	<software name="mojie3">
-		<description>Mo Jie 3 - Bu Wanme De Shijie (China)</description>
+		<description>Mo Jie 3 - Bu Wanme De Shijie (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA089"/>
@@ -25539,7 +24450,7 @@ license:CC0
 	</software>
 
 	<software name="xinshdyx">
-		<description>Xin Shediao Ying Xiong Chuan (China)</description>
+		<description>Xin Shediao Ying Xiong Chuan (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng / Sintax</publisher>
 		<info name="serial" value="CBA090"/>
@@ -25554,9 +24465,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
 	<software name="lkrdx6">
-	<!-- This is a clone of the most famous (and still undumped) game by Vast Fame: Zook Hero Z ! -->
-		<description>Luo Ke Ren DX6 (China)</description>
+		<description>Luo Ke Ren DX6 (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA091"/>
@@ -25572,7 +24483,7 @@ license:CC0
 	</software>
 
 	<software name="xinguam2">
-		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (China)</description>
+		<description>Xin Guangming Yu Hei'an 2 - Zhushen De Yichan (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA095"/>
@@ -25588,7 +24499,7 @@ license:CC0
 	</software>
 
 	<software name="smbbdx6">
-		<description>Shu Ma Bao Bei - DX6 (China)</description>
+		<description>Shu Ma Bao Bei - DX6 (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA097"/>
@@ -25604,8 +24515,8 @@ license:CC0
 	</software>
 
 	<software name="teshu2k1" cloneof="mslug2k1">
-	<!-- probably developed by BDD -->
-		<description>Teshu Budui 2001 (China, Li Cheng)</description>
+		<!-- probably developed by BDD -->
+		<description>Teshu Budui 2001 (Chi, Li Cheng)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA100"/>
@@ -25621,7 +24532,7 @@ license:CC0
 	</software>
 
 	<software name="taikond3">
-		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (China)</description>
+		<description>Taikong Zhanshi DX3 - Zui Zhong Huan Xiang (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA145"/>
@@ -25636,9 +24547,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
 	<software name="terr911">
-	<!-- This also has an English version, titled Terrifying 9/11 (only on cart?) -->
-		<description>Teshu Budui 2 - Jidi (China)</description>
+		<description>Teshu Budui 2 - Jidi (Chi)</description>
 		<year>20??</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA146"/>
@@ -25654,7 +24565,7 @@ license:CC0
 	</software>
 
 	<software name="shimianm">
-		<description>Shi Mian Maifu - Feng Yun Pian (China)</description>
+		<description>Shi Mian Maifu - Feng Yun Pian (Chi)</description>
 		<year>200?</year>
 		<publisher>Li Cheng</publisher>
 		<info name="serial" value="CBA147"/>
@@ -25698,8 +24609,8 @@ license:CC0
 -->
 
 	<software name="hpotter">
-	<!-- probably developed by BDD -->
-		<description>Harry Potter (China)</description>
+		<!-- probably developed by BDD -->
+		<description>Harry Potter (Chi)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25713,7 +24624,7 @@ license:CC0
 	</software>
 
 	<software name="iceage">
-		<description>Ice Age (China)</description>
+		<description>Ice Age (Chi)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25727,7 +24638,7 @@ license:CC0
 	</software>
 
 	<software name="iceage2a" cloneof="iceage2">
-		<description>Ice Age II (China)</description>
+		<description>Ice Age II (Chi)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
@@ -25742,7 +24653,7 @@ license:CC0
 	</software>
 
 	<software name="zhwsj">
-		<description>Zuizhong Huanxiang - Wujin Sha Jia (China)</description>
+		<description>Zuizhong Huanxiang - Wujin Sha Jia (Chi)</description>
 		<year>2002?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="最終幻想 無盡沙加 (Final Fantasy Endless Saga), Crystal Age (Official English Name by Sintax)"/>
@@ -25757,7 +24668,7 @@ license:CC0
 	</software>
 
 	<software name="zzqb">
-		<description>Zhong Zhuan Qi Bing (China)</description>
+		<description>Zhong Zhuan Qi Bing (Chi)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="重裝機兵 , Metal Max (Official English Name by Sintax)"/>
@@ -25774,22 +24685,8 @@ license:CC0
 
 <!-- Other Asian Pirate dumps to sort -->
 
-	<software name="188in1" supported="partial">
-	<!--	This dump comes from the "GBCK003" board that's soldered inside some GB Boy Colour units	-->
-		<description>Color GameBoy 188 in 1 (Hong Kong)</description>
-		<year>199?</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="gameboy_cart">
-			<feature name="pcb" value="GBCK003" />
-			<feature name="slot" value="rom_188in1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="m29w640ft.u2" size="8388608" crc="e4068d7d" sha1="e61ee50ed39fd5b5cc8bdcb96fe1c3cccdcfc76f" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="digicrs2" cloneof="pokesaph">
-		<description>Digimon Crystal II (China)</description>
+		<description>Digimon Crystal II (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -25803,7 +24700,7 @@ license:CC0
 	</software>
 
 	<software name="laofuzi">
-		<description>Lao Fuzi Chuanqi (China)</description>
+		<description>Lao Fuzi Chuanqi (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="老夫子傳奇"/>
@@ -25818,7 +24715,7 @@ license:CC0
 	</software>
 
 	<software name="yuenanzx">
-		<description>Yuenan Zhanyi X - Shenru Dihou (China)</description>
+		<description>Yuenan Zhanyi X - Shenru Dihou (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役X-深入敵後"/>
@@ -25833,7 +24730,7 @@ license:CC0
 	</software>
 
 	<software name="dballadv">
-		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (China)</description>
+		<description>Qi Long Zhu Z 3 ~ Dragon Ball - Advance Adventure (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="七龍珠Z3"/>
@@ -25847,9 +24744,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- World WarCraft? -->
 	<software name="moshosj">
-	<!-- World WarCraft? -->
-		<description>Mo Shou Shi Ji - Zhan Shen (China)</description>
+		<description>Mo Shou Shi Ji - Zhan Shen (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="魔獸世紀-戰神"/>
@@ -25864,7 +24761,7 @@ license:CC0
 	</software>
 
 	<software name="fengzg2">
-		<description>Feng Zhi Gou II (China)</description>
+		<description>Feng Zhi Gou II (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="风之谷II"/>
@@ -25879,7 +24776,7 @@ license:CC0
 	</software>
 
 	<software name="digigdb">
-		<description>2003 Shu Ma Bao Long - Ge Dou Ban (China)</description>
+		<description>2003 Shu Ma Bao Long - Ge Dou Ban (Chi)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003数码暴龙 格斗版"/>
@@ -25894,7 +24791,7 @@ license:CC0
 	</software>
 
 	<software name="lkrx5">
-		<description>Luo Ke Ren X5 (China)</description>
+		<description>Luo Ke Ren X5 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="洛克人X5, 络克英雄EXE5 ~ Luo Ke Ying Xiong EXE5 (Cart)"/>
@@ -25909,7 +24806,7 @@ license:CC0
 	</software>
 
 	<software name="crash2c" cloneof="crash2">
-		<description>2003 Gu Huo Lang II - The Huge Adventure (China)</description>
+		<description>2003 Gu Huo Lang II - The Huge Adventure (Chi)</description>
 		<year>2003?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 古惑狼II (Cart)"/>
@@ -25924,7 +24821,7 @@ license:CC0
 	</software>
 
 	<software name="iceage2">
-		<description>Bing Yuan Li Xian Ji II (China)</description>
+		<description>Bing Yuan Li Xian Ji II (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="冰原歷險記II"/>
@@ -25938,9 +24835,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- Pokemon Platinum? -->
 	<software name="pokeplat">
-	<!-- Pokemon Platinum? -->
-		<description>Kou Dai Yao Guai - Bai Jin Ban (China)</description>
+		<description>Kou Dai Yao Guai - Bai Jin Ban (Chi)</description>
 		<year>2005</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋妖怪-白金版"/>
@@ -25954,9 +24851,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- Metal Slug 3? -->
 	<software name="ynzy3">
-	<!-- Metal Slug 3? -->
-		<description>Yue Nan Zhan Yi 3 (China)</description>
+		<description>Yue Nan Zhan Yi 3 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="越南戰役3"/>
@@ -25970,9 +24867,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- TODO: study the menu and writes of this cart! -->
 	<software name="m_digi10" supported="no">
-	<!-- TODO: study the menu and writes of this cart! -->
-		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (China)</description>
+		<description>Shu Ma Bao Long Zhuan Ji 10 in 1 (Chi)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="數碼暴龍專集 10 in 1"/>
@@ -25984,9 +24881,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This got ripped by m_digi10 -->
 	<software name="digid3h" cloneof="digid3">
-	<!-- This got ripped by m_digi10 -->
-		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (China, Ripped from 10 in 1 multicart)</description>
+		<description>Chao Jin Hua - Shu Ma Bao Bei D-3 (Chi, Ripped from 10 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="超進化 數碼寶貝D-3"/>
@@ -26001,7 +24898,7 @@ license:CC0
 	</software>
 
 	<software name="fkdfw">
-		<description>Feng Kuang Da Fu Weng (China, Ripped from multicart)</description>
+		<description>Feng Kuang Da Fu Weng (Chi, Ripped from multicart)</description>
 		<year>200?</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="疯狂大富翁"/>
@@ -26016,7 +24913,7 @@ license:CC0
 	</software>
 
 	<software name="onimush2">
-		<description>Gui Wu Zhe 2 (China)</description>
+		<description>Gui Wu Zhe 2 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="鬼武者2"/>
@@ -26030,10 +24927,10 @@ license:CC0
 		</part>
 	</software>
 
+<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
+<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
 	<software name="hjtaiyou">
-	<!-- this is a sprite hack (based on Golden Sun by Camelot) of another sintax game "Castlevania DX", currently undumped -->
-	<!-- ingame title uses 黃金の太陽, so I romanized it in the Jpn way rather than in the Chinese way... -->
-		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (China)</description>
+		<description>Pian Wai Zhang Huang Jin no Taiyou - Feng Yin De Yuan Gu Lian Jin Shu (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="篇外章 黃金太陽-封印的遠古煉金術 ~ Pian Wai Zhang Huang Jin Tai Yang - Feng Yin De Yuan Gu Lian Jin Shu"/>
@@ -26047,9 +24944,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
 	<software name="dquest8">
-	<!-- this is a sprite hack (based on Dragon Quest by Enix) of another sintax game "Castlevania DX", currently undumped -->
-		<description>Yong Zhe Dou E Long VIII (China)</description>
+		<description>Yong Zhe Dou E Long VIII (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="勇者鬥惡龍VIII"/>
@@ -26064,7 +24961,7 @@ license:CC0
 	</software>
 
 	<software name="mgear2">
-		<description>He Jin Zhuang Bei II (China)</description>
+		<description>He Jin Zhuang Bei II (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="合金裝備II"/>
@@ -26079,7 +24976,7 @@ license:CC0
 	</software>
 
 	<software name="shaolin">
-		<description>Fantasic ShaoLin Kungfu (China)</description>
+		<description>Fantasic ShaoLin Kungfu (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Shaoling Legend - Hero, the saver (Cart)"/>
@@ -26094,7 +24991,7 @@ license:CC0
 	</software>
 
 	<software name="shaolinc" cloneof="shaolin">
-		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (China)</description>
+		<description>Shao Lin Shi San Gun - Ying Xiong Jiu Zhu (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="少林十三棍-英雄救主"/>
@@ -26109,7 +25006,7 @@ license:CC0
 	</software>
 
 	<software name="digiyjad">
-		<description>Digimon Yellow Jade (China)</description>
+		<description>Digimon Yellow Jade (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26123,7 +25020,7 @@ license:CC0
 	</software>
 
 	<software name="hpottr2c">
-		<description>Xiao Shi Mi Shi (China)</description>
+		<description>Xiao Shi Mi Shi (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003哈利波特2-消失的密室 ~ 2003 Harry Potter 2 - Xiao Shi De Mi Shi"/>
@@ -26138,7 +25035,7 @@ license:CC0
 	</software>
 
 	<software name="hpotter4" cloneof="hpottr2c">
-		<description>Harry Xiao Zi IV (China)</description>
+		<description>Harry Xiao Zi IV (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子IV, 2003哈利小子IV ~ 2003 Ha Li Xiao Zi IV (Cart)"/>
@@ -26153,7 +25050,7 @@ license:CC0
 	</software>
 
 	<software name="emodao">
-		<description>E Mo Dao (China, Ripped from 8 in 1 multicart)</description>
+		<description>E Mo Dao (Chi, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>Vast Fame</publisher>
 		<info name="alt_title" value="惡魔島"/>
@@ -26168,7 +25065,7 @@ license:CC0
 	</software>
 
 	<software name="qtdsheng" cloneof="xiyouji">
-		<description>Qi Tian Da Sheng - Sun Wu Kong (China, Ripped from 8 in 1 multicart)</description>
+		<description>Qi Tian Da Sheng - Sun Wu Kong (Chi, Ripped from 8 in 1 multicart)</description>
 		<year>200?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="齊天大聖 - 孫悟空"/>
@@ -26181,7 +25078,7 @@ license:CC0
 	</software>
 
 	<software name="sswy">
-		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (China, Ripped from 12 in 1 multicart)</description>
+		<description>Sheng Shou Wu Yu - Shen Long Chuan Shuo (Chi, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="聖獸物語 - 神龍傳說"/>
@@ -26197,7 +25094,7 @@ license:CC0
 
 	<software name="pokeruby">
 	<!-- 4MB rom with crc 4a68fd38 is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Ruby (China)</description>
+		<description>Pocket Monster Ruby (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Pocket Monster Carbuncle (Cart)"/>
@@ -26213,7 +25110,7 @@ license:CC0
 
 	<software name="pokesaph">
 	<!-- 4MB rom with crc 81d1e6ff is taizou's cracked version running on base MBC5 -->
-		<description>Pocket Monster Saphire (China)</description>
+		<description>Pocket Monster Saphire (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Pokémon - Sapphire Version (Cart)"/>
@@ -26227,10 +25124,10 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<software name="pokesaphc" cloneof="pokesaph">
-	<!-- This dump is "unconfirmed", in the sense that later redumps have resulted in inconsistent reads (none working except this one) -->
 	<!-- 4MB rom with crc 3a08c8eb is taizou's cracked version running on base MBC5 -->
-		<description>Kou Dai Guai Shou - Lan Bao Shi (China)</description>
+		<description>Kou Dai Guai Shou - Lan Bao Shi (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="口袋怪獸 - 藍寶石, 2003 口袋怪獸-藍寶石 (Cart)"/>
@@ -26246,7 +25143,7 @@ license:CC0
 
 	<software name="shuiji2" cloneof="pokesaph">
 	<!-- 4MB rom with crc 5f2472ad is taizou's cracked version running on base MBC5 -->
-		<description>Shu Ma Bao Long - Shui Jing Ban II (China)</description>
+		<description>Shu Ma Bao Long - Shui Jing Ban II (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="數碼暴龍 - 水晶版II"/>
@@ -26262,7 +25159,7 @@ license:CC0
 
 	<software name="firmbaby">
 	<!-- 4MB rom with crc 66539153 is taizou's cracked version running on base MBC5 -->
-		<description>The Firmament Baby (China)</description>
+		<description>The Firmament Baby (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Space Baby (Cart)"/>
@@ -26278,7 +25175,7 @@ license:CC0
 
 	<software name="taikong" cloneof="firmbaby">
 	<!-- 4MB rom with crc 5b49af92 is taizou's cracked version running on base MBC5 -->
-		<description>Tai Kong Bao Bei (China, Sintax)</description>
+		<description>Tai Kong Bao Bei (Chi, Sintax)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="太空寶貝"/>
@@ -26294,7 +25191,7 @@ license:CC0
 
 	<software name="taichi">
 	<!-- 4MB rom with crc fab140ab is taizou's cracked version running on base MBC5 -->
-		<description>Xiao Taichi - Shen Hua Li Xian (China)</description>
+		<description>Xiao Taichi - Shen Hua Li Xian (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="小太极 - 神话历险"/>
@@ -26310,7 +25207,7 @@ license:CC0
 
 	<software name="crash2">
 	<!-- 4MB rom with crc 0af243bf is taizou's cracked version running on base MBC5 -->
-		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (China)</description>
+		<description>2003 Crash Bandicoot II Advance - The Huge Adventure (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="2003 Crash II Advance (Cart)"/>
@@ -26326,7 +25223,7 @@ license:CC0
 
 	<software name="bwarr5" cloneof="dballadv">
 	<!-- 4MB rom with crc 9d332731 is taizou's cracked version running on base MBC5 -->
-		<description>Bynasty Warriors Advance 5 (China)</description>
+		<description>Bynasty Warriors Advance 5 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="叁國無雙5 ~ San Guo Wu Shang 5 (Cart)"/>
@@ -26342,7 +25239,7 @@ license:CC0
 
 	<software name="cjjqx">
 	<!-- 4MB rom with crc 378b182d is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (China)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -26358,7 +25255,7 @@ license:CC0
 
 	<software name="cjjqx1" cloneof="cjjqx">
 	<!-- 4MB rom with crc 0cea6b33 is taizou's cracked version running on base MBC5 -->
-		<description>Chao Ji Ji Qi Ren Da Zhan X (China, Alt)</description>
+		<description>Chao Ji Ji Qi Ren Da Zhan X (Chi, Alt)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="超級機器人大戰X, Super Robot War X (Cart)"/>
@@ -26374,7 +25271,7 @@ license:CC0
 
 	<software name="jinglw3">
 	<!-- rom with crc 15a4b4ec is taizou's cracked version running on base MBC5 -->
-		<description>Jing Ling Wang III (China)</description>
+		<description>Jing Ling Wang III (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="精靈王III"/>
@@ -26390,7 +25287,7 @@ license:CC0
 
 	<software name="qbtx">
 	<!-- rom with crc 5bcf90fa is taizou's cracked version running on base MBC5 -->
-		<description>Quan Ba Tian Xia (China)</description>
+		<description>Quan Ba Tian Xia (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="拳霸天下"/>
@@ -26406,7 +25303,7 @@ license:CC0
 
 	<software name="zhihuanw">
 	<!-- 4MB rom with crc 49e77dd9 is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Huan Wang - Shou Bu Qu (China)</description>
+		<description>Zhi Huan Wang - Shou Bu Qu (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="指环王 - 首部曲"/>
@@ -26422,7 +25319,7 @@ license:CC0
 
 	<software name="xqdz2">
 	<!-- 4MB rom with crc e8fd000f is taizou's cracked version running on base MBC5 -->
-		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (China)</description>
+		<description>Xing Qiu Da Zhan II - Ke Long Ren Zhan Yi (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="星球大战2 - 克隆人战役"/>
@@ -26438,7 +25335,7 @@ license:CC0
 
 	<software name="mishidem">
 	<!-- 4MB rom with crc 88a86ff4 is taizou's cracked version running on base MBC5 -->
-		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (China)</description>
+		<description>Ha Li Xiao Zi Di Er Bu - Mi Shi De Mi (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="哈利小子第二部 - 密室的秘"/>
@@ -26454,7 +25351,7 @@ license:CC0
 
 	<software name="hzqibing">
 	<!-- 4MB rom with crc bb78f17e is taizou's cracked version running on base MBC5 -->
-		<description>Hai Zhan Qi Bing (China)</description>
+		<description>Hai Zhan Qi Bing (Chi)</description>
 		<year>200?</year>
 		<publisher>Jump Technology ~ Sintax</publisher>
 		<info name="alt_title" value="海戰奇兵"/>
@@ -26470,7 +25367,7 @@ license:CC0
 
 	<software name="3gokum2">
 	<!-- 4MB rom with crc 8de5f8d5 is taizou's cracked version running on base MBC5 -->
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -26485,7 +25382,7 @@ license:CC0
 	</software>
 
 	<software name="3gokum2a" cloneof="3gokum2">
-		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (China, Pirate)</description>
+		<description>Zhen San Guo Wu Shuang 2 - Shin Sangokumusou 2 (Chi, Pirate)</description>
 		<year>200?</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<info name="alt_title" value="真三國無雙2"/>
@@ -26500,7 +25397,7 @@ license:CC0
 	</software>
 
 	<software name="spiderm3">
-		<description>Spider-Man 3 (China)</description>
+		<description>Spider-Man 3 (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="Movie Version Spider-Man 3 (Cart)"/>
@@ -26516,7 +25413,7 @@ license:CC0
 
 	<software name="chuanshu" cloneof="spiderm3">
 	<!-- Same game as spiderm3 but alt sprite (still uses spider-man in status bar!) -->
-		<description>Chuan Shuo (China)</description>
+		<description>Chuan Shuo (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="傳說"/>
@@ -26532,7 +25429,7 @@ license:CC0
 
 	<software name="zzx3" cloneof="spiderm3">
 	<!-- 4MB rom with crc 66442e7d is taizou's cracked version running on base MBC5 -->
-		<description>Zhi Zhu Xia III (China)</description>
+		<description>Zhi Zhu Xia III (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<info name="alt_title" value="蜘蛛侠3-电影版 ~ Zhi Zhu Xia 3 - Dian Ying Ban (Spider-Man 3 Movie Version)"/>
@@ -26547,7 +25444,7 @@ license:CC0
 	</software>
 
 	<software name="xfsb">
-		<description>Xin Feng Shen Bang (China, Ripped from 12 in 1 multicart)</description>
+		<description>Xin Feng Shen Bang (Chi, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="新封神榜"/>
@@ -26563,7 +25460,7 @@ license:CC0
 
 	<software name="digisaph">
 	<!-- 4MB rom with crc 88da70ac is taizou's cracked version running on base MBC5 -->
-		<description>2003 Digitmon Sapphire (China)</description>
+		<description>2003 Digitmon Sapphire (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="2003 Digimom Sapphii (Cart)"/>
@@ -26578,7 +25475,7 @@ license:CC0
 	</software>
 
 	<software name="smbl3">
-		<description>Shu Ma Bao Long 3 - Shui Jing Ban (China)</description>
+		<description>Shu Ma Bao Long 3 - Shui Jing Ban (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="數碼暴龍3-水晶版"/>
@@ -26593,7 +25490,7 @@ license:CC0
 	</software>
 
 	<software name="smbl9">
-		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (China)</description>
+		<description>Shu Ma Bao Long 9 - Bao Long Pian 2002 (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="CK019-1"/>
@@ -26608,14 +25505,14 @@ license:CC0
 		</part>
 	</software>
 
+<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<software name="chongwu">
-	<!-- 1byte difference between this and the hacked version... check what is about! -->
 	<!-- at 0x1e0 starts a routine which (at 0x1ec) reads from $41c3, then compares
 	     the value with 0x5d. if comparison fails, the code enters a routine at 0x780
 	     where it gets stuck. if comparison works, then the code goes to 0x150 as the
 	     patched version does (because the single modified byte replaces the jump to
 	     0x1e0 with the jump to 0x150). Not sure yet if current workaround is correct... -->
-		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (China)</description>
+		<description>Chong Wu Xiao Jing Ling - Jie Jin Ta Zhi Wang (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="宠物小精灵 结金塔之王"/>
@@ -26630,7 +25527,7 @@ license:CC0
 	</software>
 
 	<software name="jyqxc2">
-		<description>Jin Yong Qun Xia Chuan II (China)</description>
+		<description>Jin Yong Qun Xia Chuan II (Chi)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="金庸群侠传II"/>
@@ -26645,7 +25542,7 @@ license:CC0
 	</software>
 
 	<software name="soulfalc">
-		<description>Soul Falchion - Ge Dou Jian Shen (China)</description>
+		<description>Soul Falchion - Ge Dou Jian Shen (Chi)</description>
 		<year>2002</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="格鬥劍神"/>
@@ -26660,7 +25557,7 @@ license:CC0
 	</software>
 
 	<software name="capf2k3" cloneof="soulfalc">
-		<description>Capcom Fight 2003 (China)</description>
+		<description>Capcom Fight 2003 (Chi)</description>
 		<year>2003?</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26674,7 +25571,7 @@ license:CC0
 	</software>
 
 	<software name="heroswrd">
-		<description>Heroic Sword (China)</description>
+		<description>Heroic Sword (Chi)</description>
 		<year>20??</year>
 		<publisher>Hitek ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="英雄剑"/>
@@ -26689,7 +25586,7 @@ license:CC0
 	</software>
 
 	<software name="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26703,7 +25600,7 @@ license:CC0
 	</software>
 
 	<software name="crzyric2a" cloneof="crzyric2">
-		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (China, Alt)</description>
+		<description>Crazy Richman 2 - Bai Wang Da Fu Weng (Chi, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26717,7 +25614,7 @@ license:CC0
 	</software>
 
 	<software name="ffantx">
-		<description>Final Fantasy X: Fantasy War (China)</description>
+		<description>Final Fantasy X: Fantasy War (Chi)</description>
 		<year>20??</year>
 		<publisher>SKOB ~ Guangzhou Li Cheng</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26730,9 +25627,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of the undumped 'Zook Hero 2' -->
 	<software name="rockmnx3">
-	<!-- This is a title hack of the undumped 'Zook Hero 2' -->
-		<description>Rockman X3 (China)</description>
+		<description>Rockman X3 (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -26747,7 +25644,7 @@ license:CC0
 	</software>
 
 	<software name="rockmnx3a" cloneof="rockmnx3">
-		<description>Rockman X3 (China, Alt)</description>
+		<description>Rockman X3 (Chi, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame ~ Guangzhou Li Cheng</publisher>
 		<info name="alt_title" value="Rockman DX3 (Box)"/>
@@ -26761,9 +25658,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of the undumped 'Super Fighter S' -->
 	<software name="sf99">
-	<!-- This is a title hack of the undumped 'Super Fighter S' -->
-		<description>Super Fighters '99 (China)</description>
+		<description>Super Fighters '99 (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26775,7 +25672,7 @@ license:CC0
 	</software>
 
 	<software name="garou">
-		<description>Garou - Mark of the Wolves (China)</description>
+		<description>Garou - Mark of the Wolves (Chi)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26789,7 +25686,7 @@ license:CC0
 	</software>
 
 	<software name="garou2k3" cloneof="garou">
-		<description>Garou 2003 - Mark of the Wolfs (China)</description>
+		<description>Garou 2003 - Mark of the Wolfs (Chi)</description>
 		<year>2003?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26803,7 +25700,7 @@ license:CC0
 	</software>
 
 	<software name="fighthot">
-		<description>E' Fighter HOT (China)</description>
+		<description>E' Fighter HOT (Chi)</description>
 		<year>20??</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26816,9 +25713,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of an undumped Dragon Ball fighting game -->
 	<software name="dbf2005">
-	<!-- This is a title hack of an undumped Dragon Ball fighting game -->
-		<description>Dragonball Fight 2005 (China)</description>
+		<description>Dragonball Fight 2005 (Chi)</description>
 		<year>2005?</year>
 		<publisher>Fiver Firm</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26843,9 +25740,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
 	<software name="hpotter3c" cloneof="hpotter2">
-	<!-- This is a title hack of an undumped 'Harry Potter 3: 神奇の光輪' -->
-		<description>Harry Potter 3 2003 (China)</description>
+		<description>Harry Potter 3 2003 (Chi)</description>
 		<year>2003?</year>
 		<publisher>V.Fame?</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26859,7 +25756,7 @@ license:CC0
 	</software>
 
 	<software name="skxs">
-		<description>Shi Kong Xing Shou (China, Ripped from 12 in 1 multicart)</description>
+		<description>Shi Kong Xing Shou (Chi, Ripped from 12 in 1 multicart)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="時空星獸"/>
@@ -26874,7 +25771,7 @@ license:CC0
 	</software>
 
 	<software name="shjmlwc">
-		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (China)</description>
+		<description>Sheng Huo Jiang Mo Lu Wai Chuan - Guang Yu An De Lun Hui (Chi)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<info name="alt_title" value="聖火降魔錄外傳 - 光與暗的輪迴, 聖火降魔錄 (Box)"/>
@@ -26889,7 +25786,7 @@ license:CC0
 	</software>
 
 	<software name="xgmyha" cloneof="shjmlwc">
-		<description>Xin Guang Ming Yu Hei An (China)</description>
+		<description>Xin Guang Ming Yu Hei An (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="新光明与黑暗"/>
@@ -26904,8 +25801,8 @@ license:CC0
 	</software>
 
 	<software name="mszb3" cloneof="shjmlwc">
-	<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
-		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (China)</description>
+		<!-- Alt. Title: Warcraft 3 (Box? Catalog?) -->
+		<description>Mo Shou Zheng Ba 3 - Hun Luan Zhi Jie (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26919,7 +25816,7 @@ license:CC0
 	</software>
 
 	<software name="shuihuss">
-		<description>Shui Hu Shen Shou (China)</description>
+		<description>Shui Hu Shen Shou (Chi)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -26934,7 +25831,7 @@ license:CC0
 	</software>
 
 	<software name="shuihussa" cloneof="shuihuss">
-		<description>Shui Hu Shen Shou (China, Alt)</description>
+		<description>Shui Hu Shen Shou (Chi, Alt)</description>
 		<year>2001</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="水滸神獸"/>
@@ -26948,9 +25845,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- Title hack of the above, with VF logo removed -->
 	<software name="shuihuz" cloneof="shuihuss">
-	<!-- Title hack of the above, with VF logo removed -->
-		<description>Shui Hu Zhuan (China)</description>
+		<description>Shui Hu Zhuan (Chi)</description>
 		<year>2002</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="水滸傳"/>
@@ -26964,9 +25861,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
 	<software name="kof2003">
-	<!-- This is a title hack of an undumped game by SKPB: 'King of Fighter R-2' -->
-		<description>Ge Dou Zhi Zun 2003 (China)</description>
+		<description>Ge Dou Zhi Zun 2003 (Chi)</description>
 		<year>2003?</year>
 		<publisher>SKOB?</publisher>
 		<info name="alt_title" value="格斗至尊2003"/>
@@ -26981,7 +25878,7 @@ license:CC0
 	</software>
 
 	<software name="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (China)</description>
+		<description>Super Robot Taisen Final Vol.1 (Chi)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -26996,7 +25893,7 @@ license:CC0
 	</software>
 
 	<software name="srobotf1a" cloneof="srobotf1">
-		<description>Super Robot Taisen Final Vol.1 (China, Alt)</description>
+		<description>Super Robot Taisen Final Vol.1 (Chi, Alt)</description>
 		<year>20??</year>
 		<publisher>SKOB</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27011,7 +25908,7 @@ license:CC0
 	</software>
 
 	<software name="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (China)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (Chi)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27026,7 +25923,7 @@ license:CC0
 	</software>
 
 	<software name="sanguoasa" cloneof="sanguoas">
-		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27040,9 +25937,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
 	<software name="sanguoasb" cloneof="sanguoas">
-	<!-- This has the 1st half identical to the second, but it's slightly different from the dumps above... -->
-		<description>San Guo Zhi - Ao Shi Tian Jia (China, Alt Bad?)</description>
+		<description>San Guo Zhi - Ao Shi Tian Jia (Chi, Alt Bad?)</description>
 		<year>20??</year>
 		<publisher>V.Fame</publisher>
 		<info name="alt_title" value="三國志 - 傲視天下 (title), 三國志 - 傲視天下 (San Guo Zhi- Lie Chuan) (Box)"/>
@@ -27056,12 +25953,12 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
 	<software name="cbzz">
-	<!-- This is a title hack of an undumped Sintax game: 真三國無雙 (Zhen San Guo Wu Shuang) whose 'official' english title is True Three Kingdoms -->
-		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (China)</description>
+		<!-- Alt. Title: 吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs) -->
+		<description>Tun Shi Tian Di - Chi Bi Zhi Zhan (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="吞食天地 赤壁之戰 (Devouring of Heaven and Earth: The Battle of Red Cliffs)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="2097152">
@@ -27073,10 +25970,10 @@ license:CC0
 	</software>
 
 	<software name="smmftu">
-		<description>Shi Mian Mai Fu - Tu Long Pian (China)</description>
+		<!-- Alt. Title: 十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter) -->
+		<description>Shi Mian Mai Fu - Tu Long Pian (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="十面埋伏 屠龍篇 (House of Flying Daggers: Dragon Slayer Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -27088,10 +25985,10 @@ license:CC0
 	</software>
 
 	<software name="smmftian">
-		<description>Shi Mian Mai Fu - Tian Long Pian (China)</description>
+		<!-- Alt. Title: 十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter) -->
+		<description>Shi Mian Mai Fu - Tian Long Pian (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="十面埋伏 天龍篇 (House of Flying Daggers: Sky Dragon Chapter)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="1048576">
@@ -27103,7 +26000,7 @@ license:CC0
 	</software>
 
 	<software name="unk01" supported="no">
-		<description>Unknown RPG - Digimon? Zelda? (China, Encrypted?)</description>
+		<description>Unknown RPG - Digimon? Zelda? (Chi, Encrypted?)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27117,7 +26014,7 @@ license:CC0
 	</software>
 
 	<software name="pokedmnda" cloneof="telefngp">
-		<description>Pocket Monsters Diamond (China)</description>
+		<description>Pocket Monsters Diamond (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27132,7 +26029,7 @@ license:CC0
 	</software>
 
 	<software name="pokedmnd" cloneof="telefngp">
-		<description>Pokémon Diamond (China)</description>
+		<description>Pokémon Diamond (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27147,10 +26044,10 @@ license:CC0
 	</software>
 
 	<software name="yxcs" supported="no">
-		<description>Ying Xiong Chuan Shuo (China)</description>
+		<description>Ying Xiong Chuan Shuo (Chi)</description>
 		<year>20??</year>
 		<publisher>Waixing</publisher>
-		<info name="alt_title" value="英雄传说 (Legend of Heroes)"/>
+		<info name="alt_title" value="英雄传说 (Legend of Heroes) "/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_digimon" />
 			<dataarea name="rom" size="1048576">
@@ -27162,11 +26059,11 @@ license:CC0
 	</software>
 
 	<software name="sqsd">
-		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (China)</description>
+		<!-- Alt. Title: 石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King) -->
+		<description>Shi Qi Shi Dai - Jing Ling Wang Dan Sheng (Chi)</description>
 		<year>20??</year>
 		<publisher>GOWIN</publisher>
 		<info name="usage" value="Enable 'Skip BIOS check' configuration setting to boot"/>
-		<info name="alt_title" value="石器時代 精靈王誕生 (Stone Age - Birth of the Goblin King)"/>
 		<part name="cart" interface="gameboy_cart">
 			<feature name="slot" value="rom_yong" />
 			<dataarea name="rom" size="4194304">
@@ -27178,7 +26075,7 @@ license:CC0
 	</software>
 
 	<software name="dquest4">
-		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (China)</description>
+		<description>Dragon Quest 4 - Yongzhe Dou E Long 4 (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="勇者斗恶龙4"/>
@@ -27192,11 +26089,11 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
+	(apparently it got sent to US by a Vietnamese guy back in the 2000)
+	it can be seen on youtube. -->
 	<software name="pokecrysb" cloneof="pokecrys">
 		<!-- Notes: GBC only -->
-		<!-- This is usually referred to as 'Vietnamese bootleg' of pokecrys
-		(apparently it got sent to US by a Vietnamese guy back in the 2000)
-		it can be seen on youtube. -->
 		<description>Pocket Monsters - Crystal Version (Bootleg)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -27211,9 +26108,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Notes: GBC only -->
 	<software name="pikangtm" cloneof="smurfnig">
-		<!-- Notes: GBC only -->
-		<description>The Pikachu Nightmare (China)</description>
+		<description>The Pikachu Nightmare (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27225,7 +26122,7 @@ license:CC0
 	</software>
 
 	<software name="pokegogo" cloneof="smurfnig">
-		<description>Pocket Monsters GO!GO! GO!! (China)</description>
+		<description>Pocket Monsters GO!GO! GO!! (Chi)</description>
 		<year>20??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27239,7 +26136,7 @@ license:CC0
 <!-- These are basically the same game as Sonic 3D Blast 5, always by Yong Yong (see gameboy.xml) -->
 	<software name="sonicad7">
 		<!-- Alt. Title: Sonic 7, Sonic Adventure 7 -->
-		<description>Sonic Adventure (China)</description>
+		<description>Sonic Adventure (Chi)</description>
 		<year>1999</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27251,7 +26148,7 @@ license:CC0
 	</software>
 
 	<software name="pokeadv">
-		<description>Pokémon Adventure (China)</description>
+		<description>Pokémon Adventure (Chi)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27263,7 +26160,7 @@ license:CC0
 	</software>
 
 	<software name="dkong5">
-		<description>Donkey Kong 5 (China, Bad?)</description>
+		<description>Donkey Kong 5 (Chi, Bad?)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27276,7 +26173,7 @@ license:CC0
 
 	<software name="dkong5ts">
 	<!-- 4MB rom with crc f27a687e is taizou's cracked version running on base MBC5 -->
-		<description>Donkey Kong 5 - The Journey of Over Time and Space (China)</description>
+		<description>Donkey Kong 5 - The Journey of Over Time and Space (Chi)</description>
 		<year>200?</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27289,17 +26186,17 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sm3sp" supported="no">
-	<!--
-	There are various dumps of this:
-	2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
-	256KB version (CRC 791f8c86) which contains the first half of the rom used here
+<!--
+There are various dumps of this:
+2MB version (CRC 18fd445d) which contains 4 copies of the rom used here
+256KB version (CRC 791f8c86) which contains the first half of the rom used here
 
-	taizou dumped the game also from a multicart and got a 1MB dump containing the rom
-	used here repeated twice. we need to redump the standalone cart to confirm the size
-	but the 256KB version is definitely underdumped and misses sprite data
-	-->
-		<description>Super Mario 3 Special (China)</description>
+taizou dumped the game also from a multicart and got a 1MB dump containing the rom
+used here repeated twice. we need to redump the standalone cart to confirm the size
+but the 256KB version is definitely underdumped and misses sprite data
+-->
+	<software name="sm3sp" supported="no">
+		<description>Super Mario 3 Special (Chi)</description>
 		<year>2000</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27310,9 +26207,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn2" supported="no">
-	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Digimon 2 (China)</description>
+		<description>Digimon 2 (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27325,10 +26222,10 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="digimn2h" cloneof="digimn2">
-	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
      the real card, so it can be removed once we properly emulate the parent -->
-		<description>Digimon 2 (China, Hacked)</description>
+	<software name="digimn2h" cloneof="digimn2">
+		<description>Digimon 2 (Chi, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27342,7 +26239,7 @@ license:CC0
 	</software>
 
 	<software name="digimn3c">
-		<description>Digimon 3 Crystal (China)</description>
+		<description>Digimon 3 Crystal (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27355,9 +26252,9 @@ license:CC0
 		</part>
 	</software>
 
+<!-- This version should be the real dump, protected as the original cart -->
 	<software name="digimn4" supported="no">
-	<!-- This version should be the real dump, protected as the original cart -->
-		<description>Digimon 02 4 (China)</description>
+		<description>Digimon 02 4 (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27370,10 +26267,10 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="digimn4h" cloneof="digimn4">
-	<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
+<!-- This version bypasses the protection, but I think it's been hacked by whoever dumped
      the real card, so it can be removed once we properly emulate the parent -->
-		<description>Digimon 02 4 (China, Hacked)</description>
+	<software name="digimn4h" cloneof="digimn4">
+		<description>Digimon 02 4 (Chi, Hacked)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27387,7 +26284,7 @@ license:CC0
 	</software>
 
 	<software name="digijade" cloneof="digimn4">
-		<description>Digimon 02 Jade (China)</description>
+		<description>Digimon 02 Jade (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27401,7 +26298,7 @@ license:CC0
 	</software>
 
 	<software name="digimn5">
-		<description>Digimon 02 5 (China)</description>
+		<description>Digimon 02 5 (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27415,7 +26312,7 @@ license:CC0
 	</software>
 
 	<software name="digimn5c" cloneof="digimn5">
-		<description>Digimon 02 5 Crystal (China)</description>
+		<description>Digimon 02 5 Crystal (Chi)</description>
 		<year>20??</year>
 		<publisher>Yong Yong</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27432,7 +26329,7 @@ license:CC0
 <!-- Once sorted out what is good and what not, the entry should be moved among the Sintax games above! -->
 	<software name="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (China)</description>
+		<description>Metal Slug 2001 (Chi)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27447,7 +26344,7 @@ license:CC0
 
 	<software name="mslug2k1a" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (China, Alt 1)</description>
+		<description>Metal Slug 2001 (Chi, Alt 1)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27462,7 +26359,7 @@ license:CC0
 
 	<software name="mslug2k1b" cloneof="mslug2k1">
 		<!-- probably developed by BDD -->
-		<description>Metal Slug 2001 (China, Alt 2)</description>
+		<description>Metal Slug 2001 (Chi, Alt 2)</description>
 		<year>20??</year>
 		<publisher>Sintax</publisher>
 		<part name="cart" interface="gameboy_cart">
@@ -27476,7 +26373,7 @@ license:CC0
 	</software>
 
 <!--
-	List of unclassified roms
+List of unclassified roms
 -->
 
 
@@ -27484,11 +26381,10 @@ license:CC0
 
 	<software name="ar" supported="no">
 		<!-- Notes: GBC only -->
-		<description>Action Replay Online BIOS (Europe)</description>
+		<description>Action Replay Online BIOS (Euro)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="131072">
 				<rom name="action replay online bios (europe) (unl).bin" size="131072" crc="04c8c858" sha1="fa441c5e376b54b3503596fe8177b3a9ad79a9a8"/>
 			</dataarea>
@@ -27501,10 +26397,10 @@ license:CC0
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="gameboy_cart">
-			<feature name="slot" value="rom_mbc5" />
 			<dataarea name="rom" size="81920">
 				<rom name="gameshark online bios (usa) (unl).bin" size="81920" crc="c37d21d9" sha1="22f00e604acb827a48d4c9e109ba622f59a9d0a9"/>
 			</dataarea>
 		</part>
 	</software>
+
 </softwarelist>


### PR DESCRIPTION
Added every missing official release, using info from no-intro and other sources.
Replaced "SGB enhanced" comments with "\<feature name="enhancement" value="sgb" />" line.
Moved the GB Boy Colour internal multicart to gbcolor.xml since its menu is CGB compatible and includes at least one CGB-exclusive game.
Found a few ROMs of unknown origin in the list which don't match official dumps, I've marked them as "bad dump?" in case that they're prototypes.
Added some "going gold" dates.
Added list of known dumps not yet verified against retail cartridge (there's probably many more than these).
Canadian Zelda has now been confirmed a good dump.
Uchiiwai - Kyoudaijingi no Puzzle Game is now a clone of Splitz.

New clones:
		America Oudan Ultra Quiz Part 2 (Japan, Rev 1)
		Bokujou Monogatari GB (Japan, NP)
		Boxxle (USA)
		Fastest Lap (USA)
		Gargoyle's Quest - Ghosts'n Goblins (Europe, Rev 1)
		Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Kanji no Tatsujin (Japan)
		Goukaku Boy GOLD - Shikakui Atama o Maruku Suru - Keisan no Tatsujin (Japan, Alt)
		Hyper Lode Runner (World)
		The Jetsons - Robot Panic (USA, Rev 1)
		Jungle Strike (USA)
		Kaseki Sousei Reborn (Japan, Rev 1)
		Kinin Koumaroku Oni (Japan, Rev 1)
		Mickey Mouse V (Japan, Rev 1)
		Disney's Mulan (USA)
		Nettou World Heroes 2 Jet (Japan, Rev 1)
		Pac-In-Time (Europe, Rev 1)
		Pocket Puyo Puyo Tsuu (Japan, Rev 1, NP)
		Popeye 2 (Japan, Rev 1)
		Purikura Pocket - Fukanzen Joshikousei Manual (Japan, Rev 1, NP)
		Roger Clemens' MVP Baseball (USA, Rev 1)
		Teenage Mutant Hero Turtles III - Radical Rescue (Europe, Rev 1)
		Tetris 2 (Europe, Rev 1)
		Tintin in Tibet (Europe, En / Es / It / Sv)
		World Cup Striker (Europe, En / Fra / Ger)

Fixed dumps:
		The Adventures of Rocky and Bullwinkle (USA)
		Pang (UK)
		Suzuki Aguri no F-1 Super Driving (Japan)