### PR TITLE
Add automatic recursive-parent-search in same dir for chdman

### DIFF
--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1043,6 +1043,12 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 		{
 			if (entry->type != osd::directory::entry::entry_type::FILE)
 				continue;
+			std::string name(entry->name);
+			if (name.size() < 4)
+				continue;
+			std::string ext(name.substr(name.size()-4), name.size());
+			if (ext.compare(".chd") != 0 || ext.compare(".CHD") != 0)
+				continue;
 			filepath = parents_dirpath + PATH_SEPARATOR + entry->name;
 			err = parent->open(filepath.c_str());
 			if (err != CHDERR_NONE)

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1023,7 +1023,8 @@ static void guess_chs(std::string *filename, uint64_t filesize, int sectorsize, 
 
 static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, const std::string parents_dirpath, bool writeable = false)
 {
-	if (!input.opened()) {
+	if (!input.opened())
+  {
 		input.open(chd_path, writeable);
 	}
 	chd_file *parent = new chd_file;
@@ -1044,7 +1045,8 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 			err = parent->open(filepath.c_str());
 			if (err != CHDERR_NONE)
 				continue;
-			if (parent->sha1() == parent_sha1) {
+			if (parent->sha1() == parent_sha1)
+      {
 				paths[depth] = filepath;
 				break;
 			}
@@ -1063,11 +1065,13 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 		parent_sha1 = parent->parent_sha1();
 		parent->close();
 	}
-	for (int d = depth-1; d >= 0; d--) {
+	for (int d = depth-1; d >= 0; d--)
+  {
 		child = new chd_file;
 		err = child->open(paths[d].c_str(), writeable, parent);
 		// Should not happen, unless files changed since loop above
-		if (err != CHDERR_NONE) {
+		if (err != CHDERR_NONE)
+    {
 			printf("Error Loading: %d %s: %s\n", d, paths[d].c_str(), chd_file::error_string(err));
 			return err;
 		}
@@ -1092,7 +1096,8 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		chd_error err = input_parent_chd.open(input_chd_parent_str->second->c_str());
 		if (err != CHDERR_NONE)
 			report_error(1, "Error opening parent CHD file (%s): %s", input_chd_parent_str->second->c_str(), chd_file::error_string(err));
-		if (input_parent_chd.parent_sha1() != util::sha1_t::null) {
+		if (input_parent_chd.parent_sha1() != util::sha1_t::null)
+    {
 			std::string chd_dir;
 			const size_t sep_index = input_chd_parent_str->second->rfind(PATH_SEPARATOR);
 			if (sep_index != std::string::npos)
@@ -1112,7 +1117,8 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		chd_error err = input_chd.open(input_chd_str->second->c_str(), writeable, input_parent_chd.opened() ? &input_parent_chd : nullptr);
 		if (err != CHDERR_NONE)
 			report_error(1, "Error opening CHD file (%s): %s", input_chd_str->second->c_str(), chd_file::error_string(err));
-		if (input_chd_parent_str == params.end() && input_chd.parent_sha1() != util::sha1_t::null) {
+		if (input_chd_parent_str == params.end() && input_chd.parent_sha1() != util::sha1_t::null)
+    {
 			std::string chd_dir;
 			const size_t sep_index = input_chd_str->second->rfind(PATH_SEPARATOR);
 			if (sep_index != std::string::npos)
@@ -1202,7 +1208,8 @@ static std::string *parse_output_chd_parameters(const parameters_map &params, ch
 		chd_error err = output_parent_chd.open(output_chd_parent_str->second->c_str());
 		if (err != CHDERR_NONE)
 			report_error(1, "Error opening parent CHD file (%s): %s", output_chd_parent_str->second->c_str(), chd_file::error_string(err));
-		if (output_parent_chd.parent_sha1() != util::sha1_t::null) {
+		if (output_parent_chd.parent_sha1() != util::sha1_t::null)
+    {
 			std::string chd_dir;
 			const size_t sep_index = output_chd_parent_str->second->rfind(PATH_SEPARATOR);
 			if (sep_index != std::string::npos)

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1101,7 +1101,11 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		if (input_parent_chd.parent_sha1() != util::sha1_t::null)
     {
 			std::string chd_dir;
-			const size_t sep_index = input_chd_parent_str->second->rfind(PATH_SEPARATOR);
+#if defined(WIN32)
+			const size_t sep_index = input_chd_parent_str->second->find_last_of("/\\:");
+#else
+			const size_t sep_index = input_chd_parent_str->second->find_last_of(PATH_SEPARATOR);
+#endif
 			if (sep_index != std::string::npos)
 				chd_dir = input_chd_parent_str->second->substr(0, sep_index);
 			else

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -6,7 +6,6 @@
 
 ****************************************************************************/
 #include <stdio.h> // must be stdio.h and here otherwise issues with I64FMT in MINGW
-#include <dirent.h>
 
 // osd
 #include "osdcore.h"
@@ -1030,8 +1029,6 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 	chd_file *parent = new chd_file;
 	chd_file *child = NULL;
 
-	DIR *dir;
-	struct dirent *entry;
 	int depth = 0;
 	std::string paths[8];
 	std::string filepath;
@@ -1039,10 +1036,11 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 	chd_error err;
 	while (true)
 	{
-		dir = opendir(parents_dirpath.c_str());
-		while((entry = readdir(dir)) != NULL)
+		osd::directory::ptr dir = osd::directory::open(parents_dirpath);
+		const osd::directory::entry *entry;
+		while((entry = dir->read()) != nullptr)
 		{
-			filepath = parents_dirpath + PATH_SEPARATOR + entry->d_name;
+			filepath = parents_dirpath + PATH_SEPARATOR + entry->name;
 			err = parent->open(filepath.c_str());
 			if (err != CHDERR_NONE)
 				continue;

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1041,6 +1041,8 @@ static chd_error reopen_chd_with_parents(chd_file &input, const char* chd_path, 
 		const osd::directory::entry *entry;
 		while((entry = dir->read()) != nullptr)
 		{
+			if (entry->type != osd::directory::entry::entry_type::FILE)
+				continue;
 			filepath = parents_dirpath + PATH_SEPARATOR + entry->name;
 			err = parent->open(filepath.c_str());
 			if (err != CHDERR_NONE)

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -1107,13 +1107,9 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		if (input_parent_chd.parent_sha1() != util::sha1_t::null)
     {
 			std::string chd_dir;
-#if defined(WIN32)
-			const size_t sep_index = input_chd_parent_str->second->find_last_of("/\\:");
-#else
-			const size_t sep_index = input_chd_parent_str->second->find_last_of(PATH_SEPARATOR);
-#endif
-			if (sep_index != std::string::npos)
-				chd_dir = input_chd_parent_str->second->substr(0, sep_index);
+			auto const dirsep(std::find_if(input_chd_parent_str->second->rbegin(), input_chd_parent_str->second->rend(), &util::is_directory_separator));
+			if (dirsep != input_chd_parent_str->second->rend())
+				chd_dir = input_chd_parent_str->second->substr(0, std::distance(input_chd_parent_str->second->begin(), dirsep.base()));
 			else
 				chd_dir = ".";
 			err = reopen_chd_with_parents(input_parent_chd, input_chd_parent_str->second->c_str(), chd_dir, writeable);
@@ -1132,9 +1128,9 @@ static void parse_input_chd_parameters(const parameters_map &params, chd_file &i
 		if (input_chd_parent_str == params.end() && input_chd.parent_sha1() != util::sha1_t::null)
     {
 			std::string chd_dir;
-			const size_t sep_index = input_chd_str->second->rfind(PATH_SEPARATOR);
-			if (sep_index != std::string::npos)
-				chd_dir = input_chd_str->second->substr(0, sep_index);
+			auto const dirsep(std::find_if(input_chd_str->second->rbegin(), input_chd_str->second->rend(), &util::is_directory_separator));
+			if (dirsep != input_chd_str->second->rend())
+				chd_dir = input_chd_str->second->substr(0, std::distance(input_chd_str->second->begin(), dirsep.base()));
 			else
 				chd_dir = ".";
 			err = reopen_chd_with_parents(input_chd, input_chd_str->second->c_str(), chd_dir, writeable);
@@ -1223,9 +1219,9 @@ static std::string *parse_output_chd_parameters(const parameters_map &params, ch
 		if (output_parent_chd.parent_sha1() != util::sha1_t::null)
     {
 			std::string chd_dir;
-			const size_t sep_index = output_chd_parent_str->second->rfind(PATH_SEPARATOR);
-			if (sep_index != std::string::npos)
-				chd_dir = output_chd_parent_str->second->substr(0, sep_index);
+			auto const dirsep(std::find_if(output_chd_parent_str->second->rbegin(), output_chd_parent_str->second->rend(), &util::is_directory_separator));
+			if (dirsep != output_chd_parent_str->second->rend())
+				chd_dir = output_chd_parent_str->second->substr(0, std::distance(output_chd_parent_str->second->begin(), dirsep.base()));
 			else
 				chd_dir = ".";
 			err = reopen_chd_with_parents(output_parent_chd, output_chd_parent_str->second->c_str(), chd_dir, false);


### PR DESCRIPTION
This adds recursive parent searching (parent of parent, etc.)
This does NOT search the directory recursively
Only the dir at the same level as the CHD file is searched

Sorry for coming with a pull request already, without talking about this feature, specially since there may be multiple ways to go when selecting parents. But since I was mainly testing with emulators, namely PPSSPP and PCSX2, where games span multiple discs, I decided to implement this quickly for testing.

This implementation adds parent searching on the same directory as the CHD file itself, but not its subdirectories, and also searches for parents of parents, in case there are any.

This makes the command line switch for specifying the parent CHD obsolete in case the parent CHD is in the same dir as the child CHD.

This also enables one to create grandchildren from child CHD, such as:

Original -> Child -> Grandchild

or even:

Disc 1 -> Mod of disc 1
\\-> Disc 2 -> Mod of disc 2

The current CHD format does not forbid a parent CHD from having a parent itself, but I believe certain parts must also be changed to recursively try to read from a parent. For example:

https://github.com/mamedev/mame/blob/c865983f996ae218aee04dc105f1af6198deae50/src/lib/util/chd.cpp#L983

If it's a v5 CHD, it tries to read directly from the parent, without going through the read_hunk of the parent, like with v3/v4.
I'm not sure if this is an oversight or not. If it is, it should be changed to make use of grandchild CHD.

Edit: I should also mention that the current chdman happily accepts a child CHD as parent when creating a supposedly grandchild CHD, but it does not actually use the child's parent data to deduplicate, so it ends up being as huge, if not bigger, than the original grandparent CHD. With this patch, it deduplicates correctly, and the next generations will actually use the entire parent's data to deduplicate (but not grandparent's data though, as the CHD format only specifies the hunk is from a parent, not from a particular parent)

Edit 2: Damn, forgot Windows is not POSIX compliant. What are the preferences of this project, in terms of cross compatibility? Do you guys prefer to use something like https://github.com/tronkko/dirent? Or use preprocessing for conditional build?