### PR TITLE
Slot options list

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1466,15 +1466,11 @@ void lua_engine::initialize()
 						std::string value = machine().options().slot_option(slot.slot_name()).value();
 						if (value.compare(std::string("")) != 0)
 						{
-						result += std::string("-") + std::string(slot.slot_name()) + " " +
-									value.c_str() +
-									delim;
+							result += "-" + std::string(slot.slot_name()) + " " + value + delim;
 						}
 						else
 						{
-							result += std::string("-") + std::string(slot.slot_name()) + " " +
-										"\"\"" +
-										delim;
+							result += "-" + std::string(slot.slot_name()) + " " + "\"\"" + delim;
 						}
 					}
 					else  // not full list, just specified values
@@ -1482,9 +1478,7 @@ void lua_engine::initialize()
 						std::string specified_value = machine().options().slot_option(slot.slot_name()).specified_value();
 						if (specified_value.compare(std::string("")) != 0)
 						{
-							result += std::string("-") + std::string(slot.slot_name()) + " " +
-										specified_value.c_str() +
-										delim;
+							result += "-" + std::string(slot.slot_name()) + " " + specified_value + delim;
 						}
 					}
 				}

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1453,6 +1453,65 @@ void lua_engine::initialize()
 			}
 			return table;
 		}));
+
+	machine_type.set("slotoptions", [this](running_machine &r, bool full, std::string delim) {
+			std::string result;
+			if (delim.compare(std::string(""))==0) delim = std::string("\n");
+			for (device_slot_interface &slot : slot_interface_iterator(r.root_device()))
+			{
+				if (slot.has_selectable_options())
+				{
+					if (full)
+					{
+						std::string value = machine().options().slot_option(slot.slot_name()).value();
+						if (value.compare(std::string("")) != 0)
+						{
+						result += (std::string("-")+std::string(slot.slot_name())+" "+
+									value.c_str() +
+//									std::string("\n"));
+									delim);
+						}
+						else
+						{
+							result += (std::string("-")+std::string(slot.slot_name())+" "+
+										"\"\""+
+//										std::string("\n"));
+										delim);
+						}
+					}
+					else  // not full list, just specified values
+					{
+						std::string specified_value = machine().options().slot_option(slot.slot_name()).specified_value();
+						if (specified_value.compare(std::string("")) != 0)
+						{
+							result += (std::string("-")+std::string(slot.slot_name())+" "+
+										specified_value.c_str()+
+//										std::string("\n"));
+										delim);
+						}
+					}
+				}
+			}
+			return result;
+		});
+
+
+	machine_type.set("slotoptionsfull", sol::property([this](running_machine &r) {
+			std::string result;
+			for (device_slot_interface &slot : slot_interface_iterator(r.root_device()))
+			{
+				if (slot.has_selectable_options())
+				{
+					{
+						result += (std::string("-")+std::string(slot.slot_name()) + " " +
+									machine().options().slot_option(slot.slot_name()).value().c_str() +
+									std::string("\n"));
+					}
+				}
+			}
+			return result;
+		}));
+
 	machine_type.set("images", sol::property([this](running_machine &r) {
 			sol::table image_table = sol().create_table();
 			for(device_image_interface &image : image_interface_iterator(r.root_device()))

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1454,7 +1454,7 @@ void lua_engine::initialize()
 			return table;
 		}));
 
-	machine_type.set("slot_options", [this](running_machine &r, bool full, std::string delim) {
+	machine_type.set("slot_options_list", [this](running_machine &r, bool full, std::string delim) {
 			std::string result;
 			if (delim.compare(std::string(""))==0) delim = std::string("\n");
 			for (device_slot_interface &slot : slot_interface_iterator(r.root_device()))
@@ -1466,15 +1466,15 @@ void lua_engine::initialize()
 						std::string value = machine().options().slot_option(slot.slot_name()).value();
 						if (value.compare(std::string("")) != 0)
 						{
-						result += (std::string("-")+std::string(slot.slot_name())+" "+
+						result += std::string("-") + std::string(slot.slot_name()) + " " +
 									value.c_str() +
-									delim);
+									delim;
 						}
 						else
 						{
-							result += (std::string("-")+std::string(slot.slot_name())+" "+
-										"\"\""+
-										delim);
+							result += std::string("-") + std::string(slot.slot_name()) + " " +
+										"\"\"" +
+										delim;
 						}
 					}
 					else  // not full list, just specified values
@@ -1482,9 +1482,9 @@ void lua_engine::initialize()
 						std::string specified_value = machine().options().slot_option(slot.slot_name()).specified_value();
 						if (specified_value.compare(std::string("")) != 0)
 						{
-							result += (std::string("-")+std::string(slot.slot_name())+" "+
-										specified_value.c_str()+
-										delim);
+							result += std::string("-") + std::string(slot.slot_name()) + " " +
+										specified_value.c_str() +
+										delim;
 						}
 					}
 				}

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1454,7 +1454,7 @@ void lua_engine::initialize()
 			return table;
 		}));
 
-	machine_type.set("slotoptions", [this](running_machine &r, bool full, std::string delim) {
+	machine_type.set("slot_options", [this](running_machine &r, bool full, std::string delim) {
 			std::string result;
 			if (delim.compare(std::string(""))==0) delim = std::string("\n");
 			for (device_slot_interface &slot : slot_interface_iterator(r.root_device()))
@@ -1468,14 +1468,12 @@ void lua_engine::initialize()
 						{
 						result += (std::string("-")+std::string(slot.slot_name())+" "+
 									value.c_str() +
-//									std::string("\n"));
 									delim);
 						}
 						else
 						{
 							result += (std::string("-")+std::string(slot.slot_name())+" "+
 										"\"\""+
-//										std::string("\n"));
 										delim);
 						}
 					}
@@ -1486,7 +1484,6 @@ void lua_engine::initialize()
 						{
 							result += (std::string("-")+std::string(slot.slot_name())+" "+
 										specified_value.c_str()+
-//										std::string("\n"));
 										delim);
 						}
 					}
@@ -1494,23 +1491,6 @@ void lua_engine::initialize()
 			}
 			return result;
 		});
-
-
-	machine_type.set("slotoptionsfull", sol::property([this](running_machine &r) {
-			std::string result;
-			for (device_slot_interface &slot : slot_interface_iterator(r.root_device()))
-			{
-				if (slot.has_selectable_options())
-				{
-					{
-						result += (std::string("-")+std::string(slot.slot_name()) + " " +
-									machine().options().slot_option(slot.slot_name()).value().c_str() +
-									std::string("\n"));
-					}
-				}
-			}
-			return result;
-		}));
 
 	machine_type.set("images", sol::property([this](running_machine &r) {
 			sol::table image_table = sol().create_table();

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -124,6 +124,8 @@ void menu_slot_devices::record_current_options()
 			// get the slot option
 			const slot_option &opt(machine().options().slot_option(slot.slot_name()));
 
+printf("Slot %s , %s\n",slot.slot_name(),machine().options().slot_option(slot.slot_name()).specified_value().c_str());
+
 			// and record the value in our local cache
 			m_slot_options[slot.slot_name()] = opt.specified_value();
 		}

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -123,6 +123,7 @@ void menu_slot_devices::record_current_options()
 		{
 			// get the slot option
 			const slot_option &opt(machine().options().slot_option(slot.slot_name()));
+
 			// and record the value in our local cache
 			m_slot_options[slot.slot_name()] = opt.specified_value();
 		}

--- a/src/frontend/mame/ui/slotopt.cpp
+++ b/src/frontend/mame/ui/slotopt.cpp
@@ -123,9 +123,6 @@ void menu_slot_devices::record_current_options()
 		{
 			// get the slot option
 			const slot_option &opt(machine().options().slot_option(slot.slot_name()));
-
-printf("Slot %s , %s\n",slot.slot_name(),machine().options().slot_option(slot.slot_name()).specified_value().c_str());
-
 			// and record the value in our local cache
 			m_slot_options[slot.slot_name()] = opt.specified_value();
 		}


### PR DESCRIPTION
This is to add a function to luaengine that would return a string of the current slot options.

For example, you can ask for the list of options that are specified:

[MAME]> print(manager:machine():slot_options_list())
-sl1 parallel
-sl1:parallel:prn ap2000
-gameio joy

Or you can send it a TRUE value to get the full list of options:

[MAME]> print(manager:machine():slot_options_list(true))
-sl1 parallel
-sl1:parallel:prn ap2000
-sl2 ""
-sl3 ""
-sl4 mockingboard
-sl5 ""
-sl6 diskiing
-sl6:diskiing:0 525
-sl6:diskiing:1 525
-sl7 ""
-aux ext80
-gameio joy

You can also send a parameter that will be the delimiter between options like a space instead of the default, a "\n".

[MAME]> print(manager:machine():slot_options_list(true," "))
-sl1 parallel -sl1:parallel:prn ap2000 -sl2 "" -sl3 "" -sl4 mockingboard -sl5 "" -sl6 diskiing -sl6:diskiing:0 525 -sl6:diskiing:1 525 -sl7 "" -aux ext80 -gameio joy 

So if I use the UI to set the slot options, I can get the full list from the console and then use it to build a command line to invoke mame.