### PR TITLE
Work around Apple memory protection for DRC interpreter functionality on Apple M1

### DIFF
--- a/src/devices/cpu/drccache.cpp
+++ b/src/devices/cpu/drccache.cpp
@@ -32,7 +32,13 @@
 //-------------------------------------------------
 
 drc_cache::drc_cache(size_t bytes)
-	: m_near((drccodeptr)osd_alloc_executable(bytes)),
+	: m_near(
+#ifndef NATIVE_DRC
+			(drccodeptr)osd_alloc_mmap_rw(bytes)
+#else
+			(drccodeptr)osd_alloc_mmap_rwx(bytes)
+#endif
+		),
 		m_neartop(m_near),
 		m_base(m_near + NEAR_CACHE_SIZE),
 		m_top(m_base),
@@ -52,7 +58,7 @@ drc_cache::drc_cache(size_t bytes)
 drc_cache::~drc_cache()
 {
 	// release the memory
-	osd_free_executable(m_near, m_size);
+	osd_free_mmap(m_near, m_size);
 }
 
 

--- a/src/osd/modules/lib/osdlib_unix.cpp
+++ b/src/osd/modules/lib/osdlib_unix.cpp
@@ -54,28 +54,47 @@ void osd_process_kill()
 }
 
 //============================================================
-//  osd_alloc_executable
+//  osd_alloc_mmap_rwx
 //
-//  allocates "size" bytes of executable memory.  this must take
-//  things like NX support into account.
+//  allocates "size" bytes of read/write/execute memory.
+//  This should take things like NX support into account.
 //============================================================
 
-void *osd_alloc_executable(size_t size)
+void *osd_alloc_mmap_rwx(size_t size)
 {
 #if defined(SDLMAME_BSD) || defined(SDLMAME_MACOSX) || defined(SDLMAME_EMSCRIPTEN)
-	return (void *)mmap(0, size, PROT_EXEC|PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, -1, 0);
-#else
-	return (void *)mmap(0, size, PROT_EXEC|PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, 0, 0);
+	return (void *)mmap(0, size, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_SHARED, -1, 0);
+#elif defined(SDLMAME_UNIX)
+	return (void *)mmap(0, size, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_SHARED, 0, 0);
 #endif
 }
 
 //============================================================
-//  osd_free_executable
+//  osd_alloc_mmap_rw
 //
-//  frees memory allocated with osd_alloc_executable
+//  allocates "size" bytes of read/write (but not executable)
+//  memory.  This is for working around Apple M1 memory
+//  protection where we do not have a recompiler yet, as
+//  the MAME DRC does not currently take into account
+//  Apple's implementation of NX support
 //============================================================
 
-void osd_free_executable(void *ptr, size_t size)
+void *osd_alloc_mmap_rw(size_t size)
+{
+#if defined(SDLMAME_BSD) || defined(SDLMAME_MACOSX) || defined(SDLMAME_EMSCRIPTEN)
+	return (void *)mmap(0, size, PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, -1, 0);
+#elif defined(SDLMAME_UNIX)
+	return (void *)mmap(0, size, PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, 0, 0);
+#endif
+}
+
+//============================================================
+//  osd_free_mmap
+//
+//  frees memory allocated with osd_alloc_mmap_*
+//============================================================
+
+void osd_free_mmap(void *ptr, size_t size)
 {
 #ifdef SDLMAME_SOLARIS
 	munmap((char *)ptr, size);

--- a/src/osd/modules/lib/osdlib_win32.cpp
+++ b/src/osd/modules/lib/osdlib_win32.cpp
@@ -83,29 +83,42 @@ void osd_process_kill()
 }
 
 //============================================================
-//  osd_alloc_executable
+//  osd_alloc_mmap_rwx
 //
-//  allocates "size" bytes of executable memory.  this must take
-//  things like NX support into account.
+//  allocates "size" bytes of read/write/execute memory.
+//  This should take things like NX support into account.
 //============================================================
 
-void *osd_alloc_executable(size_t size)
+void *osd_alloc_mmap_rwx(size_t size)
 {
 	return VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 }
 
-
 //============================================================
-//  osd_free_executable
+//  osd_alloc_mmap_rw
 //
-//  frees memory allocated with osd_alloc_executable
+//  allocates "size" bytes of read/write (but not executable)
+//  memory.  This is for working around Apple M1 memory
+//  protection where we do not have a recompiler yet, as
+//  the MAME DRC does not currently take into account
+//  Apple's implementation of NX support
 //============================================================
 
-void osd_free_executable(void *ptr, size_t size)
+void *osd_alloc_mmap_rw(size_t size)
+{
+	return VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_READWRITE);
+}
+
+//============================================================
+//  osd_free_mmap
+//
+//  frees memory allocated with osd_alloc_mmap_*
+//============================================================
+
+void osd_free_mmap(void *ptr, size_t size)
 {
 	VirtualFree(ptr, 0, MEM_RELEASE);
 }
-
 
 //============================================================
 //  osd_break_into_debugger

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -664,23 +664,37 @@ void osd_work_item_release(osd_work_item *item);
 
 /// \brief Allocate memory that can contain executable code
 ///
-/// Allocated memory must be both writable and executable.  Allocated
-/// memory must be freed by calling #osd_free_executable passing the
+/// Allocated memory must be readable, writable, and executable.  Allocated
+/// memory must be freed by calling #osd_free_mmap passing the
 /// same size.
+/// NOTE: This will segfault on some platforms, particularly Apple M1
 /// \param [in] size Number of bytes to allocate.
 /// \return Pointer to allocated memory, or nullptr if allocation
 ///   failed.
-/// \sa osd_free_executable
-void *osd_alloc_executable(size_t size);
+/// \sa osd_free_mmap
+void *osd_alloc_mmap_rwx(size_t size);
 
-
-/// \brief Free memory allocated by osd_alloc_executable
+/// \brief Allocate memory that contains read/write code
 ///
-/// \param [in] ptr Pointer returned by #osd_alloc_executable.
+/// Allocated memory must be readable, writable, and not executable.
+/// Allocated memory must be freed by calling #osd_free_mmap passing the
+/// same size.
+/// This is provided as a temporary workaround for the Apple M1 platform.
+/// \return Pointer to allocated memory, or nullptr if allocation
+///   failed.
+/// \sa osd_alloc_mmap_rwx
+/// \sa osd_free_mmap
+void *osd_alloc_mmap_rw(size_t size);
+
+
+/// \brief Free memory allocated by osd_alloc_mmap_rw or osd_alloc_mmap_rwx
+///
+/// \param [in] ptr Pointer returned by #osd_alloc_mmap_rw or #osd_alloc_mmap_rwx.
 /// \param [in] size Number of bytes originally requested.  Must match
-///   the value passed to #osd_alloc_executable.
-/// \sa osd_alloc_executable
-void osd_free_executable(void *ptr, size_t size);
+///   the value passed to #osd_alloc_mmap_rw or osd_alloc_mmap_rwx.
+/// \sa osd_alloc_mmap_rw
+/// \sa osd_alloc_mmap_rwx
+void osd_free_mmap(void *ptr, size_t size);
 
 
 /// \brief Break into host debugger if attached


### PR DESCRIPTION
Apple Silicon does not allow for RWX memory pages. JITs are supposed to use a function call to toggle pages between RW- and R-X.
However, we currently are not using JIT on arm64, so we can just map the pages as RW- and the DRC interpreter should work fine. This is what's implemented here.

This (or a similar fix) should be pulled into the release0227 branch, as without it, any system that uses the DRC will segfault on startup on an Apple M1 computer.

Documentation on Apple's memory protection can be found here: https://developer.apple.com/documentation/apple_silicon/porting_just-in-time_compilers_to_apple_silicon

An alternate method, used by Firefox and DOSbox, can be found here: https://github.com/joncampbell123/dosbox-x/blob/master/src/cpu/dynamic_alloc_common.h#L155