### PR TITLE
Failed experiments in multi-channel audio

### DIFF
--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -824,8 +824,7 @@ private:
 	u32 m_finalmix_leftover;              // leftover samples in the final mix
 	u32 m_samples_this_update;            // number of samples this update
 	std::vector<s16> m_finalmix;          // final mix, in 16-bit signed format
-	std::vector<stream_buffer::sample_t> m_leftmix; // left speaker mix, in native format
-	std::vector<stream_buffer::sample_t> m_rightmix; // right speaker mix, in native format
+	std::vector<std::vector<stream_buffer::sample_t>> m_mixes; // per speaker mix, in native format
 
 	stream_buffer::sample_t m_compressor_scale; // current compressor scale factor
 	int m_compressor_counter;             // compressor update counter for backoff
@@ -840,6 +839,7 @@ private:
 	std::vector<std::unique_ptr<sound_stream>> m_stream_list; // list of streams
 	std::map<sound_stream *, u8> m_orphan_stream_list; // list of orphaned streams
 	bool m_first_reset;                   // is this our first reset?
+	int m_numstreams;
 };
 
 

--- a/src/emu/speaker.h
+++ b/src/emu/speaker.h
@@ -69,7 +69,7 @@ public:
 	speaker_device &backrest()          { set_position( 0.0, -0.2,  0.1); return *this; }
 
 	// internally for use by the sound system
-	void mix(stream_buffer::sample_t *leftmix, stream_buffer::sample_t *rightmix, attotime start, attotime end, int expected_samples, bool suppress);
+	void mix(std::vector<std::vector<stream_buffer::sample_t>> &mixes, attotime start, attotime end, int expected_samples, bool suppress);
 
 protected:
 	// device-level overrides


### PR DESCRIPTION
At some point MAME will need to be able to support outputting to more than 2 speakers.  We're seeing an increasing number of things with more exotic setups (back to back cabinets with mono speakers specific rumble-only channels etc.)

Here I've changed sound.cpp to loop over more than 2 streams,, however I can't get MAME's OSD level to initialize properly with more than 2 channels specified.

I've only include the directsound part of this example, but I get the same with xaudio, portaudio and even SDL if I try to hook things up there, either 'invalid params' or 'invalid number of channels' even if the very same code works outside of MAME and allows me to play audio across all 6 / 8 channels depending on the audio device being used.  I'm not sure what's going on, if I get the capabilities of the devices it also correctly shows 6/8 channels, but still refuses to initialize that way.

I'm making a PR out of this just in case anything useful can be extracted from it (I imagine the sound.cpp changes will be needed in some form?)  I haven't checked for any change in performance.

