### PR TITLE
Fix Bondwell 2 machine

### DIFF
--- a/src/devices/bus/bw2/ramcard.cpp
+++ b/src/devices/bus/bw2/ramcard.cpp
@@ -90,15 +90,17 @@ void bw2_ramcard_device::device_reset()
 
 uint8_t bw2_ramcard_device::bw2_cd_r(offs_t offset, uint8_t data, int ram2, int ram3, int ram4, int ram5, int ram6)
 {
-	if (!ram2)
+	if (offset < 0x8000)
 	{
-		data = m_rom->base()[offset & 0x3fff];
+		if (!ram2)
+		{
+			data = m_rom->base()[offset & 0x3fff];
+		}
+		else if (m_en && !ram5)
+		{
+			data = m_ram[(m_bank << 15) | offset];
+		}
 	}
-	else if (m_en && !ram5)
-	{
-		data = m_ram[(m_bank << 15) | offset];
-	}
-
 	return data;
 }
 
@@ -109,9 +111,12 @@ uint8_t bw2_ramcard_device::bw2_cd_r(offs_t offset, uint8_t data, int ram2, int 
 
 void bw2_ramcard_device::bw2_cd_w(offs_t offset, uint8_t data, int ram2, int ram3, int ram4, int ram5, int ram6)
 {
-	if (m_en && !ram5)
+	if (offset < 0x8000)
 	{
-		m_ram[(m_bank << 15) | offset] = data;
+		if (m_en && !ram5)
+		{
+			m_ram[(m_bank << 15) | offset] = data;
+		}
 	}
 }
 

--- a/src/mame/drivers/bw2.cpp
+++ b/src/mame/drivers/bw2.cpp
@@ -450,7 +450,7 @@ uint8_t bw2_state::ppi_pc_r()
 
 	*/
 
-	uint8_t data = 0;
+	uint8_t data = m_bank;
 
 	// centronics busy
 	data |= m_centronics_busy << 4;
@@ -459,7 +459,8 @@ uint8_t bw2_state::ppi_pc_r()
 	data |= m_mfdbk << 5;
 
 	// write protect
-	if (m_floppy) data |= m_floppy->wpt_r() << 7;
+	//if (m_floppy) data |= m_floppy->wpt_r() << 7;
+	if (m_floppy) data |= ((~m_floppy->wpt_r()) & 0x01) << 7;
 
 	return data;
 }

--- a/src/mame/drivers/bw2.cpp
+++ b/src/mame/drivers/bw2.cpp
@@ -459,7 +459,6 @@ uint8_t bw2_state::ppi_pc_r()
 	data |= m_mfdbk << 5;
 
 	// write protect
-	//if (m_floppy) data |= m_floppy->wpt_r() << 7;
 	if (m_floppy) data |= ((~m_floppy->wpt_r()) & 0x01) << 7;
 
 	return data;


### PR DESCRIPTION
- The write protection bit was inverted, with that change you can write into IMD files without error.
- The ramcard was broken, it should only respond to addresses below 0x8000, now the option -exp ramcard works and boots up correctly