### PR TITLE
pacman.cpp: upgrade clubpacm and clubpacma to working

### DIFF
--- a/src/mame/drivers/pacman.cpp
+++ b/src/mame/drivers/pacman.cpp
@@ -33,8 +33,6 @@
 
     Known issues:
         * Mystery items in Ali Baba don't work correctly because of protection.
-        * Pacman Club controls need to be demultiplexed for 2-players simultaneous mode.
-          Also need 4-players extra inputs.
 
     Known to exist but dumps needed
         * Ms Pac Plus
@@ -1094,6 +1092,27 @@ void pacman_state::woodpek_map(address_map &map)
 }
 
 
+void pacman_state::clubpacm_map(address_map &map)
+{
+	map(0x0000, 0x3fff).rom();
+	map(0x4000, 0x43ff).mirror(0xa000).ram().w(FUNC(pacman_state::pacman_videoram_w)).share("videoram");
+	map(0x4400, 0x47ff).mirror(0xa000).ram().w(FUNC(pacman_state::pacman_colorram_w)).share("colorram");
+	map(0x4800, 0x4bff).mirror(0xa000).r(FUNC(pacman_state::pacman_read_nop)).nopw();
+	map(0x4c00, 0x4fef).mirror(0xa000).ram();
+	map(0x4ff0, 0x4fff).mirror(0xa000).ram().share("spriteram");
+	map(0x5000, 0x5007).mirror(0xaf38).w(m_mainlatch, FUNC(ls259_device::write_d0));
+	map(0x5040, 0x505f).mirror(0xaf00).w(m_namco_sound, FUNC(namco_device::pacman_sound_w));
+	map(0x5060, 0x506f).mirror(0xaf00).writeonly().share("spriteram2");
+	map(0x5070, 0x507f).mirror(0xaf00).nopw();
+	map(0x5080, 0x5080).mirror(0xaf3f).nopw();
+	map(0x50c0, 0x50c0).mirror(0xaf3f).w(m_watchdog, FUNC(watchdog_timer_device::reset_w));
+	map(0x5000, 0x507f).mirror(0xaf00).r(FUNC(pacman_state::clubpacm_input_r));
+	map(0x5080, 0x5080).mirror(0xaf3f).portr("DSW1");
+	map(0x50c0, 0x50c0).mirror(0xaf3f).portr("DSW2");
+	map(0x8000, 0xbfff).rom();
+}
+
+
 void pacman_state::numcrash_map(address_map &map)
 {
 	map(0x0000, 0x1fff).rom();
@@ -1716,6 +1735,67 @@ static INPUT_PORTS_START( mschamp )
 	PORT_DIPNAME( 0x08, 0x00, DEF_STR( Unknown ) )
 	PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
 	PORT_DIPSETTING(    0x08, DEF_STR( On ) )
+INPUT_PORTS_END
+
+/* Pacman Club inputs are similar to Ms. Pac-Man, except:
+	- P1/P2 joystick inputs are multiplexed via $5004/5005 to allow 2P simultaneous play in "double command" mode
+	- no rack test switch
+	- different service mode inputs (bit 3 of DSW1 enables the test screen, bit 4 of IN1 just resets the game)
+	- different bonus life values and only two lives options
+	- difficulty switch is read, but has no effect. instead, higher difficulty is enabled in double command mode
+	- free play mode is bugged; game is supposed to set up a pointer to the watchdog address in RAM for later,
+	  but this only happens during the attract mode, which is skipped over if free play is enabled
+*/
+static INPUT_PORTS_START( clubpacm )
+	PORT_START("IN0")
+	PORT_BIT( 0x1f, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_COIN1)
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_COIN2)
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_SERVICE1)
+
+	PORT_START("IN1")
+	PORT_BIT( 0x0f, IP_ACTIVE_LOW, IPT_UNUSED )
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_SERVICE )
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START1 )
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_START2 )
+	PORT_DIPNAME( 0x80, 0x80, DEF_STR( Cabinet ) )
+	PORT_DIPSETTING( 0x80, DEF_STR( Upright ) )
+	PORT_DIPSETTING( 0x00, DEF_STR( Cocktail ) )
+
+	/* multiplexed player inputs */
+	PORT_START("P1")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_4WAY
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_4WAY
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_4WAY
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_4WAY
+	PORT_BIT( 0xf0, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("P2")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_JOYSTICK_UP ) PORT_4WAY PORT_PLAYER(2)
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_JOYSTICK_LEFT ) PORT_4WAY PORT_PLAYER(2)
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_JOYSTICK_RIGHT ) PORT_4WAY PORT_PLAYER(2)
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_JOYSTICK_DOWN ) PORT_4WAY PORT_PLAYER(2)
+	PORT_BIT( 0xf0, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("DSW1")
+	PORT_DIPNAME( 0x03, 0x01, DEF_STR( Coinage ) )
+	PORT_DIPSETTING(    0x03, DEF_STR( 2C_1C ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( 1C_1C ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( 1C_2C ) )
+	PORT_DIPSETTING(    0x00, "Free Play (Invalid)" ) /* causes watchdog reset at title screen, see comments above */
+	PORT_DIPNAME( 0x04, 0x00, DEF_STR( Lives ) )
+	PORT_DIPSETTING(    0x00, "3" )
+	PORT_DIPSETTING(    0x04, "5" )
+	PORT_SERVICE( 0x08, IP_ACTIVE_LOW )
+	PORT_DIPNAME( 0x30, 0x00, DEF_STR( Bonus_Life ) )
+	PORT_DIPSETTING(    0x00, "40000" ) /* service mode incorrectly says 20000 */
+	PORT_DIPSETTING(    0x10, "60000" ) /* service mode incorrectly says 40000 */
+	PORT_DIPSETTING(    0x20, "80000" )
+	PORT_DIPSETTING(    0x30, DEF_STR( None ) )
+	PORT_BIT( 0xc0, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("DSW2")
+	PORT_BIT( 0xff, IP_ACTIVE_HIGH, IPT_UNUSED )
 INPUT_PORTS_END
 
 
@@ -3642,6 +3722,16 @@ void pacman_state::woodpek(machine_config &config)
 	/* basic machine hardware */
 	m_maincpu->set_addrmap(AS_PROGRAM, &pacman_state::woodpek_map);
 }
+
+
+void pacman_state::clubpacm(machine_config &config)
+{
+	mspacman(config);
+
+	/* basic machine hardware */
+	m_maincpu->set_addrmap(AS_PROGRAM, &pacman_state::clubpacm_map);
+}
+
 
 void pacman_state::numcrash(machine_config &config)
 {
@@ -7648,6 +7738,18 @@ void pacman_state::init_pengomc1()
 		romdata[i] = buf[i^0xff];
 }
 
+uint8_t pacman_state::clubpacm_input_r(offs_t offset)
+{
+	uint8_t data = ioport((offset & 0x40) ? "IN1" : "IN0")->read();
+
+	if (!m_mainlatch->q5_r())
+		data &= ioport("P1")->read();
+	if (!m_mainlatch->q4_r())
+		data &= ioport("P2")->read();
+
+	return data;
+}
+
 void pacman_state::init_clubpacma()
 {
 	uint8_t *rom = memregion("maincpu")->base();
@@ -7732,9 +7834,9 @@ GAME( 198?, pacmansp,   puckman, pacman,  pacmansp, pacman_state,  empty_init,  
 
 
 
-GAME( 1989, clubpacm,  0,        woodpek, mspacman, pacman_state,  empty_init,    ROT90,  "Miky SRL", "Pacman Club / Club Lambada (Argentina)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
-GAME( 1990, clubpacma, clubpacm, woodpek, mspacman, pacman_state,  init_clubpacma,ROT90,  "Miky SRL", "Pacman Club (set 1, Argentina)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // resets during at title screen
-GAME( 1990, clubpacmb, clubpacm, woodpek, mspacman, pacman_state,  empty_init,    ROT90,  "Miky SRL", "Pacman Club (set 2, Argentina)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // encrypted
+GAME( 1989, clubpacm,  0,        clubpacm,clubpacm, pacman_state,  empty_init,    ROT90,  "Miky SRL", "Pacman Club / Club Lambada (Argentina)", MACHINE_SUPPORTS_SAVE )
+GAME( 1990, clubpacma, clubpacm, clubpacm,clubpacm, pacman_state,  init_clubpacma,ROT90,  "Miky SRL", "Pacman Club (set 1, Argentina)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // resets during at title screen
+GAME( 1990, clubpacmb, clubpacm, clubpacm,clubpacm, pacman_state,  empty_init,    ROT90,  "Miky SRL", "Pacman Club (set 2, Argentina)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING ) // encrypted
 
 GAME( 1985, jumpshot, 0,        pacman,   jumpshot, pacman_state,  init_jumpshot, ROT90,  "Bally Midway", "Jump Shot", MACHINE_SUPPORTS_SAVE )
 GAME( 1985, jumpshotp,jumpshot, pacman,   jumpshotp,pacman_state,  init_jumpshot, ROT90,  "Bally Midway", "Jump Shot Engineering Sample", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/pacman.h
+++ b/src/mame/includes/pacman.h
@@ -43,6 +43,7 @@ protected:
 	void bigbucks_map(address_map &map);
 	void bigbucks_portmap(address_map &map);
 	void birdiy_map(address_map &map);
+	void clubpacm_map(address_map &map);
 	void crushs_map(address_map &map);
 	void crushs_portmap(address_map &map);
 	void dremshpr_map(address_map &map);
@@ -139,6 +140,7 @@ protected:
 	DECLARE_WRITE_LINE_MEMBER(irq_mask_w);
 	uint8_t mspacii_protection_r(offs_t offset);
 	uint8_t cannonbp_protection_r(offs_t offset);
+	uint8_t clubpacm_input_r(offs_t offset);
 	void pacman_videoram_w(offs_t offset, uint8_t data);
 	void pacman_colorram_w(offs_t offset, uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_w);
@@ -216,6 +218,7 @@ public:
 	void vanvan(machine_config &config);
 	void s2650games(machine_config &config);
 	void woodpek(machine_config &config);
+	void clubpacm(machine_config &config);
 	void crushs(machine_config &config);
 	void superabc(machine_config &config);
 	void numcrash(machine_config &config);

--- a/src/mame/includes/pacman.h
+++ b/src/mame/includes/pacman.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "machine/74259.h"
+#include "machine/gen_latch.h"
 #include "machine/watchdog.h"
 #include "sound/namco.h"
 #include "emupal.h"
@@ -43,7 +44,6 @@ protected:
 	void bigbucks_map(address_map &map);
 	void bigbucks_portmap(address_map &map);
 	void birdiy_map(address_map &map);
-	void clubpacm_map(address_map &map);
 	void crushs_map(address_map &map);
 	void crushs_portmap(address_map &map);
 	void dremshpr_map(address_map &map);
@@ -140,7 +140,6 @@ protected:
 	DECLARE_WRITE_LINE_MEMBER(irq_mask_w);
 	uint8_t mspacii_protection_r(offs_t offset);
 	uint8_t cannonbp_protection_r(offs_t offset);
-	uint8_t clubpacm_input_r(offs_t offset);
 	void pacman_videoram_w(offs_t offset, uint8_t data);
 	void pacman_colorram_w(offs_t offset, uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_w);
@@ -177,7 +176,6 @@ public:
 	void init_mschamp();
 	void init_mbrush();
 	void init_pengomc1();
-	void init_clubpacma();
 
 protected:
 	TILEMAP_MAPPER_MEMBER(pacman_scan_rows);
@@ -218,7 +216,6 @@ public:
 	void vanvan(machine_config &config);
 	void s2650games(machine_config &config);
 	void woodpek(machine_config &config);
-	void clubpacm(machine_config &config);
 	void crushs(machine_config &config);
 	void superabc(machine_config &config);
 	void numcrash(machine_config &config);
@@ -265,6 +262,28 @@ protected:
 
 	void epos_map(address_map &map);
 	void epos_portmap(address_map &map);
+};
+
+class clubpacm_state : public pacman_state
+{
+public:
+	clubpacm_state(const machine_config &mconfig, device_type type, const char *tag)
+		: pacman_state(mconfig, type, tag)
+		, m_sublatch(*this, "sublatch")
+		, m_players(*this, "P%u", 1)
+	{ }
+
+	void clubpacm(machine_config &config);
+
+	DECLARE_CUSTOM_INPUT_MEMBER(clubpacm_input_r);
+
+	void init_clubpacma();
+
+protected:
+	void clubpacm_map(address_map &map);
+
+	required_device<generic_latch_8_device> m_sublatch;
+	required_ioport_array<2> m_players;
 };
 
 #endif // MAME_INCLUDES_PACMAN_H


### PR DESCRIPTION
These two commits add/improve a few things for `clubpacm` and `clubpacma`:
* Multiplexed P1/P2 joystick inputs for Double Command mode in `clubpacm`
* Corrections to other inputs (including dip switches)
* Simple protection(?) latch needed by at least `clubpacma`

Both of these sets should now be in good shape, aside from some bugs in the games themselves (which I tried to document in comments where possible, e.g. the broken free play setting).

The only thing I'm not really sure about is whether `clubpacm` is supposed to support third and fourth joysticks for the other side of a cocktail table, or if it's even intended to be playable in cocktail mode in the first place...