### PR TITLE
imgtool/dragondos: fix disk BASIC tokens

### DIFF
--- a/src/tools/imgtool/filtbas.cpp
+++ b/src/tools/imgtool/filtbas.cpp
@@ -602,25 +602,32 @@ static const char *const dragonbas_statements[] =
 	"=",        /* 0xcb */
 	"<",        /* 0xcc */
 	"USING",    /* 0xcd */
-	"DIR",      /* 0xce */
-	"DRIVE",    /* 0xcf */
-	"FIELD",    /* 0xd0 */
-	"FILES",    /* 0xd1 */
-	"KILL",     /* 0xd2 */
-	"LOAD",     /* 0xd3 */
-	"LSET",     /* 0xd4 */
-	"MERGE",    /* 0xd5 */
-	"RENAME",   /* 0xd6 */
-	"RSET",     /* 0xd7 */
-	"SAVE",     /* 0xd8 */
-	"WRITE",    /* 0xd9 */
-	"VERIFY",   /* 0xda */
-	"UNLOAD",   /* 0xdb */
-	"DSKINI",   /* 0xdc */
-	"BACKUP",   /* 0xdd */
-	"COPY",     /* 0xde */
-	"DSKI$",    /* 0xdf */
-	"DSKO$"     /* 0xe0 */
+	"AUTO",     /* 0xce */
+	"BACKUP",   /* 0xcf */
+	"BEEP",     /* 0xd0 */
+	"BOOT",     /* 0xd1 */
+	"CHAIN",    /* 0xd2 */
+	"COPY",     /* 0xd3 */
+	"CREATE",   /* 0xd4 */
+	"DIR",      /* 0xd5 */
+	"DRIVE",    /* 0xd6 */
+	"DSKINIT",  /* 0xd7 */
+	"FREAD",    /* 0xd8 */
+	"FWRITE",   /* 0xd9 */
+	"ERROR",    /* 0xda */
+	"KILL",     /* 0xdb */
+	"LOAD",     /* 0xdc */
+	"MERGE",    /* 0xdd */
+	"PROTECT",  /* 0xde */
+	"WAIT",     /* 0xdf */
+	"RENAME",   /* 0xe0 */
+	"SAVE",     /* 0xe1 */
+	"SREAD",    /* 0xe2 */
+	"SWRITE",   /* 0xe3 */
+	"VERIFY",   /* 0xe4 */
+	"FROM",     /* 0xe5 */
+	"FLREAD",   /* 0xe6 */
+	"SWAP"      /* 0xe7 */
 };
 
 static const char *const dragonbas_functions[] =
@@ -659,11 +666,13 @@ static const char *const dragonbas_functions[] =
 	"PPOINT",   /* 0xff9f */
 	"STRING$",  /* 0xffa0 */
 	"USR",      /* 0xffa1 */
-	"CVN",      /* 0xffa2 */
+	"LOF",      /* 0xffa2 */
 	"FREE",     /* 0xffa3 */
-	"LOC",      /* 0xffa4 */
-	"LOF",      /* 0xffa5 */
-	"MKN$"      /* 0xffa6 */
+	"ERL",      /* 0xffa4 */
+	"ERR",      /* 0xffa5 */
+	"HIMEM",    /* 0xffa6 */
+	"LOC",      /* 0xffa7 */
+	"FRE$"      /* 0xffa8 */
 };
 
 static const char *const vzbas[] =


### PR DESCRIPTION
They were copied from Color Disk BASIC. This corrects the tokens to use actual values.