### PR TITLE
fix a Genesis VDP status bit which was breaking Mega Play 68k->Z80 comms

### DIFF
--- a/src/devices/video/315_5313.cpp
+++ b/src/devices/video/315_5313.cpp
@@ -1078,12 +1078,14 @@ u16 sega315_5313_device::ctrl_port_r()
 	/* Megalo Mania also fussy - cares about pending flag*/
 
 	const int sprite_overflow = 0;
-	const int odd_frame = m_imode_odd_frame^1;
+	int odd_frame = 0;
 	int hblank_flag = 0;
 	const int dma_active = 0;
 	int vblank = m_vblank_flag;
 	const int fifo_empty = 1;
 	const int fifo_full = 0;
+
+	if (m_imode & 1) odd_frame = m_imode_odd_frame ^ 1;
 
 	const u16 hpos = get_hposition();
 

--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -3,14 +3,6 @@
 
 /*
 
-Driver is marked as NOT WORKING because interaction between BIOS and 68k side is
-not fully understood.  The BIOS often doesn't register that a game has been started
-and leaves the 'PRESS P1 OR P2 START' message onscreen during gameplay as a result.
-If this happens, the games usually then crash when you run out of lives as they end
-up in an unknown state.
-
-
-
 About MegaPlay:
 
 Megaplay games are specially designed Genesis games, produced for arcade use.
@@ -1014,18 +1006,18 @@ didn't have original Sega part numbers it's probably a converted TWC cart
 ** Probably reused cart case
 */
 
-/* -- */ GAME( 1993, megaplay, 0,        megaplay, megaplay, mplay_state, init_megaplay, ROT0, "Sega", "Mega Play BIOS",                      MACHINE_IS_BIOS_ROOT | MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 01 */ GAME( 1993, mp_sonic, megaplay, megaplay, mp_sonic, mplay_state, init_megaplay, ROT0, "Sega", "Sonic The Hedgehog (Mega Play)",      MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 02 */ GAME( 1993, mp_gaxe2, megaplay, megaplay, mp_gaxe2, mplay_state, init_megaplay, ROT0, "Sega", "Golden Axe II (Mega Play) (Rev B)",   MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 02 */ GAME( 1993, mp_gaxe2a,mp_gaxe2, megaplay, mp_gaxe2, mplay_state, init_megaplay, ROT0, "Sega", "Golden Axe II (Mega Play)",           MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 03 */ GAME( 1993, mp_gslam, megaplay, megaplay, mp_gslam, mplay_state, init_megaplay, ROT0, "Sega", "Grand Slam (Mega Play)",              MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 04 */ GAME( 1993, mp_twcup, megaplay, megaplay, mp_twc,   mplay_state, init_megaplay, ROT0, "Sega", "Tecmo World Cup (Mega Play)",         MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 05 */ GAME( 1993, mp_sor2,  megaplay, megaplay, mp_sor2,  mplay_state, init_megaplay, ROT0, "Sega", "Streets of Rage II (Mega Play)",      MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 06 */ GAME( 1993, mp_bio,   megaplay, megaplay, mp_bio,   mplay_state, init_megaplay, ROT0, "Sega", "Bio-hazard Battle (Mega Play)",       MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 07 */ GAME( 1993, mp_soni2, megaplay, megaplay, mp_soni2, mplay_state, init_megaplay, ROT0, "Sega", "Sonic The Hedgehog 2 (Mega Play)",    MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+/* -- */ GAME( 1993, megaplay, 0,        megaplay, megaplay, mplay_state, init_megaplay, ROT0, "Sega", "Mega Play BIOS",                      MACHINE_IS_BIOS_ROOT | MACHINE_IMPERFECT_GRAPHICS )
+/* 01 */ GAME( 1993, mp_sonic, megaplay, megaplay, mp_sonic, mplay_state, init_megaplay, ROT0, "Sega", "Sonic The Hedgehog (Mega Play)",      MACHINE_IMPERFECT_GRAPHICS )
+/* 02 */ GAME( 1993, mp_gaxe2, megaplay, megaplay, mp_gaxe2, mplay_state, init_megaplay, ROT0, "Sega", "Golden Axe II (Mega Play) (Rev B)",   MACHINE_IMPERFECT_GRAPHICS )
+/* 02 */ GAME( 1993, mp_gaxe2a,mp_gaxe2, megaplay, mp_gaxe2, mplay_state, init_megaplay, ROT0, "Sega", "Golden Axe II (Mega Play)",           MACHINE_IMPERFECT_GRAPHICS )
+/* 03 */ GAME( 1993, mp_gslam, megaplay, megaplay, mp_gslam, mplay_state, init_megaplay, ROT0, "Sega", "Grand Slam (Mega Play)",              MACHINE_IMPERFECT_GRAPHICS )
+/* 04 */ GAME( 1993, mp_twcup, megaplay, megaplay, mp_twc,   mplay_state, init_megaplay, ROT0, "Sega", "Tecmo World Cup (Mega Play)",         MACHINE_IMPERFECT_GRAPHICS )
+/* 05 */ GAME( 1993, mp_sor2,  megaplay, megaplay, mp_sor2,  mplay_state, init_megaplay, ROT0, "Sega", "Streets of Rage II (Mega Play)",      MACHINE_IMPERFECT_GRAPHICS )
+/* 06 */ GAME( 1993, mp_bio,   megaplay, megaplay, mp_bio,   mplay_state, init_megaplay, ROT0, "Sega", "Bio-hazard Battle (Mega Play)",       MACHINE_IMPERFECT_GRAPHICS )
+/* 07 */ GAME( 1993, mp_soni2, megaplay, megaplay, mp_soni2, mplay_state, init_megaplay, ROT0, "Sega", "Sonic The Hedgehog 2 (Mega Play)",    MACHINE_IMPERFECT_GRAPHICS )
 /* 08 - Columns 3? see below */
-/* 09 */ GAME( 1993, mp_shnb3, megaplay, megaplay, mp_shnb3, mplay_state, init_megaplay, ROT0, "Sega", "Shinobi III (Mega Play)",             MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 10 */ GAME( 1993, mp_gunhe, megaplay, megaplay, mp_gunhe, mplay_state, init_megaplay, ROT0, "Sega", "Gunstar Heroes (Mega Play)",          MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
-/* 11 */ GAME( 1993, mp_mazin, megaplay, megaplay, mp_mazin, mplay_state, init_megaplay, ROT0, "Sega", "Mazin Wars / Mazin Saga (Mega Play)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+/* 09 */ GAME( 1993, mp_shnb3, megaplay, megaplay, mp_shnb3, mplay_state, init_megaplay, ROT0, "Sega", "Shinobi III (Mega Play)",             MACHINE_IMPERFECT_GRAPHICS )
+/* 10 */ GAME( 1993, mp_gunhe, megaplay, megaplay, mp_gunhe, mplay_state, init_megaplay, ROT0, "Sega", "Gunstar Heroes (Mega Play)",          MACHINE_IMPERFECT_GRAPHICS )
+/* 11 */ GAME( 1993, mp_mazin, megaplay, megaplay, mp_mazin, mplay_state, init_megaplay, ROT0, "Sega", "Mazin Wars / Mazin Saga (Mega Play)", MACHINE_IMPERFECT_GRAPHICS )
 
-/* ?? */ GAME( 1993, mp_col3,  megaplay, megaplay, mp_col3,  mplay_state, init_megaplay, ROT0, "Sega", "Columns III (Mega Play)",             MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS )
+/* ?? */ GAME( 1993, mp_col3,  megaplay, megaplay, mp_col3,  mplay_state, init_megaplay, ROT0, "Sega", "Columns III (Mega Play)",             MACHINE_IMPERFECT_GRAPHICS )


### PR DESCRIPTION
A bit of a strange one this time, hopefully I can explain it well enough...

This fixes the "odd interlace frame" bit in the VDP status register so that it is only set if interlace is actually enabled. Believe it or not, this was actually the cause of the 68k/Z80 communications issues in Mega Play games that were causing the two CPUs to get confused about the current game state.

This appears to fix all of the sets in megaplay.cpp, but I'll use some 68k code from Sonic 2 as an example.

Every frame, the game checks the "odd frame" bit here, and sets/clears a flag in RAM accordingly:

```
ROM:000003AE                 move.w  ($C00004).l,d0
ROM:000003B4                 btst    #4,d0
ROM:000003B8                 beq.s   loc_3D0
ROM:000003BA                 move.b  #$40,($FFFFAE).l ; interlace odd frame = set flag in RAM
ROM:000003C2                 move.b  #$40,($A10007).l
ROM:000003CA                 movem.w (sp)+,d0
ROM:000003CE                 bra.s   loc_3E2
ROM:000003D0 ; ---------------------------------------------------------------------------
ROM:000003D0
ROM:000003D0 loc_3D0:
ROM:000003D0                 clr.b   ($FFFFAE).l     ; otherwise clear it
ROM:000003D6                 move.b  #0,($A10007).l
```

Later on, when the 68k sends a message to the BIOS, this flag is (for whatever reason) repeatedly ORed with the data being shifted into the I/O port:

```
ROM:000012D0                 rol.w   #2,d0           ; write next two bits into the I/O port
ROM:000012D2                 or.b    ($FFFFAE).l,d0  ; bitwise-OR the odd frame flag into the remaining data, for some reason
ROM:000012D8                 move.b  d0,d6
ROM:000012DA                 andi.b  #$43,d6
ROM:000012DE                 move.w  d6,d4
ROM:000012E0                 ori.w   #4,d4
ROM:000012E4                 move.b  d4,($A10007).l
[...]
ROM:000012F8                 move.b  d6,($A10007).l
```

As a result, if that flag in RAM is set while this is happening, it causes the wrong data to get shifted out, which was resulting in the BIOS frequently missing messages from the 68k and leaving the game in a weird state as a result.

The VDP fix was checked against the VDP implementation in Blast'Em, and all Mega Play games appear to work fine as a result of the fix.