### PR TITLE
darius: fix: MSM5205 output ports are inverted

### DIFF
--- a/src/mame/drivers/darius.cpp
+++ b/src/mame/drivers/darius.cpp
@@ -324,8 +324,8 @@ void darius_state::update_psg1(int port)
 
 void darius_state::update_da()
 {
-	const int left  = m_def_vol[(m_pan[4] >> 4) & 0x0f];
-	const int right = m_def_vol[(m_pan[4] >> 0) & 0x0f];
+	const int left  = m_def_vol[(m_pan[4] >> 0) & 0x0f];
+	const int right = m_def_vol[(m_pan[4] >> 4) & 0x0f];
 
 	if (m_msm5205_l != nullptr)
 		m_msm5205_l->flt_volume_set_volume(left / 100.0);


### PR DESCRIPTION
darius: fix: MSM5205 output ports are inverted

The stereo output channels of ADPCM chip (OKI MSM5205) are inverted.
I've confirmed it on the output of an actual arcade machine instance and the official soundtrack.

Confirmation method :
Start any variant of Darius and press F2, F3.
When the monitor test screen comes up, press 1 Player Start to enter the test mode.
Press P1 Up 46 times to set the SOUND CODE to 2E.
Press 1 Player Start to play the track 'Inorganic Beat'.
Compare the ADPCM part with official soundtrack
( e.g. https://www.youtube.com/watch?v=4toor1KlugA ) .
