### PR TITLE
centiped.cpp: support switching games in multipede

### DIFF
--- a/src/mame/drivers/centiped.cpp
+++ b/src/mame/drivers/centiped.cpp
@@ -443,14 +443,22 @@ TIMER_DEVICE_CALLBACK_MEMBER(centiped_state::generate_interrupt)
 	m_screen->update_partial(scanline);
 }
 
-MACHINE_START_MEMBER(centiped_state,centiped)
+void centiped_state::machine_start()
 {
-	m_prg_bank = 0;
-
 	save_item(NAME(m_oldpos));
 	save_item(NAME(m_sign));
 	save_item(NAME(m_dsw_select));
+}
+
+void multiped_state::machine_start()
+{
+	centiped_state::machine_start();
+
+	m_prg_bank = 0;
+	m_0xxx_base = 0x1400;
+
 	save_item(NAME(m_prg_bank));
+	save_item(NAME(m_0xxx_base));
 }
 
 
@@ -825,62 +833,53 @@ void centiped_state::milliped_map(address_map &map)
  - 2*8KB gfx roms, on a separate smaller daughterboard
 */
 
-void centiped_state::multiped_map(address_map &map)
+void multiped_state::multiped_map(address_map &map)
 {
 	map(0x0000, 0x7fff).mirror(0x8000).bankr("rombank");
 	map(0x0000, 0x03ff).ram();
-	map(0x0400, 0x07ff).rw(FUNC(centiped_state::multiped_0xxx_r), FUNC(centiped_state::multiped_0xxx_w));
+	map(0x0400, 0x07ff).rw(FUNC(multiped_state::multiped_0xxx_r), FUNC(multiped_state::multiped_0xxx_w));
 	map(0x0800, 0x080f).rw("pokey2", FUNC(pokey_device::read), FUNC(pokey_device::write));
-	map(0x1000, 0x13bf).ram().w(FUNC(centiped_state::centiped_videoram_w)).share("videoram");
+	map(0x1000, 0x13bf).ram().w(FUNC(multiped_state::centiped_videoram_w)).share("videoram");
 	map(0x13c0, 0x13ff).ram().share("spriteram");
 	map(0x1400, 0x140f).rw("pokey", FUNC(pokey_device::read), FUNC(pokey_device::write));
-	map(0x2000, 0x3fff).r(FUNC(centiped_state::multiped_2xxx_r));
-	map(0x2480, 0x249f).mirror(0x8000).w(FUNC(centiped_state::milliped_paletteram_w)).share("paletteram");
+	map(0x2000, 0x3fff).r(FUNC(multiped_state::multiped_2xxx_r));
+	map(0x2480, 0x249f).mirror(0x8000).w(FUNC(multiped_state::milliped_paletteram_w)).share("paletteram");
 	map(0x2500, 0x2507).mirror(0x8000).w("outlatch", FUNC(ls259_device::write_d7));
-	map(0x2600, 0x2600).mirror(0x8000).w(FUNC(centiped_state::irq_ack_w));
+	map(0x2600, 0x2600).mirror(0x8000).w(FUNC(multiped_state::irq_ack_w));
 	map(0x2680, 0x2680).mirror(0x8000).w("watchdog", FUNC(watchdog_timer_device::reset_w));
 	map(0x2700, 0x2700).mirror(0x8000).nopw();
 	map(0x2780, 0x27bf).mirror(0x8000).nopw();
-	map(0xa000, 0xa000).r(FUNC(centiped_state::centiped_IN0_r));
-	map(0xa001, 0xa001).r(FUNC(centiped_state::milliped_IN1_r));
-	map(0xa010, 0xa010).r(FUNC(centiped_state::milliped_IN2_r));
+	map(0xa000, 0xa000).r(FUNC(multiped_state::centiped_IN0_r));
+	map(0xa001, 0xa001).r(FUNC(multiped_state::milliped_IN1_r));
+	map(0xa010, 0xa010).r(FUNC(multiped_state::milliped_IN2_r));
 	map(0xa011, 0xa011).portr("IN3");
 	map(0xa030, 0xa030).nopr();
-	map(0xd000, 0xd7ff).w(FUNC(centiped_state::multiped_eeprom_w));
-	map(0xd800, 0xd800).mirror(0x03ff).rw(FUNC(centiped_state::multiped_eeprom_r), FUNC(centiped_state::multiped_prgbank_w));
-	map(0xdc00, 0xdc00).mirror(0x03ff).w(FUNC(centiped_state::multiped_gfxbank_w));
+	map(0xd000, 0xd7ff).w(FUNC(multiped_state::multiped_eeprom_w));
+	map(0xd800, 0xd800).mirror(0x03ff).rw(FUNC(multiped_state::multiped_eeprom_r), FUNC(multiped_state::multiped_prgbank_w));
+	map(0xdc00, 0xdc00).mirror(0x03ff).w(FUNC(multiped_state::multiped_gfxbank_w));
 }
 
-uint8_t centiped_state::multiped_0xxx_r(offs_t offset)
+uint8_t multiped_state::multiped_0xxx_r(offs_t offset)
 {
-	if (!m_prg_bank)
-		return m_maincpu->space(AS_PROGRAM).read_byte(0x1400 | offset);
-	else
-		return m_maincpu->space(AS_PROGRAM).read_byte(0x1000 | offset);
+	return m_maincpu->space(AS_PROGRAM).read_byte(m_0xxx_base | offset);
 }
 
-void centiped_state::multiped_0xxx_w(offs_t offset, uint8_t data)
+void multiped_state::multiped_0xxx_w(offs_t offset, uint8_t data)
 {
-	if (!m_prg_bank)
-		m_maincpu->space(AS_PROGRAM).write_byte(0x1400 | offset, data);
-	else
-		m_maincpu->space(AS_PROGRAM).write_byte(0x1000 | offset, data);
+	m_maincpu->space(AS_PROGRAM).write_byte(m_0xxx_base | offset, data);
 }
 
-uint8_t centiped_state::multiped_2xxx_r(offs_t offset)
+uint8_t multiped_state::multiped_2xxx_r(offs_t offset)
 {
-	if (!m_prg_bank)
-		return m_maincpu->space(AS_PROGRAM).read_byte(0xa000 | offset);
-	else
-		return ((uint8_t*)m_rombank->base())[0x2000 | offset];
+	return m_maincpu->space(AS_PROGRAM).read_byte(0xa000 | offset);
 }
 
-uint8_t centiped_state::multiped_eeprom_r()
+uint8_t multiped_state::multiped_eeprom_r()
 {
 	return m_eeprom->do_read() ? 0x80 : 0;
 }
 
-void centiped_state::multiped_eeprom_w(offs_t offset, uint8_t data)
+void multiped_state::multiped_eeprom_w(offs_t offset, uint8_t data)
 {
 	// a0: always high
 	// a3-a7: always low
@@ -900,7 +899,7 @@ void centiped_state::multiped_eeprom_w(offs_t offset, uint8_t data)
 		m_eeprom->cs_write((data & 0x80) ? ASSERT_LINE : CLEAR_LINE);
 }
 
-void centiped_state::multiped_prgbank_w(uint8_t data)
+void multiped_state::multiped_prgbank_w(uint8_t data)
 {
 	// d0-d6: N/C?
 	// d7: prg (and gfx) rom bank
@@ -910,6 +909,23 @@ void centiped_state::multiped_prgbank_w(uint8_t data)
 		m_prg_bank = bank;
 		multiped_gfxbank_w(m_gfx_bank << 6);
 		m_rombank->set_entry(bank);
+
+		if (!bank)
+		{
+			// bank 0: Millipede
+			// $0400-07ff: mirror of $1400-17ff (POKEY)
+			// $2000-3fff: mirror of $a000-bfff (I/O ports)
+			m_0xxx_base = 0x1400;
+			m_maincpu->space(AS_PROGRAM).install_read_handler(0x2000, 0x3fff, read8sm_delegate(*this, FUNC(multiped_state::multiped_2xxx_r)));
+		}
+		else
+		{
+			// bank 1: Centipede
+			// $0400-07ff: mirror of $1000-13ff (video and sprite RAM)
+			// $2000-3fff: ROM
+			m_0xxx_base = 0x1000;
+			m_maincpu->space(AS_PROGRAM).install_rom(0x2000, 0x3fff, (uint8_t*)m_rombank->base() + 0x2000);
+		}
 	}
 }
 
@@ -1766,7 +1782,6 @@ void centiped_state::centiped_base(machine_config &config)
 	/* basic machine hardware */
 	M6502(config, m_maincpu, 12096000/8);  /* 1.512 MHz (slows down to 0.75MHz while accessing playfield RAM) */
 
-	MCFG_MACHINE_START_OVERRIDE(centiped_state,centiped)
 	MCFG_MACHINE_RESET_OVERRIDE(centiped_state,centiped)
 
 	ER2055(config, m_earom);
@@ -1902,12 +1917,12 @@ void centiped_state::milliped(machine_config &config)
 	pokey2.add_route(ALL_OUTPUTS, "mono", 0.50);
 }
 
-void centiped_state::multiped(machine_config &config)
+void multiped_state::multiped(machine_config &config)
 {
 	milliped(config);
 
 	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &centiped_state::multiped_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &multiped_state::multiped_map);
 
 	config.device_remove("earom");
 	EEPROM_93C46_8BIT(config, m_eeprom);
@@ -2322,7 +2337,7 @@ void centiped_state::init_bullsdrt()
 }
 
 
-void centiped_state::init_multiped()
+void multiped_state::init_multiped()
 {
 	uint8_t *src = memregion("user1")->base();
 	uint8_t *dest = memregion("maincpu")->base();
@@ -2357,7 +2372,7 @@ GAME( 1980, magworm,   centiped, magworm,   magworm,   centiped_state, empty_ini
 GAME( 1980, magworma,  centiped, magworm,   magworm,   centiped_state, empty_init,    ROT270, "bootleg", "Magic Worm (bootleg of Centipede, set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_NOT_WORKING )
 GAME( 1982, milliped,  0,        milliped,  milliped,  centiped_state, empty_init,    ROT270, "Atari", "Millipede", MACHINE_SUPPORTS_SAVE )
 GAME( 1989, millipdd,  milliped, milliped,  milliped,  centiped_state, empty_init,    ROT270, "hack (Two-Bit Score)", "Millipede Dux (hack)", MACHINE_SUPPORTS_SAVE )
-GAME( 2002, multiped,  0,        multiped,  multiped,  centiped_state, init_multiped, ROT270, "hack (Braze Technologies)", "Multipede (Centipede/Millipede multigame kit)", MACHINE_SUPPORTS_SAVE )
+GAME( 2002, multiped,  0,        multiped,  multiped,  multiped_state, init_multiped, ROT270, "hack (Braze Technologies)", "Multipede (Centipede/Millipede multigame kit)", MACHINE_SUPPORTS_SAVE )
 
 // other Atari games
 GAME( 1980, warlords,  0,        warlords,  warlords,  centiped_state, empty_init,    ROT0,   "Atari", "Warlords", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/centiped.h
+++ b/src/mame/includes/centiped.h
@@ -36,7 +36,8 @@ public:
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		m_aysnd(*this, "aysnd")
+		m_aysnd(*this, "aysnd"),
+		m_rombank(*this, "rombank")
 	{ }
 
 	void centiped_base(machine_config &config);
@@ -69,6 +70,7 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device<ay8910_device> m_aysnd;
+	optional_memory_bank m_rombank;
 
 	uint8_t m_oldpos[4];
 	uint8_t m_sign[4];
@@ -102,6 +104,9 @@ private:
 	uint8_t caterplr_unknown_r();
 	void caterplr_AY8910_w(offs_t offset, uint8_t data);
 	uint8_t caterplr_AY8910_r(offs_t offset);
+	uint8_t multiped_0xxx_r(offs_t offset);
+	void multiped_0xxx_w(offs_t offset, uint8_t data);
+	uint8_t multiped_2xxx_r(offs_t offset);
 	uint8_t multiped_eeprom_r();
 	void multiped_eeprom_w(offs_t offset, uint8_t data);
 	void multiped_prgbank_w(uint8_t data);

--- a/src/mame/includes/centiped.h
+++ b/src/mame/includes/centiped.h
@@ -24,20 +24,18 @@ class centiped_state : public driver_device
 public:
 	centiped_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
 		m_rambase(*this, "rambase"),
 		m_videoram(*this, "videoram"),
 		m_spriteram(*this, "spriteram"),
 		m_paletteram(*this, "paletteram"),
 		m_bullsdrt_tiles_bankram(*this, "bullsdrt_bank"),
-		m_maincpu(*this, "maincpu"),
 		m_outlatch(*this, "outlatch"),
 		m_earom(*this, "earom"),
-		m_eeprom(*this, "eeprom"),
 		m_gfxdecode(*this, "gfxdecode"),
 		m_screen(*this, "screen"),
 		m_palette(*this, "palette"),
-		m_aysnd(*this, "aysnd"),
-		m_rombank(*this, "rombank")
+		m_aysnd(*this, "aysnd")
 	{ }
 
 	void centiped_base(machine_config &config);
@@ -50,10 +48,27 @@ public:
 	void centipedj(machine_config &config);
 	void mazeinv(machine_config &config);
 	void warlords(machine_config &config);
-	void multiped(machine_config &config);
 
-	void init_multiped();
 	void init_bullsdrt();
+
+protected:
+	required_device<cpu_device> m_maincpu;
+
+	uint8_t m_gfx_bank;
+	tilemap_t *m_bg_tilemap;
+
+	// drivers/centiped.cpp
+	virtual void machine_start() override;
+
+	void irq_ack_w(uint8_t data);
+	uint8_t centiped_IN0_r();
+	uint8_t centiped_IN2_r();
+	uint8_t milliped_IN1_r();
+	uint8_t milliped_IN2_r();
+
+	// video/centiped.cpp
+	void centiped_videoram_w(offs_t offset, uint8_t data);
+	void milliped_paletteram_w(offs_t offset, uint8_t data);
 
 private:
 	optional_shared_ptr<uint8_t> m_rambase;
@@ -62,33 +77,22 @@ private:
 	optional_shared_ptr<uint8_t> m_paletteram;
 	optional_shared_ptr<uint8_t> m_bullsdrt_tiles_bankram;
 
-	required_device<cpu_device> m_maincpu;
 	required_device<ls259_device> m_outlatch;
 	optional_device<er2055_device> m_earom;
-	optional_device<eeprom_serial_93cxx_device> m_eeprom;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
 	required_device<palette_device> m_palette;
 	optional_device<ay8910_device> m_aysnd;
-	optional_memory_bank m_rombank;
 
 	uint8_t m_oldpos[4];
 	uint8_t m_sign[4];
 	uint8_t m_dsw_select;
 	uint8_t m_control_select;
 	uint8_t m_flipscreen;
-	uint8_t m_prg_bank;
-	uint8_t m_gfx_bank;
 	uint8_t m_bullsdrt_sprites_bank;
 	uint8_t m_penmask[64];
-	tilemap_t *m_bg_tilemap;
 
 	// drivers/centiped.cpp
-	void irq_ack_w(uint8_t data);
-	uint8_t centiped_IN0_r();
-	uint8_t centiped_IN2_r();
-	uint8_t milliped_IN1_r();
-	uint8_t milliped_IN2_r();
 	DECLARE_WRITE_LINE_MEMBER(input_select_w);
 	DECLARE_WRITE_LINE_MEMBER(control_select_w);
 	uint8_t mazeinv_input_r();
@@ -104,27 +108,17 @@ private:
 	uint8_t caterplr_unknown_r();
 	void caterplr_AY8910_w(offs_t offset, uint8_t data);
 	uint8_t caterplr_AY8910_r(offs_t offset);
-	uint8_t multiped_0xxx_r(offs_t offset);
-	void multiped_0xxx_w(offs_t offset, uint8_t data);
-	uint8_t multiped_2xxx_r(offs_t offset);
-	uint8_t multiped_eeprom_r();
-	void multiped_eeprom_w(offs_t offset, uint8_t data);
-	void multiped_prgbank_w(uint8_t data);
 
 	// video/centiped.cpp
-	void centiped_videoram_w(offs_t offset, uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER(flip_screen_w);
-	void multiped_gfxbank_w(uint8_t data);
 	void bullsdrt_tilesbank_w(offs_t offset, uint8_t data);
 	void bullsdrt_sprites_bank_w(uint8_t data);
 	void centiped_paletteram_w(offs_t offset, uint8_t data);
-	void milliped_paletteram_w(offs_t offset, uint8_t data);
 	void mazeinv_paletteram_w(offs_t offset, uint8_t data);
 	TILE_GET_INFO_MEMBER(centiped_get_tile_info);
 	TILE_GET_INFO_MEMBER(warlords_get_tile_info);
 	TILE_GET_INFO_MEMBER(milliped_get_tile_info);
 	TILE_GET_INFO_MEMBER(bullsdrt_get_tile_info);
-	DECLARE_MACHINE_START(centiped);
 	DECLARE_MACHINE_RESET(centiped);
 	DECLARE_VIDEO_START(centiped);
 	DECLARE_VIDEO_START(bullsdrt);
@@ -152,8 +146,43 @@ private:
 	void magworm_map(address_map &map);
 	void mazeinv_map(address_map &map);
 	void milliped_map(address_map &map);
-	void multiped_map(address_map &map);
 	void warlords_map(address_map &map);
+};
+
+
+class multiped_state : public centiped_state
+{
+public:
+	multiped_state(const machine_config &mconfig, device_type type, const char *tag) :
+		centiped_state(mconfig, type, tag),
+		m_eeprom(*this, "eeprom"),
+		m_rombank(*this, "rombank")
+	{ }
+
+	void multiped(machine_config &config);
+
+	void init_multiped();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	required_device<eeprom_serial_93cxx_device> m_eeprom;
+	required_memory_bank m_rombank;
+
+	uint8_t m_prg_bank;
+	uint16_t m_0xxx_base;
+
+	uint8_t multiped_0xxx_r(offs_t offset);
+	void multiped_0xxx_w(offs_t offset, uint8_t data);
+	uint8_t multiped_2xxx_r(offs_t offset);
+	uint8_t multiped_eeprom_r();
+	void multiped_eeprom_w(offs_t offset, uint8_t data);
+	void multiped_prgbank_w(uint8_t data);
+
+	void multiped_gfxbank_w(uint8_t data);
+
+	void multiped_map(address_map &map);
 };
 
 #endif // MAME_INCLUDES_CENTIPED_H

--- a/src/mame/video/centiped.cpp
+++ b/src/mame/video/centiped.cpp
@@ -161,7 +161,7 @@ WRITE_LINE_MEMBER(centiped_state::flip_screen_w)
  *
  *************************************/
 
-void centiped_state::multiped_gfxbank_w(uint8_t data)
+void multiped_state::multiped_gfxbank_w(uint8_t data)
 {
 	// d0-d6: N/C?
 	// d7: gfx rom bank


### PR DESCRIPTION
This implements the address mirroring and configurable memory ranges used by the Multipede kit for switching games.

I also shortened the watchdog timeout in `centiped_base` to be similar to some of the other Atari drivers, since the kit relies on it to reset the system within a short period after switching games and raises an error if it doesn't.