### PR TITLE
fmtowns_cd.xml: 3 new dumps, 5 replacements, railtycn/lipsadv3 floppies

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -428,7 +428,6 @@ New Horizon CD Learning System 2 3-nen                        Tokyo Shoseki     
 New Horizon CD Running System 1-nen                           Tokyo Shoseki                     1990/7     SET(CD+FD)
 New Horizon CD Running System 2-nen                           Tokyo Shoseki                     1990/7     SET(CD+FD)
 New Horizon CD Running System 2-nen                           Tokyo Shoseki                     1991/1     SET(CD+FD)
-NHK Eigo de Asobo 3                                           Fujitsu                           1994/7     CD
 NHK Hitori de Dekiru Mon!                                     Ray                               1995/3     CD
 NHK Jissen Eikaiwa (Marty compatible)                         CRC Sougou Kenkyuusho             1993/3     CD
 NHK Jissen Eikaiwa Part 2                                     CRC Sougou Kenkyuusho             1993/12    CD
@@ -465,7 +464,6 @@ Obaachan no Chiebukuro                                        Gyousei           
 Only You: Seikimatsu Juliet-tachi                             Alice Soft                        1996/1     CD
 Orient Express                                                Gyousei                           1994/12    CD
 Oryx Blue Wave: Eikou e no Kiseki                             Data West                         1995/10    SET(CD+FD)
-Oshiete, Nouveau                                              TDK Core                          1994/3     CD
 Otto Anime-kun                                                Nihon Micom Hanbai                1990/3     CD
 Palamedes                                                     Ving                              1991/10    CD
 Pasocon de Tanoshimu Yama to Chizu                            Inter Limited Logic               1995/10    CD
@@ -488,7 +486,6 @@ Pyoko-tan no Niji no Shima: Nanairo no Ninjin wo Sagase       Nanken Koubou     
 Q2 ROM Magazine - Soukangou                                   Disinfectant                      1993/5     CD
 Queen of Duellist Gaiden + Gaiden Alpha                       Agumix                            1994/3     CD
 Quiz de Let's Go!                                             Great                             1993/3     ?
-* Railroad Tycoon                                             MicroProse Japan                  1993/12    SET(CD+FD)
 * Rainbow Islands Extra                                       Ving                              1992/4     CD
 Rakuraku Sozai Vol. 1                                         Fujitsu                           1995/3     CD
 Reijou Monogatari                                             Interheart                        1995/4     CD
@@ -3230,11 +3227,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="burai2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Burai Kanketsu-hen.ccd" size="3239" crc="c76b92a8" sha1="1900364eb3dd1017930c6b1a7091271bb94fbbbd"/>
-		<rom name="Burai Kanketsu-hen.cue" size="594" crc="07a0beed" sha1="990f39d94dc2f9b08103d8b1174b035f400bd197"/>
-		<rom name="Burai Kanketsu-hen.img" size="363736800" crc="c7df9688" sha1="e41c64943ea23e4a175805e37f458697e71ee460"/>
-		<rom name="Burai Kanketsu-hen.sub" size="14846400" crc="db0444e1" sha1="961e2f66b060f5f335fe83f46a9468769915773b"/>
+		Origin: redump.org
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 01).bin" size="20815200" crc="ea057b75" sha1="79dcfd0df5dce948596360d90e298d665a9357b9"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 02).bin" size="31575600" crc="2660447e" sha1="5b6e3b2e34107244a166a3d2e095e1c5b740291c"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 03).bin" size="35828016" crc="7e5e00f3" sha1="5524d39ec94a9f8e325d2a93df302c8f5fd55cbf"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 04).bin" size="5602464" crc="535491bf" sha1="02e5d74897c8f75e21d47e50d85d2d2b706a08a5"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 05).bin" size="20998656" crc="c4208823" sha1="6bddecbfbca1ab5d810d8685133b549b942e290f"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 06).bin" size="7625184" crc="8858251d" sha1="99cc2311b4b06429709b40fe69d55163054970ad"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 07).bin" size="34374480" crc="d8e1094f" sha1="ca34a7532ddf489108fa3e087fdee6ad13dd4fd6"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 08).bin" size="14448336" crc="84d77d0d" sha1="3dd800f2f8e5f89f0314f09b170336c55e956b23"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 09).bin" size="26024880" crc="c60879cd" sha1="73c6844554e732d74e7665a6bb0a10c4bffd692a"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 10).bin" size="5362560" crc="6c67135a" sha1="24cf0549ad8185836cfd6d400a33a2bdbd0502d8"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 11).bin" size="35037744" crc="5a3ce2e7" sha1="1d0fdfe849bc43c2deeafd3a99c025cd9c851918"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 12).bin" size="13547520" crc="cc8e5d41" sha1="09b6b81ba5736f06d5dcaf0a6a7df25a398e08ad"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 13).bin" size="12983040" crc="ba5323af" sha1="5b468cc5a0a3e5ec174bb51909e11b5b3f668ed1"/>
+		<rom name="Burai - Kanketsu-hen (Japan) (Track 14).bin" size="99513120" crc="92253ae8" sha1="c39de65f227806e1af08433fc2d2e8abe7c72c25"/>
+		<rom name="Burai - Kanketsu-hen (Japan).cue" size="1704" crc="e32613d6" sha1="ffd0f4410f9022329035047741fb3a4bf8bcb395"/>
 		-->
 		<description>Burai Kanketsu-hen</description>
 		<year>1991</year>
@@ -3245,7 +3253,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burai kanketsu-hen" sha1="acf9f3c856ef1398805509352b4e6e2f53f61b47" />
+				<disk name="burai - kanketsu-hen (japan)" sha1="d41e001618a596877865e03a401ae53577dfa89b" />
 			</diskarea>
 		</part>
 	</software>
@@ -8284,11 +8292,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="jealousy">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Jealousy.ccd" size="3239" crc="1394fcc5" sha1="36c10240660297f0a314b003fc6ece54513bf193"/>
-		<rom name="Jealousy.cue" size="584" crc="924c2fdb" sha1="29b3e09e4e63ec68ebb36a3dab80d12333b48f61"/>
-		<rom name="Jealousy.img" size="624989904" crc="692d5787" sha1="944a314004dad7bd994ea36326566fd67af3ee11"/>
-		<rom name="Jealousy.sub" size="25509792" crc="3539ea8c" sha1="ca7d7248f35a62d616f33fa834c839162b1cf00d"/>
+		Origin: redump.org
+		<rom name="Jealousy (Japan) (Track 01).bin" size="5647152" crc="9fd37d6c" sha1="34322ecc55265556bfb0d6448c61060548ec5636"/>
+		<rom name="Jealousy (Japan) (Track 02).bin" size="55034448" crc="95888189" sha1="7a042b195943f0ebfc49268d8597fc1bad47ba27"/>
+		<rom name="Jealousy (Japan) (Track 03).bin" size="56271600" crc="fc8086f2" sha1="27d4da7649b4c3f52ad19fdb36cfa526210b784f"/>
+		<rom name="Jealousy (Japan) (Track 04).bin" size="42161952" crc="331b4903" sha1="e289d3efe0116595103dcd94649c4406a4ebf881"/>
+		<rom name="Jealousy (Japan) (Track 05).bin" size="47980800" crc="0fc8d7f7" sha1="1eec94e57b51e8b56ec69781247784e9c7275373"/>
+		<rom name="Jealousy (Japan) (Track 06).bin" size="42338352" crc="0e8b205c" sha1="2f16ebe683b2976b4a7dfb1550c2057eab30c13a"/>
+		<rom name="Jealousy (Japan) (Track 07).bin" size="41630400" crc="3fdf60ce" sha1="4edc22000a6bd236a7690e31d016a806e4a7a2cd"/>
+		<rom name="Jealousy (Japan) (Track 08).bin" size="46746000" crc="1a57bfec" sha1="12cba803fcc1fa0795ec4285a631d43cd27a8d48"/>
+		<rom name="Jealousy (Japan) (Track 09).bin" size="50803200" crc="44bef5ed" sha1="097f689c619e1956eee0b45893fe717b34d24a44"/>
+		<rom name="Jealousy (Japan) (Track 10).bin" size="43923600" crc="3da971b8" sha1="d1ac590d4f425f26c2d04ba45323c12283238e54"/>
+		<rom name="Jealousy (Japan) (Track 11).bin" size="47098800" crc="7331ffa3" sha1="0eb74a0a3b7f898d31a1fef8bc013e8ddaf9536c"/>
+		<rom name="Jealousy (Japan) (Track 12).bin" size="47628000" crc="20af6b89" sha1="be444f07b49786a7acd198f35e10f5a477d3d5c8"/>
+		<rom name="Jealousy (Japan) (Track 13).bin" size="40924800" crc="e0e09c11" sha1="444214048f4eca6d4090e994efd842b665db6162"/>
+		<rom name="Jealousy (Japan) (Track 14).bin" size="56800800" crc="fa934cb8" sha1="02c05d2c7e3e678241aac181ece57af8a962ca05"/>
+		<rom name="Jealousy (Japan).cue" size="1559" crc="69fea1ec" sha1="694694a8864aabfa635caa0c33512f35d3679261"/>
 		-->
 		<description>Jealousy</description>
 		<year>1995</year>
@@ -8298,7 +8317,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jealousy" sha1="49244a1e50fc4300f4ead328d4b43c8449042d53" />
+				<disk name="jealousy (japan)" sha1="1d14efa85e889f00ce444700e6d8c53327e2496d" />
 			</diskarea>
 		</part>
 	</software>
@@ -8611,22 +8630,30 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="kindanke">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Kindan no Ketsuzoku.ccd" size="2823" crc="0eb0eeae" sha1="0c2bdf0b806b1264c57468c1e0461a2f30502b88"/>
-		<rom name="Kindan no Ketsuzoku.cue" size="685" crc="7ce5e0fc" sha1="bcdc1e469199b66ac6ac582a181e7b764e0ef064"/>
-		<rom name="Kindan no Ketsuzoku.img" size="417186000" crc="d549a494" sha1="90c756e866553d64df3a8369bed3f3fda6b19c48"/>
-		<rom name="Kindan no Ketsuzoku.sub" size="17028000" crc="41f52572" sha1="1190e57fd83e073e165caf3bec248107af4acfa0"/>
+		Origin: redump.org
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 01).bin" size="94905552" crc="49f1cb0b" sha1="25945e0786a36e3a75961fcf8d6617d1022973a3"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 02).bin" size="29275344" crc="a5d1ebf9" sha1="895a616e4698ce2587bd7baece78d0684f34e089"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 03).bin" size="32111856" crc="531e4c48" sha1="8c7ad2a7ea2ea60e6f9fec02058b581439dd7e59"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 04).bin" size="38102400" crc="8ac68a3a" sha1="6720062e60ac75c91986044cc0175dda9c833d16"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 05).bin" size="35451696" crc="a01a6374" sha1="3bb6a456b28acfac9e4c0bf6c23818a49bbc845e"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 06).bin" size="25754400" crc="1c5d69d3" sha1="941d8a3cc3cfc9be12ea3e127c10a38d65c17acc"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 07).bin" size="29282400" crc="afd11219" sha1="b5cace7f1edb06319a42cf0038979a67680a2fad"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 08).bin" size="29635200" crc="af6835ac" sha1="9a793cce40dc1c342c91c875c78c00b27cef48c2"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 09).bin" size="31573248" crc="d00a89c5" sha1="fe4ded8cd7127b3ebd902b23884c24cfc91235e5"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 10).bin" size="33516000" crc="5a761f24" sha1="fe18251170e84c2de2a40a68d0e7a2e3293903f5"/>
+		<rom name="Kindan no Ketsuzoku (Japan) (Track 11).bin" size="37577904" crc="a4ab6ec4" sha1="3cc0d6563b417e17878d48785131986cf3e93405"/>
+		<rom name="Kindan no Ketsuzoku (Japan).cue" size="1347" crc="158404c5" sha1="29c2409c2293cb1b80029fe3f189c2b77fa2683c"/>
 		-->
 		<description>Kindan no Ketsuzoku</description>
 		<year>1993</year>
 		<publisher>シーズウェア (C's Ware)</publisher>
-		<info name="serial" value="HMF-155"/>
+		<info name="serial" value="HMF-155 / 2TD-3014"/>
 		<info name="alt_title" value="禁断の血族" />
 		<info name="release" value="199407xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kindan no ketsuzoku" sha1="589dfff7b733335530a19f3a88a7cdda91826187" />
+				<disk name="kindan no ketsuzoku (japan)" sha1="8fdb182fe5904dcad4d0911938372d7d1b022d71" />
 			</diskarea>
 		</part>
 	</software>
@@ -9339,15 +9366,41 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="ldawn2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Lunatic Dawn II.ccd" size="5024" crc="130c27c9" sha1="fd9885d981912596999bca682dd5587c513bcd0f"/>
-		<rom name="Lunatic Dawn II.cue" size="1825" crc="8299d5e4" sha1="17a86c05a6b28a2590e4b96161329e0e59df4fd3"/>
-		<rom name="Lunatic Dawn II.img" size="511261296" crc="2db8badd" sha1="7a37ffa772f1ade9ab56ef6c808a96afe9e90084"/>
-		<rom name="Lunatic Dawn II.sub" size="20867808" crc="d1986582" sha1="d4f119946fb61aa6211ced6c818b112f089595b9"/>
+		Origin: redump.org
+		<rom name="Lunatic Dawn II (Japan) (Track 01).bin" size="34804896" crc="d8a381b6" sha1="8b2e9368841838771522936806d49feb9758d647"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 02).bin" size="18874800" crc="9756b934" sha1="e9899618e7b57aacbc51b988c2adfb66c9863ae2"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 03).bin" size="17816400" crc="3d83a9e5" sha1="645674ed51e5b98dbffb7febea3105e829e5f6e9"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 04).bin" size="18698400" crc="37e94fb7" sha1="56e81b915ba7af734bd29e938e666c27581ae6a1"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 05).bin" size="18522000" crc="9cb6f5dd" sha1="a22858b38b8486dff0c0aa1f3617d76ccd05425d"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 06).bin" size="21344400" crc="92248220" sha1="13472ef8ba66306925fbf94f214a365ba654572b"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 07).bin" size="17287200" crc="328a51da" sha1="6a5400fc7eafa96acd65325f62299735b22606a4"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 08).bin" size="18169200" crc="c43745fb" sha1="92bbffb0625afc40d9cc0583647c6f2cfc1ec9db"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 09).bin" size="19227600" crc="e3a5059e" sha1="45df6ae72c986045b29f6c740435771a292ef873"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 10).bin" size="16228800" crc="1146dbde" sha1="803423f586e2a5ff506206f0a4b04da8d3eb1353"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 11).bin" size="16405200" crc="b942fcae" sha1="5ccfc7fbf24312333ed94434a2e4758521f3ec0d"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 12).bin" size="24519600" crc="ac16fec2" sha1="42017dedbaa61c61472927799aabef59101d0585"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 13).bin" size="17287200" crc="c2ddfb5b" sha1="b6b692a2f2094949c8ada311bca1962f87ed31f9"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 14).bin" size="18169200" crc="f42f48f4" sha1="e421a0dd3c4bbc7506c03fac274aaf0bd1374566"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 15).bin" size="17640000" crc="11e2b513" sha1="52c010ad0a5870d84eae492c20c37b2f1e046104"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 16).bin" size="16052400" crc="3382879c" sha1="702536ce0033abdd70b2076d255046be15349aa8"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 17).bin" size="17992800" crc="8d37fbee" sha1="78c65d8a0ba4131de5608dbbd33762fe9989d231"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 18).bin" size="19580400" crc="c90d9908" sha1="2df0514e2cbecbd18a109a2cffa233f7698ee8dc"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 19).bin" size="16758000" crc="ccb92882" sha1="a1f17e75e31e2878626e6e7add17d550b05f13fd"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 20).bin" size="20462400" crc="07103a41" sha1="82d10db23cf216a1563e816ef8e8b51b5edd6bdc"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 21).bin" size="18874800" crc="2db64611" sha1="6ade4fb802781b9cfbaee91742b92a1d9ea7f0ef"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 22).bin" size="18698400" crc="3512737f" sha1="47cfde4f993db629f84abdbbffc765e32fb7bbc4"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 23).bin" size="7232400" crc="189970bd" sha1="b2ae6767c4daa6a038aad00f5124bfa179ff57d2"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 24).bin" size="1587600" crc="468ff234" sha1="cc3c5ea21d4934f4f3333bf0139a3a417d4ab459"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 25).bin" size="2646000" crc="7cab1b3d" sha1="6a6d69b4de5bd803e0d5691793c93498df026f81"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 26).bin" size="25578000" crc="b14b037f" sha1="e874d032a28b117ece7e659bb6aa091705f86d2a"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 27).bin" size="32986800" crc="9692d42d" sha1="8e8e021d1477503444f8d4dd5352d0b9483e41d1"/>
+		<rom name="Lunatic Dawn II (Japan) (Track 28).bin" size="17816400" crc="77776d02" sha1="cd97d4e9f800e77d23afa71a5a9751f3ab9da257"/>
+		<rom name="Lunatic Dawn II (Japan).cue" size="3286" crc="83fd48b7" sha1="52d19495efbb51ac5ff6fc4cb36c4f444ca21d20"/>
 		-->
 		<description>Lunatic Dawn II</description>
 		<year>1994</year>
 		<publisher>アートディンク (Artdink)</publisher>
+		<info name="serial" value="MTC-1107"/>
 		<info name="alt_title" value="ルナティックドーンII" />
 		<info name="release" value="199411xx" />
 		<info name="usage" value="Requires 4 MB RAM"/>
@@ -9359,7 +9412,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lunatic dawn ii" sha1="2e724da365c6d53e2d94f8bfb1e348a2f5b709d4" />
+				<disk name="lunatic dawn ii (japan)" sha1="923edaf8b0d1ea49eb7d8f58030502867b092b0c" />
 			</diskarea>
 		</part>
 	</software>
@@ -11274,11 +11327,29 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="necronom">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Necronomicon.ccd" size="4583" crc="42a633fc" sha1="4edd1de4cfeb80cef936189ce6f14d2a9badfb6a"/>
-		<rom name="Necronomicon.cue" size="868" crc="16626f66" sha1="a947af7d9e13bccc0ad74a9dac694378f847057a"/>
-		<rom name="Necronomicon.img" size="661370640" crc="5de570c6" sha1="1d79fbaf3b3bb7f3cbb3d06d9a8928b5c91ecbee"/>
-		<rom name="Necronomicon.sub" size="26994720" crc="b023097e" sha1="b474073d0de6a77d8d8ca4fa33886c584b16dc08"/>
+		Origin: redump.org
+		<rom name="Necronomicon (Japan) (Track 01).bin" size="41994960" crc="e69847f6" sha1="9feb6befd06ae8b8ef5db0a7456e3d55b9bdaebe"/>
+		<rom name="Necronomicon (Japan) (Track 02).bin" size="36503040" crc="65271603" sha1="e361ceab5a0d856fd8295568fd259f7a8c3e9596"/>
+		<rom name="Necronomicon (Japan) (Track 03).bin" size="35280000" crc="226713e3" sha1="8f5a855fa2ce7c95ddf94671383d5828bb672068"/>
+		<rom name="Necronomicon (Japan) (Track 04).bin" size="35632800" crc="67760d7d" sha1="5d6f2d886b209c331a7d7b8163d956a1bd048e9f"/>
+		<rom name="Necronomicon (Japan) (Track 05).bin" size="42336000" crc="0bfcd852" sha1="cc22a9f7566976a0d44345e1b83bfb1ba0433af2"/>
+		<rom name="Necronomicon (Japan) (Track 06).bin" size="26812800" crc="a9f5fccd" sha1="57995c6379842c5294c4d818f5a2641208bb0e87"/>
+		<rom name="Necronomicon (Japan) (Track 07).bin" size="35632800" crc="60cc8c91" sha1="ee7f74ec66f33dc462d76679fd58c7b957e20ce5"/>
+		<rom name="Necronomicon (Japan) (Track 08).bin" size="35456400" crc="c5ed736d" sha1="27163b06717f2a12ee4eee1f34dfa4fec23a53f3"/>
+		<rom name="Necronomicon (Japan) (Track 09).bin" size="45334800" crc="621c95dc" sha1="9f5c13183befe019cdd9612c5f5e27f98033313c"/>
+		<rom name="Necronomicon (Japan) (Track 10).bin" size="33868800" crc="273ce058" sha1="aeffbde65deff8256fda85e86464c3d0dacc1483"/>
+		<rom name="Necronomicon (Japan) (Track 11).bin" size="31752000" crc="af732c8c" sha1="6a25979a7e9deadc86b54df57a99a7df3a37ca7f"/>
+		<rom name="Necronomicon (Japan) (Track 12).bin" size="46040400" crc="c67ae671" sha1="6edf281bebb21f00d0f96c0b620498c550bf7bf0"/>
+		<rom name="Necronomicon (Japan) (Track 13).bin" size="29282400" crc="5c789854" sha1="a460a08bec2c0a1fd4b943dfda2d7c0f21316455"/>
+		<rom name="Necronomicon (Japan) (Track 14).bin" size="33516000" crc="6f93a446" sha1="958009d2a08de104462de5a29943bb212dad2db3"/>
+		<rom name="Necronomicon (Japan) (Track 15).bin" size="28929600" crc="41a47a6b" sha1="c4e057bf0eb15ddafc1791c6a848128a29a7719b"/>
+		<rom name="Necronomicon (Japan) (Track 16).bin" size="39337200" crc="4618682f" sha1="30081aa270d2cb0dbf509bde015be176fb9a27ad"/>
+		<rom name="Necronomicon (Japan) (Track 17).bin" size="35632800" crc="1ba19e3e" sha1="4d81ab67876acf2ba93f6016dc60de821233435e"/>
+		<rom name="Necronomicon (Japan) (Track 18).bin" size="34927200" crc="fbcfbc91" sha1="eaf01264849d176aab0cf80865f64c39352b5029"/>
+		<rom name="Necronomicon (Japan) (Track 19).bin" size="1234800" crc="9eae3269" sha1="ce043258165554281e3c20f84c74e89a45d8600b"/>
+		<rom name="Necronomicon (Japan) (Track 20).bin" size="10760400" crc="e3ed67da" sha1="feceacd7226f3afc97f2e51db452c4ca2d9c3a65"/>
+		<rom name="Necronomicon (Japan) (Track 21).bin" size="1105440" crc="a68cfda0" sha1="922607a261724c9694f0d322cbfade5b07f50aca"/>
+		<rom name="Necronomicon (Japan).cue" size="2397" crc="e4753387" sha1="901b5c1fdf691ebe40b28fce59ed60d2e9a90586"/>
 		-->
 		<description>Necronomicon</description>
 		<year>1994</year>
@@ -11289,7 +11360,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="necronomicon" sha1="82672ceafa32c0e9975aeda8f3f578c1c204ff52" />
+				<disk name="necronomicon (japan)" sha1="c4b0233639a9021f36ebe5f43f8a4df0ed62a4e2" />
 			</diskarea>
 		</part>
 	</software>
@@ -11494,6 +11565,105 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nhk eigo de asobo vol. 2 - bernard no daibouken (japan)" sha1="7a0772ba3044392a6df13eeeedb14ea6b1005f21" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="nhkeigo3">
+		<!--
+		Origin: redump.org
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 01).bin" size="211327200" crc="27716987" sha1="9f63a73076e70401c40c3526a9ef5647639a8f68"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 02).bin" size="8643600" crc="e7cffa1c" sha1="de355dfa38f7469b3518df1e24e419fc7b187cbb"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 03).bin" size="13935600" crc="5a45cea6" sha1="cec54cc61521e5a1b3e99d1c4bfbdee654912442"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 04).bin" size="8114400" crc="739e771a" sha1="e43a20f4473c2f1983e198d2107808dd1e685b59"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 05).bin" size="10231200" crc="6d741fc4" sha1="035adce2f48e3605cbc552e72d1932e09ebb74dc"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 06).bin" size="1411200" crc="04c5cd14" sha1="2c38a7941495aef97c997d293b995ac03d5794f2"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 07).bin" size="29988000" crc="b6cda3fd" sha1="899f3270a0a31c4e9e5d59362a4dbd22ae63a82d"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 08).bin" size="1058400" crc="99256836" sha1="3155cf298405be3bfb6c02a5c374b4e7596f04d7"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 09).bin" size="2293200" crc="b1a3c993" sha1="fecdc438cf2363f1d4fd1cfe7d1576e83d40e1d2"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 10).bin" size="4233600" crc="8a84d6d0" sha1="559622df465f88c8a200d86a0cb03ad4e68a73dc"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 11).bin" size="1058400" crc="4c0d3a4c" sha1="42eacd36ec7d4e684fa9d4cd65b05949e825e3c5"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 12).bin" size="2646000" crc="c7f27eb8" sha1="819a8fc7849bf7e660ca23d3ea6dfb9179b5d31e"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 13).bin" size="5997600" crc="fe102b64" sha1="783202f408642f06d422972f2c8793321e094c1e"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 14).bin" size="1058400" crc="b7784d58" sha1="39650659e21df8ed255fe5085659a3951a9926df"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 15).bin" size="7056000" crc="e3c60c3a" sha1="a5704f3789adfa5108f1d8d14f0c1d66c6b78a71"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 16).bin" size="2998800" crc="306ba95c" sha1="148590f9f597720f7c330e5424e692af4806f74f"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 17).bin" size="3351600" crc="eb359746" sha1="d88cbb861087c3ad3cfa3593f617c79b316dd659"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 18).bin" size="2822400" crc="4f9b3c81" sha1="5f64cfc4fbfe628b59ef7bc15478ef39c8e746af"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 19).bin" size="3528000" crc="9dba0649" sha1="ef261641af88db1113608ae9a16b1de38bcd353b"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 20).bin" size="6526800" crc="9f7a587e" sha1="07be4ec898c384f2662cd5ab490448605f88f89e"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 21).bin" size="5997600" crc="019ce5cf" sha1="c4833071e750e85560a90207855fc42a9625a7fd"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 22).bin" size="35103600" crc="f4c3e17f" sha1="56e1c01a5ab2eb60323f449726beaa7cf4720039"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 23).bin" size="6174000" crc="239c0c9f" sha1="3e56ec7fe545991ebf9fc4254d441a91d37fa280"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 24).bin" size="4762800" crc="6737405c" sha1="7e4e6978790a121a6d7f76f7cd0b858823040804"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 25).bin" size="34045200" crc="1879409c" sha1="ef35a76f40510c4bd9faa30d3f857821e69fbf46"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 26).bin" size="6174000" crc="03d4c862" sha1="bb41bd066e87a7d60fd5f991f1766f8134058fdf"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 27).bin" size="5468400" crc="9129eab1" sha1="f6d1e301f44877d0984ef7dfaa0c1bfed1b2f944"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 28).bin" size="34574400" crc="c2a2f2cc" sha1="4b892149df625abf82f0e7e916c9b14191c9142c"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 29).bin" size="4939200" crc="2c84e2af" sha1="5fc8eb0fe9f88849f27fbf97181a70cc8cdf4358"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 30).bin" size="8643600" crc="e40b012c" sha1="bf99e45ecd356a06490aa5447127547cb24aba2c"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 31).bin" size="2469600" crc="440f2354" sha1="adc4f9a3f793c17beafec1707db62e71970684d5"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 32).bin" size="3880800" crc="09852ac8" sha1="35cc855b2b5e7914d095295cfcf7e668f653320f"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 33).bin" size="2293200" crc="f3e5165b" sha1="821d9f35450cae1b2f2411f14c9eb5bab8eea1a4"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 34).bin" size="2998800" crc="88943db0" sha1="e5f0cd32c0e9cf039225d1476f5d020881e7fb9a"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 35).bin" size="2646000" crc="d0a2d0a4" sha1="ba54716bb69a0cc43fb990232d58e3a39df60514"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 36).bin" size="2998800" crc="9633a1ac" sha1="d3bc5b24a3b57d935d9a859071f7292d8d2a4a91"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 37).bin" size="1058400" crc="85a2f70e" sha1="86dea2f4118a77205465049872ce17b412597bfc"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 38).bin" size="8643600" crc="9f8e717b" sha1="0471fdb1cc6935d6fc06c33fc1e5ebf88c211ab1"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 39).bin" size="1940400" crc="c901f7d8" sha1="a6c8259e06f521ebe6ea5350ad30deb545a3dff6"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 40).bin" size="7585200" crc="a2ea6969" sha1="809694c75e5a85455d7948d6a030d15c4b8723fa"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 41).bin" size="8290800" crc="2da4f737" sha1="7ec205a13119a3c67708ac4155ec42393c4b76a2"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 42).bin" size="1764000" crc="7286ea07" sha1="aa785e6690f0884a769b59cfba25ec61e19f47c8"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 43).bin" size="2116800" crc="a23d49e5" sha1="2076e73e964f803165166101925c7369562d062a"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 44).bin" size="4762800" crc="cf23bc98" sha1="2d7957a4a005b9820dddec164f6f3e2e08533953"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 45).bin" size="1764000" crc="f73c231e" sha1="2110e44c8133c234cacdaa44a45948982110e273"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 46).bin" size="1764000" crc="0998ffc5" sha1="fb1e1cf103d07cc5abd8fa4ad73e2951b6cf98aa"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 47).bin" size="1587600" crc="d47baef6" sha1="ce125c6e5adb22ec63b2608c6a66e89b13739317"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 48).bin" size="1411200" crc="c14660e0" sha1="dcb49a777fb8d7a53b83415c5c630fe76da36eee"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 49).bin" size="1587600" crc="0ab54ee3" sha1="7b1a0562442e8a36b91004dad70c6e48c4ec77bc"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 50).bin" size="1411200" crc="672719b8" sha1="d3cdf78dbd68b8acce6219ec19fd6a13ad0dea13"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 51).bin" size="1764000" crc="f4bcd85a" sha1="db464319fb86f0658f2bac76492f4c9b3311632a"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 52).bin" size="1587600" crc="e654610c" sha1="5ac04d6097f32a142a2d3973ae1ed0bc4c8c39a5"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 53).bin" size="1411200" crc="cb253ac5" sha1="0c347c6281eae4e32506b7d0a89db9fad1bb1887"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 54).bin" size="1058400" crc="f74db355" sha1="958b6cb3ee221503c8f5aa8c273a3a7ac8822f3f"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 55).bin" size="1587600" crc="9b709665" sha1="85f95ce72527ac00b28b46dc7d8dc3d75ae5816d"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 56).bin" size="1587600" crc="f447162e" sha1="8deda8797392b8cdcb194dd5bbed3d2694e9df57"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 57).bin" size="1587600" crc="0f8dc6ca" sha1="b4441d919e97bc0718f7152825afcca6255b3407"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 58).bin" size="1234800" crc="5e8edfc6" sha1="d394b813ee6c49e6952dcaee2b36d1efb70b6e84"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 59).bin" size="1234800" crc="110f08d1" sha1="75ab76f3e3ce4ee7d38a5a33d57b627c0bed061c"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 60).bin" size="1411200" crc="4c25c381" sha1="4983835ee04356d9e2a9aea02817856c63cd7360"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 61).bin" size="1411200" crc="57d40b4d" sha1="eb1567bd6e38d26fae0819d25a4945fe704f7bd8"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 62).bin" size="8643600" crc="c0fc10af" sha1="a4027ee04dd7d90703534823e69545c34e6cbdf7"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 63).bin" size="1940400" crc="66d8f884" sha1="9526ab9f19a4afc8d66d323514e68b455a1726d7"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 64).bin" size="12171600" crc="da4b8700" sha1="d9071b3fa2a83d273fab51b9c0068570b1afea7b"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 65).bin" size="8467200" crc="7ff0c340" sha1="47459b06ebcf57910d68f123ea22677b091ef176"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 66).bin" size="3351600" crc="81a75d31" sha1="f1caa5d381e5947338f05054ae0b92cd0285371d"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 67).bin" size="1764000" crc="52c49fbc" sha1="40096acbcf48ff5186a4e2e86b88585f3feaa7e8"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 68).bin" size="7585200" crc="00e6b2f0" sha1="17e6d741774b6e0c4571ccd192ffc398721cabb8"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 69).bin" size="16758000" crc="eb82db8e" sha1="007333288c325b57a1aa24d0898714e6247a8788"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 70).bin" size="20638800" crc="69aa8628" sha1="ca52977249dd370aa7d3be16218c568b1a11e1b4"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 71).bin" size="1058400" crc="7ba298ab" sha1="5c72fc1f1ed91171bb3523c59b6361807f53ac96"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 72).bin" size="1058400" crc="6cd9582b" sha1="738afb2421360398701d768e4c7b6956f8cc3df2"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 73).bin" size="1058400" crc="27d4dabf" sha1="705e48507ca4659e781ee75a2fe76d30c4c812b1"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 74).bin" size="1411200" crc="3575badf" sha1="3305af3449b046d4ef1e5b442862ec5e525ec240"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 75).bin" size="1058400" crc="86af2499" sha1="eed83fcd059bc62e01792d581d010e57aaf1cd9c"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 76).bin" size="1058400" crc="1ad19b9b" sha1="5b4ae571d1f044ae472cdbc21134509aeabfc025"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 77).bin" size="1234800" crc="e4df5c07" sha1="968a69e5fe6777ebc61dcc3f34de09233ed0adc6"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 78).bin" size="1940400" crc="53f6c3c1" sha1="c8134d2b3a646eb99af384ce0843188a70321a9d"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 79).bin" size="1587600" crc="67d807ca" sha1="8a3d25f20b5829336665b30d6f2464da683ac21b"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan) (Track 80).bin" size="1411200" crc="240ba978" sha1="3c7595e0829aa6f6104f0e9f9a5be456e1a0bf7f"/>
+		<rom name="NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park (Japan).cue" size="12382" crc="428da735" sha1="dc0b316d01b78fd572985abf28f035e7f877de91"/>
+		-->
+		<description>NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-206 / A2760461"/>
+		<info name="alt_title" value="ＮＨＫ英語であそぼ 3 ～ベルナールのアミューズメントパーク～" />
+		<info name="release" value="199407xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nhk eigo de asobo vol. 3 - bernard no amusement park (japan)" sha1="9c87df4600a1e62df272fe1b61c3d923f5a551aa" />
 			</diskarea>
 		</part>
 	</software>
@@ -12023,6 +12193,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nobunaga no yabou - tenshouki" sha1="fe1ca3991c5a1399cd720ae177644ca314b5d004" status="baddump" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="noobow">
+		<!--
+		Origin: private dump (sampson)
+		<rom name="PNB01.BIN" size="466015872" crc="e321a989" sha1="6cdb89465315cae85276e4c02d600edfe242e3dc"/>
+		<rom name="PNB01.CUE" size="6277" crc="1a5394ce" sha1="6f80d819a7f9e66fa5ff658161f466087f116477"/>
+		-->
+		<description>Oshiete Noobow</description>
+		<year>1994</year>
+		<publisher>ＴＤＫコア (TDK Core)</publisher>
+		<info name="serial" value="HMF-110 / PNB01-FR"/>
+		<info name="alt_title" value="おしえて ぬーぼー" />
+		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="pnb01" sha1="922f25586b84d0aea1c1630fcb439f8cbbacc275" />
 			</diskarea>
 		</part>
 	</software>
@@ -13432,8 +13622,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="railtycn" supported="no">
+	<software name="railtycn">
 		<!--
 		Origin: Neo Kobe Collection
 		<rom name="Railroad Tycoon.ccd" size="2223" crc="0d66b2f2" sha1="07a4e276d83d808f21f86b32a5b0dfafa26efdb9"/>
@@ -13447,6 +13636,11 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="HME-245"/>
 		<info name="alt_title" value="レイルロードタイクーン" />
 		<info name="release" value="199312xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="railroad_boot.bin" size="1261568" crc="12182b7a" sha1="00094bab0b9969524ec3694a38b1fa3cd1993d8b" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="railroad tycoon" sha1="175a06c227bb9c61a86e808d45a976e9892155d1" />
@@ -17940,7 +18134,7 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Z's Triphony DigitalCraft Towns (Japan) (Rev A).bin" size="20815200" crc="0b236cbb" sha1="c11d402af69cb6faac8b9d2e5562ccf14e13b35f"/>
 		<rom name="Z's Triphony DigitalCraft Towns (Japan) (Rev A).cue" size="113" crc="c6698b0f" sha1="a74c7c4911991ea4adff4748eeb225f1bf20cd36"/>
 		-->
-		<description>Z's Triphony DigitalCraft Towns</description>
+		<description>Z's Triphony DigitalCraft Towns (HMB-212A)</description>
 		<year>1990</year>
 		<publisher>ツァイト (Zeit)</publisher>
 		<info name="serial" value="HMB-212A"/>
@@ -17949,6 +18143,25 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="z's triphony digitalcraft towns (japan) (rev a)" sha1="1467a31fbc79e0eb4316773055468f03d28c2894" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="ztdco" cloneof="ztdc">
+		<!--
+		Origin: redump.org
+		<rom name="Z's Triphony DigitalCraft Towns (Japan).bin" size="14460096" crc="fcb85250" sha1="3fe11ba7d1488b31883044eb72fe43eabddfe104"/>
+		<rom name="Z's Triphony DigitalCraft Towns (Japan).cue" size="105" crc="e9d3d283" sha1="dbea85f233b8e2e396a95f1f0e15f8acd858b19c"/>
+		-->
+		<description>Z's Triphony DigitalCraft Towns (HMB-212)</description>
+		<year>1990</year>
+		<publisher>ツァイト (Zeit)</publisher>
+		<info name="serial" value="HMB-212"/>
+		<info name="release" value="199012xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="z's triphony digitalcraft towns (japan)" sha1="653d32f88bd032fb23a2f790f187e98f3d3c52e1" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -9667,8 +9667,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk? -->
-	<software name="lipsadv3" supported="no">
+	<software name="lipsadv3">
 		<!--
 		Origin: redump.org
 		<rom name="Lip 3 - Lipstick Adventure 3 (Japan) (Track 01).bin" size="52567200" crc="7462e0c3" sha1="48900be15c74d4099e25710dcd5e6f26123c1d7f"/>
@@ -9691,6 +9690,15 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="HME-221"/>
 		<info name="release" value="199305xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<!-- 
+				This image has been reconstructed manually by creating empty files with the names that the game expects and re-initializing them with the in-game option.
+				It's enough to make the game work, but it should be replaced with an actual dump of the original disk.
+				-->
+				<rom name="lip3_userdisk.hdm" size="1261568" crc="d1ea991e" sha1="da73198e178d90871b0b8e90f5b0ee8bc2a9c5eb" offset="000000" status="baddump" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="lip 3 - lipstick adventure 3 (japan)" sha1="c0507c340b55c1fa08a8080e0fc3d53d271f6a1e" />


### PR DESCRIPTION
- New dumps (working):

NHK Eigo de Asobo Vol. 3 - Bernard no Amusement Park [redump.org]
Oshiete Noobow [sampson]
Z's Triphony DigitalCraft Towns (HMB-212) [redump.org]

- Replaced entries with dumps from redump.org:

Burai Kanketsu-hen
Jealousy
Kindan no Ketsuzoku
Lunatic Dawn II
Necronomicon

- Added floppy disk dump to Railroad Tycoon and promoted to working [anonymous]

- Added a recreated floppy image for Lipstick Adventure 3 (marked as a bad dump), and promoted to working.