### PR TITLE
Adjust CoCo 3 PIA mirrors

### DIFF
--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -82,8 +82,13 @@
 #include "formats/sdf_dsk.h"
 #include "formats/os9_dsk.h"
 
-// #define VERBOSE (LOG_GENERAL )
+//#define LOG_GENERAL   (1U << 0) //defined in logmacro.h already
+#define LOG_WDFDC   (1U << 1) // Shows register setup
+
+//#define VERBOSE (LOG_GENERAL )
 #include "logmacro.h"
+
+#define LOGWDFDC(...)   LOGMASKED(LOG_WDFDC,  __VA_ARGS__)
 
 /***************************************************************************
     PARAMETERS
@@ -514,19 +519,19 @@ u8 coco_fdc_device_base::scs_read(offs_t offset)
 	{
 		case 8:
 			result = m_wd17xx->status_r();
-			LOG("m_wd17xx->status_r: %2.2x\n", result );
+			LOGWDFDC("m_wd17xx->status_r: %2.2x\n", result );
 			break;
 		case 9:
 			result = m_wd17xx->track_r();
-			LOG("m_wd17xx->track_r: %2.2x\n", result );
+			LOGWDFDC("m_wd17xx->track_r: %2.2x\n", result );
 			break;
 		case 10:
 			result = m_wd17xx->sector_r();
-			LOG("m_wd17xx->sector_r: %2.2x\n", result );
+			LOGWDFDC("m_wd17xx->sector_r: %2.2x\n", result );
 			break;
 		case 11:
 			result = m_wd17xx->data_r();
-			LOG("m_wd17xx->data_r: %2.2x\n", result );
+			LOGWDFDC("m_wd17xx->data_r: %2.2x\n", result );
 			break;
 	}
 
@@ -571,19 +576,19 @@ void coco_fdc_device_base::scs_write(offs_t offset, u8 data)
 			dskreg_w(data);
 			break;
 		case 8:
-			LOG("m_wd17xx->cmd_w: %2.2x\n", data );
+			LOGWDFDC("m_wd17xx->cmd_w: %2.2x\n", data );
 			m_wd17xx->cmd_w(data);
 			break;
 		case 9:
-			LOG("m_wd17xx->track_w: %2.2x\n", data );
+			LOGWDFDC("m_wd17xx->track_w: %2.2x\n", data );
 			m_wd17xx->track_w(data);
 			break;
 		case 10:
-			LOG("m_wd17xx->sector_w: %2.2x\n", data );
+			LOGWDFDC("m_wd17xx->sector_w: %2.2x\n", data );
 			m_wd17xx->sector_w(data);
 			break;
 		case 11:
-			LOG("m_wd17xx->data_w: %2.2x\n", data );
+			LOGWDFDC("m_wd17xx->data_w: %2.2x\n", data );
 			m_wd17xx->data_w(data);
 			break;
 	};

--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -65,6 +65,15 @@
 
 #define SWITCH_CONFIG_TAG   "switch"
 
+//#define LOG_GENERAL   (1U << 0) //defined in logmacro.h already
+#define LOG_CART   (1U << 1) // shows cart line changes
+#define LOG_SWITCH (1U << 2) // shows switch changes
+//#define VERBOSE (LOG_CART|LOG_SWITCH)
+
+#include "logmacro.h"
+
+#define LOGCART(...)     LOGMASKED(LOG_CART,  __VA_ARGS__)
+#define LOGSWITCH(...)   LOGMASKED(LOG_SWITCH,  __VA_ARGS__)
 
 //**************************************************************************
 //  MACROS / CONSTANTS
@@ -333,6 +342,8 @@ cococart_slot_device &coco_multipak_device::active_cts_slot()
 
 void coco_multipak_device::set_select(u8 new_select)
 {
+	LOGSWITCH( "set_select: 0x%02X\n", new_select);
+
 	// identify old value for CART, in case this needs to change
 	cococart_slot_device::line_value old_cart = active_cts_slot().get_line_value(line::CART);
 
@@ -382,6 +393,7 @@ void coco_multipak_device::update_line(int slot_number, line ln)
 	case line::CART:
 		// only propagate if this is coming from the slot specified
 		propagate = slot_number == active_cts_slot_number();
+		LOGCART( "update_line: slot: %d, line: CART, value: %s, propogate: %s\n", slot_number, owning_slot().line_value_string(slot(slot_number).get_line_value(ln)), propagate ? "yes" : "no" );
 		break;
 
 	case line::NMI:

--- a/src/devices/bus/coco/cococart.h
+++ b/src/devices/bus/coco/cococart.h
@@ -137,9 +137,10 @@ private:
 	device_cococart_interface   *m_cart;
 
 	// methods
-	void set_line(const char *line_name, coco_cartridge_line &line, line_value value);
+	void set_line(line ln, coco_cartridge_line &line, line_value value);
 	void set_line_timer(coco_cartridge_line &line, line_value value);
 	void twiddle_line_if_q(coco_cartridge_line &line);
+public:
 	static const char *line_value_string(line_value value);
 };
 

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -3003,9 +3003,7 @@ int wd1772_device::settle_time() const
 
 wd1773_device::wd1773_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) : wd_fdc_digital_device_base(mconfig, WD1773, tag, owner, clock)
 {
-	const static int wd1773_step_times[4] = { 6000, 12000, 20000, 30000 };
-
-	step_times = wd1773_step_times;
+	step_times = wd_digital_step_times;
 	delay_register_commit = 16;
 	delay_command_commit = 48;
 	disable_mfm = false;

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -3003,7 +3003,9 @@ int wd1772_device::settle_time() const
 
 wd1773_device::wd1773_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) : wd_fdc_digital_device_base(mconfig, WD1773, tag, owner, clock)
 {
-	step_times = wd_digital_step_times;
+	const static int wd1773_step_times[4] = { 6000, 12000, 20000, 30000 };
+
+	step_times = wd1773_step_times;
 	delay_register_commit = 16;
 	delay_command_commit = 48;
 	disable_mfm = false;

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -41,8 +41,8 @@ void coco3_state::coco3_mem(address_map &map)
 	map(0xC000, 0xDFFF).bankr("rbank6").bankw("wbank6");
 	map(0xE000, 0xFDFF).bankr("rbank7").bankw("wbank7");
 	map(0xFE00, 0xFEFF).bankr("rbank8").bankw("wbank8");
-	map(0xFF00, 0xFF1F).rw(PIA0_TAG, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xFF20, 0xFF3F).r(PIA1_TAG, FUNC(pia6821_device::read)).w(FUNC(coco3_state::ff20_write));
+	map(0xFF00, 0xFF1B).rw(PIA0_TAG, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xFF1c, 0xFF3F).r(PIA1_TAG, FUNC(pia6821_device::read)).w(FUNC(coco3_state::ff20_write));
 	map(0xFF40, 0xFF5F).rw(FUNC(coco3_state::ff40_read), FUNC(coco3_state::ff40_write));
 	map(0xFF60, 0xFF8F).rw(FUNC(coco3_state::ff60_read), FUNC(coco3_state::ff60_write));
 	map(0xFF90, 0xFFDF).rw(m_gime, FUNC(gime_device::read), FUNC(gime_device::write));

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -41,8 +41,8 @@ void coco3_state::coco3_mem(address_map &map)
 	map(0xC000, 0xDFFF).bankr("rbank6").bankw("wbank6");
 	map(0xE000, 0xFDFF).bankr("rbank7").bankw("wbank7");
 	map(0xFE00, 0xFEFF).bankr("rbank8").bankw("wbank8");
-	map(0xFF00, 0xFF1B).rw(PIA0_TAG, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
-	map(0xFF1c, 0xFF3F).r(PIA1_TAG, FUNC(pia6821_device::read)).w(FUNC(coco3_state::ff20_write));
+	map(0xFF00, 0xFF0F).rw(PIA0_TAG, FUNC(pia6821_device::read), FUNC(pia6821_device::write));
+	map(0xFF20, 0xFF2F).r(PIA1_TAG, FUNC(pia6821_device::read)).w(FUNC(coco3_state::ff20_write));
 	map(0xFF40, 0xFF5F).rw(FUNC(coco3_state::ff40_read), FUNC(coco3_state::ff40_write));
 	map(0xFF60, 0xFF8F).rw(FUNC(coco3_state::ff60_read), FUNC(coco3_state::ff60_write));
 	map(0xFF90, 0xFFDF).rw(m_gime, FUNC(gime_device::read), FUNC(gime_device::write));


### PR DESCRIPTION
The PIA mirroring uses fewer addresses than the CoCo 1 & 2. This agrees with Tepolt (Table 7-1) and a oscilloscope testing.
I also added some more granular logging in the cartridge interrupt system to help track this issue down.