### PR TITLE
Makefile: add GEN_FOLDERS dependency to mucld.hxx

### DIFF
--- a/makefile
+++ b/makefile
@@ -1738,7 +1738,7 @@ $(GENDIR)/%.lh: $(SRC)/%.lay scripts/build/complay.py | $(GEN_FOLDERS)
 	@echo Compressing $<...
 	$(SILENT)$(PYTHON) scripts/build/complay.py $< $@ layout_$(basename $(notdir $<))
 
-$(GENDIR)/mame/machine/mulcd.hxx: $(SRC)/mame/machine/mulcd.ppm scripts/build/file2str.py
+$(GENDIR)/mame/machine/mulcd.hxx: $(SRC)/mame/machine/mulcd.ppm scripts/build/file2str.py | $(GEN_FOLDERS)
 	@echo Converting $<...
 	$(SILENT)$(PYTHON) scripts/build/file2str.py $< $@ mulcd_bkg uint8_t
 


### PR DESCRIPTION
A parallel build appears to sometimes fail with:

```
Converting src/mame/machine/mulcd.ppm...
Unable to open output file 'build/generated/mame/machine/mulcd.hxx'
make: *** [makefile:1728: build/generated/mame/machine/mulcd.hxx] Error 255
```

This commit adds the same dependency that other files in GENDIR have.