### PR TITLE
Reenabling the write accessor for the LUA input_class enabled property

### DIFF
--- a/src/frontend/mame/luaengine_input.cpp
+++ b/src/frontend/mame/luaengine_input.cpp
@@ -379,7 +379,7 @@ void lua_engine::initialize_input(sol::table &emu)
 
 	auto input_class_type = sol().registry().new_usertype<input_class>("input_class", sol::no_constructor);
 	input_class_type["name"] = sol::property(&input_class::name);
-	input_class_type["enabled"] = sol::property(&input_class::enabled);
+	input_class_type["enabled"] = sol::property(&input_class::enabled, &input_class::enable);
 	input_class_type["multi"] = sol::property(&input_class::multi);
 	input_class_type["devices"] = sol::property(
 			[this] (input_class &devclass)


### PR DESCRIPTION
This is used by BletchMAME to toggle mouse capture on and off