### PR TITLE
psx.cpp: Fix horizontal screen could be cut off (Resolve MT 02957)

### DIFF
--- a/src/devices/video/psx.cpp
+++ b/src/devices/video/psx.cpp
@@ -741,6 +741,13 @@ uint32_t psxgpu_device::update_screen(screen_device &screen, bitmap_rgb32 &bitma
 
 		n_left = ( ( (int32_t)n_horiz_disstart - n_overscanleft ) * (int32_t)n_screenwidth ) / 2560;
 		n_columns = ( ( ( (int32_t)n_horiz_disend - n_horiz_disstart ) * (int32_t)n_screenwidth ) / 2560 );
+
+		/* adjustment to prevent the screen is cut off */
+		if( n_left > n_screenwidth - n_columns )
+		{
+			n_left = n_screenwidth - n_columns;
+		}
+
 		if( n_left < 0 )
 		{
 			n_x = -n_left;


### PR DESCRIPTION
To resolve the issue that the screen of soulclbr, tektagt and clones is cut off (MT 02957), I added position adjustment code. Please review it.

![0002](https://user-images.githubusercontent.com/11531985/103458766-8ccd8880-4d4e-11eb-8093-5be58e7e0bb9.png)
Screen is shifted to the right by 9 pixels. (current)

![0000](https://user-images.githubusercontent.com/11531985/103458769-9820b400-4d4e-11eb-90e1-bd368f67c5b5.png)
After adjust horizontal position.