### PR TITLE
k001005.cpp: Add missing command

### DIFF
--- a/src/mame/video/k001005.cpp
+++ b/src/mame/video/k001005.cpp
@@ -782,7 +782,7 @@ void k001005_renderer::render_polygons()
 				render_triangle(visarea, rd_scan_tex2d, 5, v[2], v[3], v[0]);
 			}
 		}
-		else if (cmd == 0x80000121 || cmd == 0x80000126)
+		else if (cmd == 0x80000106 || cmd == 0x80000121 || cmd == 0x80000126)
 		{
 			// no texture, color gouraud, Z
 


### PR DESCRIPTION
Added a missing command only used in jetwave's "How to Control" screen.  This screen would show some model of the jetski in turning the handlebars and leaning on the jetski for controls. This fixes an issue where not only the model(s) wouldn't be present but the game would slow down complaining about an unknown polygon command.