### PR TITLE
klax.cpp: get bootleg sets working

### DIFF
--- a/src/mame/drivers/klax.cpp
+++ b/src/mame/drivers/klax.cpp
@@ -88,6 +88,9 @@ void klax_bootleg_state::machine_start()
 
 	m_audio_sample[0] = m_audio_sample[1] = 0x00;
 	m_audio_nibble = 0;
+
+	save_pointer(NAME(m_audio_sample), 2);
+	save_item(NAME(m_audio_nibble));
 }
 
 /*************************************
@@ -274,7 +277,7 @@ void klax_bootleg_state::klax5bl(machine_config &config)
 	m_mob->set_origin(8, 7); // sprites are offset in bootlegs
 	m_gfxdecode->set_info(gfx_klax5bl);
 
-	MSM5205(config, m_msm[0], 384000);
+	MSM5205(config, m_msm[0], 384000); // clock speed / prescaler not verified
 	m_msm[0]->vck_callback().set(FUNC(klax_bootleg_state::m5205_int1));
 	m_msm[0]->set_prescaler_selector(msm5205_device::S64_4B); /* ? */
 	m_msm[0]->add_route(ALL_OUTPUTS, "mono", 1.00);
@@ -408,7 +411,7 @@ ROM_START( klax5bl2 ) // derived from 'klax5' set, closer than klax5bl
 	ROM_LOAD16_BYTE( "2.ic12", 0x20001, 0x10000, CRC(adbe33a8) SHA1(c6c4f9ea5224169dbf4dda1062954563ebab18d4) )
 
 	ROM_REGION( 0x40000, "audiocpu", 0 )
-	ROM_LOAD( "6.ic22", 0x00000, 0x10000, CRC(edd4c42c) SHA1(22f992615afa24a7a671ed2f5cf08f25965d5b3a) )
+	ROM_LOAD( "6.ic22", 0x00000, 0x10000, CRC(edd4c42c) SHA1(22f992615afa24a7a671ed2f5cf08f25965d5b3a) ) // likely a bad dump of "3.bin" from klax5bl
 	ROM_LOAD( "5.ic23", 0x10000, 0x10000, CRC(a245e005) SHA1(8843edfa9deec405f491647d40007d0a38c25262) )
 
 	ROM_REGION( 0x40000, "gfx1", 0 )
@@ -583,13 +586,13 @@ ROM_END
  *
  *************************************/
 
-GAME( 1989, klax,     0,    klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 6)", 0 )
-GAME( 1989, klax5,    klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 5)", 0 )
-GAME( 1989, klax4,    klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 4)", 0 )
-GAME( 1989, klaxj4,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Japan, version 4)", 0 )
-GAME( 1989, klaxj3,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Japan, version 3)", 0 )
-GAME( 1989, klaxd2,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Germany, version 2)", 0 )
+GAME( 1989, klax,     0,    klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 6)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klax5,    klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 5)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klax4,    klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (version 4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klaxj4,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Japan, version 4)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klaxj3,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Japan, version 3)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klaxd2,   klax, klax,    klax, klax_state,         empty_init, ROT0, "Atari Games",        "Klax (Germany, version 2)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1989, klax5bl,  klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg",            "Klax (version 5, bootleg set 1)", 0 )
-GAME( 1989, klax5bl2, klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg",            "Klax (version 5, bootleg set 2)", 0 )
-GAME( 1989, klax5bl3, klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg (Playmark)", "Klax (version 5, bootleg set 3)", MACHINE_NOT_WORKING ) /* encrypted Z80 opcodes */
+GAME( 1989, klax5bl,  klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg",            "Klax (version 5, bootleg set 1)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klax5bl2, klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg",            "Klax (version 5, bootleg set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1989, klax5bl3, klax, klax5bl, klax, klax_bootleg_state, empty_init, ROT0, "bootleg (Playmark)", "Klax (version 5, bootleg set 3)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) /* encrypted Z80 opcodes */

--- a/src/mame/includes/klax.h
+++ b/src/mame/includes/klax.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "machine/timer.h"
+#include "sound/msm5205.h"
 #include "video/atarimo.h"
 #include "screen.h"
 #include "tilemap.h"
@@ -27,6 +28,8 @@ public:
 		, m_mob(*this, "mob")
 		, m_p1(*this, "P1")
 		, m_audiocpu(*this, "audiocpu")
+		, m_msm(*this, "msm%u", 1)
+		, m_rombank(*this, "rombank")
 	{ }
 
 	void klax(machine_config &config);
@@ -59,11 +62,21 @@ private:
 	required_ioport m_p1;
 
 	// bootleg hardware
+	DECLARE_MACHINE_START(klax5bl);
+
+	void m5205_int1(int state);
+
 	uint8_t audio_ram_r(offs_t offset);
 	void audio_ram_w(offs_t offset, uint8_t data);
+	void audio_sample_w(offs_t offset, uint8_t data);
+	void audio_ctrl_w(uint8_t data);
 
 	optional_device<cpu_device> m_audiocpu;
+	optional_device_array<msm5205_device, 2> m_msm;
+	optional_memory_bank m_rombank;
 	std::unique_ptr<uint8_t[]> m_audio_ram;
+	uint8_t m_audio_sample[2];
+	bool m_audio_nibble;
 
 	static const atari_motion_objects_config s_mob_config;
 };

--- a/src/mame/includes/klax.h
+++ b/src/mame/includes/klax.h
@@ -26,10 +26,13 @@ public:
 		, m_playfield_tilemap(*this, "playfield")
 		, m_mob(*this, "mob")
 		, m_p1(*this, "P1")
+		, m_audiocpu(*this, "audiocpu")
 	{ }
 
 	void klax(machine_config &config);
 	void klax5bl(machine_config &config);
+
+	void init_bootleg();
 
 private:
 	virtual void machine_reset() override;
@@ -54,6 +57,13 @@ private:
 	required_device<atari_motion_objects_device> m_mob;
 
 	required_ioport m_p1;
+
+	// bootleg hardware
+	uint8_t audio_ram_r(offs_t offset);
+	void audio_ram_w(offs_t offset, uint8_t data);
+
+	optional_device<cpu_device> m_audiocpu;
+	std::unique_ptr<uint8_t[]> m_audio_ram;
 
 	static const atari_motion_objects_config s_mob_config;
 };

--- a/src/mame/includes/klax.h
+++ b/src/mame/includes/klax.h
@@ -65,29 +65,28 @@ public:
 		, m_audiocpu(*this, "audiocpu")
 		, m_msm(*this, "msm%u", 1)
 		, m_rombank(*this, "rombank")
+		, m_audio_ram(*this, "audioram")
 	{ }
 
 	void klax5bl(machine_config &config);
 
-	void init_klax5bl();
-
 private:
-	DECLARE_MACHINE_START(klax5bl);
+	virtual void machine_start() override;
 
 	void m5205_int1(int state);
 
 	void bootleg_sound_map(address_map &map);
 	void klax5bl_map(address_map &map);
 
-	uint8_t audio_ram_r(offs_t offset);
-	void audio_ram_w(offs_t offset, uint8_t data);
+	uint16_t audio_ram_r(offs_t offset);
+	void audio_ram_w(offs_t offset, uint16_t data);
 	void audio_sample_w(offs_t offset, uint8_t data);
 	void audio_ctrl_w(uint8_t data);
 
 	required_device<cpu_device> m_audiocpu;
 	required_device_array<msm5205_device, 2> m_msm;
 	required_memory_bank m_rombank;
-	std::unique_ptr<uint8_t[]> m_audio_ram;
+	required_shared_ptr<uint8_t> m_audio_ram;
 	uint8_t m_audio_sample[2];
 	bool m_audio_nibble;
 };

--- a/src/mame/includes/klax.h
+++ b/src/mame/includes/klax.h
@@ -70,9 +70,10 @@ public:
 
 	void klax5bl(machine_config &config);
 
-private:
+protected:
 	virtual void machine_start() override;
 
+private:
 	void m5205_int1(int state);
 
 	void bootleg_sound_map(address_map &map);

--- a/src/mame/includes/klax.h
+++ b/src/mame/includes/klax.h
@@ -27,17 +27,12 @@ public:
 		, m_playfield_tilemap(*this, "playfield")
 		, m_mob(*this, "mob")
 		, m_p1(*this, "P1")
-		, m_audiocpu(*this, "audiocpu")
-		, m_msm(*this, "msm%u", 1)
-		, m_rombank(*this, "rombank")
 	{ }
 
+	void klax_base(machine_config &config);
 	void klax(machine_config &config);
-	void klax5bl(machine_config &config);
 
-	void init_bootleg();
-
-private:
+protected:
 	virtual void machine_reset() override;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(scanline_update);
@@ -49,8 +44,6 @@ private:
 	TILE_GET_INFO_MEMBER(get_playfield_tile_info);
 	u32 screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	void bootleg_sound_map(address_map &map);
-	void klax5bl_map(address_map &map);
 	void klax_map(address_map &map);
 
 	required_device<cpu_device> m_maincpu;
@@ -61,24 +54,42 @@ private:
 
 	required_ioport m_p1;
 
-	// bootleg hardware
+	static const atari_motion_objects_config s_mob_config;
+};
+
+class klax_bootleg_state : public klax_state
+{
+public:
+	klax_bootleg_state(const machine_config &mconfig, device_type type, const char *tag)
+		: klax_state(mconfig, type, tag)
+		, m_audiocpu(*this, "audiocpu")
+		, m_msm(*this, "msm%u", 1)
+		, m_rombank(*this, "rombank")
+	{ }
+
+	void klax5bl(machine_config &config);
+
+	void init_klax5bl();
+
+private:
 	DECLARE_MACHINE_START(klax5bl);
 
 	void m5205_int1(int state);
+
+	void bootleg_sound_map(address_map &map);
+	void klax5bl_map(address_map &map);
 
 	uint8_t audio_ram_r(offs_t offset);
 	void audio_ram_w(offs_t offset, uint8_t data);
 	void audio_sample_w(offs_t offset, uint8_t data);
 	void audio_ctrl_w(uint8_t data);
 
-	optional_device<cpu_device> m_audiocpu;
-	optional_device_array<msm5205_device, 2> m_msm;
-	optional_memory_bank m_rombank;
+	required_device<cpu_device> m_audiocpu;
+	required_device_array<msm5205_device, 2> m_msm;
+	required_memory_bank m_rombank;
 	std::unique_ptr<uint8_t[]> m_audio_ram;
 	uint8_t m_audio_sample[2];
 	bool m_audio_nibble;
-
-	static const atari_motion_objects_config s_mob_config;
 };
 
 #endif // MAME_INCLUDES_KLAX_H


### PR DESCRIPTION
This PR gets the Klax bootleg sets working, including sound.

A few notes:
* I'm not sure if the audio frequency is correct. I used the standard 384kHz oscillators for both MSM5205s with the f/64 prescaler, but it's about two semitones lower than the non-bootleg sets.
* "6.ic22" from klax5bl2 might be a bad dump? It's the same as the version from klax5bl but with random bytes missing (mostly in the middle of ADPCM data, but also at the Z80 reset address)
* klax5bl3 is still "not working" since the audio CPU uses encrypted opcodes, but it's otherwise identical to klax5bl2.