### PR TITLE
coco_ssc.ccp: fix speech in Pegsaus and the Phantom Riders

### DIFF
--- a/src/devices/bus/coco/coco_ssc.cpp
+++ b/src/devices/bus/coco/coco_ssc.cpp
@@ -28,9 +28,6 @@
         * – Active low
     Port D is the 8-bit data bus.
 
-	Note: Status flags are forced to certain values after a reset to get
-	      Pegasus and the Phantom Riders working with speech.
-
 ***************************************************************************/
 
 #include "emu.h"

--- a/src/devices/bus/coco/coco_ssc.h
+++ b/src/devices/bus/coco/coco_ssc.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Nathan Woods
+// copyright-holders:tim lindner
 #ifndef MAME_BUS_COCO_COCO_SSC_H
 #define MAME_BUS_COCO_COCO_SSC_H
 


### PR DESCRIPTION
This game requires very specific status values after a reset. The speech chip was incorrectly being reset too soon in the process. The logging system was modernized. The device busy delay timer was unneeded, so removed. Tested with BASIC commands from manual, Pitfall 2, and PandPR.