### PR TITLE
sgi_mips.xml: Add Developer Toolbox CDs

### DIFF
--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -1400,6 +1400,42 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="dev_toolbox_42">
+		<description>Developer Toolbox 4.2</description>
+		<year>1994</year> <!-- 08/94 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="devtoolbox42" sha1="9b85e8d9d35635794408a8ce7d168af96e14bc47" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="dev_toolbox_61">
+		<description>Developer Toolbox 6.1</description>
+		<year>1996</year> <!-- 09/96 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="devtoolbox61-0" sha1="191db2ed342be4f514e9be29e8793fbc5718bf77" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="devtoolbox61-1" sha1="c978ecf1333446424d952646d95ce52b2c20496e" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<!-- Origin: nixzone.nl -->
+			<diskarea name="cdrom">
+				<disk name="devtoolbox61-2" sha1="928cfe53e856de90a554fe1b82594b119b7b255c" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="dmdo_1_1">
 		<description>Digital Media Dev Option 1.1</description>
 		<year>1993</year> <!-- 03/93 -->

--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -1417,18 +1417,21 @@ license:CC0
 		<year>1996</year> <!-- 09/96 -->
 		<publisher>Silicon Graphics</publisher>
 		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="Developer Toolbox 6.1 (CD 0)" />
 			<!-- Origin: nixzone.nl -->
 			<diskarea name="cdrom">
 				<disk name="devtoolbox61-0" sha1="191db2ed342be4f514e9be29e8793fbc5718bf77" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdrom">
+			<feature name="part_id" value="Developer Toolbox 6.1 (CD 1)" />
 			<!-- Origin: nixzone.nl -->
 			<diskarea name="cdrom">
 				<disk name="devtoolbox61-1" sha1="c978ecf1333446424d952646d95ce52b2c20496e" />
 			</diskarea>
 		</part>
 		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Developer Toolbox 6.1 (CD 2)" />
 			<!-- Origin: nixzone.nl -->
 			<diskarea name="cdrom">
 				<disk name="devtoolbox61-2" sha1="928cfe53e856de90a554fe1b82594b119b7b255c" />


### PR DESCRIPTION
This PR adds the developer toolbox CDs from [nixzone.nl](http://nixzone.nl/hotmix/).

I could not find any SGI P/N for them online, so for now they were added without. The year was inferred from the README and COPYRIGHT files on the CD. The only information I could find is [this archived page](http://archive.irixnet.org/sgistuff/software/irixintro/index.html) on irixnet (which was archived from nekochan.net before it went dark), which has some pictures of the Developer Toolbox 4.2 CD

Yes, the Developer Toolbox 6.1 really starts numbering with CD 0 (not CD 1), confirmed by the README on the first CD.

The CHDs are available to download [here](https://s3.au.de:8082/md1-stuff/developer_toolbox_chds.zip)