### PR TITLE
starshp1: Fix tilemap size, get rid of uninitialized chars on screen

### DIFF
--- a/src/mame/drivers/starshp1.cpp
+++ b/src/mame/drivers/starshp1.cpp
@@ -164,7 +164,7 @@ void starshp1_state::starshp1_map(address_map &map)
 	map(0xc300, 0xc3ff).w(FUNC(starshp1_state::starshp1_sspic_w)); /* spaceship picture */
 	map(0xc400, 0xc400).portr("COINAGE");
 	map(0xc400, 0xc4ff).w(FUNC(starshp1_state::starshp1_ssadd_w)); /* spaceship address */
-	map(0xc800, 0xc9ff).ram().w(FUNC(starshp1_state::starshp1_playfield_w)).share("playfield_ram");
+	map(0xc800, 0xc8ff).ram().w(FUNC(starshp1_state::starshp1_playfield_w)).share("playfield_ram");
 	map(0xcc00, 0xcc0f).writeonly().share("hpos_ram");
 	map(0xd000, 0xd00f).writeonly().share("vpos_ram");
 	map(0xd400, 0xd40f).writeonly().share("obj_ram");

--- a/src/mame/video/starshp1.cpp
+++ b/src/mame/video/starshp1.cpp
@@ -355,6 +355,7 @@ uint32_t starshp1_state::screen_update_starshp1(screen_device &screen, bitmap_in
 		draw_circle(bitmap);
 
 	rectangle tilemaprect(0, m_bg_tilemap->width(), 0, m_bg_tilemap->height());
+	tilemaprect &= cliprect;
 	m_bg_tilemap->draw(screen, bitmap, tilemaprect, 0, 0);
 
 	if (m_phasor != 0)

--- a/src/mame/video/starshp1.cpp
+++ b/src/mame/video/starshp1.cpp
@@ -56,7 +56,7 @@ void starshp1_state::video_start()
 
 	int i;
 
-	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(starshp1_state::get_tile_info)), TILEMAP_SCAN_ROWS, 16, 8, 32, 32);
+	m_bg_tilemap = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(starshp1_state::get_tile_info)), TILEMAP_SCAN_ROWS, 16, 8, 32, 8);
 
 	m_bg_tilemap->set_transparent_pen(0);
 
@@ -354,7 +354,8 @@ uint32_t starshp1_state::screen_update_starshp1(screen_device &screen, bitmap_in
 	if (m_circle_kill == 0 && m_circle_mod == 0)
 		draw_circle(bitmap);
 
-	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
+	rectangle tilemaprect(0, m_bg_tilemap->width(), 0, m_bg_tilemap->height());
+	m_bg_tilemap->draw(screen, bitmap, tilemaprect, 0, 0);
 
 	if (m_phasor != 0)
 		draw_phasor(bitmap);


### PR DESCRIPTION
Fixed a bug where there was garbage on the screen from extra unitialized ram being drawn on the screen.  The ram region here is only 256 bytes - and it is drawn at the top of the screen only, by the hardware.  I was surprised that drawing a smaller tilemap defaults to drawing to the entire screen, so I made a special cliprect.  Please let me know if I am missing something fundamental about cliprects and tilemaps.