### PR TITLE
ibm5150 - Blockout bad dump

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -8147,8 +8147,9 @@ has been replaced with an all-zero block. -->
 		<publisher>California Dreams</publisher>
 		<info name="developer" value="P.Z.Karen Co. Development Group" />
 		<part name="flop1" interface="floppy_5_25">
+			<!-- Bad Dump, modified OEM ID and modified root -->
 			<dataarea name="flop" size = "368640">
-				<rom name="Blockout [California Dreams] [1989] [5.25] [Disk 1 of 1].img" size="368640" crc="9bd2f1b3" sha1="06aebc57c7eeec4a38ed35bdc58d6d681f8627f4"/>
+				<rom name="Blockout [California Dreams] [1989] [5.25] [Disk 1 of 1].img" size="368640" crc="9bd2f1b3" sha1="06aebc57c7eeec4a38ed35bdc58d6d681f8627f4" status="baddump" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -8147,7 +8147,7 @@ has been replaced with an all-zero block. -->
 		<publisher>California Dreams</publisher>
 		<info name="developer" value="P.Z.Karen Co. Development Group" />
 		<part name="flop1" interface="floppy_5_25">
-			<!-- Bad Dump, modified OEM ID and modified root -->
+			<!-- Not a pristine dump, has modified OEM ID and modified root -->
 			<dataarea name="flop" size = "368640">
 				<rom name="Blockout [California Dreams] [1989] [5.25] [Disk 1 of 1].img" size="368640" crc="9bd2f1b3" sha1="06aebc57c7eeec4a38ed35bdc58d6d681f8627f4" status="baddump" />
 			</dataarea>


### PR DESCRIPTION
blockout: Marked as bad dump (modified OEM ID and modified root)