### PR TITLE
allow 8751 MCU to access tile ram as well as text RAM on the pre-system16 boards (Quartet / Quartet 2)

### DIFF
--- a/src/mame/drivers/segas16a.cpp
+++ b/src/mame/drivers/segas16a.cpp
@@ -490,7 +490,9 @@ void segas16a_state::mcu_io_w(offs_t offset, uint8_t data)
 
 		// access text RAM
 		case 1:
-			if (offset >= 0x8000 && offset < 0x9000)
+			if (offset < 0x8000)
+				m_maincpu->space(AS_PROGRAM).write_byte(0x400001 ^ (offset & 0x7fff), data);
+			else if (offset < 0x9000)
 				m_maincpu->space(AS_PROGRAM).write_byte(0x410001 ^ (offset & 0xfff), data);
 			else
 				logerror("%03X: MCU movx write mode %02X offset %04X = %02X\n", m_mcu->pc(), m_mcu_control, offset, data);
@@ -540,8 +542,11 @@ uint8_t segas16a_state::mcu_io_r(address_space &space, offs_t offset)
 
 		// access text RAM
 		case 1:
-			if (offset >= 0x8000 && offset < 0x9000)
+			if (offset < 0x8000)
+				return m_maincpu->space(AS_PROGRAM).read_byte(0x400001 ^ (offset & 0x7fff));
+			else if (offset < 0x9000)
 				return m_maincpu->space(AS_PROGRAM).read_byte(0x410001 ^ (offset & 0xfff));
+
 			logerror("%03X: MCU movx read mode %02X offset %04X\n", m_mcu->pc(), m_mcu_control, offset);
 			return 0xff;
 


### PR DESCRIPTION
Needed for moving platforms in stage 15, see https://mametesters.org/view.php?id=7792

again I think this is a case of 'has never worked in MAME' because the old protection sims didn't do this either