### PR TITLE
picture_image_device::get_bitmap can return a null reference

### DIFF
--- a/src/devices/bus/a2bus/computereyes2.cpp
+++ b/src/devices/bus/a2bus/computereyes2.cpp
@@ -196,7 +196,7 @@ void a2bus_computereyes2_device::write_c0nx(uint8_t offset, uint8_t data)
 				m_x = m_y = 0;
 				std::fill_n(m_a2_bitmap, 280*193, 0);
 
-				m_bitmap = &m_picture->get_bitmap();
+				m_bitmap = m_picture->get_bitmap();
 				if (m_bitmap)
 				{
 					// convert arbitrary sized ARGB32 image to a 188x193 image with 256 levels of grayscale

--- a/src/devices/bus/a2gameio/computereyes.cpp
+++ b/src/devices/bus/a2gameio/computereyes.cpp
@@ -82,7 +82,7 @@ WRITE_LINE_MEMBER(apple2_compeyes_device::an0_w)
 
 	std::fill_n(m_a2_bitmap, 280*192, 0);
 
-	m_bitmap = &m_picture->get_bitmap();
+	m_bitmap = m_picture->get_bitmap();
 	if (m_bitmap)
 	{
 		// convert arbitrary sized ARGB32 image to a 280x192 image with 256 levels of grayscale

--- a/src/devices/imagedev/picture.h
+++ b/src/devices/imagedev/picture.h
@@ -41,7 +41,7 @@ public:
 	virtual bool is_reset_on_load() const noexcept override { return false; }
 	virtual const char *file_extensions() const noexcept override { return "png"; }
 
-	bitmap_argb32 &get_bitmap() { return *m_picture; }
+	bitmap_argb32 *get_bitmap() { return m_picture; }
 
 protected:
 	// device-level overrides


### PR DESCRIPTION
null references are not valid in C++ so compilers like to eliminate the null pointer check. This can result in a segfault,

eg, `mame apple2e -gameio compeyes` will segfault if no image (`-pic`) is provided.

switched to use a pointer instead.
