### PR TITLE
vsnes: working sound + "improved" graphics in Vs. SMB bootleg sets

### DIFF
--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -283,7 +283,9 @@ void ppu2c04_clone_device::device_start()
 
 	(theoretically this can cause the wrong sprite tiles to be drawn for
 	one frame after changing CHR banks, but the Vs. SMB bootlegs that use
-	this clone hardware don't actually have CHR bank switching anyway)
+	this clone hardware don't actually have CHR bank switching anyway.
+	also generally affects PPU-side read timings involving the OAM, but
+	this still doesn't seem to matter for Vs. SMB specifically)
 	*/
 	m_spritebuf = make_unique_clear<uint8_t[]>(SPRITERAM_SIZE);
 	save_pointer(NAME(m_spritebuf), SPRITERAM_SIZE);

--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -279,7 +279,11 @@ void ppu2c04_clone_device::device_start()
 	causing sprite rendering to be one frame behind tile/background rendering
 	(mainly noticeable during scrolling)
 	to simulate that, we can just have a secondary OAM buffer and swap them
-	at the end of each frame
+	at the end of each frame.
+
+	(theoretically this can cause the wrong sprite tiles to be drawn for
+	one frame after changing CHR banks, but the Vs. SMB bootlegs that use
+	this clone hardware don't actually have CHR bank switching anyway)
 	*/
 	m_spritebuf = make_unique_clear<uint8_t[]>(SPRITERAM_SIZE);
 	save_pointer(NAME(m_spritebuf), SPRITERAM_SIZE);

--- a/src/devices/video/ppu2c0x.cpp
+++ b/src/devices/video/ppu2c0x.cpp
@@ -481,9 +481,9 @@ void ppu2c04_clone_device::init_palette_tables()
 	{
 		/* A7 line on palette ROMs is always high, color bits are in reverse order */
 		u8 color = m_palette_data[color_num | 0x80];
-		int R = bitswap<3>(color,      0, 1, 2);
-		int G = bitswap<3>(color >> 3, 0, 1, 2);
-		int B = bitswap<2>(color >> 6, 0, 1);
+		int R = bitswap<3>(color, 0, 1, 2);
+		int G = bitswap<3>(color, 3, 4, 5);
+		int B = bitswap<2>(color, 6, 7);
 
 		m_nespens[color_num] = (pal3bit(R) << 16) | (pal3bit(G) << 8) | pal2bit(B);
 	}

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -300,17 +300,30 @@ public:
 	ppu2c05_04_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
+class ppu2c04_clone_device : public ppu2c0x_device {
+public:
+	ppu2c04_clone_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	virtual void draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32 &bitmap) override;
+
+protected:
+	virtual void init_palette_tables() override;
+
+private:
+	required_region_ptr<uint8_t> m_palette_data;
+};
 
 // device type definition
 //extern const device_type PPU_2C0X;
-DECLARE_DEVICE_TYPE(PPU_2C02,    ppu2c02_device)    // NTSC NES
-DECLARE_DEVICE_TYPE(PPU_2C03B,   ppu2c03b_device)   // Playchoice 10
-DECLARE_DEVICE_TYPE(PPU_2C04,    ppu2c04_device)    // Vs. Unisystem
-DECLARE_DEVICE_TYPE(PPU_2C07,    ppu2c07_device)    // PAL NES
-DECLARE_DEVICE_TYPE(PPU_PALC,    ppupalc_device)    // PAL Clones
-DECLARE_DEVICE_TYPE(PPU_2C05_01, ppu2c05_01_device) // Vs. Unisystem (Ninja Jajamaru Kun)
-DECLARE_DEVICE_TYPE(PPU_2C05_02, ppu2c05_02_device) // Vs. Unisystem (Mighty Bomb Jack)
-DECLARE_DEVICE_TYPE(PPU_2C05_03, ppu2c05_03_device) // Vs. Unisystem (Gumshoe)
-DECLARE_DEVICE_TYPE(PPU_2C05_04, ppu2c05_04_device) // Vs. Unisystem (Top Gun)
+DECLARE_DEVICE_TYPE(PPU_2C02,    ppu2c02_device)       // NTSC NES
+DECLARE_DEVICE_TYPE(PPU_2C03B,   ppu2c03b_device)      // Playchoice 10
+DECLARE_DEVICE_TYPE(PPU_2C04,    ppu2c04_device)       // Vs. Unisystem
+DECLARE_DEVICE_TYPE(PPU_2C07,    ppu2c07_device)       // PAL NES
+DECLARE_DEVICE_TYPE(PPU_PALC,    ppupalc_device)       // PAL Clones
+DECLARE_DEVICE_TYPE(PPU_2C05_01, ppu2c05_01_device)    // Vs. Unisystem (Ninja Jajamaru Kun)
+DECLARE_DEVICE_TYPE(PPU_2C05_02, ppu2c05_02_device)    // Vs. Unisystem (Mighty Bomb Jack)
+DECLARE_DEVICE_TYPE(PPU_2C05_03, ppu2c05_03_device)    // Vs. Unisystem (Gumshoe)
+DECLARE_DEVICE_TYPE(PPU_2C05_04, ppu2c05_04_device)    // Vs. Unisystem (Top Gun)
+DECLARE_DEVICE_TYPE(PPU_2C04C,   ppu2c04_clone_device) // Vs. Unisystem (Super Mario Bros. bootlegs)
 
 #endif // MAME_VIDEO_PPU2C0X_H

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -53,14 +53,17 @@ public:
 
 	enum
 	{
-		NTSC_SCANLINES_PER_FRAME   = 262,
-		PAL_SCANLINES_PER_FRAME    = 312,
+		NTSC_SCANLINES_PER_FRAME     = 262,
+		PAL_SCANLINES_PER_FRAME      = 312,
+		VS_CLONE_SCANLINES_PER_FRAME = 280,
 
-		BOTTOM_VISIBLE_SCANLINE    = 239,
-		VBLANK_FIRST_SCANLINE      = 241,
-		VBLANK_FIRST_SCANLINE_PALC = 291,
-		VBLANK_LAST_SCANLINE_NTSC  = 260,
-		VBLANK_LAST_SCANLINE_PAL   = 310
+		BOTTOM_VISIBLE_SCANLINE        = 239,
+		VBLANK_FIRST_SCANLINE          = 241,
+		VBLANK_FIRST_SCANLINE_PALC     = 291,
+		VBLANK_FIRST_SCANLINE_VS_CLONE = 240,
+		VBLANK_LAST_SCANLINE_NTSC      = 260,
+		VBLANK_LAST_SCANLINE_PAL       = 310,
+		VBLANK_LAST_SCANLINE_VS_CLONE  = 279
 
 		// Both the scanline immediately before and immediately after VBLANK
 		// are non-rendering and non-vblank.
@@ -207,6 +210,7 @@ protected:
 	int                         m_back_color;           /* background color */
 	int                         m_refresh_data;         /* refresh-related */
 	int                         m_x_fine;               /* refresh-related */
+	int                         m_toggle;               /* used to latch hi-lo scroll */
 	int                         m_tilecount;            /* MMC5 can change attributes to subsets of the 34 visible tiles */
 	latch_delegate              m_latch;
 
@@ -228,7 +232,6 @@ private:
 	devcb_write_line            m_int_callback;         /* nmi access callback from interface */
 
 	int                         m_refresh_latch;        /* refresh-related */
-	int                         m_toggle;               /* used to latch hi-lo scroll */
 	int                         m_add;              /* vram increment amount */
 	int                         m_videomem_addr;        /* videomem address pointer */
 	int                         m_data_latch;           /* latched videomem data */
@@ -304,9 +307,12 @@ class ppu2c04_clone_device : public ppu2c0x_device {
 public:
 	ppu2c04_clone_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 
+	virtual uint8_t read(offs_t offset) override;
+	virtual void write(offs_t offset, uint8_t data) override;
+
+	virtual void draw_background(uint8_t *line_priority) override;
 	virtual void draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32 &bitmap) override;
 
-protected:
 	virtual void init_palette_tables() override;
 
 private:

--- a/src/devices/video/ppu2c0x.h
+++ b/src/devices/video/ppu2c0x.h
@@ -312,11 +312,17 @@ public:
 
 	virtual void draw_background(uint8_t *line_priority) override;
 	virtual void draw_sprite_pixel(int sprite_xpos, int color, int pixel, uint8_t pixel_data, bitmap_rgb32 &bitmap) override;
+	virtual void draw_sprites(uint8_t *line_priority) override;
 
 	virtual void init_palette_tables() override;
 
+protected:
+	virtual void device_start() override;
+
 private:
 	required_region_ptr<uint8_t> m_palette_data;
+
+	std::unique_ptr<uint8_t[]>   m_spritebuf; /* buffered sprite ram for next frame */
 };
 
 // device type definition

--- a/src/mame/drivers/vsnes.cpp
+++ b/src/mame/drivers/vsnes.cpp
@@ -2872,9 +2872,9 @@ GAME( 1986, rbibb,    0,         vsnes,         rbibb,    vsnes_state, init_rbib
 GAME( 1986, rbibba,   rbibb,     vsnes,         rbibb,    vsnes_state, init_rbibb,    ROT0, "Namco",                  "Vs. Atari R.B.I. Baseball (set 2)", 0 )
 GAME( 1986, suprmrio, 0,         vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "Nintendo",               "Vs. Super Mario Bros. (set SM4-4 E)", 0 )
 GAME( 1986, suprmrioa,suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "Nintendo",               "Vs. Super Mario Bros. (set ?, harder)", 0 )
-GAME( 1986, suprmriobl,suprmrio, vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 1)", MACHINE_IMPERFECT_GRAPHICS) // timer starts at 200(!)
-GAME( 1986, suprmriobl2,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 2)", MACHINE_IMPERFECT_GRAPHICS) // timer starts at 300
-GAME( 1986, suprmriobl3,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 3)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // timer starts at 300
+GAME( 1986, suprmriobl,suprmrio, vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 1)", 0) // timer starts at 200(!)
+GAME( 1986, suprmriobl2,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 2)", 0) // timer starts at 300
+GAME( 1986, suprmriobl3,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 3)", MACHINE_NOT_WORKING ) // timer starts at 300
 GAME( 1988, skatekds, suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "hack (Two-Bit Score)",   "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)", 0 )
 GAME( 1985, vsskykid, 0,         vsnes,         vsskykid, vsnes_state, init_MMC3,     ROT0, "Namco",                  "Vs. Super SkyKid", 0 )
 GAME( 1987, tkoboxng, 0,         vsnes,         tkoboxng, vsnes_state, init_tkoboxng, ROT0, "Namco / Data East USA",  "Vs. T.K.O. Boxing", 0 )

--- a/src/mame/drivers/vsnes.cpp
+++ b/src/mame/drivers/vsnes.cpp
@@ -1955,7 +1955,7 @@ ROM_START( suprmriobl )
 	ROM_REGION( 0x10000, "sub", 0 ) /* Z80 memory */
 	ROM_LOAD( "1.bin",  0x0000, 0x2000, CRC(9e3557f2) SHA1(11a0de2c0154f7ac120d9774cb5d1051e0156822) )
 
-	ROM_REGION( 0x10000, "unk", 0 ) /* first half is some sort of table */
+	ROM_REGION( 0x10000, "unk", 0 ) /* Table used by clone PPU for sprite flipping, etc. */
 	ROM_LOAD( "3.bin",  0x0000, 0x8000, CRC(67a467f9) SHA1(61cd1db7cd52faa31153b89f6b98c9b78bf4ca4f) )
 
 	ROM_REGION( 0x4000, "gfx1", 0 ) /* PPU memory */
@@ -1984,7 +1984,7 @@ ROM_START( suprmriobl2 )
 	ROM_REGION( 0x10000, "sub", 0 ) /* Z80 memory */
 	ROM_LOAD( "1-2764.bin",  0x0000, 0x2000, CRC(95856e07) SHA1(c681cfdb656e687bc59080df56c9c38e13be4bb8) )
 
-	ROM_REGION( 0x10000, "unk", 0 ) /* first half is some sort of table */
+	ROM_REGION( 0x10000, "unk", 0 ) /* Table used by clone PPU for sprite flipping, etc. */
 	ROM_LOAD( "3-27256.bin",  0x0000, 0x8000, CRC(67a467f9) SHA1(61cd1db7cd52faa31153b89f6b98c9b78bf4ca4f) )
 
 	ROM_REGION( 0x4000, "gfx1", 0 ) /* PPU memory */
@@ -2000,10 +2000,10 @@ ROM_START( suprmriobl3 )
 	ROM_REGION( 0x10000, "maincpu", 0 ) // 6502 memory
 	ROM_LOAD( "sm_4.bin",  0x8000, 0x8000, CRC(663b1753) SHA1(b0d2057c4545f2d6534cafb16086826c8ba49f5a) )
 
-	ROM_REGION( 0x10000, "sub", 0 ) // Z80 memory
-	ROM_LOAD( "sm_1.bin",  0x0000, 0x2000, CRC(7f6dda4a) SHA1(0e92a1255ce13ae1215b531f268cd4874e20d611) )
+	ROM_REGION( 0x10000, "sub", 0 ) // Z80 memory (NMI and IRQ return instructions are corrupted)
+	ROM_LOAD( "sm_1.bin",  0x0000, 0x2000, BAD_DUMP CRC(7f6dda4a) SHA1(0e92a1255ce13ae1215b531f268cd4874e20d611) )
 
-	ROM_REGION( 0x10000, "unk", 0 ) // First half is some sort of table
+	ROM_REGION( 0x10000, "unk", 0 ) // Table used by clone PPU for sprite flipping, etc.
 	ROM_LOAD( "sm_3.bin",  0x0000, 0x8000, CRC(67a467f9) SHA1(61cd1db7cd52faa31153b89f6b98c9b78bf4ca4f) )
 
 	ROM_REGION( 0x4000, "gfx1", 0 ) // PPU memory

--- a/src/mame/drivers/vsnes.cpp
+++ b/src/mame/drivers/vsnes.cpp
@@ -1975,6 +1975,9 @@ ROM_START( suprmriobl )
 	ROM_LOAD( "pal16r6.5",  0x000, 0x104, CRC(ceff7c7c) SHA1(52fd344c591478469369cd0862d1facfe23e12fb) )
 	ROM_LOAD( "pal16r8.6",  0x000, 0x104, CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) )
 	ROM_LOAD( "pal16r8a.7", 0x000, 0x104, CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) )
+
+	ROM_REGION(0x0100, "epld", 0)
+	ROM_LOAD("ep1200.bin", 0x000, 0x100, NO_DUMP) // Not dumped
 ROM_END
 
 ROM_START( suprmriobl2 )
@@ -1994,38 +1997,18 @@ ROM_START( suprmriobl2 )
 	ROM_REGION(0x100, "ppu1:palette", 0)
 	ROM_LOAD_NIB_HIGH( "prom6301.1", 0x000, 0x100, BAD_DUMP CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) ) // Not from this PCB
 	ROM_LOAD_NIB_LOW ( "prom6301.2", 0x000, 0x100, BAD_DUMP CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) ) // Not from this PCB
-ROM_END
 
-ROM_START( suprmriobl3 )
-	ROM_REGION( 0x10000, "maincpu", 0 ) // 6502 memory
-	ROM_LOAD( "sm_4.bin",  0x8000, 0x8000, CRC(663b1753) SHA1(b0d2057c4545f2d6534cafb16086826c8ba49f5a) )
+	ROM_REGION(0x4000, "pals", 0)
+	ROM_LOAD("pal16l8.1", 0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e)) // Not from this PCB
+	ROM_LOAD("pal16r6a.2", 0x000, 0x104, NO_DUMP)
+	ROM_LOAD("pal16r8.3", 0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e)) // Not from this PCB
+	ROM_LOAD("pal16l8.4", 0x000, 0x104, BAD_DUMP CRC(6f6de82d) SHA1(3d59b222d25457b2f89b559409721db37d6a81d8)) // Not from this PCB
+	ROM_LOAD("pal16r6.5", 0x000, 0x104, BAD_DUMP CRC(ceff7c7c) SHA1(52fd344c591478469369cd0862d1facfe23e12fb)) // Not from this PCB
+	ROM_LOAD("pal16r8.6", 0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e)) // Not from this PCB
+	ROM_LOAD("pal16r8a.7", 0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e)) // Not from this PCB
 
-	ROM_REGION( 0x10000, "sub", 0 ) // Z80 memory (NMI and IRQ return instructions are corrupted)
-	ROM_LOAD( "sm_1.bin",  0x0000, 0x2000, BAD_DUMP CRC(7f6dda4a) SHA1(0e92a1255ce13ae1215b531f268cd4874e20d611) )
-
-	ROM_REGION( 0x10000, "unk", 0 ) // Table used by clone PPU for sprite flipping, etc.
-	ROM_LOAD( "sm_3.bin",  0x0000, 0x8000, CRC(67a467f9) SHA1(61cd1db7cd52faa31153b89f6b98c9b78bf4ca4f) )
-
-	ROM_REGION( 0x4000, "gfx1", 0 ) // PPU memory
-	ROM_LOAD( "sm_2.bin",  0x0000, 0x2000, CRC(a5f771d1) SHA1(b3f916700035d5556cca009ab83300fb662a868f) )
-	ROM_LOAD( "sm_5.bin",  0x2000, 0x2000, CRC(a08903ca) SHA1(7ecec519ac973168a84505ddede4f248b554fd85) )
-
-	/* this set has some extra files compared to "suprmriobl2", they probably exist on that pcb too though */
-	ROM_REGION(0x100, "ppu1:palette", 0)
-	ROM_LOAD_NIB_HIGH( "prom6301.1", 0x000, 0x100, BAD_DUMP CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) ) // Not from this PCB
-	ROM_LOAD_NIB_LOW ( "prom6301.2", 0x000, 0x100, BAD_DUMP CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) ) // Not from this PCB
-
-	ROM_REGION( 0x4000, "pals", 0 )
-	ROM_LOAD( "pal16l8.1",  0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) ) // Not from this PCB
-	ROM_LOAD( "pal16r6a.2", 0x000, 0x104, NO_DUMP )
-	ROM_LOAD( "pal16r8.3",  0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) ) // Not from this PCB
-	ROM_LOAD( "pal16l8.4",  0x000, 0x104, BAD_DUMP CRC(6f6de82d) SHA1(3d59b222d25457b2f89b559409721db37d6a81d8) ) // Not from this PCB
-	ROM_LOAD( "pal16r6.5",  0x000, 0x104, BAD_DUMP CRC(ceff7c7c) SHA1(52fd344c591478469369cd0862d1facfe23e12fb) ) // Not from this PCB
-	ROM_LOAD( "pal16r8.6",  0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) ) // Not from this PCB
-	ROM_LOAD( "pal16r8a.7", 0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) ) // Not from this PCB
-
-	ROM_REGION( 0x0100, "epld", 0 )
-	ROM_LOAD( "ep1200.bin",  0x000, 0x100, NO_DUMP ) // Not dumped
+	ROM_REGION(0x0100, "epld", 0)
+	ROM_LOAD("ep1200.bin", 0x000, 0x100, NO_DUMP) // Not dumped
 ROM_END
 
 ROM_START( skatekds )
@@ -2874,7 +2857,6 @@ GAME( 1986, suprmrio, 0,         vsnes,         suprmrio, vsnes_state, init_vsno
 GAME( 1986, suprmrioa,suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "Nintendo",               "Vs. Super Mario Bros. (set ?, harder)", 0 )
 GAME( 1986, suprmriobl,suprmrio, vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 1)", 0) // timer starts at 200(!)
 GAME( 1986, suprmriobl2,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 2)", 0) // timer starts at 300
-GAME( 1986, suprmriobl3,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 3)", MACHINE_NOT_WORKING ) // timer starts at 300
 GAME( 1988, skatekds, suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "hack (Two-Bit Score)",   "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)", 0 )
 GAME( 1985, vsskykid, 0,         vsnes,         vsskykid, vsnes_state, init_MMC3,     ROT0, "Namco",                  "Vs. Super SkyKid", 0 )
 GAME( 1987, tkoboxng, 0,         vsnes,         tkoboxng, vsnes_state, init_tkoboxng, ROT0, "Namco / Data East USA",  "Vs. T.K.O. Boxing", 0 )

--- a/src/mame/drivers/vsnes.cpp
+++ b/src/mame/drivers/vsnes.cpp
@@ -1861,7 +1861,7 @@ void vsnes_state::vsnes_bootleg(machine_config &config)
 	screen1.set_visarea(0*8, 32*8-1, 0*8, 30*8-1);
 	screen1.set_screen_update("ppu1", FUNC(ppu2c0x_device::screen_update));
 
-	PPU_2C04(config, m_ppu1);
+	PPU_2C04C(config, m_ppu1);
 	m_ppu1->set_cpu_tag(m_maincpu);
 	m_ppu1->set_screen("screen1");
 	m_ppu1->int_callback().set_inputline(m_maincpu, INPUT_LINE_NMI);
@@ -1966,9 +1966,9 @@ ROM_START( suprmriobl )
 	ROM_LOAD( "5.bin",  0x2000, 0x2000, CRC(15506b86) SHA1(69ecf7a3cc8bf719c1581ec7c0d68798817d416f) )
 
 	/* this set has some extra files compared to "suprmriobl2", they probably exist on that pcb too though */
-	ROM_REGION( 0x200, "proms", 0 )
-	ROM_LOAD( "prom6301.1",  0x000, 0x100, CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) )
-	ROM_LOAD( "prom6301.2",  0x100, 0x100, CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) )
+	ROM_REGION( 0x100, "ppu1:palette", 0 )
+	ROM_LOAD_NIB_HIGH( "prom6301.1",  0x000, 0x100, CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) )
+	ROM_LOAD_NIB_LOW ( "prom6301.2",  0x000, 0x100, CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) )
 
 	ROM_REGION( 0x4000, "pals", 0 )
 	ROM_LOAD( "pal16l8.1",  0x000, 0x104, CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) )
@@ -1978,8 +1978,6 @@ ROM_START( suprmriobl )
 	ROM_LOAD( "pal16r6.5",  0x000, 0x104, CRC(ceff7c7c) SHA1(52fd344c591478469369cd0862d1facfe23e12fb) )
 	ROM_LOAD( "pal16r8.6",  0x000, 0x104, CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) )
 	ROM_LOAD( "pal16r8a.7", 0x000, 0x104, CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) )
-
-	PALETTE_2C04_0004("ppu1:palette")
 ROM_END
 
 ROM_START( suprmriobl2 )
@@ -1996,7 +1994,9 @@ ROM_START( suprmriobl2 )
 	ROM_LOAD( "2-2764.bin",  0x0000, 0x2000, CRC(42418d40) SHA1(22ab61589742cfa4cc6856f7205d7b4b8310bc4d) )
 	ROM_LOAD( "5-2764.bin",  0x2000, 0x2000, CRC(15506b86) SHA1(69ecf7a3cc8bf719c1581ec7c0d68798817d416f) )
 
-	PALETTE_2C04_0004("ppu1:palette")
+	ROM_REGION(0x100, "ppu1:palette", 0)
+	ROM_LOAD_NIB_HIGH( "prom6301.1", 0x000, 0x100, BAD_DUMP CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) ) // Not from this PCB
+	ROM_LOAD_NIB_LOW ( "prom6301.2", 0x000, 0x100, BAD_DUMP CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) ) // Not from this PCB
 ROM_END
 
 ROM_START( suprmriobl3 )
@@ -2014,9 +2014,9 @@ ROM_START( suprmriobl3 )
 	ROM_LOAD( "sm_5.bin",  0x2000, 0x2000, CRC(a08903ca) SHA1(7ecec519ac973168a84505ddede4f248b554fd85) )
 
 	/* this set has some extra files compared to "suprmriobl2", they probably exist on that pcb too though */
-	ROM_REGION( 0x200, "proms", 0 )
-	ROM_LOAD( "prom6301.1",  0x000, 0x100, BAD_DUMP CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) ) // Not from this PCB
-	ROM_LOAD( "prom6301.2",  0x100, 0x100, BAD_DUMP CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) ) // Not from this PCB
+	ROM_REGION(0x100, "ppu1:palette", 0)
+	ROM_LOAD_NIB_HIGH( "prom6301.1", 0x000, 0x100, BAD_DUMP CRC(a31dc330) SHA1(b652003f7e252bac3bdb19412839c2f03af7f8b8) ) // Not from this PCB
+	ROM_LOAD_NIB_LOW ( "prom6301.2", 0x000, 0x100, BAD_DUMP CRC(019c6141) SHA1(fdeda4dea6506807a3324fa941f0684208aa3b4b) ) // Not from this PCB
 
 	ROM_REGION( 0x4000, "pals", 0 )
 	ROM_LOAD( "pal16l8.1",  0x000, 0x104, BAD_DUMP CRC(bd76fb53) SHA1(2d0634e8edb3289a103719466465e9777606086e) ) // Not from this PCB
@@ -2029,8 +2029,6 @@ ROM_START( suprmriobl3 )
 
 	ROM_REGION( 0x0100, "epld", 0 )
 	ROM_LOAD( "ep1200.bin",  0x000, 0x100, NO_DUMP ) // Not dumped
-
-	PALETTE_2C04_0004("ppu1:palette") // Not from this PCB
 ROM_END
 
 ROM_START( skatekds )
@@ -2877,9 +2875,9 @@ GAME( 1986, rbibb,    0,         vsnes,         rbibb,    vsnes_state, init_rbib
 GAME( 1986, rbibba,   rbibb,     vsnes,         rbibb,    vsnes_state, init_rbibb,    ROT0, "Namco",                  "Vs. Atari R.B.I. Baseball (set 2)", 0 )
 GAME( 1986, suprmrio, 0,         vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "Nintendo",               "Vs. Super Mario Bros. (set SM4-4 E)", 0 )
 GAME( 1986, suprmrioa,suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "Nintendo",               "Vs. Super Mario Bros. (set ?, harder)", 0 )
-GAME( 1986, suprmriobl,suprmrio, vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 1)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS) // timer starts at 200(!)
-GAME( 1986, suprmriobl2,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 2)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS) // timer starts at 300
-GAME( 1986, suprmriobl3,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 3)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_COLORS | MACHINE_NOT_WORKING ) // timer starts at 300
+GAME( 1986, suprmriobl,suprmrio, vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 1)", MACHINE_IMPERFECT_GRAPHICS) // timer starts at 200(!)
+GAME( 1986, suprmriobl2,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 2)", MACHINE_IMPERFECT_GRAPHICS) // timer starts at 300
+GAME( 1986, suprmriobl3,suprmrio,vsnes_bootleg, suprmrio, vsnes_state, init_bootleg,  ROT0, "bootleg",                "Vs. Super Mario Bros. (bootleg with Z80, set 3)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NOT_WORKING ) // timer starts at 300
 GAME( 1988, skatekds, suprmrio,  vsnes,         suprmrio, vsnes_state, init_vsnormal, ROT0, "hack (Two-Bit Score)",   "Vs. Skate Kids. (Graphic hack of Super Mario Bros.)", 0 )
 GAME( 1985, vsskykid, 0,         vsnes,         vsskykid, vsnes_state, init_MMC3,     ROT0, "Namco",                  "Vs. Super SkyKid", 0 )
 GAME( 1987, tkoboxng, 0,         vsnes,         tkoboxng, vsnes_state, init_tkoboxng, ROT0, "Namco / Data East USA",  "Vs. T.K.O. Boxing", 0 )

--- a/src/mame/drivers/vsnes.cpp
+++ b/src/mame/drivers/vsnes.cpp
@@ -276,10 +276,9 @@ void vsnes_state::vsnes_cpu1_bootleg_map(address_map &map)
 	map(0x0000, 0x07ff).mirror(0x1800).ram().share("work_ram");
 	map(0x2000, 0x3fff).rw(m_ppu1, FUNC(ppu2c0x_device::read), FUNC(ppu2c0x_device::write));
 	map(0x4000, 0x400f).w(FUNC(vsnes_state::bootleg_sound_write));
-	map(0x4014, 0x4014).w(FUNC(vsnes_state::sprite_dma_0_w));
 	map(0x4016, 0x4016).rw(FUNC(vsnes_state::vsnes_in0_r), FUNC(vsnes_state::vsnes_in0_w));
 	map(0x4017, 0x4017).r(FUNC(vsnes_state::vsnes_in1_r)); /* IN1 - input port 2 / PSG second control register */
-	map(0x4020, 0x4020).rw(FUNC(vsnes_state::vsnes_coin_counter_r), FUNC(vsnes_state::vsnes_coin_counter_w));
+	map(0x4020, 0x4020).w(FUNC(vsnes_state::vsnes_coin_counter_w));
 	map(0x6000, 0x7fff).bankrw("extra1");
 	map(0x8000, 0xffff).rom();
 }
@@ -1849,7 +1848,7 @@ void vsnes_state::vsnes_bootleg(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &vsnes_state::vsnes_cpu1_bootleg_map);
 	/* some carts also trigger IRQs */
 	MCFG_MACHINE_RESET_OVERRIDE(vsnes_state,vsnes)
-	MCFG_MACHINE_START_OVERRIDE(vsnes_state,vsnes)
+	MCFG_MACHINE_START_OVERRIDE(vsnes_state,bootleg)
 
 	Z80(config, m_subcpu, XTAL(16'000'000)/8); // Z8400APS-Z80CPU
 	m_subcpu->set_addrmap(AS_PROGRAM, &vsnes_state::vsnes_bootleg_z80_map);
@@ -1865,8 +1864,6 @@ void vsnes_state::vsnes_bootleg(machine_config &config)
 	m_ppu1->set_cpu_tag(m_maincpu);
 	m_ppu1->set_screen("screen1");
 	m_ppu1->int_callback().set_inputline(m_maincpu, INPUT_LINE_NMI);
-	m_ppu1->use_sprite_write_limitation_disable(); // bootleg seems to need this - code to set the sprite address is replaced with complete copy loops??
-	m_ppu1->set_scanlines_per_frame(screen1.height());
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/includes/vsnes.h
+++ b/src/mame/includes/vsnes.h
@@ -100,6 +100,7 @@ private:
 	DECLARE_MACHINE_RESET(vsnes);
 	DECLARE_MACHINE_START(vsdual);
 	DECLARE_MACHINE_RESET(vsdual);
+	DECLARE_MACHINE_START(bootleg);
 	void v_set_videorom_bank(  int start, int count, int vrom_start_bank );
 	void mapper4_set_prg(  );
 	void mapper4_set_chr(  );
@@ -109,6 +110,7 @@ private:
 	uint8_t vsnes_bootleg_z80_data_r();
 	uint8_t vsnes_bootleg_z80_address_r(offs_t offset);
 	void vsnes_bootleg_scanline(int scanline, int vblank, int blanked);
+	uint8_t vsnes_bootleg_ppudata();
 
 	void vsnes_bootleg_z80_map(address_map &map);
 	void vsnes_cpu1_bootleg_map(address_map &map);

--- a/src/mame/includes/vsnes.h
+++ b/src/mame/includes/vsnes.h
@@ -125,6 +125,7 @@ private:
 	std::unique_ptr<uint8_t[]> m_vram;
 	uint8_t* m_vrom[2];
 	std::unique_ptr<uint8_t[]> m_nt_ram[2];
+	memory_bank* m_bank_vrom[8];
 	uint8_t* m_nt_page[2][4];
 	uint32_t m_vrom_size[2];
 	int m_vrom_banks;

--- a/src/mame/includes/vsnes.h
+++ b/src/mame/includes/vsnes.h
@@ -44,6 +44,7 @@ public:
 	void init_platoon();
 	void init_rbibb();
 	void init_vsdual();
+	void init_bootleg();
 
 private:
 	required_device<cpu_device> m_maincpu;
@@ -104,10 +105,10 @@ private:
 	void mapper4_set_chr(  );
 	void mapper4_irq( int scanline, int vblank, int blanked );
 
-	uint8_t vsnes_bootleg_z80_latch_r();
 	void bootleg_sound_write(offs_t offset, uint8_t data);
 	uint8_t vsnes_bootleg_z80_data_r();
-	uint8_t vsnes_bootleg_z80_address_r();
+	uint8_t vsnes_bootleg_z80_address_r(offs_t offset);
+	void vsnes_bootleg_scanline(int scanline, int vblank, int blanked);
 
 	void vsnes_bootleg_z80_map(address_map &map);
 	void vsnes_cpu1_bootleg_map(address_map &map);
@@ -146,4 +147,5 @@ private:
 
 	uint8_t m_bootleg_sound_offset;
 	uint8_t m_bootleg_sound_data;
+	int m_bootleg_latched_scanline;
 };

--- a/src/mame/machine/vsnes.cpp
+++ b/src/mame/machine/vsnes.cpp
@@ -1050,3 +1050,29 @@ void vsnes_state::init_vsdual()
 	m_maincpu->space(AS_PROGRAM).install_ram(0x6000, 0x7fff, &prg[0x6000]);
 	m_subcpu->space(AS_PROGRAM).install_ram(0x6000, 0x7fff, &prg[0x6000]);
 }
+
+/**********************************************************************************/
+/* Vs. Super Mario Bros (Bootleg) */
+
+void vsnes_state::vsnes_bootleg_scanline(int scanline, int vblank, int blanked)
+{
+	// Z80 IRQ is controlled by two factors:
+	// - bit 6 of current (next) scanline number
+	// - bit 6 of latched scanline number from Z80 reading $4000
+	if (!(m_bootleg_latched_scanline & 0x40))
+	{
+		m_subcpu->set_input_line(INPUT_LINE_IRQ0, ((scanline + 1) & 0x40) ? ASSERT_LINE : CLEAR_LINE);
+	}
+}
+
+void vsnes_state::init_bootleg()
+{
+	m_bootleg_sound_offset = 0;
+	m_bootleg_sound_data = 0;
+	m_bootleg_latched_scanline = 0;
+
+	m_ppu1->set_scanline_callback(*this, FUNC(vsnes_state::vsnes_bootleg_scanline));
+
+	/* normal banking */
+	init_vsnormal();
+}

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41404,7 +41404,6 @@ suprmrio                        // (c) 1986 Nintendo
 suprmrioa                       // (c) 1986 Nintendo
 suprmriobl                      // bootleg
 suprmriobl2                     // bootleg
-suprmriobl3                     // bootleg
 supxevs                         // (c) 1986 Nintendo
 tkoboxng                        // (c) 1987 Data East
 topgun                          // (c) 1987 Konami


### PR DESCRIPTION
Based on kevtris' [schematics](http://blog.kevtris.org/blogfiles/vssmbbootleg.PDF) and [video](https://www.youtube.com/watch?v=g8gZT1F9UkE), these commits:
* get the two SN76489s connected and working (w/ the expected Z80 interrupt behavior when the 6502 writes sound registers)
* run the 6502, Z80, and both SN76489s at the correct clock speeds
* add a new PPU subclass `ppu2c04_clone_device` which implements the bootlegs' register behavior, palettes, video timing, and other differences
* mark the Z80 ROM in the `suprmriobl3` set as a bad dump due to corrupted return instructions in both interrupt handlers

I removed `MACHINE_NOT_WORKING` from sets 1 and 2 but left it on set 3 due to the bad Z80 ROM.

What I'm not sure about at the moment:
* Audio levels: I have both SN76489s at 50% right now, but it seems "better" to have the second one closer to 100% instead (otherwise its emulation of the noise channel is much quieter than it seems from kevtris' video footage)