### PR TITLE
next: add some more roms

### DIFF
--- a/src/mame/drivers/next.cpp
+++ b/src/mame/drivers/next.cpp
@@ -1131,10 +1131,16 @@ void next_state::nextctc(machine_config &config)
 	ROM_REGION32_BE( 0x20000, "user1", ROMREGION_ERASEFF ) \
 	ROM_SYSTEM_BIOS( 0, "v12", "v1.2" ) /* MAC address/serial number word at 0xC: 005AD0 */ \
 	ROMX_LOAD( "rev_1.2.bin",     0x0000, 0x10000, CRC(7070bd78) SHA1(e34418423da61545157e36b084e2068ad41c9e24), ROM_BIOS(0)) /* Label: "(C) 1990 NeXT, Inc. // All Rights Reserved. // Release 1.2 // 1142.02", underlabel exists but unknown */ \
-	ROM_SYSTEM_BIOS( 1, "v10", "v1.0 v41" ) /* MAC address/serial number word at 0xC: 003090 */ \
-	ROMX_LOAD( "rev_1.0_v41.bin", 0x0000, 0x10000, CRC(54df32b9) SHA1(06e3ecf09ab67a571186efd870e6b44028612371), ROM_BIOS(1)) /* Label: "(C) 1989 NeXT, Inc. // All Rights Reserved. // Release 1.0 // 1142.00", underlabel: "MYF // 1.0.41 // 0D5C" */ \
-	ROM_SYSTEM_BIOS( 2, "v10p", "v1.0 v41 alternate" ) /* MAC address/serial number word at 0xC: 0023D9 */ \
-	ROMX_LOAD( "rev_1.0_proto.bin", 0x0000, 0x10000, CRC(f44974f9) SHA1(09eaf9f5d47e379cfa0e4dc377758a97d2869ddc), ROM_BIOS(2)) /* Label: "(C) 1989 NeXT, Inc. // All Rights Reserved. // Release 1.0 // 1142.00", no underlabel */
+	ROM_SYSTEM_BIOS( 1, "v11", "v1.1 v42" ) /* MAC address/serial number word at 0xC: 0052D2 */ \
+	ROMX_LOAD( "rev_1.1_v42.bin",     0x0000, 0x10000, CRC(6cabe43e) SHA1(19ca721af5e637a94bf96ff19729abd0c79e1638), ROM_BIOS(1)) \
+	ROM_SYSTEM_BIOS( 2, "v10", "v1.0 v41" ) /* MAC address/serial number word at 0xC: 003090 */ \
+	ROMX_LOAD( "rev_1.0_v41.bin", 0x0000, 0x10000, CRC(54df32b9) SHA1(06e3ecf09ab67a571186efd870e6b44028612371), ROM_BIOS(2)) /* Label: "(C) 1989 NeXT, Inc. // All Rights Reserved. // Release 1.0 // 1142.00", underlabel: "MYF // 1.0.41 // 0D5C" */ \
+	ROM_SYSTEM_BIOS( 3, "v10p", "v1.0 v41 alternate" ) /* MAC address/serial number word at 0xC: 0023D9 */ \
+	ROMX_LOAD( "rev_1.0_proto.bin", 0x0000, 0x10000, CRC(f44974f9) SHA1(09eaf9f5d47e379cfa0e4dc377758a97d2869ddc), ROM_BIOS(3)) /* Label: "(C) 1989 NeXT, Inc. // All Rights Reserved. // Release 1.0 // 1142.00", no underlabel */ \
+	ROM_SYSTEM_BIOS( 4, "v10q", "v1.0 v40" ) /* MAC address/serial number word at 0xC: 001ED0 */ \
+	ROMX_LOAD( "rev_1.0_v40.bin", 0x0000, 0x10000, CRC(9effb1b9) SHA1(94a3e30a92f7a9c7d44b90ac7954ed8ec5b7f6ca), ROM_BIOS(4)) \
+	ROM_SYSTEM_BIOS( 5, "v08", "v0.8 v31" ) /* MAC address/serial number word at 0xC: 001A3D */ \
+	ROMX_LOAD( "rev_0.8_v31.bin", 0x0000, 0x10000, CRC(907ee077) SHA1(cfd853c8b22b1a41d6b35609fc029a905482ad6d), ROM_BIOS(5))
 
 #define ROM_NEXT_V2 \
 	ROM_REGION32_BE( 0x20000, "user1", ROMREGION_ERASEFF ) \
@@ -1146,17 +1152,21 @@ void next_state::nextctc(machine_config &config)
 	ROMX_LOAD( "rev_2.2_v63.bin", 0x0000, 0x20000, CRC(739d7c07) SHA1(48ffe54cf2038782a92a0850337c5c6213c98571), ROM_BIOS(2)) /* Label: "(C) 1990 NeXT Computer, Inc. // All Rights Reserved. // Release 2.1 // 2918.AB" */ \
 	ROM_SYSTEM_BIOS( 3, "v21", "v2.1 v59" ) /* MAC address/serial number word at 0xC: 0072FE */ \
 	ROMX_LOAD( "rev_2.1_v59.bin", 0x0000, 0x20000, CRC(f20ef956) SHA1(09586c6de1ca73995f8c9b99870ee3cc9990933a), ROM_BIOS(3)) \
-	ROM_SYSTEM_BIOS( 4, "v12", "v1.2 v58" ) /* MAC address/serial number word at 0xC: 006372 */ \
-	ROMX_LOAD( "rev_1.2_v58.bin", 0x0000, 0x20000, CRC(b815b6a4) SHA1(97d8b09d03616e1487e69d26609487486db28090), ROM_BIOS(4)) /* Label: "V58 // (C) 1990 NeXT, Inc. // All Rights Reserved // Release 1.2 // 1142.02" */
+	ROM_SYSTEM_BIOS( 4, "v20", "v2.0 v58" ) /* MAC address/serial number word at 0xC: 0063E4 */ \
+	ROMX_LOAD( "rev_2.0_v58.bin", 0x0000, 0x20000, CRC(52a26b78) SHA1(6f168fbc354199ad5a6bfc82be00673751fc0119), ROM_BIOS(3)) \
+	ROM_SYSTEM_BIOS( 5, "v12", "v1.2 v58" ) /* MAC address/serial number word at 0xC: 006372 */ \
+	ROMX_LOAD( "rev_1.2_v58.bin", 0x0000, 0x20000, CRC(b815b6a4) SHA1(97d8b09d03616e1487e69d26609487486db28090), ROM_BIOS(5)) /* Label: "V58 // (C) 1990 NeXT, Inc. // All Rights Reserved // Release 1.2 // 1142.02" */
 
 #define ROM_NEXT_V3 \
 	ROM_REGION32_BE( 0x20000, "user1", ROMREGION_ERASEFF ) \
 	ROM_SYSTEM_BIOS( 0, "v33", "v3.3 v74" ) /* MAC address/serial number word at 0xC: 123456 */ \
-	ROMX_LOAD( "rev_3.3_v74.bin", 0x0000, 0x20000, CRC(fbc3a2cd) SHA1(a9bef655f26f97562de366e4a33bb462e764c929), ROM_BIOS(0)) \
-	ROM_SYSTEM_BIOS( 1, "v32", "v3.2 v72" ) /* MAC address/serial number word at 0xC: 012f31 */ \
-	ROMX_LOAD( "rev_3.2_v72.bin", 0x0000, 0x20000, CRC(e750184f) SHA1(ccebf03ed090a79c36f761265ead6cd66fb04329), ROM_BIOS(1)) \
-	ROM_SYSTEM_BIOS( 2, "v30", "v3.0 v70" ) /* MAC address/serial number word at 0xC: 0106e8 */ \
-	ROMX_LOAD( "rev_3.0_v70.bin", 0x0000, 0x20000, CRC(37250453) SHA1(a7e42bd6a25c61903c8ca113d0b9a624325ee6cf), ROM_BIOS(2))
+	ROMX_LOAD( "rev_3.3_v74.bin", 0x0000, 0x20000, CRC(fbc3a2cd) SHA1(a9bef655f26f97562de366e4a33bb462e764c929), ROM_BIOS(0)) /* Label: NeXT Computer // (C) 1992 // Rev 3.3 v74 */ \
+	ROM_SYSTEM_BIOS( 1, "v32", "v3.2 v72" ) /* MAC address/serial number word at 0xC: 012F31 */ \
+	ROMX_LOAD( "rev_3.2_v72.bin", 0x0000, 0x20000, CRC(e750184f) SHA1(ccebf03ed090a79c36f761265ead6cd66fb04329), ROM_BIOS(1)) /* Label: MYF // 2919 // REV 3.2V72 */ \
+	ROM_SYSTEM_BIOS( 2, "v31", "v3.1 v71" ) /* MAC address/serial number word at 0xC: 0129F2 */ \
+	ROMX_LOAD( "rev_3.1_v71.bin", 0x0000, 0x20000, CRC(0371daa7) SHA1(61fc4bec520022ff7a20e2c930d59fd9883e8917), ROM_BIOS(2)) \
+	ROM_SYSTEM_BIOS( 3, "v30", "v3.0 v70" ) /* MAC address/serial number word at 0xC: 0106E8 */ \
+	ROMX_LOAD( "rev_3.0_v70.bin", 0x0000, 0x20000, CRC(37250453) SHA1(a7e42bd6a25c61903c8ca113d0b9a624325ee6cf), ROM_BIOS(3)) /* Label: NeXT Computer, // Inc. (C) 1991 // Rev 3.0 v70 M */
 
 
 ROM_START(next)


### PR DESCRIPTION
Add ROM definitions from http://www.nextcomputers.org/NeXTfiles/Software/ROM_Files/ for:
rev_0.8_v31.bin
rev_1.0_v40.bin
rev_1.1_v42.bin
rev_2.0_v58.bin
rev_3.1_v71.bin

and add a missing labels for the existing matching ROMs:
rev_3.0_v70.bin
rev_3.2_v72.bin
rev_3.3_v74.bin
