### PR TITLE
Apple II a2bus Orange Micro Grappler Plus driver

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2398,6 +2398,8 @@ if (BUSES["A2BUS"]~=null) then
 		MAME_DIR .. "src/devices/bus/a2bus/uthernet.h",
 		MAME_DIR .. "src/devices/bus/a2bus/sider.cpp",
 		MAME_DIR .. "src/devices/bus/a2bus/sider.h",
+		MAME_DIR .. "src/devices/bus/a2bus/grapplerplus.cpp",
+		MAME_DIR .. "src/devices/bus/a2bus/grapplerplus.h",
 	}
 end
 

--- a/src/devices/bus/a2bus/grapplerplus.cpp
+++ b/src/devices/bus/a2bus/grapplerplus.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:R. Belmont, Golden Child
 /*********************************************************************
 
-    grapplerplus.c
+    grapplerplus.cpp
 
     Orange Micro Grappler Plus Apple II Parallel Interface Card
 
@@ -17,11 +17,8 @@
 
 DEFINE_DEVICE_TYPE(A2BUS_GRAPPLERPLUS, a2bus_grapplerplus_device, "grapplerplus", "Grappler Interface Card")
 
-#define GRAPPLERPLUS_ROM_REGION  "grapplerplus_rom"
-#define GRAPPLERPLUS_CENTRONICS_TAG "centronics"
-
 ROM_START( grapplerplus )
-	ROM_REGION(0x001000, GRAPPLERPLUS_ROM_REGION, 0)
+	ROM_REGION(0x001000, "grapplerplus_rom", 0)
 	ROM_LOAD( "grapplerplus.bin", 0x000000, 0x001000, CRC(6f88b70c) SHA1(433ae61a0553ee9c1628ea5b6376dac848c04cad) )
 ROM_END
 
@@ -86,10 +83,10 @@ a2bus_grapplerplus_device::a2bus_grapplerplus_device(const machine_config &mconf
 	device_t(mconfig, type, tag, owner, clock),
 	device_a2bus_card_interface(mconfig, *this),
 	m_dsw1(*this, "DSW1"),
-	m_ctx(*this, GRAPPLERPLUS_CENTRONICS_TAG),
+	m_ctx(*this, "centronics"),
 	m_ctx_data_in(*this, "ctx_data_in"),
 	m_ctx_data_out(*this, "ctx_data_out"),
-	m_rom(*this, GRAPPLERPLUS_ROM_REGION),
+	m_rom(*this, "grapplerplus_rom"),
 	m_started(false), m_ack(0), m_busy(0), m_perror(0), m_select(0), m_irqbit(0), m_irqenable(false), m_timer(nullptr)
 {
 }
@@ -129,8 +126,6 @@ void a2bus_grapplerplus_device::device_reset()
 void a2bus_grapplerplus_device::device_timer(emu_timer &timer, device_timer_id tid, int param, void *ptr)
 {
 	clear_strobe();
-
-	m_timer->adjust(attotime::never);
 }
 
 /*-------------------------------------------------
@@ -140,7 +135,7 @@ void a2bus_grapplerplus_device::device_timer(emu_timer &timer, device_timer_id t
 uint8_t a2bus_grapplerplus_device::read_cnxx(uint8_t offset)
 {
 	m_rombank = 0; // reads to cnxx will reset rom bank to bank 1
-	return m_rom[(offset&0xff)];
+	return m_rom[(offset & 0xff)];
 }
 
 /*-------------------------------------------------
@@ -199,9 +194,9 @@ void a2bus_grapplerplus_device::write_c0nx(uint8_t offset, uint8_t data)
 
 WRITE_LINE_MEMBER( a2bus_grapplerplus_device::ack_w )
 {
+	m_ack = state;
 	if (m_started)
 	{
-		m_ack = state;
 		if (state && m_irqenable)
 		{
 			raise_slot_irq();
@@ -212,17 +207,17 @@ WRITE_LINE_MEMBER( a2bus_grapplerplus_device::ack_w )
 
 WRITE_LINE_MEMBER( a2bus_grapplerplus_device::perror_w )
 {
-	m_perror = (state == ASSERT_LINE) ? true : false;
+	m_perror = state;
 }
 
 WRITE_LINE_MEMBER( a2bus_grapplerplus_device::busy_w )
 {
-	m_busy = (state == ASSERT_LINE) ? true : false;
+	m_busy = state;
 }
 
 WRITE_LINE_MEMBER( a2bus_grapplerplus_device::select_w )
 {
-	m_select = (state == ASSERT_LINE) ? true : false;
+	m_select = state;
 }
 
 void a2bus_grapplerplus_device::start_strobe()

--- a/src/devices/bus/a2bus/grapplerplus.cpp
+++ b/src/devices/bus/a2bus/grapplerplus.cpp
@@ -1,0 +1,236 @@
+// license:BSD-3-Clause
+// copyright-holders:R. Belmont, Golden Child
+/*********************************************************************
+
+    grapplerplus.c
+
+    Orange Micro Grappler Plus Apple II Parallel Interface Card
+
+*********************************************************************/
+
+#include "emu.h"
+#include "grapplerplus.h"
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(A2BUS_GRAPPLERPLUS, a2bus_grapplerplus_device, "grapplerplus", "Grappler Interface Card")
+
+#define GRAPPLERPLUS_ROM_REGION  "grapplerplus_rom"
+#define GRAPPLERPLUS_CENTRONICS_TAG "centronics"
+
+ROM_START( grapplerplus )
+	ROM_REGION(0x001000, GRAPPLERPLUS_ROM_REGION, 0)
+	ROM_LOAD( "grapplerplus.bin", 0x000000, 0x001000, CRC(6f88b70c) SHA1(433ae61a0553ee9c1628ea5b6376dac848c04cad) )
+ROM_END
+
+static INPUT_PORTS_START( grapplerplus )
+	PORT_START("DSW1")
+	PORT_DIPNAME( 0x01, 0x00, "MSB Control (SW1)" )
+	PORT_DIPSETTING( 0x00, "7 bit only" )
+	PORT_DIPSETTING( 0x01, "8 bit" )
+
+	PORT_DIPNAME( 0x0e, 0x0e, "Printer Type ID (SW2-4)" )
+	PORT_DIPSETTING( 0x0e, "Epson Series" )
+	PORT_DIPSETTING( 0x06, "NEC 8023/C. Itoh 8510/DMP 85" )
+	PORT_DIPSETTING( 0x0a, "Star Gemini" )
+	PORT_DIPSETTING( 0x02, "Anadex Printers" )
+	PORT_DIPSETTING( 0x0c, "Okidata 82A, 83A, 84, 92, 93" )
+	PORT_DIPSETTING( 0x08, "Okidata 84 w/o Step II Graphics" )
+	PORT_DIPSETTING( 0x04, "Apple Dot Matrix" )
+INPUT_PORTS_END
+
+ioport_constructor a2bus_grapplerplus_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( grapplerplus );
+}
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void a2bus_grapplerplus_device::device_add_mconfig(machine_config &config)
+{
+	CENTRONICS(config, m_ctx, centronics_devices, "printer");
+	m_ctx->set_data_input_buffer(m_ctx_data_in);
+	m_ctx->busy_handler().set(FUNC(a2bus_grapplerplus_device::busy_w));
+	m_ctx->perror_handler().set(FUNC(a2bus_grapplerplus_device::perror_w));
+	m_ctx->select_handler().set(FUNC(a2bus_grapplerplus_device::select_w));
+	m_ctx->ack_handler().set(FUNC(a2bus_grapplerplus_device::ack_w));
+
+	INPUT_BUFFER(config, m_ctx_data_in);
+	OUTPUT_LATCH(config, m_ctx_data_out);
+	m_ctx->set_output_latch(*m_ctx_data_out);
+}
+
+//-------------------------------------------------
+//  rom_region - device-specific ROM region
+//-------------------------------------------------
+
+const tiny_rom_entry *a2bus_grapplerplus_device::device_rom_region() const
+{
+	return ROM_NAME( grapplerplus );
+}
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+a2bus_grapplerplus_device::a2bus_grapplerplus_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	a2bus_grapplerplus_device(mconfig, A2BUS_GRAPPLERPLUS, tag, owner, clock)
+{
+}
+
+a2bus_grapplerplus_device::a2bus_grapplerplus_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_a2bus_card_interface(mconfig, *this),
+	m_dsw1(*this, "DSW1"),
+	m_ctx(*this, GRAPPLERPLUS_CENTRONICS_TAG),
+	m_ctx_data_in(*this, "ctx_data_in"),
+	m_ctx_data_out(*this, "ctx_data_out"), m_rom(nullptr),
+	m_started(false), m_ack(0), m_irqenable(false), m_autostrobe(false), m_timer(nullptr)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void a2bus_grapplerplus_device::device_start()
+{
+	m_rom = device().machine().root_device().memregion(this->subtag(GRAPPLERPLUS_ROM_REGION).c_str())->base();
+
+	m_timer = timer_alloc(0, nullptr);
+	m_timer->adjust(attotime::never);
+
+	save_item(NAME(m_ack));
+	save_item(NAME(m_irqenable));
+	save_item(NAME(m_autostrobe));
+}
+
+void a2bus_grapplerplus_device::device_reset()
+{
+	m_started = true;
+	m_ack = 0;
+	m_irqenable = false;
+	m_irqbit = false;
+	m_autostrobe = false;
+	lower_slot_irq();
+	m_timer->adjust(attotime::never);
+
+	// set initial state of the strobe line depending on the dipswitch
+	clear_strobe();
+}
+
+void a2bus_grapplerplus_device::device_timer(emu_timer &timer, device_timer_id tid, int param, void *ptr)
+{
+	clear_strobe();
+
+	m_timer->adjust(attotime::never);
+}
+
+/*-------------------------------------------------
+    read_cnxx - called for reads from this card's cnxx space
+-------------------------------------------------*/
+
+uint8_t a2bus_grapplerplus_device::read_cnxx(uint8_t offset)
+{
+	m_rombank = 0; // reads to cnxx will reset rom bank to bank 1
+	return m_rom[(offset&0xff)];
+}
+
+/*-------------------------------------------------
+    read_c0nx - called for reads from this card's c0nx space
+-------------------------------------------------*/
+
+uint8_t a2bus_grapplerplus_device::read_c0nx(uint8_t offset)
+{
+	uint8_t printertype = ~(m_dsw1->read()) & 0x0e;
+
+	return  ((m_irqbit ? 1 : 0) << 7) |
+			(BIT(printertype,1) << 6) |
+			(BIT(printertype,2) << 5) |
+			(BIT(printertype,3) << 4) |
+			((m_busy ? 1 : 0)   << 3) |
+			((m_perror ? 1 : 0) << 2) |
+			((m_select ? 1 : 0) << 1) |
+			((m_ack ? 1 : 0)    << 0);
+}
+
+uint8_t a2bus_grapplerplus_device::read_c800(uint16_t offset)
+{
+	return m_rom[offset + (m_rombank==0 ? 0x0 : 0x800)];
+}
+
+/*-------------------------------------------------
+    write_c0nx - called for writes to this card's c0nx space
+-------------------------------------------------*/
+
+void a2bus_grapplerplus_device::write_c0nx(uint8_t offset, uint8_t data)
+{
+	switch (offset)
+	{
+		case 0: // Output data and send a strobe
+			m_ctx_data_out->write(data);
+			start_strobe();
+			break;
+
+		case 1: // Set rom bank to bank 2
+			m_rombank=1;
+			break;
+
+		case 2: // Reset interrupt request and IRQ data bit
+			m_irqenable = false;
+			m_irqbit = false;
+			break;
+
+		case 4: // Output data, strobe, enable interrupt on ACK
+			m_ctx_data_out->write(data);
+			start_strobe();
+			m_irqenable = true;
+			m_irqbit = false;
+			break;
+	}
+}
+
+WRITE_LINE_MEMBER( a2bus_grapplerplus_device::ack_w )
+{
+	if (m_started)
+	{
+		m_ack = state;
+		if (state && m_irqenable)
+		{
+			raise_slot_irq();
+			m_irqbit = true;
+		}
+	}
+}
+
+WRITE_LINE_MEMBER( a2bus_grapplerplus_device::perror_w )
+{
+	m_perror = (state == ASSERT_LINE) ? true : false;
+}
+
+WRITE_LINE_MEMBER( a2bus_grapplerplus_device::busy_w )
+{
+	m_busy = (state == ASSERT_LINE) ? true : false;
+}
+
+WRITE_LINE_MEMBER( a2bus_grapplerplus_device::select_w )
+{
+	m_select = (state == ASSERT_LINE) ? true : false;
+}
+
+void a2bus_grapplerplus_device::start_strobe()
+{
+	int usec = 1;  // strobe length in microseconds
+	m_ctx->write_strobe(CLEAR_LINE);
+	m_timer->adjust(attotime::from_usec(usec), 0, attotime::never);
+}
+
+void a2bus_grapplerplus_device::clear_strobe()
+{
+	m_ctx->write_strobe(ASSERT_LINE);
+}
+

--- a/src/devices/bus/a2bus/grapplerplus.h
+++ b/src/devices/bus/a2bus/grapplerplus.h
@@ -2,7 +2,7 @@
 // copyright-holders:R. Belmont, Golden Child
 /*********************************************************************
 
-    grapplerplus.cpp
+    grapplerplus.h
 
     Orange Micro Grappler Plus Apple II Parallel Interface Card
 

--- a/src/devices/bus/a2bus/grapplerplus.h
+++ b/src/devices/bus/a2bus/grapplerplus.h
@@ -51,6 +51,7 @@ protected:
 	required_device<centronics_device> m_ctx;
 	required_device<input_buffer_device> m_ctx_data_in;
 	required_device<output_latch_device> m_ctx_data_out;
+	required_region_ptr<u8> m_rom;
 
 private:
 	DECLARE_WRITE_LINE_MEMBER( ack_w );
@@ -58,7 +59,6 @@ private:
 	DECLARE_WRITE_LINE_MEMBER( perror_w );
 	DECLARE_WRITE_LINE_MEMBER( select_w );
 
-	uint8_t *m_rom;
 	bool m_started;
 	uint8_t m_ack;
 	uint8_t m_busy;
@@ -66,7 +66,6 @@ private:
 	uint8_t m_select;
 	uint8_t m_irqbit;
 	bool m_irqenable;
-	bool m_autostrobe;
 	emu_timer *m_timer;
 	uint8_t m_rombank;
 };

--- a/src/devices/bus/a2bus/grapplerplus.h
+++ b/src/devices/bus/a2bus/grapplerplus.h
@@ -1,0 +1,77 @@
+// license:BSD-3-Clause
+// copyright-holders:R. Belmont, Golden Child
+/*********************************************************************
+
+    grapplerplus.cpp
+
+    Orange Micro Grappler Plus Apple II Parallel Interface Card
+
+*********************************************************************/
+
+#ifndef MAME_BUS_A2BUS_GRAPPLERPLUS_H
+#define MAME_BUS_A2BUS_GRAPPLERPLUS_H
+
+#pragma once
+
+#include "a2bus.h"
+#include "bus/centronics/ctronics.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class a2bus_grapplerplus_device:
+	public device_t,
+	public device_a2bus_card_interface
+{
+public:
+	// construction/destruction
+	a2bus_grapplerplus_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	a2bus_grapplerplus_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+	virtual ioport_constructor device_input_ports() const override;
+
+	virtual uint8_t read_c0nx(uint8_t offset) override;
+	virtual void write_c0nx(uint8_t offset, uint8_t data) override;
+	virtual uint8_t read_cnxx(uint8_t offset) override;
+	virtual uint8_t read_c800(uint16_t offset) override;
+
+	void start_strobe();
+	void clear_strobe();
+
+	required_ioport m_dsw1;
+
+	required_device<centronics_device> m_ctx;
+	required_device<input_buffer_device> m_ctx_data_in;
+	required_device<output_latch_device> m_ctx_data_out;
+
+private:
+	DECLARE_WRITE_LINE_MEMBER( ack_w );
+	DECLARE_WRITE_LINE_MEMBER( busy_w );
+	DECLARE_WRITE_LINE_MEMBER( perror_w );
+	DECLARE_WRITE_LINE_MEMBER( select_w );
+
+	uint8_t *m_rom;
+	bool m_started;
+	uint8_t m_ack;
+	uint8_t m_busy;
+	uint8_t m_perror;
+	uint8_t m_select;
+	uint8_t m_irqbit;
+	bool m_irqenable;
+	bool m_autostrobe;
+	emu_timer *m_timer;
+	uint8_t m_rombank;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(A2BUS_GRAPPLERPLUS, a2bus_grapplerplus_device)
+
+#endif  // MAME_BUS_A2BUS_GRAPPLERPLUS_H

--- a/src/mame/drivers/apple2.cpp
+++ b/src/mame/drivers/apple2.cpp
@@ -91,6 +91,7 @@ II Plus: RAM options reduced to 16/32/48 KB.
 #include "bus/a2bus/transwarp.h"
 #include "bus/a2bus/byte8251.h"
 #include "bus/a2bus/a2iwm.h"
+#include "bus/a2bus/grapplerplus.h"
 
 #include "bus/a2gameio/gameio.h"
 
@@ -1325,6 +1326,7 @@ static void apple2_cards(device_slot_interface &device)
 	device.option_add("applesurance", A2BUS_APPLESURANCE);  /* Applesurance Diagnostic Controller */
 //  device.option_add("magicmusician", A2BUS_MAGICMUSICIAN);    /* Magic Musician Card */
 	device.option_add("byte8251", A2BUS_BYTE8251); /* BYTE Magazine 8251 serial card */
+	device.option_add("grapplerplus", A2BUS_GRAPPLERPLUS); /* Orange Micro Grappler Plus Parallel Interface card */
 }
 
 void apple2_state::apple2_common(machine_config &config)

--- a/src/mame/drivers/apple2e.cpp
+++ b/src/mame/drivers/apple2e.cpp
@@ -177,6 +177,7 @@ MIG RAM page 2 $CE02 is the speaker/slot bitfield and $CE03 is the paddle/accele
 #include "bus/a2bus/a2iwm.h"
 #include "bus/a2bus/uthernet.h"
 #include "bus/a2bus/sider.h"
+#include "bus/a2bus/grapplerplus.h"
 #include "bus/a2gameio/gameio.h"
 
 #include "bus/rs232/rs232.h"
@@ -4528,6 +4529,7 @@ static void apple2_cards(device_slot_interface &device)
 	device.option_add("uthernet", A2BUS_UTHERNET); /* A2RetroSystems Uthernet card */
 	device.option_add("sider2", A2BUS_SIDER2); /* Advanced Tech Systems / First Class Peripherals Sider 2 SASI card */
 	device.option_add("sider1", A2BUS_SIDER1); /* Advanced Tech Systems / First Class Peripherals Sider 1 SASI card */
+	device.option_add("grapplerplus", A2BUS_GRAPPLERPLUS); /* Orange Micro Grappler Plus Parallel Interface card */
 }
 
 static void apple2eaux_cards(device_slot_interface &device)

--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -110,6 +110,7 @@
 //#include "bus/a2bus/ramfast.h"
 #include "bus/a2bus/uthernet.h"
 #include "bus/a2bus/sider.h"
+#include "bus/a2bus/grapplerplus.h"
 
 #include "bus/a2gameio/gameio.h"
 
@@ -4593,6 +4594,7 @@ static void apple2_cards(device_slot_interface &device)
 	device.option_add("uthernet", A2BUS_UTHERNET);  /* A2RetroSystems Uthernet card */
 	device.option_add("sider2", A2BUS_SIDER2); /* Advanced Tech Systems / First Class Peripherals Sider 2 SASI card */
 	device.option_add("sider1", A2BUS_SIDER1); /* Advanced Tech Systems / First Class Peripherals Sider 1 SASI card */
+	device.option_add("grapplerplus", A2BUS_GRAPPLERPLUS); /* Orange Micro Grappler Plus Parallel Interface card */
 }
 
 void apple2gs_state::apple2gs(machine_config &config)


### PR DESCRIPTION
A driver for the Orange Micro Grappler Plus.

./mame64 apple2e -sl1 grapplerplus -sl1:grapplerplus:centronics ap2000

A simple test is to boot the apple 2, reset, then do PR#1   then type CTRL+I G enter.  This will do a graphic dump.

CTRL+I DG enter  is double size.
CTRL+I DERG enter is double size emphasized rotate graphic dump.
CTRL+I S will do a screen dump.

