### PR TITLE
msm5232: fix: behaviour when the 'arm' flag set while envelope generator is on a decay state

### DIFF
--- a/src/devices/sound/msm5232.cpp
+++ b/src/devices/sound/msm5232.cpp
@@ -437,7 +437,11 @@ void msm5232_device::write(offs_t offset, uint8_t data)
 			m_control1 = data;
 
 			for (i=0; i<4; i++)
+			{
+				if ( (data&0x10) && (m_voi[i].eg_sect == 1) )
+					m_voi[i].eg_sect = 0;
 				m_voi[i].eg_arm = data&0x10;
+			}
 
 			m_EN_out16[0] = (data&1) ? ~0:0;
 			m_EN_out8[0]  = (data&2) ? ~0:0;
@@ -458,7 +462,11 @@ void msm5232_device::write(offs_t offset, uint8_t data)
 			gate_update();
 
 			for (i=0; i<4; i++)
+			{
+				if ( (data&0x10) && (m_voi[i+4].eg_sect == 1) )
+					m_voi[i+4].eg_sect = 0;
 				m_voi[i+4].eg_arm = data&0x10;
+			}
 
 			m_EN_out16[1] = (data&1) ? ~0:0;
 			m_EN_out8[1]  = (data&2) ? ~0:0;


### PR DESCRIPTION
msm5232, a tone generator chip which is used by some early TAITO and Alpha Denshi arcade PCBs, has 'arm' flag that alters behaviour of envelope generation.

Basically, the 'arm' flag turns Attack-Decay-Release envelope generation to simpler ON/OFF states.
If the 'arm' flag set, the transition from Attack to Decay doesn't occur unless explicitly indicated.

On current implement, when this 'arm' flag is set on a channel which is on a Decay state, the Decay state continues.
It seems that, the state should be turned into a Attack state in this situation.
