### PR TITLE
Fix NuBus image compilation.

### DIFF
--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -189,10 +189,7 @@ void nubus_image_device::device_start()
 
 	m_image = subdevice<messimg_disk_image_device>(IMAGE_DISK0_TAG);
 
-	filectx.filename.reserve(128);
-	filectx.curdir.reserve(1024);
-	filectx.curdir[0] = '.';
-	filectx.curdir[1] = '\0';
+	filectx.curdir = ".";
 	filectx.dirp = nullptr;
 	filectx.fd = nullptr;
 }
@@ -286,7 +283,6 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 	case kFileCmdGetFile:
 		{
 			std::string fullpath;
-			fullpath.reserve(1024);
 			fullpath = current_dir;
 			fullpath += PATH_SEPARATOR;
 			fullpath += filename;
@@ -298,7 +294,6 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 	case kFileCmdPutFile:
 		{
 			std::string fullpath;
-			fullpath.reserve(1024);
 			fullpath = current_dir;
 			fullpath += PATH_SEPARATOR;
 			fullpath += filename;

--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -282,8 +282,7 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 		break;
 	case kFileCmdGetFile:
 		{
-			std::string fullpath;
-			fullpath = current_dir;
+            std::string fullpath(current_dir);
 			fullpath += PATH_SEPARATOR;
 			fullpath += filename;
 			if(osd_file::open(fullpath, OPEN_FLAG_READ, filectx.fd, filectx.filelen) != osd_file::error::NONE)
@@ -293,8 +292,7 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 		break;
 	case kFileCmdPutFile:
 		{
-			std::string fullpath;
-			fullpath = current_dir;
+			std::string fullpath(current_dir);
 			fullpath += PATH_SEPARATOR;
 			fullpath += filename;
 			uint64_t filesize; // unused, but it's an output from the open call

--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -257,8 +257,11 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 		if ((filectx.filename[0] == '/') || (filectx.filename[0] == '$')) {
 			strcpy((char*)filectx.curdir, (char*)filectx.filename);
 		} else {
-			strcat((char*)filectx.curdir, "/");
-			strcat((char*)filectx.curdir, (char*)filectx.filename);
+		    if (strlen((char*)filectx.curdir) + strlen((char*)filectx.filename) + 1 < 1024)
+            {
+                strcat((char*)filectx.curdir, "/");
+                strcat((char*)filectx.curdir, (char*)filectx.filename);
+            }
 		}
 		break;
 	case kFileCmdGetFirstListing:

--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -257,11 +257,11 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 		if ((filectx.filename[0] == '/') || (filectx.filename[0] == '$')) {
 			strcpy((char*)filectx.curdir, (char*)filectx.filename);
 		} else {
-		    if (strlen((char*)filectx.curdir) + strlen((char*)filectx.filename) + 1 < 1024)
-            {
-                strcat((char*)filectx.curdir, "/");
-                strcat((char*)filectx.curdir, (char*)filectx.filename);
-            }
+			if (strlen((char*)filectx.curdir) + strlen((char*)filectx.filename) + 1 < sizeof(filectx.curdir))
+			{
+				strcat((char*)filectx.curdir, "/");
+				strcat((char*)filectx.curdir, (char*)filectx.filename);
+			}
 		}
 		break;
 	case kFileCmdGetFirstListing:

--- a/src/devices/bus/nubus/nubus_image.h
+++ b/src/devices/bus/nubus/nubus_image.h
@@ -38,8 +38,8 @@ protected:
 	struct nbfilectx
 	{
 		uint32_t curcmd;
-		std::string filename;
-		std::string curdir;
+		uint8_t filename[128];
+		uint8_t curdir[1024];
 		osd::directory::ptr dirp;
 		osd_file::ptr fd;
 		uint64_t filelen;

--- a/src/devices/bus/nubus/nubus_image.h
+++ b/src/devices/bus/nubus/nubus_image.h
@@ -38,8 +38,8 @@ protected:
 	struct nbfilectx
 	{
 		uint32_t curcmd;
-		uint8_t filename[128];
-		uint8_t curdir[1024];
+		std::string filename;
+		std::string curdir;
 		osd::directory::ptr dirp;
 		osd_file::ptr fd;
 		uint64_t filelen;


### PR DESCRIPTION
Compilation with `g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0` causes : 

```
Compiling src/devices/bus/nubus/nubus_image.cpp...
In file included from /usr/include/string.h:495,
                 from /usr/include/c++/9/cstring:42,
                 from ../../../../../src/emu/emucore.h:20,
                 from ../../../../../src/emu/emu.h:30:
In function ‘char* strcat(char*, const char*)’,
    inlined from ‘void nubus_image_device::file_cmd_w(uint32_t)’ at ../../../../../src/devices/bus/nubus/nubus_image.cpp:261:10:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:128:33: error: ‘char* __builtin___strcat_chk(char*, const char*, long unsigned int)’ accessing 129 or more bytes at offsets 988 and 860 may overlap 1 byte at offset 988 [-Werror=restrict]
  128 |   return __builtin___strcat_chk (__dest, __src, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is a tentative fix.
