### PR TITLE
[coco] Remove IRQ trampolines from coco driver family

### DIFF
--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -494,13 +494,16 @@ void coco12_state::coco(machine_config &config)
 	m_maincpu->set_dasm_override(FUNC(coco_state::dasm_override));
 
 	// devices
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));
 	pia0.writepb_handler().set(FUNC(coco_state::pia0_pb_w));
 	pia0.ca2_handler().set(FUNC(coco_state::pia0_ca2_w));
 	pia0.cb2_handler().set(FUNC(coco_state::pia0_cb2_w));
-	pia0.irqa_handler().set(FUNC(coco_state::pia0_irq_a));
-	pia0.irqb_handler().set(FUNC(coco_state::pia0_irq_b));
+	pia0.irqa_handler().set(m_irqs, FUNC(input_merger_device::in_w<0>));
+	pia0.irqb_handler().set(m_irqs, FUNC(input_merger_device::in_w<1>));
 
 	pia6821_device &pia1(PIA6821(config, PIA1_TAG, 0));
 	pia1.readpa_handler().set(FUNC(coco_state::pia1_pa_r));
@@ -509,8 +512,8 @@ void coco12_state::coco(machine_config &config)
 	pia1.writepb_handler().set(FUNC(coco_state::pia1_pb_w));
 	pia1.ca2_handler().set(FUNC(coco_state::pia1_ca2_w));
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
-	pia1.irqa_handler().set(FUNC(coco_state::pia1_firq_a));
-	pia1.irqb_handler().set(FUNC(coco_state::pia1_firq_b));
+	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
+	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
 
 	SAM6883(config, m_sam, XTAL(14'318'181), m_maincpu);
 	m_sam->set_addrmap(0, &coco12_state::coco_ram);

--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -494,8 +494,8 @@ void coco12_state::coco(machine_config &config)
 	m_maincpu->set_dasm_override(FUNC(coco_state::dasm_override));
 
 	// devices
-	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
-	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);
 
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -262,8 +262,8 @@ void coco3_state::coco3(machine_config &config)
 	m_maincpu->set_dasm_override(FUNC(coco_state::dasm_override));
 
 	// devices
-	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
-	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);
 
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -262,13 +262,16 @@ void coco3_state::coco3(machine_config &config)
 	m_maincpu->set_dasm_override(FUNC(coco_state::dasm_override));
 
 	// devices
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));
 	pia0.writepb_handler().set(FUNC(coco_state::pia0_pb_w));
 	pia0.ca2_handler().set(FUNC(coco_state::pia0_ca2_w));
 	pia0.cb2_handler().set(FUNC(coco_state::pia0_cb2_w));
-	pia0.irqa_handler().set(FUNC(coco_state::pia0_irq_a));
-	pia0.irqb_handler().set(FUNC(coco_state::pia0_irq_b));
+	pia0.irqa_handler().set(m_irqs, FUNC(input_merger_device::in_w<0>));
+	pia0.irqb_handler().set(m_irqs, FUNC(input_merger_device::in_w<1>));
 
 	pia6821_device &pia1(PIA6821(config, PIA1_TAG, 0));
 	pia1.readpa_handler().set(FUNC(coco_state::pia1_pa_r));
@@ -277,8 +280,8 @@ void coco3_state::coco3(machine_config &config)
 	pia1.writepb_handler().set(FUNC(coco_state::pia1_pb_w));
 	pia1.ca2_handler().set(FUNC(coco_state::pia1_ca2_w));
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
-	pia1.irqa_handler().set(FUNC(coco_state::pia1_firq_a));
-	pia1.irqb_handler().set(FUNC(coco_state::pia1_firq_b));
+	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
+	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
 
 	// Becker Port device
 	COCO_DWSOCK(config, DWSOCK_TAG, 0);
@@ -309,8 +312,8 @@ void coco3_state::coco3(machine_config &config)
 	m_gime->set_screen(COMPOSITE_SCREEN_TAG);
 	m_gime->hsync_wr_callback().set(PIA0_TAG, FUNC(pia6821_device::ca1_w));
 	m_gime->fsync_wr_callback().set(PIA0_TAG, FUNC(pia6821_device::cb1_w));
-	m_gime->irq_wr_callback().set(FUNC(coco3_state::gime_irq_w));
-	m_gime->firq_wr_callback().set(FUNC(coco3_state::gime_firq_w));
+	m_gime->irq_wr_callback().set(m_irqs, FUNC(input_merger_device::in_w<2>));
+	m_gime->firq_wr_callback().set(m_firqs, FUNC(input_merger_device::in_w<2>));
 	m_gime->floating_bus_rd_callback().set(FUNC(coco3_state::floating_bus_r));
 
 	// composite monitor
@@ -351,8 +354,8 @@ void coco3_state::coco3p(machine_config &config)
 	m_gime->set_screen(COMPOSITE_SCREEN_TAG);
 	m_gime->hsync_wr_callback().set(PIA0_TAG, FUNC(pia6821_device::ca1_w));
 	m_gime->fsync_wr_callback().set(PIA0_TAG, FUNC(pia6821_device::cb1_w));
-	m_gime->irq_wr_callback().set(FUNC(coco3_state::gime_irq_w));
-	m_gime->firq_wr_callback().set(FUNC(coco3_state::gime_firq_w));
+	m_gime->irq_wr_callback().set(m_irqs, FUNC(input_merger_device::in_w<2>));
+	m_gime->firq_wr_callback().set(m_firqs, FUNC(input_merger_device::in_w<2>));
 	m_gime->floating_bus_rd_callback().set(FUNC(coco3_state::floating_bus_r));
 }
 

--- a/src/mame/drivers/dragon.cpp
+++ b/src/mame/drivers/dragon.cpp
@@ -260,13 +260,16 @@ void dragon_state::dragon_base(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &dragon_state::dragon_mem);
 
 	// devices
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));
 	pia0.writepb_handler().set(FUNC(coco_state::pia0_pb_w));
 	pia0.ca2_handler().set(FUNC(coco_state::pia0_ca2_w));
 	pia0.cb2_handler().set(FUNC(coco_state::pia0_cb2_w));
-	pia0.irqa_handler().set(FUNC(coco_state::pia0_irq_a));
-	pia0.irqb_handler().set(FUNC(coco_state::pia0_irq_b));
+	pia0.irqa_handler().set(m_irqs, FUNC(input_merger_device::in_w<0>));
+	pia0.irqb_handler().set(m_irqs, FUNC(input_merger_device::in_w<1>));
 
 	pia6821_device &pia1(PIA6821(config, PIA1_TAG, 0));
 	pia1.readpa_handler().set(FUNC(coco_state::pia1_pa_r));
@@ -275,8 +278,8 @@ void dragon_state::dragon_base(machine_config &config)
 	pia1.writepb_handler().set(FUNC(coco_state::pia1_pb_w));
 	pia1.ca2_handler().set(FUNC(coco_state::pia1_ca2_w));
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
-	pia1.irqa_handler().set(FUNC(coco_state::pia1_firq_a));
-	pia1.irqb_handler().set(FUNC(coco_state::pia1_firq_b));
+	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
+	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
 
 	SAM6883(config, m_sam, 14.218_MHz_XTAL, m_maincpu);
 	m_sam->set_addrmap(0, &dragon_state::coco_ram);
@@ -349,7 +352,7 @@ void dragon64_state::dragon64(machine_config &config)
 	// acia
 	mos6551_device &acia(MOS6551(config, "acia", 0));
 	acia.set_xtal(1.8432_MHz_XTAL);
-	acia.irq_handler().set(FUNC(dragon64_state::acia_irq));
+	acia.irq_handler().set(m_irqs, FUNC(input_merger_device::in_w<2>));
 	acia.txd_handler().set("rs232", FUNC(rs232_port_device::write_txd));
 
 	rs232_port_device &rs232(RS232_PORT(config, "rs232", default_rs232_devices, nullptr));
@@ -361,11 +364,6 @@ void dragon64_state::dragon64(machine_config &config)
 	// software lists
 	SOFTWARE_LIST(config, "dragon_flex_list").set_original("dragon_flex");
 	SOFTWARE_LIST(config, "dragon_os9_list").set_original("dragon_os9");
-}
-
-WRITE_LINE_MEMBER( dragon64_state::acia_irq )
-{
-	m_maincpu->set_input_line(M6809_IRQ_LINE, state ? ASSERT_LINE : CLEAR_LINE);
 }
 
 void dragon64_state::dragon64h(machine_config &config)
@@ -445,8 +443,8 @@ void dragon_alpha_state::dgnalpha(machine_config &config)
 	// pia 2
 	pia6821_device &pia2(PIA6821(config, PIA2_TAG, 0));
 	pia2.writepa_handler().set(FUNC(dragon_alpha_state::pia2_pa_w));
-	pia2.irqa_handler().set(FUNC(dragon_alpha_state::pia2_firq_a));
-	pia2.irqb_handler().set(FUNC(dragon_alpha_state::pia2_firq_b));
+	pia2.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
+	pia2.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
 
 	// software lists
 	SOFTWARE_LIST(config, "dgnalpha_flop_list").set_original("dgnalpha_flop");

--- a/src/mame/drivers/dragon.cpp
+++ b/src/mame/drivers/dragon.cpp
@@ -260,8 +260,8 @@ void dragon_state::dragon_base(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &dragon_state::dragon_mem);
 
 	// devices
-	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);;
-	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);;
+	INPUT_MERGER_ANY_HIGH(config, m_irqs).output_handler().set_inputline(m_maincpu, M6809_IRQ_LINE);
+	INPUT_MERGER_ANY_HIGH(config, m_firqs).output_handler().set_inputline(m_maincpu, M6809_FIRQ_LINE);
 
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));
@@ -415,7 +415,7 @@ void dragon_alpha_state::dgnalpha(machine_config &config)
 	sam().set_addrmap(5, &dragon_alpha_state::dgnalpha_io1);
 
 	// input merger
-	INPUT_MERGER_ANY_HIGH(config, m_nmis).output_handler().set_inputline(m_maincpu, INPUT_LINE_NMI);;
+	INPUT_MERGER_ANY_HIGH(config, m_nmis).output_handler().set_inputline(m_maincpu, INPUT_LINE_NMI);
 
 	// cartridge
 	cococart_slot_device &cartslot(COCOCART_SLOT(config, CARTRIDGE_TAG, DERIVED_CLOCK(1, 1), dragon_cart, nullptr));

--- a/src/mame/drivers/dragon.cpp
+++ b/src/mame/drivers/dragon.cpp
@@ -75,7 +75,7 @@ void dragon_alpha_state::dgnalpha_io1(address_map &map)
 	map(0x0c, 0x0c).mirror(0x10).rw(m_fdc, FUNC(wd2797_device::data_r), FUNC(wd2797_device::data_w));
 	map(0x0d, 0x0d).mirror(0x10).rw(m_fdc, FUNC(wd2797_device::sector_r), FUNC(wd2797_device::sector_w));
 	map(0x0e, 0x0e).mirror(0x10).rw(m_fdc, FUNC(wd2797_device::track_r), FUNC(wd2797_device::track_w));
-	map(0x0f, 0x0f).mirror(0x10).rw(m_fdc, FUNC(wd2797_device::data_r), FUNC(wd2797_device::cmd_w));
+	map(0x0f, 0x0f).mirror(0x10).rw(m_fdc, FUNC(wd2797_device::status_r), FUNC(wd2797_device::cmd_w));
 }
 
 
@@ -443,8 +443,8 @@ void dragon_alpha_state::dgnalpha(machine_config &config)
 	// pia 2
 	pia6821_device &pia2(PIA6821(config, PIA2_TAG, 0));
 	pia2.writepa_handler().set(FUNC(dragon_alpha_state::pia2_pa_w));
-	pia2.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
-	pia2.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
+	pia2.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<2>));
+	pia2.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<3>));
 
 	// software lists
 	SOFTWARE_LIST(config, "dgnalpha_flop_list").set_original("dgnalpha_flop");

--- a/src/mame/drivers/dragon.cpp
+++ b/src/mame/drivers/dragon.cpp
@@ -414,10 +414,13 @@ void dragon_alpha_state::dgnalpha(machine_config &config)
 	sam().set_addrmap(4, &dragon_alpha_state::d64_io0);
 	sam().set_addrmap(5, &dragon_alpha_state::dgnalpha_io1);
 
+	// input merger
+	INPUT_MERGER_ANY_HIGH(config, m_nmis).output_handler().set_inputline(m_maincpu, INPUT_LINE_NMI);;
+
 	// cartridge
 	cococart_slot_device &cartslot(COCOCART_SLOT(config, CARTRIDGE_TAG, DERIVED_CLOCK(1, 1), dragon_cart, nullptr));
 	cartslot.cart_callback().set([this] (int state) { cart_w(state != 0); }); // lambda because name is overloaded
-	cartslot.nmi_callback().set_inputline(m_maincpu, INPUT_LINE_NMI);
+	cartslot.nmi_callback().set(m_nmis, FUNC(input_merger_device::in_w<0>));
 	cartslot.halt_callback().set_inputline(m_maincpu, INPUT_LINE_HALT);
 
 	// acia

--- a/src/mame/includes/coco.h
+++ b/src/mame/includes/coco.h
@@ -24,7 +24,7 @@
 #include "machine/bankdev.h"
 #include "sound/dac.h"
 #include "screen.h"
-
+#include "machine/input_merger.h"
 
 //**************************************************************************
 //  MACROS / CONSTANTS
@@ -102,8 +102,6 @@ public:
 	void pia0_pb_w(uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER( pia0_ca2_w );
 	DECLARE_WRITE_LINE_MEMBER( pia0_cb2_w );
-	DECLARE_WRITE_LINE_MEMBER( pia0_irq_a );
-	DECLARE_WRITE_LINE_MEMBER( pia0_irq_b );
 
 	// PIA1
 	uint8_t pia1_pa_r();
@@ -112,8 +110,6 @@ public:
 	void pia1_pb_w(uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER( pia1_ca2_w );
 	DECLARE_WRITE_LINE_MEMBER( pia1_cb2_w );
-	DECLARE_WRITE_LINE_MEMBER( pia1_firq_a );
-	DECLARE_WRITE_LINE_MEMBER( pia1_firq_b );
 
 	// floating bus & "space"
 	uint8_t floating_bus_r()   { return floating_bus_read(); }
@@ -138,12 +134,6 @@ protected:
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
-
-	// interrupts
-	virtual bool firq_get_line(void);
-	virtual bool irq_get_line(void);
-	void recalculate_irq(void);
-	void recalculate_firq(void);
 
 	// changed handlers
 	virtual void pia1_pa_changed(uint8_t data);
@@ -242,7 +232,9 @@ protected:
 	optional_device<coco_vhd_image_device> m_vhd_0;
 	optional_device<coco_vhd_image_device> m_vhd_1;
 	optional_device<beckerport_device> m_beckerport;
-	optional_ioport                    m_beckerportconfig;
+	optional_ioport m_beckerportconfig;
+	required_device<input_merger_device> m_irqs;
+	required_device<input_merger_device> m_firqs;
 
 	// input ports
 	required_ioport_array<7> m_keyboard;

--- a/src/mame/includes/coco3.h
+++ b/src/mame/includes/coco3.h
@@ -44,9 +44,6 @@ public:
 	virtual uint8_t ff40_read(offs_t offset) override;
 	virtual void ff40_write(offs_t offset, uint8_t data) override;
 
-	DECLARE_WRITE_LINE_MEMBER(gime_firq_w) { recalculate_firq(); }
-	DECLARE_WRITE_LINE_MEMBER(gime_irq_w) { recalculate_irq(); }
-
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	void coco3p(machine_config &config);
@@ -56,10 +53,6 @@ public:
 	void coco3_mem(address_map &map);
 protected:
 	virtual void update_cart_base(uint8_t *cart_base) override;
-
-	// interrupts
-	virtual bool firq_get_line(void) override;
-	virtual bool irq_get_line(void) override;
 
 	// miscellaneous
 	virtual void update_keyboard_input(uint8_t value) override;

--- a/src/mame/includes/dgnalpha.h
+++ b/src/mame/includes/dgnalpha.h
@@ -55,8 +55,6 @@ private:
 
 	/* pia2 */
 	void pia2_pa_w(uint8_t data);
-	DECLARE_WRITE_LINE_MEMBER( pia2_firq_a );
-	DECLARE_WRITE_LINE_MEMBER( pia2_firq_b );
 
 	/* psg */
 	uint8_t psg_porta_read();
@@ -69,9 +67,6 @@ private:
 	/* driver overrides */
 	virtual void device_start(void) override;
 	virtual void device_reset(void) override;
-
-	/* interrupts */
-	virtual bool firq_get_line(void) override;
 
 	void dgnalpha_io1(address_map &map);
 

--- a/src/mame/includes/dgnalpha.h
+++ b/src/mame/includes/dgnalpha.h
@@ -44,7 +44,8 @@ public:
 		m_pia_2(*this, PIA2_TAG),
 		m_ay8912(*this, AY8912_TAG),
 		m_fdc(*this, WD2797_TAG),
-		m_floppy(*this, WD2797_TAG ":%u", 0U)
+		m_floppy(*this, WD2797_TAG ":%u", 0U),
+		m_nmis(*this, "nmis")
 	{
 	}
 
@@ -74,6 +75,7 @@ private:
 	required_device<ay8912_device> m_ay8912;
 	required_device<wd2797_device> m_fdc;
 	required_device_array<floppy_connector, 4> m_floppy;
+	required_device<input_merger_device> m_nmis;
 
 	/* modem */
 	uint8_t modem_r(offs_t offset);

--- a/src/mame/includes/dragon.h
+++ b/src/mame/includes/dragon.h
@@ -69,7 +69,7 @@ public:
 	void dragon64(machine_config &config);
 	void tanodr64h(machine_config &config);
 	void dragon64h(machine_config &config);
-	DECLARE_WRITE_LINE_MEMBER( acia_irq );
+
 protected:
 	void d64_rom0(address_map &map);
 	void d64_rom1(address_map &map);

--- a/src/mame/machine/coco.cpp
+++ b/src/mame/machine/coco.cpp
@@ -98,6 +98,8 @@ coco_state::coco_state(const machine_config &mconfig, device_type type, const ch
 	m_vhd_1(*this, VHD1_TAG),
 	m_beckerport(*this, DWSOCK_TAG),
 	m_beckerportconfig(*this, BECKERPORT_TAG),
+	m_irqs(*this, "irqs"),
+	m_firqs(*this, "firqs"),
 	m_keyboard(*this, "row%u", 0),
 	m_joystick_type_control(*this, CTRL_SEL_TAG),
 	m_joystick_hires_control(*this, HIRES_INTF_TAG),
@@ -374,29 +376,6 @@ WRITE_LINE_MEMBER( coco_state::pia0_cb2_w )
 }
 
 
-
-//-------------------------------------------------
-//  pia0_irq_a
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( coco_state::pia0_irq_a )
-{
-	recalculate_irq();
-}
-
-
-
-//-------------------------------------------------
-//  pia0_irq_b
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( coco_state::pia0_irq_b )
-{
-	recalculate_irq();
-}
-
-
-
 /***************************************************************************
   PIA1 ($FF20-$FF3F) (Chip U4)
 
@@ -522,29 +501,6 @@ WRITE_LINE_MEMBER( coco_state::pia1_cb2_w )
 }
 
 
-
-//-------------------------------------------------
-//  pia1_firq_a
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( coco_state::pia1_firq_a )
-{
-	recalculate_firq();
-}
-
-
-
-//-------------------------------------------------
-//  pia1_firq_b
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( coco_state::pia1_firq_b )
-{
-	recalculate_firq();
-}
-
-
-
 /***************************************************************************
   CPU INTERRUPTS
 
@@ -564,56 +520,6 @@ WRITE_LINE_MEMBER( coco_state::pia1_firq_b )
   -----
 
 ***************************************************************************/
-
-//-------------------------------------------------
-//  irq_get_line - gets the value of the FIRQ line
-//  passed into the CPU
-//-------------------------------------------------
-
-bool coco_state::irq_get_line(void)
-{
-	return pia_0().irq_a_state() || pia_0().irq_b_state();
-}
-
-
-
-//-------------------------------------------------
-//  recalculate_irq
-//-------------------------------------------------
-
-void coco_state::recalculate_irq(void)
-{
-	bool line = irq_get_line();
-	if (LOG_INTERRUPTS)
-		logerror("recalculate_irq():  line=%d\n", line ? 1 : 0);
-	m_maincpu->set_input_line(M6809_IRQ_LINE, line ? ASSERT_LINE : CLEAR_LINE);
-}
-
-
-
-//-------------------------------------------------
-//  firq_get_line - gets the value of the FIRQ line
-//  passed into the CPU
-//-------------------------------------------------
-
-bool coco_state::firq_get_line(void)
-{
-	return pia_1().irq_a_state() || pia_1().irq_b_state();
-}
-
-
-
-//-------------------------------------------------
-//  recalculate_firq
-//-------------------------------------------------
-
-void coco_state::recalculate_firq(void)
-{
-	bool line = firq_get_line();
-	if (LOG_INTERRUPTS)
-		logerror("recalculate_firq():  line=%d\n", line ? 1 : 0);
-	m_maincpu->set_input_line(M6809_FIRQ_LINE, line ? ASSERT_LINE : CLEAR_LINE);
-}
 
 
 

--- a/src/mame/machine/coco3.cpp
+++ b/src/mame/machine/coco3.cpp
@@ -87,28 +87,6 @@ void coco3_state::ff40_write(offs_t offset, uint8_t data)
 
 
 //-------------------------------------------------
-//  firq_get_line
-//-------------------------------------------------
-
-bool coco3_state::firq_get_line(void)
-{
-	return coco_state::firq_get_line() || m_gime->firq_r();
-}
-
-
-
-//-------------------------------------------------
-//  irq_get_line
-//-------------------------------------------------
-
-bool coco3_state::irq_get_line(void)
-{
-	return coco_state::irq_get_line() || m_gime->irq_r();
-}
-
-
-
-//-------------------------------------------------
 //  update_keyboard_input
 //-------------------------------------------------
 

--- a/src/mame/machine/dgnalpha.cpp
+++ b/src/mame/machine/dgnalpha.cpp
@@ -91,7 +91,6 @@ void dragon_alpha_state::device_reset(void)
 }
 
 
-
 /***************************************************************************
   MODEM
 ***************************************************************************/
@@ -162,44 +161,6 @@ void dragon_alpha_state::pia2_pa_w(uint8_t data)
 			m_ay8912->address_w(m_pia_2->b_output());
 			break;
 	}
-}
-
-
-
-//-------------------------------------------------
-//  pia1_firq_a
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( dragon_alpha_state::pia2_firq_a )
-{
-	recalculate_firq();
-}
-
-
-
-//-------------------------------------------------
-//  pia1_firq_b
-//-------------------------------------------------
-
-WRITE_LINE_MEMBER( dragon_alpha_state::pia2_firq_b )
-{
-	recalculate_firq();
-}
-
-
-
-/***************************************************************************
-  CPU INTERRUPTS
-***************************************************************************/
-
-//-------------------------------------------------
-//  firq_get_line - gets the value of the FIRQ line
-//  passed into the CPU
-//-------------------------------------------------
-
-bool dragon_alpha_state::firq_get_line(void)
-{
-	return dragon_state::firq_get_line() || m_pia_2->irq_a_state() || m_pia_2->irq_b_state();
 }
 
 

--- a/src/mame/machine/dgnalpha.cpp
+++ b/src/mame/machine/dgnalpha.cpp
@@ -220,11 +220,11 @@ WRITE_LINE_MEMBER( dragon_alpha_state::fdc_intrq_w )
 	if (state)
 	{
 		if (m_pia_2->ca2_output_z())
-			m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
+			m_nmis->in_w<1>(1);
 	}
 	else
 	{
-		m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
+		m_nmis->in_w<1>(0);
 	}
 }
 

--- a/src/mame/machine/dragon.cpp
+++ b/src/mame/machine/dragon.cpp
@@ -57,7 +57,7 @@ void dragon_state::pia1_pa_changed(uint8_t data)
 	/* if strobe bit is high send data from pia0 port b to dragon parallel printer */
 	if (data & 0x02)
 	{
-		uint8_t output = pia_1().b_output();
+		uint8_t output = pia_0().b_output();
 		m_printer->output(output);
 	}
 }


### PR DESCRIPTION
When adding a proper ACIA to the Dragon 64 driver it was requested to use an input merger to handle all the interrupt sources. This required changes all the way down to the base driver. 

Also fix small typo when handling the parallel port on the Dragon 32.