### PR TITLE
sgi_mips: new software list additions

### DIFF
--- a/hash/sgi_mips.xml
+++ b/hash/sgi_mips.xml
@@ -1194,6 +1194,19 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="wavefront_4_5">
+		<description>Alias|Wavefront Composer 4.5</description>
+		<year>1997</year> <!-- 08/1997 -->
+		<publisher>Walias|Wavefront, Inc.</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="812-0506-004"/>
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="wavefront_composer_4_5" sha1="ae5e0f16a4370ad83a26c2286be791fe81759ca1" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="webforce_feb_98">
 		<description>WebFORCE February 1998</description>
 		<year>1998</year> <!-- 02/98 -->
@@ -1212,6 +1225,45 @@ license:CC0
 			<!-- Origin: BitSavers -->
 			<diskarea name="cdrom">
 				<disk name="webforce_2_of_2_february_1998" sha1="42f14378b5e635228a4febd032a74a5b89402eef" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="webforce_aug_98">
+		<description>Media Value Pack WebFORCE August 1998 for IRIX 6.5</description>
+		<year>1998</year> <!-- 08/98 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_id" value="812-0533-001"/>
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="webforce_august_1998" sha1="587208016f769555a06e70947879075b4ef40bfa" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pdfgenerator_1_2">
+		<description>PDF Generator 1.2 for IRIX 6.2, 6.3, 6.4 and 6.5</description>
+		<year>1998</year> <!-- 07/98 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_id" value="812-0528-001"/>
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="pdf_generator_1_2" sha1="cdb0bb0abb41f31973231a4706a9acc496011e8f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="intranetjunction">
+		<description>Intranet Junction 1.0.2 for IRIX 6.2, 6.3, 6.4 and 6.5</description>
+		<year>1998</year> <!-- 07/98 -->
+		<publisher>Silicon Graphics</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_id" value="812-0587-003"/>
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="intranet_junction_1_0_2" sha1="1dfedcbd84a56adea8a0aa58a088256927780f49" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
This PR adds the following 4 discs to the softlist:
- PDF Generator 1.2
- Intranet Junction 1.0.2
- Media Value Pack WebFORCE August 1998
- Alias|Wavefront Composer 4.5

The CHD files can be downloaded [here](https://md1-stuff.s3.au.de:8082/sgi_mips_chds.zip)

The dumps were sourced from [archive.org](https://archive.org/details/sgiO2softwarelibrary.7z) (not dumped by me).

They come from the "O2 Software Library", a pack of CDs that came bundled with some O2 models and had time-limited eval licenses included.
![boxfront](https://user-images.githubusercontent.com/43795/99888832-e28f1b00-2c4f-11eb-9f42-610395a1e04f.jpg)

Here are scans of the discs:
![discs1](https://user-images.githubusercontent.com/43795/99888839-fe92bc80-2c4f-11eb-8a7c-c2e9a2212c70.jpg)
![discs2](https://user-images.githubusercontent.com/43795/99888841-00f51680-2c50-11eb-9fcd-6ff8d9aaa018.jpg)

(A fifth disc with Cosmo Suite was also included, but that is already in the softlist)

Since the licenses have expired long ago, I figured it would be safe to post them here as well
![templicenses](https://user-images.githubusercontent.com/43795/99888869-56312800-2c50-11eb-816a-ffd16e4b441f.jpg)

What would be the best way to preserve the license information? Should I add it (as comment block) to the softlist?