### PR TITLE
rebalance sound after ymz280b change

### DIFF
--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -1069,8 +1069,8 @@ WRITE_LINE_MEMBER( firebeat_state::ata_interrupt )
 
 void firebeat_state::cdrom_config(device_t *device)
 {
-	device->subdevice<cdda_device>("cdda")->add_route(0, "^^lspeaker", 1.0);
-	device->subdevice<cdda_device>("cdda")->add_route(1, "^^rspeaker", 1.0);
+	device->subdevice<cdda_device>("cdda")->add_route(0, "^^lspeaker", 0.5);
+	device->subdevice<cdda_device>("cdda")->add_route(1, "^^rspeaker", 0.5);
 	device = device->subdevice("cdda");
 }
 
@@ -1212,8 +1212,8 @@ void firebeat_state::firebeat_spu(machine_config &config)
 	TIMER(config, "sputimer").configure_periodic(FUNC(firebeat_state::spu_timer_callback), attotime::from_hz(1000));
 
 	rf5c400_device &rf5c400(RF5C400(config, "rf5c400", XTAL(16'934'400)));
-	rf5c400.add_route(0, "lspeaker", 1.0);
-	rf5c400.add_route(1, "rspeaker", 1.0);
+	rf5c400.add_route(0, "lspeaker", 0.5);
+	rf5c400.add_route(1, "rspeaker", 0.5);
 
 	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "cdrom", nullptr, true);
 	m_spuata->irq_handler().set(FUNC(firebeat_state::spu_ata_interrupt));

--- a/src/mame/drivers/gunpey.cpp
+++ b/src/mame/drivers/gunpey.cpp
@@ -1218,8 +1218,8 @@ void gunpey_state::gunpey(machine_config &config)
 	SPEAKER(config, "rspeaker").front_right();
 
 	OKIM6295(config, m_oki, XTAL(16'934'400) / 8, okim6295_device::PIN7_LOW);
-	m_oki->add_route(ALL_OUTPUTS, "lspeaker", 0.25);
-	m_oki->add_route(ALL_OUTPUTS, "rspeaker", 0.25);
+	m_oki->add_route(ALL_OUTPUTS, "lspeaker", 0.125);
+	m_oki->add_route(ALL_OUTPUTS, "rspeaker", 0.125);
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400)));
 	ymz.add_route(0, "lspeaker", 0.25);

--- a/src/mame/drivers/konamim2.cpp
+++ b/src/mame/drivers/konamim2.cpp
@@ -1106,8 +1106,8 @@ INPUT_PORTS_END
 
 void konamim2_state::cr589_config(device_t *device)
 {
-	device->subdevice<cdda_device>("cdda")->add_route(0, ":lspeaker", 1.0);
-	device->subdevice<cdda_device>("cdda")->add_route(1, ":rspeaker", 1.0);
+	device->subdevice<cdda_device>("cdda")->add_route(0, ":lspeaker", 0.5);
+	device->subdevice<cdda_device>("cdda")->add_route(1, ":rspeaker", 0.5);
 	device = device->subdevice("cdda");
 }
 

--- a/src/mame/drivers/realbrk.cpp
+++ b/src/mame/drivers/realbrk.cpp
@@ -795,8 +795,8 @@ void realbrk_state::realbrk(machine_config &config)
 	ymz.add_route(1, "rspeaker", 0.50);
 
 	ym2413_device &ymsnd(YM2413(config, "ymsnd", XTAL(3'579'545)));
-	ymsnd.add_route(ALL_OUTPUTS, "lspeaker", 0.50);
-	ymsnd.add_route(ALL_OUTPUTS, "rspeaker", 0.50);
+	ymsnd.add_route(ALL_OUTPUTS, "lspeaker", 0.25);
+	ymsnd.add_route(ALL_OUTPUTS, "rspeaker", 0.25);
 }
 
 void realbrk_state::pkgnsh(machine_config &config)

--- a/src/mame/drivers/tecmosys.cpp
+++ b/src/mame/drivers/tecmosys.cpp
@@ -480,14 +480,14 @@ void tecmosys_state::tecmosys(machine_config &config)
 
 	ymf262_device &ymf(YMF262(config, "ymf", XTAL(14'318'181)));
 	ymf.irq_handler().set_inputline("audiocpu", 0);
-	ymf.add_route(0, "lspeaker", 1.00);
-	ymf.add_route(1, "rspeaker", 1.00);
-	ymf.add_route(2, "lspeaker", 1.00);
-	ymf.add_route(3, "rspeaker", 1.00);
+	ymf.add_route(0, "lspeaker", 0.50);
+	ymf.add_route(1, "rspeaker", 0.50);
+	ymf.add_route(2, "lspeaker", 0.50);
+	ymf.add_route(3, "rspeaker", 0.50);
 
 	okim6295_device &oki(OKIM6295(config, "oki", XTAL(16'000'000)/8, okim6295_device::PIN7_HIGH));
-	oki.add_route(ALL_OUTPUTS, "lspeaker", 0.50);
-	oki.add_route(ALL_OUTPUTS, "rspeaker", 0.50);
+	oki.add_route(ALL_OUTPUTS, "lspeaker", 0.25);
+	oki.add_route(ALL_OUTPUTS, "rspeaker", 0.25);
 	oki.set_addrmap(0, &tecmosys_state::oki_map);
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400)));

--- a/src/mame/drivers/vgmplay.cpp
+++ b/src/mame/drivers/vgmplay.cpp
@@ -3751,13 +3751,13 @@ void vgmplay_state::vgmplay(machine_config &config)
 	// TODO: prevent error.log spew
 	YMZ280B(config, m_ymz280b[0], 0);
 	m_ymz280b[0]->set_addrmap(0, &vgmplay_state::ymz280b_map<0>);
-	m_ymz280b[0]->add_route(0, m_mixer, 0.25, AUTO_ALLOC_INPUT, 0);
-	m_ymz280b[0]->add_route(1, m_mixer, 0.25, AUTO_ALLOC_INPUT, 1);
+	m_ymz280b[0]->add_route(0, m_mixer, 0.50, AUTO_ALLOC_INPUT, 0);
+	m_ymz280b[0]->add_route(1, m_mixer, 0.50, AUTO_ALLOC_INPUT, 1);
 
 	YMZ280B(config, m_ymz280b[1], 0);
 	m_ymz280b[1]->set_addrmap(0, &vgmplay_state::ymz280b_map<1>);
-	m_ymz280b[1]->add_route(0, m_mixer, 0.25, AUTO_ALLOC_INPUT, 0);
-	m_ymz280b[1]->add_route(1, m_mixer, 0.25, AUTO_ALLOC_INPUT, 1);
+	m_ymz280b[1]->add_route(0, m_mixer, 0.50, AUTO_ALLOC_INPUT, 0);
+	m_ymz280b[1]->add_route(1, m_mixer, 0.50, AUTO_ALLOC_INPUT, 1);
 
 	RF5C164(config, m_rf5c164, 0);
 	m_rf5c164->set_addrmap(0, &vgmplay_state::rf5c164_map<0>);

--- a/src/mame/drivers/zn.cpp
+++ b/src/mame/drivers/zn.cpp
@@ -187,9 +187,9 @@ void zn_state::zn_1mb_vram(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	spu_device &spu(SPU(config, "spu", XTAL(67'737'600)/2, subdevice<psxcpu_device>("maincpu")));
-	spu.add_route(0, "lspeaker", 0.35);
-	spu.add_route(1, "rspeaker", 0.35);
+	SPU(config, m_spu, XTAL(67'737'600)/2, subdevice<psxcpu_device>("maincpu"));
+	m_spu->add_route(0, "lspeaker", 0.35);
+	m_spu->add_route(1, "rspeaker", 0.35);
 
 	AT28C16(config, "at28c16", 0);
 }
@@ -232,9 +232,9 @@ void zn_state::zn2(machine_config &config)
 	SPEAKER(config, "lspeaker").front_left();
 	SPEAKER(config, "rspeaker").front_right();
 
-	spu_device &spu(SPU(config, "spu", XTAL(67'737'600)/2, subdevice<psxcpu_device>("maincpu")));
-	spu.add_route(0, "lspeaker", 0.35);
-	spu.add_route(1, "rspeaker", 0.35);
+	SPU(config, m_spu, XTAL(67'737'600)/2, subdevice<psxcpu_device>("maincpu"));
+	m_spu->add_route(0, "lspeaker", 0.35);
+	m_spu->add_route(1, "rspeaker", 0.35);
 
 	AT28C16(config, "at28c16", 0);
 }
@@ -2148,6 +2148,10 @@ void atlus_zn_state::coh1001l(machine_config &config)
 
 	GENERIC_LATCH_16(config, m_soundlatch16);
 	m_soundlatch16->data_pending_callback().set_inputline(m_audiocpu, 3);
+
+	m_spu->reset_routes();
+	m_spu->add_route(0, "lspeaker", 0.175);
+	m_spu->add_route(1, "rspeaker", 0.175);
 
 	ymz280b_device &ymz(YMZ280B(config, "ymz", XTAL(16'934'400)));
 	ymz.irq_handler().set_inputline(m_audiocpu, 2);

--- a/src/mame/includes/zn.h
+++ b/src/mame/includes/zn.h
@@ -51,6 +51,7 @@ public:
 		m_cat702(*this, "cat702_%u", 1),
 		m_znmcu(*this, "znmcu"),
 		m_maincpu(*this, "maincpu"),
+		m_spu(*this, "spu"),
 		m_ram(*this, "maincpu:ram"),
 		m_znmcu_dataout(1)
 	{
@@ -88,6 +89,7 @@ protected:
 	required_device_array<cat702_device, 2> m_cat702;
 	required_device<znmcu_device> m_znmcu;
 	required_device<cpu_device> m_maincpu;
+	required_device<spu_device> m_spu;
 	required_device<ram_device> m_ram;
 
 	int m_cat702_dataout[2];


### PR DESCRIPTION
these seem to be the only place it's used in a multi-chip setup.

calcune.cpp does have the genesis PSG sound on the VDP, but makes no use of it
suprnova.cpp was highlighted to me but the only MSM is the RTC?

in most cases volume levels of other chips have been reduced, although for vgmplay.cpp I just bumped the YMZ up, as there seems to be no other practical way to handle that

zn.cpp is the only one that required a header file changing (to add m_spu) and only hvnsgate + cbaj use the ymz, so spu levels were dipped for just the atlus config.