### PR TITLE
intelfsh: Force fujitsu_29f016a to return status bits during clearing regardless of sector

### DIFF
--- a/src/devices/machine/intelfsh.cpp
+++ b/src/devices/machine/intelfsh.cpp
@@ -701,7 +701,10 @@ uint32_t intelfsh_device::read_full(uint32_t address)
 		break;
 	case FM_ERASEAMD4:
 		// reads outside of the erasing sector return normal data
-		if ((address < m_erase_sector) || (address >= m_erase_sector+(64*1024)))
+		if (
+			!(m_maker_id == MFG_FUJITSU && m_device_id == 0xad) /* Firebeat: pop'n music will poll sector 0 for status updates even when clearing section 1 and beyond */
+			&& ((address < m_erase_sector) || (address >= m_erase_sector+(64*1024)))
+		)
 		{
 			switch( m_bits )
 			{


### PR DESCRIPTION
This is a hack. The Fujitsu 29F016A datasheet specifically states "data polling must be performed at an address within any of the sectors being erased" whereas Konami is polling outside of the sectors.

All of the following information is based off pop'n music 6 in the Firebeat driver.

When initializing the flash memory, the following sequence of commands are issued in the following order:
1. Chip clear command issued, polling sector 0 until it's finished
2. Sector 0 clear command issued, polling sector 0 until it's finished
3. Sector 1 clear command issued, polling sector 0 until it's finished
4. Sector x clear command issued (looped until entire chip is erased again), polling sector 0 until it's finished

The polling code reads the first two bytes of the sector and XORs them together. The result is expected to be non-0.

Steps 1 and 2 work as expected. At step 3 the game errors out with a "FLASH RAM ERROR" message because it's erasing sector 1 but polling sector 0 which is returning `FF FF` instead of the expected status bits.