### PR TITLE
Mame: Fix compilation error on older MacOS/Xcode releases, for file 'src/osd/modules/file/posixfile.cpp'

### DIFF
--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -37,6 +37,11 @@
 #endif
 #endif
 
+// Fix for MacOS compilation errors
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
+
 // MAME headers
 #include "posixfile.h"
 #include "unicode.h"


### PR DESCRIPTION
Tracked by ticket:
https://github.com/mamedev/mame/issues/7536
