### PR TITLE
firebeat: Change clock speed from 64 MHz to 66 MHz

### DIFF
--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -11,7 +11,7 @@
     GQ972 PWB(A2) 0000070609 Main board
     -----------------------------------
         OSC 64.00MHz
-        IBM PowerPC 403GCX at 64MHz
+        IBM PowerPC 403GCX at 66MHz
         (2x) Konami 0000057714 (2D object processor)
         Yamaha YMZ280B (ADPCM sound chip)
         Epson RTC65271 RTC/NVRAM
@@ -1078,7 +1078,7 @@ static void firebeat_ata_devices(device_slot_interface &device)
 void firebeat_state::firebeat(machine_config &config)
 {
 	/* basic machine hardware */
-	PPC403GCX(config, m_maincpu, XTAL(64'000'000));
+	PPC403GCX(config, m_maincpu, XTAL(66'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_state::firebeat_map);
 	m_maincpu->set_vblank_int("screen", FUNC(firebeat_state::firebeat_interrupt));
 
@@ -1134,7 +1134,7 @@ void firebeat_state::firebeat(machine_config &config)
 void firebeat_state::firebeat2(machine_config &config)
 {
 	/* basic machine hardware */
-	PPC403GCX(config, m_maincpu, XTAL(64'000'000));
+	PPC403GCX(config, m_maincpu, XTAL(66'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_state::firebeat2_map);
 	m_maincpu->set_vblank_int("lscreen", FUNC(firebeat_state::firebeat_interrupt));
 

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -10,7 +10,7 @@
 
     GQ972 PWB(A2) 0000070609 Main board
     -----------------------------------
-        OSC 64.00MHz
+        OSC 66.0000MHz
         IBM PowerPC 403GCX at 66MHz
         (2x) Konami 0000057714 (2D object processor)
         Yamaha YMZ280B (ADPCM sound chip)


### PR DESCRIPTION
Originally the CPU was implemented as 66 MHz but was changed from 66 MHz to 64 MHz in a commit 8 years ago. At 64 MHz, the music notes gradually get more and more off time as the song progress. Setting it back to 66 MHz fixes the timing issues.

For reference, the datasheets for the PowerPC 403GCX that I could find list the CPU frequencies as 50 MHz, 66 MHz, and 80 MHz.
http://www.icbase.com/pdf/IBM/IBM01670106.pdf

[note] I am not familiar with this driver/hardware so I am not comfortable making the change myself, but the only other usage of the PowerPC 403GCX that I could find also uses a suspicious clock speed.
ref: https://github.com/mamedev/mame/blob/master/src/mame/drivers/konendev.cpp#L410