### PR TITLE
gamegear, sg1000, sms software list additions

### DIFF
--- a/hash/gamegear.xml
+++ b/hash/gamegear.xml
@@ -355,6 +355,17 @@ A few games have been listed as rumored, but they might very well be fake (pleas
 		</part>
 	</software>
 
+	<software name="agassip" cloneof="agassi">
+		<description>Andre Agassi Tennis (prototype)</description>
+		<year>1993</year>
+		<publisher>TecMagik</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="andre agassi tennis (prototype).bin" size="262144" crc="f167028e" sha1="891407182b761957f9655f9c7d5365aa858fe49f"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="arcadecl">
 		<description>Arcade Classics (USA)</description>
 		<year>1996</year>
@@ -1217,6 +1228,17 @@ a certain item) -->
 		</part>
 	</software>
 
+	<software name="bublboblp" cloneof="bublbobl">
+		<description>Bubble Bobble (prototype)</description>
+		<year>1994</year>
+		<publisher>Taito</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="bubble bobble (prototype).bin" size="262144" crc="be2dc770" sha1="6d4b02f63d5d0c5ffead8fb8c4726fd610c245ad"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bugsbun">
 		<description>Bugs Bunny in Double Trouble (Euro, USA)</description>
 		<year>1996</year>
@@ -1662,6 +1684,17 @@ a certain item) -->
 		</part>
 	</software>
 
+	<software name="chicagop25" cloneof="chicago">
+		<description>Empire Syndicate (Chicago Syndicate) (prototype, 19950320)</description>
+		<year>1995</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="524288">
+				<rom name="chicago syndicate (prototype - mar 20, 1995).bin" size="524288" crc="635bc4f5" sha1="0f4f83552680129d242a5f7646cf6739d3ecb70a"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="choplft3">
 		<description>Choplifter III (USA)</description>
 		<year>1993</year>
@@ -1732,6 +1765,18 @@ a certain item) -->
 			<feature name="slot" value="codemasters" />
 			<dataarea name="rom" size="262144">
 				<rom name="cj elephant fugitive.bin" size="262144" crc="72981057" sha1="a60815aa0c6ec2bc5ad7f817668b74a42bb64026"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cjp" cloneof="cj">
+		<description>CJ Elephant Fugitive (prototype)</description>
+		<year>1993</year>
+		<publisher>Codemasters</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<feature name="slot" value="codemasters" />
+			<dataarea name="rom" size="262144">
+				<rom name="cj elephant fugitive (prototype).bin" size="262144" crc="3ace6335" sha1="322ea1294833659a205e313ca49667b921891e85"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2097,6 +2142,18 @@ a certain item) -->
 		</part>
 	</software>
 
+	<software name="dinobash">
+		<description>Dinobasher Starring Bignose the Caveman (Euro, prototype)</description>
+		<year>1993</year>
+		<publisher>Codemasters</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<feature name="slot" value="codemasters" />
+			<dataarea name="rom" size="262144">
+				<rom name="dinobasher starring bignose the caveman (europe) (proto).bin" size="262144" crc="2306aaf4" sha1="46d1689c09705341f593a18d4e9cfd7805ecff88" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Developers: Aspect -->
 	<software name="donald42" cloneof="deepduck">
 		<description>Donald Duck no 4-Tsu no Hihou (Jpn)</description>
@@ -2224,6 +2281,17 @@ a certain item) -->
 		<part name="cart" interface="gamegear_cart">
 			<dataarea name="rom" size="262144">
 				<rom name="dragon - the bruce lee story (usa).bin" size="262144" crc="17f588e8" sha1="60c7cbe782c3df094452835076b9425c329c82ee"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dragonp" cloneof="dragon">
+		<description>Dragon - The Bruce Lee Story (prototype)</description>
+		<year>1993</year>
+		<publisher>Virgin Interactive</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="dragon - the bruce lee story (prototype).bin" size="262144" crc="12e0e85b" sha1="b9a396be0e009c951f85bdd6e81ffe1a71232e44"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3689,13 +3757,24 @@ a certain item) -->
 	</software>
 
 	<software name="kawasaki">
-		<description>Kawasaki Superbike Challenge (Euro, USA)</description>
+		<description>Kawasaki Superbike Challenge (Euro)</description>
 		<year>1995</year>
 		<publisher>Domark</publisher>
 		<info name="serial" value="T-88098, T-88118-50"/>
 		<part name="cart" interface="gamegear_cart">
 			<dataarea name="rom" size="262144">
-				<rom name="kawasaki superbike challenge (usa, europe).bin" size="262144" crc="23f9150a" sha1="7b0801c4ad6c15546f61decf2620f198b990425d"/>
+				<rom name="kawasaki superbike challenge (europe).bin" size="262144" crc="23f9150a" sha1="7b0801c4ad6c15546f61decf2620f198b990425d"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="kawasakius" cloneof="kawasaki">
+		<description>Kawasaki Superbike Challenge (USA)</description>
+		<year>1993</year>
+		<publisher>Domark</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="kawaksaki superbike challenge (usa).bin" size="262144" crc="fc508318" sha1="ba5981fed892a62006b20b6c913dcac84573f345"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4543,6 +4622,18 @@ a certain item) -->
 			<feature name="slot" value="codemasters" />
 			<dataarea name="rom" size="262144">
 				<rom name="micro machines (europe).bin" size="262144" crc="f7c524f6" sha1="7b2d39b68622e18eac6c27fd961133b1d002342b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="micromacp" cloneof="micromac" supported="partial">
+		<description>Micro Machines (prototype)</description>
+		<year>1993</year>
+		<publisher>Codemasters</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<feature name="slot" value="codemasters" />
+			<dataarea name="rom" size="262144">
+				<rom name="micro machines (prototype).bin" size="262144" crc="c21e6cd0" sha1="51cb41c00020f80d7c3c80b217b41841ad59a825"/>
 			</dataarea>
 		</part>
 	</software>
@@ -7840,7 +7931,7 @@ a certain item) -->
 		<publisher>Black Pearl</publisher>
 		<part name="cart" interface="gamegear_cart">
 			<dataarea name="rom" size="524288">
-				<rom name="sports illustrated championship football &amp; baseball (usa, europe).bin" size="524288" crc="de25e2d8" sha1="781bc3ef9fbbbfcb5452dad99633b65c172b62fa"/>
+				<rom name="sports illustrated championship football &amp; baseball (usa, europe).bin" size="524288" crc="920ea193" sha1="c74a38e73facd557264a299e8799df480ad6d06f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -9974,6 +10065,28 @@ a certain item) -->
 		<part name="cart" interface="gamegear_cart">
 			<dataarea name="rom" size="524288">
 				<rom name="x-men - mojo world (prototype - jun 29,  1996).bin" size="524288" crc="ba71da19" sha1="cc3fc3b57bcd4daea90a572c935013d286ebbb99"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="xtermin" supported="no">
+		<description>X-Terminator v2.1 for Game Gear (USA, Euro)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="8192">
+				<rom name="x-terminator v2.1.bin" size="8192" crc="0f448220" sha1="b6664c21a99a96392fe79237d326e96ac0bdd52a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="xterminj" cloneof="xtermin" supported="no">
+		<description>X-Terminator v2.1J for Game Gear (Jpn)</description>
+		<year>19??</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="gamegear_cart">
+			<dataarea name="rom" size="8192">
+				<rom name="x-terminator v2.1j.bin" size="8192" crc="e498090d" sha1="ee2123cc2addd9e48d3f4dc909334504c5b330ab"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/sg1000.xml
+++ b/hash/sg1000.xml
@@ -143,6 +143,18 @@ A135 : 森林歷險記 / Sēnlín lìxiǎn jì -> Pitfall II (same as R-049 by A
 		</part>
 	</software>
 
+	<software name="3ninmja" cloneof="3ninmj">
+		<description>San-nin Mahjong (Jpn, alt)</description>
+		<year>1984</year>
+		<publisher>Tsukuda Original</publisher>
+		<info name="alt_title" value="三人麻雀"/>
+		<part name="cart" interface="sg1000_cart">
+			<dataarea name="rom" size="40960">
+				<rom name="san-nin mahjong (alt).bin" size="40960" crc="0e641f36" sha1="a5c2acba93cd3809577f401c00fa9d728627ed60" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bankp">
 		<description>Bank Panic (Jpn)</description>
 		<year>1985</year>

--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -2763,6 +2763,17 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="gamcheck">
+		<description>Game de Check! Koutsuu Anzen (Jpn, prototype)</description>
+		<year>1987</year>
+		<publisher>Tokio Marine</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="game de check koutsuu anzen (jpn, prototype).bin" size="262144" crc="9afab511" sha1="72353c77efa078e88483858201f5bdf832f5c01c" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="robocop">
 		<description>Gangcheol RoboCop (Kor)</description>
 		<year>1992</year>

--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -53,6 +53,18 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="3dgunner">
+		<description>3D Gunner (prototype)</description>
+		<year>198?</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<sharedfeat name="ctrl1_default" value="lphaser" />
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="32768">
+				<rom name="3d gunner (prototype).bin" size="32768" crc="56dcb2d4" sha1="2f66b626416902a4b0a81c682c9c40579f32e7be" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="3dragon">
 		<description>The Three Dragon Story (Kor)</description>
 		<year>19??</year>
@@ -286,6 +298,17 @@ license:CC0
 			<feature name="ic1" value="MPR-12408" />
 			<dataarea name="rom" size="131072">
 				<rom name="mpr-12408.ic1" size="131072" crc="013c0a94" sha1="2d0a581da1c787b1407fb1cfefd0571e37899978" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="alexhitwp" cloneof="alexhitw">
+		<description>Alex Kidd - High-Tech World (prototype)</description>
+		<year>1989</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="131072">
+				<rom name="alex kidd high tech world (prototype).bin" size="131072" crc="2d7fabb2" sha1="98a0d2aa3221dde30e0883760e4b6a62f2271bc5" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -1114,6 +1137,18 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="bombraidp" cloneof="bombraid">
+		<description>Battle Wings (Bomber Raid, prototype)</description>
+		<year>1989</year>
+		<publisher>Sega</publisher>
+		<info name="alt_title" value="ボンバーレイド" />
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="battle wings (prototye).bin" size="262144" crc="fae0ade7" sha1="99fef1cca416df8586d3aaf76d147e86e69dbdad" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="bnzabros">
 		<description>Bonanza Bros. (Euro, Bra)</description>
 		<year>1991</year>
@@ -1725,6 +1760,17 @@ license:CC0
 		<part name="cart" interface="sms_cart">
 			<dataarea name="rom" size="131072">
 				<rom name="cyborg hunter (usa, europe).bin" size="131072" crc="908e7524" sha1="b6131585cb944d7fae69ad609802a1b5d51b442f" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="cyborghp" cloneof="cyborgh">
+		<description>Cyborg Hunter (prototype)</description>
+		<year>1988</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="131072">
+				<rom name="cyborg hunter (prototype).bin" size="131072" crc="691211a1" sha1="6e1259bf0d8888d63d5033a0fafd53592b5697e2" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -3230,6 +3276,17 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="hangonp" cloneof="hangon">
+		<description>Hang-On (prototype)</description>
+		<year>1985</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="32768">
+				<rom name="hang-on (prototype).bin" size="32768" crc="649f29e8" sha1="817d7bba41f0619342127d562f848045b9ddd7ea" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Notes: optional SK-1100 keyboard support (except for Hang-On) -->
 	<software name="hangonaw">
 		<description>Hang-On &amp; Astro Warrior (USA)</description>
@@ -4217,7 +4274,7 @@ license:CC0
 	<!-- Notes: 3D glasses support -->
 	<software name="missil3d">
 		<description>Missile Defense 3-D (Euro, USA, Bra)</description>
-		<year>19??</year>
+		<year>1987</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="8001, 023.230"/>
 		<sharedfeat name="ctrl1_default" value="lphaser" />
@@ -4227,6 +4284,20 @@ license:CC0
 			<feature name="ic1" value="MPR-10844 W29" />
 			<dataarea name="rom" size="131072">
 				<rom name="mpr-10844 w29.ic1" size="131072" crc="fbe5cfbb" sha1="86242fcc8b9f93cdad2241f40c3eebbf4c9ff213" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Notes: 3D glasses support -->
+	<software name="missil3dp" cloneof="missil3d">
+		<description>Missile Defense 3-D (prototype)</description>
+		<year>1987</year>
+		<publisher>Sega</publisher>
+		<sharedfeat name="ctrl1_default" value="lphaser" />
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="131072">
+				<!-- 2 (eep)rom chips on pcb -->
+				<rom name="missile-3d (prototype).bin" size="131072" crc="43def05d" sha1="0275f34127af816779a332becd692b8a6dbeefb7" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -4651,6 +4722,17 @@ license:CC0
 			<feature name="ic1" value="MPR-12130" />
 			<dataarea name="rom" size="262144">
 				<rom name="mpr-12130.ic1" size="262144" crc="d6f43dda" sha1="93c3fbe23848556fc6a737db1b5182537db5961d" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="outrun3dp" cloneof="outrun3d">
+		<description>Out Run 3-D (prototype)</description>
+		<year>1988</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="262144">
+				<rom name="out run 3d (prototype).bin" size="262144" crc="4e684ec0" sha1="9b52818e8c1bd31cfbe1d7107d572049207a705f" offset="000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -6002,6 +6084,19 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="solomonp" cloneof="solomon">
+		<description>Solomon no Kagi - Oujo Rihita no Namida (prototype)</description>
+		<year>1988</year>
+		<publisher>Salio</publisher>
+		<info name="alt_title" value="ソロモンの鍵 -王女リヒタの涙-" />
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="131072">
+				<!-- cartridge contains 2 eproms, labels on the chips: 6301 CHR and 6302 P-->
+				<rom name="solomon no kagi - oujo rihita no namida (prototype).bin" size="131072" crc="92dc4cd6" sha1="4587743e156bddf59e268f89bc08a9450eabe5ea" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sonic">
 		<description>Sonic The Hedgehog (Euro, USA, Bra)</description>
 		<year>1991</year>
@@ -6631,6 +6726,17 @@ license:CC0
 		<part name="cart" interface="sms_cart">
 			<dataarea name="rom" size="131072">
 				<rom name="super off road (europe).bin" size="131072" crc="54f68c2a" sha1="804cd74bbcf452613f6c3a722be1c94338499813" offset="000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="superoffp" cloneof="superoff">
+		<description>Super Off Road (prototype)</description>
+		<year>1992</year>
+		<publisher>Virgin Interactive</publisher>
+		<part name="cart" interface="sms_cart">
+			<dataarea name="rom" size="131072">
+				<rom name="super off road (prototype).bin" size="131072" crc="ce8d6846" sha1="f8267cc15123bc5cfec53298e403232da373822b" offset="000000" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -5,7 +5,6 @@ license:CC0
 
   Undumped games
 
-  - Game de check! Koutsuu Anzen
   - Great Ice Hockey Jpn ? (Only 1000 copies were distributed through a
   BEEP! magazine contest in 1987, to celebrate the release of Phantasy Star)
   - Tec Toy SMS 3 with built-in games (74 game, 112 games, 120 games or


### PR DESCRIPTION
gamegear:
- Redumped Sports Illustrated Championship Football & Baseball (Euro, USA) [smspower]

New working software list additions
-----------------------------------
gamegear:
  Andre Agassi Tennis (prototype),
  Bubble Bobble (prototype),
  CJ Elephant Fugitive (prototype),
  Dinobasher Starring Bignose the Caveman (prototype),
  Dragon - The Bruce Lee Story (prototype),
  Empire Syndicate (Chicago Syndicate) (prototype, 19950320),
  Kawasaki Superbike Challenge (USA),
  Micro Machines (prototype)  [smspower]
sg1000:
  San-nin Mahjong (Jpn, alt)  [smspower]
sms:
  3D Gunner (prototype),
  Alex Kidd - High Tech World (prototype),
  Battle Wings (Bomber Raid, prototype),
  Cyborg Hunter (prototype),
  Game de Check! Koutsuu Anzen (Jpn, prototype)
  Hang-On (prototype),
  Missile Defense 3-D (prototype),
  Out Run 3-D (prototype),
  Solomon no Kagi - Oujo Rihita no Namida (prototype),
  Super Off Road (prototype)  [smspower]

New NOT_WORKING software list additions
---------------------------------------
gamegear:
  X-Terminator v2.1 for Game Gear (Euro, USA),
  X-Terminator v2.1J for Game Gear (Jpn)  [smspower]