### PR TITLE
Remove unused functionality from nubus_image and add .dsk as image extension

### DIFF
--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -34,7 +34,7 @@ public:
 	virtual bool is_creatable() const noexcept override { return false; }
 	virtual bool must_be_loaded() const noexcept override { return false; }
 	virtual bool is_reset_on_load() const noexcept override { return false; }
-	virtual const char *file_extensions() const noexcept override { return "img"; }
+	virtual const char *file_extensions() const noexcept override { return "img,dsk"; }
 	virtual const char *custom_instance_name() const noexcept override { return "disk"; }
 	virtual const char *custom_brief_instance_name() const noexcept override { return "disk"; }
 
@@ -181,18 +181,9 @@ void nubus_image_device::device_start()
 
 	nubus().install_device(slotspace, slotspace+3, read32smo_delegate(*this, FUNC(nubus_image_device::image_r)), write32smo_delegate(*this, FUNC(nubus_image_device::image_w)));
 	nubus().install_device(slotspace+4, slotspace+7, read32smo_delegate(*this, FUNC(nubus_image_device::image_status_r)), write32smo_delegate(*this, FUNC(nubus_image_device::image_status_w)));
-	nubus().install_device(slotspace+8, slotspace+11, read32smo_delegate(*this, FUNC(nubus_image_device::file_cmd_r)), write32smo_delegate(*this, FUNC(nubus_image_device::file_cmd_w)));
-	nubus().install_device(slotspace+12, slotspace+15, read32smo_delegate(*this, FUNC(nubus_image_device::file_data_r)), write32smo_delegate(*this, FUNC(nubus_image_device::file_data_w)));
-	nubus().install_device(slotspace+16, slotspace+19, read32smo_delegate(*this, FUNC(nubus_image_device::file_len_r)), write32smo_delegate(*this, FUNC(nubus_image_device::file_len_w)));
-	nubus().install_device(slotspace+20, slotspace+147, read32sm_delegate(*this, FUNC(nubus_image_device::file_name_r)), write32sm_delegate(*this, FUNC(nubus_image_device::file_name_w)));
 	nubus().install_device(superslotspace, superslotspace+((256*1024*1024)-1), read32s_delegate(*this, FUNC(nubus_image_device::image_super_r)), write32s_delegate(*this, FUNC(nubus_image_device::image_super_w)));
 
 	m_image = subdevice<messimg_disk_image_device>(IMAGE_DISK0_TAG);
-
-	filectx.curdir[0] = '.';
-	filectx.curdir[1] = '\0';
-	filectx.dirp = nullptr;
-	filectx.fd = nullptr;
 }
 
 //-------------------------------------------------
@@ -243,125 +234,4 @@ uint32_t nubus_image_device::image_super_r(offs_t offset, uint32_t mem_mask)
 	uint32_t *image = (uint32_t*)m_image->m_data.get();
 	uint32_t data = image[offset];
 	return ((data & 0xff) << 24) | ((data & 0xff00) << 8) | ((data & 0xff0000) >> 8) | ((data & 0xff000000) >> 24);
-}
-
-void nubus_image_device::file_cmd_w(uint32_t data)
-{
-//  data = ((data & 0xff) << 24) | ((data & 0xff00) << 8) | ((data & 0xff0000) >> 8) | ((data & 0xff000000) >> 24);
-	filectx.curcmd = data;
-	switch(data) {
-	case kFileCmdGetDir:
-		strcpy((char*)filectx.filename, (char*)filectx.curdir);
-		break;
-	case kFileCmdSetDir:
-		if ((filectx.filename[0] == '/') || (filectx.filename[0] == '$')) {
-			strcpy((char*)filectx.curdir, (char*)filectx.filename);
-		} else {
-			strcat((char*)filectx.curdir, "/");
-			strcat((char*)filectx.curdir, (char*)filectx.filename);
-		}
-		break;
-	case kFileCmdGetFirstListing:
-		filectx.dirp = osd::directory::open((const char *)filectx.curdir);
-		[[fallthrough]];
-	case kFileCmdGetNextListing:
-		if (filectx.dirp) {
-			osd::directory::entry const *const dp = filectx.dirp->read();
-			if(dp) {
-				strncpy((char*)filectx.filename, dp->name, sizeof(filectx.filename));
-			} else {
-				memset(filectx.filename, 0, sizeof(filectx.filename));
-			}
-		}
-		else {
-			memset(filectx.filename, 0, sizeof(filectx.filename));
-		}
-		break;
-	case kFileCmdGetFile:
-		{
-			std::string fullpath;
-			fullpath.reserve(1024);
-			fullpath.assign((const char *)filectx.curdir);
-			fullpath.append(PATH_SEPARATOR);
-			fullpath.append((const char*)filectx.filename);
-			if(osd_file::open(fullpath, OPEN_FLAG_READ, filectx.fd, filectx.filelen) != osd_file::error::NONE)
-				osd_printf_error("Error opening %s\n", fullpath);
-			filectx.bytecount = 0;
-		}
-		break;
-	case kFileCmdPutFile:
-		{
-			std::string fullpath;
-			fullpath.reserve(1024);
-			fullpath.assign((const char *)filectx.curdir);
-			fullpath.append(PATH_SEPARATOR);
-			fullpath.append((const char*)filectx.filename);
-			uint64_t filesize; // unused, but it's an output from the open call
-			if(osd_file::open(fullpath, OPEN_FLAG_WRITE|OPEN_FLAG_CREATE, filectx.fd, filesize) != osd_file::error::NONE)
-				osd_printf_error("Error opening %s\n", fullpath);
-			filectx.bytecount = 0;
-		}
-		break;
-	}
-}
-
-uint32_t nubus_image_device::file_cmd_r()
-{
-	return 0;
-}
-
-void nubus_image_device::file_data_w(uint32_t data)
-{
-	std::uint32_t count = 4;
-	std::uint32_t actualcount = 0;
-
-	data = swapendian_int32(data);
-	if(filectx.fd) {
-		//data = big_endianize_int32(data);
-		if((filectx.bytecount + count) > filectx.filelen) count = filectx.filelen - filectx.bytecount;
-		filectx.fd->write(&data, filectx.bytecount, count, actualcount);
-		filectx.bytecount += actualcount;
-
-		if(filectx.bytecount >= filectx.filelen) {
-			filectx.fd.reset();
-		}
-	}
-}
-
-uint32_t nubus_image_device::file_data_r()
-{
-	if(filectx.fd) {
-		std::uint32_t ret;
-		std::uint32_t actual = 0;
-		filectx.fd->read(&ret, filectx.bytecount, sizeof(ret), actual);
-		filectx.bytecount += actual;
-		if(actual < sizeof(ret)) {
-			filectx.fd.reset();
-		}
-		return big_endianize_int32(ret);
-	}
-	return 0;
-}
-
-void nubus_image_device::file_len_w(uint32_t data)
-{
-	data = swapendian_int32(data);
-	filectx.filelen = big_endianize_int32(data);
-}
-
-uint32_t nubus_image_device::file_len_r()
-{
-	return filectx.filelen;
-}
-
-void nubus_image_device::file_name_w(offs_t offset, uint32_t data)
-{
-	((uint32_t*)(filectx.filename))[offset] = big_endianize_int32(data);
-}
-
-uint32_t nubus_image_device::file_name_r(offs_t offset)
-{
-	uint32_t ret;
-	ret = big_endianize_int32(((uint32_t*)(filectx.filename))[offset]);
-	return ret;
 }

--- a/src/devices/bus/nubus/nubus_image.h
+++ b/src/devices/bus/nubus/nubus_image.h
@@ -25,27 +25,6 @@ public:
 	nubus_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 protected:
-	enum
-	{
-		kFileCmdGetDir = 1,
-		kFileCmdSetDir,
-		kFileCmdGetFirstListing,
-		kFileCmdGetNextListing,
-		kFileCmdGetFile,
-		kFileCmdPutFile
-	};
-
-	struct nbfilectx
-	{
-		uint32_t curcmd;
-		uint8_t filename[128];
-		uint8_t curdir[1024];
-		osd::directory::ptr dirp;
-		osd_file::ptr fd;
-		uint64_t filelen;
-		uint32_t bytecount;
-	};
-
 	nubus_image_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
 	// device-level overrides
@@ -62,17 +41,8 @@ protected:
 	void image_w(uint32_t data);
 	uint32_t image_super_r(offs_t offset, uint32_t mem_mask = ~0);
 	void image_super_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t file_cmd_r();
-	void file_cmd_w(uint32_t data);
-	uint32_t file_data_r();
-	void file_data_w(uint32_t data);
-	uint32_t file_len_r();
-	void file_len_w(uint32_t data);
-	uint32_t file_name_r(offs_t offset);
-	void file_name_w(offs_t offset, uint32_t data);
 
 	messimg_disk_image_device *m_image;
-	nbfilectx filectx;
 };
 
 


### PR DESCRIPTION
I went over the source code of the nb_image device-side ROM, which can be found at http://synack.net/~bbraun/macsrc/messdriver0.4.cpt.hqx, and determined that these features are not used. 

This code trips up FORTIFY_SOURCE (see #7513), because of unsafe uses of strcpy() and strcat() — however, since those features were never implemented device-side, that code is unnecessary.

Therefore, this PR removes the unused functionality. I have tested these changes using the maciici driver.

This PR also adds .dsk as a possible image extension, as it is common for Mac images to have it instead of .img.