### PR TITLE
Plug and Play work (lots of new sets from Sean etc.)

### DIFF
--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -2762,6 +2762,7 @@ createMESSProjects(_target, _subtarget, "leapfrog")
 files {
 	MAME_DIR .. "src/mame/drivers/leapster.cpp",
 	MAME_DIR .. "src/mame/drivers/leapfrog_leappad.cpp",
+	MAME_DIR .. "src/mame/drivers/leapfrog_iquest.cpp",
 }
 
 createMESSProjects(_target, _subtarget, "lsi")

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -3478,6 +3478,8 @@ files {
 	MAME_DIR .. "src/mame/includes/megadriv.h",
 	MAME_DIR .. "src/mame/drivers/megadriv_rad.cpp",
 	MAME_DIR .. "src/mame/includes/megadriv_rad.h",
+	MAME_DIR .. "src/mame/drivers/megadriv_vt_hybrid.cpp",
+	MAME_DIR .. "src/mame/drivers/megadriv_sunplus_hybrid.cpp",
 	MAME_DIR .. "src/mame/drivers/segapico.cpp",
 	MAME_DIR .. "src/mame/drivers/sega_sawatte.cpp",
 	MAME_DIR .. "src/mame/drivers/sega_beena.cpp",

--- a/src/mame/drivers/leapfrog_iquest.cpp
+++ b/src/mame/drivers/leapfrog_iquest.cpp
@@ -1,0 +1,124 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+/******************************************************************************
+
+   Leapfrog IQuest
+
+   has LCD display, resolution unknown
+
+*******************************************************************************/
+
+#include "emu.h"
+
+#include "cpu/mcs51/mcs51.h"
+
+#include "bus/generic/slot.h"
+#include "bus/generic/carts.h"
+
+#include "screen.h"
+#include "softlist.h"
+#include "speaker.h"
+#include "screen.h"
+
+class leapfrog_iquest_state : public driver_device
+{
+public:
+	leapfrog_iquest_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_cart(*this, "cartslot")
+		, m_screen(*this, "screen")
+		, m_cart_region(nullptr)
+	{ }
+
+	void leapfrog_iquest(machine_config &config);
+
+private:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+	void prog_map(address_map &map);
+	void ext_map(address_map &map);
+
+	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	DECLARE_DEVICE_IMAGE_LOAD_MEMBER(cart_load);
+
+	required_device<mcs51_cpu_device> m_maincpu;
+	required_device<generic_slot_device> m_cart;
+	required_device<screen_device> m_screen;
+	memory_region *m_cart_region;
+};
+
+
+
+void leapfrog_iquest_state::machine_start()
+{
+	// if there's a cart, override the standard mapping
+	if (m_cart && m_cart->exists())
+	{
+		std::string region_tag;
+		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+	}
+}
+
+void leapfrog_iquest_state::machine_reset()
+{
+}
+
+void leapfrog_iquest_state::prog_map(address_map &map)
+{
+	map(0x0000, 0xffff).rom().region("maincpu", 0x10000); // TODO: banking
+}
+
+void leapfrog_iquest_state::ext_map(address_map &map)
+{
+}
+
+DEVICE_IMAGE_LOAD_MEMBER(leapfrog_iquest_state::cart_load)
+{
+	uint32_t size = m_cart->common_get_size("rom");
+
+	m_cart->rom_alloc(size, GENERIC_ROM16_WIDTH, ENDIANNESS_LITTLE);
+	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");
+
+	return image_init_result::PASS;
+}
+
+static INPUT_PORTS_START( leapfrog_iquest )
+INPUT_PORTS_END
+
+uint32_t leapfrog_iquest_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	return 0;
+}
+
+
+void leapfrog_iquest_state::leapfrog_iquest(machine_config &config)
+{
+	I8032(config, m_maincpu, 96000000/10); // unknown clock
+	m_maincpu->set_addrmap(AS_PROGRAM, &leapfrog_iquest_state::prog_map);
+	m_maincpu->set_addrmap(AS_IO, &leapfrog_iquest_state::ext_map);
+
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(60);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(10));
+	m_screen->set_size(160, 160);
+	m_screen->set_visarea(0, 160-1, 0, 160-1);
+	m_screen->set_screen_update(FUNC(leapfrog_iquest_state::screen_update));
+	//m_screen->screen_vblank().set(FUNC(leapfrog_iquest_state::screen_vblank));
+
+	GENERIC_CARTSLOT(config, m_cart, generic_plain_slot, "leapfrog_iquest_cart");
+	m_cart->set_width(GENERIC_ROM16_WIDTH);
+	m_cart->set_device_load(FUNC(leapfrog_iquest_state::cart_load));
+
+	SOFTWARE_LIST(config, "cart_list").set_original("leapfrog_iquest_cart");
+}
+
+ROM_START( iquest )
+	ROM_REGION( 0x400000, "maincpu", ROMREGION_ERASEFF )
+	ROM_LOAD( "iquest.bin", 0x000000, 0x400000, CRC(f785dc4e) SHA1(ec002c18df536737334fe6b7db0e7342bad7b66b))
+ROM_END
+
+//    year, name,        parent,    compat, machine,            input,            class,                  init,       company,    fullname,                         flags
+CONS( 200?, iquest,      0,         0,      leapfrog_iquest,    leapfrog_iquest,  leapfrog_iquest_state,  empty_init, "LeapFrog", "IQuest (US)",                    MACHINE_IS_SKELETON )

--- a/src/mame/drivers/leapfrog_iquest.cpp
+++ b/src/mame/drivers/leapfrog_iquest.cpp
@@ -57,8 +57,7 @@ void leapfrog_iquest_state::machine_start()
 	// if there's a cart, override the standard mapping
 	if (m_cart && m_cart->exists())
 	{
-		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(std::string(m_cart->tag()) + GENERIC_ROM_REGION_TAG);
 	}
 }
 

--- a/src/mame/drivers/leapfrog_leappad.cpp
+++ b/src/mame/drivers/leapfrog_leappad.cpp
@@ -114,8 +114,7 @@ void leapfrog_leappad_state::machine_start()
 	// if there's a cart, override the standard mapping
 	if (m_cart && m_cart->exists())
 	{
-		std::string region_tag;
-		m_cart_region = memregion(region_tag.assign(m_cart->tag()).append(GENERIC_ROM_REGION_TAG).c_str());
+		m_cart_region = memregion(std::string(m_cart->tag()) + GENERIC_ROM_REGION_TAG);
 	}
 }
 

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -268,7 +268,7 @@ INPUT_PORTS_END
  *
  *************************************/
 
-MACHINE_START_MEMBER(md_cons_state, md_common)
+void md_cons_state::machine_start()
 {
 	static const char *const pad6names[2][4] = {
 		{ "PAD1_6B", "PAD2_6B", "UNUSED", "UNUSED" },
@@ -336,9 +336,10 @@ void md_cons_state::install_tmss()
 
 }
 
-MACHINE_START_MEMBER(md_cons_state, ms_megadriv)
+
+void md_cons_slot_state::machine_start()
 {
-	MACHINE_START_CALL_MEMBER( md_common );
+	md_cons_state::machine_start();
 
 	// the SVP introduces some kind of DMA 'lag', which we have to compensate for, this is obvious even on gfx DMAd from ROM (the Speedometer)
 	if (m_cart->get_type() == SEGA_SVP)
@@ -363,10 +364,9 @@ void md_cons_state::machine_reset()
 		m_32x->pause_cpu();
 }
 
-
-MACHINE_START_MEMBER(md_cons_state, ms_megacd)
+void md_cons_cd_state::machine_start()
 {
-	MACHINE_START_CALL_MEMBER( md_common );
+	md_cons_state::machine_start();
 
 	// the segaCD introduces some kind of DMA 'lag', which we have to compensate for,
 	// at least when reading wordram? we might need to check what mode we're in the DMA...
@@ -397,43 +397,37 @@ WRITE_LINE_MEMBER(md_cons_state::screen_vblank_console)
 	}
 }
 
-void md_cons_state::ms_megadriv(machine_config &config)
+void md_cons_slot_state::ms_megadriv(machine_config &config)
 {
 	md_ntsc(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	MD_CART_SLOT(config, m_cart, md_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
 }
 
-void md_cons_state::ms_megadpal(machine_config &config)
+void md_cons_slot_state::ms_megadpal(machine_config &config)
 {
 	md_pal(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	MD_CART_SLOT(config, m_cart, md_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
 }
 
-void md_cons_state::ms_megadriv2(machine_config &config)
+void md_cons_slot_state::ms_megadriv2(machine_config &config)
 {
 	md2_ntsc(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	MD_CART_SLOT(config, m_cart, md_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
 }
 
-void md_cons_state::genesis_tmss(machine_config &config)
+void md_cons_slot_state::genesis_tmss(machine_config &config)
 {
 	ms_megadriv(config);
 	subdevice<software_list_device>("cart_list")->set_filter("TMSS");
@@ -442,8 +436,6 @@ void md_cons_state::genesis_tmss(machine_config &config)
 void md_cons_state::dcat16_megadriv(machine_config &config)
 {
 	dcat16_megadriv_base(config);
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -642,8 +634,6 @@ void md_cons_state::genesis_32x(machine_config &config)
 {
 	md_ntsc(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
 	m_vdp->set_md_32x_interrupt(FUNC(md_cons_state::_32x_interrupt_callback));
@@ -676,8 +666,6 @@ void md_cons_state::mdj_32x(machine_config &config)
 {
 	md_ntsc(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
 	m_vdp->set_md_32x_interrupt(FUNC(md_cons_state::_32x_interrupt_callback));
@@ -709,8 +697,6 @@ void md_cons_state::mdj_32x(machine_config &config)
 void md_cons_state::md_32x(machine_config &config)
 {
 	md_pal(config);
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
 
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
@@ -772,11 +758,9 @@ ROM_END
 
 /****************************************** SegaCD emulation ****************************************/
 
-void md_cons_state::genesis_scd(machine_config &config)
+void md_cons_cd_state::genesis_scd(machine_config &config)
 {
 	md_ntsc(config);
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -792,12 +776,10 @@ void md_cons_state::genesis_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("segacd");
 }
 
-void md_cons_state::genesis2_scd(machine_config &config)
+void md_cons_cd_state::genesis2_scd(machine_config &config)
 {
 	md2_ntsc(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	SEGA_SEGACD_US(config, m_segacd, 0);
@@ -812,12 +794,10 @@ void md_cons_state::genesis2_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("segacd");
 }
 
-void md_cons_state::md_scd(machine_config &config)
+void md_cons_cd_state::md_scd(machine_config &config)
 {
 	md_pal(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	SEGA_SEGACD_EUROPE(config, m_segacd, 0);
@@ -832,12 +812,10 @@ void md_cons_state::md_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("megacd");
 }
 
-void md_cons_state::md2_scd(machine_config &config)
+void md_cons_cd_state::md2_scd(machine_config &config)
 {
 	md2_pal(config);
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	SEGA_SEGACD_EUROPE(config, m_segacd, 0);
@@ -852,11 +830,9 @@ void md_cons_state::md2_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("megacd");
 }
 
-void md_cons_state::mdj_scd(machine_config &config)
+void md_cons_cd_state::mdj_scd(machine_config &config)
 {
 	md_ntsc(config);
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -872,11 +848,9 @@ void md_cons_state::mdj_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("megacdj");
 }
 
-void md_cons_state::md2j_scd(machine_config &config)
+void md_cons_cd_state::md2j_scd(machine_config &config)
 {
 	md2_ntsc(config);
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -894,7 +868,7 @@ void md_cons_state::md2j_scd(machine_config &config)
 
 /******************SEGA CD + 32X****************************/
 
-void md_cons_state::genesis_32x_scd(machine_config &config)
+void md_cons_cd_state::genesis_32x_scd(machine_config &config)
 {
 	genesis_32x(config);
 
@@ -907,8 +881,6 @@ void md_cons_state::genesis_32x_scd(machine_config &config)
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-
 	config.device_remove("cartslot");
 	GENERIC_CARTSLOT(config, "cartslot", generic_plain_slot, "_32x_cart", "32x,bin").set_device_load(FUNC(md_cons_state::_32x_cart));
 
@@ -916,7 +888,7 @@ void md_cons_state::genesis_32x_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("segacd");
 }
 
-void md_cons_state::md_32x_scd(machine_config &config)
+void md_cons_cd_state::md_32x_scd(machine_config &config)
 {
 	md_32x(config);
 
@@ -929,8 +901,6 @@ void md_cons_state::md_32x_scd(machine_config &config)
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
 
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-
 	config.device_remove("cartslot");
 	GENERIC_CARTSLOT(config, "cartslot", generic_plain_slot, "_32x_cart", "32x,bin").set_device_load(FUNC(md_cons_state::_32x_cart));
 
@@ -938,7 +908,7 @@ void md_cons_state::md_32x_scd(machine_config &config)
 	SOFTWARE_LIST(config, "cd_list").set_original("megacd");
 }
 
-void md_cons_state::mdj_32x_scd(machine_config &config)
+void md_cons_cd_state::mdj_32x_scd(machine_config &config)
 {
 	mdj_32x(config);
 
@@ -950,8 +920,6 @@ void md_cons_state::mdj_32x_scd(machine_config &config)
 	config.set_perfect_quantum("segacd:segacd_68k"); // perfect sync to the fastest cpu
 
 	CDROM(config, "cdrom").set_interface("scd_cdrom");
-
-	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
 
 	config.device_remove("cartslot");
 	GENERIC_CARTSLOT(config, "cartslot", generic_plain_slot, "_32x_cart", "32x,bin").set_device_load(FUNC(md_cons_state::_32x_cart));
@@ -1172,12 +1140,12 @@ ROM_END
 ***************************************************************************/
 
 /*    YEAR  NAME          PARENT    COMPAT  MACHINE          INPUT     CLASS          INIT          COMPANY   FULLNAME */
-CONS( 1989, genesis,      0,        0,      ms_megadriv,     md,       md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC)",  MACHINE_SUPPORTS_SAVE )
-CONS( 1990, megadriv,     genesis,  0,      ms_megadpal,     md,       md_cons_state, init_md_eur,  "Sega",   "Mega Drive (Europe, PAL)", MACHINE_SUPPORTS_SAVE )
-CONS( 1988, megadrij,     genesis,  0,      ms_megadriv,     md,       md_cons_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
+CONS( 1989, genesis,      0,        0,      ms_megadriv,     md,       md_cons_slot_state, init_genesis, "Sega",   "Genesis (USA, NTSC)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1990, megadriv,     genesis,  0,      ms_megadpal,     md,       md_cons_slot_state, init_md_eur,  "Sega",   "Mega Drive (Europe, PAL)", MACHINE_SUPPORTS_SAVE )
+CONS( 1988, megadrij,     genesis,  0,      ms_megadriv,     md,       md_cons_slot_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
 
 // 1990+ models had the TMSS security chip, leave this as a clone, it reduces compatibility and nothing more.
-CONS( 1990, genesis_tmss, genesis,  0,      genesis_tmss,    md,       md_cons_state, init_genesis, "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1990, genesis_tmss, genesis,  0,      genesis_tmss,    md,       md_cons_slot_state, init_genesis, "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )
 
 // the 32X plugged in the cart slot, games plugged into the 32x.  Maybe it should be handled as an expansion device?
 CONS( 1994, 32x,          0,        0,      genesis_32x,     md,       md_cons_state, init_genesis, "Sega",   "Genesis with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
@@ -1185,32 +1153,32 @@ CONS( 1994, 32xe,         32x,      0,      md_32x,          md,       md_cons_s
 CONS( 1994, 32xj,         32x,      0,      mdj_32x,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega Drive with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
 
 // the SegaCD plugged into the expansion port..
-CONS( 1992, segacd,       0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Sega",   "Sega CD (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd,       segacd,   0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1991, megacdj,      segacd,   0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD (Japan, NTSC)", MACHINE_NOT_WORKING ) // this bios doesn't work with our ram interleave needed by a few games?!
-CONS( 1991, megacda,      segacd,   0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD (Asia, PAL)", MACHINE_NOT_WORKING )
-CONS( 1993, segacd2,      0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Sega",   "Sega CD 2 (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd2,      segacd2,  0,      md_scd,          md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD 2 (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1993, megacd2j,     segacd2,  0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD 2 (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, aiwamcd,      segacd2,  0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "AIWA",   "Mega-CD CSD-G1M (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, laseract,     0,        0,      genesis_scd,     md,       md_cons_state, init_genesis, "Pioneer","LaserActive (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, laseractj,    laseract, 0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Pioneer","LaserActive (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, xeye,         0,        0,      genesis2_scd,    md,       md_cons_state, init_genesis, "JVC",    "X'eye (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1992, wmega,        xeye,     0,      mdj_scd,         md,       md_cons_state, init_md_jpn,  "Sega",   "Wondermega (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1993, wmegam2,      xeye,     0,      md2j_scd,        md,       md_cons_state, init_md_jpn,  "Victor", "Wondermega M2 (Japan, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, cdx,          0,        0,      genesis2_scd,    md,       md_cons_state, init_genesis, "Sega",   "CDX (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1994, multmega,     cdx,      0,      md2_scd,         md,       md_cons_state, init_md_eur,  "Sega",   "Multi-Mega (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1992, segacd,       0,        0,      genesis_scd,     md,       md_cons_cd_state, init_genesis, "Sega",   "Sega CD (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd,       segacd,   0,      md_scd,          md,       md_cons_cd_state, init_md_eur,  "Sega",   "Mega-CD (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1991, megacdj,      segacd,   0,      mdj_scd,         md,       md_cons_cd_state, init_md_jpn,  "Sega",   "Mega-CD (Japan, NTSC)", MACHINE_NOT_WORKING ) // this bios doesn't work with our ram interleave needed by a few games?!
+CONS( 1991, megacda,      segacd,   0,      md_scd,          md,       md_cons_cd_state, init_md_eur,  "Sega",   "Mega-CD (Asia, PAL)", MACHINE_NOT_WORKING )
+CONS( 1993, segacd2,      0,        0,      genesis_scd,     md,       md_cons_cd_state, init_genesis, "Sega",   "Sega CD 2 (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd2,      segacd2,  0,      md_scd,          md,       md_cons_cd_state, init_md_eur,  "Sega",   "Mega-CD 2 (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1993, megacd2j,     segacd2,  0,      mdj_scd,         md,       md_cons_cd_state, init_md_jpn,  "Sega",   "Mega-CD 2 (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, aiwamcd,      segacd2,  0,      mdj_scd,         md,       md_cons_cd_state, init_md_jpn,  "AIWA",   "Mega-CD CSD-G1M (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, laseract,     0,        0,      genesis_scd,     md,       md_cons_cd_state, init_genesis, "Pioneer","LaserActive (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, laseractj,    laseract, 0,      mdj_scd,         md,       md_cons_cd_state, init_md_jpn,  "Pioneer","LaserActive (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, xeye,         0,        0,      genesis2_scd,    md,       md_cons_cd_state, init_genesis, "JVC",    "X'eye (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1992, wmega,        xeye,     0,      mdj_scd,         md,       md_cons_cd_state, init_md_jpn,  "Sega",   "Wondermega (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1993, wmegam2,      xeye,     0,      md2j_scd,        md,       md_cons_cd_state, init_md_jpn,  "Victor", "Wondermega M2 (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, cdx,          0,        0,      genesis2_scd,    md,       md_cons_cd_state, init_genesis, "Sega",   "CDX (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, multmega,     cdx,      0,      md2_scd,         md,       md_cons_cd_state, init_md_eur,  "Sega",   "Multi-Mega (Europe, PAL)", MACHINE_NOT_WORKING )
 
 //32X plugged in the cart slot + SegaCD plugged into the expansion port..
-CONS( 1994, 32x_scd,      0,        0,      genesis_32x_scd, md,       md_cons_state, init_genesis, "Sega",   "Sega CD with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
-CONS( 1995, 32x_mcd,      32x_scd,  0,      md_32x_scd,      md,       md_cons_state, init_md_eur,  "Sega",   "Mega-CD with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
-CONS( 1994, 32x_mcdj,     32x_scd,  0,      mdj_32x_scd,     md,       md_cons_state, init_md_jpn,  "Sega",   "Mega-CD with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1994, 32x_scd,      0,        0,      genesis_32x_scd, md,       md_cons_cd_state, init_genesis, "Sega",   "Sega CD with 32X (USA, NTSC)", MACHINE_NOT_WORKING )
+CONS( 1995, 32x_mcd,      32x_scd,  0,      md_32x_scd,      md,       md_cons_cd_state, init_md_eur,  "Sega",   "Mega-CD with 32X (Europe, PAL)", MACHINE_NOT_WORKING )
+CONS( 1994, 32x_mcdj,     32x_scd,  0,      mdj_32x_scd,     md,       md_cons_cd_state, init_md_jpn,  "Sega",   "Mega-CD with 32X (Japan, NTSC)", MACHINE_NOT_WORKING )
 
 // handheld hardware
-CONS( 1995, gen_nomd,     0,        0,      ms_megadriv2,    gen_nomd, md_cons_state, init_genesis, "Sega",   "Genesis Nomad (USA Genesis handheld)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1995, gen_nomd,     0,        0,      ms_megadriv2,    gen_nomd, md_cons_slot_state, init_genesis, "Sega",   "Genesis Nomad (USA Genesis handheld)",  MACHINE_SUPPORTS_SAVE )
 
 // handheld without LCD
-CONS( 1993, megajet,      gen_nomd, 0,      ms_megadriv2,    megajet,  md_cons_state, init_md_jpn,  "Sega",   "Mega Jet (Japan Mega Drive handheld)",  MACHINE_SUPPORTS_SAVE )
+CONS( 1993, megajet,      gen_nomd, 0,      ms_megadriv2,    megajet,  md_cons_slot_state, init_md_jpn,  "Sega",   "Mega Jet (Japan Mega Drive handheld)",  MACHINE_SUPPORTS_SAVE )
 
 /* clone hardware - not sure if this hardware is running some kind of emulator, or enhanced MD clone, or just custom banking */
-CONS( 200?, dcat16,       0,        0,      dcat16_megadriv, md,       md_cons_state, init_genesis, "Firecore",   "D-CAT16 (Mega Drive handheld)",  MACHINE_NOT_WORKING )
+CONS( 200?, dcat16,       0,        0,      dcat16_megadriv, md,       md_cons_slot_state, init_genesis, "Firecore",   "D-CAT16 (Mega Drive handheld)",  MACHINE_NOT_WORKING )

--- a/src/mame/drivers/megadriv.cpp
+++ b/src/mame/drivers/megadriv.cpp
@@ -352,9 +352,17 @@ MACHINE_START_MEMBER(md_cons_state, ms_megadriv)
 	{
 		install_cartslot();
 	}
-
-
 }
+
+void md_cons_state::machine_reset()
+{
+	md_base_state::machine_reset();
+
+	// if the system has a 32x, pause the extra CPUs until they are actually turned on
+	if (m_32x)
+		m_32x->pause_cpu();
+}
+
 
 MACHINE_START_MEMBER(md_cons_state, ms_megacd)
 {
@@ -363,15 +371,6 @@ MACHINE_START_MEMBER(md_cons_state, ms_megacd)
 	// the segaCD introduces some kind of DMA 'lag', which we have to compensate for,
 	// at least when reading wordram? we might need to check what mode we're in the DMA...
 	m_vdp->set_dma_delay(2);
-}
-
-MACHINE_RESET_MEMBER(md_cons_state, ms_megadriv)
-{
-	MACHINE_RESET_CALL_MEMBER( megadriv );
-
-	// if the system has a 32x, pause the extra CPUs until they are actually turned on
-	if (m_32x)
-		m_32x->pause_cpu();
 }
 
 // same as screen_eof_megadriv but with addition of 32x and SegaCD/MegaCD pieces
@@ -403,7 +402,6 @@ void md_cons_state::ms_megadriv(machine_config &config)
 	md_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -416,7 +414,6 @@ void md_cons_state::ms_megadpal(machine_config &config)
 	md_pal(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -429,7 +426,6 @@ void md_cons_state::ms_megadriv2(machine_config &config)
 	md2_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megadriv)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -448,7 +444,6 @@ void md_cons_state::dcat16_megadriv(machine_config &config)
 	dcat16_megadriv_base(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -648,7 +643,6 @@ void md_cons_state::genesis_32x(machine_config &config)
 	md_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
@@ -683,7 +677,6 @@ void md_cons_state::mdj_32x(machine_config &config)
 	md_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
@@ -718,7 +711,6 @@ void md_cons_state::md_32x(machine_config &config)
 	md_pal(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, md_common)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	m_vdp->set_md_32x_scanline(FUNC(md_cons_state::_32x_scanline_callback));
 	m_vdp->set_md_32x_scanline_helper(FUNC(md_cons_state::_32x_scanline_helper_callback));
@@ -785,7 +777,6 @@ void md_cons_state::genesis_scd(machine_config &config)
 	md_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -806,7 +797,6 @@ void md_cons_state::genesis2_scd(machine_config &config)
 	md2_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -827,7 +817,6 @@ void md_cons_state::md_scd(machine_config &config)
 	md_pal(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -848,7 +837,6 @@ void md_cons_state::md2_scd(machine_config &config)
 	md2_pal(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -869,7 +857,6 @@ void md_cons_state::mdj_scd(machine_config &config)
 	md_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
@@ -890,7 +877,6 @@ void md_cons_state::md2j_scd(machine_config &config)
 	md2_ntsc(config);
 
 	MCFG_MACHINE_START_OVERRIDE(md_cons_state, ms_megacd)
-	MCFG_MACHINE_RESET_OVERRIDE(md_cons_state, ms_megadriv)
 
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 

--- a/src/mame/drivers/megadriv_acbl.cpp
+++ b/src/mame/drivers/megadriv_acbl.cpp
@@ -940,12 +940,13 @@ INPUT_PORTS_END
 void md_boot_state::megadrvb(machine_config &config)
 {
 	md_ntsc(config);
-	MCFG_MACHINE_START_OVERRIDE(md_boot_state, md_bootleg)
 }
 
-MACHINE_START_MEMBER(md_boot_state, md_6button)
+
+void md_boot_6button_state::machine_start()
 {
-	MACHINE_START_CALL_MEMBER(md_bootleg);
+	md_base_state::machine_start();
+	m_vdp->stop_timers();
 
 	m_io_pad_6b[0] = ioport("EXTRA1");
 	m_io_pad_6b[1] = ioport("EXTRA2");
@@ -957,11 +958,11 @@ MACHINE_START_MEMBER(md_boot_state, md_6button)
 		m_io_timeout[i] = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(md_base_state::io_timeout_timer_callback),this), (void*)(uintptr_t)i);
 }
 
-void md_boot_state::megadrvb_6b(machine_config &config)
+void md_boot_6button_state::megadrvb_6b(machine_config &config)
 {
 	md_ntsc(config);
-	MCFG_MACHINE_START_OVERRIDE(md_boot_state, md_6button)
 }
+
 
 
 /*************************************
@@ -1345,14 +1346,14 @@ ROM_END
  *************************************/
 
 GAME( 1993, aladmdb,  0, megadrvb,     aladmdb,  md_boot_state, init_aladmdb,  ROT0, "bootleg / Sega",   "Aladdin (bootleg of Japanese Megadrive version)",                                       0 )
-GAME( 1996, mk3mdb,   0, megadrvb_6b,  mk3mdb,   md_boot_state, init_mk3mdb,   ROT0, "bootleg / Midway", "Mortal Kombat 3 (bootleg of Megadrive version)",                                        0 )
-GAME( 1994, ssf2mdb,  0, megadrvb_6b,  ssf2mdb,  md_boot_state, init_ssf2mdb,  ROT0, "bootleg / Capcom", "Super Street Fighter II - The New Challengers (bootleg of Japanese MegaDrive version)", 0 )
+GAME( 1996, mk3mdb,   0, megadrvb_6b,  mk3mdb,   md_boot_6button_state, init_mk3mdb,   ROT0, "bootleg / Midway", "Mortal Kombat 3 (bootleg of Megadrive version)",                                        0 )
+GAME( 1994, ssf2mdb,  0, megadrvb_6b,  ssf2mdb,  md_boot_6button_state, init_ssf2mdb,  ROT0, "bootleg / Capcom", "Super Street Fighter II - The New Challengers (bootleg of Japanese MegaDrive version)", 0 )
 GAME( 1993, srmdb,    0, megadrvb,     srmdb,    md_boot_state, init_srmdb,    ROT0, "bootleg / Konami", "Sunset Riders (bootleg of Megadrive version)",                                          0 )
 GAME( 1995, topshoot, 0, md_bootleg,   topshoot, md_boot_state, init_topshoot, ROT0, "Sun Mixing",       "Top Shooter",                                                                           0 )
 GAME( 1996, sbubsm,   0, md_bootleg,   sbubsm,   md_boot_state, init_sbubsm,   ROT0, "Sun Mixing",       "Super Bubble Bobble (Sun Mixing, Megadrive clone hardware)",                            0 )
 GAME( 1993, sonic2mb, 0, md_bootleg,   sonic2mb, md_boot_state, init_sonic2mb, ROT0, "bootleg / Sega",   "Sonic The Hedgehog 2 (bootleg of Megadrive version)",                                   0 ) // Flying wires going through the empty PIC space aren't completely understood
 GAME( 1994, barek2mb, 0, md_bootleg,   barek2,   md_boot_state, init_barek2,   ROT0, "bootleg / Sega",   "Bare Knuckle II (bootleg of Megadrive version)",                                        MACHINE_UNEMULATED_PROTECTION | MACHINE_NOT_WORKING ) // Needs PIC hook up
 GAME( 1994, barek3mb, 0, megadrvb,     barek3,   md_boot_state, init_barek3,   ROT0, "bootleg / Sega",   "Bare Knuckle III (bootleg of Megadrive version)",                                       0 )
-GAME( 1994, bk3ssrmb, 0, megadrvb_6b,  bk3ssrmb, md_boot_state, init_bk3ssrmb, ROT0, "bootleg / Sega",   "Bare Knuckle III / Sunset Riders (bootleg of Megadrive versions)",                      MACHINE_NOT_WORKING ) // Currently boots as Bare Knuckle III, mechanism to switch game not found yet
+GAME( 1994, bk3ssrmb, 0, megadrvb_6b,  bk3ssrmb, md_boot_6button_state, init_bk3ssrmb, ROT0, "bootleg / Sega",   "Bare Knuckle III / Sunset Riders (bootleg of Megadrive versions)",                      MACHINE_NOT_WORKING ) // Currently boots as Bare Knuckle III, mechanism to switch game not found yet
 GAME( 1993, twinktmb, 0, md_bootleg,   twinktmb, md_boot_state, init_twinktmb, ROT0, "bootleg / Sega",   "Twinkle Tale (bootleg of Megadrive version)",                                           MACHINE_UNEMULATED_PROTECTION | MACHINE_NOT_WORKING ) // Needs PIC decap or simulation
 GAME( 1993, jparkmb,  0, md_bootleg,   twinktmb, md_boot_state, init_jparkmb,  ROT0, "bootleg / Sega",   "Jurassic Park (bootleg of Megadrive version)",                                          MACHINE_UNEMULATED_PROTECTION | MACHINE_NOT_WORKING ) // Needs PIC decap or simulation

--- a/src/mame/drivers/megadriv_rad.cpp
+++ b/src/mame/drivers/megadriv_rad.cpp
@@ -234,6 +234,10 @@ void megadriv_radica_state::init_megadriv_radica_6button_ntsc()
 	m_megadrive_io_write_data_port_ptr = write16sm_delegate(*this, FUNC(md_base_state::megadrive_io_write_data_port_6button));
 }
 
+// US versions show 'Genesis' on the menu,    show a www.radicagames.com splash screen, and use NTSC versions of the ROMs, sometimes region locked
+// EU versions show 'Mega Drive' on the menu, show a www.radicagames.com splash screen, and use PAL versions of the ROMs, sometimes region locked
+// UK versions show "Mega Drive' on the menu, show a www.radicauk.com splash screen,    and use PAL versions of the ROMs, sometimes region locked
+
 
 CONS( 2004, rad_gen1,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 1 (Radica, Arcade Legends) (USA)", 0)
 CONS( 2004, rad_md1,   rad_gen1, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 1 (Radica, Arcade Legends) (Europe)", 0)

--- a/src/mame/drivers/megadriv_rad.cpp
+++ b/src/mame/drivers/megadriv_rad.cpp
@@ -102,7 +102,7 @@ static INPUT_PORTS_START( megadriv_radica_6button )
 INPUT_PORTS_END
 
 
-MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_6button)
+void megadriv_radica_6button_state::machine_start()
 {
 	md_base_state::machine_start();
 	m_vdp->stop_timers();
@@ -119,49 +119,41 @@ MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_6button)
 	save_item(NAME(m_bank));
 }
 
-MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_3button)
+void megadriv_radica_3button_state::machine_start()
 {
 	md_base_state::machine_start();
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
 }
 
-MACHINE_RESET_MEMBER(megadriv_radica_state, megadriv_radica)
+void megadriv_radica_3button_state::machine_reset()
 {
 	m_bank = 0;
 	md_base_state::machine_reset();
 }
 
-void megadriv_radica_state::megadriv_radica_3button_ntsc(machine_config &config)
+void megadriv_radica_3button_state::megadriv_radica_3button_ntsc(machine_config &config)
 {
 	md_ntsc(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_radica_state::megadriv_radica_map);
-	MCFG_MACHINE_START_OVERRIDE(megadriv_radica_state, megadriv_radica_3button)
-	MCFG_MACHINE_RESET_OVERRIDE(megadriv_radica_state, megadriv_radica)
 }
 
-void megadriv_radica_state::megadriv_radica_3button_pal(machine_config &config)
+void megadriv_radica_3button_state::megadriv_radica_3button_pal(machine_config &config)
 {
 	md_pal(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_radica_state::megadriv_radica_map);
-	MCFG_MACHINE_START_OVERRIDE(megadriv_radica_state, megadriv_radica_3button)
-	MCFG_MACHINE_RESET_OVERRIDE(megadriv_radica_state, megadriv_radica)
 }
 
-void megadriv_radica_state::megadriv_radica_6button_pal(machine_config &config)
+void megadriv_radica_6button_state::megadriv_radica_6button_pal(machine_config &config)
 {
 	md_pal(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_radica_state::megadriv_radica_map);
-	MCFG_MACHINE_START_OVERRIDE(megadriv_radica_state, megadriv_radica_6button)
-	MCFG_MACHINE_RESET_OVERRIDE(megadriv_radica_state, megadriv_radica)
 }
 
-void megadriv_radica_state::megadriv_radica_6button_ntsc(machine_config &config)
+void megadriv_radica_6button_state::megadriv_radica_6button_ntsc(machine_config &config)
 {
 	md_ntsc(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_radica_state::megadriv_radica_map);
-	MCFG_MACHINE_START_OVERRIDE(megadriv_radica_state, megadriv_radica_6button)
-	MCFG_MACHINE_RESET_OVERRIDE(megadriv_radica_state, megadriv_radica)
 }
 
 
@@ -218,7 +210,7 @@ ROM_START( rad_orun )
 ROM_END
 
 
-void megadriv_radica_state::init_megadriv_radica_6button_pal()
+void megadriv_radica_6button_state::init_megadriv_radica_6button_pal()
 {
 	init_megadrie();
 	// 6 button game, so overwrite 3 button io handlers
@@ -226,7 +218,7 @@ void megadriv_radica_state::init_megadriv_radica_6button_pal()
 	m_megadrive_io_write_data_port_ptr = write16sm_delegate(*this, FUNC(md_base_state::megadrive_io_write_data_port_6button));
 }
 
-void megadriv_radica_state::init_megadriv_radica_6button_ntsc()
+void megadriv_radica_6button_state::init_megadriv_radica_6button_ntsc()
 {
 	init_megadriv();
 	// 6 button game, so overwrite 3 button io handlers
@@ -239,26 +231,26 @@ void megadriv_radica_state::init_megadriv_radica_6button_ntsc()
 // UK versions show "Mega Drive' on the menu, show a www.radicauk.com splash screen,    and use PAL versions of the ROMs, sometimes region locked
 
 
-CONS( 2004, rad_gen1,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 1 (Radica, Arcade Legends) (USA)", 0)
-CONS( 2004, rad_md1,   rad_gen1, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 1 (Radica, Arcade Legends) (Europe)", 0)
+CONS( 2004, rad_gen1,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 1 (Radica, Arcade Legends) (USA)", 0)
+CONS( 2004, rad_md1,   rad_gen1, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 1 (Radica, Arcade Legends) (Europe)", 0)
 // A UK version exists, showing the Radica UK boot screen
 
-CONS( 2004, rad_gen2,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 2 (Radica, Arcade Legends) (USA)", 0)
-CONS( 2004, rad_md2,   rad_gen2, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 2 (Radica, Arcade Legends) (UK)", 0)
+CONS( 2004, rad_gen2,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 2 (Radica, Arcade Legends) (USA)", 0)
+CONS( 2004, rad_md2,   rad_gen2, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 2 (Radica, Arcade Legends) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 // box calls this Volume 3
-CONS( 2004, rad_sonic, 0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (USA)", 0)
-CONS( 2004, rad_sonicp,rad_sonic,0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (UK)", 0)
+CONS( 2004, rad_sonic, 0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadriv,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (USA)", 0)
+CONS( 2004, rad_sonicp,rad_sonic,0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadrie,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
 
-CONS( 2004, rad_sf2,   0,        0, megadriv_radica_6button_ntsc, megadriv_radica_6button,         megadriv_radica_state, init_megadriv_radica_6button_ntsc,"Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (USA)", 0)
-CONS( 2004, rad_sf2p,  rad_sf2,  0, megadriv_radica_6button_pal,  megadriv_radica_6button,         megadriv_radica_state, init_megadriv_radica_6button_pal, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (UK)", 0)
+CONS( 2004, rad_sf2,   0,        0, megadriv_radica_6button_ntsc, megadriv_radica_6button,         megadriv_radica_6button_state, init_megadriv_radica_6button_ntsc,"Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (USA)", 0)
+CONS( 2004, rad_sf2p,  rad_sf2,  0, megadriv_radica_6button_pal,  megadriv_radica_6button,         megadriv_radica_6button_state, init_megadriv_radica_6button_pal, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 // still branded as Arcade Legends even if none of these were ever arcade games, European exclusive
-CONS( 2004, rad_ssoc,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button,         megadriv_radica_state, init_megadrie,                    "Radica / Sensible Software / Sega", "Sensible Soccer plus [Cannon Fodder, Mega lo Mania] (Radica, Arcade Legends) (UK)", 0)
+CONS( 2004, rad_ssoc,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button,         megadriv_radica_3button_state, init_megadrie,                    "Radica / Sensible Software / Sega", "Sensible Soccer plus [Cannon Fodder, Mega lo Mania] (Radica, Arcade Legends) (UK)", 0)
 // is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 // not region locked, no Radica logos, uncertain if other regions would differ
-CONS( 2004, rad_orun,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Out Run 2019 (Radica Plug & Play, UK)", 0)
+CONS( 2004, rad_orun,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_3button_state, init_megadrie,                    "Radica / Sega",                     "Out Run 2019 (Radica Plug & Play, UK)", 0)

--- a/src/mame/drivers/megadriv_rad.cpp
+++ b/src/mame/drivers/megadriv_rad.cpp
@@ -104,7 +104,7 @@ INPUT_PORTS_END
 
 MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_6button)
 {
-	MACHINE_START_CALL_MEMBER(megadriv);
+	md_base_state::machine_start();
 	m_vdp->stop_timers();
 
 	m_io_pad_6b[0] = ioport("EXTRA1");
@@ -121,7 +121,7 @@ MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_6button)
 
 MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_3button)
 {
-	MACHINE_START_CALL_MEMBER(megadriv);
+	md_base_state::machine_start();
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
 }
@@ -129,7 +129,7 @@ MACHINE_START_MEMBER(megadriv_radica_state, megadriv_radica_3button)
 MACHINE_RESET_MEMBER(megadriv_radica_state, megadriv_radica)
 {
 	m_bank = 0;
-	MACHINE_RESET_CALL_MEMBER(megadriv);
+	md_base_state::machine_reset();
 }
 
 void megadriv_radica_state::megadriv_radica_3button_ntsc(machine_config &config)

--- a/src/mame/drivers/megadriv_rad.cpp
+++ b/src/mame/drivers/megadriv_rad.cpp
@@ -167,37 +167,47 @@ void megadriv_radica_state::megadriv_radica_6button_ntsc(machine_config &config)
 
 ROM_START( rad_sf2 )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "genesis2player.bin", 0x000000, 0x400000, CRC(a4426df8) SHA1(091f2a95ebd091141de5bcb83562c6087708cb32) )
+	ROM_LOAD16_WORD_SWAP( "radica_megadrive_streetfighter2_usa.bin", 0x000000, 0x400000, CRC(a4426df8) SHA1(091f2a95ebd091141de5bcb83562c6087708cb32) )
 ROM_END
 
 ROM_START( rad_sf2p )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "radicasf.bin", 0x000000, 0x400000,  CRC(868afb44) SHA1(f4339e36272c18b1d49aa4095127ed18e0961df6) )
+	ROM_LOAD16_WORD_SWAP( "radica_megadrive_streetfighter2_uk.bin", 0x000000, 0x400000,  CRC(868afb44) SHA1(f4339e36272c18b1d49aa4095127ed18e0961df6) )
 ROM_END
 
 ROM_START( rad_gen1 )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "radicav1.bin", 0x000000, 0x400000,  CRC(3b4c8438) SHA1(5ed9c053f9ebc8d4bf571d57e562cf347585d158) )
+	ROM_LOAD16_WORD_SWAP( "radica_megadrive_vol1_blue_usa.bin", 0x000000, 0x400000,  CRC(3b4c8438) SHA1(5ed9c053f9ebc8d4bf571d57e562cf347585d158) )
 ROM_END
 
 ROM_START( rad_md1 )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "radica.bin", 0x000000, 0x400000, CRC(85867db1) SHA1(ddc596e2e68dc872bc0679a2de7a295b4c6d6b8e) )
+	ROM_LOAD16_WORD_SWAP( "radica_megadrive_vol1_blue_europe.bin", 0x000000, 0x400000, CRC(85867db1) SHA1(ddc596e2e68dc872bc0679a2de7a295b4c6d6b8e) )
 ROM_END
 
 ROM_START( rad_gen2 )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "genesisred.bin", 0x000000, 0x400000, CRC(7c1a0f0e) SHA1(a6441f75a4cd48f1563aeafdfbdde00202d4067c) )
+	ROM_LOAD16_WORD_SWAP( "radica_genesis_vol2_red_usa.bin", 0x000000, 0x400000, CRC(7c1a0f0e) SHA1(a6441f75a4cd48f1563aeafdfbdde00202d4067c) )
+ROM_END
+
+ROM_START( rad_md2 )
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD16_WORD_SWAP( "radica_megadrive_vol2_red_uk.bin", 0x000000, 0x400000, CRC(b68fd025) SHA1(b8f9c505653d6dd2b62840f078f828360faf8abc) )
 ROM_END
 
 ROM_START( rad_ssoc )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD( "sensiblesoccer.bin", 0x000000, 0x400000,  CRC(b8745ab3) SHA1(0ab3f26e5ffd288e5a3a5db676951b9095299eb0) ) // should be byteswapped?
+	ROM_LOAD( "radica_sensiblesoccer_uk.bin", 0x000000, 0x400000,  CRC(b8745ab3) SHA1(0ab3f26e5ffd288e5a3a5db676951b9095299eb0) ) // should be byteswapped?
 ROM_END
 
 ROM_START( rad_sonic )
 	ROM_REGION( 0x400000, "maincpu", 0 )
-	ROM_LOAD16_WORD_SWAP( "supersonicgold.bin", 0x000000, 0x400000, CRC(853c9140) SHA1(cf70a9cdd3be4d8d1b6195698db3a941f4908791) )
+	ROM_LOAD16_WORD_SWAP( "radica_supersonicgold_usa.bin", 0x000000, 0x400000, CRC(853c9140) SHA1(cf70a9cdd3be4d8d1b6195698db3a941f4908791) )
+ROM_END
+
+ROM_START( rad_sonicp )
+	ROM_REGION( 0x400000, "maincpu", 0 )
+	ROM_LOAD16_WORD_SWAP( "radica_supersonicgold_uk.bin", 0x000000, 0x400000, CRC(ed774018) SHA1(cc2f7183e128c947463e3a43a0184b835ea16db8) )
 ROM_END
 
 // once byteswapped this matches "outrun 2019 (usa) (beta).bin  megadriv:outr2019up Out Run 2019 (USA, Prototype)"
@@ -227,16 +237,24 @@ void megadriv_radica_state::init_megadriv_radica_6button_ntsc()
 
 CONS( 2004, rad_gen1,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 1 (Radica, Arcade Legends) (USA)", 0)
 CONS( 2004, rad_md1,   rad_gen1, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 1 (Radica, Arcade Legends) (Europe)", 0)
+// A UK version exists, showing the Radica UK boot screen
 
 CONS( 2004, rad_gen2,  0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Genesis Collection Volume 2 (Radica, Arcade Legends) (USA)", 0)
+CONS( 2004, rad_md2,   rad_gen2, 0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Mega Drive Collection Volume 2 (Radica, Arcade Legends) (UK)", 0)
+// is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 // box calls this Volume 3
 CONS( 2004, rad_sonic, 0,        0, megadriv_radica_3button_ntsc, megadriv_radica_3button_1player, megadriv_radica_state, init_megadriv,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (USA)", 0)
+CONS( 2004, rad_sonicp,rad_sonic,0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Super Sonic Gold (Radica Plug & Play) (UK)", 0)
+// is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 CONS( 2004, rad_sf2,   0,        0, megadriv_radica_6button_ntsc, megadriv_radica_6button,         megadriv_radica_state, init_megadriv_radica_6button_ntsc,"Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (USA)", 0)
-CONS( 2004, rad_sf2p,  rad_sf2,  0, megadriv_radica_6button_pal,  megadriv_radica_6button,         megadriv_radica_state, init_megadriv_radica_6button_pal, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (Europe)", 0)
+CONS( 2004, rad_sf2p,  rad_sf2,  0, megadriv_radica_6button_pal,  megadriv_radica_6button,         megadriv_radica_state, init_megadriv_radica_6button_pal, "Radica / Capcom / Sega",            "Street Fighter II: Special Champion Edition [Ghouls'n Ghosts] (Radica, Arcade Legends) (UK)", 0)
+// is there a Europe version with Radica Games boot screen and Mega Drive text?
 
 // still branded as Arcade Legends even if none of these were ever arcade games, European exclusive
-CONS( 2004, rad_ssoc,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button,         megadriv_radica_state, init_megadrie,                    "Radica / Sensible Software / Sega", "Sensible Soccer plus [Cannon Fodder, Mega lo Mania] (Radica, Arcade Legends) (Europe)", 0)
+CONS( 2004, rad_ssoc,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button,         megadriv_radica_state, init_megadrie,                    "Radica / Sensible Software / Sega", "Sensible Soccer plus [Cannon Fodder, Mega lo Mania] (Radica, Arcade Legends) (UK)", 0)
+// is there a Europe version with Radica Games boot screen and Mega Drive text?
 
-CONS( 2004, rad_orun,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Out Run 2019 (Radica Plug & Play, Europe)", 0)
+// not region locked, no Radica logos, uncertain if other regions would differ
+CONS( 2004, rad_orun,  0,        0, megadriv_radica_3button_pal,  megadriv_radica_3button_1player, megadriv_radica_state, init_megadrie,                    "Radica / Sega",                     "Out Run 2019 (Radica Plug & Play, UK)", 0)

--- a/src/mame/drivers/megadriv_sunplus_hybrid.cpp
+++ b/src/mame/drivers/megadriv_sunplus_hybrid.cpp
@@ -1,0 +1,179 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+/*
+	This is an enhanced 'Mega Drive / Genesis on a Chip' combined with a SunPlus SPG2xx system for the 'Bonus Games' menu
+
+	It can take MegaDrive cartridges
+
+	The MD side of things doesn't work as it needs enhanced chipset emulation?
+
+	TODO:
+	hook up the SunPlus side again (see spg2xx_zone.cpp for hookup)
+
+*/
+
+#include "emu.h"
+#include "includes/megadriv.h"
+
+class megadriv_sunplus_state : public md_base_state
+{
+public:
+	megadriv_sunplus_state(const machine_config &mconfig, device_type type, const char *tag)
+		// Mega Drive part
+		: md_base_state(mconfig, type, tag),
+		m_md_is_running(false),
+		m_bank(0),
+		m_rom(*this, "maincpu")
+	{}
+
+	// Mega Drive part
+	DECLARE_MACHINE_START(megadriv_sunplus);
+	uint16_t read(offs_t offset);
+	void megadriv_sunplus_pal(machine_config &config);
+	void megadriv_sunplus_map(address_map &map);
+
+	void init_reactmd();
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	bool m_md_is_running;
+
+	// Mega Drive part
+	int m_bank;
+	required_region_ptr<uint16_t> m_rom;
+	uint32_t screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank_hybrid);
+
+};
+
+
+// todo, use actual MD map, easier once maps are part of base class.
+void megadriv_sunplus_state::megadriv_sunplus_map(address_map &map)
+{
+	map(0x000000, 0x3fffff).r(FUNC(megadriv_sunplus_state::read)); /* Cartridge Program Rom */
+	map(0xa00000, 0xa01fff).rw(FUNC(megadriv_sunplus_state::megadriv_68k_read_z80_ram), FUNC(megadriv_sunplus_state::megadriv_68k_write_z80_ram));
+	map(0xa02000, 0xa03fff).w(FUNC(megadriv_sunplus_state::megadriv_68k_write_z80_ram));
+	map(0xa04000, 0xa04003).rw(FUNC(megadriv_sunplus_state::megadriv_68k_YM2612_read), FUNC(megadriv_sunplus_state::megadriv_68k_YM2612_write));
+	map(0xa06000, 0xa06001).w(FUNC(megadriv_sunplus_state::megadriv_68k_z80_bank_write));
+	map(0xa10000, 0xa1001f).rw(FUNC(megadriv_sunplus_state::megadriv_68k_io_read), FUNC(megadriv_sunplus_state::megadriv_68k_io_write));
+	map(0xa11100, 0xa11101).rw(FUNC(megadriv_sunplus_state::megadriv_68k_check_z80_bus), FUNC(megadriv_sunplus_state::megadriv_68k_req_z80_bus));
+	map(0xa11200, 0xa11201).w(FUNC(megadriv_sunplus_state::megadriv_68k_req_z80_reset));
+	map(0xc00000, 0xc0001f).rw(m_vdp, FUNC(sega315_5313_device::vdp_r), FUNC(sega315_5313_device::vdp_w));
+	map(0xe00000, 0xe0ffff).ram().mirror(0x1f0000).share("megadrive_ram");
+}
+
+uint16_t megadriv_sunplus_state::read(offs_t offset)
+{
+	return m_rom[(((m_bank * 0x10000) + (offset << 1)) & (0x400000 - 1))/2];
+}
+
+
+// controller is wired directly into unit, no controller slots
+static INPUT_PORTS_START( megadriv_sunplus )
+	PORT_INCLUDE( md_common )
+
+	PORT_MODIFY("PAD1")
+#if 0
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_START1 )
+#else
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
+#endif
+
+	PORT_MODIFY("PAD2")
+#if 0
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_START2 )
+##else
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
+#endif
+INPUT_PORTS_END
+
+
+void megadriv_sunplus_state::machine_start()
+{
+	printf("machine_start\n");
+
+	// Mega Drive part
+	MACHINE_START_CALL_MEMBER(megadriv); // legacy call type for MD base code
+	m_vdp->stop_timers();
+	save_item(NAME(m_bank));
+
+	m_screen->set_screen_update(FUNC(megadriv_sunplus_state::screen_update_hybrid)); 
+	m_screen->screen_vblank().set(FUNC(megadriv_sunplus_state::screen_vblank_hybrid)); 
+}
+
+void megadriv_sunplus_state::machine_reset()
+{
+	printf("machine_reset\n");
+	MACHINE_RESET_CALL_MEMBER(megadriv); // legacy call type for MD base code
+}
+
+uint32_t megadriv_sunplus_state::screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	if (m_md_is_running)
+	{
+		/* Copies a bitmap */
+		return screen_update_megadriv(screen, bitmap, cliprect);
+	}
+
+	return 0;
+}
+
+WRITE_LINE_MEMBER(megadriv_sunplus_state::screen_vblank_hybrid)
+{
+	if (m_md_is_running)
+	{
+		/* Used to Sync the timing */
+		md_base_state::screen_vblank_megadriv(state);
+	}
+}
+
+
+void megadriv_sunplus_state::megadriv_sunplus_pal(machine_config &config)
+{
+	md_pal(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_sunplus_state::megadriv_sunplus_map);
+}
+
+
+void megadriv_sunplus_state::init_reactmd()
+{
+	uint16_t *ROM = (uint16_t*)memregion("sunplus")->base();
+	int size = memregion("sunplus")->bytes();
+
+	for (int i = 0; i < size/2; i++)
+	{
+		ROM[i] = bitswap<16>(ROM[i], 15, 13, 14, 12,  7,  6,  5,  4,
+									 11, 10, 9,  8,   3,  1,  2,  0);
+
+		ROM[i] = ROM[i] ^ 0xa5a5;
+	}
+
+	init_megadrie();
+}
+
+
+ROM_START( reactmd )
+	ROM_REGION( 0x2000000, "maincpu", ROMREGION_ERASE00 ) // this contains the MD games and main boot menu
+	ROM_LOAD16_WORD_SWAP( "reactormd.bin", 0x0000, 0x2000000, CRC(fe9664a4) SHA1(d475b524f576c9d1d90aed20c7467cc652396baf) )
+
+	ROM_REGION( 0x4000000, "sunplus", ROMREGION_ERASE00 ) // this contains the SunPlus games
+	ROM_LOAD16_WORD_SWAP( "reactor_md_sunplus-full.bin", 0x0000, 0x4000000, CRC(843aa58c) SHA1(07cdc6d4aa0057939c145ece01a9aca73c7f1f2b) )
+	ROM_IGNORE(0x4000000) // the 2nd half of the ROM can't be accessed by the PCB (address line tied low) (contains garbage? data)
+ROM_END
+
+
+// Two systems in one unit - Genesis on a Chip and SunPlus, only the SunPlus part is currently emulated.  Genesis on a chip is a very poor implementation with many issues on real hardware.
+// This should actually boot to a menu on the MD size, with the SunPlus only being enabled if selected from that menu.  MD side menu runs in some enhanced / custom MD mode though.
+// Badminton hangs, as it does in the 49-in-1 above
+CONS( 2009, reactmd,  0, 0, megadriv_sunplus_pal,    megadriv_sunplus, megadriv_sunplus_state,      init_reactmd,    "AtGames / Sega / Waixing",                              "Reactor MD (PAL)",                    MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+

--- a/src/mame/drivers/megadriv_sunplus_hybrid.cpp
+++ b/src/mame/drivers/megadriv_sunplus_hybrid.cpp
@@ -100,10 +100,9 @@ INPUT_PORTS_END
 
 void megadriv_sunplus_state::machine_start()
 {
-	printf("machine_start\n");
+	logerror("megadriv_sunplus_state::machine_start\n");
+	md_base_state::machine_start();
 
-	// Mega Drive part
-	MACHINE_START_CALL_MEMBER(megadriv); // legacy call type for MD base code
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
 
@@ -113,8 +112,8 @@ void megadriv_sunplus_state::machine_start()
 
 void megadriv_sunplus_state::machine_reset()
 {
-	printf("machine_reset\n");
-	MACHINE_RESET_CALL_MEMBER(megadriv); // legacy call type for MD base code
+	logerror("megadriv_sunplus_state::machine_reset\n");
+	md_base_state::machine_reset();
 }
 
 uint32_t megadriv_sunplus_state::screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)

--- a/src/mame/drivers/megadriv_sunplus_hybrid.cpp
+++ b/src/mame/drivers/megadriv_sunplus_hybrid.cpp
@@ -28,7 +28,6 @@ public:
 	{}
 
 	// Mega Drive part
-	DECLARE_MACHINE_START(megadriv_sunplus);
 	uint16_t read(offs_t offset);
 	void megadriv_sunplus_pal(machine_config &config);
 	void megadriv_sunplus_map(address_map &map);

--- a/src/mame/drivers/megadriv_sunplus_hybrid.cpp
+++ b/src/mame/drivers/megadriv_sunplus_hybrid.cpp
@@ -22,7 +22,7 @@ public:
 	megadriv_sunplus_state(const machine_config &mconfig, device_type type, const char *tag)
 		// Mega Drive part
 		: md_base_state(mconfig, type, tag),
-		m_md_is_running(false),
+		m_md_is_running(true),
 		m_bank(0),
 		m_rom(*this, "maincpu")
 	{}
@@ -105,9 +105,6 @@ void megadriv_sunplus_state::machine_start()
 
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
-
-	m_screen->set_screen_update(FUNC(megadriv_sunplus_state::screen_update_hybrid)); 
-	m_screen->screen_vblank().set(FUNC(megadriv_sunplus_state::screen_vblank_hybrid)); 
 }
 
 void megadriv_sunplus_state::machine_reset()
@@ -141,6 +138,9 @@ void megadriv_sunplus_state::megadriv_sunplus_pal(machine_config &config)
 {
 	md_pal(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_sunplus_state::megadriv_sunplus_map);
+
+	m_screen->set_screen_update(FUNC(megadriv_sunplus_state::screen_update_hybrid)); 
+	m_screen->screen_vblank().set(FUNC(megadriv_sunplus_state::screen_vblank_hybrid)); 
 }
 
 

--- a/src/mame/drivers/megadriv_vt_hybrid.cpp
+++ b/src/mame/drivers/megadriv_vt_hybrid.cpp
@@ -21,7 +21,7 @@ public:
 	megadriv_vt0203_state(const machine_config &mconfig, device_type type, const char *tag)
 		// Mega Drive part
 		: md_base_state(mconfig, type, tag),
-		m_md_is_running(false),
+		m_md_is_running(true),
 		m_bank(0),
 		m_rom(*this, "maincpu")
 	{}
@@ -102,9 +102,6 @@ void megadriv_vt0203_state::machine_start()
 
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
-
-	m_screen->set_screen_update(FUNC(megadriv_vt0203_state::screen_update_hybrid)); 
-	m_screen->screen_vblank().set(FUNC(megadriv_vt0203_state::screen_vblank_hybrid)); 
 }
 
 void megadriv_vt0203_state::machine_reset()
@@ -138,6 +135,9 @@ void megadriv_vt0203_state::megadriv_vt0203_pal(machine_config &config)
 {
 	md_pal(config);
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_vt0203_state::megadriv_vt0203_map);
+
+	m_screen->set_screen_update(FUNC(megadriv_vt0203_state::screen_update_hybrid)); 
+	m_screen->screen_vblank().set(FUNC(megadriv_vt0203_state::screen_vblank_hybrid)); 
 }
 
 

--- a/src/mame/drivers/megadriv_vt_hybrid.cpp
+++ b/src/mame/drivers/megadriv_vt_hybrid.cpp
@@ -136,7 +136,10 @@ void megadriv_vt0203_state::megadriv_vt0203_pal(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_vt0203_state::megadriv_vt0203_map);
 
 	m_screen->set_screen_update(FUNC(megadriv_vt0203_state::screen_update_hybrid)); 
-	m_screen->screen_vblank().set(FUNC(megadriv_vt0203_state::screen_vblank_hybrid)); 
+	m_screen->screen_vblank().set(FUNC(megadriv_vt0203_state::screen_vblank_hybrid));
+
+	// TODO: add the VT part, this might require refactoring of the VT stuff as the SoC currently contains the screen
+	//       but instead we'll need to use a shared screen that is reconfigured depending on which part is enabled
 }
 
 

--- a/src/mame/drivers/megadriv_vt_hybrid.cpp
+++ b/src/mame/drivers/megadriv_vt_hybrid.cpp
@@ -1,0 +1,163 @@
+// license:BSD-3-Clause
+// copyright-holders:David Haywood
+
+/*
+	This is an enhanced 'Mega Drive / Genesis on a Chip' combined with a VT02/VT03 system for the 'Bonus Games' menu
+
+	The menu for the MD side of things doesn't work as it needs enhanced chipset emulation?
+	at the moment it just boots the game in the lowest ROM bank (Flicky)
+
+	TODO:
+	hook up the VT side again
+
+*/
+
+#include "emu.h"
+#include "includes/megadriv.h"
+
+class megadriv_vt0203_state : public md_base_state
+{
+public:
+	megadriv_vt0203_state(const machine_config &mconfig, device_type type, const char *tag)
+		// Mega Drive part
+		: md_base_state(mconfig, type, tag),
+		m_md_is_running(false),
+		m_bank(0),
+		m_rom(*this, "maincpu")
+	{}
+
+	// Mega Drive part
+	DECLARE_MACHINE_START(megadriv_vt0203);
+	uint16_t read(offs_t offset);
+	void megadriv_vt0203_pal(machine_config &config);
+	void megadriv_vt0203_map(address_map &map);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+
+private:
+	bool m_md_is_running;
+
+	// Mega Drive part
+	int m_bank;
+	required_region_ptr<uint16_t> m_rom;
+	uint32_t screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	DECLARE_WRITE_LINE_MEMBER(screen_vblank_hybrid);
+
+};
+
+
+// todo, use actual MD map, easier once maps are part of base class.
+void megadriv_vt0203_state::megadriv_vt0203_map(address_map &map)
+{
+	map(0x000000, 0x3fffff).r(FUNC(megadriv_vt0203_state::read)); /* Cartridge Program Rom */
+	map(0xa00000, 0xa01fff).rw(FUNC(megadriv_vt0203_state::megadriv_68k_read_z80_ram), FUNC(megadriv_vt0203_state::megadriv_68k_write_z80_ram));
+	map(0xa02000, 0xa03fff).w(FUNC(megadriv_vt0203_state::megadriv_68k_write_z80_ram));
+	map(0xa04000, 0xa04003).rw(FUNC(megadriv_vt0203_state::megadriv_68k_YM2612_read), FUNC(megadriv_vt0203_state::megadriv_68k_YM2612_write));
+	map(0xa06000, 0xa06001).w(FUNC(megadriv_vt0203_state::megadriv_68k_z80_bank_write));
+	map(0xa10000, 0xa1001f).rw(FUNC(megadriv_vt0203_state::megadriv_68k_io_read), FUNC(megadriv_vt0203_state::megadriv_68k_io_write));
+	map(0xa11100, 0xa11101).rw(FUNC(megadriv_vt0203_state::megadriv_68k_check_z80_bus), FUNC(megadriv_vt0203_state::megadriv_68k_req_z80_bus));
+	map(0xa11200, 0xa11201).w(FUNC(megadriv_vt0203_state::megadriv_68k_req_z80_reset));
+	map(0xc00000, 0xc0001f).rw(m_vdp, FUNC(sega315_5313_device::vdp_r), FUNC(sega315_5313_device::vdp_w));
+	map(0xe00000, 0xe0ffff).ram().mirror(0x1f0000).share("megadrive_ram");
+}
+
+uint16_t megadriv_vt0203_state::read(offs_t offset)
+{
+	return m_rom[(((m_bank * 0x10000) + (offset << 1)) & (0x400000 - 1))/2];
+}
+
+
+// controller is wired directly into unit, no controller slots
+static INPUT_PORTS_START( megadriv_vt0203 )
+	PORT_INCLUDE( md_common )
+
+	PORT_MODIFY("PAD1")
+#if 0
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1)
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_START1 )
+#else
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
+#endif
+
+	PORT_MODIFY("PAD2")
+#if 0
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2)
+	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_START2 )
+##else
+	PORT_BIT( 0x00ff, IP_ACTIVE_LOW, IPT_UNUSED )
+#endif
+INPUT_PORTS_END
+
+
+void megadriv_vt0203_state::machine_start()
+{
+	printf("machine_start\n");
+
+	// Mega Drive part
+	MACHINE_START_CALL_MEMBER(megadriv); // legacy call type for MD base code
+	m_vdp->stop_timers();
+	save_item(NAME(m_bank));
+
+	m_screen->set_screen_update(FUNC(megadriv_vt0203_state::screen_update_hybrid)); 
+	m_screen->screen_vblank().set(FUNC(megadriv_vt0203_state::screen_vblank_hybrid)); 
+}
+
+void megadriv_vt0203_state::machine_reset()
+{
+	printf("machine_reset\n");
+	MACHINE_RESET_CALL_MEMBER(megadriv); // legacy call type for MD base code
+}
+
+uint32_t megadriv_vt0203_state::screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	if (m_md_is_running)
+	{
+		/* Copies a bitmap */
+		return screen_update_megadriv(screen, bitmap, cliprect);
+	}
+
+	return 0;
+}
+
+WRITE_LINE_MEMBER(megadriv_vt0203_state::screen_vblank_hybrid)
+{
+	if (m_md_is_running)
+	{
+		/* Used to Sync the timing */
+		md_base_state::screen_vblank_megadriv(state);
+	}
+}
+
+
+void megadriv_vt0203_state::megadriv_vt0203_pal(machine_config &config)
+{
+	md_pal(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &megadriv_vt0203_state::megadriv_vt0203_map);
+}
+
+
+ROM_START( sarc110 )
+	ROM_REGION( 0x1000000, "maincpu", 0 ) // Mega Drive part
+	ROM_LOAD16_WORD_SWAP( "superarcade.bin", 0x000000, 0x1000000, CRC(be732867) SHA1(3857b2fbddd6a548c81caf64122e47a0df079be5) )
+
+	ROM_REGION( 0x400000, "mainrom", 0 ) // VT02/03 part
+	ROM_LOAD( "ic1.prg", 0x00000, 0x400000, CRC(de76f71f) SHA1(ff6b37a76c6463af7ae901918fc008b4a2863951) )
+ROM_END
+
+ROM_START( sarc110a )
+	ROM_REGION( 0x1000000, "maincpu", 0 ) // Mega Drive part
+	ROM_LOAD16_WORD_SWAP( "superarcade.bin", 0x000000, 0x1000000, CRC(be732867) SHA1(3857b2fbddd6a548c81caf64122e47a0df079be5) )
+
+	ROM_REGION( 0x400000, "mainrom", 0 ) // VT02/03 part
+	ROM_LOAD( "ic1_ver2.prg", 0x00000, 0x400000, CRC(b97a0dc7) SHA1(bace32d73184df914113de5336e29a7a6f4c03fa) )
+ROM_END
+
+
+CONS( 200?, sarc110, 0,       0, megadriv_vt0203_pal,  megadriv_vt0203, megadriv_vt0203_state, init_megadrie, "<unknown>",                     "Super Arcade 101-in-1 (set 1)", MACHINE_NOT_WORKING)
+CONS( 200?, sarc110a,sarc110, 0, megadriv_vt0203_pal,  megadriv_vt0203, megadriv_vt0203_state, init_megadrie, "<unknown>",                     "Super Arcade 101-in-1 (set 2)", MACHINE_NOT_WORKING)

--- a/src/mame/drivers/megadriv_vt_hybrid.cpp
+++ b/src/mame/drivers/megadriv_vt_hybrid.cpp
@@ -97,10 +97,9 @@ INPUT_PORTS_END
 
 void megadriv_vt0203_state::machine_start()
 {
-	printf("machine_start\n");
+	logerror("megadriv_vt0203_state::machine_start\n");
+	md_base_state::machine_start();
 
-	// Mega Drive part
-	MACHINE_START_CALL_MEMBER(megadriv); // legacy call type for MD base code
 	m_vdp->stop_timers();
 	save_item(NAME(m_bank));
 
@@ -110,8 +109,8 @@ void megadriv_vt0203_state::machine_start()
 
 void megadriv_vt0203_state::machine_reset()
 {
-	printf("machine_reset\n");
-	MACHINE_RESET_CALL_MEMBER(megadriv); // legacy call type for MD base code
+	logerror("megadriv_vt0203_state::machine_reset\n");
+	md_base_state::machine_reset();
 }
 
 uint32_t megadriv_vt0203_state::screen_update_hybrid(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)

--- a/src/mame/drivers/megadriv_vt_hybrid.cpp
+++ b/src/mame/drivers/megadriv_vt_hybrid.cpp
@@ -27,7 +27,6 @@ public:
 	{}
 
 	// Mega Drive part
-	DECLARE_MACHINE_START(megadriv_vt0203);
 	uint16_t read(offs_t offset);
 	void megadriv_vt0203_pal(machine_config &config);
 	void megadriv_vt0203_map(address_map &map);

--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -59,6 +59,9 @@ public:
 	DECLARE_READ_LINE_MEMBER(start1_r);
 	DECLARE_READ_LINE_MEMBER(start2_r);
 
+protected:
+	virtual void machine_reset() override;
+
 private:
 
 	uint16_t extra_ram_r(offs_t offset);
@@ -81,7 +84,6 @@ private:
 	uint8_t vdp1_count_r(offs_t offset);
 
 	DECLARE_VIDEO_START(megplay);
-	DECLARE_MACHINE_RESET(megaplay);
 	uint32_t screen_update_megplay(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
 	void megaplay_bios_io_map(address_map &map);
@@ -648,7 +650,7 @@ uint32_t mplay_state::screen_update_megplay(screen_device &screen, bitmap_rgb32 
 	return 0;
 }
 
-MACHINE_RESET_MEMBER(mplay_state,megaplay)
+void mplay_state::machine_reset()
 {
 	m_bios_mode = MP_ROM;
 	m_bios_bank_addr = 0;

--- a/src/mame/drivers/megaplay.cpp
+++ b/src/mame/drivers/megaplay.cpp
@@ -653,7 +653,7 @@ MACHINE_RESET_MEMBER(mplay_state,megaplay)
 	m_bios_mode = MP_ROM;
 	m_bios_bank_addr = 0;
 	m_readpos = 1;
-	MACHINE_RESET_CALL_MEMBER(megadriv);
+	md_base_state::machine_reset();
 }
 
 void mplay_state::megaplay(machine_config &config)

--- a/src/mame/drivers/megatech.cpp
+++ b/src/mame/drivers/megatech.cpp
@@ -114,6 +114,9 @@ public:
 	void init_mt_crt();
 	void init_mt_slot();
 
+protected:
+	virtual void machine_reset() override;
+
 private:
 
 	void megatech(machine_config &config);
@@ -137,7 +140,6 @@ private:
 	uint8_t sms_ioport_dd_r();
 	void mt_sms_standard_rom_bank_w(address_space &space, offs_t offset, uint8_t data);
 
-	DECLARE_MACHINE_RESET(megatech);
 
 	image_init_result load_cart(device_image_interface &image, generic_slot_device *slot, int gameno);
 	DECLARE_DEVICE_IMAGE_LOAD_MEMBER( mt_cart1 ) { return load_cart(image, m_cart1, 0); }
@@ -644,7 +646,7 @@ WRITE_LINE_MEMBER(mtech_state::screen_vblank_main)
 		screen_vblank_megadriv(state);
 }
 
-MACHINE_RESET_MEMBER(mtech_state, megatech)
+void mtech_state::machine_reset()
 {
 	m_mt_bank_addr = 0;
 	md_base_state::machine_reset();
@@ -701,8 +703,6 @@ void mtech_state::megatech(machine_config &config)
 	io2.out_portd_cb().set(FUNC(mtech_state::bios_portd_w));
 	io2.in_porte_cb().set(FUNC(mtech_state::bios_porte_r));
 	io2.out_porte_cb().set(FUNC(mtech_state::bios_porte_w));
-
-	MCFG_MACHINE_RESET_OVERRIDE(mtech_state, megatech)
 
 	config.set_default_layout(layout_dualhovu);
 

--- a/src/mame/drivers/megatech.cpp
+++ b/src/mame/drivers/megatech.cpp
@@ -647,7 +647,7 @@ WRITE_LINE_MEMBER(mtech_state::screen_vblank_main)
 MACHINE_RESET_MEMBER(mtech_state, megatech)
 {
 	m_mt_bank_addr = 0;
-	MACHINE_RESET_CALL_MEMBER(megadriv);
+	md_base_state::machine_reset();
 
 	std::string region_tag;
 	if (m_cart1->get_rom_size() > 0)

--- a/src/mame/drivers/nes_clone.cpp
+++ b/src/mame/drivers/nes_clone.cpp
@@ -963,6 +963,12 @@ ROM_START( papsudok )
 	ROM_LOAD( "sudoku2.bin", 0x00000, 0x80000, CRC(d1ffcc1e) SHA1(2010e60933a08d0b9271ef37f338758aacba6d2d) )
 ROM_END
 
+ROM_START( nytsudo )
+	ROM_REGION( 0x80000, "maincpu", 0 )
+	ROM_LOAD( "nytsudoku.bin", 0x00000, 0x80000, CRC(9aab1977) SHA1(6948f34d67204287418cdf79f1ca0fa0c26670e3) )
+ROM_END
+
+
 ROM_START( pjoypj001 )
 	ROM_REGION( 0x100000, "maincpu", ROMREGION_ERASE00 )
 	ROM_LOAD( "powerjoy_pj001_lh28f008sc_89a6.bin", 0x00000, 0x100000, CRC(e655e0aa) SHA1(c96d3422e26451c366fee2151fedccb95014cbc7) )
@@ -1005,7 +1011,8 @@ CONS( 200?, dnce2000, 0, 0, nes_clone_dnce2000, dnce2000, nes_clone_dnce2000_sta
 // Alt. version was released with 'New York Times' titlescreen
 CONS( 200?, papsudok,     0,  0,  nes_clone_suduko, papsudok, nes_clone_suduko_state, init_sudoku, "Nice Code", "Plug and Play Sudoku Game (NES based)", 0 ) // plays, but unclear how 'save' feature is meant to work, is it meant to save after shutdown or not? no obvious writes
 
-CONS( 200?, vtvppong,  0,  0,  nes_clone_vtvppong,    nes_clone, nes_clone_vtvppong_state, init_vtvppong, "<unknown>", "Virtual TV Ping Pong", MACHINE_NOT_WORKING )
+CONS( 200?, nytsudo,      0,  0,  nes_clone_suduko, papsudok, nes_clone_suduko_state, init_sudoku, "Excalibur / Nice Code", "The New York Times Sudoku", 0 ) // based on the above
 
+CONS( 200?, vtvppong,  0,  0,  nes_clone_vtvppong,    nes_clone, nes_clone_vtvppong_state, init_vtvppong, "<unknown>", "Virtual TV Ping Pong", MACHINE_NOT_WORKING )
 
 CONS( 200?, pjoypj001, 0, 0, nes_clone, nes_clone, nes_clone_state, init_nes_clone, "Trump Grand", "PowerJoy (PJ001, NES based plug & play)", MACHINE_NOT_WORKING )

--- a/src/mame/drivers/nes_sh6578.cpp
+++ b/src/mame/drivers/nes_sh6578.cpp
@@ -724,6 +724,12 @@ ROM_START( vsmaxx25 )
 	ROM_LOAD( "vsmaxx25_am29lv160dt_000122c4.bin", 0x00000, 0x200000, CRC(0efd1625) SHA1(34e83f748af3eee475c5b2b24ff03c00c1b5b8ed) )
 ROM_END
 
+ROM_START( dgun806 )
+	ROM_REGION( 0x200000, "maincpu", 0 )
+	ROM_LOAD( "dgpnpdgu806as29lv160be_000422c4.BIN", 0x00000, 0x200000, CRC(576d6caf) SHA1(fdfa4712e6ed66d2af41ccfbfbf870cd01f7b0f7) )
+ROM_END
+
+
 
 
 CONS( 200?, maxx5in1,  0, 0,  nes_sh6578, nes_sh6578, nes_sh6578_state,  init_nes_sh6578, "Senario / JungleTac", "Vs Maxx 5-in-1 Casino / Senario Card & Casino Games", 0 ) // advertised on box as 'With Solitaire" (was there an even older version without it?)
@@ -745,6 +751,10 @@ CONS( 2004?, vsmaxx15,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_state, init
 // This is from the blue coloured unit with the 1p/2p slider (does it do anything / get read anywhere?)
 // A version of the 25-in-1 on VT hardware also exists, with the downgraded version of Big Racing & removed copyrights etc. (probably the purple tinted version without the 1p/2p slider)
 CONS( 2004?, vsmaxx25,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_max10in1_state, init_nes_sh6578, "Senario / JungleTac", "Vs Maxx 25-in-1", MACHINE_NOT_WORKING )
+
+CONS( 2004?, dgun806,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_max10in1_state, init_nes_sh6578, "dreamGEAR", "Plug 'N' Play 25-in-1 (DGUN-806)", MACHINE_NOT_WORKING )
+
+
 
 // titles below need inputs mapping to go further
 

--- a/src/mame/drivers/nes_sh6578.cpp
+++ b/src/mame/drivers/nes_sh6578.cpp
@@ -726,7 +726,7 @@ ROM_END
 
 ROM_START( dgun806 )
 	ROM_REGION( 0x200000, "maincpu", 0 )
-	ROM_LOAD( "dgpnpdgu806as29lv160be_000422c4.BIN", 0x00000, 0x200000, CRC(576d6caf) SHA1(fdfa4712e6ed66d2af41ccfbfbf870cd01f7b0f7) )
+	ROM_LOAD( "dgpnpdgu806as29lv160be_000422c4.bin", 0x00000, 0x200000, CRC(576d6caf) SHA1(fdfa4712e6ed66d2af41ccfbfbf870cd01f7b0f7) )
 ROM_END
 
 
@@ -750,8 +750,9 @@ CONS( 2004?, vsmaxx15,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_state, init
 
 // This is from the blue coloured unit with the 1p/2p slider (does it do anything / get read anywhere?)
 // A version of the 25-in-1 on VT hardware also exists, with the downgraded version of Big Racing & removed copyrights etc. (probably the purple tinted version without the 1p/2p slider)
-CONS( 2004?, vsmaxx25,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_max10in1_state, init_nes_sh6578, "Senario / JungleTac", "Vs Maxx 25-in-1", MACHINE_NOT_WORKING )
+CONS( 2004?, vsmaxx25,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_max10in1_state, init_nes_sh6578, "Senario / JungleTac", "Vs Maxx 25-in-1 (SH6578 hardware)", MACHINE_NOT_WORKING )
 
+// DGUN-806 on sticker on battery compartment. DreamGear had some other products with the same pad type but different DGUN numbers on the packaging, is the ROM the same?
 CONS( 2004?, dgun806,    0,  0,  nes_sh6578, nes_sh6578, nes_sh6578_max10in1_state, init_nes_sh6578, "dreamGEAR", "Plug 'N' Play 25-in-1 (DGUN-806)", MACHINE_NOT_WORKING )
 
 

--- a/src/mame/drivers/nes_vt02_vt03.cpp
+++ b/src/mame/drivers/nes_vt02_vt03.cpp
@@ -1356,8 +1356,8 @@ CONS( 200?, majgnc,    0, 0,  nes_vt_1mb, majgnc, nes_vt_state,  empty_init, "Ma
 
 // CPU die is marked 'VH2009' There's also a 62256 RAM chip on the PCB, some scrambled opcodes
 CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario / JungleTac",   "Vs Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
+CONS( 200?, vsmax25v,  0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario / JungleTac",   "Vs Maxx 25-in-1 (VT03 hardware)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid / JungleTac",  "TV MegaMax active power game system 30-in-1 (MegaMax GPD001SDG)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
-CONS( 200?, vsmax25v,  0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Vs Maxx 25-in-1 (VT03 hardware)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, dgun851,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Plug 'N' Play 30-in-1 (DGUN-851)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, dgun853,   0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Plug 'N' Play 50-in-1 (DGUN-853)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit / JungleTac", "35 in 1 Super Twins", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )

--- a/src/mame/drivers/nes_vt02_vt03.cpp
+++ b/src/mame/drivers/nes_vt02_vt03.cpp
@@ -72,6 +72,7 @@ public:
 		m_soc(*this, "soc")
 	{ }
 
+	void nes_vt_pal_1mb(machine_config& config);
 	void nes_vt_pal_2mb(machine_config& config);
 	void nes_vt_pal_4mb(machine_config& config);
 	void nes_vt_pal_8mb(machine_config& config);
@@ -539,6 +540,13 @@ void nes_vt_state::nes_vt_32mb(machine_config& config)
 	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_state::vt_external_space_map_32mbyte);
 }
 
+void nes_vt_state::nes_vt_pal_1mb(machine_config& config)
+{
+	NES_VT02_VT03_SOC_PAL(config, m_soc, PAL_APU_CLOCK);
+	configure_soc(m_soc);
+	m_soc->set_addrmap(AS_PROGRAM, &nes_vt_state::vt_external_space_map_1mbyte);
+}
+
 void nes_vt_state::nes_vt_pal_2mb(machine_config& config)
 {
 	NES_VT02_VT03_SOC_PAL(config, m_soc, PAL_APU_CLOCK);
@@ -981,6 +989,11 @@ ROM_START( mc_dgear )
 	ROM_LOAD( "dreamgear 75-in-1.prg", 0x00000, 0x400000, CRC(9aabcb8f) SHA1(aa9446b7777fa64503871225fcaf2a17aafd9af1) )
 ROM_END
 
+ROM_START( sudo6in1 )
+	ROM_REGION( 0x100000, "mainrom", 0 )
+	ROM_LOAD( "6n1sudoku.bin", 0x00000, 0x100000, CRC(31089cd4) SHA1(dbfe41d327278dbfa46c7ad7ef327c20648562c1) )
+ROM_END
+
 ROM_START( sen101 )
 	ROM_REGION( 0x400000, "mainrom", 0 )
 	ROM_LOAD( "101n1.bin", 0x00000, 0x400000, CRC(b03e1824) SHA1(c9ac4e16220414c1aa679133191140ced9986e9c) )
@@ -1011,9 +1024,19 @@ ROM_START( vsmaxx17 )
 	ROM_LOAD( "vsmaxx17.bin", 0x00000, 0x200000, CRC(f3fccbb9) SHA1(8b70b10d28f03e72f6b35199001955033a65fd5d) )  // M6MG3D641RB
 ROM_END
 
+ROM_START( vsmax25v )
+	ROM_REGION( 0x400000, "mainrom", 0 )
+	ROM_LOAD( "vsmaxx25n1_2.bin", 0x00000, 0x400000, CRC(e17e076d) SHA1(0f4e3b6b33ab75dcc12dc02d3347ddb53275c777) )
+ROM_END
+
 ROM_START( dgun851 )
 	ROM_REGION( 0x400000, "mainrom", 0 )
 	ROM_LOAD( "dgun851.bin", 0x00000, 0x400000, CRC(9d51c9fc) SHA1(6f49ea3343eb6e90938aabc9660783f1fc7f6084) )
+ROM_END
+
+ROM_START( dgun853 )
+	ROM_REGION( 0x800000, "mainrom", 0 )
+	ROM_LOAD( "dgpnp50n1dgun853.bin", 0x00000, 0x800000, CRC(118f7286) SHA1(0f4ad7141e887bddba1ab37e75de08e9d56ad841) )
 ROM_END
 
 ROM_START( vsmaxx77 )
@@ -1076,15 +1099,7 @@ ROM_START( pjoys60 )
 	ROM_LOAD( "power joy supermax 60-in-1.prg", 0x00000, 0x400000, CRC(1ab45228) SHA1(d148924afc39fc588235331a1a30df6e0d8e1e18) )
 ROM_END
 
-ROM_START( sarc110 )
-	ROM_REGION( 0x400000, "mainrom", 0 )
-	ROM_LOAD( "ic1.prg", 0x00000, 0x400000, CRC(de76f71f) SHA1(ff6b37a76c6463af7ae901918fc008b4a2863951) )
-ROM_END
 
-ROM_START( sarc110a )
-	ROM_REGION( 0x400000, "mainrom", 0 )
-	ROM_LOAD( "ic1_ver2.prg", 0x00000, 0x400000, CRC(b97a0dc7) SHA1(bace32d73184df914113de5336e29a7a6f4c03fa) )
-ROM_END
 
 // CoolBoy AEF-390 8bit Console, B8VPCBVer03 20130703 0401E2015897A
 ROM_START( mc_8x6cb )
@@ -1313,6 +1328,7 @@ CONS( 200?, wldsoctv,  0,  0,  nes_vt_pal_4mb,        nes_vt,  nes_vt_wldsoctv_s
 // for testing 'Shark', 'Octopus', 'Harbor', and 'Earth Fighter' use the extended colour modes, other games just seem to use standard NES modes
 CONS( 200?, mc_dgear,  0,  0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "dreamGEAR", "dreamGEAR 75-in-1", MACHINE_IMPERFECT_GRAPHICS )
 
+CONS( 200?, sudo6in1,  0,  0,  nes_vt_pal_1mb,    nes_vt, nes_vt_state, empty_init, "Nice Code", "6-in-1 Sudoku Plug & Play", MACHINE_IMPERFECT_GRAPHICS ) // no manufacturer info on packaging, games seem to be from Nice Code, although this isn't certain
 
 
 // small black unit, dpad on left, 4 buttons (A,B,X,Y) on right, Start/Reset/Select in middle, unit text "Sudoku Plug & Play TV Game"
@@ -1341,7 +1357,9 @@ CONS( 200?, majgnc,    0, 0,  nes_vt_1mb, majgnc, nes_vt_state,  empty_init, "Ma
 // CPU die is marked 'VH2009' There's also a 62256 RAM chip on the PCB, some scrambled opcodes
 CONS( 2004, vsmaxx17,  0,  0,  nes_vt_vh2009_2mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario / JungleTac",   "Vs Maxx 17-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND ) // from a Green unit, '17 Classic & Racing Game'
 CONS( 2004, polmega,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Polaroid / JungleTac",  "TV MegaMax active power game system 30-in-1 (MegaMax GPD001SDG)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 200?, vsmax25v,  0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Vs Maxx 25-in-1 (VT03 hardware)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, dgun851,   0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Plug 'N' Play 30-in-1 (DGUN-851)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
+CONS( 200?, dgun853,   0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "dreamGEAR / JungleTac", "Plug 'N' Play 50-in-1 (DGUN-853)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, silv35,    0,  0,  nes_vt_vh2009_4mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "SilverLit / JungleTac", "35 in 1 Super Twins", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 2004, vsmaxxvd,  0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario / JungleTac",   "Vs Maxx Video Extreme 50-in-1 (with Speed Racer and Snood)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
 CONS( 200?, vsmaxx77,  0,  0,  nes_vt_vh2009_8mb,        nes_vt, nes_vt_swap_op_d5_d6_state, empty_init, "Senario / JungleTac",   "Vs Maxx Wireless 77-in-1", MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND )
@@ -1370,9 +1388,6 @@ CONS( 200?, zdog,      0,  0,  nes_vt_hummer_4mb,    nes_vt, nes_vt_hum_state, e
 CONS( 200?, pjoyn50,    0,        0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "<unknown>", "PowerJoy Navigator 50 in 1", MACHINE_IMPERFECT_GRAPHICS )
 CONS( 200?, pjoys30,    0,        0,  nes_vt_pjoy_4mb,    nes_vt, nes_vt_pjoy_state, empty_init, "<unknown>", "PowerJoy Supermax 30 in 1", MACHINE_IMPERFECT_GRAPHICS )
 CONS( 200?, pjoys60,    0,        0,  nes_vt_pjoy_4mb,    nes_vt, nes_vt_pjoy_state, empty_init, "<unknown>", "PowerJoy Supermax 60 in 1", MACHINE_IMPERFECT_GRAPHICS )
-// has a non-enhanced version of 'Octopus' as game 30
-CONS( 200?, sarc110,    0,        0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Super Arcade 110 (set 1)", MACHINE_IMPERFECT_GRAPHICS )
-CONS( 200?, sarc110a,   sarc110,  0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "<unknown>", "Super Arcade 110 (set 2)", MACHINE_IMPERFECT_GRAPHICS )
 // both offer chinese or english menus
 CONS( 200?, mc_110cb,   0,        0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "CoolBoy", "110 in 1 CoolBaby (CoolBoy RS-1S)", MACHINE_IMPERFECT_GRAPHICS )
 CONS( 200?, mc_138cb,   0,        0,  nes_vt_4mb,    nes_vt, nes_vt_state, empty_init, "CoolBoy", "138 in 1 CoolBaby (CoolBoy RS-5, PCB060-10009011V1.3)", MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/drivers/puckpkmn.cpp
+++ b/src/mame/drivers/puckpkmn.cpp
@@ -284,8 +284,6 @@ void md_boot_state::puckpkmn(machine_config &config)
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &md_boot_state::puckpkmn_map);
 
-	MCFG_MACHINE_START_OVERRIDE(md_boot_state, md_bootleg)
-
 	config.device_remove("genesis_snd_z80");
 
 	okim6295_device &oki(OKIM6295(config, "oki", XTAL(4'000'000) / 4, okim6295_device::PIN7_HIGH));

--- a/src/mame/drivers/segapico.cpp
+++ b/src/mame/drivers/segapico.cpp
@@ -404,7 +404,6 @@ void pico_state::pico(machine_config &config)
 	config.device_remove("ymsnd");
 
 	MCFG_MACHINE_START_OVERRIDE( pico_state, pico )
-	MCFG_MACHINE_RESET_OVERRIDE( pico_base_state, ms_megadriv )
 
 	PICO_CART_SLOT(config, m_picocart, pico_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("pico");
@@ -425,7 +424,6 @@ void pico_state::picopal(machine_config &config)
 	config.device_remove("ymsnd");
 
 	MCFG_MACHINE_START_OVERRIDE( pico_state, pico )
-	MCFG_MACHINE_RESET_OVERRIDE( pico_base_state, ms_megadriv )
 
 	PICO_CART_SLOT(config, m_picocart, pico_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("pico");
@@ -624,7 +622,6 @@ void copera_state::copera(machine_config &config)
 	config.device_remove("ymsnd");
 
 	MCFG_MACHINE_START_OVERRIDE( copera_state, copera )
-	MCFG_MACHINE_RESET_OVERRIDE( copera_state, ms_megadriv )
 
 	COPERA_CART_SLOT(config, m_picocart, copera_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("copera");

--- a/src/mame/drivers/spg2xx_zone.cpp
+++ b/src/mame/drivers/spg2xx_zone.cpp
@@ -303,14 +303,7 @@ ROM_START( zone40 )
 	ROM_LOAD16_WORD_SWAP( "zone40.bin", 0x0000, 0x4000000, CRC(4ba1444f) SHA1(de83046ab93421486668a247972ad6d3cda19440) )
 ROM_END
 
-ROM_START( reactmd )
-	ROM_REGION( 0x4000000, "maincpu", ROMREGION_ERASE00 ) // this contains the SunPlus games
-	ROM_LOAD16_WORD_SWAP( "reactor_md_sunplus-full.bin", 0x0000, 0x4000000, CRC(843aa58c) SHA1(07cdc6d4aa0057939c145ece01a9aca73c7f1f2b) )
-	ROM_IGNORE(0x4000000) // the 2nd half of the ROM can't be accessed by the PCB (address line tied low) (contains garbage? data)
 
-	ROM_REGION( 0x2000000, "mdrom", ROMREGION_ERASE00 ) // this contains the MD games and main boot menu
-	ROM_LOAD16_WORD_SWAP( "reactormd.bin", 0x0000, 0x2000000, CRC(fe9664a4) SHA1(d475b524f576c9d1d90aed20c7467cc652396baf) )
-ROM_END
 
 ROM_START( itvg49 )
 	ROM_REGION( 0x8000000, "maincpu", ROMREGION_ERASE00 )
@@ -369,10 +362,6 @@ CONS( 2009, itvg49,   0, 0, zone40p,    wirels60, zone40_state,      init_reactm
 CONS( 200?, zonemini, 0, 0, zone40,     wirels60, zone40_state,      init_reactmd,    "Ultimate Products Ltd. / Waixing",                      "Zone Mini",                           MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 CONS( 2009, react,    0, 0, zone40,     wirels60, zone40_state,      init_reactmd,    "Ultimate Products Ltd. / Waixing",                      "Reactor 32-in-1 (NTSC)",              MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
-// Two systems in one unit - Genesis on a Chip and SunPlus, only the SunPlus part is currently emulated.  Genesis on a chip is a very poor implementation with many issues on real hardware.
-// This should actually boot to a menu on the MD size, with the SunPlus only being enabled if selected from that menu.  MD side menu runs in some enhanced / custom MD mode tho.
-// Badminton hangs, as it does in the 49-in-1 above
-CONS( 2009, reactmd,  0, 0, zone40p,    wirels60, zone40_state,      init_reactmd,    "AtGames / Sega / Waixing",                              "Reactor MD (PAL)",                    MACHINE_NOT_WORKING | MACHINE_IMPERFECT_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // These have a newer selection of games by JungleTac instead of the Waixing ones
 

--- a/src/mame/includes/megadriv.h
+++ b/src/mame/includes/megadriv.h
@@ -131,8 +131,7 @@ public:
 
 	void megadriv_stop_scanline_timer();
 
-	DECLARE_MACHINE_START( megadriv );
-	DECLARE_MACHINE_RESET( megadriv );
+
 	DECLARE_VIDEO_START( megadriv );
 	uint32_t screen_update_megadriv(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank_megadriv);
@@ -150,6 +149,10 @@ public:
 	void megadriv_map(address_map &map);
 	void megadriv_z80_io_map(address_map &map);
 	void megadriv_z80_map(address_map &map);
+
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 };
 
 class md_cons_state : public md_base_state
@@ -183,7 +186,6 @@ public:
 	DECLARE_MACHINE_START( md_common );     // setup ioport_port
 	DECLARE_MACHINE_START( ms_megadriv );   // setup ioport_port + install cartslot handlers
 	DECLARE_MACHINE_START( ms_megacd );     // setup ioport_port + dma delay for cd
-	DECLARE_MACHINE_RESET( ms_megadriv );
 
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank_console);
 
@@ -215,6 +217,10 @@ public:
 	void genesis_scd(machine_config &config);
 	void genesis2_scd(machine_config &config);
 	void genesis_tmss(machine_config &config);
+
+protected:
+	//virtual void machine_start() override;
+	virtual void machine_reset() override;
 };
 
 #endif // MAME_INCLUDES_MEGADRIV_H

--- a/src/mame/includes/megadriv.h
+++ b/src/mame/includes/megadriv.h
@@ -144,6 +144,7 @@ public:
 	void md_pal(machine_config &config);
 	void md2_pal(machine_config &config);
 	void md_bootleg(machine_config &config);
+
 	void dcat16_megadriv_base(machine_config &config);
 	void dcat16_megadriv_map(address_map &map);
 	void megadriv_map(address_map &map);
@@ -183,10 +184,6 @@ public:
 	uint8_t mess_md_io_read_data_port(offs_t offset);
 	void mess_md_io_write_data_port(offs_t offset, uint16_t data);
 
-	DECLARE_MACHINE_START( md_common );     // setup ioport_port
-	DECLARE_MACHINE_START( ms_megadriv );   // setup ioport_port + install cartslot handlers
-	DECLARE_MACHINE_START( ms_megacd );     // setup ioport_port + dma delay for cd
-
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank_console);
 
 	DECLARE_DEVICE_IMAGE_LOAD_MEMBER( _32x_cart );
@@ -199,28 +196,56 @@ public:
 	void install_tmss();
 	uint16_t tmss_r(offs_t offset);
 	void tmss_swap_w(uint16_t data);
-	void genesis_32x_scd(machine_config &config);
-	void mdj_32x_scd(machine_config &config);
-	void ms_megadpal(machine_config &config);
 	void dcat16_megadriv_base(machine_config &config);
 	void dcat16_megadriv(machine_config &config);
-	void md_32x_scd(machine_config &config);
-	void mdj_32x(machine_config &config);
-	void ms_megadriv(machine_config &config);
-	void ms_megadriv2(machine_config &config);
-	void mdj_scd(machine_config &config);
-	void md2j_scd(machine_config &config);
+
 	void md_32x(machine_config &config);
 	void genesis_32x(machine_config &config);
-	void md_scd(machine_config &config);
-	void md2_scd(machine_config &config);
-	void genesis_scd(machine_config &config);
-	void genesis2_scd(machine_config &config);
-	void genesis_tmss(machine_config &config);
+	void mdj_32x(machine_config &config);
 
 protected:
-	//virtual void machine_start() override;
+	virtual void machine_start() override;
 	virtual void machine_reset() override;
+};
+
+class md_cons_slot_state : public md_cons_state
+{
+public:
+	md_cons_slot_state(const machine_config &mconfig, device_type type, const char *tag) :
+		md_cons_state(mconfig, type, tag)
+	{ }
+
+	void ms_megadpal(machine_config &config);
+	void ms_megadriv(machine_config &config);
+	void ms_megadriv2(machine_config &config);
+
+	void genesis_tmss(machine_config &config);
+
+
+protected:
+	virtual void machine_start() override;
+};
+
+class md_cons_cd_state : public md_cons_state
+{
+public:
+	md_cons_cd_state(const machine_config &mconfig, device_type type, const char *tag) :
+		md_cons_state(mconfig, type, tag)
+	{ }
+
+	void genesis_scd(machine_config &config);
+	void genesis2_scd(machine_config &config);
+	void md_scd(machine_config &config);
+	void md2_scd(machine_config &config);
+	void mdj_scd(machine_config &config);
+
+	void mdj_32x_scd(machine_config &config);
+	void md2j_scd(machine_config &config);
+	void genesis_32x_scd(machine_config &config);
+	void md_32x_scd(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
 };
 
 #endif // MAME_INCLUDES_MEGADRIV_H

--- a/src/mame/includes/megadriv.h
+++ b/src/mame/includes/megadriv.h
@@ -52,6 +52,7 @@ public:
 		m_scan_timer(*this, "md_scan_timer"),
 		m_vdp(*this,"gen_vdp"),
 		m_megadrive_ram(*this,"megadrive_ram"),
+		m_screen(*this,"megadriv"),
 		m_io_reset(*this, "RESET"),
 		m_megadrive_io_read_data_port_ptr(*this),
 		m_megadrive_io_write_data_port_ptr(*this)
@@ -63,6 +64,7 @@ public:
 	optional_device<timer_device> m_scan_timer;
 	required_device<sega315_5313_device> m_vdp;
 	optional_shared_ptr<uint16_t> m_megadrive_ram;
+	optional_device<screen_device> m_screen;
 
 	optional_ioport m_io_reset;
 	ioport_port *m_io_pad_3b[4];

--- a/src/mame/includes/megadriv_acbl.h
+++ b/src/mame/includes/megadriv_acbl.h
@@ -47,7 +47,12 @@ private:
 	uint16_t puckpkmna_70001c_r();
 	uint16_t puckpkmna_4b2476_r();
 
-	DECLARE_MACHINE_START(md_bootleg) { MACHINE_START_CALL_MEMBER(megadriv); m_vdp->stop_timers(); }
+	DECLARE_MACHINE_START(md_bootleg)
+	{
+		md_base_state::machine_start();
+		m_vdp->stop_timers();
+	}
+
 	DECLARE_MACHINE_START(md_6button);
 
 	void jzth_map(address_map &map);

--- a/src/mame/includes/megadriv_acbl.h
+++ b/src/mame/includes/megadriv_acbl.h
@@ -11,7 +11,6 @@ public:
 	: md_base_state(mconfig, type, tag) { m_protcount = 0;}
 
 	void megadrvb(machine_config &config);
-	void megadrvb_6b(machine_config &config);
 	void md_bootleg(machine_config &config);
 	void puckpkmn(machine_config &config);
 	void jzth(machine_config &config);
@@ -47,14 +46,6 @@ private:
 	uint16_t puckpkmna_70001c_r();
 	uint16_t puckpkmna_4b2476_r();
 
-	DECLARE_MACHINE_START(md_bootleg)
-	{
-		md_base_state::machine_start();
-		m_vdp->stop_timers();
-	}
-
-	DECLARE_MACHINE_START(md_6button);
-
 	void jzth_map(address_map &map);
 	void md_bootleg_map(address_map &map);
 	void puckpkmn_map(address_map &map);
@@ -64,6 +55,21 @@ private:
 	int m_aladmdb_mcu_port;
 
 	int m_protcount;
+};
+
+class md_boot_6button_state : public md_boot_state
+{
+public:
+	md_boot_6button_state(const machine_config& mconfig, device_type type, const char* tag)
+		: md_boot_state(mconfig, type, tag)
+	{
+	}
+
+	void megadrvb_6b(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
 };
 
 #endif // MAME_INCLUDES_MEGADRIV_ACBL_H

--- a/src/mame/includes/megadriv_rad.h
+++ b/src/mame/includes/megadriv_rad.h
@@ -13,25 +13,49 @@ public:
 		m_rom(*this, "maincpu")
 	{}
 
-	void init_megadriv_radica_6button_pal();
-	void init_megadriv_radica_6button_ntsc();
-
-	DECLARE_MACHINE_START(megadriv_radica_6button);
-	DECLARE_MACHINE_START(megadriv_radica_3button);
-	DECLARE_MACHINE_RESET(megadriv_radica);
 
 	uint16_t read(offs_t offset);
 	uint16_t read_a13(offs_t offset);
 
-	void megadriv_radica_6button_ntsc(machine_config &config);
-	void megadriv_radica_6button_pal(machine_config &config);
+	void megadriv_radica_map(address_map &map);
+
+protected:
+	int m_bank;
+
+private:
+	required_region_ptr<uint16_t> m_rom;
+};
+
+class megadriv_radica_3button_state : public megadriv_radica_state
+{
+public:
+	megadriv_radica_3button_state(const machine_config& mconfig, device_type type, const char* tag)
+		: megadriv_radica_state(mconfig, type, tag)
+	{}
+public:
 	void megadriv_radica_3button_ntsc(machine_config &config);
 	void megadriv_radica_3button_pal(machine_config &config);
 
-	void megadriv_radica_map(address_map &map);
-private:
-	int m_bank;
-	required_region_ptr<uint16_t> m_rom;
+protected:
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
 };
+
+class megadriv_radica_6button_state : public megadriv_radica_3button_state
+{
+public:
+	void megadriv_radica_6button_ntsc(machine_config &config);
+	void megadriv_radica_6button_pal(machine_config &config);
+
+	void init_megadriv_radica_6button_pal();
+	void init_megadriv_radica_6button_ntsc();
+
+public:
+	megadriv_radica_6button_state(const machine_config& mconfig, device_type type, const char* tag)
+		: megadriv_radica_3button_state(mconfig, type, tag)
+	{}
+	virtual void machine_start() override;
+};
+
 
 #endif // MAME_INCLUDES_MEGADRIV_RAD_H

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -789,7 +789,7 @@ VIDEO_START_MEMBER(md_base_state,megadriv)
 {
 }
 
-MACHINE_START_MEMBER(md_base_state,megadriv)
+void md_base_state::machine_start()
 {
 	m_io_pad_3b[0] = ioport("PAD1");
 	m_io_pad_3b[1] = ioport("PAD2");
@@ -802,7 +802,7 @@ MACHINE_START_MEMBER(md_base_state,megadriv)
 	save_item(NAME(m_megadrive_io_tx_regs));
 }
 
-MACHINE_RESET_MEMBER(md_base_state,megadriv)
+void md_base_state::machine_reset()
 {
 	/* default state of z80 = reset, with bus */
 	osd_printf_debug("Resetting Megadrive / Genesis\n");
@@ -908,8 +908,8 @@ void md_base_state::md_ntsc(machine_config &config)
 	m_z80snd->set_addrmap(AS_IO, &md_base_state::megadriv_z80_io_map);
 	/* IRQ handled via the timers */
 
-	MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
-	MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
+	//MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
+	//MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
 
 	megadriv_timers(config);
 
@@ -973,8 +973,8 @@ void md_base_state::md_pal(machine_config &config)
 	m_z80snd->set_addrmap(AS_IO, &md_base_state::megadriv_z80_io_map);
 	/* IRQ handled via the timers */
 
-	MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
-	MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
+	//MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
+	//MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
 
 	megadriv_timers(config);
 

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -908,9 +908,6 @@ void md_base_state::md_ntsc(machine_config &config)
 	m_z80snd->set_addrmap(AS_IO, &md_base_state::megadriv_z80_io_map);
 	/* IRQ handled via the timers */
 
-	//MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
-	//MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
-
 	megadriv_timers(config);
 
 	SEGA315_5313(config, m_vdp, MASTER_CLOCK_NTSC, m_maincpu);
@@ -972,9 +969,6 @@ void md_base_state::md_pal(machine_config &config)
 	m_z80snd->set_addrmap(AS_PROGRAM, &md_base_state::megadriv_z80_map);
 	m_z80snd->set_addrmap(AS_IO, &md_base_state::megadriv_z80_io_map);
 	/* IRQ handled via the timers */
-
-	//MCFG_MACHINE_START_OVERRIDE(md_base_state,megadriv)
-	//MCFG_MACHINE_RESET_OVERRIDE(md_base_state,megadriv)
 
 	megadriv_timers(config);
 

--- a/src/mame/machine/megadriv.cpp
+++ b/src/mame/machine/megadriv.cpp
@@ -922,14 +922,14 @@ void md_base_state::md_ntsc(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
 	m_vdp->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
 
-	screen_device &screen(SCREEN(config, "megadriv", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(double(MASTER_CLOCK_NTSC) / 10.0 / 262.0 / 342.0); // same as SMS?
-//  screen.set_refresh_hz(double(MASTER_CLOCK_NTSC) / 8.0 / 262.0 / 427.0); // or 427 Htotal?
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0)); // Vblank handled manually.
-	screen.set_size(64*8, 620);
-	screen.set_visarea(0, 32*8-1, 0, 28*8-1);
-	screen.set_screen_update(FUNC(md_base_state::screen_update_megadriv)); /* Copies a bitmap */
-	screen.screen_vblank().set(FUNC(md_base_state::screen_vblank_megadriv)); /* Used to Sync the timing */
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(double(MASTER_CLOCK_NTSC) / 10.0 / 262.0 / 342.0); // same as SMS?
+//  m_screen->set_refresh_hz(double(MASTER_CLOCK_NTSC) / 8.0 / 262.0 / 427.0); // or 427 Htotal?
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0)); // Vblank handled manually.
+	m_screen->set_size(64*8, 620);
+	m_screen->set_visarea(0, 32*8-1, 0, 28*8-1);
+	m_screen->set_screen_update(FUNC(md_base_state::screen_update_megadriv)); /* Copies a bitmap */
+	m_screen->screen_vblank().set(FUNC(md_base_state::screen_vblank_megadriv)); /* Used to Sync the timing */
 
 	MCFG_VIDEO_START_OVERRIDE(md_base_state, megadriv)
 
@@ -987,14 +987,14 @@ void md_base_state::md_pal(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
 	m_vdp->add_route(ALL_OUTPUTS, "rspeaker", 0.50);
 
-	screen_device &screen(SCREEN(config, "megadriv", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(double(MASTER_CLOCK_PAL) / 10.0 / 313.0 / 342.0); // same as SMS?
-//  screen.set_refresh_hz(double(MASTER_CLOCK_PAL) / 8.0 / 313.0 / 423.0); // or 423 Htotal?
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(0)); // Vblank handled manually.
-	screen.set_size(64*8, 620);
-	screen.set_visarea(0, 32*8-1, 0, 28*8-1);
-	screen.set_screen_update(FUNC(md_base_state::screen_update_megadriv)); /* Copies a bitmap */
-	screen.screen_vblank().set(FUNC(md_base_state::screen_vblank_megadriv)); /* Used to Sync the timing */
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(double(MASTER_CLOCK_PAL) / 10.0 / 313.0 / 342.0); // same as SMS?
+//  m_screen->set_refresh_hz(double(MASTER_CLOCK_PAL) / 8.0 / 313.0 / 423.0); // or 423 Htotal?
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(0)); // Vblank handled manually.
+	m_screen->set_size(64*8, 620);
+	m_screen->set_visarea(0, 32*8-1, 0, 28*8-1);
+	m_screen->set_screen_update(FUNC(md_base_state::screen_update_megadriv)); /* Copies a bitmap */
+	m_screen->screen_vblank().set(FUNC(md_base_state::screen_vblank_megadriv)); /* Used to Sync the timing */
 
 	MCFG_VIDEO_START_OVERRIDE(md_base_state, megadriv)
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -22268,9 +22268,18 @@ rad_sf2p                        // (c)2004 Radica
 rad_gen1                        // (c)2004 Radica
 rad_gen2                        // (c)2004 Radica
 rad_md1
+rad_md2
 rad_ssoc                        // (c)2004 Radica
 rad_sonic
+rad_sonicp
 rad_orun
+
+@source:megadriv_sunplus_hybrid.cpp
+reactmd
+
+@source:megadriv_vt_hybrid.cpp
+sarc110
+sarc110a
 
 @source:megaphx.cpp
 megaphx                         // (c) 1991 Dinamic / Inder
@@ -32203,6 +32212,7 @@ afbm7800
 dnce2000
 vtvppong
 papsudok
+nytsudo
 
 @source:nes_sh6578.cpp
 bandgpad
@@ -32215,6 +32225,7 @@ maxx6in1
 max10in1
 vsmaxx25
 vsmaxx15
+dgun806
 
 @source:nes_vt02_vt03.cpp
 vdogdeme
@@ -32229,6 +32240,7 @@ sporzbx
 sporztn
 wldsoctv
 mc_dgear
+sudo6in1
 sudopptv
 megapad
 ablmini
@@ -32240,7 +32252,9 @@ majkon
 majgnc
 vsmaxx17
 polmega
+vsmax25v
 dgun851
+dgun853
 silv35
 vsmaxxvd
 vsmaxx77
@@ -32254,8 +32268,6 @@ zdog
 pjoyn50
 pjoys30
 pjoys60
-sarc110
-sarc110a
 mc_110cb
 mc_138cb
 cbrs8
@@ -38340,7 +38352,6 @@ ddmmeg12
 @source:spg2xx_zone.cpp
 wirels60                        // Wireless 60
 zone40                          // Zone 40
-reactmd
 itvg49
 zone60                          // Zone 60
 zone100                         //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -19371,6 +19371,9 @@ lckydraw                        // (c) 1979 Mirco
 @source:lcmate2.cpp
 lcmate2                         //
 
+@source:leapfrog_iquest.cpp
+iquest
+
 @source:leapfrog_leappad.cpp
 leappad                         // (c) 2001 LeapFrog / Knowledge Kids Enterprises, Inc.
 leappadca                       // (c) 2004 LeapFrog

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -498,6 +498,7 @@ lb186.cpp
 lbpc.cpp
 lc80.cpp
 lcmate2.cpp
+leapfrog_iquest.cpp
 leapfrog_leappad.cpp
 leapster.cpp
 learnwin.cpp

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -547,6 +547,8 @@ mdisk.cpp
 mdt60.cpp
 megadriv.cpp
 megadriv_rad.cpp
+megadriv_sunplus_hybrid.cpp
+megadriv_vt_hybrid.cpp
 mekd1.cpp
 mekd2.cpp
 mekd3.cpp


### PR DESCRIPTION
new WORKING machines
-----
The New York Times Sudoku [David Haywood, Sean Riddle, Kamaal Brown]
Vs Maxx 25-in-1 (VT03 hardware) [David Haywood, Sean Riddle, Kamaal Brown]
6-in-1 Sudoku Plug & Play [David Haywood, Sean Riddle]
Plug 'N' Play 50-in-1 (DGUN-853) [David Haywood, Sean Riddle, Kamaal Brown]

new WORKING clones
-----
Mega Drive Collection Volume 2 (Radica, Arcade Legends) (UK) [David Haywood, Sean Riddle]
Super Sonic Gold (Radica Plug & Play) (UK) [David Haywood, Sean Riddle]

new NOT WORKING machines
-----
Plug 'N' Play 25-in-1 (DGUN-806) [David Haywood, Sean Riddle, Kamaal Brown]
IQuest (US) [David Haywood, Sean Riddle, Kamaal Brown]

- Added MegaDrive side ROM to sarc110 sets, moved to skeleton 'hybrid' driver based on megadriv_rad.cpp and demoted to not working for now as they're meant to boot from the MD side with the VT03 games as bonus items [Sean Riddle, Team Europe]
- Moved reactmd to a skeleton 'hybrid' driver, demoted to not working, it's also meant to boot from the MD side with the SunPlus games as bonus items. [David Haywood]

