### PR TITLE
cosmic.cpp: Fixed bug in sound output handler and cleaned up sample playback code

### DIFF
--- a/src/mame/drivers/cosmic.cpp
+++ b/src/mame/drivers/cosmic.cpp
@@ -221,66 +221,42 @@ void cosmic_state::cosmica_sound_output_w(offs_t offset, uint8_t data)
 				{
 				case 2:
 					if (m_samples->playing(2))
-					{
 						m_samples->stop(2);
-						m_samples->start(2, 3);
-					}
-					else
-						m_samples->start(2, 3);
+					m_samples->start(2, 3);
 					break;
 
 				case 3:
 					if (m_samples->playing(3))
-					{
 						m_samples->stop(3);
-						m_samples->start(3, 4);
-					}
-					else
-						m_samples->start(3, 4);
+					m_samples->start(3, 4);
 					break;
 
 				case 4:
 					if (m_samples->playing(4))
-					{
 						m_samples->stop(4);
-						m_samples->start(4, 5);
-					}
-					else
-						m_samples->start(4, 5);
+					m_samples->start(4, 5);
 					break;
 
 				case 5:
 					if (m_samples->playing(5))
-					{
 						m_samples->stop(5);
-						m_samples->start(5, 6);
-					}
-					else
-						m_samples->start(5, 6);
+					m_samples->start(5, 6);
 					break;
 
 				case 6:
 					if (m_samples->playing(6))
-					{
 						m_samples->stop(6);
-						m_samples->start(6, 7);
-					}
-					else
-						m_samples->start(6, 7);
+					m_samples->start(6, 7);
 					break;
 
 				case 7:
 					if (m_samples->playing(7))
-					{
 						m_samples->stop(7);
-						m_samples->start(7, 8);
-					}
-					else
-						m_samples->start(7, 8);
+					m_samples->start(7, 8);
 					break;
 				}
 			}
-			[[fallthrough]]; // FIXME: really?
+			break;
 
 		case 3: /*Dive Bombing Type B (G.S.B)*/
 			if (data)


### PR DESCRIPTION
Some cleanup to sample playback for cosmica - remove some redundant calls, and turn the questionable `[[fallthrough]]` into a `break`