### PR TITLE
Hp9845: added the capability to interface to an external BiSync connection

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -2615,6 +2615,8 @@ if (BUSES["RS232"]~=null) then
 		MAME_DIR .. "src/devices/bus/rs232/swtpc8212.h",
 		MAME_DIR .. "src/devices/bus/rs232/exorterm.cpp",
 		MAME_DIR .. "src/devices/bus/rs232/exorterm.h",
+		MAME_DIR .. "src/devices/bus/rs232/sync_io.cpp",
+		MAME_DIR .. "src/devices/bus/rs232/sync_io.h",
 	}
 end
 

--- a/src/devices/bus/hp9845_io/98046.h
+++ b/src/devices/bus/hp9845_io/98046.h
@@ -85,6 +85,8 @@ private:
 	DECLARE_WRITE_LINE_MEMBER(rs232_dcd_w);
 	DECLARE_WRITE_LINE_MEMBER(rs232_dsr_w);
 	DECLARE_WRITE_LINE_MEMBER(rs232_cts_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_rxc_w);
+	DECLARE_WRITE_LINE_MEMBER(rs232_txc_w);
 	bool rx_fifo_flag() const;
 	bool tx_fifo_flag() const;
 	void update_flg();
@@ -95,6 +97,9 @@ private:
 	void set_r6_r7_pending(bool state);
 	uint8_t get_hs_input() const;
 	void set_brgs(uint8_t sel);
+	void rxc_w(bool state);
+	void txc_w(bool state);
+	static bool is_ext_clock(uint8_t sel);
 };
 
 // device type definitions

--- a/src/devices/bus/rs232/rs232.cpp
+++ b/src/devices/bus/rs232/rs232.cpp
@@ -171,6 +171,7 @@ device_rs232_port_interface::~device_rs232_port_interface()
 #include "swtpc8212.h"
 #include "terminal.h"
 #include "ie15.h"
+#include "sync_io.h"
 
 void default_rs232_devices(device_slot_interface &device)
 {
@@ -184,4 +185,5 @@ void default_rs232_devices(device_slot_interface &device)
 	device.option_add("sunkbd", SUN_KBD_ADAPTOR);
 	device.option_add("ie15", SERIAL_TERMINAL_IE15);
 	device.option_add("swtpc8212", SERIAL_TERMINAL_SWTPC8212);
+	device.option_add("sync_io", SYNC_IO);
 }

--- a/src/devices/bus/rs232/sync_io.cpp
+++ b/src/devices/bus/rs232/sync_io.cpp
@@ -1,0 +1,192 @@
+// license:BSD-3-Clause
+// copyright-holders: F. Ulivi
+/*********************************************************************
+
+    sync_io.cpp
+
+    Synchronous I/O on RS232 port
+
+*********************************************************************/
+
+#include "emu.h"
+#include "sync_io.h"
+
+// Debugging
+
+#include "logmacro.h"
+#undef VERBOSE
+#define VERBOSE LOG_GENERAL
+
+// Bit manipulation
+namespace {
+	template<typename T> constexpr T BIT_MASK(unsigned n)
+	{
+		return (T)1U << n;
+	}
+
+	template<typename T> void BIT_CLR(T& w , unsigned n)
+	{
+		w &= ~BIT_MASK<T>(n);
+	}
+
+	template<typename T> void BIT_SET(T& w , unsigned n)
+	{
+		w |= BIT_MASK<T>(n);
+	}
+}
+
+// Timers
+enum {
+	TMR_ID_CLK
+};
+
+sync_io_device::sync_io_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig , SYNC_IO , tag , owner , clock)
+	, device_rs232_port_interface(mconfig , *this)
+	, m_stream(*this , "stream")
+	, m_rs232_baud(*this , "RS232_BAUD")
+	, m_rts_duplex(*this , "rtsduplex")
+	, m_txc_setting(*this , "txcontrol")
+	, m_rxc_setting(*this , "rxcontrol")
+{
+}
+
+sync_io_device:: ~sync_io_device()
+{
+}
+
+WRITE_LINE_MEMBER(sync_io_device::input_txd)
+{
+	m_txd = state;
+	LOG("TxD %d %u\n" , state , m_tx_counter);
+}
+
+WRITE_LINE_MEMBER(sync_io_device::input_rts)
+{
+	m_rts = state;
+}
+
+static INPUT_PORTS_START(sync_io)
+	PORT_RS232_BAUD("RS232_BAUD" , RS232_BAUD_2400 , "Baud rate" , sync_io_device , update_serial)
+
+	PORT_START("rtsduplex")
+	PORT_CONFNAME(1 , 1 , "RTS controls half-duplex")
+	PORT_CONFSETTING(0 , DEF_STR(Off))
+	PORT_CONFSETTING(1 , DEF_STR(On))
+
+	PORT_START("txcontrol")
+	PORT_CONFNAME(1 , 1 , "TxC generated")
+	PORT_CONFSETTING(0 , "Always")
+	PORT_CONFSETTING(1 , "When Tx is active")
+
+	PORT_START("rxcontrol")
+	PORT_CONFNAME(3 , 1 , "RxC generated")
+	PORT_CONFSETTING(0 , "Always")
+	PORT_CONFSETTING(1 , "When Rx is active")
+	PORT_CONFSETTING(2 , "When a byte is available")
+INPUT_PORTS_END
+
+ioport_constructor sync_io_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(sync_io);
+}
+
+void sync_io_device::device_add_mconfig(machine_config &config)
+{
+	BITBANGER(config , m_stream , 0);
+}
+
+void sync_io_device::device_start()
+{
+	m_clk_timer = timer_alloc(TMR_ID_CLK);
+}
+
+void sync_io_device::device_reset()
+{
+	output_dcd(0);
+	output_dsr(0);
+	output_rxd(1);
+	output_cts(1);
+
+	update_serial(0);
+
+	m_rx_byte = 0xff;
+	m_rx_counter = 0;
+	m_tx_counter = 0;
+	m_tx_enabled = false;
+	m_rx_enabled = false;
+
+	output_txc(1);
+	output_rxc(1);
+}
+
+void sync_io_device::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
+{
+	switch (id) {
+	case TMR_ID_CLK:
+		m_clk = !m_clk;
+		if (m_clk) {
+			output_txc(1);
+			output_rxc(1);
+			if (m_tx_enabled) {
+				// Rising edge: capture TxD
+				m_tx_byte = (m_tx_byte >> 1) & 0x7f;
+				if (m_txd) {
+					BIT_SET(m_tx_byte , 7);
+				}
+				if (++m_tx_counter >= 8) {
+					LOG("Tx %02x @%s\n" , m_tx_byte , machine().time().to_string());
+					m_tx_counter = 0;
+					m_stream->output(m_tx_byte);
+					m_tx_enabled = false;
+				}
+			}
+		} else {
+			if (!m_tx_enabled) {
+				m_tx_enabled = !m_rts || !m_rts_duplex->read();
+				output_cts(!m_tx_enabled);
+			}
+			if (m_tx_enabled || m_txc_setting->read() == 0) {
+				output_txc(0);
+			}
+			if (!m_rx_enabled) {
+				m_rx_enabled = m_rts || !m_rts_duplex->read();
+				if (m_rx_enabled) {
+					if (m_stream->input(&m_rx_byte , 1) == 0) {
+						m_rx_byte = ~0;
+						if (m_rxc_setting->read() == 2) {
+							m_rx_enabled = false;
+						}
+					} else {
+						LOG("Rx %02x @%s\n" , m_rx_byte , machine().time().to_string());
+					}
+				}
+			}
+			if (m_rx_enabled || m_rxc_setting->read() == 0) {
+				output_rxc(0);
+			}
+			if (m_rx_enabled) {
+				// Falling edge: update RxD
+				output_rxd(BIT(m_rx_byte , 0));
+				m_rx_byte >>= 1;
+				if (++m_rx_counter >= 8) {
+					m_rx_counter = 0;
+					m_rx_enabled = false;
+				}
+			}
+		}
+		break;
+
+	default:
+		break;
+	}
+}
+
+WRITE_LINE_MEMBER(sync_io_device::update_serial)
+{
+	auto baud_rate = convert_baud(m_rs232_baud->read());
+	auto period = attotime::from_hz(baud_rate * 2);
+	m_clk_timer->adjust(period , 0 , period);
+}
+
+DEFINE_DEVICE_TYPE(SYNC_IO, sync_io_device, "sync_io", "RS232 Synchronous I/O")

--- a/src/devices/bus/rs232/sync_io.h
+++ b/src/devices/bus/rs232/sync_io.h
@@ -1,0 +1,61 @@
+// license:BSD-3-Clause
+// copyright-holders: F. Ulivi
+/*********************************************************************
+
+    sync_io.h
+
+    Synchronous I/O on RS232 port
+
+*********************************************************************/
+
+#ifndef MAME_BUS_RS232_SYNC_IO_H
+#define MAME_BUS_RS232_SYNC_IO_H
+
+#pragma once
+
+#include "rs232.h"
+#include "imagedev/bitbngr.h"
+
+class sync_io_device : public device_t, public device_rs232_port_interface
+{
+public:
+	// construction/destruction
+	sync_io_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	virtual ~sync_io_device();
+
+	virtual DECLARE_WRITE_LINE_MEMBER(input_txd) override;
+	virtual DECLARE_WRITE_LINE_MEMBER(input_rts) override;
+
+	DECLARE_WRITE_LINE_MEMBER(update_serial);
+
+protected:
+	// device-level overrides
+	virtual ioport_constructor device_input_ports() const override;
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
+private:
+	required_device<bitbanger_device> m_stream;
+	required_ioport m_rs232_baud;
+	required_ioport m_rts_duplex;
+	required_ioport m_txc_setting;
+	required_ioport m_rxc_setting;
+
+	emu_timer *m_clk_timer;
+	bool m_clk;
+	bool m_txd;
+	bool m_rts;
+	bool m_tx_enabled;
+	bool m_rx_enabled;
+	uint8_t m_tx_byte;
+	uint8_t m_rx_byte;
+	uint8_t m_tx_counter;
+	uint8_t m_rx_counter;
+};
+
+// device type definitions
+DECLARE_DEVICE_TYPE(SYNC_IO, sync_io_device)
+
+#endif // MAME_BUS_RS232_SYNC_IO_H


### PR DESCRIPTION
Hi,

this PR adds an option to RS232 ports for synchronous I/O through a bitbanger. This sync_io device provides external clocking to the port and supports both half and full-duplex modes.
I've also added the support for external clocking to HP98046 serial module.
With these additions I managed to use a RJE program on HP9845 to connect to an Hercules-emulated IBM S/370 mainframe. I'm going to write a procedure for this for those who are interested.
Thanks.
--F.Ulivi
