### PR TITLE
machines promoted to WORKING (Plug and Play)

### DIFF
--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -622,11 +622,7 @@ void ppu2c0x_device::draw_background(uint8_t* line_priority)
 {
 	bitmap_rgb32& bitmap = *m_bitmap;
 
-//	uint8_t color_mask = 0x3f;
-//	if (m_regs[PPU_CONTROL1] & PPU_CONTROL1_DISPLAY_MONO)
-//		color_mask = 0x30;
-
-	uint16_t palval = m_back_color;// &color_mask;
+	uint16_t palval = m_back_color;
 
 	/* cache the background pen */
 	uint32_t back_pen = palval;

--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -293,11 +293,6 @@ inline void ppu2c0x_device::writebyte(offs_t address, uint8_t data)
  *
  *************************************/
 
-void ppu2c0x_device::init_palette_tables()
-{
-	init_palette_tables(false);
-}
-
 rgb_t ppu2c0x_device::nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy)
 {
 	const double tint = 0.22; /* adjust to taste */
@@ -393,7 +388,7 @@ rgb_t ppu2c0x_device::nespal_to_RGB(int color_intensity, int color_num, int colo
 	return rgb_t(floor(R + .5), floor(G + .5), floor(B + .5));
 }
 
-void ppu2c0x_device::init_palette_tables(bool indirect)
+void ppu2c0x_device::init_palette_tables()
 {
 	bool is_pal = m_scanlines_per_frame != NTSC_SCANLINES_PER_FRAME;
 
@@ -418,13 +413,6 @@ void ppu2c0x_device::init_palette_tables(bool indirect)
 				rgb_t col = nespal_to_RGB(color_intensity, color_num, color_emphasis, is_pal);
 
 				m_nespens[entry] = (uint32_t)col;
-
-				/* Round, and set the value */
-				//if (indirect)
-				//	set_indirect_color(entry++, col);
-				//else
-				//	set_pen_color(entry++, col);
-
 				entry++;
 				
 			}

--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -244,11 +244,6 @@ void ppu2c0x_device::start_nopalram()
 	save_item(NAME(m_tilecount));
 	save_pointer(NAME(m_spriteram), SPRITERAM_SIZE);
 
-	/* TODO FIX
-	save_pointer(NAME(m_colortable), ARRAY_LENGTH(default_colortable));
-	save_pointer(NAME(m_colortable_mono), ARRAY_LENGTH(default_colortable_mono));
-	*/
-
 	save_item(NAME(*m_bitmap));
 }
 

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -212,7 +212,7 @@ protected:
 
 	uint8_t readbyte(offs_t address);
 
-	rgb_t m_nespens[0x200];
+	uint32_t m_nespens[0x200];
 private:
 	static constexpr device_timer_id TIMER_HBLANK = 0;
 	static constexpr device_timer_id TIMER_NMI = 1;

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -42,8 +42,7 @@
 
 class ppu2c0x_device :  public device_t,
 						public device_memory_interface,
-						public device_video_interface,
-						public device_palette_interface
+						public device_video_interface
 {
 public:
 	typedef device_delegate<void (int scanline, int vblank, int blanked)> scanline_delegate;
@@ -79,12 +78,11 @@ public:
 	rgb_t nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy);
 	virtual void init_palette();
 	void init_palette(bool indirect);
-	virtual uint32_t palette_entries() const override { return 4*16*8; }
 
 	virtual void read_tile_plane_data(int address, int color);
 	virtual void shift_tile_plane_data(uint8_t &pix);
-	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest);
-	virtual void draw_tile(uint8_t *line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t *&dest);
+	virtual void draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t *&dest);
+	virtual void draw_tile(uint8_t *line_priority, int color_byte, int color_bits, int address, int start_x, uint32_t back_pen, uint32_t *&dest);
 	virtual void draw_background( uint8_t *line_priority );
 	void draw_background_pen();
 
@@ -205,8 +203,6 @@ protected:
 	int                         m_refresh_data;         /* refresh-related */
 	int                         m_x_fine;               /* refresh-related */
 	int                         m_tilecount;            /* MMC5 can change attributes to subsets of the 34 visible tiles */
-	//std::unique_ptr<pen_t[]>    m_colortable;          /* color table modified at run time */
-	//std::unique_ptr<pen_t[]>    m_colortable_mono;     /* monochromatic color table modified at run time */
 	latch_delegate              m_latch;
 
 

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -75,6 +75,7 @@ public:
 	auto int_callback() { return m_int_callback.bind(); }
 
 	/* routines */
+	void apply_color_emphasis_and_clamp(bool is_pal_or_dendy, int color_emphasis, double& R, double& G, double& B);
 	rgb_t nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy);
 	virtual void init_palette_tables();
 
@@ -209,7 +210,7 @@ protected:
 
 	uint8_t readbyte(offs_t address);
 
-	uint32_t m_nespens[0x200];
+	uint32_t m_nespens[0x40*8];
 private:
 	static constexpr device_timer_id TIMER_HBLANK = 0;
 	static constexpr device_timer_id TIMER_NMI = 1;

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -77,7 +77,6 @@ public:
 	/* routines */
 	rgb_t nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy);
 	virtual void init_palette_tables();
-	void init_palette_tables(bool indirect);
 
 	virtual void read_tile_plane_data(int address, int color);
 	virtual void shift_tile_plane_data(uint8_t &pix);

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -76,7 +76,7 @@ public:
 	auto int_callback() { return m_int_callback.bind(); }
 
 	/* routines */
-	rgb_t nespal_to_RGB(int color_intensity, int color_num);
+	rgb_t nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy);
 	virtual void init_palette();
 	void init_palette(bool indirect);
 	virtual uint32_t palette_entries() const override { return 4*16*8; }

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -83,8 +83,8 @@ public:
 
 	virtual void read_tile_plane_data(int address, int color);
 	virtual void shift_tile_plane_data(uint8_t &pix);
-	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest, const pen_t *color_table);
-	virtual void draw_tile(uint8_t *line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t *&dest, const pen_t *color_table);
+	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest);
+	virtual void draw_tile(uint8_t *line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t *&dest);
 	virtual void draw_background( uint8_t *line_priority );
 	void draw_background_pen();
 
@@ -205,12 +205,14 @@ protected:
 	int                         m_refresh_data;         /* refresh-related */
 	int                         m_x_fine;               /* refresh-related */
 	int                         m_tilecount;            /* MMC5 can change attributes to subsets of the 34 visible tiles */
-	std::unique_ptr<pen_t[]>    m_colortable;          /* color table modified at run time */
-	std::unique_ptr<pen_t[]>    m_colortable_mono;     /* monochromatic color table modified at run time */
+	//std::unique_ptr<pen_t[]>    m_colortable;          /* color table modified at run time */
+	//std::unique_ptr<pen_t[]>    m_colortable_mono;     /* monochromatic color table modified at run time */
 	latch_delegate              m_latch;
 
 
 	uint8_t readbyte(offs_t address);
+
+	rgb_t m_nespens[0x200];
 private:
 	static constexpr device_timer_id TIMER_HBLANK = 0;
 	static constexpr device_timer_id TIMER_NMI = 1;

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -76,8 +76,8 @@ public:
 
 	/* routines */
 	rgb_t nespal_to_RGB(int color_intensity, int color_num, int color_emphasis, bool is_pal_or_dendy);
-	virtual void init_palette();
-	void init_palette(bool indirect);
+	virtual void init_palette_tables();
+	void init_palette_tables(bool indirect);
 
 	virtual void read_tile_plane_data(int address, int color);
 	virtual void shift_tile_plane_data(uint8_t &pix);
@@ -182,6 +182,8 @@ protected:
 
 	required_device<cpu_device> m_cpu;
 
+	void start_nopalram();
+
 	int                         m_scanlines_per_frame;  /* number of scanlines per frame */
 	int                         m_security_value;       /* 2C05 protection */
 	int                         m_vblank_first_scanline;  /* the very first scanline where VBLANK occurs */
@@ -244,7 +246,7 @@ class ppu2c0x_rgb_device : public ppu2c0x_device {
 protected:
 	ppu2c0x_rgb_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock = 0);
 
-	virtual void init_palette() override;
+	virtual void init_palette_tables() override;
 
 private:
 	required_region_ptr<uint8_t> m_palette_data;

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -84,6 +84,7 @@ public:
 	virtual void draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t *&dest);
 	virtual void draw_tile(uint8_t *line_priority, int color_byte, int color_bits, int address, int start_x, uint32_t back_pen, uint32_t *&dest);
 	virtual void draw_background( uint8_t *line_priority );
+	virtual void draw_back_pen(uint32_t* dst, int back_pen);
 	void draw_background_pen();
 
 	virtual void read_sprite_plane_data(int address);
@@ -129,6 +130,8 @@ public:
 	void set_vram_dest(uint16_t dest);
 
 	void ppu2c0x(address_map &map);
+
+	bool in_vblanking() { return (m_scanline >= m_vblank_first_scanline - 1); }
 protected:
 	ppu2c0x_device(const machine_config& mconfig, device_type type, const char* tag, device_t* owner, uint32_t clock, address_map_constructor internal_map);
 

--- a/src/devices/video/ppu2c0x_sh6578.cpp
+++ b/src/devices/video/ppu2c0x_sh6578.cpp
@@ -51,12 +51,14 @@ void ppu_sh6578_device::ppu_internal_map(address_map& map)
 
 void ppu_sh6578_device::device_start()
 {
-	ppu2c0x_device::device_start();
+	start_nopalram();
 
 	m_palette_ram.resize(0x40);
 
 	for (int i = 0; i < 0x40; i++)
 		m_palette_ram[i] = 0x00;
+
+	save_item(NAME(m_palette_ram));
 }
 
 void ppu_sh6578_device::device_reset()

--- a/src/devices/video/ppu2c0x_sh6578.cpp
+++ b/src/devices/video/ppu2c0x_sh6578.cpp
@@ -88,8 +88,8 @@ void ppu_sh6578_device::scanline_increment_fine_ycounter()
 
 void ppu_sh6578_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32& bitmap)
 {
-	//uint8_t palval = m_palette_ram[(pixel_data | color << 2)] & 0x3f;
-	bitmap.pix32(m_scanline, sprite_xpos + pixel) = 0;// this->pen(palval); // TODO FIX
+	uint8_t palval = m_palette_ram[(pixel_data | color << 2)] & 0x3f;
+	bitmap.pix32(m_scanline, sprite_xpos + pixel) = m_nespens[palval];
 }
 
 void ppu_sh6578_device::read_tile_plane_data(int address, int color)
@@ -136,12 +136,12 @@ void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int co
 
 			if (!trans)
 			{
-				pen = 0;// this->pen(palval); TODO FIX
+				pen = m_nespens[palval];
 			}
 			else
 			{
-				//uint8_t palval = m_palette_ram[0x0] & 0x3f;
-				pen = 0;// this->pen(palval); TODO FIX
+				uint8_t palval = m_palette_ram[0x0] & 0x3f;
+				pen = m_nespens[palval];
 			}
 
 			*dest = pen;
@@ -158,25 +158,24 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 {
 	bitmap_rgb32& bitmap = *m_bitmap;
 
-	//uint8_t color_mask = 0xff;
+	uint8_t color_mask = 0xff;
 	//const pen_t* color_table;
 
 	/* setup the color mask and colortable to use */
-	/* TODO FIX
+
+	//TODO FIX
 	if (m_regs[PPU_CONTROL1] & PPU_CONTROL1_DISPLAY_MONO)
 	{
 		color_mask = 0xf0;
-		color_table = m_colortable_mono.get();
 	}
 	else
 	{
 		color_mask = 0xff;
-		color_table = m_colortable.get();
 	}
-	*/
+	
 
 	/* cache the background pen */
-	pen_t back_pen = 0;// pen(m_back_color & color_mask); TODO FIX
+	pen_t back_pen = m_nespens[m_back_color & color_mask];
 
 	/* determine where in the nametable to start drawing from */
 	/* based on the current scanline and scroll regs */

--- a/src/devices/video/ppu2c0x_sh6578.cpp
+++ b/src/devices/video/ppu2c0x_sh6578.cpp
@@ -88,8 +88,8 @@ void ppu_sh6578_device::scanline_increment_fine_ycounter()
 
 void ppu_sh6578_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32& bitmap)
 {
-	uint8_t palval = m_palette_ram[(pixel_data | color << 2)] & 0x3f;
-	bitmap.pix32(m_scanline, sprite_xpos + pixel) = this->pen(palval);
+	//uint8_t palval = m_palette_ram[(pixel_data | color << 2)] & 0x3f;
+	bitmap.pix32(m_scanline, sprite_xpos + pixel) = 0;// this->pen(palval); // TODO FIX
 }
 
 void ppu_sh6578_device::read_tile_plane_data(int address, int color)
@@ -101,7 +101,7 @@ void ppu_sh6578_device::read_tile_plane_data(int address, int color)
 	m_extplanebuf[1] = readbyte(address + 24);
 }
 
-void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest)
+void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, uint32_t back_pen, uint32_t*& dest)
 {
 	int color = color_byte;
 
@@ -136,12 +136,12 @@ void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int co
 
 			if (!trans)
 			{
-				pen = this->pen(palval);
+				pen = 0;// this->pen(palval); TODO FIX
 			}
 			else
 			{
-				uint8_t palval = m_palette_ram[0x0] & 0x3f;
-				pen = this->pen(palval);
+				//uint8_t palval = m_palette_ram[0x0] & 0x3f;
+				pen = 0;// this->pen(palval); TODO FIX
 			}
 
 			*dest = pen;
@@ -158,7 +158,7 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 {
 	bitmap_rgb32& bitmap = *m_bitmap;
 
-	uint8_t color_mask = 0xff;
+	//uint8_t color_mask = 0xff;
 	//const pen_t* color_table;
 
 	/* setup the color mask and colortable to use */
@@ -176,7 +176,7 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 	*/
 
 	/* cache the background pen */
-	pen_t back_pen = pen(m_back_color & color_mask);
+	pen_t back_pen = 0;// pen(m_back_color & color_mask); TODO FIX
 
 	/* determine where in the nametable to start drawing from */
 	/* based on the current scanline and scroll regs */

--- a/src/devices/video/ppu2c0x_sh6578.cpp
+++ b/src/devices/video/ppu2c0x_sh6578.cpp
@@ -101,7 +101,7 @@ void ppu_sh6578_device::read_tile_plane_data(int address, int color)
 	m_extplanebuf[1] = readbyte(address + 24);
 }
 
-void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest, const pen_t* color_table)
+void ppu_sh6578_device::draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest)
 {
 	int color = color_byte;
 
@@ -158,10 +158,11 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 {
 	bitmap_rgb32& bitmap = *m_bitmap;
 
-	uint8_t color_mask;
-	const pen_t* color_table;
+	uint8_t color_mask = 0xff;
+	//const pen_t* color_table;
 
 	/* setup the color mask and colortable to use */
+	/* TODO FIX
 	if (m_regs[PPU_CONTROL1] & PPU_CONTROL1_DISPLAY_MONO)
 	{
 		color_mask = 0xf0;
@@ -172,6 +173,7 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 		color_mask = 0xff;
 		color_table = m_colortable.get();
 	}
+	*/
 
 	/* cache the background pen */
 	pen_t back_pen = pen(m_back_color & color_mask);
@@ -225,7 +227,7 @@ void ppu_sh6578_device::draw_background(uint8_t* line_priority)
 			// plus something that accounts for y
 			address += scroll_y_fine;
 
-			draw_tile(line_priority, (color_byte >> 4) & 0xf, 0, address, start_x, back_pen, dest, color_table);
+			draw_tile(line_priority, (color_byte >> 4) & 0xf, 0, address, start_x, back_pen, dest);
 
 			start_x += 8;
 

--- a/src/devices/video/ppu2c0x_sh6578.h
+++ b/src/devices/video/ppu2c0x_sh6578.h
@@ -33,7 +33,7 @@ private:
 	void scanline_increment_fine_ycounter() override;
 
 	void read_tile_plane_data(int address, int color) override;
-	void draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest, const pen_t* color_table) override;
+	void draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest) override;
 
 	virtual void draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32& bitmap) override;
 	//virtual void draw_sprites(uint8_t* line_priority) override;

--- a/src/devices/video/ppu2c0x_sh6578.h
+++ b/src/devices/video/ppu2c0x_sh6578.h
@@ -33,7 +33,7 @@ private:
 	void scanline_increment_fine_ycounter() override;
 
 	void read_tile_plane_data(int address, int color) override;
-	void draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, pen_t back_pen, uint32_t*& dest) override;
+	void draw_tile(uint8_t* line_priority, int color_byte, int color_bits, int address, int start_x, uint32_t back_pen, uint32_t*& dest) override;
 
 	virtual void draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32& bitmap) override;
 	//virtual void draw_sprites(uint8_t* line_priority) override;

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -414,13 +414,13 @@ void ppu_vt03_device::shift_tile_plane_data(uint8_t& pix)
 	}
 }
 
-void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t*& dest, const pen_t* color_table)
+void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t*& dest)
 {
 	int is4bpp = get_201x_reg(0x0) & 0x02;
 
 	if (!is4bpp)
 	{
-		ppu2c0x_device::draw_tile_pixel(pix, color, back_pen, dest, color_table);
+		ppu2c0x_device::draw_tile_pixel(pix, color, back_pen, dest);
 	}
 	else
 	{

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -453,7 +453,7 @@ void ppu_vt03_device::draw_tile_pixel_inner(uint8_t pen, uint32_t *dest)
 			//	palval &= 0x30;
 
 			// apply colour emphasis (does it really exist here?) (we haven't calculated any colours for it, so ths has no effect)
-			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 11);
+			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 10);
 
 			uint32_t pix;
 			pix = m_vtpens_rgb555[palval & 0x3ffff];
@@ -469,10 +469,10 @@ void ppu_vt03_device::draw_tile_pixel_inner(uint8_t pen, uint32_t *dest)
 			//	palval &= 0x30;
 
 			// apply colour emphasis (does it really exist here?) (we haven't calculated any colours for it, so ths has no effect)
-			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 8);
+			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 7);
 
 			uint32_t pix;
-			pix = m_vtpens_rgb444[palval & 0x7ffff];
+			pix = m_vtpens_rgb444[palval & 0x7fff];
 			*dest = pix;
 		}
 		else // VT03 mode
@@ -485,10 +485,10 @@ void ppu_vt03_device::draw_tile_pixel_inner(uint8_t pen, uint32_t *dest)
 			//	palval &= 0x30;
 
 			// apply colour emphasis (does it really exist here?) (we calculate values for it when building the palette lookup)
-			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 8);
+			palval |= ((m_regs[PPU_CONTROL1] & PPU_CONTROL1_COLOR_EMPHASIS) << 7);
 
 			uint32_t pix;
-			pix = m_vtpens[palval  & 0x7ffff];
+			pix = m_vtpens[palval  & 0x7fff];
 			*dest = pix;
 		}
 	}

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -75,19 +75,11 @@ void ppu_vt03_device::set_new_pen(int i)
 		if (m_pal_mode == PAL_MODE_NEW_RGB)
 		{
 			
-			uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0xff) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0xff) << 8);
-			uint8_t blue = (rgbval & 0x001f) << 3;
-			uint8_t green = (rgbval & 0x3e0) >> 2;
-			uint8_t red = (rgbval & 0x7C00) >> 7;
-			set_pen_color(i & 0x7f, rgb_t(red, green, blue));
+
 		}
 		else if (m_pal_mode == PAL_MODE_NEW_RGB12)
 		{
-			uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0x3f) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0x3f) << 6);
-			uint8_t red = (rgbval & 0x000f) << 4;
-			uint8_t green = (rgbval & 0x0f0);
-			uint8_t blue = (rgbval & 0xf00) >> 4;
-			set_pen_color(i & 0x7f, rgb_t(red, green, blue));
+
 		}
 		else
 		{
@@ -170,6 +162,43 @@ uint8_t ppu_vt03_device::read_extended(offs_t offset)
 }
 
 
+
+void ppu_vt03_device::init_vtxx_rgb555_palette_tables()
+{
+	int entry = 0;
+	for (int emp = 0; emp < 8; emp++)
+	{
+		for (int palval = 0; palval < 0x8000; palval++)
+		{
+		//	uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0xff) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0xff) << 8);
+			uint8_t blue = (palval & 0x001f) << 3;
+			uint8_t green = (palval & 0x3e0) >> 2;
+			uint8_t red = (palval & 0x7C00) >> 7;
+
+			// TODO: apply emphasis values if they work in this mode
+			m_vtpens_rgb555[entry] = rgb_t(red, green, blue);
+			entry++;
+		}
+	}
+}
+
+void ppu_vt03_device::init_vtxx_rgb444_palette_tables()
+{
+	int entry = 0;
+	for (int emp = 0; emp < 8; emp++)
+	{
+		for (int palval = 0; palval < 0x1000; palval++)
+		{
+			//uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0x3f) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0x3f) << 6);
+			uint8_t red = (palval & 0x000f) << 4;
+			uint8_t green = (palval & 0x0f0);
+			uint8_t blue = (palval & 0xf00) >> 4;
+			// TODO: apply emphasis values if they work in this mode
+			m_vtpens_rgb444[entry] = rgb_t(red, green, blue);
+			entry++;
+		}
+	}
+}
 // what cases are palmode 1 anyway?
 void ppu_vt03_device::init_vt03_palette_tables(int palmode)
 {
@@ -251,6 +280,8 @@ void ppu_vt03_device::device_start()
 	save_item(NAME(m_201x_regs));
 
 	init_vt03_palette_tables(0);
+	init_vtxx_rgb555_palette_tables();
+	init_vtxx_rgb444_palette_tables();
 }
 
 uint8_t ppu_vt03_device::get_201x_reg(int reg)

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -69,14 +69,16 @@ void ppu_vt03_device::set_201x_descramble(uint8_t reg0, uint8_t reg1, uint8_t re
 
 void ppu_vt03_device::set_new_pen(int i)
 {
+#if 0 // TODO FIX
 	if ((i < 0x20) && ((i & 0x3) == 0))
 	{
-		set_pen_color(i & 0x7f, rgb_t(0, 0, 0));
+		set_pen_color(i & 0x7f, rgb_t(0, 0, 0)); TODO FIX
 	}
 	else
 	{
 		if (m_pal_mode == PAL_MODE_NEW_RGB)
 		{
+			
 			uint16_t rgbval = (m_newpal[i & 0x7f] & 0xff) | ((m_newpal[(i & 0x7f) + 0x80] & 0xff) << 8);
 			uint8_t blue = (rgbval & 0x001f) << 3;
 			uint8_t green = (rgbval & 0x3e0) >> 2;
@@ -151,7 +153,7 @@ void ppu_vt03_device::set_new_pen(int i)
 			set_pen_color(i & 0x7f, rgb_t(RV, GV, BV));
 		}
 	}
-
+#endif
 
 }
 
@@ -353,7 +355,7 @@ void ppu_vt03_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, u
 	{
 		if (!is16pix)
 		{
-			bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen(pixel_data + (4 * color));
+			//bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen(pixel_data + (4 * color));  TODO FIX
 		}
 		else
 		{
@@ -361,9 +363,13 @@ void ppu_vt03_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, u
 			    we probably need to split them out again and draw them at xpos+8 with a
 			    cliprect - not seen used yet */
 			if ((pixel_data & 0x03) != 0)
-				bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen((pixel_data & 0x03) + (4 * color));
+			{
+				//bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen((pixel_data & 0x03) + (4 * color)); TODO FIX
+			}
 			if (((pixel_data >> 5) & 0x03) != 0)
-				bitmap.pix32(m_scanline, sprite_xpos + pixel + 8) = pen(((pixel_data >> 5) & 0x03) + (4 * color));
+			{
+				//bitmap.pix32(m_scanline, sprite_xpos + pixel + 8) = pen(((pixel_data >> 5) & 0x03) + (4 * color)); TODO FIX
+			}
 			//ppu2c0x_device::draw_sprite_pixel(sprite_xpos, color, pixel, pixel_data & 0x03, bitmap);
 			//ppu2c0x_device::draw_sprite_pixel(sprite_xpos, color, pixel + 8, (pixel_data >> 5) & 0x03, bitmap);
 		}
@@ -414,7 +420,7 @@ void ppu_vt03_device::shift_tile_plane_data(uint8_t& pix)
 	}
 }
 
-void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t*& dest)
+void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t*& dest)
 {
 	int is4bpp = get_201x_reg(0x0) & 0x02;
 
@@ -424,6 +430,7 @@ void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, ui
 	}
 	else
 	{
+		/* TODO FIX 
 		int basepen;
 		int pen;
 
@@ -445,6 +452,7 @@ void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, ui
 			pen = 0; // fixme backpen logic probably differs on vt03 due to extra colours
 		}
 		*dest = this->pen(pen);
+		*/
 	}
 }
 
@@ -482,7 +490,7 @@ void ppu_vt03_device::set_2010_reg(uint8_t data)
 		{
 			for (int i = 0; i < 256; i++)
 			{
-				set_pen_indirect(i, i);
+				//set_pen_indirect(i, i);  TODO FIX
 			}
 		}
 	}

--- a/src/devices/video/ppu2c0x_vt.cpp
+++ b/src/devices/video/ppu2c0x_vt.cpp
@@ -47,14 +47,10 @@ ppu_vt03pal_device::ppu_vt03pal_device(const machine_config& mconfig, const char
 
 uint8_t ppu_vt03_device::palette_read(offs_t offset)
 {
-	if (m_201x_regs[0] & 0x80)
-	{
-		return m_newpal[offset];
-	}
-	else
-	{
+	if (offset < 0x20)
 		return ppu2c0x_device::palette_read(offset);
-	}
+	else
+		return m_palette_ram[offset];
 }
 
 void ppu_vt03_device::set_201x_descramble(uint8_t reg0, uint8_t reg1, uint8_t reg2, uint8_t reg3, uint8_t reg4, uint8_t reg5)
@@ -79,7 +75,7 @@ void ppu_vt03_device::set_new_pen(int i)
 		if (m_pal_mode == PAL_MODE_NEW_RGB)
 		{
 			
-			uint16_t rgbval = (m_newpal[i & 0x7f] & 0xff) | ((m_newpal[(i & 0x7f) + 0x80] & 0xff) << 8);
+			uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0xff) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0xff) << 8);
 			uint8_t blue = (rgbval & 0x001f) << 3;
 			uint8_t green = (rgbval & 0x3e0) >> 2;
 			uint8_t red = (rgbval & 0x7C00) >> 7;
@@ -87,7 +83,7 @@ void ppu_vt03_device::set_new_pen(int i)
 		}
 		else if (m_pal_mode == PAL_MODE_NEW_RGB12)
 		{
-			uint16_t rgbval = (m_newpal[i & 0x7f] & 0x3f) | ((m_newpal[(i & 0x7f) + 0x80] & 0x3f) << 6);
+			uint16_t rgbval = (m_palette_ram[i & 0x7f] & 0x3f) | ((m_palette_ram[(i & 0x7f) + 0x80] & 0x3f) << 6);
 			uint8_t red = (rgbval & 0x000f) << 4;
 			uint8_t green = (rgbval & 0x0f0);
 			uint8_t blue = (rgbval & 0xf00) >> 4;
@@ -95,62 +91,6 @@ void ppu_vt03_device::set_new_pen(int i)
 		}
 		else
 		{
-			// Credit to NewRisingSun
-			uint16_t palval = (m_newpal[i & 0x7f] & 0x3f) | ((m_newpal[(i & 0x7f) + 0x80] & 0x3f) << 6);
-			int nPhase = (palval >> 0) & 0xF;
-			int nLuma = (palval >> 4) & 0xF;
-			int nChroma = (palval >> 8) & 0xF;
-			float phaseOffset = -11.0;
-			//bool inverted = false;
-			if ((nLuma < (nChroma + 1) >> 1 || nLuma > 15 - (nChroma >> 1)) && (m_pal_mode != PAL_MODE_NEW_VG))
-			{
-				//inverted = true;
-				// Strange color number wrap-around. Is this for protection reasons, or a bug of the original hardware?
-				// The VT03 data sheet advises programmers that 4 <= nLuma*2 +nChroma <= 0x1F, which does not correspond exactly to this condition.
-				static const unsigned char altPhases[16] = { 13,  7,  8,  9, 10, 11, 12,  1,  2,  3,  4,  5,  6,  0, 14, 15 };
-				static const float    altPhaseOffset[16] = { -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5,  0, -5, -5, -5 }; // Slight tweak in phase 6 for Z-Dog
-				phaseOffset += altPhaseOffset[nPhase]; // These "alternative" colors seem to be slightly shifted in addition to being wrapped-around, at least in EmuVT.
-				nPhase = altPhases[nPhase];
-				nChroma = 16 - nChroma;
-				nLuma = (nLuma - 8) & 0xF;
-			}
-
-			float fLuma = (nLuma - 4) / 9.625;     // Value determined from matching saturation =0 phases 1-12
-			float fChroma = nChroma / 18.975;      // Value determined from matching phases 0 and 13 across all luminance and saturation levels
-			float fPhase = ((nPhase - 2) * 30.0 + phaseOffset) * M_PI / 180.0;
-
-			if (m_pal_mode == PAL_MODE_NEW_VG)
-			{
-				if (fPhase > 0 && fPhase < 13)
-				{
-					fLuma /= 1.5;
-					fChroma /= 2;
-				}
-			}
-
-			float Y = fLuma;
-			float C = fChroma;
-			if (nPhase == 0 || nPhase > 12) C = 0.0;// Phases 0 and 13-15 are grays
-			if (nPhase == 0) Y += fChroma;        // Phase 0 is the upper bound of the waveform
-			if (nPhase == 13) Y -= fChroma;        // Phase 13 is the lower bound of the waveform
-			if (nPhase >= 14) Y = 0.0;             // Phases 14 and 15 always black
-
-			float V = sin(fPhase) * C * 1.05; // 1.05 needed to get closer to EmuVT palette's color levels in phases 1-12
-			float U = cos(fPhase) * C * 1.05;
-			float R = Y + 1.1400 * V + 0.0000 * U;
-			float G = Y - 0.5807 * V - 0.3940 * U;
-			float B = Y - 0.0000 * V + 2.0290 * U;
-			if (R < 0.0) R = 0.0;
-			if (R > 1.0) R = 1.0;
-			if (G < 0.0) G = 0.0;
-			if (G > 1.0) G = 1.0;
-			if (B < 0.0) B = 0.0;
-			if (B > 1.0) B = 1.0;
-			int RV = R * 255.0;
-			int GV = G * 255.0;
-			int BV = B * 255.0;
-
-			set_pen_color(i & 0x7f, rgb_t(RV, GV, BV));
 		}
 	}
 #endif
@@ -159,20 +99,13 @@ void ppu_vt03_device::set_new_pen(int i)
 
 void ppu_vt03_device::palette_write(offs_t offset, uint8_t data)
 {
-	//logerror("pal write %d %02x\n", offset, data);
-	// why is the check pal_mask = (m_pal_mode == PAL_MODE_NEW_VG) ? 0x08 : 0x80 in set_2010_reg and 0x04 : 0x80 here?
-	uint8_t pal_mask = (m_pal_mode == PAL_MODE_NEW_VG) ? 0x04 : 0x80;
-
-	if (m_201x_regs[0] & pal_mask)
+	if (offset < 0x20)
 	{
-		m_newpal[offset & 0xff] = data;
-		set_new_pen(offset);
+		ppu2c0x_device::palette_write(offset, data);
 	}
 	else
 	{
-		//if(m_pal_mode == PAL_MODE_NEW_VG) // ddrdismx writes the palette before setting the register but doesn't use 'PAL_MODE_NEW_VG', Konami logo is missing if you don't allow writes to be stored for when we switch
-		m_newpal[offset & 0xff] = data;
-		ppu2c0x_device::palette_write(offset, data);
+		m_palette_ram[offset] = data;
 	}
 }
 
@@ -237,20 +170,87 @@ uint8_t ppu_vt03_device::read_extended(offs_t offset)
 }
 
 
-void ppu_vt03_device::init_palette()
+void ppu_vt03_device::init_vt03_palette_tables()
 {
-	// todo, work out the format of the 12 palette bits instead of just calling the main init
-	ppu2c0x_device::init_palette(true);
+	// the 12-bit VT HSV format, Credit to NewRisingSun
+	int entry = 0;
+	for (int emp = 0; emp < 8; emp++)
+	{
+		for (int palval = 0; palval < 0x1000; palval++)
+		{
+			int nPhase = (palval >> 0) & 0xF;
+			int nLuma = (palval >> 4) & 0xF;
+			int nChroma = (palval >> 8) & 0xF;
+			float phaseOffset = -11.0;
+			//bool inverted = false;
+			if ((nLuma < (nChroma + 1) >> 1 || nLuma > 15 - (nChroma >> 1)) && (m_pal_mode != PAL_MODE_NEW_VG))
+			{
+				//inverted = true;
+				// Strange color number wrap-around. Is this for protection reasons, or a bug of the original hardware?
+				// The VT03 data sheet advises programmers that 4 <= nLuma*2 +nChroma <= 0x1F, which does not correspond exactly to this condition.
+				static const unsigned char altPhases[16] = { 13,  7,  8,  9, 10, 11, 12,  1,  2,  3,  4,  5,  6,  0, 14, 15 };
+				static const float    altPhaseOffset[16] = { -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5, -5,  0, -5, -5, -5 }; // Slight tweak in phase 6 for Z-Dog
+				phaseOffset += altPhaseOffset[nPhase]; // These "alternative" colors seem to be slightly shifted in addition to being wrapped-around, at least in EmuVT.
+				nPhase = altPhases[nPhase];
+				nChroma = 16 - nChroma;
+				nLuma = (nLuma - 8) & 0xF;
+			}
+
+			float fLuma = (nLuma - 4) / 9.625;     // Value determined from matching saturation =0 phases 1-12
+			float fChroma = nChroma / 18.975;      // Value determined from matching phases 0 and 13 across all luminance and saturation levels
+			float fPhase = ((nPhase - 2) * 30.0 + phaseOffset) * M_PI / 180.0;
+
+			//if (m_pal_mode == PAL_MODE_NEW_VG)
+			if (1)
+			{
+				if (fPhase > 0 && fPhase < 13)
+				{
+					fLuma /= 1.5;
+					fChroma /= 2;
+				}
+			}
+
+			float Y = fLuma;
+			float C = fChroma;
+			if (nPhase == 0 || nPhase > 12) C = 0.0;// Phases 0 and 13-15 are grays
+			if (nPhase == 0) Y += fChroma;        // Phase 0 is the upper bound of the waveform
+			if (nPhase == 13) Y -= fChroma;        // Phase 13 is the lower bound of the waveform
+			if (nPhase >= 14) Y = 0.0;             // Phases 14 and 15 always black
+
+			float V = sin(fPhase) * C * 1.05; // 1.05 needed to get closer to EmuVT palette's color levels in phases 1-12
+			float U = cos(fPhase) * C * 1.05;
+			float R = Y + 1.1400 * V + 0.0000 * U;
+			float G = Y - 0.5807 * V - 0.3940 * U;
+			float B = Y - 0.0000 * V + 2.0290 * U;
+			if (R < 0.0) R = 0.0;
+			if (R > 1.0) R = 1.0;
+			if (G < 0.0) G = 0.0;
+			if (G > 1.0) G = 1.0;
+			if (B < 0.0) B = 0.0;
+			if (B > 1.0) B = 1.0;
+			int RV = R * 255.0;
+			int GV = G * 255.0;
+			int BV = B * 255.0;
+
+			m_vtpens[entry] = rgb_t(RV, GV, BV);
+			entry++;
+		}
+	}
 }
 
 void ppu_vt03_device::device_start()
 {
-	ppu2c0x_device::device_start();
+	start_nopalram();
 
-	m_newpal = std::make_unique<uint8_t[]>(0x100);
-	save_pointer(NAME(m_newpal), 0x100);
+	m_palette_ram.resize(0x100);
 
+	for (int i = 0; i < 0x100; i++)
+		m_palette_ram[i] = 0x00;
+
+	save_item(NAME(m_palette_ram));
 	save_item(NAME(m_201x_regs));
+
+	init_vt03_palette_tables();
 }
 
 uint8_t ppu_vt03_device::get_201x_reg(int reg)
@@ -272,7 +272,7 @@ void ppu_vt03_device::device_reset()
 	m_read_bg.resolve_safe(0);
 	m_read_sp.resolve_safe(0);
 	for (int i = 0; i < 0xff; i++)
-		m_newpal[i] = 0x0;
+		m_palette_ram[i] = 0x0;
 
 	// todo: what are the actual defaults for these?
 	for (int i = 0; i < 0x20; i++)
@@ -280,7 +280,6 @@ void ppu_vt03_device::device_reset()
 
 	//m_201x_regs[0] = 0x86; // alt fix for ddrdismx would be to set the default palette mode here
 
-	init_palette();
 
 	m_read_bg4_bg3 = 0;
 	m_va34 = 0;
@@ -355,7 +354,14 @@ void ppu_vt03_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, u
 	{
 		if (!is16pix)
 		{
-			//bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen(pixel_data + (4 * color));  TODO FIX
+			uint8_t pen = pixel_data + (4 * color);
+
+			uint16_t penval;
+			penval = (m_palette_ram[pen & 0x7f] & 0x3f) | ((m_palette_ram[(pen & 0x7f) + 0x80] & 0x3f) << 6);
+			uint32_t palval;
+			palval = m_vtpens[penval];
+
+			bitmap.pix32(m_scanline, sprite_xpos + pixel) = palval;
 		}
 		else
 		{
@@ -364,11 +370,25 @@ void ppu_vt03_device::draw_sprite_pixel(int sprite_xpos, int color, int pixel, u
 			    cliprect - not seen used yet */
 			if ((pixel_data & 0x03) != 0)
 			{
-				//bitmap.pix32(m_scanline, sprite_xpos + pixel) = pen((pixel_data & 0x03) + (4 * color)); TODO FIX
+				uint8_t pen = (pixel_data & 0x03) + (4 * color);
+
+				uint16_t penval;
+				penval = (m_palette_ram[pen & 0x7f] & 0x3f) | ((m_palette_ram[(pen & 0x7f) + 0x80] & 0x3f) << 6);
+				uint32_t palval;
+				palval = m_vtpens[penval];
+
+				bitmap.pix32(m_scanline, sprite_xpos + pixel) = palval;
 			}
 			if (((pixel_data >> 5) & 0x03) != 0)
 			{
-				//bitmap.pix32(m_scanline, sprite_xpos + pixel + 8) = pen(((pixel_data >> 5) & 0x03) + (4 * color)); TODO FIX
+				uint8_t pen = ((pixel_data >> 5) & 0x03) + (4 * color);
+
+				uint16_t penval;
+				penval = (m_palette_ram[pen & 0x7f] & 0x3f) | ((m_palette_ram[(pen & 0x7f) + 0x80] & 0x3f) << 6);
+				uint32_t palval;
+				palval = m_vtpens[penval];
+
+				bitmap.pix32(m_scanline, sprite_xpos + pixel + 8) = palval;
 			}
 			//ppu2c0x_device::draw_sprite_pixel(sprite_xpos, color, pixel, pixel_data & 0x03, bitmap);
 			//ppu2c0x_device::draw_sprite_pixel(sprite_xpos, color, pixel + 8, (pixel_data >> 5) & 0x03, bitmap);
@@ -430,7 +450,6 @@ void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen,
 	}
 	else
 	{
-		/* TODO FIX 
 		int basepen;
 		int pen;
 
@@ -451,8 +470,13 @@ void ppu_vt03_device::draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen,
 		{
 			pen = 0; // fixme backpen logic probably differs on vt03 due to extra colours
 		}
-		*dest = this->pen(pen);
-		*/
+
+		uint16_t penval;
+		penval = (m_palette_ram[pen & 0x7f] & 0x3f) | ((m_palette_ram[(pen & 0x7f) + 0x80] & 0x3f) << 6);
+		uint32_t palval;
+		palval = m_vtpens[penval];
+		*dest = palval;
+		
 	}
 }
 
@@ -476,24 +500,6 @@ void ppu_vt03_device::set_2010_reg(uint8_t data)
 	    2   : SP16EN
 	    1   : BK16EN
 	    0   : PIX16EN */
-	uint8_t pal_mask = (m_pal_mode == PAL_MODE_NEW_VG) ? 0x08 : 0x80;
-	if ((m_201x_regs[0x0] & pal_mask) != (data & pal_mask))
-	{
-		if (data & pal_mask)
-		{
-			for (int i = 0; i < 256; i++)
-			{
-				set_new_pen(i);
-			}
-		}
-		else
-		{
-			for (int i = 0; i < 256; i++)
-			{
-				//set_pen_indirect(i, i);  TODO FIX
-			}
-		}
-	}
 
 	m_201x_regs[0x0] = data;
 }

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -40,7 +40,7 @@ public:
 	virtual uint8_t palette_read(offs_t offset) override;
 	virtual void palette_write(offs_t offset, uint8_t data) override;
 
-	void init_vt03_palette_tables();
+	void init_vt03_palette_tables(int palmode);
 
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -46,7 +46,7 @@ public:
 
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
-	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest, const pen_t *color_table) override;
+	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest) override;
 
 	virtual void read_sprite_plane_data(int address) override;
 	virtual void make_sprite_pixel_data(uint8_t &pixel_data, int flipx) override;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -45,6 +45,7 @@ public:
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
 	virtual void draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t *&dest) override;
+	inline void draw_tile_pixel_inner(uint8_t pen, uint32_t *dest);
 
 	virtual void read_sprite_plane_data(int address) override;
 	virtual void make_sprite_pixel_data(uint8_t &pixel_data, int flipx) override;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -40,7 +40,7 @@ public:
 	virtual uint8_t palette_read(offs_t offset) override;
 	virtual void palette_write(offs_t offset, uint8_t data) override;
 
-	virtual void init_palette() override;
+	void init_vt03_palette_tables();
 
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
@@ -68,11 +68,11 @@ protected:
 	bool m_is_pal;
 	bool m_is_50hz;
 
+	uint32_t m_vtpens[0x1000*8];
+
 private:
 	devcb_read8 m_read_bg;
 	devcb_read8 m_read_sp;
-
-	std::unique_ptr<uint8_t[]> m_newpal;
 
 	int m_read_bg4_bg3;
 	int m_va34;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -19,7 +19,6 @@
 enum vtxx_pal_mode {
 	PAL_MODE_VT0x,
 	PAL_MODE_NEW_RGB,
-	PAL_MODE_NEW_VG,
 	PAL_MODE_NEW_RGB12,
 };
 
@@ -92,8 +91,6 @@ private:
 	vtxx_pal_mode m_pal_mode = PAL_MODE_VT0x;
 
 	void set_2010_reg(uint8_t data);
-
-	void set_new_pen(int i);
 };
 
 class ppu_vt03pal_device : public ppu_vt03_device {

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -40,13 +40,11 @@ public:
 	virtual uint8_t palette_read(offs_t offset) override;
 	virtual void palette_write(offs_t offset, uint8_t data) override;
 
-	virtual uint32_t palette_entries() const override { return 256; }
-	virtual uint32_t palette_indirect_entries() const override { return 4*16*8; }
 	virtual void init_palette() override;
 
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
-	virtual void draw_tile_pixel(uint8_t pix, int color, pen_t back_pen, uint32_t *&dest) override;
+	virtual void draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t *&dest) override;
 
 	virtual void read_sprite_plane_data(int address) override;
 	virtual void make_sprite_pixel_data(uint8_t &pixel_data, int flipx) override;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -47,6 +47,7 @@ public:
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
 	virtual void draw_tile_pixel(uint8_t pix, int color, uint32_t back_pen, uint32_t *&dest) override;
 	inline void draw_tile_pixel_inner(uint8_t pen, uint32_t *dest);
+	virtual void draw_back_pen(uint32_t* dst, int back_pen) override;
 
 	virtual void read_sprite_plane_data(int address) override;
 	virtual void make_sprite_pixel_data(uint8_t &pixel_data, int flipx) override;

--- a/src/devices/video/ppu2c0x_vt.h
+++ b/src/devices/video/ppu2c0x_vt.h
@@ -41,6 +41,8 @@ public:
 	virtual void palette_write(offs_t offset, uint8_t data) override;
 
 	void init_vt03_palette_tables(int palmode);
+	void init_vtxx_rgb555_palette_tables();
+	void init_vtxx_rgb444_palette_tables();
 
 	virtual void read_tile_plane_data(int address, int color) override;
 	virtual void shift_tile_plane_data(uint8_t &pix) override;
@@ -70,6 +72,8 @@ protected:
 	bool m_is_50hz;
 
 	uint32_t m_vtpens[0x1000*8];
+	uint32_t m_vtpens_rgb555[0x8000*8];
+	uint32_t m_vtpens_rgb444[0x1000*8];
 
 private:
 	devcb_read8 m_read_bg;

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -2208,7 +2208,7 @@ CONS( 200?, timetp7,   0, 0,  nes_vt_pal_2mb, timetp36, nes_vt_timetp36_state,  
 
 // this is VT09 based
 CONS( 2009, cybar120,  0,  0,  nes_vt_vg_16mb, nes_vt, nes_vt_hh_state, empty_init, "Defender", "Defender M2500P 120-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
-CONS( 2005, vgpocket,  0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket (VG-2000)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 2005, vgpocket,  0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket (VG-2000)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // Butterfly Catch (same game as Insect Chase in polmega) is broken
 CONS( 200?, vgpmini,   0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket Mini (VG-1500)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 // VG Pocket Max (VG-2500) (blue case, 75 games)
 // VG Pocket Max (VG-3000) (white case, 75 games) (does the game selection differ, or only the case?)
@@ -2220,9 +2220,9 @@ CONS( 200?, vgpmini,   0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_ini
 CONS( 200?, dgun2500,  0,  0,  nes_vt_dg_baddma_16mb, nes_vt, nes_vt_dg_state, empty_init, "dreamGEAR", "dreamGEAR Wireless Motion Control with 130 games (DGUN-2500)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND)
 
 // CPU die is marked 'VH2009' There's also a 62256 RAM chip on the PCB, some scrambled opcodes
-CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid", "Megamax GPD001SDG", MACHINE_NOT_WORKING )
+CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid", "Megamax GPD001SDG", MACHINE_NOT_WORKING ) // Insect Chase is broken
 CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb_alt,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Vs. Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
-CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit", "35 in 1 Super Twins", MACHINE_NOT_WORKING )
+CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit", "35 in 1 Super Twins", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 // die is marked as VH2009, as above, but no scrambled opcodes here
 CONS( 201?, techni4,   0,  0,  nes_vt_pal_2mb,      nes_vt, nes_vt_state,        empty_init, "Technigame", "Technigame Super 4-in-1 Sports (PAL)", MACHINE_IMPERFECT_GRAPHICS )
 

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -732,34 +732,6 @@ void nes_vt_ablpinb_state::in0_w(uint8_t data)
 }
 
 
-/* not strictly needed, but helps us see where things are in ROM to aid with figuring out banking schemes*/
-static const gfx_layout helper_layout =
-{
-	8,8,
-	RGN_FRAC(1,1),
-	4,
-	{ 0*64, 1*64, 2*64, 3*64 },
-	{ 0,1,2,3,4,5,6,7 },
-	{ 0*8, 1*8, 2*8, 3*8, 4*8, 5*8, 6*8, 7*8 },
-	4*64
-};
-
-static const gfx_layout helper2_layout =
-{
-	8,8,
-	RGN_FRAC(1,1),
-	4,
-	{ 0*8, 1*8, 2*8, 3*8 },
-	{ 0,1,2,3,4,5,6,7 },
-	{ 0*16, 1*16, 2*16, 3*16,4*16,5*16,5*16,6*16,7*16 },
-	4*64
-};
-
-static GFXDECODE_START( vt03_gfx_helper )
-	GFXDECODE_ENTRY( "mainrom", 0, helper_layout,  0x0, 2  )
-	GFXDECODE_ENTRY( "mainrom", 0, helper2_layout,  0x0, 2  )
-GFXDECODE_END
-
 void nes_vt_base_state::configure_soc(nes_vt_soc_device* soc)
 {
 	soc->set_addrmap(AS_PROGRAM, &nes_vt_state::vt_external_space_map_32mbyte);
@@ -777,7 +749,6 @@ void nes_vt_vg_1mb_majgnc_state::nes_vt_vg_1mb_majgnc(machine_config &config)
 {
 	NES_VT_SOC(config, m_soc, NTSC_APU_CLOCK);
 	configure_soc(m_soc);
-	m_soc->set_default_palette_mode(PAL_MODE_NEW_VG);
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_vg_1mb_majgnc_state::vt_external_space_map_1mbyte);
 }
 
@@ -912,8 +883,6 @@ void nes_vt_waixing_alt_sporzpp_state::nes_vt_waixing_alt_4mb_sporzpp(machine_co
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_ablping_state::vt_external_space_map_4mbyte);
 	m_soc->set_201x_descramble(0x3, 0x2, 0x7, 0x6, 0x5, 0x4);
 	m_soc->set_8000_scramble(0x5, 0x4, 0x3, 0x2, 0x7, 0x6, 0x7, 0x8);
-
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 
@@ -924,7 +893,6 @@ void nes_vt_hum_state::nes_vt_hummer_2mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_sp69_state::vt_external_space_map_2mbyte);
 	m_soc->set_201x_descramble(0x7, 0x6, 0x5, 0x4, 0x2, 0x3);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x7, 0x8);
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 void nes_vt_hum_state::nes_vt_hummer_4mb(machine_config& config)
@@ -941,7 +909,6 @@ void nes_vt_pjoy_state::nes_vt_pjoy_4mb(machine_config &config)
 	m_soc->set_201x_descramble(0x2, 0x3, 0x4, 0x5, 0x6, 0x7);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x8, 0x7);
 	m_soc->set_410x_scramble(0x8, 0x7);
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 
@@ -952,7 +919,6 @@ void nes_vt_sp69_state::nes_vt_4mb_sp69(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_sp69_state::vt_external_space_map_4mbyte);
 	m_soc->set_201x_descramble(0x4, 0x7, 0x2, 0x6, 0x5, 0x3);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x7, 0x8);
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 void nes_vt_ablping_state::nes_vt_2mb_ablping(machine_config &config)
@@ -968,8 +934,6 @@ void nes_vt_ablping_state::nes_vt_2mb_ablping(machine_config &config)
 	m_soc->extra_read_3_callback().set(FUNC(nes_vt_ablping_state::ablping_extraio_r));
 	m_soc->extra_write_2_callback().set(FUNC(nes_vt_ablping_state::ablping_extraio_w));
 	m_soc->extra_write_3_callback().set(FUNC(nes_vt_ablping_state::ablping_extraio_w));
-
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 uint8_t nes_vt_base_state::upper_412c_r()
@@ -995,8 +959,6 @@ void nes_vt_state::nes_vt_4k_ram(machine_config &config)
 	/* basic machine hardware */
 	NES_VT_SOC_4KRAM(config, m_soc, NTSC_APU_CLOCK);
 	configure_soc(m_soc);
-
-	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 
 	dynamic_cast<nes_vt_soc_4kram_device&>(*m_soc).upper_read_412c_callback().set(FUNC(nes_vt_state::upper_412c_r));
 	dynamic_cast<nes_vt_soc_4kram_device&>(*m_soc).upper_read_412d_callback().set(FUNC(nes_vt_state::upper_412d_r));
@@ -1090,7 +1052,6 @@ void nes_vt_hh_state::nes_vt_vg(machine_config &config)
 	NES_VT_SOC_8KRAM_DG(config.replace(), m_soc, NTSC_APU_CLOCK);
 	configure_soc(m_soc);
 
-	m_soc->set_default_palette_mode(PAL_MODE_NEW_VG);
 	m_soc->force_bad_dma();
 }
 
@@ -1117,7 +1078,6 @@ void nes_vt_hh_state::nes_vt_vg_1mb_majkon(machine_config &config)
 	nes_vt_dg(config);
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_hh_state::vt_external_space_map_1mbyte);
 
-	m_soc->set_default_palette_mode(PAL_MODE_NEW_VG);
 }
 
 
@@ -1365,8 +1325,6 @@ void nes_vt_swap_op_d5_d6_state::nes_vt_vh2009(machine_config &config)
 
 	NES_VT_SOC_SCRAMBLE(config.replace(), m_soc, NTSC_APU_CLOCK);
 	configure_soc(m_soc);
-
-	//m_soc->set_default_palette_mode(PAL_MODE_NEW_VG); // gives better title screens, but worse ingame, must be able to switch
 }
 
 void nes_vt_swap_op_d5_d6_state::nes_vt_vh2009_1mb(machine_config& config)
@@ -1379,7 +1337,6 @@ void nes_vt_swap_op_d5_d6_state::nes_vt_vh2009_2mb_alt(machine_config& config)
 {
 	nes_vt_vh2009(config);
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_swap_op_d5_d6_state::vt_external_space_map_2mbyte);
-	m_soc->set_default_palette_mode(PAL_MODE_NEW_VG); // gives better title, but causes some games to have black palette, needs proper switching!
 }
 void nes_vt_swap_op_d5_d6_state::nes_vt_vh2009_4mb(machine_config& config)
 {
@@ -1398,7 +1355,6 @@ void nes_vt_swap_op_d5_d6_state::nes_vt_senwld_512kb(machine_config &config)
 {
 	nes_vt_vh2009(config);
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_swap_op_d5_d6_state::vt_external_space_map_senwld_512kbyte);
-	m_soc->set_default_palette_mode(PAL_MODE_NEW_VG);
 }
 
 static INPUT_PORTS_START( nes_vt_fp )
@@ -2300,7 +2256,7 @@ CONS( 201?, denv150,   0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_stat
 
 // CPU die is marked 'VH2009' There's also a 62256 RAM chip on the PCB, some scrambled opcodes
 CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid", "Megamax GPD001SDG", MACHINE_NOT_WORKING )
-CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb_alt,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Vs. Maxx 17-in-1", MACHINE_NOT_WORKING ) // from a Green unit, '17 Classic & Racing Game'
+CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb_alt,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Vs. Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS  | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
 CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit", "35 in 1 Super Twins", MACHINE_NOT_WORKING )
 // die is marked as VH2009, as above, but no scrambled opcodes here
 CONS( 201?, techni4,   0,  0,  nes_vt_pal_2mb,      nes_vt, nes_vt_state,        empty_init, "Technigame", "Technigame Super 4-in-1 Sports (PAL)", MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -105,6 +105,7 @@ public:
 	void nes_vt_1mb_baddma(machine_config& config);
 	void nes_vt_2mb_baddma(machine_config& config);
 	void nes_vt_4mb_baddma(machine_config& config);
+	void nes_vt_4mb_baddma_rasterhack(machine_config& config);
 	void nes_vt_4mb(machine_config& config);
 	void nes_vt_8mb(machine_config& config);
 	void nes_vt_16mb(machine_config& config);
@@ -169,6 +170,7 @@ public:
 	{ }
 
 	void nes_vt_waixing_512kb(machine_config& config);
+	void nes_vt_waixing_512kb_rasterhack(machine_config& config);
 	void nes_vt_waixing_2mb(machine_config& config);
 };
 
@@ -366,6 +368,7 @@ public:
 
 	void nes_vt_vg(machine_config& config);
 	void nes_vt_vg_4mb(machine_config& config);
+	void nes_vt_vg_4mb_rasterhack(machine_config& config);
 	void nes_vt_vg_8mb(machine_config& config);
 	void nes_vt_vg_16mb(machine_config& config);
 
@@ -789,6 +792,13 @@ void nes_vt_state::nes_vt_4mb_baddma(machine_config& config)
 {
 	nes_vt_4mb(config);
 	m_soc->force_bad_dma();
+
+}
+
+void nes_vt_state::nes_vt_4mb_baddma_rasterhack(machine_config& config)
+{
+	nes_vt_2mb_baddma(config);
+	m_soc->force_raster_timing_hack();
 }
 
 
@@ -848,6 +858,13 @@ void nes_vt_waixing_state::nes_vt_waixing_512kb(machine_config &config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_waixing_state::vt_external_space_map_512kbyte);
 	m_soc->set_201x_descramble(0x3, 0x2, 0x7, 0x6, 0x5, 0x4);
 }
+
+void nes_vt_waixing_state::nes_vt_waixing_512kb_rasterhack(machine_config &config)
+{
+	nes_vt_waixing_512kb(config);
+	m_soc->force_raster_timing_hack();
+}
+
 
 void nes_vt_waixing_state::nes_vt_waixing_2mb(machine_config &config)
 {
@@ -1067,6 +1084,13 @@ void nes_vt_hh_state::nes_vt_vg_4mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_hh_state::vt_external_space_map_4mbyte);
 }
 
+void nes_vt_hh_state::nes_vt_vg_4mb_rasterhack(machine_config& config)
+{
+	nes_vt_vg_4mb(config);
+	m_soc->force_raster_timing_hack();
+}
+
+
 void nes_vt_hh_state::nes_vt_vg_16mb(machine_config& config)
 {
 	nes_vt_vg(config);
@@ -1077,7 +1101,7 @@ void nes_vt_hh_state::nes_vt_vg_1mb_majkon(machine_config &config)
 {
 	nes_vt_dg(config);
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_hh_state::vt_external_space_map_1mbyte);
-
+	m_soc->force_raster_timing_hack();
 }
 
 
@@ -2134,7 +2158,7 @@ CONS( 2016, msisinv,    0,  0,  nes_vt_1mb_baddma, nes_vt_msi, nes_vt_state, emp
 
 // This is from the version with the same case type as the above MSI units.
 // MSI also issued a version in the original Majesco shell but with the updated case logos and boot logos in the software, the software on that revision might match this one.
-CONS( 2016, msifrog,    0,  0,  nes_vt_4mb_baddma, nes_vt_msi, nes_vt_state, empty_init, "MSI / Konami", "Frogger (MSI Plug & Play, white joystick)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // raster timing issues, mode change issues
+CONS( 2016, msifrog,    0,  0,  nes_vt_4mb_baddma_rasterhack, nes_vt_msi, nes_vt_state, empty_init, "MSI / Konami", "Frogger (MSI Plug & Play, white joystick)",  MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) //  raster timing for need a hack
 
 // MSI Midway (Joust+Gauntlet 2 + Defender 2) has 2x Globs, rather than Glob + Flash ROM
 
@@ -2158,14 +2182,14 @@ CONS( 200?, mc_dgear,  0,  0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, 
 
 // all software in this runs in the VT03 enhanced mode, it also includes an actual licensed VT03 port of Frogger.
 // all games work OK except Frogger which has serious graphical issues
-CONS( 2006, vgtablet,  0, 0,  nes_vt_vg_4mb,        nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products (licensed by Konami)", "VG Pocket Tablet (VG-4000)", MACHINE_NOT_WORKING ) // raster timing is broken for Frogger
+CONS( 2006, vgtablet,  0, 0,  nes_vt_vg_4mb_rasterhack,  nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products (licensed by Konami)", "VG Pocket Tablet (VG-4000)", MACHINE_NOT_WORKING ) // raster timing for Frogger needs a hack, controls fail in several games eg Stellar Attack, River Quest
 // There is a 2004 Majesco Frogger "TV game" that appears to contain the same version of Frogger as above but with no other games, so probably fits here.
-CONS( 2004, majkon,    0, 0,  nes_vt_vg_1mb_majkon, nes_vt, nes_vt_hh_state, empty_init, "Majesco (licensed from Konami)", "Konami Collector's Series Arcade Advanced", MACHINE_NOT_WORKING ) // raster timing is broken for Frogger, palette issues
+CONS( 2004, majkon,    0, 0,  nes_vt_vg_1mb_majkon, nes_vt, nes_vt_hh_state, empty_init, "Majesco (licensed from Konami)", "Konami Collector's Series Arcade Advanced", MACHINE_NOT_WORKING ) // raster timing for Frogger needs a hack, Green Beret has other serious issues
 
-CONS( 200?, majgnc,    0, 0,  nes_vt_vg_1mb_majgnc, majgnc, nes_vt_vg_1mb_majgnc_state,  empty_init, "Majesco", "Golden Nugget Casino", MACHINE_NOT_WORKING )
+CONS( 200?, majgnc,    0, 0,  nes_vt_vg_1mb_majgnc, majgnc, nes_vt_vg_1mb_majgnc_state,  empty_init, "Majesco", "Golden Nugget Casino", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 // small black unit, dpad on left, 4 buttons (A,B,X,Y) on right, Start/Reset/Select in middle, unit text "Sudoku Plug & Play TV Game"
-CONS( 200?, sudopptv,  0, 0,  nes_vt_waixing_512kb,        nes_vt, nes_vt_waixing_state, empty_init, "Smart Planet", "Sudoku Plug & Play TV Game '6 Intelligent Games'", MACHINE_NOT_WORKING )
+CONS( 200?, sudopptv,  0, 0,  nes_vt_waixing_512kb_rasterhack,        nes_vt, nes_vt_waixing_state, empty_init, "Smart Planet", "Sudoku Plug & Play TV Game '6 Intelligent Games'", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 CONS( 200?, megapad,   0, 0,  nes_vt_waixing_2mb,        nes_vt, nes_vt_waixing_state, empty_init, "Waixing", "Megapad 31-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // Happy Biqi has broken sprites, investigate before promoting
 
@@ -2175,7 +2199,7 @@ CONS( 2006, ablmini,   0, 0,  nes_vt_waixing_alt_pal_8mb, nes_vt, nes_vt_waixing
 CONS( 200?, solargm,   0,  0, nes_vt_waixing_alt_pal_8mb, nes_vt, nes_vt_waixing_alt_state, empty_init, "<unknown>", "Solar Games 80-in-1 (PAL)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // Solar Games logo is also found in the SunPlus based Millennium Arcade units
 
 // silver 'N64' type controller design
-CONS( 200?, zudugo,    0, 0,  nes_vt_waixing_alt_4mb,     nes_vt, nes_vt_waixing_alt_state, empty_init, "Macro Winners / Waixing", "Zudu-go / 2udu-go", MACHINE_IMPERFECT_GRAPHICS ) // the styling on the box looks like a '2' in places, a 'Z' in others.
+CONS( 200?, zudugo,    0, 0,  nes_vt_waixing_alt_4mb,     nes_vt, nes_vt_waixing_alt_state, empty_init, "Macro Winners / Waixing", "Zudu-go / 2udu-go", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // the styling on the box looks like a '2' in places, a 'Z' in others.
 
  // needs PCM samples, Y button is not mapped (not used by any of the games? some sources indicate it's just a hardware autofire button)
 CONS( 200?, timetp36,  0, 0,  nes_vt_pal_4mb, timetp36, nes_vt_timetp36_state,        empty_init, "TimeTop", "Super Game 36-in-1 (TimeTop SuperGame) (PAL)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
@@ -2183,11 +2207,9 @@ CONS( 200?, timetp36,  0, 0,  nes_vt_pal_4mb, timetp36, nes_vt_timetp36_state,  
 CONS( 200?, timetp7,   0, 0,  nes_vt_pal_2mb, timetp36, nes_vt_timetp36_state,        empty_init, "TimeTop", "Super Game 7-in-1 (TimeTop SuperGame) (PAL)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 
 // this is VT09 based
-// it boots, most games correct, but palette issues in some games still (usually they appear greyscale)
-// and colors overall a bit off
-CONS( 2009, cybar120,  0,  0,  nes_vt_vg_16mb, nes_vt, nes_vt_hh_state, empty_init, "Defender", "Defender M2500P 120-in-1", MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS )
-CONS( 2005, vgpocket,  0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket (VG-2000)", MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS )
-CONS( 200?, vgpmini,   0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket Mini (VG-1500)", MACHINE_WRONG_COLORS | MACHINE_IMPERFECT_GRAPHICS )
+CONS( 2009, cybar120,  0,  0,  nes_vt_vg_16mb, nes_vt, nes_vt_hh_state, empty_init, "Defender", "Defender M2500P 120-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 2005, vgpocket,  0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket (VG-2000)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 200?, vgpmini,   0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_init, "Performance Designed Products", "VG Pocket Mini (VG-1500)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 // VG Pocket Max (VG-2500) (blue case, 75 games)
 // VG Pocket Max (VG-3000) (white case, 75 games) (does the game selection differ, or only the case?)
 // VG Pocket Caplet is SunPlus hardware instead, see spg2xx_lexibook.cpp
@@ -2197,75 +2219,15 @@ CONS( 200?, vgpmini,   0,  0,  nes_vt_vg_4mb, nes_vt, nes_vt_hh_state, empty_ini
 // emulation
 CONS( 200?, dgun2500,  0,  0,  nes_vt_dg_baddma_16mb, nes_vt, nes_vt_dg_state, empty_init, "dreamGEAR", "dreamGEAR Wireless Motion Control with 130 games (DGUN-2500)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND)
 
-// don't even get to menu. very enhanced chipset, VT368/9?
-CONS( 2012, dgun2561,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "dreamGEAR", "My Arcade Portable Gaming System with 140 Games (DGUN-2561)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 2016, dgun2593,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "dreamGEAR", "My Arcade Retro Arcade Machine - 300 Handheld Video Games (DGUN-2593)", MACHINE_NOT_WORKING ) // 128Mbyte ROM, must be externally banked or different addressing scheme
-
-CONS( 200?, lxcmcy,    0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmc250,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - 250-in-1 (JL2375)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmcysw,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Star Wars Rebels", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmcyfz,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Frozen", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmcydp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Disney Princess", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmcysp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Marvel Ultimate Spider-Man", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxcmcycr,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Cars", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-// the data order is swapped for this one, maybe other internal differences?
-CONS( 200?, lxcmcypp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, init_lxcmcypp, "Lexibook", "Lexibook Compact Cyber Arcade - Paw Patrol", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
-
-
-CONS( 200?, lxccminn,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Console Colour - Minnie Mouse", MACHINE_NOT_WORKING ) // 64Mbyte (used) ROM, must be externally banked, or different addressing scheme
-CONS( 200?, lxccplan,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Console Colour - Disney's Planes", MACHINE_NOT_WORKING ) // 64Mbyte (used) ROM, must be externally banked, or different addressing scheme
-
-
-// GB-NO13-Main-VT389-2 on PCBs
-CONS( 2016, rtvgc300,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )  // 64Mbyte ROM, must be externally banked, or different addressing scheme
-CONS( 2017, rtvgc300fz,0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )  // 64Mbyte ROM, must be externally banked, or different addressing scheme
-
-
-/* The following are also confirmed to be NES/VT derived units, most having a standard set of games with a handful of lazy graphic mods thrown in to fit the unit theme
-
-    (handhekd units, use standard AAA batteries)
-    Lexibook Compact Cyber Arcade - Cars
-    Lexibook Compact Cyber Arcade - Barbie
-    Lexibook Compact Cyber Arcade - Finding Dory
-    Lexibook Compact Cyber Arcade - PJ Masks
-
-    (Handheld units, but different form factor to Compact Cyber Arcade, charged via USB)
-    Lexibook Console Colour - Barbie
-
-    (units for use with TV)
-    Lexibook Retro TV Game Console (300 Games) - Cars
-    Lexibook Retro TV Game Console (300 Games) - PJ Masks
-
-    (more?)
-
-    There are also updated 'Compact Cyber Arcade' branded units with a large + D-pad and internal battery / USB charger for
-    Spiderman
-    Frozen
-    (generic)
-    it isn't verified if these use the same ROMs as the original Compact Cyber Arcade releases, or if the software has been updated
-
-*/
-
-// intial code isn't valid? scrambled?
-CONS( 201?, red5mam,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "Red5", "Mini Arcade Machine (Red5)", MACHINE_NOT_WORKING ) // 128Mbyte ROM, must be externally banked or different addressing scheme
-
-
-
-CONS( 201?, denv150,   0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "Denver", "Denver Game Console GMP-240C 150-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-
-
 // CPU die is marked 'VH2009' There's also a 62256 RAM chip on the PCB, some scrambled opcodes
 CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid", "Megamax GPD001SDG", MACHINE_NOT_WORKING )
-CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb_alt,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Vs. Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS  | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
+CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb_alt,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Vs. Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
 CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit", "35 in 1 Super Twins", MACHINE_NOT_WORKING )
 // die is marked as VH2009, as above, but no scrambled opcodes here
 CONS( 201?, techni4,   0,  0,  nes_vt_pal_2mb,      nes_vt, nes_vt_state,        empty_init, "Technigame", "Technigame Super 4-in-1 Sports (PAL)", MACHINE_IMPERFECT_GRAPHICS )
 
  // seems to use PCM for all sound, some garbage at bottom of screen, needs correct inputs (seems to respond to start, and any direction input for 'hit' - check if they're power related)
 CONS( 200?, protpp,   0,  0,  nes_vt_vh2009_1mb,      nes_vt, nes_vt_swap_op_d5_d6_state,        init_protpp, "Protocol", "Virtual Ping Pong (Protocol)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND )
-
-// same encryption as above, but seems like newer hardware (or the above aren't using most of the features)
-CONS( 200?, lpgm240,    0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "<unknown>", "Let's Play! Game Machine 240 in 1", MACHINE_NOT_WORKING ) // mini 'retro-arcade' style cabinet
 
 // this has 'Shark' and 'Octopus' etc. like mc_dgear but uses scrambled bank registers
 // This was also often found in cart form with SunPlus / Famiclone hybrid systems to boost the game count, eg. the WiWi (ROM verified to match)
@@ -2337,23 +2299,16 @@ CONS( 201?, mc_tv200,   0,        0,  nes_vt_8mb,    nes_vt, nes_vt_state, empty
  // probably another Thumbs Up product? cursor doesn't work unless nes_vt_hh machine is used? possibly newer than VT02 as it runs from an SPI ROM, might just not use enhanced features.  Some minor game name changes to above (eg Smackdown just becomes Wrestling)
 CONS( 201?, unkra200,   mc_tv200, 0,  nes_vt_hh_8mb, nes_vt, nes_vt_hh_state, empty_init, "<unknown>", "200 in 1 Retro Arcade", MACHINE_IMPERFECT_GRAPHICS )
 
-
 // available in a number of colours, with various brands, but likely all the same.
 // This was a red coloured pad, contains various unlicensed bootleg reskinned NES game eg Blob Buster is a hack of Dig Dug 2 and there are also hacks of Xevious, Donkey Kong Jr, Donkey Kong 3 and many others.
 CONS( 201?, ppgc200g,   0,         0,  nes_vt_8mb, nes_vt, nes_vt_state, empty_init, "<unknown>", "Plug & Play Game Controller with 200 Games (Supreme 200)", MACHINE_IMPERFECT_GRAPHICS )
-
 
 // Probably VT09 or similar
 // Use DIP switch to select console or cartridge, as cartridge is fake and just toggles a ROM high address bit
 // (which can also be overriden by GPIO)
 CONS( 2017, fapocket,   0,        0,  nes_vt_fa_4x16mb, nes_vt_fa, nes_vt_dg_fapocket_state, empty_init, "<unknown>",   "Family Pocket 638 in 1", MACHINE_IMPERFECT_GRAPHICS ) // has external banking (4x 16mbyte banks)
 
-
-CONS( 2017, otrail,     0,        0,  nes_vt_dg_1mb, nes_vt, nes_vt_dg_state, empty_init, "Basic Fun", "The Oregon Trail", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-
 CONS( 2005, senwld,   0,          0,  nes_vt_senwld_512kb,    nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario", "Win, Lose or Draw (Senario)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS ) // needs RAM in banked space, Alpha display emulating, Touchpad emulating etc.
-
-
 
 // Runs well, minor GFX issues in intro
 CONS( 2017, sy889,      0,        0,  nes_vt_hh_8mb, nes_vt, nes_vt_hh_state, empty_init, "SY Corp",   "SY-889 300 in 1 Handheld", MACHINE_IMPERFECT_GRAPHICS )
@@ -2374,5 +2329,74 @@ CONS( 2015, rminitv,   0,  0,  nes_vt_fp_pal_32mb, nes_vt, nes_vt_hh_state, empt
 // New platform with scrambled opcodes, same as DGUN-2561. Runs fine with minor GFX and sound issues in menu
 // Use DIP switch to select console or cartridge, as cartridge is fake and just toggles a GPIO
 CONS( 2016, fcpocket,  0,  0,  nes_vt_fp_4x16mb,   nes_vt_fp, nes_vt_hh_state, empty_init, "<unknown>",   "FC Pocket 600 in 1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )  // has external banking (2x 32mbyte banks)
+
+
+/****************************************************************************************************************
+
+	Things below seem on heavily enhanced hardware of unknown VT type
+
+	It's possible it is the same as some of the ones above (sy889, rminitv, dgun2573 etc.) but with more features used
+	or in some cases somehing almost entirely different that doesn't belong here
+
+/***************************************************************************************************************/
+
+// don't even get to menu. very enhanced chipset, VT368/9?
+CONS( 2012, dgun2561,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "dreamGEAR", "My Arcade Portable Gaming System with 140 Games (DGUN-2561)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 2016, dgun2593,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "dreamGEAR", "My Arcade Retro Arcade Machine - 300 Handheld Video Games (DGUN-2593)", MACHINE_NOT_WORKING ) // 128Mbyte ROM, must be externally banked or different addressing scheme
+
+CONS( 200?, lxcmcy,    0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmc250,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - 250-in-1 (JL2375)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmcysw,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Star Wars Rebels", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmcyfz,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Frozen", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmcydp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Disney Princess", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmcysp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Marvel Ultimate Spider-Man", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxcmcycr,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Compact Cyber Arcade - Cars", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+// the data order is swapped for this one, maybe other internal differences?
+CONS( 200?, lxcmcypp,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, init_lxcmcypp, "Lexibook", "Lexibook Compact Cyber Arcade - Paw Patrol", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme
+
+
+CONS( 200?, lxccminn,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Console Colour - Minnie Mouse", MACHINE_NOT_WORKING ) // 64Mbyte (used) ROM, must be externally banked, or different addressing scheme
+CONS( 200?, lxccplan,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Console Colour - Disney's Planes", MACHINE_NOT_WORKING ) // 64Mbyte (used) ROM, must be externally banked, or different addressing scheme
+
+
+// GB-NO13-Main-VT389-2 on PCBs
+CONS( 2016, rtvgc300,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Retro TV Game Console - 300 Games", MACHINE_NOT_WORKING )  // 64Mbyte ROM, must be externally banked, or different addressing scheme
+CONS( 2017, rtvgc300fz,0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init,    "Lexibook", "Lexibook Retro TV Game Console - Frozen - 300 Games", MACHINE_NOT_WORKING )  // 64Mbyte ROM, must be externally banked, or different addressing scheme
+
+
+/* The following are also confirmed to be NES/VT derived units, most having a standard set of games with a handful of lazy graphic mods thrown in to fit the unit theme
+
+    (handhekd units, use standard AAA batteries)
+    Lexibook Compact Cyber Arcade - Cars
+    Lexibook Compact Cyber Arcade - Barbie
+    Lexibook Compact Cyber Arcade - Finding Dory
+    Lexibook Compact Cyber Arcade - PJ Masks
+
+    (Handheld units, but different form factor to Compact Cyber Arcade, charged via USB)
+    Lexibook Console Colour - Barbie
+
+    (units for use with TV)
+    Lexibook Retro TV Game Console (300 Games) - Cars
+    Lexibook Retro TV Game Console (300 Games) - PJ Masks
+
+    (more?)
+
+    There are also updated 'Compact Cyber Arcade' branded units with a large + D-pad and internal battery / USB charger for
+    Spiderman
+    Frozen
+    (generic)
+    it isn't verified if these use the same ROMs as the original Compact Cyber Arcade releases, or if the software has been updated
+
+*/
+
+// intial code isn't valid? scrambled?
+CONS( 201?, red5mam,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "Red5", "Mini Arcade Machine (Red5)", MACHINE_NOT_WORKING ) // 128Mbyte ROM, must be externally banked or different addressing scheme
+
+CONS( 201?, denv150,   0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "Denver", "Denver Game Console GMP-240C 150-in-1", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+
+// same encryption as above, but seems like newer hardware (or the above aren't using most of the features)
+CONS( 200?, lpgm240,    0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "<unknown>", "Let's Play! Game Machine 240 in 1", MACHINE_NOT_WORKING ) // mini 'retro-arcade' style cabinet
+
+CONS( 2017, otrail,     0,        0,  nes_vt_dg_1mb, nes_vt, nes_vt_dg_state, empty_init, "Basic Fun", "The Oregon Trail", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
 
 CONS( 200?, zonefusn,  0,         0,  nes_vt_fp_16mb,     nes_vt, nes_vt_hh_state, empty_init, "Ultimate Products / Jungle's Soft", "Zone Fusion",  MACHINE_NOT_WORKING )

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -2335,10 +2335,13 @@ CONS( 2016, fcpocket,  0,  0,  nes_vt_fp_4x16mb,   nes_vt_fp, nes_vt_hh_state, e
 
 	Things below seem on heavily enhanced hardware of unknown VT type
 
-	It's possible it is the same as some of the ones above (sy889, rminitv, dgun2573 etc.) but with more features used
-	or in some cases somehing almost entirely different that doesn't belong here
+	It's possible some of these are the same as some of the ones above (sy889, rminitv, dgun2573 etc.) but with
+	more features used.
 
-/***************************************************************************************************************/
+	In some cases these might be almost entirely different, and it is likely a number don't belong in this
+	driver at all.
+
+****************************************************************************************************************/
 
 // don't even get to menu. very enhanced chipset, VT368/9?
 CONS( 2012, dgun2561,  0,  0,  nes_vt_cy_bigger, nes_vt, nes_vt_cy_lexibook_state, empty_init, "dreamGEAR", "My Arcade Portable Gaming System with 140 Games (DGUN-2561)", MACHINE_NOT_WORKING ) // 64Mbyte ROM, must be externally banked, or different addressing scheme

--- a/src/mame/drivers/nes_vt.cpp
+++ b/src/mame/drivers/nes_vt.cpp
@@ -913,7 +913,7 @@ void nes_vt_waixing_alt_sporzpp_state::nes_vt_waixing_alt_4mb_sporzpp(machine_co
 	m_soc->set_201x_descramble(0x3, 0x2, 0x7, 0x6, 0x5, 0x4);
 	m_soc->set_8000_scramble(0x5, 0x4, 0x3, 0x2, 0x7, 0x6, 0x7, 0x8);
 
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 
@@ -924,7 +924,7 @@ void nes_vt_hum_state::nes_vt_hummer_2mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_sp69_state::vt_external_space_map_2mbyte);
 	m_soc->set_201x_descramble(0x7, 0x6, 0x5, 0x4, 0x2, 0x3);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x7, 0x8);
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 void nes_vt_hum_state::nes_vt_hummer_4mb(machine_config& config)
@@ -941,7 +941,7 @@ void nes_vt_pjoy_state::nes_vt_pjoy_4mb(machine_config &config)
 	m_soc->set_201x_descramble(0x2, 0x3, 0x4, 0x5, 0x6, 0x7);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x8, 0x7);
 	m_soc->set_410x_scramble(0x8, 0x7);
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 
@@ -952,7 +952,7 @@ void nes_vt_sp69_state::nes_vt_4mb_sp69(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_sp69_state::vt_external_space_map_4mbyte);
 	m_soc->set_201x_descramble(0x4, 0x7, 0x2, 0x6, 0x5, 0x3);
 	m_soc->set_8000_scramble(0x6, 0x7, 0x2, 0x3, 0x4, 0x5, 0x7, 0x8);
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 void nes_vt_ablping_state::nes_vt_2mb_ablping(machine_config &config)
@@ -969,7 +969,7 @@ void nes_vt_ablping_state::nes_vt_2mb_ablping(machine_config &config)
 	m_soc->extra_write_2_callback().set(FUNC(nes_vt_ablping_state::ablping_extraio_w));
 	m_soc->extra_write_3_callback().set(FUNC(nes_vt_ablping_state::ablping_extraio_w));
 
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 }
 
 uint8_t nes_vt_base_state::upper_412c_r()
@@ -996,7 +996,7 @@ void nes_vt_state::nes_vt_4k_ram(machine_config &config)
 	NES_VT_SOC_4KRAM(config, m_soc, NTSC_APU_CLOCK);
 	configure_soc(m_soc);
 
-	GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper);
+	// GFXDECODE(config, "gfxdecode", "soc:ppu", vt03_gfx_helper); TODO FIX
 
 	dynamic_cast<nes_vt_soc_4kram_device&>(*m_soc).upper_read_412c_callback().set(FUNC(nes_vt_state::upper_412c_r));
 	dynamic_cast<nes_vt_soc_4kram_device&>(*m_soc).upper_read_412d_callback().set(FUNC(nes_vt_state::upper_412d_r));

--- a/src/mame/machine/nes_vt_soc.cpp
+++ b/src/mame/machine/nes_vt_soc.cpp
@@ -985,13 +985,6 @@ void nes_vt_soc_device::do_dma(uint8_t data, bool has_ntsc_bug)
 		length -= 1;
 		src_addr += 1;
 	}
-	//TODO (always false)
-	//else if ((dma_mode == 1) && ((m_ppu->get_vram_dest() & 0xFF00) == 0x3F01) && !(m_ppu->get_201x_reg(0x1) & 0x80))
-	//{
-	//  // Legacy mode for DGUN-2573 compat
-	//  m_ppu->set_vram_dest(0x3F00);
-	//  m_ppu->set_palette_mode(PAL_MODE_VT0x);
-	//}
 
 	for (int i = 0; i < length; i++)
 	{

--- a/src/mame/machine/nes_vt_soc.cpp
+++ b/src/mame/machine/nes_vt_soc.cpp
@@ -121,6 +121,7 @@ nes_vt_soc_device::nes_vt_soc_device(const machine_config& mconfig, device_type 
 
 	m_default_palette_mode = PAL_MODE_VT0x;
 	m_force_baddma = false;
+	m_use_raster_timing_hack = false;
 }
 
 nes_vt_soc_device::nes_vt_soc_device(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock) :
@@ -380,6 +381,12 @@ void nes_vt_soc_device::scrambled_410x_w(uint16_t offset, uint8_t data)
 		// load latched value and start counting
 		m_410x[0x2] = data; // value doesn't matter?
 		m_timer_val = m_410x[0x1];
+
+		// HACK for some one line errors in various games and completely broken rasters in msifrog, TOOD: find real source of issue (bad timing of interrupt or counter changes, or latching of data?)
+		if (m_use_raster_timing_hack)
+			if (m_ppu->in_vblanking())
+				m_timer_val--;
+
 		m_timer_running = 1;
 		break;
 

--- a/src/mame/machine/nes_vt_soc.h
+++ b/src/mame/machine/nes_vt_soc.h
@@ -50,7 +50,8 @@ public:
 
 	void set_8000_scramble(uint8_t reg0, uint8_t reg1, uint8_t reg2, uint8_t reg3, uint8_t reg4, uint8_t reg5, uint8_t reg6, uint8_t reg7);
 	void set_410x_scramble(uint8_t reg0, uint8_t reg1);
-	void force_bad_dma() { m_force_baddma = true; };
+	void force_bad_dma() { m_force_baddma = true; }
+	void force_raster_timing_hack() { m_use_raster_timing_hack = true; }
 
 	void set_default_palette_mode(vtxx_pal_mode pmode) { m_default_palette_mode = pmode; }
 
@@ -91,7 +92,6 @@ protected:
 	void psg1_4015_w(uint8_t data);
 	void psg1_4017_w(uint8_t data);
 	void vt_dma_w(uint8_t data);
-	void vt_fixed_dma_w(uint8_t data);
 	void do_dma(uint8_t data, bool has_ntsc_bug);
 	void vt03_4034_w(uint8_t data);
 
@@ -161,6 +161,7 @@ private:
 	uint8_t m_2012_2017_descramble[0x6]; // passed to PPU in reset
 	vtxx_pal_mode m_default_palette_mode;
 	bool m_force_baddma;
+	bool m_use_raster_timing_hack;
 };
 
 class nes_vt_soc_pal_device : public nes_vt_soc_device


### PR DESCRIPTION
machines promoted to WORKING
--------
Golden Nugget Casino [David Haywood, Sean Riddle]
Sudoku Plug & Play TV Game '6 Intelligent Games' [David Haywood, Sean Riddle]
Frogger (MSI Plug & Play, white joystick) [David Haywood, Sean Riddle]
35 in 1 Super Twins [David Haywood, Sean Riddle]
Vs. Maxx 17-in-1 [David Haywood, Sean Riddle]

- made use of the code that was already partially present in the NES PPU code to handle emphasis modes, used to highlight tally bars etc. in 'nes rampart', apply a red tint to 'fds bublbobl' and dim the screen in a number of other games.

- fixed a number of issues with VT palette modes that was causing black screens in many games, allowing them to be promoted

- added a timing kludge for interrupts in the NES Frogger titles, until timings are better overall,makes playfield stable here and in a number of other places so that other things can be improved

*note*  "Vs. Maxx 17-in-1" was added as NOT WORKING in this same cycle so if this gets merged before freeze they'll need to be moved to the 'new working' section.

This is a checkpoint, further code improvements and refactors will come later.