### PR TITLE
sgi_mips.xml: more Hot Mix CDs for SGI

### DIFF
--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -1688,6 +1688,19 @@ license:CC0
 
 	<!-- Hot Mix -->
 
+	<software name="hotmix_1">
+		<description>Hot Mix Volume 1</description>
+		<year>1992</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-8101-001"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_1" sha1="3d55993a7ebf9b9d607edda155ac90e78f8c8e09" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="hotmix_4">
 		<description>Hot Mix 4</description>
 		<year>1993</year>
@@ -1740,9 +1753,35 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="hotmix_9">
+		<description>Hot Mix Volume 9</description>
+		<year>1994</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-8101-009"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_9" sha1="0cac323851e8502eee63283e737d541bf806fa09" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hotmix_10">
+		<description>Hot Mix Volume 10</description>
+		<year>1995</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-8101-010"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_10" sha1="97b2604f21474fa376c94ca66f6e465e730e7123" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="hotmix_11">
 		<description>Hot Mix Volume 11</description>
-		<year>1994</year>
+		<year>1995</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="cdrom" interface="cdrom">
 			<feature name="part_number" value="812-8101-011"/>
@@ -1755,13 +1794,65 @@ license:CC0
 
 	<software name="hotmix_12">
 		<description>Hot Mix Volume 12</description>
-		<year>1994</year>
+		<year>1995</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="cdrom" interface="cdrom">
 			<feature name="part_number" value="812-8101-012"/>
 			<!-- Origin: private dump -->
 			<diskarea name="cdrom">
 				<disk name="hot_mix_volume_12" sha1="34f76d048973a2b4a7ae8471420f87ab2ac4d762" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hotmix_13">
+		<description>Hot Mix Volume 13</description>
+		<year>1996</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="814-8101-013"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_13" sha1="36360aac69a12728b6716d5f584768db5fad1400" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hotmix_14">
+		<description>Hot Mix Volume 14</description>
+		<year>1996</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0544-003"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_14" sha1="3e3a962260923f58edafd3052b9133789057998c" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hotmix_15">
+		<description>Hot Mix Volume 15</description>
+		<year>1996</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0544-004"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_15" sha1="173163f1366fd729d80857f097fd0b9c1f8778f4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hotmix_16">
+		<description>Hot Mix Volume 16</description>
+		<year>1997</year>
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0544-005"/>
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="hot_mix_16" sha1="47b4d2ad094d204d726c3d9fb2a181e11af7422f" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
This commit adds some more "Hot Mix" CDs to the SGI softlist. They were all sourced from the Internet and are not dumped by me, that's why they are all standard MODE1 dumps (not RAW)

I also corrected the year on the Hot Mix 11 and Hot Mix 12 CDs:
* For Hot Mix 11, the year in the ISO9660 PVD is 1995, and all files are also dated 1995, and the copyright in the file "HTML/APPSDIR/APPS.HTM" also says 1995
* For Hot Mix 12, all files are dated 1995, and since it's unlikely to have come before Hot Mix 11, 1995 is certainly the correct year

For the naming ("Hot Mix Volume X" vs. just "Hot Mix X") I looked at various sources
* For Volume 1, the string "Hot Mix, Volume One" appears in the README on disc
* For Volume 9, the cover says "Volume 9" (as can be seen on later Hot Mix CDs, as the covers are included as GIF files)
* For Volumes 10, 13, 14, 15 and 16, the string "Hot Mix Volume X" or some variant thereof appears in some README file on the disc and/or the ISO9660 PVD

The SGI P/Ns were sourced from lists and databases on the internet, mainly [this](http://archive.irixnet.org/apocrypha/nekonomicon/forum/10/16723664/1.html)

The CHD files themselves are still uploading but will be available [here](https://s3.au.de:8082/md1-stuff/hot_mix_chds.zip) in a bit