### PR TITLE
SONY video equipment (DFS-500 Video Mixer and VCRs)

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3648,7 +3648,9 @@ files {
 
 createMESSProjects(_target, _subtarget, "sony")
 files {
+	MAME_DIR .. "src/mame/drivers/betacam.cpp",
 	MAME_DIR .. "src/mame/drivers/bvm.cpp",
+	MAME_DIR .. "src/mame/drivers/dfs500.cpp",
 	MAME_DIR .. "src/mame/drivers/pockstat.cpp",
 	MAME_DIR .. "src/mame/drivers/psx.cpp",
 	MAME_DIR .. "src/mame/machine/psxcd.cpp",
@@ -3656,6 +3658,7 @@ files {
 	MAME_DIR .. "src/mame/drivers/pve500.cpp",
 	MAME_DIR .. "src/mame/drivers/smc777.cpp",
 	MAME_DIR .. "src/mame/drivers/ps2sony.cpp",
+	MAME_DIR .. "src/mame/drivers/umatic.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "sony_news")

--- a/src/mame/drivers/betacam.cpp
+++ b/src/mame/drivers/betacam.cpp
@@ -1,0 +1,135 @@
+// license:GPL-2.0+
+// copyright-holders:Felipe Sanches
+/****************************************************************************
+
+    Skeleton driver for Sony BETACAM-SP Videocassete Players and Recorders
+
+    List of major ICs:
+     - IC202 - H8/534 (Hitachi Single-Chip Microcomputer)
+     - IC227 - MB88201 (MB88200 Series CMOS Low end Single-Chip 4-Bit Microprocessor)
+     - IC211 - CXD1095BQ (C-MOS I/O PORT EXPANDER)
+     - IC226 - CXD1095BQ (C-MOS I/O PORT EXPANDER)
+     - IC100 - CXD8384Q (C-MOS LTC READER/GENERATOR)
+     - IC219 - CXD2202Q (SERVO IC)
+     - IC213 - LC3564BM-10 (Sanyo 64Kbit SRAM (8192-word x8-bit))
+     - IC1 - D70320GJ-8 (CPU NEC V25)
+     - IC3 - LC3564BM-10 (Sanyo 64Kbit SRAM (8192-word x8-bit))
+     - IC5 - CXD8176AQ (C-MOS DUAL PORT RAM CONTROLLER)
+     - IC15 - D6453GT (MOS INTEGRATED CIRCUIT CMOS LSI FOR 12 lines X 24 columns CHARACTER DISPLAY ON SCREEN)
+
+****************************************************************************/
+
+#include "emu.h"
+#include "cpu/nec/v25.h"
+#include "cpu/h8500/h8534.h"
+#include "machine/cxd1095.h"
+
+class betacam_state : public driver_device
+{
+public:
+	betacam_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_systemcpu(*this, "systemcpu")
+		, m_servocpu(*this, "servocpu")
+	{
+	}
+
+	void betacam(machine_config &config);
+
+private:
+	void system_mem_map(address_map &map);
+	void servo_mem_map(address_map &map);
+
+	required_device<v25_device> m_systemcpu;
+	required_device<h8534_device> m_servocpu;
+};
+
+
+void betacam_state::system_mem_map(address_map &map)
+{
+	map(0x17f00, 0x17fff).ram();                        //   256b ?
+	map(0x18000, 0x189fe).ram();                        //   8kb SRAM at IC3
+	map(0x189ff, 0x189ff).noprw();                      //   ZERO
+	map(0x18a00, 0x19fff).ram();                        //   8kb SRAM at IC3 (init SS:SP)
+	map(0x20800, 0x20fff).ram().share("svram");         //   2kb servo dual-port SRAM
+	map(0x21800, 0x2183f).ram().share("ltcram");        //   64b LTC SRAM
+	map(0xe0000, 0xfffff).rom().region("systemcpu", 0); // 128kb EPROM at IC4
+}
+
+
+void betacam_state::servo_mem_map(address_map &map)
+{
+	map(0x00000, 0x3ffff).rom().region("servocpu", 0); //guessed
+	map(0x40000, 0x41fff).ram(); //guessed
+	//map(0x?????, 0x?????).rw("cxdio0", FUNC(cxd1095_device::read), FUNC(cxd1095_device::write));
+	//map(0x?????, 0x?????).rw("cxdio1", FUNC(cxd1095_device::read), FUNC(cxd1095_device::write));
+}
+
+
+static INPUT_PORTS_START(betacam)
+	PORT_START("DSW1")
+	PORT_DIPUNUSED_DIPLOC( 0x01, 0x00, "SW1:1" )
+	PORT_DIPNAME( 0x02, 0x00, "RGB Output Sel" ) PORT_DIPLOCATION("SW1:2")
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPSETTING(    0x02, DEF_STR( Yes ) )
+	PORT_DIPNAME( 0x04, 0x00, "RGB Input Sel" ) PORT_DIPLOCATION("SW1:3")
+	PORT_DIPSETTING(    0x04, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPNAME( 0x08, 0x00, "Wide" ) PORT_DIPLOCATION("SW1:4")
+	PORT_DIPSETTING(    0x08, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPNAME( 0x10, 0x00, "R/P E/F" ) PORT_DIPLOCATION("SW1:5")
+	PORT_DIPSETTING(    0x10, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPNAME( 0x20, 0x20, "Rec/Player" ) PORT_DIPLOCATION("SW1:6")
+	PORT_DIPSETTING(    0x20, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPNAME( 0x40, 0x00, "J U/C" ) PORT_DIPLOCATION("SW1:7")
+	PORT_DIPSETTING(    0x40, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+	PORT_DIPNAME( 0x80, 0x00, "NTSC / PAL" ) PORT_DIPLOCATION("SW1:8")
+	PORT_DIPSETTING(    0x80, DEF_STR( Yes ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( No ) )
+INPUT_PORTS_END
+
+void betacam_state::betacam(machine_config &config)
+{
+	V25(config, m_systemcpu, 16_MHz_XTAL); // NEC upD70320GJ-8
+	m_systemcpu->set_addrmap(AS_PROGRAM, &betacam_state::system_mem_map);
+	m_systemcpu->p2_in_cb().set_ioport("DSW1");
+
+	HD6475348(config, m_servocpu, 20_MHz_XTAL); //Actual chip is marked "H8/534 6435348F 10"
+	m_servocpu->set_addrmap(AS_PROGRAM, &betacam_state::servo_mem_map);
+
+	//CXD1095(config, "cxdio0");
+	//CXD1095(config, "cxdio1");
+}
+
+ROM_START(uvw1200)
+	ROM_REGION(0x20000, "systemcpu", 0)
+	ROM_LOAD("75932697_uvw-1000_sy_v2.00_f8b4.ic4", 0x00000, 0x20000, CRC(08e9b891) SHA1(3e01f0e037e83825dcb4a745ddc9148cf3cc7674))
+
+	ROM_REGION(0x40000, "servocpu", 0)
+	ROM_LOAD("75953491_uvw-1000_sv_v2.04_f024.ic212", 0x00000, 0x40000, CRC(dc2b8d4b) SHA1(f10a3dc0c317582e3dcb6f3dcc741c0d55c6fd22))
+ROM_END
+
+ROM_START(uvw1600)
+	ROM_REGION(0x20000, "systemcpu", 0)
+	ROM_LOAD("75925907_uvw-1000_sy_v1.03_e3b4.ic4", 0x00000, 0x20000, CRC(f9e575ce) SHA1(2f802c5685f7ce00586079ad5bc456083c595d66))
+
+	ROM_REGION(0x40000, "servocpu", 0)
+	ROM_LOAD("75927098_uvw-1000_sv_v1.04_150c.ic212", 0x00000, 0x40000, CRC(b4cb9c02) SHA1(92ae5ce303b9f67977b960047bac7f6bb337b8c0))
+ROM_END
+
+ROM_START(uvw1800)
+	ROM_REGION(0x20000, "systemcpu", 0)
+	ROM_LOAD("75925907_uvw-1000_sy_v1.03_e3b4.ic4", 0x00000, 0x20000, CRC(f9e575ce) SHA1(2f802c5685f7ce00586079ad5bc456083c595d66))
+
+	ROM_REGION(0x40000, "servocpu", 0)
+	ROM_LOAD("75927098_uvw-1000_sv_v1.04_150c.ic212", 0x00000, 0x40000, CRC(b4cb9c02) SHA1(92ae5ce303b9f67977b960047bac7f6bb337b8c0))
+ROM_END
+
+//   YEAR  NAME   PARENT/COMPAT MACHINE  INPUT    CLASS          INIT       COMPANY  FULLNAME                                                FLAGS
+SYST(199?, uvw1200,   0, 0,     betacam, betacam, betacam_state, empty_init, "Sony", "BETACAM-SP Videocassete Player UVW-1200 RGB",          MACHINE_IS_SKELETON)
+SYST(199?, uvw1600,   0, 0,     betacam, betacam, betacam_state, empty_init, "Sony", "BETACAM-SP Videocassete Player/Recorder UVW-1600 RGB", MACHINE_IS_SKELETON)
+SYST(199?, uvw1800,   0, 0,     betacam, betacam, betacam_state, empty_init, "Sony", "BETACAM-SP Videocassete Player/Recorder UVW-1800 RGB", MACHINE_IS_SKELETON)

--- a/src/mame/drivers/dfs500.cpp
+++ b/src/mame/drivers/dfs500.cpp
@@ -1,0 +1,1031 @@
+// license:GPL-2.0+
+// copyright-holders:Felipe Sanches
+/****************************************************************************
+
+    Sony DFS-500 DME Video Mixer
+
+    An artwork layout for this is under development at:
+    https://github.com/felipesanches/dfs500_MAME_artwork
+
+    ===== Current status of this driver =====
+    Upon power up, the ROM version number is displayed: "1.03"
+    And after a while, we get an error: "Er02"
+
+    This is likely due to bugs in this driver rendering the control panel unable to
+    communicate properly with the video mixer maincpu via a serial interface.
+
+    Apparently the maincpu does not respond to the control panel commands because it gets
+    lost earlier, while trying to communicate with the secondary cpu (the "effects" cpu)
+    via a pair of 16 bit latches.
+
+    The effects CPU does not yet reply due to some other problem in the driver.
+    I guess it is related to the "OREG2" in its memory map which have not yet been
+    properly declared. We'll need to further study that portion of the circuit in the
+    service manual in order to finish declaring the effects_cpu memory map layout.
+
+    ===== Usage: =====
+    According to the service manual, the LED test mode can be enabled by simultaneously
+    pressing these buttons in the control panel:
+    * FOREGROUND VTR A
+    * BACKGROUND VTR B
+    * Location
+    With the default key mappings in this driver, this can be achieved by pressing Q + 2 + L
+
+    * All LEDs and 7-seg displays blink sequentialy.
+    * If you press any button on the control panel, the sequence of blinking resumes from
+      that selected area of the panel.
+    * To stop the blinking sequence you can press the keypad ENTER key.
+
+    ===== Notes on the video hardware: =====
+    This video mixer accepts 4 input video signals to be mixed. This driver currently emulates
+    this by using static PNG images provided in the command line with the -inputN flags (with N = 1 to 4)
+
+    The DSP circuitry was not yet emulated, and the minimal video code in this driver currently
+    simply bypasses the input #1 into the output. Once the serial communication between control panel and
+    maincpu is fixed, we should at least see the video output changing when pressing the BACKGROUND input
+    selector buttons VTR A, VTR B, 3 and 4 (to select ammong the 4 video inputs).
+
+****************************************************************************/
+#include "emu.h"
+#include "cpu/nec/nec.h"
+#include "machine/gen_latch.h"
+#include "machine/pit8253.h"
+#include "machine/pic8259.h"
+#include "machine/i8251.h"
+#include "machine/upd7004.h"
+#include "sound/beep.h"
+#include "speaker.h"
+#include "imagedev/picture.h"
+#include "screen.h"
+#include "dfs500.lh"
+
+#define VIDEO_WIDTH 768
+#define VIDEO_HEIGHT 256
+
+class dfs500_state : public driver_device
+{
+public:
+	dfs500_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_cpanelcpu(*this, "cpanelcpu")
+		, m_maincpu(*this, "maincpu")
+		, m_effectcpu(*this, "effectcpu")
+		, m_pit(*this, "pit")
+		, m_pic(*this, "pic")
+		, m_serial1(*this, "serial1")
+		, m_serial2(*this, "serial2")
+		, m_cpanel_serial(*this, "cpanel_serial")
+		, m_cpanel_pit(*this, "cpanel_pit")
+		, m_adc(*this, "adc")
+		, m_rombank1(*this, "rombank1")
+		, m_rombank2(*this, "rombank2")
+		, m_buzzer(*this, "buzzer")
+		, m_screen(*this, "screen")
+		, m_input(*this, "input%u", 1U)
+		, m_dipswitch(*this, {"DSW_S1", "DSW_S2", "DSW_S3"})
+	{
+	}
+
+	void dfs500(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	void cpanelcpu_mem_map(address_map &map);
+	void cpanelcpu_io_map(address_map &map);
+	void maincpu_mem_map(address_map &map);
+	void maincpu_io_map(address_map &map);
+	void effectcpu_mem_map(address_map &map);
+	uint8_t pit_r(offs_t offset);
+	void pit_w(offs_t offset, uint8_t data);
+	uint8_t cpanel_pit_r(offs_t offset);
+	void cpanel_pit_w(offs_t offset, uint8_t data);
+	uint8_t pic_r(offs_t offset);
+	void pic_w(offs_t offset, uint8_t data);
+	void rombank1_entry_w(offs_t offset, uint8_t data);
+	void rombank2_entry_w(offs_t offset, uint8_t data);
+	void input_select_w(offs_t offset, uint8_t data);
+	uint16_t RA0_r(offs_t offset);
+	uint16_t RB0_r(offs_t offset);
+	void WA0_w(offs_t offset, uint16_t data);
+	void WB0_w(offs_t offset, uint16_t data);
+	uint16_t RA1_r(offs_t offset);
+	uint8_t RB1_r(offs_t offset);
+	uint8_t RB2_r(offs_t offset);
+	uint8_t cpanel_reg0_r(offs_t offset);
+	uint8_t cpanel_reg2_r(offs_t offset);
+	void cpanel_reg0_w(offs_t offset, uint8_t data);
+	void cpanel_reg1_w(offs_t offset, uint8_t data);
+	void cpanel_reg2_w(offs_t offset, uint8_t data);
+	uint8_t cpanel_buzzer_r(offs_t offset);
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, rectangle const &cliprect);
+	IRQ_CALLBACK_MEMBER(irq_callback);
+
+	uint8_t m_int_vector;
+	uint8_t m_sel10;
+	uint8_t m_sel32;
+	uint8_t m_sel54;
+	uint8_t m_input_sel_A;
+	uint8_t m_input_sel_B;
+	uint16_t m_maincpu_latch16;
+	uint16_t m_effectcpu_latch16;
+	bool m_TOC;
+	bool m_TOE;
+	// TODO: bool m_BVS;
+	uint8_t m_trans_rate[2];
+	uint8_t m_pattern_number[3];
+	uint8_t m_userprogram_status;
+	uint8_t m_userprogram_edit;
+	uint8_t m_trail_duration;
+	uint8_t m_snapshot;
+	uint8_t m_dot_points1;
+	uint8_t m_dot_points2;
+	bool m_buzzer_state;
+
+	required_device<v20_device> m_cpanelcpu;
+	required_device<v30_device> m_maincpu;
+	required_device<v30_device> m_effectcpu;
+	required_device<pit8254_device> m_pit;
+	required_device<pic8259_device> m_pic;
+	required_device<i8251_device> m_serial1;
+	required_device<i8251_device> m_serial2;
+	required_device<i8251_device> m_cpanel_serial;
+	required_device<pit8254_device> m_cpanel_pit;
+	required_device<upd7004_device> m_adc;
+	required_memory_bank m_rombank1;
+	required_memory_bank m_rombank2;
+	required_device<beep_device> m_buzzer;
+	required_device<screen_device> m_screen;
+	required_device_array<picture_image_device, 4> m_input;
+	required_ioport_array<3> m_dipswitch;
+};
+
+IRQ_CALLBACK_MEMBER(dfs500_state::irq_callback)
+{
+	return m_int_vector;
+}
+
+void dfs500_state::machine_start()
+{
+	m_serial1->write_cts(0);
+	m_serial2->write_cts(0);
+	m_cpanel_serial->write_cts(0);
+	m_rombank1->configure_entries(0, 128, memregion("effectdata")->base(), 0x4000);
+	m_rombank2->configure_entries(0, 128, memregion("effectdata")->base(), 0x4000);
+}
+
+void dfs500_state::machine_reset()
+{
+	m_buzzer_state = false;
+	m_buzzer->set_state(0);
+	m_rombank1->set_entry(0);
+	m_rombank2->set_entry(0);
+	m_maincpu_latch16 = 0x0000;
+	m_effectcpu_latch16 = 0x0000;
+	m_TOC = false;
+	m_TOE = false;
+	m_int_vector = 0x00;
+	m_sel10 = 0;
+	m_sel32 = 0;
+	m_sel54 = 0;
+}
+
+uint32_t dfs500_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, rectangle const &cliprect)
+{
+	bitmap_argb32 *input_bitmap = &m_input[m_input_sel_A & 3]->get_bitmap();
+
+	if (input_bitmap)
+	{
+		// convert arbitrary sized ARGB32 image to a full-screen image
+		double stepx = double (input_bitmap->width()) / VIDEO_WIDTH;
+		double stepy = double (input_bitmap->height()) / VIDEO_HEIGHT;
+
+		for (unsigned screen_y = screen.visible_area().min_y; screen_y <= screen.visible_area().max_y; screen_y++)
+		{
+			for (unsigned screen_x = screen.visible_area().min_x; screen_x <= screen.visible_area().max_x; screen_x++)
+			{
+				bitmap.pix(screen_y, screen_x) = input_bitmap->pix(
+					int(double (screen_y % VIDEO_HEIGHT) * stepy),
+					int(double (screen_x % VIDEO_WIDTH) * stepx));
+			}
+		}
+	}
+	return 0;
+}
+
+uint8_t dfs500_state::pit_r(offs_t offset)
+{
+	// CXQ71054P (Programmable Timer / Counter)
+	return m_pit->read((offset >> 1) & 3); // addressed by CPU's address bits AB2 and AB1
+}
+
+void dfs500_state::pit_w(offs_t offset, uint8_t data)
+{
+	// CXQ71054P (Programmable Timer / Counter)
+	m_pit->write((offset >> 1) & 3, data); // addressed by CPU's address bits AB2 and AB1
+}
+
+uint8_t dfs500_state::cpanel_pit_r(offs_t offset)
+{
+	// CXQ71054P (Programmable Timer / Counter)
+	return m_cpanel_pit->read((offset >> 1) & 3); // addressed by CPU's address bits AB2 and AB1
+}
+
+void dfs500_state::cpanel_pit_w(offs_t offset, uint8_t data)
+{
+	// CXQ71054P (Programmable Timer / Counter)
+	m_cpanel_pit->write((offset >> 1) & 3, data); // addressed by CPU's address bits AB2 and AB1
+}
+
+uint8_t dfs500_state::pic_r(offs_t offset)
+{
+	// PD71059C (Programmable Interrupt Controller)
+	return m_pic->read((offset >> 1) & 1); // addressed by CPU's address bit AB1
+}
+
+void dfs500_state::pic_w(offs_t offset, uint8_t data)
+{
+	// PD71059C (Programmable Interrupt Controller)
+	m_pic->write((offset >> 1) & 1, data); // addressed by CPU's address bit AB1
+}
+
+void dfs500_state::rombank1_entry_w(offs_t offset, uint8_t data)
+{
+	m_rombank1->set_entry(((data >> 1) & 0x40) | (data & 0x3f));
+}
+
+void dfs500_state::rombank2_entry_w(offs_t offset, uint8_t data)
+{
+	m_rombank2->set_entry(((data >> 1) & 0x40) | (data & 0x3f));
+}
+
+void dfs500_state::input_select_w(offs_t offset, uint8_t data)
+{
+	// Selects sources of video input on the AD-76 board.
+	m_input_sel_A = (data >> 3) & 0x7;
+	m_input_sel_B = data & 0x7;
+}
+
+void dfs500_state::WA0_w(offs_t offset, uint16_t data)
+{
+	m_effectcpu_latch16 = data;
+	m_TOC = true;
+}
+
+uint16_t dfs500_state::RA0_r(offs_t offset)
+{
+	m_TOE = false;
+	return m_maincpu_latch16;
+}
+
+uint16_t dfs500_state::RA1_r(offs_t offset)
+{
+	// "TEST, 1, OPT2, OPT1, RFLD, VD, TOC, TOE"
+	uint8_t value = 0x40;
+	// FIXME! Add other signals.
+	if (m_TOC) value |= 0x02;
+	if (m_TOE) value |= 0x01;
+	value |= ((m_dipswitch[2]->read() & 0x0f) << 8); // "DSW_S3": (Unknown)
+	return value;
+}
+
+void dfs500_state::WB0_w(offs_t offset, uint16_t data)
+{
+	m_maincpu_latch16 = data;
+	m_TOE = true;
+}
+
+uint16_t dfs500_state::RB0_r(offs_t offset)
+{
+	m_TOC = false;
+	return m_effectcpu_latch16;
+}
+
+uint8_t dfs500_state::RB1_r(offs_t offset)
+{
+	//"TEST, OPT2, OPT1, VD, T2, T1, TOE, TOC"
+	uint8_t value = 0;
+	// FIXME! Add other signals.
+	if (m_TOE) value |= 0x02;
+	if (m_TOC) value |= 0x01;
+	return value;
+}
+
+uint8_t dfs500_state::RB2_r(offs_t offset)
+{
+	uint8_t value = 0;
+	value |= ((m_dipswitch[0]->read() & 0x0f) << 4); // ("DSW_S1": Editing Control Unit Select)
+	value |= (m_dipswitch[1]->read() & 0x0f);        // ("DSW_S2": Freeze Timing)
+	// TODO:
+	// if (m_BVS) value |= 0x10;
+	return value;
+}
+
+uint8_t dfs500_state::cpanel_reg0_r(offs_t offset)
+{
+	uint8_t data;
+	switch (offset & 0x0f)
+	{
+		case 0: // RD0
+			data = 0x00;
+			//TODO: if (m_RVD) data |= 0x02;
+			//TODO: if (m_adc->eoc_r()) data |= 0x01;
+			return data;
+		case 1: return ioport("RD1")->read();
+		case 2: return ioport("RD2")->read();
+		case 3: return ioport("RD3")->read();
+		case 4: return ioport("RD4")->read();
+		case 5: return ioport("RD5")->read();
+		case 6: return 0xff; //TODO: RD6
+		case 7: return 0xff; //TODO: RD7
+		case 8: return ioport("RD8")->read();
+		case 9: return ioport("RD9")->read();
+		default:
+			return 0xff;
+	}
+}
+
+uint8_t dfs500_state::cpanel_reg2_r(offs_t offset)
+{
+	switch (offset & 0x07)
+	{
+		case 0: return ioport("RD10")->read();
+		case 1: return ioport("RD11")->read();
+		case 2: return ioport("RD12")->read();
+		default:
+			return 0xff;
+	}
+}
+
+void dfs500_state::cpanel_reg0_w(offs_t offset, uint8_t data)
+{
+	static const uint8_t ls247_map[16] =
+		{ 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07,0x7f,0x6f,0x58,0x4c,0x62,0x69,0x78,0x00 };
+
+	switch (offset & 0x0f)
+	{
+		case 0: // WR0 on IC48 KY-223
+			// Dot-points on 7seg digits:
+			// D7 = not connected
+			// D6 = LD206 = DP on trans_rate100
+			// D5 = LD198 = DP on trans_rate10
+			// D4 = LD190 = DP on trans_rate1
+			// D3 = LD182 = DP on pattern_number1000
+			// D2 = LD174 = DP on pattern_number100
+			// D1 = LD186 or LD168 (?) = DP on pattern_number10
+			// D0 = LD158 = DP on pattern_number1
+			m_dot_points2 = data;
+			output().set_value("trans_rate100", ls247_map[m_trans_rate[1] & 0x0f] | (BIT(data >> 6, 0) << 7));
+			output().set_value("trans_rate10", ls247_map[(m_trans_rate[0] >> 4) & 0x0f] | (BIT(data >> 5, 0) << 7));
+			output().set_value("trans_rate1", ls247_map[m_trans_rate[0] & 0x0f] | (BIT(data >> 4, 0) << 7));
+			output().set_value("pattern_number1000", (m_pattern_number[2] & 0x7f) | (BIT(data >> 3, 0) << 7));
+			output().set_value("pattern_number100", (m_pattern_number[1] & 0x7f) | (BIT(data >> 2, 0) << 7));
+			output().set_value("pattern_number10", ls247_map[(m_pattern_number[0] >> 4) & 0x0f] | (BIT(data >> 1, 0) << 7));
+			output().set_value("pattern_number1", ls247_map[m_pattern_number[0] & 0x0f] | (BIT(data >> 0, 0) << 7));
+			break;
+		case 1: // WR1 on IC50 KY-223
+			m_pattern_number[2] = data;
+			output().set_value("pattern_number1000", (data & 0x7f) | (BIT(m_dot_points2 >> 3, 0) << 7));
+			break;
+		case 2: // WR2 on IC52 KY-223
+			m_pattern_number[1] = data;
+			output().set_value("pattern_number100", (data & 0x7f) | (BIT(m_dot_points2 >> 2, 0) << 7));
+			break;
+		case 3: // WR3 on IC53 KY-223
+			m_pattern_number[0] = data;
+			output().set_value("pattern_number10", ls247_map[(data >> 4) & 0x0f] | (BIT(m_dot_points2 >> 1, 0) << 7));
+			output().set_value("pattern_number1", ls247_map[data & 0x0f] | (BIT(m_dot_points2 >> 0, 0) << 7));
+			break;
+		case 4: // WR4 on IC56 KY-223
+			output().set_value("matte_copy", BIT(data, 7)); // LD63
+			output().set_value("mattes_col_bkgd", BIT(data, 6)); // LD62
+			output().set_value("pattern_number_set", BIT(data, 5)); // LD64
+			output().set_value("effect_ctrl_title", BIT(data, 4)); // LD65
+			output().set_value("effect_ctrl_dsk", BIT(data, 3)); // LD66
+			output().set_value("effect_ctrl_modify", BIT(data, 2)); // LD69
+			output().set_value("effect_ctrl_linear", BIT(data, 1)); // LD68
+			output().set_value("effect_ctrl_nonlin", BIT(data, 0)); // LD67
+			break;
+		case 5: // WR5 on IC58 KY-223
+			output().set_value("mattes_bord_mat", BIT(data, 7)); // LD61
+			output().set_value("mattes_shad_mat", BIT(data, 6)); // LD60
+			output().set_value("mattes_dsk_mat", BIT(data, 5)); // LD59
+			output().set_value("mattes_dsk_bord", BIT(data, 4)); // LD58
+			output().set_value("top_left",  BIT(data, 3)); // LD57
+			output().set_value("top_right", BIT(data, 2)); // LD56
+			output().set_value("btm_left", BIT(data, 1)); // LD55  //The service manual seems to be incorrect here.
+			output().set_value("btm_right",  BIT(data, 0)); // LD54  // It seems to mistakenly swap LD54 and LD55.
+			break;
+		case 6: // WR6 on IC60 KY-223
+			output().set_value("wide_bord", BIT(data, 6)); // LD53
+			output().set_value("narw_bord", BIT(data, 5)); // LD52
+			output().set_value("drop_bord", BIT(data, 4)); // LD51
+			output().set_value("double", BIT(data, 3)); // LD50
+			output().set_value("dsk_fill_video", BIT(data, 2)); // LD48
+			output().set_value("dsk_fill_mat", BIT(data, 1)); // LD47
+			output().set_value("dsk_fill_none", BIT(data, 0)); // LD46
+			break;
+		case 7: // WR7 on IC82 KY-223
+			output().set_value("dsk_mask_normal", BIT(data, 7)); // LD42
+			output().set_value("dsk_mask_invert", BIT(data, 6)); // LD44
+			output().set_value("dsk_key_inv", BIT(data, 5)); // LD41
+			output().set_value("dsk_ext_key", BIT(data, 4)); // LD43
+			output().set_value("border", BIT(data, 3)); // LD49
+			output().set_value("title_frgd_bus", BIT(data, 2)); // LD40
+			output().set_value("title_bord_mat", BIT(data, 1)); // LD39
+			output().set_value("title_shad_mat", BIT(data, 0)); // LD38
+			break;
+		case 8: // WR8 on IC64 KY-223
+			output().set_value("background_4", BIT(data, 7) << 1 | BIT(data, 3)); // LD78
+			output().set_value("background_3", BIT(data, 6) << 1 | BIT(data, 2)); // LD77
+			output().set_value("background_vtr_b", BIT(data, 5) << 1 | BIT(data, 1)); // LD76
+			output().set_value("background_vtr_a", BIT(data, 4) << 1 | BIT(data, 0)); // LD75
+			break;
+		case 9: // WR9 on IC66 KY-223
+			output().set_value("foreground_4", BIT(data, 7) << 1 | BIT(data, 3)); // LD73
+			output().set_value("foreground_3", BIT(data, 6) << 1 | BIT(data, 2)); // LD72
+			output().set_value("foreground_vtr_b", BIT(data, 5) << 1 | BIT(data, 1)); // LD71
+			output().set_value("foreground_vtr_a", BIT(data, 4) << 1 | BIT(data, 0)); // LD70
+			break;
+		case 10: // WR10 on IC68 KY-223
+			output().set_value("mask_normal", BIT(data, 7)); // LD34
+			output().set_value("mask_invert", BIT(data, 6)); // LD36
+			output().set_value("key_inv", BIT(data, 5)); // LD33
+			output().set_value("ext_key", BIT(data, 4)); // LD35
+			output().set_value("title", BIT(data, 3)); // LD37
+			output().set_value("background_int_video", BIT(data, 2) << 1 | BIT(data, 1)); // LD79
+			break;
+		case 11: // WR11 on IC70 KY-223
+			output().set_value("int_video_col_bkgd", BIT(data, 7)); // LD82
+			output().set_value("int_video_col_bar", BIT(data, 6)); // LD81
+			output().set_value("int_video_grid", BIT(data, 5)); // LD80
+			output().set_value("foreground_int_video", BIT(data, 4) << 1 | BIT(data, 3)); // LD74
+			output().set_value("freeze_field", BIT(data, 2)); // LD83
+			output().set_value("freeze_frame", BIT(data, 1)); // LD84
+			output().set_value("trans_rate_effect", BIT(data, 0)); // LD88
+			break;
+		case 12: // WR12 on IC72 KY-223
+			m_trans_rate[0] = data;
+			output().set_value("trans_rate10", ls247_map[(data >> 4) & 0x0f] | (BIT(m_dot_points2 >> 5, 0) << 7));
+			output().set_value("trans_rate1", ls247_map[data & 0x0f] | (BIT(m_dot_points2 >> 4, 0) << 7));
+			break;
+		case 13: // WR13 on IC75 KY-223
+			m_trans_rate[0] = data & 0x0f;
+			output().set_value("effect_ctrl_shift", BIT(data, 5)); // LD234
+			output().set_value("effect_ctrl_mask", BIT(data, 4)); // LD235
+			output().set_value("dsk_mix", BIT(data, 7) << 1 | BIT(data, 6)); // LD45
+			output().set_value("trans_rate100", (ls247_map[data & 0x0F]) | (BIT(m_dot_points2 >> 6, 0) << 7));
+			break;
+		case 14: // WR14 on IC77 KY-223
+			output().set_value("transition_effect", BIT(data, 7)); // LD85
+			output().set_value("trans_rate_dsk", BIT(data, 6)); // LD86
+			output().set_value("transition_dsk", BIT(data, 5)); // LD87
+			output().set_value("transition_reverse", BIT(data, 4)); // LD91
+			output().set_value("transition_0", BIT(data, 3));
+			output().set_value("transition_1", BIT(data, 2));
+			output().set_value("transition_2", BIT(data, 1));
+			output().set_value("transition_3", BIT(data, 0));
+			break;
+		case 15: // WR15 on IC79 KY-223
+			output().set_value("transition_4", BIT(data, 7));
+			output().set_value("transition_5", BIT(data, 6));
+			output().set_value("transition_6", BIT(data, 5));
+			output().set_value("transition_7", BIT(data, 4));
+			output().set_value("transition_8", BIT(data, 3));
+			output().set_value("transition_9", BIT(data, 2));
+			output().set_value("transition_10", BIT(data, 1));
+			output().set_value("transition_11", BIT(data, 0));
+			break;
+		default:
+			break;
+	}
+}
+
+
+void dfs500_state::cpanel_reg1_w(offs_t offset, uint8_t data)
+{
+	switch (offset & 7)
+	{
+		case 0: // WR16 on IC81 KY-223
+			output().set_value("transition_12", BIT(data, 7)); // LD221 ?
+			output().set_value("transition_13", BIT(data, 6)); // LD220 ?
+			output().set_value("transition_14", BIT(data, 5)); // LD219 ?
+			output().set_value("transition_15", BIT(data, 4)); // LD218 ?
+			output().set_value("transition_16", BIT(data, 3)); // LD217 ?
+			output().set_value("transition_17", BIT(data, 2)); // LD216 ?
+			output().set_value("transition_18", BIT(data, 1)); // LD215 ?
+			output().set_value("transition_19", BIT(data, 0)); // LD214 ?
+			break;
+		case 1: // WR17 on IC83 KY-223
+			output().set_value("trans_rate_norm_rev", BIT(data, 7)); // LD90
+			output().set_value("transition_auto_trans", BIT(data, 6)); // LD89
+			output().set_value("direct_pattern", BIT(data, 5)); // LD96
+			output().set_value("keypad_0", BIT(data, 4)); // LD97
+			output().set_value("keypad_1", BIT(data, 3)); // LD98
+			output().set_value("keypad_2", BIT(data, 2)); // LD99
+			output().set_value("keypad_3", BIT(data, 1)); // LD100
+			output().set_value("keypad_rst", BIT(data, 0)); // LD101
+			break;
+		case 2: // WR18 on IC81 KY-223
+			output().set_value("keypad_4", BIT(data, 7)); // LD102
+			output().set_value("keypad_5", BIT(data, 6)); // LD103
+			output().set_value("keypad_6", BIT(data, 5)); // LD104
+			output().set_value("keypad_del", BIT(data, 4)); // LD105
+			output().set_value("keypad_7", BIT(data, 3)); // LD106
+			output().set_value("keypad_8", BIT(data, 2)); // LD107
+			output().set_value("keypad_9", BIT(data, 1)); // LD108
+			output().set_value("keypad_ins", BIT(data, 0)); // LD109
+			break;
+		case 3: // WR19 on IC87 KY-223
+			output().set_value("mode_pattern", BIT(data, 7)); // LD95
+			output().set_value("mode_trans", BIT(data, 6)); // LD94
+			output().set_value("mode_user_pgm", BIT(data, 5)); // LD93
+			output().set_value("mode_snap_shot", BIT(data, 4)); // LD92
+
+			//Selectors for analog inputs to ADC:
+			m_sel10 = data & 0x03;
+			m_sel32 = (data >> 2) & 0x03;
+			break;
+		case 7: // WR20 on IC47 KY-223
+			// Here "data" holds the 8-bit value of the "interrupt vector number"
+                        //  to be put on the data bus when the CPU asserts /INTAK (Interrupt Acknowledge)
+			m_int_vector = data;
+			// FIXME: Is this an alternative way of doing it?
+			//        m_cpanelcpu->set_input_line_and_vector(0, HOLD_LINE, data);
+			break;
+		default:
+			break;
+	}
+}
+
+void dfs500_state::cpanel_reg2_w(offs_t offset, uint8_t data)
+{
+	static const uint8_t ls247_map[16] =
+		{ 0x3f,0x06,0x5b,0x4f,0x66,0x6d,0x7d,0x07,0x7f,0x6f,0x58,0x4c,0x62,0x69,0x78,0x00 };
+
+	switch (offset&7)
+	{
+		case 0: // WR21 on IC7 KY-225
+			m_snapshot = data;
+			output().set_value("snapshot10", ls247_map[(data >> 4) & 0x0F] | (BIT(m_dot_points1 >> 5, 0) << 7));
+			output().set_value("snapshot1", ls247_map[data & 0x0F] | (BIT(m_dot_points1 >> 4, 0) << 7));
+			break;
+		case 1: // WR22 on IC10 KY-225
+			output().set_value("editor_enable", BIT(data, 7)); // LD1
+			output().set_value("learn", BIT(data, 6)); // LD4
+			output().set_value("recall", BIT(data, 5)); // LD3
+			output().set_value("hold_input", BIT(data, 4)); // LD2
+			output().set_value("lighting", BIT(data, 3)); // LD5
+			output().set_value("lighting_spot", BIT(data, 2)); // LD8
+			output().set_value("lighting_line", BIT(data, 1)); // LD7
+			output().set_value("lighting_plane", BIT(data, 0)); // LD6
+			break;
+		case 2: // WR23 on IC12 KY-225
+			output().set_value("trail", BIT(data, 7)); // LD15
+			output().set_value("drop_border", BIT(data, 6)); // LD20
+			output().set_value("lighting_width_wide", BIT(data, 5)); // LD11
+			output().set_value("lighting_width_medium", BIT(data, 4)); // LD10
+			output().set_value("lighting_width_narrow", BIT(data, 3)); // LD9
+			output().set_value("lighting_intensity_high", BIT(data, 2)); // LD14
+			output().set_value("lighting_intensity_medium", BIT(data, 1)); // LD13
+			output().set_value("lighting_intensity_low", BIT(data, 0)); // LD12
+			break;
+		case 3: // WR24 on IC14 KY-225
+			output().set_value("trail_drop_type_hard", BIT(data, 7)); // LD19
+			output().set_value("trail_drop_type_soft", BIT(data, 6)); // LD18
+			output().set_value("trail_drop_type_hard_star", BIT(data, 5)); // LD17
+			output().set_value("trail_drop_type_soft_star", BIT(data, 4)); // LD16
+			output().set_value("trail_drop_fill_self", BIT(data, 3)); // LD24
+			output().set_value("trail_drop_fill_bord_mat", BIT(data, 2)); // LD23
+			output().set_value("trail_drop_fill_shad_mat", BIT(data, 1)); // LD22
+			output().set_value("trail_drop_fill_rndm_mat", BIT(data, 0)); // LD21
+			break;
+		case 4: // WR25 on IC18 KY-225
+			m_trail_duration = data;
+			output().set_value("trail_shadow_frames10", ls247_map[(data >> 4) & 0x0F] | (BIT(m_dot_points1 >> 3, 0) << 7));
+			output().set_value("trail_shadow_frames1", ls247_map[data & 0x0F] | (BIT(m_dot_points1 >> 2, 0) << 7));
+			break;
+		case 5: // WR26 on IC16 KY-225
+			output().set_value("shadow", BIT(data, 7)); // LD25
+			output().set_value("trail_frames_duration", BIT(data, 6)); // LD28
+			output().set_value("trail_frames_wid_pos", BIT(data, 5)); // LD27
+			output().set_value("trail_frames_density", BIT(data, 4)); // LD26
+			output().set_value("edge_border", BIT(data, 3)); // LD29
+			output().set_value("edge_soft", BIT(data, 2)); // LD30
+			output().set_value("edit_led", BIT(data, 1)); // LD31
+			output().set_value("location", BIT(data, 0)); // LD32
+			break;
+		case 6: // WR27 on IC21 KY-225
+			m_sel54 = (data >> 6) & 3; // D7/D6 = SEL5/SEL4 signals to IC26	
+			// Dot-points on 7seg digits:
+			// D5 = LD150 = DP on user program status 
+			// D4 = LD142 = DP on user program edit
+			// D3 = LD134 = DP on trail_duration10
+			// D2 = LD126 = DP on trail_duration1
+			// D1 = LD118 = DP on snap_shot10
+			// D0 = LD110 = DP on snap_/shot1
+			m_dot_points1 = data;
+			output().set_value("status", ls247_map[m_userprogram_status] | (BIT(data >> 5, 0) << 7));
+			output().set_value("edit", ls247_map[m_userprogram_edit] | (BIT(data >> 4, 0) << 7));
+			output().set_value("trail_shadow_frames10", ls247_map[(m_trail_duration >> 4) & 0x0F] | (BIT(data >> 3, 0) << 7));
+			output().set_value("trail_shadow_frames1", ls247_map[m_trail_duration & 0x0F] | (BIT(data >> 2, 0) << 7));
+			output().set_value("snapshot10", ls247_map[(m_snapshot >> 4) & 0x0F] | (BIT(data >> 1, 0) << 7));
+			output().set_value("snapshot1", ls247_map[m_snapshot & 0x0F] | (BIT(data >> 0, 0) << 7));
+			break;
+		case 7: // WR28 on IC23 KY-225
+			m_userprogram_status = (data >> 4) & 0x0F;
+			m_userprogram_edit = data & 0x0F;
+			output().set_value("status", ls247_map[(data >> 4) & 0x0F] | (BIT(m_dot_points1 >> 5, 0) << 7));
+			output().set_value("edit", ls247_map[data & 0x0F] | (BIT(m_dot_points1 >> 4, 0) << 7));
+			break;
+		default:
+			break;
+	}
+}
+
+uint8_t dfs500_state::cpanel_buzzer_r(offs_t offset)
+{
+// FIXME: Not sure yet what to do here...
+// TODO:	m_buzzer_state = !m_buzzer_state;
+// TODO:	m_buzzer->set_state(m_buzzer_state);
+	return 0;
+}
+
+void dfs500_state::cpanelcpu_mem_map(address_map &map)
+{
+	map(0x00000, 0x07fff).mirror(0xe0000).ram();                        // 32kb SRAM chip at IC15 on KY-223
+	map(0x08000, 0x08000).mirror(0xe0ffd).rw(m_cpanel_serial, FUNC(i8251_device::data_r), FUNC(i8251_device::data_w));       // "IO" IC17 on KY-223
+	map(0x08002, 0x08002).mirror(0xe0ffd).rw(m_cpanel_serial, FUNC(i8251_device::status_r), FUNC(i8251_device::control_w));
+	map(0x09000, 0x09007).mirror(0xe0ff8).rw(FUNC(dfs500_state::cpanel_pit_r), FUNC(dfs500_state::cpanel_pit_w));       // "TIMER" IC16 on KY-223
+	map(0x0a000, 0x0a001).mirror(0xe0ffe).rw("adc", FUNC(upd7004_device::read), FUNC(upd7004_device::write));       // ADC at IC19 on KY-223
+	map(0x0b000, 0x0b00f).mirror(0xe0ff0).rw(FUNC(dfs500_state::cpanel_reg0_r), FUNC(dfs500_state::cpanel_reg0_w));       // "REG0" Switches(?) & LEDs on KY-223
+	map(0x0c000, 0x0c007).mirror(0xe0ff8).w(FUNC(dfs500_state::cpanel_reg1_w));       // "REG1" LEDs on KY-223
+	map(0x0d000, 0x0d007).mirror(0xe0ff8).rw(FUNC(dfs500_state::cpanel_reg2_r), FUNC(dfs500_state::cpanel_reg2_w));       // "REG2" Switches(?) & LEDs on KY-225
+	map(0x0f000, 0x0f007).mirror(0xe0ff8).r(FUNC(dfs500_state::cpanel_buzzer_r)); // "BUZZER" IC89
+	map(0x10000, 0x17fff).mirror(0xe8000).rom().region("cpanelcpu", 0); // 32kb EPROM at IC14
+}
+
+void dfs500_state::cpanelcpu_io_map(address_map &map)
+{
+	//FIXME! map(0x0000, 0x0007).mirror(0x8ff8).rw(FUNC(dfs500_state::...), FUNC(dfs500_state::...));
+}
+
+void dfs500_state::maincpu_mem_map(address_map &map)
+{
+	//FIXME: The RAM mirror should be 0xe0000 according to IC49 on board SY-172 (as it is wired on the service manual schematics)
+	//       but I saw unmapped accesses to the A15 mirror of this range on the MAME debugger, which suggests the 0xe8000 value used below:
+	map(0x00000, 0x07fff).mirror(0xe8000).ram();                      // 4x 8kb SRAM chips at IC59/IC60/IC61/IC62 
+	map(0x10000, 0x1ffff).mirror(0xe0000).rom().region("maincpu", 0); // 2x 32kb EPROMs at IC1/IC2
+}
+
+void dfs500_state::maincpu_io_map(address_map &map)
+{
+	map(0x0000, 0x0007).mirror(0x8ff8).rw(FUNC(dfs500_state::pit_r), FUNC(dfs500_state::pit_w));                    // "IO1" IC51
+	map(0x1000, 0x1001).mirror(0x8ffc).rw(FUNC(dfs500_state::pic_r), FUNC(dfs500_state::pic_w));                    // "IO2" IC52
+	map(0x2000, 0x2000).mirror(0x8ffd).rw(m_serial1, FUNC(i8251_device::data_r), FUNC(i8251_device::data_w));       // "IO3" IC53
+	map(0x2002, 0x2002).mirror(0x8ffd).rw(m_serial1, FUNC(i8251_device::status_r), FUNC(i8251_device::control_w));
+	map(0x3000, 0x3000).mirror(0x8ffd).rw(m_serial2, FUNC(i8251_device::data_r), FUNC(i8251_device::data_w));       // "IO4" IC54
+	map(0x3002, 0x3002).mirror(0x8ffd).rw(m_serial2, FUNC(i8251_device::status_r), FUNC(i8251_device::control_w));
+	map(0x4000, 0x4001).mirror(0x8ff0).r(FUNC(dfs500_state::RB0_r));                                                // "RB0" IC32/IC33
+	map(0x4002, 0x4003).mirror(0x8ff0).r(FUNC(dfs500_state::RB1_r));                                                // "RB1" IC55
+	map(0x4004, 0x4005).mirror(0x8ff0).r(FUNC(dfs500_state::RB2_r));                                                // "RB2" IC56
+	map(0x5000, 0x5001).mirror(0x8ff0).w(FUNC(dfs500_state::WB0_w));                                                // "WB0" IC26/IC27
+}
+
+void dfs500_state::effectcpu_mem_map(address_map &map)
+{
+	// Note: As far as I can tell by the schematics in the service manual, the ram mirror should be 0x90000.
+	//       But I see unmapped read acesses to 0x4800, which induces me to make the mirror 0x94000, instead.
+	//	 FIXME: This should be double-checked!
+	map(0x00000, 0x03fff).mirror(0x94000).ram();                        // 2x 8kb SRAM chips at IC23/IC24 
+	map(0x08000, 0x0bfff).mirror(0x90000).bankr("rombank1");            // Effect data on 4x 512kb EPROMs at IC5/IC6/IC7/IC8
+	map(0x0c000, 0x0ffff).mirror(0x90000).bankr("rombank2");            // Second banked view of the contents of the same effect data EPROMs
+	map(0x20000, 0x20001).mirror(0x9fffe).noprw(); // FIXME: Do something with the MTRX signal generated by this memory access
+	map(0x46000, 0x46fff).mirror(0x91000).ram().share("sgram"); // IC80/IC81 at FM-29 (4/6)
+	                                                            // Selected by IC201 at FM-29 (3/6)
+	map(0x68000, 0x68001).mirror(0x907fe).rw(FUNC(dfs500_state::RA0_r), FUNC(dfs500_state::WA0_w)); // "RA0" IC26/IC27 & "WA0" IC32/IC33
+	                                                                                                // 16-bit data latches for communication between CPUs
+	map(0x68800, 0x68801).mirror(0x907fe).r(FUNC(dfs500_state::RA1_r));            // "RA1" IC25/IC64
+	map(0x69000, 0x69000).mirror(0x907ff).w(FUNC(dfs500_state::rombank2_entry_w)); // "WA2" IC29
+	map(0x69800, 0x69800).mirror(0x907ff).w(FUNC(dfs500_state::rombank1_entry_w)); // "WA3" IC30
+	map(0x6a000, 0x6a000).mirror(0x907ff).w(FUNC(dfs500_state::input_select_w));   // "WA4" IC31
+	map(0x70000, 0x7ffff).mirror(0x80000).rom().region("effectcpu", 0); // 2x 64kb EPROMs at IC3/IC4,
+	                                                                    // Note: the 1st half of each is entirely made of 0xFF
+	
+	// ==== "ORG1" registers ====
+	// "controlsignals" (Not sure yet of their actual use)
+	// D13: PS2
+	// D12: PS1
+	// D11: FGS1
+	// D10: FGS0
+	// D9: BGS1
+	// D8: BGS0
+	// D7: TKON
+	// D6: TKCONT
+	// D5: AM2
+	// D4: AM1
+	// D3: AM0
+	// D2: BM2
+	// D1: BM1
+	// D0: BM0
+	map(0x6b078, 0x6b079).mirror(0x90700).w("controlsignals", FUNC(generic_latch_16_device::write));
+
+	// "Reg7_5":
+	//  Not sure yet of their actual use...
+	map(0x6b07a, 0x6b07b).mirror(0x90700).w("reg7_5", FUNC(generic_latch_16_device::write));
+
+	// XFLT: Feeds into chips IC107 (CKD8070K "Horizontal Variable Filter") and IC108 (CXD8276Q "CMOS Linear Interpolation")
+	//        at PCB FM-29 (6/6); Foreground Bus Digital Lowpass Filter
+	map(0x6b07c, 0x6b07d).mirror(0x90700).w("xflt", FUNC(generic_latch_16_device::write));
+
+	// YFLT: Feeds into chips IC114 (CKD8263Q "Vertical Variable Filter") and IC115 (CXD8276Q "CMOS Linear Interpolation")
+	//        at PCB FM-29 (6/6); Foreground Bus Digital Lowpass Filter
+	map(0x6b07e, 0x6b07f).mirror(0x90700).w("yflt", FUNC(generic_latch_16_device::write));
+
+	// ==== "ORG2" registers: ====
+	// VE,6-8B/DA,2-23B
+	//map(0x6B800, 0x6B800).mirror(0x907ff).w(...);
+	map(0xc0000, 0xdffff).nopw(); // FIXME! Temporarily quieting unmapped access log messages on this range...
+
+	// TODO: CKD8263Q: "Color Bar Pattern Generator"
+
+	// ==== Under development ====
+	// Here are some temporary notes on the bit-patterns for decoding the addresses
+	// of portions of the circuit related to the remainder of this memory map
+	//
+	// IC73:
+	// BA15..12 = 0110 MEMPRG 0x06000
+
+	// REGA: AA18=0 AA17=0 AA15=0 AA14=1
+	// !REGA: AA18=1 AA17=1 AA15=1 AA14=0
+	// WRA:  /WR
+	// WAn:  !REGA & !WRA & n=AA13/12/11
+	// WAn:  ?11? 10nn n??? ???? ????
+	
+	// ARAM = AA18/17=10
+	// ARAMW = ?
+	// MTRX = ?
+	// OREG1 = REGA=0 (AA18...14=00x01) AA13..11=110 => x00x 0111 0xxx xxxx xxxx => map(0x07000, 0x07001).mirror(0x90000)
+	// OREG2 = REGA=0 (AA18...14=00x01) AA13..11=111 => x00x 0111 1xxx xxxx xxxx => map(0x07800, 0x07801).mirror(0x90000)
+	// OBUS = active-low "ARAM or MTR or OREG1 or OREG2"
+}
+
+static INPUT_PORTS_START(dfs500)
+	PORT_START("DSW_S1")
+	PORT_DIPNAME( 0x0f, 0x02, "Editing Control Unit Select" )   PORT_DIPLOCATION("S1:4,3,2,1")
+	PORT_DIPSETTING(    0x08, "BVE-600" )
+	PORT_DIPSETTING(    0x04, "ONE-GPI" )
+	PORT_DIPSETTING(    0x02, "BVE-900" )
+	PORT_DIPSETTING(    0x01, "BVS-300" )
+
+	PORT_START("DSW_S2")
+	PORT_DIPNAME( 0x0f, 0x07, "Freeze Timing" )   PORT_DIPLOCATION("S2:4,3,2,1")
+	PORT_DIPSETTING(    0x07, "8" )
+	PORT_DIPSETTING(    0x0b, "4" )
+	PORT_DIPSETTING(    0x0d, "2" )
+	PORT_DIPSETTING(    0x0e, "1" )
+
+	PORT_START("DSW_S3")
+	PORT_DIPNAME( 0x08, 0x08, "Field freeze" )   PORT_DIPLOCATION("S3:4")
+	PORT_DIPSETTING(    0x00, "Odd Field" )
+	PORT_DIPSETTING(    0x08, "Even Freeze" )
+	PORT_DIPNAME( 0x04, 0x04, "Color-Matte Compensation" )   PORT_DIPLOCATION("S3:3")
+	PORT_DIPSETTING(    0x00, "Illegal compensation" )
+	PORT_DIPSETTING(    0x04, "Limit compensation" )
+	PORT_DIPNAME( 0x02, 0x02, "Set up" )   PORT_DIPLOCATION("S3:2")
+	PORT_DIPSETTING(    0x00, "7.5%" )
+	PORT_DIPSETTING(    0x02, "0%" )
+	PORT_DIPNAME( 0x01, 0x00, "Freeze (When changing the crosspoint)" )   PORT_DIPLOCATION("S3:1")
+	PORT_DIPSETTING(    0x00, "2 Frames" )
+	PORT_DIPSETTING(    0x01, "0 Frame" )
+
+	PORT_START("RD1")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EFFECT CONTROL: SHIFT") // SW74
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK BORDER") // SW32
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MATTES/BKGD: SELECT") // SW35
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("MATTES/BKGD: MATTE COPY") // SW36
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("PATTERN NUMBER: SET") // SW37
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EFFECT CONTROL: TITLE") // SW38
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EFFECT CONTROL: DSK") // SW39
+
+	PORT_START("RD2")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK KEY INV") // SW26
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK EXT KEY") // SW28
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK NORMAL") // SW27
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK INVERT") // SW29
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DOWNSTREAM KEYER: FILL") // SW31
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DSK MIX") // SW30
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DOWNSTREAM KEYER: TYPE") // SW33
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DOWNSTREAM KEYER: POSITION") // SW34
+
+	PORT_START("RD3")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("BKGD BUS INT VIDEO") PORT_CODE(KEYCODE_5) // SW49
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FRGD BUS INT VIDEO") PORT_CODE(KEYCODE_T) // SW44
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEY INV") // SW20
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EXT KEY") // SW22
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TITLE: FILL") // SW25
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TITLE") // SW24
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("NORMAL") // SW21
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("INVERT") // SW23
+
+	PORT_START("RD4")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("BKGD BUS 4") PORT_CODE(KEYCODE_4) // SW48
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("BKGD BUS 3") PORT_CODE(KEYCODE_3) // SW47
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("BKGD BUS 2") PORT_CODE(KEYCODE_2) // SW46
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("BKGD BUS 1") PORT_CODE(KEYCODE_1) // SW45
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FRGD BUS 4") PORT_CODE(KEYCODE_R) // SW43
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FRGD BUS 3") PORT_CODE(KEYCODE_E) // SW42
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FRGD BUS 2") PORT_CODE(KEYCODE_W) // SW41
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FRGD BUS 1") PORT_CODE(KEYCODE_Q) // SW40
+
+	PORT_START("RD5")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD: DIRECT") // SW57
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EFFECT TRANSITION: REVERSE") // SW56
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EFFECT TRANSITION: AUTO TRANS") // SW55
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRANS RATE: EFFECT") // SW53
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRANS RATE: DSK") // SW54
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FREEZE FIELD") // SW51
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("FREEZE FRAME") // SW52
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("INT VIDEO SELECT") PORT_CODE(KEYCODE_I)// SW50
+
+	PORT_START("RD8")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 0") PORT_CODE(KEYCODE_0_PAD) // SW58
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD DOWN") PORT_CODE(KEYCODE_DOWN) // SW59
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD UP") PORT_CODE(KEYCODE_UP) // SW60
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD ENTER") PORT_CODE(KEYCODE_ENTER_PAD) // SW61
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 1") PORT_CODE(KEYCODE_1_PAD) // SW62
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 2") PORT_CODE(KEYCODE_2_PAD) // SW63
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 3") PORT_CODE(KEYCODE_3_PAD) // SW64
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD RST") // SW65
+
+	PORT_START("RD9")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 4") PORT_CODE(KEYCODE_4_PAD) // SW66
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 5") PORT_CODE(KEYCODE_5_PAD) // SW67
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 6") PORT_CODE(KEYCODE_6_PAD) // SW68
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD DEL") PORT_CODE(KEYCODE_DEL)// SW69
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 7") PORT_CODE(KEYCODE_7_PAD) // SW70
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 8") PORT_CODE(KEYCODE_8_PAD) // SW71
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD 9") PORT_CODE(KEYCODE_9_PAD) // SW72
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("KEYPAD INS") PORT_CODE(KEYCODE_INSERT)// SW73
+	
+	PORT_START("RD10")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("LIGHTING INTENSITY") // SW8
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("LIGHTING WIDTH") // SW7
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("LIGHTING TYPE") // SW6
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("LIGHTING") // SW5
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("LEARN") // SW4
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("RECALL") // SW3
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("HOLD INPUT") // SW2
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EDITOR ENABLE") // SW1
+
+	PORT_START("RD11")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EDGE SOFT") // SW16
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("EDGE BORDER") // SW15
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRAIL/SHADOW DENSITY/POSITION") // SW14
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("SHADOW") // SW13
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRAIL/SHADOW FILL") // SW12
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("DROP BORDER") // SW11
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRAIL/SHADOW TYPE") // SW10
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("TRAIL") // SW9
+
+	PORT_START("RD12")
+	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("USER PGM LOCATION") PORT_CODE(KEYCODE_L) // SW19
+	PORT_BIT(0x02, IP_ACTIVE_LOW, IPT_UNUSED)
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYPAD) PORT_NAME("USER PGM EDIT") // SW17
+INPUT_PORTS_END
+
+void dfs500_state::dfs500(machine_config &config)
+{
+	/******************* Control Panel ******************************/
+	// NEC D70108C-8 at IC10 (a CPU compatible with Intel 8088)
+	V20(config, m_cpanelcpu, 8_MHz_XTAL);
+	m_cpanelcpu->set_addrmap(AS_PROGRAM, &dfs500_state::cpanelcpu_mem_map);
+	m_cpanelcpu->set_addrmap(AS_IO, &dfs500_state::cpanelcpu_io_map);
+	m_cpanelcpu->set_irq_acknowledge_callback(FUNC(dfs500_state::irq_callback));
+
+	// CXQ71054P at IC16 (Programmable Timer / Counter)
+	PIT8254(config, m_cpanel_pit, 0);
+	m_cpanel_pit->set_clk<0>(8_MHz_XTAL);
+	m_cpanel_pit->set_clk<1>(8_MHz_XTAL/2);
+	m_cpanel_pit->out_handler<1>().set(m_cpanel_pit, FUNC(pit8254_device::write_clk2));
+	m_cpanel_pit->out_handler<0>().set(m_cpanel_serial, FUNC(i8251_device::write_txc));
+	m_cpanel_pit->out_handler<0>().append(m_cpanel_serial, FUNC(i8251_device::write_rxc));
+
+	// CXQ71051P at IC17 (Serial Interface Unit)
+	I8251(config, m_cpanel_serial, 8_MHz_XTAL/2);
+	m_cpanel_serial->txd_handler().set(m_serial1, FUNC(i8251_device::write_rxd));
+	m_cpanel_serial->rxrdy_handler().set_inputline(m_cpanelcpu, 0);
+
+	UPD7004(config, m_adc, 8_MHz_XTAL/2);
+	// FIXME! m_adc->eoc_ff_callback(). [...] Set bit D0 on register RD0 IC35 KY223
+	// TODO: m_adc->in_callback<7>().set_ioport("XCOM");
+	// TODO: m_adc->in_callback<6>().set_ioport("YCOM");
+	// TODO: m_adc->in_callback<5>().set_ioport("XCOM1");
+	// TODO: m_adc->in_callback<4>().set_ioport("YCOM1");
+	// TODO: m_adc->in_callback<3>().set_ioport("XCOM0");
+	// TODO: m_adc->in_callback<2>().set_ioport("YCOM0");
+	// TODO: m_adc->in_callback<1>().set_ioport("TCLIP2");
+	// TODO: m_adc->in_callback<0>().set_ioport("TCLIP1");
+
+	//Buzzer		
+	SPEAKER(config, "mono").front_center();
+	BEEP(config, "buzzer", 4000).add_route(ALL_OUTPUTS, "mono", 0.05); // incorrect/arbitrary freq.
+	                                                                   // I did not calculate the correct one yet.
+
+	/******************* Effects Processing Unit ********************/
+	// CXQ70116P-10 at IC40 (same as V20, but with a 16-bit data bus)
+	V30(config, m_maincpu, 8_MHz_XTAL);
+	m_maincpu->set_addrmap(AS_PROGRAM, &dfs500_state::maincpu_mem_map);
+	m_maincpu->set_irq_acknowledge_callback("pic", FUNC(pic8259_device::inta_cb));
+
+	// CXQ70116P-10 at IC9
+	V30(config, m_effectcpu, 8_MHz_XTAL);
+	m_effectcpu->set_addrmap(AS_PROGRAM, &dfs500_state::effectcpu_mem_map);
+
+	// CXQ71054P at IC51 (Programmable Timer / Counter)
+	PIT8254(config, m_pit, 0);
+	m_pit->set_clk<0>(8_MHz_XTAL);
+	m_pit->set_clk<1>(8_MHz_XTAL);
+	m_pit->out_handler<1>().set(m_pit, FUNC(pit8254_device::write_clk2));
+	m_pit->out_handler<0>().set(m_serial1, FUNC(i8251_device::write_txc));
+	m_pit->out_handler<0>().append(m_serial1, FUNC(i8251_device::write_rxc));
+	m_pit->out_handler<0>().append(m_serial2, FUNC(i8251_device::write_txc));
+	m_pit->out_handler<0>().append(m_serial2, FUNC(i8251_device::write_rxc));
+
+	// NEC D71059C at IC52 (Programmable Interruption Controller)
+	PIC8259(config, m_pic, 0);
+	m_pic->out_int_callback().set_inputline(m_maincpu, 0);
+
+	// CXQ71051P at IC53 (Serial Interface Unit)
+	I8251(config, m_serial1, 8_MHz_XTAL);
+	m_serial1->txd_handler().set(m_cpanel_serial, FUNC(i8251_device::write_rxd));
+	m_serial1->txrdy_handler().set(m_pic, FUNC(pic8259_device::ir7_w));
+
+	// CXQ71051P at IC54 (Serial Interface Unit)
+	I8251(config, m_serial2, 8_MHz_XTAL);
+	m_serial2->txrdy_handler().set(m_pic, FUNC(pic8259_device::ir6_w));
+	// FIXME: Declare an interface to hook this up to another emulated device in MAME (such as pve500)
+	//
+	// This goes to the CN21 EDITOR D-SUB CONNECTOR on board CN-573
+	// I think the purpose of this is to connect to an editor such as the Sony PVE-500.
+	//
+	// m_serial2->txd_handler().set(m_..., FUNC(..._device::write_txd)); "XMIT"
+	// m_...->rxd_handler().set(m_serial2, FUNC(i8251_device::write_rxd)); "RCV"
+
+	GENERIC_LATCH_16(config, "controlsignals");
+	GENERIC_LATCH_16(config, "reg7_5");
+	GENERIC_LATCH_16(config, "xflt");
+	GENERIC_LATCH_16(config, "yflt");
+
+	// In the future this could become IMAGE_AVIVIDEO (or even, perhaps, we
+	// should add support for capturing frames from real video devices such
+	// as a webcam on /dev/video0)
+	IMAGE_PICTURE(config, m_input[0]);
+	IMAGE_PICTURE(config, m_input[1]);
+	IMAGE_PICTURE(config, m_input[2]);
+	IMAGE_PICTURE(config, m_input[3]);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_size(VIDEO_WIDTH, VIDEO_HEIGHT);
+	m_screen->set_visarea(0, VIDEO_WIDTH-1, 0, VIDEO_HEIGHT-1);
+	m_screen->set_screen_update(FUNC(dfs500_state::screen_update));
+
+	config.set_default_layout(layout_dfs500);
+}
+
+ROM_START(dfs500)
+	// Process Unit System Control:
+	ROM_REGION(0x8000, "cpanelcpu", 0)
+	ROM_LOAD("27c256b_npky14_v1.03_293-83_5500_ky223_sony94.ic14", 0x0000, 0x8000, CRC(8b9e564a) SHA1(aa8a1f211a7834fb15f7ecbc58570f566c0ef5ab))
+
+	// Process Unit System Control:
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD16_BYTE("27c256b_npsys1_v1.03_293-84_3eb5_sy172_sony94.ic1", 0x0001, 0x8000, CRC(4604e7c0) SHA1(80f965b69a163a6278d6f54db741f4c5ada1cb59))
+	ROM_LOAD16_BYTE("27c256b_npsys2_v1.03_293-85_3ecd_sy172_sony94.ic2", 0x0000, 0x8000, CRC(b80a66e6) SHA1(407ddc5fee61920bfbe90c20faf4482ceef1ad4f))
+
+	// Process Unit Effect Control:
+	ROM_REGION(0x10000, "effectcpu", 0)
+	ROM_LOAD16_BYTE("27c512_npsys3_v1.04_293-86_b7d0_sy172_sony94.ic3", 0x0001, 0x8000, CRC(69238d02) SHA1(288babc7547858a3ca3f65af0be76f72335392ea))
+	ROM_CONTINUE(0x0001, 0x8000)
+	ROM_LOAD16_BYTE("27c512_npsys4_v1.04_293-87_b771_sy172_sony94.ic4", 0x0000, 0x8000, CRC(541abd4f) SHA1(e51f5ca6416c17535f2d2a13a7bedfb3b4b4a58b))
+	ROM_CONTINUE(0x0000, 0x8000)
+
+	// Process Unit Effect Data:
+	ROM_REGION(0x200000, "effectdata", 0)
+	ROM_LOAD("27c4001-12f1_sy172_v1.01_d216.ic5", 0x000000,  0x80000, CRC(ae094fcb) SHA1(c29c27b3c80e67caba2078bb60696c1b8692eb8b))
+	ROM_LOAD("27c4001-12f1_sy172_v1.01_d225.ic6", 0x080000,  0x80000, CRC(caa6ccb2) SHA1(9b72dc47cf4cc9c2f9915ea4f1bd7b5136e29db5))
+	ROM_LOAD("27c4001-12f1_sy172_v1.01_cc13.ic7", 0x100000,  0x80000, CRC(e1fe8606) SHA1(a573c7023daeb84d5a1182db4051b1bccfcfc1f8))
+	ROM_LOAD("27c4001-12f1_sy172_v1.01_c42d.ic8", 0x180000,  0x80000, CRC(66e0f20f) SHA1(e82562ae1eeecc5c97b0f40e01102c2ebe0d6276))
+ROM_END
+
+//   YEAR  NAME   PARENT/COMPAT MACHINE  INPUT    CLASS          INIT     COMPANY  FULLNAME                     FLAGS
+SYST(1994, dfs500,    0, 0,     dfs500, dfs500, dfs500_state, empty_init, "Sony", "DFS-500 DME Video Switcher", MACHINE_NOT_WORKING)

--- a/src/mame/drivers/umatic.cpp
+++ b/src/mame/drivers/umatic.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Felipe Sanches
 /****************************************************************************
 
-    Skeleton driver for Sony U-Matic Videocassete Recorder
+	Skeleton driver for Sony U-Matic Videocassete Recorder
 
 ****************************************************************************/
 
@@ -21,51 +21,51 @@ public:
 	}
 
 	void umatic(machine_config &config);
-  uint8_t io_read(offs_t offset);
-  void io_write(offs_t offset, uint8_t data);
+	uint8_t io_read(offs_t offset);
+	void io_write(offs_t offset, uint8_t data);
 
 private:
 	void mem_map(address_map &map);
 	void io_map(address_map &map);
 
 	required_device<z80_device> m_maincpu;
-  required_device<z80ctc_device> m_ctc;
+	required_device<z80ctc_device> m_ctc;
 };
 
 void umatic_state::io_write(offs_t offset, uint8_t data)
 {
-  //FIXME!
+	//FIXME!
 }
 
 uint8_t umatic_state::io_read(offs_t offset)
 {
-  switch(offset & 7){
-    case 0: return 0; //FIXME!
-    case 1: return 0; //FIXME!
-    case 2: return 0; //FIXME!
-    case 3: return 0; //FIXME!
-    case 4: return 0x04; //FIXME!
-    case 5: return 0; //FIXME!
-    case 6: return 0; //FIXME!
-    case 7: return 0; //FIXME!
-  }
+	switch(offset & 7){
+		case 0: return 0; //FIXME!
+		case 1: return 0; //FIXME!
+		case 2: return 0; //FIXME!
+		case 3: return 0; //FIXME!
+		case 4: return 0x04; //FIXME!
+		case 5: return 0; //FIXME!
+		case 6: return 0; //FIXME!
+		case 7: return 0; //FIXME!
+	}
 
-  return 0;
+	return 0;
 }
 
 void umatic_state::io_map(address_map &map)
 {
-  map.unmap_value_high();
-  map.global_mask(0xff);
-  map(0x00, 0x03).mirror(0x7c).rw(m_ctc, FUNC(z80ctc_device::read), FUNC(z80ctc_device::write));
-  map(0x80, 0x87).mirror(0x78).rw(FUNC(umatic_state::io_read), FUNC(umatic_state::io_write));
+	map.unmap_value_high();
+	map.global_mask(0xff);
+	map(0x00, 0x03).mirror(0x7c).rw(m_ctc, FUNC(z80ctc_device::read), FUNC(z80ctc_device::write));
+	map(0x80, 0x87).mirror(0x78).rw(FUNC(umatic_state::io_read), FUNC(umatic_state::io_write));
 }
 
 void umatic_state::mem_map(address_map &map)
 {
-	map(0x0000, 0x17ff).rom(); // 8k-byte EPROM at IC26, but only the first 6kb are mapped.
-                             // And remaining unmapped content is all 0xFF.
-	map(0x1800, 0x1fff).ram(); // 2k-byte CXK5816PN-15L at IC17
+	map(0x0000, 0x17ff).rom();	// 8k-byte EPROM at IC26, but only the first 6kb are mapped.
+					// And remaining unmapped content is all 0xFF.
+	map(0x1800, 0x1fff).ram();	// 2k-byte CXK5816PN-15L at IC17
 }
 
 static INPUT_PORTS_START(umatic)
@@ -74,13 +74,13 @@ INPUT_PORTS_END
 void umatic_state::umatic(machine_config &config)
 {
 	Z80(config, m_maincpu, 4.9152_MHz_XTAL / 2); // LH0080 SHARP
-  m_maincpu->set_addrmap(AS_PROGRAM, &umatic_state::mem_map);
-  m_maincpu->set_addrmap(AS_IO, &umatic_state::io_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &umatic_state::mem_map);
+	m_maincpu->set_addrmap(AS_IO, &umatic_state::io_map);
 
-  // peripheral hardware
-  Z80CTC(config, m_ctc, 4.9152_MHz_XTAL / 16); // LH0082 SHARP
-  m_ctc->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
-  //TODO: m_ctc->zc_callback<2>().set(...); // "search freq out" ?
+	// peripheral hardware
+	Z80CTC(config, m_ctc, 4.9152_MHz_XTAL / 16); // LH0082 SHARP
+	m_ctc->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+	//TODO: m_ctc->zc_callback<2>().set(...); // "search freq out" ?
 }
 
 ROM_START(vo5850pm)

--- a/src/mame/drivers/umatic.cpp
+++ b/src/mame/drivers/umatic.cpp
@@ -1,0 +1,92 @@
+// license:GPL-2.0+
+// copyright-holders:Felipe Sanches
+/****************************************************************************
+
+    Skeleton driver for Sony U-Matic Videocassete Recorder
+
+****************************************************************************/
+
+#include "emu.h"
+#include "cpu/z80/z80.h"
+#include "machine/z80ctc.h"
+
+class umatic_state : public driver_device
+{
+public:
+	umatic_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_ctc(*this, "ctc")
+	{
+	}
+
+	void umatic(machine_config &config);
+  uint8_t io_read(offs_t offset);
+  void io_write(offs_t offset, uint8_t data);
+
+private:
+	void mem_map(address_map &map);
+	void io_map(address_map &map);
+
+	required_device<z80_device> m_maincpu;
+  required_device<z80ctc_device> m_ctc;
+};
+
+void umatic_state::io_write(offs_t offset, uint8_t data)
+{
+  //FIXME!
+}
+
+uint8_t umatic_state::io_read(offs_t offset)
+{
+  switch(offset & 7){
+    case 0: return 0; //FIXME!
+    case 1: return 0; //FIXME!
+    case 2: return 0; //FIXME!
+    case 3: return 0; //FIXME!
+    case 4: return 0x04; //FIXME!
+    case 5: return 0; //FIXME!
+    case 6: return 0; //FIXME!
+    case 7: return 0; //FIXME!
+  }
+
+  return 0;
+}
+
+void umatic_state::io_map(address_map &map)
+{
+  map.unmap_value_high();
+  map.global_mask(0xff);
+  map(0x00, 0x03).mirror(0x7c).rw(m_ctc, FUNC(z80ctc_device::read), FUNC(z80ctc_device::write));
+  map(0x80, 0x87).mirror(0x78).rw(FUNC(umatic_state::io_read), FUNC(umatic_state::io_write));
+}
+
+void umatic_state::mem_map(address_map &map)
+{
+	map(0x0000, 0x17ff).rom(); // 8k-byte EPROM at IC26, but only the first 6kb are mapped.
+                             // And remaining unmapped content is all 0xFF.
+	map(0x1800, 0x1fff).ram(); // 2k-byte CXK5816PN-15L at IC17
+}
+
+static INPUT_PORTS_START(umatic)
+INPUT_PORTS_END
+
+void umatic_state::umatic(machine_config &config)
+{
+	Z80(config, m_maincpu, 4.9152_MHz_XTAL / 2); // LH0080 SHARP
+  m_maincpu->set_addrmap(AS_PROGRAM, &umatic_state::mem_map);
+  m_maincpu->set_addrmap(AS_IO, &umatic_state::io_map);
+
+  // peripheral hardware
+  Z80CTC(config, m_ctc, 4.9152_MHz_XTAL / 16); // LH0082 SHARP
+  m_ctc->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ0);
+  //TODO: m_ctc->zc_callback<2>().set(...); // "search freq out" ?
+}
+
+ROM_START(vo5850pm)
+	ROM_REGION(0x2000, "maincpu", 0)
+	ROM_LOAD("2764_s68_ev1-25.ic26", 0x0000, 0x2000, CRC(7f3c191d) SHA1(4843399f86a15133e966c9e8992eafac03818916))
+ROM_END
+
+//   YEAR  NAME   PARENT/COMPAT MACHINE  INPUT    CLASS             INIT COMPANY  FULLNAME                                    FLAGS
+SYST(19??, vo5850pm,    0, 0,   umatic, umatic, umatic_state, empty_init, "Sony", "U-Matic Videocassete Recorder VO-5850PM",  MACHINE_IS_SKELETON)

--- a/src/mame/layout/dfs500.lay
+++ b/src/mame/layout/dfs500.lay
@@ -1,0 +1,500 @@
+<?xml version="1.0"?>
+<!--
+license:CC0
+-->
+<mamelayout version="2">
+	<element name="digit" defstate="255">
+		<led7seg>
+			<color red="1" green="0.0" blue="0.0" />
+		</led7seg>
+	</element>
+
+	<element name="led" defstate="1">
+		<disk state="1">
+			<color red="1" green="0.4" blue="0.4" />
+		</disk>
+		<disk state="0">
+			<color red="0.5" green="0.5" blue="0.5" />
+		</disk>
+	</element>
+
+	<element name="squared_led" defstate="1">
+		<rect state="1">
+			<color red="0.4" green="1.0" blue="0.4" />
+		</rect>
+		<rect state="0">
+			<color red="0.05" green="0.3" blue="0.05" />
+		</rect>
+	</element>
+
+	<element name="digit_bg" defstate="0">
+		<rect state="0">
+			<color red="0.1" green="0.05" blue="0.05" />
+		</rect>
+	</element>
+
+	<element name="background">
+		<rect>
+			<color red="0.6" green="0.6" blue="0.6" />
+		</rect>
+	</element>
+
+	<!-- Snap Shot -->
+
+	<!-- Lighting -->
+	<element name="lighting_spot" defstate="0">
+		<text state="1" string="SPOT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SPOT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_line" defstate="0">
+		<text state="1" string="LINE"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="LINE"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_plane" defstate="0">
+		<text state="1" string="PLANE"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="PLANE"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_width_wide" defstate="0">
+		<text state="1" string="WIDE"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="WIDE"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_width_medium" defstate="0">
+		<text state="1" string="MEDIUM"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="MEDIUM"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_width_narrow" defstate="0">
+		<text state="1" string="NARROW"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="NARROW"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_intensity_high" defstate="0">
+		<text state="1" string="HIGH"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="HIGH"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_intensity_medium" defstate="0">
+		<text state="1" string="MEDIUM"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="MEDIUM"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="lighting_intensity_low" defstate="0">
+		<text state="1" string="LOW"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="LOW"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Trail/Shadow -->
+	<element name="trail_drop_type_hard" defstate="0">
+		<text state="1" string="HARD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="HARD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_type_soft" defstate="0">
+		<text state="1" string="SOFT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SOFT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_type_hard_star" defstate="0">
+		<text state="1" string="HARD STAR"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="HARD STAR"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_type_soft_star" defstate="0">
+		<text state="1" string="SOFT STAR"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SOFT STAR"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_fill_self" defstate="0">
+		<text state="1" string="SELF"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SELF"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_fill_bord_mat" defstate="0">
+		<text state="1" string="BORD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="BORD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_fill_shad_mat" defstate="0">
+		<text state="1" string="SHAD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SHAD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_drop_fill_rndm_mat" defstate="0">
+		<text state="1" string="RNDM MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="RNDM MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_frames_duration" defstate="0">
+		<text state="1" string="DURATION"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DURATION"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_frames_wid_pos" defstate="0">
+		<text state="1" string="WID/POS"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="WID/POS"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trail_frames_density" defstate="0">
+		<text state="1" string="DENSITY"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DENSITY"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Edge -->
+
+	<!-- User Program -->
+
+	<!-- Location -->
+
+	<!-- Title -->
+	<element name="title_frgd_bus" defstate="0">
+		<text state="1" string="FRGD BUS"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="FRGD BUS"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="title_bord_mat" defstate="0">
+		<text state="1" string="BORD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="BORD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="title_shad_mat" defstate="0">
+		<text state="1" string="SHAD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SHAD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Mattes/Bkgd -->
+	<element name="mattes_col_bkgd" defstate="0">
+		<text state="1" string="COL BKGD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="COL BKGD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mattes_bord_mat" defstate="0">
+		<text state="1" string="BORD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="BORD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mattes_shad_mat" defstate="0">
+		<text state="1" string="SHAD MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SHAD MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mattes_dsk_mat" defstate="0">
+		<text state="1" string="DSK MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DSK MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mattes_dsk_bord" defstate="0">
+		<text state="1" string="DSK BORD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DSK BORD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Downstream Keyer -->
+	<element name="wide_bord" defstate="0">
+		<text state="1" string="WIDE BORD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="WIDE BORD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="narw_bord" defstate="0">
+		<text state="1" string="NARW BORD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="NARW BORD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="drop_bord" defstate="0">
+		<text state="1" string="DROP BORD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DROP BORD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="double" defstate="0">
+		<text state="1" string="DOUBLE"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DOUBLE"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="top_left" defstate="0">
+		<text state="1" string="TOP LEFT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="TOP LEFT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="top_right" defstate="0">
+		<text state="1" string="TOP RIGHT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="TOP RIGHT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="btm_right" defstate="0">
+		<text state="1" string="BTM RIGHT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="BTM RIGHT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="btm_left" defstate="0">
+		<text state="1" string="BTM LEFT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="BTM LEFT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="dsk_fill_video" defstate="0">
+		<text state="1" string="DSK VIDEO"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DSK VIDEO"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="dsk_fill_mat" defstate="0">
+		<text state="1" string="DSK MAT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DSK MAT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="dsk_fill_none" defstate="0">
+		<text state="1" string="NONE"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="NONE"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+
+	<!-- Effect Control -->
+	<element name="effect_ctrl_modify" defstate="0">
+		<text state="1" string="MODIFY"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="MODIFY"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="effect_ctrl_linear" defstate="0">
+		<text state="1" string="LINEAR"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="LINEAR"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="effect_ctrl_nonlin" defstate="0">
+		<text state="1" string="NON-LIN"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="NON-LIN"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="effect_ctrl_mask" defstate="0">
+		<text state="1" string="MASK"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="MASK"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Background -->
+	<element name="no_color_button">
+		<rect><color red="0.6" green="0.6" blue="0.6" /></rect>
+	</element>
+
+	<element name="single_color_button" defstate="0">
+		<rect state="0"><color red="0.6" green="0.6" blue="0.6" /></rect>
+		<rect state="1"><color red="1.0" green="0.8" blue="0.3" /></rect>
+	</element>
+
+	<element name="multi_color_button" defstate="0">
+		<rect state="0"><color red="0.6" green="0.6" blue="0.6" /></rect>
+		<rect state="1"><color red="1.0" green="0.3" blue="0.3" /></rect>
+		<rect state="2"><color red="1.0" green="0.8" blue="0.3" /></rect>
+		<rect state="3"><color red="1.0" green="1.0" blue="0.5" /></rect>
+	</element>
+
+	<!-- Foreground -->
+
+	<!-- Int Video -->
+	<element name="int_video_col_bkgd" defstate="0">
+		<text state="1" string="COL BKGD"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="COL BKGD"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="int_video_col_bar" defstate="0">
+		<text state="1" string="COL BAR"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="COL BAR"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="int_video_grid" defstate="0">
+		<text state="1" string="GRID"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="GRID"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Effect Transition -->
+	<element name="trans_rate_effect" defstate="0">
+		<text state="1" string="EFFECT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="EFFECT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trans_rate_dsk" defstate="0">
+		<text state="1" string="DSK"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="DSK"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="trans_rate_norm_rev" defstate="0">
+		<text state="1" string="NORM/REV"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="NORM/REV"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Pattern Number -->
+
+	<!-- Mode -->
+	<element name="mode_pattern" defstate="0">
+		<text state="1" string="PATTERN"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="PATTERN"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mode_trans" defstate="0">
+		<text state="1" string="TRANS"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="TRANS"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mode_user_pgm" defstate="0">
+		<text state="1" string="USER PGM"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="USER PGM"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+	<element name="mode_snap_shot" defstate="0">
+		<text state="1" string="SNAP SHOT"><color red="0.7" green="0.9" blue="0.2" /></text>
+		<text state="0" string="SNAP SHOT"><color red="0.4" green="0.4" blue="0.4" /></text>
+	</element>
+
+	<!-- Pattern / Key Pad -->
+
+
+	<view name="Control Panel">
+		<bounds x="0" y="0" width="1888" height="927" />
+		<!--<element ref="background"><bounds x="0" y="0" width="1120" height="927" /></element>-->
+		<screen index="0"><bounds x="1120" y="207" width="768" height="512" /></screen>
+
+		<element name="editor_enable" ref="led"><bounds x="117" y="182"  width="9" height="9" /></element>
+
+		<!-- Snap Shot -->
+		<element name="snapshot_background" ref="digit_bg"><bounds x="154" y="84"  width="52" height="38" /></element>
+		<element name="snapshot10" ref="digit"><bounds x="154" y="84"  width="26" height="38" /></element>
+		<element name="snapshot1"  ref="digit"><bounds x="180" y="84"  width="26" height="38" /></element>
+		<element name="learn"      ref="led"><bounds x="179" y="139"  width="9" height="9" /></element>
+		<element name="recall"     ref="led"><bounds x="185" y="182"  width="9" height="9" /></element>
+		<element name="hold_input" ref="led"><bounds x="190" y="221"  width="9" height="9" /></element>
+
+		<!-- Lighting -->
+		<element name="lighting_spot"  ref="lighting_spot" ><bounds x="243" y="86" width="32" height="12" /></element>
+		<element name="lighting_line"  ref="lighting_line" ><bounds x="248" y="114" width="27" height="12" /></element>
+		<element name="lighting_plane" ref="lighting_plane"><bounds x="246" y="141" width="36" height="12" /></element>
+		<element name="lighting_width_wide"   ref="lighting_width_wide"  ><bounds x="313" y="86" width="32" height="12" /></element>
+		<element name="lighting_width_medium" ref="lighting_width_medium"><bounds x="309" y="113" width="44" height="12" /></element>
+		<element name="lighting_width_narrow" ref="lighting_width_narrow"><bounds x="309" y="140" width="49" height="12" /></element>
+		<element name="lighting_intensity_high"   ref="lighting_intensity_high"  ><bounds x="384" y="86" width="30" height="12" /></element>
+		<element name="lighting_intensity_medium" ref="lighting_intensity_medium"><bounds x="378" y="113" width="44" height="12" /></element>
+		<element name="lighting_intensity_low"    ref="lighting_intensity_low"   ><bounds x="386" y="140" width="30" height="12" /></element>
+
+		<element name="lighting" ref="led"><bounds x="333" y="220"  width="9" height="9" /></element>
+
+		<!-- Trail/Shadow -->
+		<element name="trail_shadow_background" ref="digit_bg"><bounds x="594" y="84"  width="52" height="38" /></element>
+		<element name="trail_shadow_frames10"   ref="digit"><bounds x="594" y="84"  width="26" height="38" /></element>
+		<element name="trail_shadow_frames1"    ref="digit"><bounds x="620" y="84"  width="26" height="38" /></element>
+		<element name="trail"       ref="led"><bounds x="478" y="220"  width="9" height="9" /></element>
+		<element name="drop_border" ref="led"><bounds x="544" y="220"  width="9" height="9" /></element>
+		<element name="shadow"      ref="led"><bounds x="614" y="220"  width="9" height="9" /></element>
+		<element name="trail_drop_type_hard"       ref="trail_drop_type_hard"     ><bounds x="462" y="85" width="36" height="12" /></element>
+		<element name="trail_drop_type_soft"       ref="trail_drop_type_soft"     ><bounds x="462" y="104" width="36" height="12" /></element>
+		<element name="trail_drop_type_hard_star"  ref="trail_drop_type_hard_star"><bounds x="452" y="122" width="59" height="12" /></element>
+		<element name="trail_drop_type_soft_star"  ref="trail_drop_type_soft_star"><bounds x="453" y="140" width="59" height="12" /></element>
+		<element name="trail_drop_fill_self"     ref="trail_drop_fill_self"    ><bounds x="535" y="85" width="31" height="12" /></element>
+		<element name="trail_drop_fill_bord_mat" ref="trail_drop_fill_bord_mat"><bounds x="519" y="104" width="59" height="12" /></element>
+		<element name="trail_drop_fill_shad_mat" ref="trail_drop_fill_shad_mat"><bounds x="519" y="122" width="59" height="12" /></element>
+		<element name="trail_drop_fill_rndm_mat" ref="trail_drop_fill_rndm_mat"><bounds x="519" y="140" width="59" height="12" /></element>
+		<element name="trail_frames_duration" ref="trail_frames_duration"><bounds x="657" y="100" width="54" height="12" /></element>
+		<element name="trail_frames_wid_pos" ref="trail_frames_wid_pos"><bounds x="657" y="119" width="51" height="12" /></element>
+		<element name="trail_frames_density" ref="trail_frames_density"><bounds x="658" y="139" width="47" height="12" /></element>
+
+		<!-- Edge -->
+		<element name="edge_border" ref="led"><bounds x="763" y="103"  width="9" height="9" /></element>
+		<element name="edge_soft"   ref="led"><bounds x="758" y="144"  width="9" height="9" /></element>
+
+		<!-- User Program -->
+		<element name="status_background" ref="digit_bg"><bounds x="841" y="84"  width="26" height="38" /></element>
+		<element name="status"     ref="digit"><bounds x="841" y="84"  width="26" height="38" /></element>
+		<element name="edit_background" ref="digit_bg"><bounds x="833" y="148"  width="26" height="38" /></element>
+		<element name="edit"       ref="digit"><bounds x="833" y="148" width="26" height="38" /></element>
+		<element name="edit_led"   ref="led"><bounds x="837" y="220"  width="9" height="9" /></element>
+
+		<!-- Location -->
+		<element name="location"   ref="led"><bounds x="914" y="221"  width="9" height="9" /></element>
+
+		<!-- Title -->
+		<element name="mask_normal" ref="led"><bounds x="100" y="384"  width="9" height="9" /></element>
+		<element name="mask_invert" ref="led"><bounds x="143" y="384"  width="9" height="9" /></element>
+		<element name="key_inv"     ref="led"><bounds x="98"  y="440"  width="9" height="9" /></element>
+		<element name="ext_key"     ref="led"><bounds x="140" y="440"  width="9" height="9" /></element>
+		<element name="title"       ref="led"><bounds x="117" y="495"  width="9" height="9" /></element>
+		<element name="title_frgd_bus" ref="title_frgd_bus"><bounds x="181" y="342" width="52" height="12" /></element>
+		<element name="title_bord_mat" ref="title_bord_mat"><bounds x="180" y="361" width="52" height="12" /></element>
+		<element name="title_shad_mat" ref="title_shad_mat"><bounds x="180" y="381" width="52" height="12" /></element>
+
+		<!-- Mattes/Bkgd -->
+		<element name="matte_copy" ref="led"><bounds x="275" y="495"  width="9" height="9" /></element>
+		<element name="mattes_col_bkgd" ref="mattes_col_bkgd"><bounds x="258" y="342" width="53" height="12" /></element>
+		<element name="mattes_bord_mat" ref="mattes_bord_mat"><bounds x="258" y="358" width="53" height="12" /></element>
+		<element name="mattes_shad_mat" ref="mattes_shad_mat"><bounds x="257" y="375" width="53" height="12" /></element>
+		<element name="mattes_dsk_mat"  ref="mattes_dsk_mat"><bounds x="260" y="390" width="46" height="12" /></element>
+		<element name="mattes_dsk_bord" ref="mattes_dsk_bord"><bounds x="257" y="407" width="52" height="12" /></element>
+
+		<!-- Downstream Keyer -->
+		<element name="wide_bord" ref="wide_bord"><bounds x="393" y="344" width="50" height="12" /></element>
+		<element name="narw_bord" ref="narw_bord"><bounds x="392" y="363" width="53" height="12" /></element>
+		<element name="drop_bord" ref="drop_bord"><bounds x="392" y="383" width="52" height="12" /></element>
+		<element name="double"    ref="double"   ><bounds x="396" y="403" width="43" height="12" /></element>
+		<element name="top_left"  ref="top_left" ><bounds x="452" y="344" width="50" height="12" /></element>
+		<element name="top_right" ref="top_right"><bounds x="450" y="364" width="54" height="12" /></element>
+		<element name="btm_left"  ref="btm_left" ><bounds x="448" y="383" width="56" height="12" /></element>
+		<element name="btm_right" ref="btm_right"><bounds x="450" y="403" width="52" height="12" /></element>
+		<element name="border" ref="led"><bounds x="442" y="495"  width="9" height="9" /></element>
+		<element name="dsk_mask_normal" ref="led"><bounds x="534" y="385"  width="9" height="9" /></element>
+		<element name="dsk_mask_invert" ref="led"><bounds x="576" y="385"  width="9" height="9" /></element>
+		<element name="dsk_key_inv"     ref="led"><bounds x="534" y="442"  width="9" height="9" /></element>
+		<element name="dsk_ext_key"     ref="led"><bounds x="576" y="442"  width="9" height="9" /></element>
+		<element name="dsk_fill_video" ref="dsk_fill_video"><bounds x="608" y="345" width="52" height="12" /></element>
+		<element name="dsk_fill_mat"   ref="dsk_fill_mat"  ><bounds x="611" y="364" width="46" height="12" /></element>
+		<element name="dsk_fill_none"  ref="dsk_fill_none" ><bounds x="619" y="383" width="32" height="12" /></element>
+		<element name="dsk_mix"     ref="multi_color_button"><bounds x="537" y="478"  width="43" height="43" /></element>
+
+		<!-- Effect Control -->
+		<element name="effect_ctrl_title"  ref="led"><bounds x="693" y="442"  width="9" height="9" /></element>
+		<element name="effect_ctrl_dsk"    ref="led"><bounds x="736" y="442"  width="9" height="9" /></element>
+		<element name="effect_ctrl_shift"  ref="led"><bounds x="820" y="497"  width="9" height="9" /></element>
+		<element name="pattern_number_set" ref="led"><bounds x="1016" y="497"  width="9" height="9" /></element>
+		<element name="effect_ctrl_modify"  ref="effect_ctrl_modify" ><bounds x="695" y="346" width="42" height="12" /></element>
+		<element name="effect_ctrl_linear"  ref="effect_ctrl_linear" ><bounds x="696" y="366" width="40" height="12" /></element>
+		<element name="effect_ctrl_nonlin"  ref="effect_ctrl_nonlin" ><bounds x="693" y="385" width="46" height="12" /></element>
+		<element name="effect_ctrl_mask"    ref="effect_ctrl_mask"   ><bounds x="700" y="405" width="32" height="12" /></element>
+
+		<!-- Background -->
+		<element name="background_vtr_a"     ref="multi_color_button"><bounds x="79" y="560"  width="43" height="43" /></element>
+		<element name="background_vtr_b"     ref="multi_color_button"><bounds x="124" y="560"  width="43" height="43" /></element>
+		<element name="background_3"         ref="multi_color_button"><bounds x="169" y="560"  width="43" height="43" /></element>
+		<element name="background_4"         ref="multi_color_button"><bounds x="214" y="560"  width="43" height="43" /></element>
+		<element name="background_int_video" ref="multi_color_button"><bounds x="259" y="560"  width="43" height="43" /></element>
+<!--		<text string="VTR A"><color red="0.1" green="0.1" blue="0.1" /></text> -->
+
+		<!-- Foreground -->
+		<element name="foreground_vtr_a"     ref="multi_color_button"><bounds x="75" y="663"  width="43" height="43" /></element>
+		<element name="foreground_vtr_b"     ref="multi_color_button"><bounds x="120" y="663"  width="43" height="43" /></element>
+		<element name="foreground_3"         ref="multi_color_button"><bounds x="165" y="663"  width="43" height="43" /></element>
+		<element name="foreground_4"         ref="multi_color_button"><bounds x="210" y="663"  width="43" height="43" /></element>
+		<element name="foreground_int_video" ref="multi_color_button"><bounds x="255" y="663"  width="43" height="43" /></element>
+
+		<!-- Int Video -->
+		<element name="int_video_col_bkgd"  ref="int_video_col_bkgd" ><bounds x="321" y="578" width="52" height="12" /></element>
+		<element name="int_video_col_bar"   ref="int_video_col_bar"  ><bounds x="322" y="610" width="47" height="12" /></element>
+		<element name="int_video_grid"      ref="int_video_grid"     ><bounds x="331" y="643" width="28" height="12" /></element>
+
+		<!-- Effect Transition -->
+		<element name="trans_rate_background" ref="digit_bg"><bounds x="428" y="571"  width="78" height="38" /></element>
+		<element name="trans_rate100"  ref="digit"><bounds x="428" y="571"  width="26" height="38" /></element>
+		<element name="trans_rate10"   ref="digit"><bounds x="454" y="571"  width="26" height="38" /></element>
+		<element name="trans_rate1"    ref="digit"><bounds x="480" y="571"  width="26" height="38" /></element>
+		<element name="trans_rate_effect"   ref="trans_rate_effect"  ><bounds x="419" y="626" width="40" height="12" /></element>
+		<element name="trans_rate_dsk"      ref="trans_rate_dsk"     ><bounds x="482" y="625" width="23" height="12" /></element>
+		<element name="trans_rate_norm_rev" ref="trans_rate_norm_rev"><bounds x="531" y="609" width="56" height="12" /></element>
+		<element name="transition_effect"  ref="led"><bounds x="433" y="668"  width="9" height="9" /></element>
+		<element name="transition_dsk"     ref="led"><bounds x="490" y="668"  width="9" height="9" /></element>
+		<element name="transition_reverse" ref="led"><bounds x="555" y="668"  width="9" height="9" /></element>
+		<element name="freeze_field"   ref="led"><bounds x="433" y="740"  width="9" height="9" /></element>
+		<element name="freeze_frame"   ref="led"><bounds x="490" y="740"  width="9" height="9" /></element>
+		<element name="transition_auto_trans"  ref="single_color_button"><bounds x="537" y="716"  width="43" height="43" /></element>
+		<element name="transition_0"   ref="squared_led"><bounds x="623" y="598.197"  width="14" height="4.5" /></element>
+		<element name="transition_1"   ref="squared_led"><bounds x="623" y="604.966"  width="14" height="4.5" /></element>
+		<element name="transition_2"   ref="squared_led"><bounds x="623" y="611.735"  width="14" height="4.5" /></element>
+		<element name="transition_3"   ref="squared_led"><bounds x="623" y="618.503"  width="14" height="4.5" /></element>
+		<element name="transition_4"   ref="squared_led"><bounds x="623" y="625.272"  width="14" height="4.5" /></element>
+		<element name="transition_5"   ref="squared_led"><bounds x="623" y="632.041"  width="14" height="4.5" /></element>
+		<element name="transition_6"   ref="squared_led"><bounds x="623" y="638.809"  width="14" height="4.5" /></element>
+		<element name="transition_7"   ref="squared_led"><bounds x="623" y="645.578"  width="14" height="4.5" /></element>
+		<element name="transition_8"   ref="squared_led"><bounds x="623" y="652.347"  width="14" height="4.5" /></element>
+		<element name="transition_9"   ref="squared_led"><bounds x="623" y="659.116"  width="14" height="4.5" /></element>
+		<element name="transition_10"  ref="squared_led"><bounds x="623" y="665.884"  width="14" height="4.5" /></element>
+		<element name="transition_11"  ref="squared_led"><bounds x="623" y="672.653"  width="14" height="4.5" /></element>
+		<element name="transition_12"  ref="squared_led"><bounds x="623" y="679.422"  width="14" height="4.5" /></element>
+		<element name="transition_13"  ref="squared_led"><bounds x="623" y="686.19"  width="14" height="4.5" /></element>
+		<element name="transition_14"  ref="squared_led"><bounds x="623" y="692.959"  width="14" height="4.5" /></element>
+		<element name="transition_15"  ref="squared_led"><bounds x="623" y="699.728"  width="14" height="4.5" /></element>
+		<element name="transition_16"  ref="squared_led"><bounds x="623" y="706.497"  width="14" height="4.5" /></element>
+		<element name="transition_17"  ref="squared_led"><bounds x="623" y="713.265"  width="14" height="4.5" /></element>
+		<element name="transition_18"  ref="squared_led"><bounds x="623" y="720.034"  width="14" height="4.5" /></element>
+		<element name="transition_19"  ref="squared_led"><bounds x="623" y="726.803"  width="14" height="4.5" /></element>
+
+		<!-- Pattern Number -->
+		<element name="pattern_number_background" ref="digit_bg"><bounds x="871" y="483"  width="108" height="41" /></element>
+		<element name="pattern_number1000" ref="digit"><bounds x="873" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number100"  ref="digit"><bounds x="899" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number10"   ref="digit"><bounds x="925" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number1"    ref="digit"><bounds x="951" y="485"  width="26" height="37" /></element>
+
+		<!-- Mode -->
+		<element name="direct_pattern"   ref="led"><bounds x="822" y="574"  width="9" height="9" /></element>
+		<element name="mode_pattern"   ref="mode_pattern"  ><bounds x="801" y="621" width="47" height="12" /></element>
+		<element name="mode_trans"     ref="mode_trans"    ><bounds x="806" y="654" width="38" height="12" /></element>
+		<element name="mode_user_pgm"  ref="mode_user_pgm" ><bounds x="799" y="687" width="54" height="12" /></element>
+		<element name="mode_snap_shot" ref="mode_snap_shot"><bounds x="805" y="720" width="44" height="12" /></element>
+
+		<!-- Pattern / Key Pad -->
+		<element name="keypad_7"     ref="single_color_button"><bounds x="866" y="558"  width="43" height="43" /></element>
+		<element name="keypad_8"     ref="single_color_button"><bounds x="911" y="558"  width="43" height="43" /></element>
+		<element name="keypad_9"     ref="single_color_button"><bounds x="956" y="558"  width="43" height="43" /></element>
+		<element name="keypad_ins"   ref="single_color_button"><bounds x="1001" y="558"  width="43" height="43" /></element>
+		<element name="keypad_4"     ref="single_color_button"><bounds x="866" y="603"  width="43" height="43" /></element>
+		<element name="keypad_5"     ref="single_color_button"><bounds x="911" y="603"  width="43" height="43" /></element>
+		<element name="keypad_6"     ref="single_color_button"><bounds x="956" y="603"  width="43" height="43" /></element>
+		<element name="keypad_del"   ref="single_color_button"><bounds x="1001" y="603"  width="43" height="43" /></element>
+		<element name="keypad_1"     ref="single_color_button"><bounds x="866" y="648"  width="43" height="43" /></element>
+		<element name="keypad_2"     ref="single_color_button"><bounds x="911" y="648"  width="43" height="43" /></element>
+		<element name="keypad_3"     ref="single_color_button"><bounds x="956" y="648"  width="43" height="43" /></element>
+		<element name="keypad_rst"   ref="single_color_button"><bounds x="1001" y="648"  width="43" height="43" /></element>
+		<element name="keypad_0"     ref="single_color_button"><bounds x="866" y="693"  width="43" height="43" /></element>
+		<element name="keypad_down"  ref="no_color_button"><bounds x="911" y="693"  width="43" height="43" /></element>
+		<element name="keypad_up"    ref="no_color_button"><bounds x="956" y="693"  width="43" height="43" /></element>
+		<element name="keypad_enter" ref="no_color_button"><bounds x="1001" y="693"  width="43" height="43" /></element>
+	</view>
+</mamelayout>

--- a/src/mame/layout/dfs500.lay
+++ b/src/mame/layout/dfs500.lay
@@ -304,146 +304,153 @@ license:CC0
 
 	<view name="Control Panel">
 		<bounds x="0" y="0" width="1888" height="927" />
-		<!--<element ref="background"><bounds x="0" y="0" width="1120" height="927" /></element>-->
 		<screen index="0"><bounds x="1120" y="207" width="768" height="512" /></screen>
 
-		<element name="editor_enable" ref="led"><bounds x="117" y="182"  width="9" height="9" /></element>
+		<element name="LD1" ref="led"><!-- EDITOR ENABLE --><bounds x="117" y="182"  width="9" height="9" /></element>
 
 		<!-- Snap Shot -->
 		<element name="snapshot_background" ref="digit_bg"><bounds x="154" y="84"  width="52" height="38" /></element>
-		<element name="snapshot10" ref="digit"><bounds x="154" y="84"  width="26" height="38" /></element>
-		<element name="snapshot1"  ref="digit"><bounds x="180" y="84"  width="26" height="38" /></element>
-		<element name="learn"      ref="led"><bounds x="179" y="139"  width="9" height="9" /></element>
-		<element name="recall"     ref="led"><bounds x="185" y="182"  width="9" height="9" /></element>
-		<element name="hold_input" ref="led"><bounds x="190" y="221"  width="9" height="9" /></element>
+		<element name="snapshot_1" ref="digit"><bounds x="154" y="84"  width="26" height="38" /></element>
+		<element name="snapshot_0" ref="digit"><bounds x="180" y="84"  width="26" height="38" /></element>
+		<element name="LD4" ref="led"><!-- LEARN --><bounds x="179" y="139"  width="9" height="9" /></element>
+		<element name="LD3" ref="led"><!-- RECALL --><bounds x="185" y="182"  width="9" height="9" /></element>
+		<element name="LD2" ref="led"><!-- HOLD INPUT --><bounds x="190" y="221"  width="9" height="9" /></element>
 
 		<!-- Lighting -->
-		<element name="lighting_spot"  ref="lighting_spot" ><bounds x="243" y="86" width="32" height="12" /></element>
-		<element name="lighting_line"  ref="lighting_line" ><bounds x="248" y="114" width="27" height="12" /></element>
-		<element name="lighting_plane" ref="lighting_plane"><bounds x="246" y="141" width="36" height="12" /></element>
-		<element name="lighting_width_wide"   ref="lighting_width_wide"  ><bounds x="313" y="86" width="32" height="12" /></element>
-		<element name="lighting_width_medium" ref="lighting_width_medium"><bounds x="309" y="113" width="44" height="12" /></element>
-		<element name="lighting_width_narrow" ref="lighting_width_narrow"><bounds x="309" y="140" width="49" height="12" /></element>
-		<element name="lighting_intensity_high"   ref="lighting_intensity_high"  ><bounds x="384" y="86" width="30" height="12" /></element>
-		<element name="lighting_intensity_medium" ref="lighting_intensity_medium"><bounds x="378" y="113" width="44" height="12" /></element>
-		<element name="lighting_intensity_low"    ref="lighting_intensity_low"   ><bounds x="386" y="140" width="30" height="12" /></element>
-
-		<element name="lighting" ref="led"><bounds x="333" y="220"  width="9" height="9" /></element>
+		<element name="LD8"  ref="lighting_spot"><bounds x="243" y="86" width="32" height="12" /></element>
+		<element name="LD7"  ref="lighting_line"><bounds x="248" y="114" width="27" height="12" /></element>
+		<element name="LD6"  ref="lighting_plane"><bounds x="246" y="141" width="36" height="12" /></element>
+		<element name="LD11" ref="lighting_width_wide"><bounds x="313" y="86" width="32" height="12" /></element>
+		<element name="LD10" ref="lighting_width_medium"><bounds x="309" y="113" width="44" height="12" /></element>
+		<element name="LD9"  ref="lighting_width_narrow"><bounds x="309" y="140" width="49" height="12" /></element>
+		<element name="LD14" ref="lighting_intensity_high"><bounds x="384" y="86" width="30" height="12" /></element>
+		<element name="LD13" ref="lighting_intensity_medium"><bounds x="378" y="113" width="44" height="12" /></element>
+		<element name="LD12" ref="lighting_intensity_low"><bounds x="386" y="140" width="30" height="12" /></element>
+		<element name="LD5"  ref="led"><!-- LIGHTING --><bounds x="333" y="220"  width="9" height="9" /></element>
 
 		<!-- Trail/Shadow -->
 		<element name="trail_shadow_background" ref="digit_bg"><bounds x="594" y="84"  width="52" height="38" /></element>
-		<element name="trail_shadow_frames10"   ref="digit"><bounds x="594" y="84"  width="26" height="38" /></element>
-		<element name="trail_shadow_frames1"    ref="digit"><bounds x="620" y="84"  width="26" height="38" /></element>
-		<element name="trail"       ref="led"><bounds x="478" y="220"  width="9" height="9" /></element>
-		<element name="drop_border" ref="led"><bounds x="544" y="220"  width="9" height="9" /></element>
-		<element name="shadow"      ref="led"><bounds x="614" y="220"  width="9" height="9" /></element>
-		<element name="trail_drop_type_hard"       ref="trail_drop_type_hard"     ><bounds x="462" y="85" width="36" height="12" /></element>
-		<element name="trail_drop_type_soft"       ref="trail_drop_type_soft"     ><bounds x="462" y="104" width="36" height="12" /></element>
-		<element name="trail_drop_type_hard_star"  ref="trail_drop_type_hard_star"><bounds x="452" y="122" width="59" height="12" /></element>
-		<element name="trail_drop_type_soft_star"  ref="trail_drop_type_soft_star"><bounds x="453" y="140" width="59" height="12" /></element>
-		<element name="trail_drop_fill_self"     ref="trail_drop_fill_self"    ><bounds x="535" y="85" width="31" height="12" /></element>
-		<element name="trail_drop_fill_bord_mat" ref="trail_drop_fill_bord_mat"><bounds x="519" y="104" width="59" height="12" /></element>
-		<element name="trail_drop_fill_shad_mat" ref="trail_drop_fill_shad_mat"><bounds x="519" y="122" width="59" height="12" /></element>
-		<element name="trail_drop_fill_rndm_mat" ref="trail_drop_fill_rndm_mat"><bounds x="519" y="140" width="59" height="12" /></element>
-		<element name="trail_frames_duration" ref="trail_frames_duration"><bounds x="657" y="100" width="54" height="12" /></element>
-		<element name="trail_frames_wid_pos" ref="trail_frames_wid_pos"><bounds x="657" y="119" width="51" height="12" /></element>
-		<element name="trail_frames_density" ref="trail_frames_density"><bounds x="658" y="139" width="47" height="12" /></element>
+		<element name="trail_shadow_frames_1"   ref="digit"><bounds x="594" y="84"  width="26" height="38" /></element>
+		<element name="trail_shadow_frames_0"   ref="digit"><bounds x="620" y="84"  width="26" height="38" /></element>
+		<element name="LD15" ref="led"><!-- TRAIL --><bounds x="478" y="220"  width="9" height="9" /></element>
+		<element name="LD20" ref="led"><!-- DROP BORDER --><bounds x="544" y="220"  width="9" height="9" /></element>
+		<element name="LD25" ref="led"><!-- SHADOW --><bounds x="614" y="220"  width="9" height="9" /></element>
+		<element name="LD19" ref="trail_drop_type_hard"><bounds x="462" y="85" width="36" height="12" /></element>
+		<element name="LD18" ref="trail_drop_type_soft"><bounds x="462" y="104" width="36" height="12" /></element>
+		<element name="LD17" ref="trail_drop_type_hard_star"><bounds x="452" y="122" width="59" height="12" /></element>
+		<element name="LD16" ref="trail_drop_type_soft_star"><bounds x="453" y="140" width="59" height="12" /></element>
+		<element name="LD24" ref="trail_drop_fill_self"><bounds x="535" y="85" width="31" height="12" /></element>
+		<element name="LD23" ref="trail_drop_fill_bord_mat"><bounds x="519" y="104" width="59" height="12" /></element>
+		<element name="LD22" ref="trail_drop_fill_shad_mat"><bounds x="519" y="122" width="59" height="12" /></element>
+		<element name="LD21" ref="trail_drop_fill_rndm_mat"><bounds x="519" y="140" width="59" height="12" /></element>
+		<element name="LD28" ref="trail_frames_duration"><bounds x="657" y="100" width="54" height="12" /></element>
+		<element name="LD27" ref="trail_frames_wid_pos"><bounds x="657" y="119" width="51" height="12" /></element>
+		<element name="LD26" ref="trail_frames_density"><bounds x="658" y="139" width="47" height="12" /></element>
 
 		<!-- Edge -->
-		<element name="edge_border" ref="led"><bounds x="763" y="103"  width="9" height="9" /></element>
-		<element name="edge_soft"   ref="led"><bounds x="758" y="144"  width="9" height="9" /></element>
+		<element name="LD29" ref="led"><!-- EDGE BORDER --><bounds x="763" y="103"  width="9" height="9" /></element>
+		<element name="LD30" ref="led"><!-- EDGE SOFT --><bounds x="758" y="144"  width="9" height="9" /></element>
 
 		<!-- User Program -->
 		<element name="status_background" ref="digit_bg"><bounds x="841" y="84"  width="26" height="38" /></element>
-		<element name="status"     ref="digit"><bounds x="841" y="84"  width="26" height="38" /></element>
+		<element name="status" ref="digit"><bounds x="841" y="84"  width="26" height="38" /></element>
 		<element name="edit_background" ref="digit_bg"><bounds x="833" y="148"  width="26" height="38" /></element>
-		<element name="edit"       ref="digit"><bounds x="833" y="148" width="26" height="38" /></element>
-		<element name="edit_led"   ref="led"><bounds x="837" y="220"  width="9" height="9" /></element>
+		<element name="edit" ref="digit"><bounds x="833" y="148" width="26" height="38" /></element>
+		<element name="LD31" ref="led"><!-- EDIT --><bounds x="837" y="220"  width="9" height="9" /></element>
 
 		<!-- Location -->
-		<element name="location"   ref="led"><bounds x="914" y="221"  width="9" height="9" /></element>
+		<element name="LD32" ref="led"><!-- LOCATION --><bounds x="914" y="221"  width="9" height="9" /></element>
 
 		<!-- Title -->
-		<element name="mask_normal" ref="led"><bounds x="100" y="384"  width="9" height="9" /></element>
-		<element name="mask_invert" ref="led"><bounds x="143" y="384"  width="9" height="9" /></element>
-		<element name="key_inv"     ref="led"><bounds x="98"  y="440"  width="9" height="9" /></element>
-		<element name="ext_key"     ref="led"><bounds x="140" y="440"  width="9" height="9" /></element>
-		<element name="title"       ref="led"><bounds x="117" y="495"  width="9" height="9" /></element>
-		<element name="title_frgd_bus" ref="title_frgd_bus"><bounds x="181" y="342" width="52" height="12" /></element>
-		<element name="title_bord_mat" ref="title_bord_mat"><bounds x="180" y="361" width="52" height="12" /></element>
-		<element name="title_shad_mat" ref="title_shad_mat"><bounds x="180" y="381" width="52" height="12" /></element>
+		<element name="LD34" ref="led"><!-- MASK NORMAL --><bounds x="100" y="384"  width="9" height="9" /></element>
+		<element name="LD36" ref="led"><!-- MASK INVERT --><bounds x="143" y="384"  width="9" height="9" /></element>
+		<element name="LD33" ref="led"><!-- KEY INV --><bounds x="98"  y="440"  width="9" height="9" /></element>
+		<element name="LD35" ref="led"><!-- EXT KEY --><bounds x="140" y="440"  width="9" height="9" /></element>
+		<element name="LD37" ref="led"><!-- TITLE --><bounds x="117" y="495"  width="9" height="9" /></element>
+		<element name="LD40" ref="title_frgd_bus"><bounds x="181" y="342" width="52" height="12" /></element>
+		<element name="LD39" ref="title_bord_mat"><bounds x="180" y="361" width="52" height="12" /></element>
+		<element name="LD38" ref="title_shad_mat"><bounds x="180" y="381" width="52" height="12" /></element>
 
 		<!-- Mattes/Bkgd -->
-		<element name="matte_copy" ref="led"><bounds x="275" y="495"  width="9" height="9" /></element>
-		<element name="mattes_col_bkgd" ref="mattes_col_bkgd"><bounds x="258" y="342" width="53" height="12" /></element>
-		<element name="mattes_bord_mat" ref="mattes_bord_mat"><bounds x="258" y="358" width="53" height="12" /></element>
-		<element name="mattes_shad_mat" ref="mattes_shad_mat"><bounds x="257" y="375" width="53" height="12" /></element>
-		<element name="mattes_dsk_mat"  ref="mattes_dsk_mat"><bounds x="260" y="390" width="46" height="12" /></element>
-		<element name="mattes_dsk_bord" ref="mattes_dsk_bord"><bounds x="257" y="407" width="52" height="12" /></element>
+		<element name="LD63" ref="led"><!-- MATTE COPY --><bounds x="275" y="495"  width="9" height="9" /></element>
+		<element name="LD62" ref="mattes_col_bkgd"><bounds x="258" y="342" width="53" height="12" /></element>
+		<element name="LD61" ref="mattes_bord_mat"><bounds x="258" y="358" width="53" height="12" /></element>
+		<element name="LD60" ref="mattes_shad_mat"><bounds x="257" y="375" width="53" height="12" /></element>
+		<element name="LD59" ref="mattes_dsk_mat"><bounds x="260" y="390" width="46" height="12" /></element>
+		<element name="LD58" ref="mattes_dsk_bord"><bounds x="257" y="407" width="52" height="12" /></element>
 
 		<!-- Downstream Keyer -->
-		<element name="wide_bord" ref="wide_bord"><bounds x="393" y="344" width="50" height="12" /></element>
-		<element name="narw_bord" ref="narw_bord"><bounds x="392" y="363" width="53" height="12" /></element>
-		<element name="drop_bord" ref="drop_bord"><bounds x="392" y="383" width="52" height="12" /></element>
-		<element name="double"    ref="double"   ><bounds x="396" y="403" width="43" height="12" /></element>
-		<element name="top_left"  ref="top_left" ><bounds x="452" y="344" width="50" height="12" /></element>
-		<element name="top_right" ref="top_right"><bounds x="450" y="364" width="54" height="12" /></element>
-		<element name="btm_left"  ref="btm_left" ><bounds x="448" y="383" width="56" height="12" /></element>
-		<element name="btm_right" ref="btm_right"><bounds x="450" y="403" width="52" height="12" /></element>
-		<element name="border" ref="led"><bounds x="442" y="495"  width="9" height="9" /></element>
-		<element name="dsk_mask_normal" ref="led"><bounds x="534" y="385"  width="9" height="9" /></element>
-		<element name="dsk_mask_invert" ref="led"><bounds x="576" y="385"  width="9" height="9" /></element>
-		<element name="dsk_key_inv"     ref="led"><bounds x="534" y="442"  width="9" height="9" /></element>
-		<element name="dsk_ext_key"     ref="led"><bounds x="576" y="442"  width="9" height="9" /></element>
-		<element name="dsk_fill_video" ref="dsk_fill_video"><bounds x="608" y="345" width="52" height="12" /></element>
-		<element name="dsk_fill_mat"   ref="dsk_fill_mat"  ><bounds x="611" y="364" width="46" height="12" /></element>
-		<element name="dsk_fill_none"  ref="dsk_fill_none" ><bounds x="619" y="383" width="32" height="12" /></element>
-		<element name="dsk_mix"     ref="multi_color_button"><bounds x="537" y="478"  width="43" height="43" /></element>
+		<element name="LD53" ref="wide_bord"><bounds x="393" y="344" width="50" height="12" /></element>
+		<element name="LD52" ref="narw_bord"><bounds x="392" y="363" width="53" height="12" /></element>
+		<element name="LD51" ref="drop_bord"><bounds x="392" y="383" width="52" height="12" /></element>
+		<element name="LD50" ref="double"><bounds x="396" y="403" width="43" height="12" /></element>
+		<element name="LD57" ref="top_left"><bounds x="452" y="344" width="50" height="12" /></element>
+		<element name="LD56" ref="top_right"><bounds x="450" y="364" width="54" height="12" /></element>
+		<element name="LD55" ref="btm_left" ><bounds x="448" y="383" width="56" height="12" /></element>
+		<element name="LD54" ref="btm_right"><bounds x="450" y="403" width="52" height="12" /></element>
+		<element name="LD49" ref="led"><!-- BORDER --><bounds x="442" y="495"  width="9" height="9" /></element>
+		<element name="LD42" ref="led"><!-- DSK MASK NORMAL --><bounds x="534" y="385"  width="9" height="9" /></element>
+		<element name="LD44" ref="led"><!-- DSK MASK INVERT --><bounds x="576" y="385"  width="9" height="9" /></element>
+		<element name="LD41" ref="led"><!-- DSK KEY INV --><bounds x="534" y="442"  width="9" height="9" /></element>
+		<element name="LD43" ref="led"><!-- DSK EXT KEY --><bounds x="576" y="442"  width="9" height="9" /></element>
+		<element name="LD48" ref="dsk_fill_video"><bounds x="608" y="345" width="52" height="12" /></element>
+		<element name="LD47" ref="dsk_fill_mat"  ><bounds x="611" y="364" width="46" height="12" /></element>
+		<element name="LD46" ref="dsk_fill_none" ><bounds x="619" y="383" width="32" height="12" /></element>
+		<element name="LD45" ref="multi_color_button"><bounds x="537" y="478"  width="43" height="43" /></element>
 
 		<!-- Effect Control -->
-		<element name="effect_ctrl_title"  ref="led"><bounds x="693" y="442"  width="9" height="9" /></element>
-		<element name="effect_ctrl_dsk"    ref="led"><bounds x="736" y="442"  width="9" height="9" /></element>
-		<element name="effect_ctrl_shift"  ref="led"><bounds x="820" y="497"  width="9" height="9" /></element>
-		<element name="pattern_number_set" ref="led"><bounds x="1016" y="497"  width="9" height="9" /></element>
-		<element name="effect_ctrl_modify"  ref="effect_ctrl_modify" ><bounds x="695" y="346" width="42" height="12" /></element>
-		<element name="effect_ctrl_linear"  ref="effect_ctrl_linear" ><bounds x="696" y="366" width="40" height="12" /></element>
-		<element name="effect_ctrl_nonlin"  ref="effect_ctrl_nonlin" ><bounds x="693" y="385" width="46" height="12" /></element>
-		<element name="effect_ctrl_mask"    ref="effect_ctrl_mask"   ><bounds x="700" y="405" width="32" height="12" /></element>
+		<element name="LD65"  ref="led"><!-- EFFECT CTRL: TITLE --><bounds x="693" y="442"  width="9" height="9" /></element>
+		<element name="LD66"  ref="led"><!-- EFFECT CTRL: DSK --><bounds x="736" y="442"  width="9" height="9" /></element>
+		<element name="LD234" ref="led"><!-- EFFECT CTRL: SHIFT --><bounds x="820" y="497"  width="9" height="9" /></element>
+		<element name="LD64"  ref="led"><!-- PATTERN NUMBER: SET --><bounds x="1016" y="497"  width="9" height="9" /></element>
+		<element name="LD69"  ref="effect_ctrl_modify"><bounds x="695" y="346" width="42" height="12" /></element>
+		<element name="LD68"  ref="effect_ctrl_linear"><bounds x="696" y="366" width="40" height="12" /></element>
+		<element name="LD67"  ref="effect_ctrl_nonlin"><bounds x="693" y="385" width="46" height="12" /></element>
+		<element name="LD235" ref="effect_ctrl_mask"><bounds x="700" y="405" width="32" height="12" /></element>
 
 		<!-- Background -->
-		<element name="background_vtr_a"     ref="multi_color_button"><bounds x="79" y="560"  width="43" height="43" /></element>
-		<element name="background_vtr_b"     ref="multi_color_button"><bounds x="124" y="560"  width="43" height="43" /></element>
-		<element name="background_3"         ref="multi_color_button"><bounds x="169" y="560"  width="43" height="43" /></element>
-		<element name="background_4"         ref="multi_color_button"><bounds x="214" y="560"  width="43" height="43" /></element>
-		<element name="background_int_video" ref="multi_color_button"><bounds x="259" y="560"  width="43" height="43" /></element>
-<!--		<text string="VTR A"><color red="0.1" green="0.1" blue="0.1" /></text> -->
+		<element name="LD75" ref="multi_color_button"><!-- VTR A --><bounds x="79" y="560"  width="43" height="43" /></element>
+		<element name="LD76" ref="multi_color_button"><!-- VTR B --><bounds x="124" y="560"  width="43" height="43" /></element>
+		<element name="LD77" ref="multi_color_button"><!-- 3 --><bounds x="169" y="560"  width="43" height="43" /></element>
+		<element name="LD78" ref="multi_color_button"><!-- 4 --><bounds x="214" y="560"  width="43" height="43" /></element>
+		<element name="LD79" ref="multi_color_button"><!-- INT VIDEO --><bounds x="259" y="560"  width="43" height="43" /></element>
+<!-- TODO:	<text string="VTR A"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="VTR B"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="3"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="4"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="INT VIDEO"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
 
 		<!-- Foreground -->
-		<element name="foreground_vtr_a"     ref="multi_color_button"><bounds x="75" y="663"  width="43" height="43" /></element>
-		<element name="foreground_vtr_b"     ref="multi_color_button"><bounds x="120" y="663"  width="43" height="43" /></element>
-		<element name="foreground_3"         ref="multi_color_button"><bounds x="165" y="663"  width="43" height="43" /></element>
-		<element name="foreground_4"         ref="multi_color_button"><bounds x="210" y="663"  width="43" height="43" /></element>
-		<element name="foreground_int_video" ref="multi_color_button"><bounds x="255" y="663"  width="43" height="43" /></element>
+		<element name="LD70" ref="multi_color_button"><!-- VTR A --><bounds x="75" y="663"  width="43" height="43" /></element>
+		<element name="LD71" ref="multi_color_button"><!-- VTR B --><bounds x="120" y="663"  width="43" height="43" /></element>
+		<element name="LD72" ref="multi_color_button"><!-- 3 --><bounds x="165" y="663"  width="43" height="43" /></element>
+		<element name="LD73" ref="multi_color_button"><!-- 4 --><bounds x="210" y="663"  width="43" height="43" /></element>
+		<element name="LD74" ref="multi_color_button"><!-- INT VIDEO --><bounds x="255" y="663"  width="43" height="43" /></element>
+<!-- TODO:	<text string="VTR A"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="VTR B"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="3"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="4"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
+<!-- TODO:	<text string="INT VIDEO"><color red="0.1" green="0.1" blue="0.1" /><bounds x="..." y="..."  width="..." height="..." /></text> -->
 
 		<!-- Int Video -->
-		<element name="int_video_col_bkgd"  ref="int_video_col_bkgd" ><bounds x="321" y="578" width="52" height="12" /></element>
-		<element name="int_video_col_bar"   ref="int_video_col_bar"  ><bounds x="322" y="610" width="47" height="12" /></element>
-		<element name="int_video_grid"      ref="int_video_grid"     ><bounds x="331" y="643" width="28" height="12" /></element>
+		<element name="LD82" ref="int_video_col_bkgd"><bounds x="321" y="578" width="52" height="12" /></element>
+		<element name="LD81" ref="int_video_col_bar"><bounds x="322" y="610" width="47" height="12" /></element>
+		<element name="LD80" ref="int_video_grid"><bounds x="331" y="643" width="28" height="12" /></element>
 
 		<!-- Effect Transition -->
 		<element name="trans_rate_background" ref="digit_bg"><bounds x="428" y="571"  width="78" height="38" /></element>
-		<element name="trans_rate100"  ref="digit"><bounds x="428" y="571"  width="26" height="38" /></element>
-		<element name="trans_rate10"   ref="digit"><bounds x="454" y="571"  width="26" height="38" /></element>
-		<element name="trans_rate1"    ref="digit"><bounds x="480" y="571"  width="26" height="38" /></element>
-		<element name="trans_rate_effect"   ref="trans_rate_effect"  ><bounds x="419" y="626" width="40" height="12" /></element>
-		<element name="trans_rate_dsk"      ref="trans_rate_dsk"     ><bounds x="482" y="625" width="23" height="12" /></element>
-		<element name="trans_rate_norm_rev" ref="trans_rate_norm_rev"><bounds x="531" y="609" width="56" height="12" /></element>
-		<element name="transition_effect"  ref="led"><bounds x="433" y="668"  width="9" height="9" /></element>
-		<element name="transition_dsk"     ref="led"><bounds x="490" y="668"  width="9" height="9" /></element>
-		<element name="transition_reverse" ref="led"><bounds x="555" y="668"  width="9" height="9" /></element>
-		<element name="freeze_field"   ref="led"><bounds x="433" y="740"  width="9" height="9" /></element>
-		<element name="freeze_frame"   ref="led"><bounds x="490" y="740"  width="9" height="9" /></element>
-		<element name="transition_auto_trans"  ref="single_color_button"><bounds x="537" y="716"  width="43" height="43" /></element>
+		<element name="trans_rate_2" ref="digit"><bounds x="428" y="571"  width="26" height="38" /></element>
+		<element name="trans_rate_1" ref="digit"><bounds x="454" y="571"  width="26" height="38" /></element>
+		<element name="trans_rate_0" ref="digit"><bounds x="480" y="571"  width="26" height="38" /></element>
+		<element name="LD88" ref="trans_rate_effect"><!-- TRANS RATE EFFECT --><bounds x="419" y="626" width="40" height="12" /></element>
+		<element name="LD86" ref="trans_rate_dsk"><!-- TRANS RATE DSK --><bounds x="482" y="625" width="23" height="12" /></element>
+		<element name="LD90" ref="trans_rate_norm_rev"><!-- TRANS RATE NORM/REV --><bounds x="531" y="609" width="56" height="12" /></element>
+		<element name="LD85" ref="led"><!-- TRANSITION EFFECT --><bounds x="433" y="668"  width="9" height="9" /></element>
+		<element name="LD87" ref="led"><!-- TRANSITION DSK --><bounds x="490" y="668"  width="9" height="9" /></element>
+		<element name="LD91" ref="led"><!-- TRANSITION REVERSE --><bounds x="555" y="668"  width="9" height="9" /></element>
+		<element name="LD83" ref="led"><!-- FREEZE FIELD --><bounds x="433" y="740"  width="9" height="9" /></element>
+		<element name="LD84" ref="led"><!-- FREEZE FRAME --><bounds x="490" y="740"  width="9" height="9" /></element>
+		<element name="LD89" ref="single_color_button"><!-- TRANSITION AUTO TRANS --><bounds x="537" y="716"  width="43" height="43" /></element>
 		<element name="transition_0"   ref="squared_led"><bounds x="623" y="598.197"  width="14" height="4.5" /></element>
 		<element name="transition_1"   ref="squared_led"><bounds x="623" y="604.966"  width="14" height="4.5" /></element>
 		<element name="transition_2"   ref="squared_led"><bounds x="623" y="611.735"  width="14" height="4.5" /></element>
@@ -467,34 +474,34 @@ license:CC0
 
 		<!-- Pattern Number -->
 		<element name="pattern_number_background" ref="digit_bg"><bounds x="871" y="483"  width="108" height="41" /></element>
-		<element name="pattern_number1000" ref="digit"><bounds x="873" y="485"  width="26" height="37" /></element>
-		<element name="pattern_number100"  ref="digit"><bounds x="899" y="485"  width="26" height="37" /></element>
-		<element name="pattern_number10"   ref="digit"><bounds x="925" y="485"  width="26" height="37" /></element>
-		<element name="pattern_number1"    ref="digit"><bounds x="951" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number_3" ref="digit"><bounds x="873" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number_2" ref="digit"><bounds x="899" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number_1" ref="digit"><bounds x="925" y="485"  width="26" height="37" /></element>
+		<element name="pattern_number_0" ref="digit"><bounds x="951" y="485"  width="26" height="37" /></element>
 
 		<!-- Mode -->
-		<element name="direct_pattern"   ref="led"><bounds x="822" y="574"  width="9" height="9" /></element>
-		<element name="mode_pattern"   ref="mode_pattern"  ><bounds x="801" y="621" width="47" height="12" /></element>
-		<element name="mode_trans"     ref="mode_trans"    ><bounds x="806" y="654" width="38" height="12" /></element>
-		<element name="mode_user_pgm"  ref="mode_user_pgm" ><bounds x="799" y="687" width="54" height="12" /></element>
-		<element name="mode_snap_shot" ref="mode_snap_shot"><bounds x="805" y="720" width="44" height="12" /></element>
+		<element name="LD96" ref="led"><!-- DIRECT PATTERN --><bounds x="822" y="574"  width="9" height="9" /></element>
+		<element name="LD95" ref="mode_pattern"  ><bounds x="801" y="621" width="47" height="12" /></element>
+		<element name="LD94" ref="mode_trans"    ><bounds x="806" y="654" width="38" height="12" /></element>
+		<element name="LD93" ref="mode_user_pgm" ><bounds x="799" y="687" width="54" height="12" /></element>
+		<element name="LD92" ref="mode_snap_shot"><bounds x="805" y="720" width="44" height="12" /></element>
 
 		<!-- Pattern / Key Pad -->
-		<element name="keypad_7"     ref="single_color_button"><bounds x="866" y="558"  width="43" height="43" /></element>
-		<element name="keypad_8"     ref="single_color_button"><bounds x="911" y="558"  width="43" height="43" /></element>
-		<element name="keypad_9"     ref="single_color_button"><bounds x="956" y="558"  width="43" height="43" /></element>
-		<element name="keypad_ins"   ref="single_color_button"><bounds x="1001" y="558"  width="43" height="43" /></element>
-		<element name="keypad_4"     ref="single_color_button"><bounds x="866" y="603"  width="43" height="43" /></element>
-		<element name="keypad_5"     ref="single_color_button"><bounds x="911" y="603"  width="43" height="43" /></element>
-		<element name="keypad_6"     ref="single_color_button"><bounds x="956" y="603"  width="43" height="43" /></element>
-		<element name="keypad_del"   ref="single_color_button"><bounds x="1001" y="603"  width="43" height="43" /></element>
-		<element name="keypad_1"     ref="single_color_button"><bounds x="866" y="648"  width="43" height="43" /></element>
-		<element name="keypad_2"     ref="single_color_button"><bounds x="911" y="648"  width="43" height="43" /></element>
-		<element name="keypad_3"     ref="single_color_button"><bounds x="956" y="648"  width="43" height="43" /></element>
-		<element name="keypad_rst"   ref="single_color_button"><bounds x="1001" y="648"  width="43" height="43" /></element>
-		<element name="keypad_0"     ref="single_color_button"><bounds x="866" y="693"  width="43" height="43" /></element>
-		<element name="keypad_down"  ref="no_color_button"><bounds x="911" y="693"  width="43" height="43" /></element>
-		<element name="keypad_up"    ref="no_color_button"><bounds x="956" y="693"  width="43" height="43" /></element>
-		<element name="keypad_enter" ref="no_color_button"><bounds x="1001" y="693"  width="43" height="43" /></element>
+		<element name="LD106" ref="single_color_button"><!-- KEYPAD 7 --><bounds x="866" y="558"  width="43" height="43" /></element>
+		<element name="LD107" ref="single_color_button"><!-- KEYPAD 8 --><bounds x="911" y="558"  width="43" height="43" /></element>
+		<element name="LD108" ref="single_color_button"><!-- KEYPAD 9 --><bounds x="956" y="558"  width="43" height="43" /></element>
+		<element name="LD109" ref="single_color_button"><!-- KEYPAD INS --><bounds x="1001" y="558"  width="43" height="43" /></element>
+		<element name="LD102" ref="single_color_button"><!-- KEYPAD 4 --><bounds x="866" y="603"  width="43" height="43" /></element>
+		<element name="LD103" ref="single_color_button"><!-- KEYPAD 5 --><bounds x="911" y="603"  width="43" height="43" /></element>
+		<element name="LD104" ref="single_color_button"><!-- KEYPAD 6 --><bounds x="956" y="603"  width="43" height="43" /></element>
+		<element name="LD105" ref="single_color_button"><!-- KEYPAD DEL --><bounds x="1001" y="603"  width="43" height="43" /></element>
+		<element name="LD98"  ref="single_color_button"><!-- KEYPAD 1 --><bounds x="866" y="648"  width="43" height="43" /></element>
+		<element name="LD99"  ref="single_color_button"><!-- KEYPAD 2 --><bounds x="911" y="648"  width="43" height="43" /></element>
+		<element name="LD100" ref="single_color_button"><!-- KEYPAD 3 --><bounds x="956" y="648"  width="43" height="43" /></element>
+		<element name="LD101" ref="single_color_button"><!-- KEYPAD RST --><bounds x="1001" y="648"  width="43" height="43" /></element>
+		<element name="LD97"  ref="single_color_button"><!-- KEYPAD 0 --><bounds x="866" y="693"  width="43" height="43" /></element>
+		<element name="keypad_down"  ref="no_color_button"><!-- KEYPAD DOWN --><bounds x="911" y="693"  width="43" height="43" /></element>
+		<element name="keypad_up"    ref="no_color_button"><!-- KEYPAD UP --><bounds x="956" y="693"  width="43" height="43" /></element>
+		<element name="keypad_enter" ref="no_color_button"><!-- KEYPAD ENTER --><bounds x="1001" y="693"  width="43" height="43" /></element>
 	</view>
 </mamelayout>

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -3368,6 +3368,11 @@ bestleaw                        // bootleg
 @source:beta.cpp
 beta                            //
 
+@source:betacam.cpp
+uvw1200                         // 199? Sony Betacam-SP UVW-1200
+uvw1600                         // 199? Sony Betacam-SP UVW-1600
+uvw1800                         // 199? Sony Betacam-SP UVW-1800
+
 @source:bfcobra.cpp
 beeline                         // 1991 BFM
 brkball                         // 1994 BFM / ATOD
@@ -12112,6 +12117,9 @@ destroyr1                       // 030131-030136    1977/10 [6800]
 @source:dfruit.cpp
 dfruit                          //
 gemcrush
+
+@source:dfs500.cpp
+dfs500                          // 1994 Sony DFS-500 Video Mixer
 
 @source:dg680.cpp
 dg680                           //
@@ -40905,6 +40913,9 @@ ultratnk                        // 009801           1978/02 [6502]
 
 @source:ultrsprt.cpp
 fiveside                        // GX479 (c)1995
+
+@source:umatic.cpp
+vo5850pm                        // Sony U-Matic VO-5850PM
 
 @source:umipoker.cpp
 saiyukip                        //

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -113,6 +113,7 @@ bebox.cpp
 bert.cpp
 besta.cpp
 beta.cpp
+betacam.cpp
 bigbord2.cpp
 binbug.cpp
 bitel.cpp
@@ -219,6 +220,7 @@ debut.cpp
 decstation.cpp
 dectalk.cpp
 decwritr.cpp
+dfs500.cpp
 dg680.cpp
 dgn_beta.cpp
 diablo1300.cpp
@@ -1042,6 +1044,7 @@ tx0.cpp
 uchroma68.cpp
 uknc.cpp
 ultim809.cpp
+umatic.cpp
 unichamp.cpp
 unior.cpp
 unistar.cpp


### PR DESCRIPTION
This is a followup to PR #7346 

This PR includes:
* New non-working driver: SONY DFS-500 DME Video Mixer (1994)
* New skeleton drivers for SONY VCRs: U-Matic vo5850PM and BETACAM-SP models UVW-1200, UVW-1600, UVW-1800

I've completely removed any use of the legacy `output().set_value` API calls and adopted `output_finders`, as suggested by @cuavas at https://github.com/mamedev/mame/pull/7346#issuecomment-710344184

Internal Artwork Layout:
![Screenshot from 2020-10-18 05-02-05](https://user-images.githubusercontent.com/213676/96361784-19c55600-10ff-11eb-87b1-1ea7643b550e.png)

External Artwork Layout: (hosted at https://github.com/felipesanches/dfs500_MAME_artwork):
![Screenshot from 2020-10-18 05-01-27](https://user-images.githubusercontent.com/213676/96361789-31044380-10ff-11eb-9f29-1a9d86d7e470.png)

