### PR TITLE
FreeBSD fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -196,7 +196,7 @@ GENIEOS := solaris
 endif
 ifeq ($(firstword $(filter FreeBSD,$(UNAME))),FreeBSD)
 OS := freebsd
-GENIEOS := freebsd
+GENIEOS := bsd
 endif
 ifeq ($(firstword $(filter GNU/kFreeBSD,$(UNAME))),GNU/kFreeBSD)
 OS := freebsd

--- a/scripts/src/3rdparty.lua
+++ b/scripts/src/3rdparty.lua
@@ -1390,6 +1390,12 @@ end
 		end
 	end
 
+	if _OPTIONS["targetos"]=="freebsd" then
+		buildoptions {
+			backtick(pkgconfigcmd() .. " --cflags gl")
+		}
+	end
+
 	defines {
 		"__STDC_LIMIT_MACROS",
 		"__STDC_FORMAT_MACROS",

--- a/src/osd/modules/file/posixptty.cpp
+++ b/src/osd/modules/file/posixptty.cpp
@@ -19,7 +19,7 @@
 #include <unistd.h>
 #include <cstdlib>
 
-#if defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <termios.h>
 #include <libutil.h>
 #elif defined(__NetBSD__) || defined(__OpenBSD__) || defined(__APPLE__)


### PR DESCRIPTION
Those 3 commits (+2 in 3rdparty, see https://github.com/evadot/mame/commits/fbsd) makes mame compilable on FreeBSD.
I'll work with upstream so they include the fixes and get back here when it's done.
When everything compile out of the box I'll add a CI target as travis supports FreeBSD.