### PR TITLE
fmtowns_flop.xml: add the World of Xeen disk

### DIFF
--- a/hash/fmtowns_flop.xml
+++ b/hash/fmtowns_flop.xml
@@ -1524,6 +1524,20 @@ Zurukamashi Ver 2.0                                           Nikkonren Kikaku  
 		</part>
 	</software>
 
+	<software name="mightmgw">
+		<description>Might and Magic - World of Xeen</description>
+		<year>1994</year>
+		<publisher>スタークラフト (Starcraft)</publisher>
+		<info name="alt_title" value="ワールド・オブ・ジーン" />
+		<info name="usage" value="Requires 4 MB RAM"/>
+		<info name="usage" value="This disk combines MM4 and MM5 into a single game. Requires both CDs and a save disk from either game. Boot TownsOS 2.1 and run the icon on drive A to install." />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="might and magic - world of xeen (install disk).hdm" size="1261568" crc="42475067" sha1="f4a7c497b185f707ed2bf7077801adfcd20b5278"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mjfantt">
 		<description>Mahjong Gensoukyoku / Mahjong Fantasia Taikenban</description>
 		<year>1992</year>

--- a/hash/fmtowns_flop.xml
+++ b/hash/fmtowns_flop.xml
@@ -1529,8 +1529,7 @@ Zurukamashi Ver 2.0                                           Nikkonren Kikaku  
 		<year>1994</year>
 		<publisher>スタークラフト (Starcraft)</publisher>
 		<info name="alt_title" value="ワールド・オブ・ジーン" />
-		<info name="usage" value="Requires 4 MB RAM"/>
-		<info name="usage" value="This disk combines MM4 and MM5 into a single game. Requires both CDs and a save disk from either game. Boot TownsOS 2.1 and run the icon on drive A to install." />
+		<info name="usage" value="This disk combines MM4 and MM5 into a single game. Requires 4 MB RAM, both CDs and a save disk from either game. Boot TownsOS 2.1 and run the icon on drive A to install." />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="might and magic - world of xeen (install disk).hdm" size="1261568" crc="42475067" sha1="f4a7c497b185f707ed2bf7077801adfcd20b5278"/>


### PR DESCRIPTION
Just a quick change to add Might and Magic: World of Xeen to the FM Towns floppy softlist. For some reason I completely forgot about this disk until now, even though it's been in the last release of the Neo Kobe Collection for about 4 years.