### PR TITLE
darius2 darius2d warriorb: fix: stereo output channels are inverted

### DIFF
--- a/src/mame/drivers/ninjaw.cpp
+++ b/src/mame/drivers/ninjaw.cpp
@@ -373,6 +373,7 @@ void ninjaw_state::pancontrol_w(offs_t offset, u8 data)
 {
 	filter_volume_device *flt = nullptr;
 	offset &= 3;
+	offset ^= 1;
 
 	switch (offset)
 	{

--- a/src/mame/drivers/warriorb.cpp
+++ b/src/mame/drivers/warriorb.cpp
@@ -182,6 +182,7 @@ void warriorb_state::pancontrol_w(offs_t offset, u8 data)
 {
 	filter_volume_device *flt = nullptr;
 	offset &= 3;
+	offset ^= 1;
 
 	switch (offset)
 	{


### PR DESCRIPTION
darius2 darius2d warriorb: fix: stereo output channels are inverted

Stereo output channels on Darius II / Warrior Blade are inverted .
It can be observed on titles that use same hardware.
As for darius2, both dual screen and triple screen variants have same issue.

I've compared it with actual arcade machines and official soundtracks.

Step to reproduce/comparison:

Start any variant of Darius II(darius2/darius2d/sagaia ...) and press F2, F3.
When the monitor test screen comes up, press [1 Player Start] to enter the test mode.
Press [P1 Up] 10 times to set the SOUND value to 0A.
Press [1 Player Start] to play the track 'Olga Breeze'.
Compare the playback with a proper source
( e.g. https://mora.jp/package/43000033/ZTTL9023/  track#3) .

Start warriorb and press F2, F3.
When the monitor test screen comes up, press [1 Player Start] to enter the test mode.
Press [P1 Up] 12 times to set the SOUND value to C0.
Press [P1 Button 1]  to play the track 'B.G.M.1 "Rising"'.
Compare the playback with a proper source
( e.g. https://mora.jp/package/43000033/ZTTL-9072/  track#4) .

ninjaw ( The Ninja Warriors: which uses the same emulation code with darius2) should have the same issue but I can't confirm it because it seems that the game don't utilize any stereo outout.