### PR TITLE
ibm5150 - New working software list additions

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -2544,6 +2544,35 @@ Known PC Booter Games Not Dumped, Or Dumped and Lost when Demonlord's Site went 
 		</part>
 	</software>
 
+	<software name="wcsoccer">
+		<description>World Championship Soccer (5.25")</description>
+		<year>1991</year>
+		<publisher>Elite</publisher>
+		<info name="developer" value="Sega" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="World Championship Soccer [Elite] [1991] [5.25DD] [Disk 1 of 2].img" size="368640" crc="4a11940c" sha1="073745c4068a75728a4651d51efa9b2aed7811b2"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="World Championship Soccer [Elite] [1991] [5.25DD] [Disk 2 of 2].img" size="368640" crc="63188d60" sha1="548afbdb42bab9b2ce8102938e7fa46ce9caf3c1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wcsoccer35" cloneof="wcsoccer">
+		<description>World Championship Soccer (3.5")</description>
+		<year>1991</year>
+		<publisher>Elite</publisher>
+		<info name="developer" value="Sega" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="World Championship Soccer [Elite] [1991] [3.5DD] [Disk 1 of 1].img" size="737280" crc="af6ecc3f" sha1="be4b5d14d6d252b033b482aa71ac64b56cac4a63"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="baseball">
 		<description>The World's Greatest Baseball Game</description>
 		<year>1985</year>
@@ -8892,6 +8921,43 @@ has been replaced with an all-zero block. -->
 		</part>
 	</software>
 
+	<software name="dicktrcs">
+		<description>Dick Tracy: The Crime-Solving Adventure</description>
+		<year>1991</year>
+		<publisher>Walt Disney Computer Software</publisher>
+		<info name="developer" value="Distinctive Software" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 1 of 6].img" size="368640" crc="e0d7efc8" sha1="53ad373ecce74a10da96ba1450482100b2a34731"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 2 of 6].img" size="368640" crc="668328bc" sha1="95b5cac2aba1f4aa3cf0589af54013fcdc207f73"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 3 of 6].img" size="368640" crc="d929159f" sha1="4f963ca78b7118675a47942b3bdf8198c89c83ff"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 4 of 6].img" size="368640" crc="7d64e652" sha1="f3961779db9133cef15dd6f7f438b832e8b4580d"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 5 of 6].img" size="368640" crc="c62a8853" sha1="d25905161b42f6b3c596f7a5fb7f84139d5670a6"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="Dick Tracy The Crime-Solving Adventure [Disney] [1991] [5.25DD] [Disk 6 of 6].img" size="368640" crc="51dbf6d1" sha1="bd161bc26f536ab93baa633125e3f056d8f4ae2c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="diehard">
 		<description>Die Hard (5.25")</description>
 		<year>1989</year>
@@ -9251,6 +9317,24 @@ has been replaced with an all-zero block. -->
 		<part name="flop5" interface="floppy_5_25">
 			<dataarea name="flop" size = "368640">
 				<rom name="Drakkhen (USA, Europe) (EGA, CGA) (5.25'') (Disk 5).img" size="368640" crc="0f814482" sha1="1f12e5315de9e3d82b74ccfeb7b3711dd6bac41e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ducktale">
+		<description>Duck Tales: The Quest for Gold</description>
+		<year>1990</year>
+		<publisher>Walt Disney Computer Software</publisher>
+		<info name="developer" value="Incredible Technologies" />
+		<info name="version" value="version 1.0" />
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="DuckTales - The Quest for Gold [Disney] [1990] [5.25DD] [Disk 1 of 2].img" size="368640" crc="4dbc4e43" sha1="263c7222e77d4ac12cc38c94095fb90b3d1add70"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_5_25">
+			<dataarea name="flop" size = "368640">
+				<rom name="DuckTales - The Quest for Gold [Disney] [1990] [5.25DD] [Disk 2 of 2].img" size="368640" crc="5310b7e3" sha1="f0c60c11f400374b0ee63b85e95e74b901cc81bf"/>
 			</dataarea>
 		</part>
 	</software>
@@ -11626,7 +11710,7 @@ has been replaced with an all-zero block. -->
 		</part>
 	</software>
 
-	<software name="paprboy2">
+	<software name="paperbo2">
 		<description>Paperboy 2</description>
 		<year>1991</year>
 		<publisher>Mindscape</publisher>
@@ -12554,12 +12638,29 @@ has been replaced with an all-zero block. -->
 		<info name="version" value="2.00" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="simcityc.img" size="737280" crc="caafe010" sha1="312acedea33f2e7b8e4329092696a1313eb4d994"/>
+				<rom name="SimCity Classic [Maxis] [1993] [3.5DD] [Disk 1 of 2].img" size="737280" crc="40e80233" sha1="6fc894f9e8abb25e1429d6df9aea93abfdc3c670"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
 			<dataarea name="flop" size="737280">
-				<rom name="simcitycd2.img" size="737280" crc="5088846e" sha1="449a83461d24d9a8be69cae35bea61359cfe1893"/>
+				<rom name="SimCity Classic [Maxis] [1993] [3.5DD] [Disk 2 of 2].img" size="737280" crc="83292905" sha1="6512895b53e3132195b8e7b0d18391188d08ee13"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="simcityclg">
+		<description>SimCity Classic Graphics (SimCity Classic addon)</description>
+		<year>1994</year>
+		<publisher>Brøderbund Software</publisher>
+		<info name="developer" value="Maxis Software" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="SimCity Classic Graphics [Maxis] [1994] [3.5DD] [Disk 1 of 2].img" size="737280" crc="3f50caad" sha1="2719e16277cec240876649246c5a79bde77c67b4"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<dataarea name="flop" size="737280">
+				<rom name="SimCity Classic Graphics [Maxis] [1994] [3.5DD] [Disk 2 of 2].img" size="737280" crc="e4047260" sha1="785316e028a64a31d57e352cb87a234a7ddcf742"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
Added: [dicktrcs] Dick Tracy: The Crime-Solving Adventure
Added: [ducktale] DuckTales: The Quest for Gold
Added: [simcityclg] SimCity Classic Graphics (add-on for Classic version)
Added: World Championship Soccer (5.25")
Added: World Championship Soccer (3.5")
Redumped: [simcitycl] - SimCity Classic (3.5", v2.00) -> The old set has a modified root and OEM ID
Renamed: [paprboy2] Paperboy 2 -> [paperbo2] Paperboy 2 -> standardize name, like the others software lists (megadriv, snes, amigaocs_flop)