### PR TITLE
Cleanups and corrections for CoCo cartridge slot configuration

### DIFF
--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -153,12 +153,13 @@ namespace
 
 static void coco_cart_slot1_3(device_slot_interface &device)
 {
-	coco_cart_add_devices(device, false, false);
+	coco_cart_add_basic_devices(device);
 }
 
 static void coco_cart_slot4(device_slot_interface &device)
 {
-	coco_cart_add_devices(device, true, false);
+	coco_cart_add_basic_devices(device);
+	coco_cart_add_fdcs(device);
 }
 
 

--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -57,16 +57,6 @@
 #include "coco_multi.h"
 
 #include "cococart.h"
-#include "coco_dcmodem.h"
-#include "coco_fdc.h"
-#include "coco_gmc.h"
-#include "coco_orch90.h"
-#include "coco_pak.h"
-#include "coco_ram.h"
-#include "coco_rs232.h"
-#include "coco_ssc.h"
-#include "coco_stecomp.h"
-#include "coco_sym12.h"
 
 #define SLOT1_TAG           "slot1"
 #define SLOT2_TAG           "slot2"
@@ -163,32 +153,12 @@ namespace
 
 static void coco_cart_slot1_3(device_slot_interface &device)
 {
-	device.option_add("banked_16k", COCO_PAK_BANKED);
-	device.option_add("dcmodem", COCO_DCMODEM);
-	device.option_add("games_master", COCO_PAK_GMC);
-	device.option_add("orch90", COCO_ORCH90);
-	device.option_add("pak", COCO_PAK);
-	device.option_add("ram", COCO_PAK_RAM);
-	device.option_add("rs232", COCO_RS232);
-	device.option_add("ssc", COCO_SSC);
-	device.option_add("stecomp", COCO_STEREO_COMPOSER);
-	device.option_add("sym12", COCO_SYM12);
+	coco_cart_add_devices(device, false, false);
 }
+
 static void coco_cart_slot4(device_slot_interface &device)
 {
-	device.option_add("banked_16k", COCO_PAK_BANKED);
-	device.option_add("cc2hdb1", COCO2_HDB1);
-	device.option_add("cc3hdb1", COCO3_HDB1);
-	device.option_add("dcmodem", COCO_DCMODEM);
-	device.option_add("fdcv11", COCO_FDC_V11);
-	device.option_add("games_master", COCO_PAK_GMC);
-	device.option_add("orch90", COCO_ORCH90);
-	device.option_add("pak", COCO_PAK);
-	device.option_add("ram", COCO_PAK_RAM);
-	device.option_add("rs232", COCO_RS232);
-	device.option_add("ssc", COCO_SSC);
-	device.option_add("stecomp", COCO_STEREO_COMPOSER);
-	device.option_add("sym12", COCO_SYM12);
+	coco_cart_add_devices(device, true, false);
 }
 
 

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -40,6 +40,19 @@
 #include "emu.h"
 #include "cococart.h"
 
+#include "coco_dcmodem.h"
+#include "coco_fdc.h"
+#include "coco_gmc.h"
+#include "coco_multi.h"
+#include "coco_orch90.h"
+#include "coco_pak.h"
+#include "coco_psg.h"
+#include "coco_ram.h"
+#include "coco_rs232.h"
+#include "coco_ssc.h"
+#include "coco_stecomp.h"
+#include "coco_sym12.h"
+
 
 /***************************************************************************
     PARAMETERS
@@ -648,4 +661,43 @@ address_space &device_cococart_interface::cartridge_space()
 void device_cococart_interface::set_line_value(cococart_slot_device::line line, cococart_slot_device::line_value value)
 {
 	owning_slot().set_line_value(line, value);
+}
+
+
+//-------------------------------------------------
+//  coco_cart_add_devices - configures CoCo device
+//	slots (both the main slot and slots on a Mulit-Pak
+//-------------------------------------------------
+
+void coco_cart_add_devices(device_slot_interface &device, bool include_fdcs, bool include_multi_pak)
+{
+	device.option_add_internal("banked_16k", COCO_PAK_BANKED);
+	device.option_add("ccpsg", COCO_PSG);
+	device.option_add("dcmodem", COCO_DCMODEM);
+	device.option_add("games_master", COCO_PAK_GMC);
+	device.option_add("orch90", COCO_ORCH90);
+	device.option_add_internal("pak", COCO_PAK);
+	device.option_add("ram", COCO_PAK_RAM);
+	device.option_add("rs232", COCO_RS232);
+	device.option_add("ssc", COCO_SSC);
+	device.option_add("stecomp", COCO_STEREO_COMPOSER);
+	device.option_add("sym12", COCO_SYM12);
+
+	// FDCs are optional because if they are on a Multi-Pak interface, they must
+	// be on Slot 4
+	if (include_fdcs)
+	{
+		device.option_add("cc2hdb1", COCO2_HDB1);
+		device.option_add("cc3hdb1", COCO3_HDB1);
+		device.option_add("cd6809_fdc", CD6809_FDC);
+		device.option_add("cp450_fdc", CP450_FDC);
+		device.option_add("fdc", COCO_FDC);
+		device.option_add("fdcv11", COCO_FDC_V11);
+	}
+
+	// and the Multi-Pak itself is otional because they cannot be daisy chained
+	if (include_multi_pak)
+	{
+		device.option_add("multi", COCO_MULTIPAK);
+	}
 }

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -665,12 +665,12 @@ void device_cococart_interface::set_line_value(cococart_slot_device::line line, 
 
 
 //-------------------------------------------------
-//  coco_cart_add_devices - configures CoCo device
-//	slots (both the main slot and slots on a Mulit-Pak
+//  coco_cart_add_basic_devices
 //-------------------------------------------------
 
-void coco_cart_add_devices(device_slot_interface &device, bool include_fdcs, bool include_multi_pak)
+void coco_cart_add_basic_devices(device_slot_interface &device)
 {
+	// basic devices, on both the main slot and the Multi-Pak interface
 	device.option_add_internal("banked_16k", COCO_PAK_BANKED);
 	device.option_add("ccpsg", COCO_PSG);
 	device.option_add("dcmodem", COCO_DCMODEM);
@@ -682,22 +682,32 @@ void coco_cart_add_devices(device_slot_interface &device, bool include_fdcs, boo
 	device.option_add("ssc", COCO_SSC);
 	device.option_add("stecomp", COCO_STEREO_COMPOSER);
 	device.option_add("sym12", COCO_SYM12);
+}
 
+
+//-------------------------------------------------
+//  coco_cart_add_fdcs
+//-------------------------------------------------
+
+void coco_cart_add_fdcs(device_slot_interface &device)
+{
 	// FDCs are optional because if they are on a Multi-Pak interface, they must
 	// be on Slot 4
-	if (include_fdcs)
-	{
-		device.option_add("cc2hdb1", COCO2_HDB1);
-		device.option_add("cc3hdb1", COCO3_HDB1);
-		device.option_add("cd6809_fdc", CD6809_FDC);
-		device.option_add("cp450_fdc", CP450_FDC);
-		device.option_add("fdc", COCO_FDC);
-		device.option_add("fdcv11", COCO_FDC_V11);
-	}
+	device.option_add("cc2hdb1", COCO2_HDB1);
+	device.option_add("cc3hdb1", COCO3_HDB1);
+	device.option_add("cd6809_fdc", CD6809_FDC);
+	device.option_add("cp450_fdc", CP450_FDC);
+	device.option_add("fdc", COCO_FDC);
+	device.option_add("fdcv11", COCO_FDC_V11);
+}
 
-	// and the Multi-Pak itself is otional because they cannot be daisy chained
-	if (include_multi_pak)
-	{
-		device.option_add("multi", COCO_MULTIPAK);
-	}
+
+//-------------------------------------------------
+//  coco_cart_add_multi_pak
+//-------------------------------------------------
+
+void coco_cart_add_multi_pak(device_slot_interface &device)
+{
+	// and the Multi-Pak itself is optional because they cannot be daisy chained
+	device.option_add("multi", COCO_MULTIPAK);
 }

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -225,4 +225,6 @@ private:
 	device_cococart_host_interface * m_host;
 };
 
+void coco_cart_add_devices(device_slot_interface &device, bool include_fdcs, bool include_multi_pak);
+
 #endif // MAME_BUS_COCO_COCOCART_H

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -225,6 +225,10 @@ private:
 	device_cococart_host_interface * m_host;
 };
 
-void coco_cart_add_devices(device_slot_interface &device, bool include_fdcs, bool include_multi_pak);
+// methods for configuring CoCo slot devices (the expansion cart
+// itself, as well as slots on the Multi-Pak)
+void coco_cart_add_basic_devices(device_slot_interface &device);
+void coco_cart_add_fdcs(device_slot_interface &device);
+void coco_cart_add_multi_pak(device_slot_interface &device);
 
 #endif // MAME_BUS_COCO_COCOCART_H

--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -26,19 +26,7 @@
 #include "emu.h"
 #include "includes/coco12.h"
 
-#include "bus/coco/coco_dcmodem.h"
-#include "bus/coco/coco_dwsock.h"
-#include "bus/coco/coco_fdc.h"
-#include "bus/coco/coco_gmc.h"
-#include "bus/coco/coco_multi.h"
-#include "bus/coco/coco_orch90.h"
-#include "bus/coco/coco_pak.h"
-#include "bus/coco/coco_psg.h"
-#include "bus/coco/coco_ram.h"
-#include "bus/coco/coco_rs232.h"
-#include "bus/coco/coco_ssc.h"
-#include "bus/coco/coco_stecomp.h"
-#include "bus/coco/coco_sym12.h"
+#include "bus/coco/cococart.h"
 #include "bus/coco/coco_t4426.h"
 
 #include "cpu/m6809/m6809.h"
@@ -402,30 +390,14 @@ INPUT_PORTS_END
 //**************************************************************************
 
 //-------------------------------------------------
-//  SLOT_INTERFACE_START(coco_cart)
+//  coco_cart
 //-------------------------------------------------
 
 void coco_cart(device_slot_interface &device)
 {
-	device.option_add("banked_16k", COCO_PAK_BANKED);
-	device.option_add("cc2hdb1", COCO2_HDB1);
-	device.option_add("cc3hdb1", COCO3_HDB1);
-	device.option_add("ccpsg", COCO_PSG);
-	device.option_add("cd6809_fdc", CD6809_FDC);
-	device.option_add("cp450_fdc", CP450_FDC);
-	device.option_add("dcmodem", COCO_DCMODEM);
-	device.option_add("fdc", COCO_FDC);
-	device.option_add("fdcv11", COCO_FDC_V11);
-	device.option_add("games_master", COCO_PAK_GMC);
-	device.option_add("multi", COCO_MULTIPAK);
-	device.option_add("orch90", COCO_ORCH90);
-	device.option_add("pak", COCO_PAK);
-	device.option_add("ram", COCO_PAK_RAM);
-	device.option_add("rs232", COCO_RS232);
-	device.option_add("ssc", COCO_SSC);
-	device.option_add("stecomp", COCO_STEREO_COMPOSER);
-	device.option_add("sym12", COCO_SYM12);
+	coco_cart_add_devices(device, true, true);
 }
+
 
 //-------------------------------------------------
 //  SLOT_INTERFACE_START(t4426_cart)

--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -395,7 +395,9 @@ INPUT_PORTS_END
 
 void coco_cart(device_slot_interface &device)
 {
-	coco_cart_add_devices(device, true, true);
+	coco_cart_add_basic_devices(device);
+	coco_cart_add_fdcs(device);
+	coco_cart_add_multi_pak(device);
 }
 
 


### PR DESCRIPTION
1. Consolidated CoCo cartridge slot device configuration, to remove duplicate code that was specific to slots on the Multi-Pak interface.
2. Marked "pak" and "banked_16k" as internal, as they are not standalone