### PR TITLE
k573mcr: Implementation of JVS memory card reader device for System 573

### DIFF
--- a/src/devices/machine/jvsdev.cpp
+++ b/src/devices/machine/jvsdev.cpp
@@ -82,10 +82,23 @@ void jvs_device::message(uint8_t dest, const uint8_t *send_buffer, uint32_t send
 		next_device->message(dest, send_buffer, send_size, recv_buffer, recv_size);
 }
 
+int jvs_device::device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
+{
+	// Override this function to provide device-specific JVS message handling.
+	// If -1 is returned then the base message handler will be used.
+	return -1;
+}
+
 int jvs_device::handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
 {
+	int device_ret;
 	uint32_t old_reset_counter = jvs_reset_counter;
 	jvs_reset_counter = 0;
+
+	device_ret = device_handle_message(send_buffer, send_size, recv_buffer);
+	if (device_ret != -1) {
+		return device_ret;
+	}
 
 	switch(send_buffer[0]) {
 	case 0xf0:

--- a/src/devices/machine/jvsdev.cpp
+++ b/src/devices/machine/jvsdev.cpp
@@ -82,23 +82,10 @@ void jvs_device::message(uint8_t dest, const uint8_t *send_buffer, uint32_t send
 		next_device->message(dest, send_buffer, send_size, recv_buffer, recv_size);
 }
 
-int jvs_device::device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
-{
-	// Override this function to provide device-specific JVS message handling.
-	// If -1 is returned then the base message handler will be used.
-	return -1;
-}
-
 int jvs_device::handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
 {
-	int device_ret;
 	uint32_t old_reset_counter = jvs_reset_counter;
 	jvs_reset_counter = 0;
-
-	device_ret = device_handle_message(send_buffer, send_size, recv_buffer);
-	if (device_ret != -1) {
-		return device_ret;
-	}
 
 	switch(send_buffer[0]) {
 	case 0xf0:

--- a/src/devices/machine/jvsdev.h
+++ b/src/devices/machine/jvsdev.h
@@ -37,7 +37,7 @@ protected:
 	virtual bool analogs(uint8_t *&buf, uint8_t count);
 	virtual bool swoutputs(uint8_t count, const uint8_t *vals);
 	virtual bool swoutputs(uint8_t id, uint8_t val);
-	virtual int device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer);
+	virtual int handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer);
 
 	required_device<jvs_host> host;
 
@@ -46,7 +46,6 @@ private:
 	uint8_t jvs_address;
 	uint32_t jvs_reset_counter;
 
-	int handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer);
 };
 
 #endif // MAME_MACHINE_JVSDEV_H

--- a/src/devices/machine/jvsdev.h
+++ b/src/devices/machine/jvsdev.h
@@ -37,6 +37,7 @@ protected:
 	virtual bool analogs(uint8_t *&buf, uint8_t count);
 	virtual bool swoutputs(uint8_t count, const uint8_t *vals);
 	virtual bool swoutputs(uint8_t id, uint8_t val);
+	virtual int device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer);
 
 	required_device<jvs_host> host;
 

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -2042,7 +2042,7 @@ double konami573_cassette_xi_device::punchmania_inputs_callback(uint8_t input)
 	int pads = state->m_pads->read();
 	for( int i = 0; i < 6; i++ )
 	{
-		if( ( pads & ( 1 << i ) ) != 0 )
+		if( BIT( pads, i ) )
 		{
 			pad_position[ i ] = 5;
 		}

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -2415,7 +2415,7 @@ void ksys573_state::konami573(machine_config &config)
 	adc0834_device &adc(ADC0834(config, "adc0834"));
 	adc.set_input_callback(FUNC(ksys573_state::analogue_inputs_callback));
 
-	SYS573_JVS_HOST(config, "sys573_jvs_host", 0);
+	SYS573_JVS_HOST(config, m_sys573_jvs_host, 0);
 }
 
 // Variants with additional digital sound board
@@ -2525,7 +2525,7 @@ void ksys573_state::ddr2mc2(machine_config &config)
 	k573a(config);
 	cassx(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::ddr2ml(machine_config &config)
@@ -2534,7 +2534,7 @@ void ksys573_state::ddr2ml(machine_config &config)
 	pccard1_16mb(config);
 	cassx(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::ddrbocd(machine_config &config)
@@ -2552,7 +2552,7 @@ void ksys573_state::ddr3m(machine_config &config)
 	pccard2_32mb(config);
 	cassyyi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::ddr3mp(machine_config &config)
@@ -2563,7 +2563,7 @@ void ksys573_state::ddr3mp(machine_config &config)
 	pccard2_32mb(config);
 	cassxzi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::ddrusa(machine_config &config)
@@ -2582,7 +2582,7 @@ void ksys573_state::ddr5m(machine_config &config)
 	pccard2_32mb(config);
 	casszi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 // Dancing Stage
@@ -2669,7 +2669,7 @@ void ksys573_state::ddr4ms(machine_config &config)
 	pccard2_32mb(config);
 	cassxzi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 // DrumMania
@@ -2733,7 +2733,7 @@ void ksys573_state::gtrfrk2m(machine_config &config)
 	pccard1_32mb(config); // HACK: The installation tries to check and erase 32mb but only flashes 16mb.
 
 	// For Guitar Freaks 2nd Mix Link Ver 1 (memory cards) and Link Ver 2 (memory cards + controllers)
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::gtrfrk3m(machine_config &config)
@@ -2742,7 +2742,7 @@ void ksys573_state::gtrfrk3m(machine_config &config)
 	cassxzi(config);
 	pccard1_16mb(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, m_sys573_jvs_host);
 }
 
 void ksys573_state::gtrfrk5m(machine_config &config)

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -425,15 +425,12 @@ int jvs_master::received_packet(uint8_t *buffer)
 	get_raw_reply(data, length);
 
 	if (length > 0) {
-		// The games don't unescape the data in memory even.
+		// The games don't unescape the data in memory.
 		// This causes issues any time 0xe0 or 0xd0 shows up in
 		// the original response data and were escaped.
 		// Sending an unescaped "encoded" packet works perfectly
 		// in-game.
-		uint8_t checksum = 0;
-		for (int i = 0; i < length; i++) {
-			checksum += data[i];
-		}
+		uint8_t checksum = std::accumulate(data, data + length, 0);
 
 		buffer[0] = 0xe0;
 		memcpy(buffer + 1, data, length);
@@ -1058,8 +1055,9 @@ void ksys573_state::machine_reset()
 
 	m_jvs_input_idx_r = m_jvs_input_idx_w = 0;
 	m_jvs_output_idx_w = m_jvs_output_len_w = 0;
-	memset(m_jvs_input_buffer, 0, 512);
-	memset(m_jvs_output_buffer, 0, 512);
+
+	std::fill_n(m_jvs_input_buffer, sizeof(m_jvs_input_buffer), 0);
+	std::fill_n(m_jvs_output_buffer, sizeof(m_jvs_output_buffer), 0);
 }
 
 WRITE_LINE_MEMBER(ksys573_state::sys573_vblank)
@@ -1249,7 +1247,7 @@ void ksys573_state::gx700pwbf_io_w(offs_t offset, uint16_t data, uint16_t mem_ma
 
 void ksys573_state::gx700pwfbf_init( void ( ksys573_state::*output_callback_func )( ATTR_UNUSED offs_t offset, ATTR_UNUSED uint8_t data ) )
 {
-	memset( m_gx700pwbf_output_data, 0, sizeof( m_gx700pwbf_output_data ) );
+	std::fill_n( m_gx700pwbf_output_data, sizeof( m_gx700pwbf_output_data ), 0);
 
 	m_gx700pwfbf_output_callback = output_callback_func;
 

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -490,6 +490,7 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_ram(*this, "maincpu:ram"),
 		m_flashbank(*this, "flashbank"),
+		m_in2(*this, "IN2"),
 		m_out1(*this, "OUT1"),
 		m_out2(*this, "OUT2"),
 		m_cd(*this, "CD"),
@@ -736,6 +737,7 @@ private:
 	required_device<psxcpu_device> m_maincpu;
 	required_device<ram_device> m_ram;
 	required_device<address_map_bank_device> m_flashbank;
+	required_ioport m_in2;
 	required_ioport m_out1;
 	required_ioport m_out2;
 	required_ioport m_cd;
@@ -879,7 +881,7 @@ uint16_t ksys573_state::port_in2_jvs_r(offs_t offset, uint16_t mem_mask)
 {
 	if (offset == 0) {
 		// 0x1f400008-0x1f400009 are for inputs
-		return ioport("IN2")->read();
+		return m_in2->read();
 	}
 
     if (m_jvs_output_len_w <= 0) {

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -393,16 +393,16 @@ G: gun mania only, drives air soft gun (this game uses real BB bullet)
 // #define JVS_DEBUG
 
 /*
- * Class declaration for jvs_master
+ * Class declaration for sys573_jvs_host
  */
 
-DECLARE_DEVICE_TYPE(JVS_MASTER, jvs_master)
+DECLARE_DEVICE_TYPE(SYS573_JVS_HOST, sys573_jvs_host)
 
-class jvs_master : public jvs_host
+class sys573_jvs_host : public jvs_host
 {
 public:
 	// construction/destruction
-	jvs_master(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	sys573_jvs_host(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	void send_packet(uint8_t *data, int length);
 	int received_packet(uint8_t *buffer);
 
@@ -412,20 +412,20 @@ private:
 	int output_buffer_size = 0;
 };
 
-DEFINE_DEVICE_TYPE(JVS_MASTER, jvs_master, "jvs_master", "JVS MASTER")
+DEFINE_DEVICE_TYPE(SYS573_JVS_HOST, sys573_jvs_host, "sys573_jvs_host", "JVS Host (System 573)")
 
-jvs_master::jvs_master(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: jvs_host(mconfig, JVS_MASTER, tag, owner, clock)
+sys573_jvs_host::sys573_jvs_host(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: jvs_host(mconfig, SYS573_JVS_HOST, tag, owner, clock)
 {
 	output_buffer_size = 0;
 }
 
-READ_LINE_MEMBER( jvs_master::jvs_sense_r )
+READ_LINE_MEMBER( sys573_jvs_host::jvs_sense_r )
 {
 	return !get_address_set_line();
 }
 
-int jvs_master::received_packet(uint8_t *buffer)
+int sys573_jvs_host::received_packet(uint8_t *buffer)
 {
 	if (jvs_sense_r()) {
 		// The game will send the command twice to reset, but the command
@@ -458,7 +458,7 @@ int jvs_master::received_packet(uint8_t *buffer)
 	return (int)length;
 }
 
-void jvs_master::send_packet(uint8_t *data, int length)
+void sys573_jvs_host::send_packet(uint8_t *data, int length)
 {
 	while (length > 0)
 	{
@@ -501,7 +501,7 @@ public:
 		m_gunmania_id(*this, "gunmania_id"),
 		m_duart(*this, "mb89371"),
 		m_lamps(*this, "lamp%u", 0U),
-		m_jvs_master(*this, "jvs_master")
+		m_sys573_jvs_host(*this, "sys573_jvs_host")
 	{ }
 
 	void drmn9m(machine_config &config);
@@ -748,7 +748,7 @@ private:
 	optional_device<mb89371_device> m_duart;
 	output_finder<2> m_lamps;
 
-	required_device<jvs_master> m_jvs_master;
+	required_device<sys573_jvs_host> m_sys573_jvs_host;
 };
 
 void ksys573_state::konami573_map(address_map &map)
@@ -858,7 +858,7 @@ void ksys573_state::jvs_input_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 		LOGJVS("\n");
 
 		int command_size = m_jvs_input_buffer[2] + 3;
-		m_jvs_master->send_packet(m_jvs_input_buffer + 1, command_size - 2); // jvshost doesn't actually check the checksum, so don't send it
+		m_sys573_jvs_host->send_packet(m_jvs_input_buffer + 1, command_size - 2); // jvshost doesn't actually check the checksum, so don't send it
 
 		m_jvs_input_idx_w = 0;
 		m_jvs_input_idx_r = 0;
@@ -902,7 +902,7 @@ uint16_t ksys573_state::port_in2_jvs_r(offs_t offset, uint16_t mem_mask)
 READ_LINE_MEMBER( ksys573_state::jvs_rx_r )
 {
 	if (m_jvs_output_len_w <= 0) {
-		m_jvs_output_len_w = m_jvs_master->received_packet(m_jvs_output_buffer);
+		m_jvs_output_len_w = m_sys573_jvs_host->received_packet(m_jvs_output_buffer);
 	}
 
 	return m_jvs_output_len_w > 0;
@@ -2415,7 +2415,7 @@ void ksys573_state::konami573(machine_config &config)
 	adc0834_device &adc(ADC0834(config, "adc0834"));
 	adc.set_input_callback(FUNC(ksys573_state::analogue_inputs_callback));
 
-	JVS_MASTER(config, "jvs_master", 0);
+	SYS573_JVS_HOST(config, "sys573_jvs_host", 0);
 }
 
 // Variants with additional digital sound board
@@ -2525,7 +2525,7 @@ void ksys573_state::ddr2mc2(machine_config &config)
 	k573a(config);
 	cassx(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::ddr2ml(machine_config &config)
@@ -2534,7 +2534,7 @@ void ksys573_state::ddr2ml(machine_config &config)
 	pccard1_16mb(config);
 	cassx(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::ddrbocd(machine_config &config)
@@ -2552,7 +2552,7 @@ void ksys573_state::ddr3m(machine_config &config)
 	pccard2_32mb(config);
 	cassyyi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::ddr3mp(machine_config &config)
@@ -2563,7 +2563,7 @@ void ksys573_state::ddr3mp(machine_config &config)
 	pccard2_32mb(config);
 	cassxzi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::ddrusa(machine_config &config)
@@ -2582,7 +2582,7 @@ void ksys573_state::ddr5m(machine_config &config)
 	pccard2_32mb(config);
 	casszi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 // Dancing Stage
@@ -2669,7 +2669,7 @@ void ksys573_state::ddr4ms(machine_config &config)
 	pccard2_32mb(config);
 	cassxzi(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 // DrumMania
@@ -2733,7 +2733,7 @@ void ksys573_state::gtrfrk2m(machine_config &config)
 	pccard1_32mb(config); // HACK: The installation tries to check and erase 32mb but only flashes 16mb.
 
 	// For Guitar Freaks 2nd Mix Link Ver 1 (memory cards) and Link Ver 2 (memory cards + controllers)
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::gtrfrk3m(machine_config &config)
@@ -2742,7 +2742,7 @@ void ksys573_state::gtrfrk3m(machine_config &config)
 	cassxzi(config);
 	pccard1_16mb(config);
 
-	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "jvs_master");
+	KONAMI_573_MEMORY_CARD_READER(config, "k573mcr", 0, "sys573_jvs_host");
 }
 
 void ksys573_state::gtrfrk5m(machine_config &config)
@@ -2945,7 +2945,7 @@ static INPUT_PORTS_START( konami573 )
 	PORT_BIT( 0x00010000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER( "adc0834", adc083x_device, do_read )
 //  PORT_BIT( 0x00020000, IP_ACTIVE_LOW, IPT_UNKNOWN )
 	PORT_BIT( 0x00040000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER( "cassette", konami573_cassette_slot_device, read_line_secflash_sda )
-	PORT_BIT( 0x00080000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER( "jvs_master", jvs_master, jvs_sense_r )
+	PORT_BIT( 0x00080000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER( "sys573_jvs_host", sys573_jvs_host, jvs_sense_r )
 	PORT_BIT( 0x00100000, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_DEVICE_MEMBER( DEVICE_SELF, ksys573_state, jvs_rx_r )
 	PORT_BIT( 0x00200000, IP_ACTIVE_HIGH, IPT_UNKNOWN ) // JVS-related
 //  PORT_BIT( 0x00400000, IP_ACTIVE_LOW, IPT_UNKNOWN )

--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -390,8 +390,6 @@ G: gun mania only, drives air soft gun (this game uses real BB bullet)
 
 #define ATAPI_CYCLES_PER_SECTOR ( 5000 )  // plenty of time to allow DMA setup etc.  BIOS requires this be at least 2000, individual games may vary.
 
-// #define JVS_DEBUG
-
 /*
  * Class declaration for sys573_jvs_host
  */

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -200,7 +200,7 @@ bool k573mcr_device::memcard_write(uint32_t port_no, uint16_t block_addr, uint8_
 	return controller_port_send_byte(port_no, 0) == 'G';
 }
 
-int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
+int k573mcr_device::handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
 {
 	// Notes:
 	// 80678::E0:01:06:70:02:01:C0:00:3A: <- Command from game (E0:01:...)
@@ -226,7 +226,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 			// access to test such a thing.
 			// Reset immediately to hack around that error.
 			device_reset();
-			return -1;
+			break;
 
 		case 0x14:
 			// Function list returns nothing on
@@ -461,7 +461,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 	}
 
 	// Command not recognized, pass it off to the base message handler
-	return -1;
+	return jvs_device::handle_message(send_buffer, send_size, recv_buffer);
 }
 
 ROM_START( k573mcr )

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -48,7 +48,7 @@ Notes:
 
 k573mcr_device::k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	jvs_device(mconfig, KONAMI_573_MEMORY_CARD_READER, tag, owner, clock),
-	m_ports{{*this, "port1"}, {*this, "port2"}}
+	m_ports(*this, "port%u", 0U)
 {
 	m_ram = std::make_unique<uint8_t[]>(RAM_SIZE);
 }

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -48,7 +48,8 @@ Notes:
 
 k573mcr_device::k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	jvs_device(mconfig, KONAMI_573_MEMORY_CARD_READER, tag, owner, clock),
-	m_ports(*this, "port%u", 0U)
+	m_ports(*this, "port%u", 0U),
+	m_meta(*this, "META")
 {
 	m_ram = std::make_unique<uint8_t[]>(RAM_SIZE);
 }
@@ -371,7 +372,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 				int memcard_addr = ((send_buffer[2] << 8) | send_buffer[3]) & 0x7fff;
 				int ram_addr = (send_buffer[4] << 16) | (send_buffer[5] << 8) | send_buffer[6];
 				int block_count = (send_buffer[7] << 8) | send_buffer[8];
-				bool is_ejected = BIT(ioport("META")->read(), memcard_port); // Forcefully ejected using hotkey
+				bool is_ejected = BIT(m_meta->read(), memcard_port); // Forcefully ejected using hotkey
 
 				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
 					// Check if card is inserted
@@ -404,7 +405,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 				int memcard_port = send_buffer[5] >> 7;
 				int memcard_addr = ((send_buffer[5] << 8) | send_buffer[6]) & 0x7fff;
 				int block_count = (send_buffer[7] << 8) | send_buffer[8];
-				bool is_ejected = BIT(ioport("META")->read(), memcard_port); // Forcefully ejected using hotkey
+				bool is_ejected = BIT(m_meta->read(), memcard_port); // Forcefully ejected using hotkey
 
 				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
 					// Check if card is inserted

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -66,7 +66,7 @@ void k573mcr_device::device_reset()
 {
 	jvs_device::device_reset();
 
-	memset(m_ram.get(), 0, RAM_SIZE);
+	std::fill_n(m_ram.get(), RAM_SIZE, 0);
 	m_is_memcard_initialized = false;
 	m_status = 0;
 }

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -111,7 +111,7 @@ uint8_t k573mcr_device::controller_port_send_byte(uint32_t port_no, uint8_t data
 
 	for (int i = 0; i < 8; i++) {
 		port->clock_w(0);
-		port->tx_w(!!(data & (1 << i)));
+		port->tx_w(BIT(data, i));
 		port->clock_w(1);
 		output |= port->rx_r() << i;
 	}
@@ -371,7 +371,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 				int memcard_addr = ((send_buffer[2] << 8) | send_buffer[3]) & 0x7fff;
 				int ram_addr = (send_buffer[4] << 16) | (send_buffer[5] << 8) | send_buffer[6];
 				int block_count = (send_buffer[7] << 8) | send_buffer[8];
-				bool is_ejected = !(ioport("META")->read() & (1 << memcard_port)); // Forcefully ejected using hotkey
+				bool is_ejected = BIT(ioport("META")->read(), memcard_port); // Forcefully ejected using hotkey
 
 				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
 					// Check if card is inserted
@@ -404,7 +404,7 @@ int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t s
 				int memcard_port = send_buffer[5] >> 7;
 				int memcard_addr = ((send_buffer[5] << 8) | send_buffer[6]) & 0x7fff;
 				int block_count = (send_buffer[7] << 8) | send_buffer[8];
-				bool is_ejected = !(ioport("META")->read() & (1 << memcard_port)); // Forcefully ejected using hotkey
+				bool is_ejected = BIT(ioport("META")->read(), memcard_port); // Forcefully ejected using hotkey
 
 				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
 					// Check if card is inserted
@@ -476,8 +476,8 @@ const tiny_rom_entry *k573mcr_device::device_rom_region() const
 
 INPUT_PORTS_START( k573mcr_meta_controls )
 	PORT_START("META")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE1) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 1")
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_SERVICE2) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 2")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_SERVICE1) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 1")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_SERVICE2) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 2")
 INPUT_PORTS_END
 
 ioport_constructor k573mcr_device::device_input_ports() const

--- a/src/mame/machine/k573mcr.cpp
+++ b/src/mame/machine/k573mcr.cpp
@@ -1,24 +1,466 @@
 // license:BSD-3-Clause
-// copyright-holders:smf
+// copyright-holders:smf, windyfairy
 /*
  * Konami 573 Memory Card Reader
- *
- */
+
+  Main PCB Layout
+  ---------------
+  GE885-PWB(A)A
+  (C)1999 KONAMI CO. LTD.
+  |---------------------------------------|
+  |   PQ30RV11                            |
+  |         |----------|  |-------|  CN61 |
+  | DIP8    |          |  | XCS05 |       |
+  |         |   TMPR   |  | /10   |       |
+  |         |  3904AF  |  |-------|  CN62 |
+  |         |          |                  |
+  | CN65    |----------|                  |
+  |        8.25 MHz                  CN67 |
+  |                       EP4M16          |
+  |             DRAM4M                    |
+  |                                       |
+  |                               --------|
+  | USB-A                    CN64 |
+  |                               |
+  |          ADM485JR             |
+  | USB-B                    CN63 |
+  |-------------------------------|
+
+Notes:
+	DIP8       - 8-position DIP switch
+	CN61       - BS8PSHF1AA 8 pin connector, connects to memory card harness
+	CN62       - BS8PSHF1AA 8 pin connector
+	CN63       - 6P-SHVQ labeled "0", GE885-JB security dongle is connected here
+	CN64       - 6P-SHVQ labeled "1"
+	CN65       - B4PS-VH, 4 pin power connector
+	CN67       - BS15PSHF1AA, 15-pin connector, unpopulated
+	USB-A      - USB-A connector
+	USB-B      - USB-B connector, connects to USB on System 573 motherboard
+	ADM485JR   - Analog Devices ADM485 low power EIA RS-485 transceiver
+	TMPR3904AF - Toshiba TMPR3904AF RISC Microprocessor
+	XCS05/10   - XILINX XCS10XL VQ100AKP9909 A2026631A
+	DRAM4M     - Silicon Magic 66 MHz C9742 SM81C256K16CJ-35, 256K x 16 EDO DRAM
+	EP4M16     - ROM labeled "855-A01"
+*/
 
 #include "emu.h"
 #include "k573mcr.h"
 
-/*
-  GE885-PWB(A)A ( contains Toshiba tmpr3904af, ram, rom, tranceiver and glue ).
-*/
-
 k573mcr_device::k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, KONAMI_573_MEMORY_CARD_READER, tag, owner, clock)
+	jvs_device(mconfig, KONAMI_573_MEMORY_CARD_READER, tag, owner, clock),
+	m_ports{{*this, "port1"}, {*this, "port2"}}
 {
+	m_ram = std::make_unique<uint8_t[]>(RAM_SIZE);
 }
 
 void k573mcr_device::device_start()
 {
+	jvs_device::device_start();
+
+	save_pointer(NAME(m_ram), RAM_SIZE);
+	save_item(NAME(m_is_memcard_initialized));
+	save_item(NAME(m_status));
+}
+
+void k573mcr_device::device_reset()
+{
+	jvs_device::device_reset();
+
+	memset(m_ram.get(), 0, RAM_SIZE);
+	m_is_memcard_initialized = false;
+	m_status = 0;
+}
+
+void k573mcr_device::device_add_mconfig(machine_config &config)
+{
+	// The actual controllers are only used in Guitar Freaks and it was
+	// meant to be used with the home version PS1 guitar controller.
+	// The PS1 guitar controller isn't emulated in MAME and it doesn't
+	// make much sense to have it enabled by default. You can still select
+	// a controller through the slots menu.
+	// The memory card ports are still usable even without a controller
+	// enabled which is the main reason for using the PSX controller ports.
+	PSX_CONTROLLER_PORT(config, m_ports[0], psx_controllers, nullptr);
+	PSX_CONTROLLER_PORT(config, m_ports[1], psx_controllers, nullptr);
+}
+
+const char *k573mcr_device::device_id()
+{
+	return "KONAMI CO.,LTD.;White I/O;Ver1.0;White I/O PCB";
+}
+
+uint8_t k573mcr_device::command_format_version()
+{
+	return 0x11;
+}
+
+uint8_t k573mcr_device::jvs_standard_version()
+{
+	return 0x20;
+}
+
+uint8_t k573mcr_device::comm_method_version()
+{
+	return 0x10;
+}
+
+uint8_t k573mcr_device::controller_port_send_byte(uint32_t port_no, uint8_t data)
+{
+	auto port = m_ports[port_no];
+	uint8_t output = 0;
+
+	for (int i = 0; i < 8; i++) {
+		port->clock_w(0);
+		port->tx_w(!!(data & (1 << i)));
+		port->clock_w(1);
+		output |= port->rx_r() << i;
+	}
+
+	return output;
+}
+
+bool k573mcr_device::pad_read(uint32_t port_no, uint8_t *output)
+{
+	m_ports[port_no]->sel_w(1);
+	m_ports[port_no]->sel_w(0);
+
+	controller_port_send_byte(port_no, 0x01);
+	uint8_t a = controller_port_send_byte(port_no, 'B');
+	uint8_t b = controller_port_send_byte(port_no, 0);
+	*output++ = controller_port_send_byte(port_no, 0);
+	*output++ = controller_port_send_byte(port_no, 0);
+
+	return a == 0x41 && b == 0x5a;
+}
+
+bool k573mcr_device::memcard_read(uint32_t port_no, uint16_t block_addr, uint8_t *output)
+{
+	m_ports[port_no]->sel_w(1);
+	m_ports[port_no]->sel_w(0);
+
+	controller_port_send_byte(port_no, 0x81);
+
+	if (controller_port_send_byte(port_no, 'R') == 0xff) { // state_command, Request read
+		return false;
+	}
+
+	controller_port_send_byte(port_no, 0); // state_command -> state_cmdack
+	controller_port_send_byte(port_no, 0); // state_cmdack -> state_wait
+	controller_port_send_byte(port_no, block_addr >> 8); // state_wait -> state_addr_hi
+	controller_port_send_byte(port_no, block_addr & 0xff); // state_addr_hi -> state_addr_lo
+
+	if (controller_port_send_byte(port_no, 0) != 0x5c) {  // state_addr_lo -> state_read
+		// If the command wasn't correct then it transitions to state_illegal at this point
+		return false;
+	}
+
+	controller_port_send_byte(port_no, 0); // Skip 0x5d
+	controller_port_send_byte(port_no, 0); // Skip addr hi
+	controller_port_send_byte(port_no, 0); // Skip addr lo
+
+	for (int i = 0; i < MEMCARD_BLOCK_SIZE; i++) {
+		auto c = controller_port_send_byte(port_no, 0);
+		if (output != nullptr) {
+			*output++ = c;
+		}
+	}
+
+	controller_port_send_byte(port_no, 0);
+
+	return controller_port_send_byte(port_no, 0) == 'G';
+}
+
+bool k573mcr_device::memcard_write(uint32_t port_no, uint16_t block_addr, uint8_t *input)
+{
+	m_ports[port_no]->sel_w(1);
+	m_ports[port_no]->sel_w(0);
+
+	controller_port_send_byte(port_no, 0x81);
+
+	if (controller_port_send_byte(port_no, 'W') == 0xff) { // state_command, Request write
+		return false;
+	}
+
+	controller_port_send_byte(port_no, 0); // state_command -> state_cmdack
+	controller_port_send_byte(port_no, 0); // state_cmdack -> state_wait
+	controller_port_send_byte(port_no, block_addr >> 8); // state_wait -> state_addr_hi
+	controller_port_send_byte(port_no, block_addr & 0xff); // state_addr_hi -> state_addr_lo
+
+	uint8_t checksum = (block_addr >> 8) ^ (block_addr & 0xff);
+	for (int i = 0; i < MEMCARD_BLOCK_SIZE; i++) {
+		controller_port_send_byte(port_no, input[i]); // state_read
+		checksum ^= input[i];
+	}
+
+	controller_port_send_byte(port_no, checksum);
+	controller_port_send_byte(port_no, 0);
+	controller_port_send_byte(port_no, 0);
+
+	return controller_port_send_byte(port_no, 0) == 'G';
+}
+
+int k573mcr_device::device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer)
+{
+	// Notes:
+	// 80678::E0:01:06:70:02:01:C0:00:3A: <- Command from game (E0:01:...)
+	// 80681::E0:00:03:01:01:05: <- Response from memory card reader device (E0:00:...)
+	//
+	// The returned value of this function should be 0 (invalid parameters), -1 (unknown command), or the number of bytes in the message.
+	// The number of bytes to return is covered by the xx section:
+	// 80678::E0:01:yy:xx:xx:xx:xx:xx:3A:
+	// This should correspond to yy - 1, but you don't actually get access to yy in the message handler so you must calculate it yourself.
+	//
+	// recv_buffer will correspond to this part when returning data:
+	// 80681::E0:00:03:01:rr:05:
+	// In some special cases there is an empty respond but that is not supported in MAME currently so a single byte is returned instead.
+
+	switch(send_buffer[0]) {
+		case 0xf0:
+			// The bootloader for System 573 games checks for the master calendar which initializes the JVS device.
+			// After the bootloader, the actual game's code tries to initialize the JVS device again and (seemingly)
+			// expects it to be in a fresh state. Since it was already initialized in the bootloader, it will throw
+			// the error message "JVS SUBS RESET ERROR".
+			// There might be something else that happens on real hardware between when it loads the bootloader
+			// and when it starts the actual game's code that resets the JVS device, but I do not have hands on
+			// access to test such a thing.
+			// Reset immediately to hack around that error.
+			device_reset();
+			return -1;
+
+		case 0x14:
+			// Function list returns nothing on
+			// 75502::E0:01:02:14:17:
+			// 75503::E0:00:04:01:01:00:06:
+			*recv_buffer++ = 0x01;
+			*recv_buffer++ = 0x00;
+			return 1;
+
+		case 0x70:
+		{
+			int ram_addr = (send_buffer[2] << 16) | (send_buffer[3] << 8) | send_buffer[4];
+			int target_len = send_buffer[5];
+
+			if (send_buffer[1] == 0) {
+				// Buffer read
+				// 39595::E0:01:07:70:00:02:00:00:80:FA:
+				// 39596::E0:00:83:01:01:4D:43:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+				//       :00:00:00:00:00:00:
+				*recv_buffer++ = 0x01;
+
+				if (target_len > 0 && ram_addr + target_len < RAM_SIZE) {
+					memcpy(recv_buffer, &m_ram[ram_addr], target_len);
+					recv_buffer += target_len;
+				}
+
+				return 6;
+			} else if (send_buffer[1] == 1) {
+				// Buffer write
+				// 77565::E0:01:87:70:01:02:04:00:80:24:A5:04:70:30:30:7A
+				//       :24:87:C6:85:10:00:64:05:58:02:44:45:CA:8C:FD:A2
+				//       :00:04:A3:00:04:8C:A6:00:FF:08:8C:00:82:00:20:00
+				//       :E8:00:F4:00:DD:F8:C0:24:EF:85:FC:21:20:20:04:5B
+				//       :14:40:51:73:77:
+				// 77583::E0:00:01:
+				if (target_len > 0) {
+					memcpy(&m_ram[ram_addr], send_buffer + 6, target_len);
+				}
+
+				*recv_buffer++ = 0x01;
+
+				return 6 + target_len;
+			} else if (send_buffer[1] == 2) {
+				// Set execution address
+				// 80678::E0:01:06:70:02:01:C0:00:3A:
+				// 80681::E0:00:03:01:01:05:
+				*recv_buffer++ = 0x01;
+
+				return 5;
+			}
+
+			return -1;
+		}
+
+		case 0x71:
+		{
+			// Status request
+			// 81681::E0:01:02:71:74:
+			// 81682::E0:00:05:01:01:00:00:07:
+			*recv_buffer++ = 0x01;
+			*recv_buffer++ = m_status >> 8;
+			*recv_buffer++ = m_status & 0xff;
+
+			return 1;
+		}
+
+		case 0x72:
+		{
+			// Security plate
+			uint8_t cmd = send_buffer[1] & ~1;
+			int sec_slot = send_buffer[1] & 1;
+
+			if (cmd == 0x00) {
+				// Packet: e0 01 03 72 00 76 slot 0 (CN63)
+				// Packet: e0 01 03 72 01 77 slot 1 (CN64)
+				*recv_buffer++ = 0x01;
+
+				return 2;
+			} else if (cmd == 0x10) {
+				// Set password (presumably to unlock/read security dongle)
+				// Packet: e0 01 0b 72 10 a4 60 f0 5d ea c4 5d ec d6
+				*recv_buffer++ = 0x01;
+
+				return 10;
+			} else if (cmd == 0x20) {
+				// Get dongle data? (slot 0: GE885-JB, slot 1: ?)
+				// Packet: e0 01 0a 72 20 00 00 02 00 00 00 08 a7
+				// It seems that as long as the checksum matches, the game will accept it as valid
+				int ram_addr = (send_buffer[4] << 16) | (send_buffer[5] << 8) | send_buffer[6];
+
+				m_ram[ram_addr] = 'J';
+				m_ram[ram_addr + 1] = sec_slot ? 'A' : 'B'; // GF uses GE929-JA, but the games will accept anything
+				m_ram[ram_addr + 2] = 0x00;
+				m_ram[ram_addr + 3] = 0x00;
+				m_ram[ram_addr + 4] = ~(m_ram[ram_addr] + m_ram[ram_addr + 1]); // Checksum byte
+
+				*recv_buffer++ = 0x01;
+
+				return 9;
+			} else if (cmd == 0x40) {
+				// Get some kind of registration info from dongle?
+				// Game code calls it "config register"
+				// Packet: e0 01 06 72 40 02 00 00 bb
+				int ram_addr = (send_buffer[2] << 16) | (send_buffer[3] << 8) | send_buffer[4];
+
+				m_ram[ram_addr] = 0xFF;
+				m_ram[ram_addr + 1] = 0xFF;
+				m_ram[ram_addr + 2] = 0xAC;
+				m_ram[ram_addr + 3] = 0x09;
+				m_ram[ram_addr + 4] = 0x00;
+
+				*recv_buffer++ = 0x01;
+
+				return 5;
+			}
+
+			return -1;
+		}
+
+		case 0x73:
+		{
+			// Execute previously set address (0x70 0x02)
+			// 81674::E0:01:02:73:76:
+			// 81675::E0:00:03:01:01:05:
+			*recv_buffer++ = 0x01;
+
+			return 1;
+		}
+
+		case 0x76:
+		{
+			// Memory card
+			if (send_buffer[1] == 0x74) {
+				// Read from card
+				// Packet (port 2): e0 01 0a 76 74 80 00 02 00 00 00 01 78
+				int memcard_port = send_buffer[2] >> 7;
+				int memcard_addr = ((send_buffer[2] << 8) | send_buffer[3]) & 0x7fff;
+				int ram_addr = (send_buffer[4] << 16) | (send_buffer[5] << 8) | send_buffer[6];
+				int block_count = (send_buffer[7] << 8) | send_buffer[8];
+				bool is_ejected = !(ioport("META")->read() & (1 << memcard_port)); // Forcefully ejected using hotkey
+
+				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
+					// Check if card is inserted
+					m_status = MEMCARD_AVAILABLE;
+				} else {
+					m_status = MEMCARD_UNAVAILABLE;
+				}
+
+				if (m_status == MEMCARD_AVAILABLE) {
+					for (int i = 0; i < block_count; i++) {
+						m_status |= MEMCARD_READING;
+
+						if (memcard_read(memcard_port, memcard_addr + i, &m_ram[ram_addr + (i * MEMCARD_BLOCK_SIZE)])) {
+							m_status = MEMCARD_AVAILABLE;
+						} else {
+							m_status = MEMCARD_ERROR;
+							break;
+						}
+					}
+				}
+
+				*recv_buffer++ = 0x01;
+				*recv_buffer++ = 0x01;
+
+				return 9;
+			} else if (send_buffer[1] == 0x75) {
+				// Write to card
+				// Packet: e0 01 0a 76 75 02 00 00 00 3f 00 01 38
+				int ram_addr = (send_buffer[2] << 16) | (send_buffer[3] << 8) | send_buffer[4];
+				int memcard_port = send_buffer[5] >> 7;
+				int memcard_addr = ((send_buffer[5] << 8) | send_buffer[6]) & 0x7fff;
+				int block_count = (send_buffer[7] << 8) | send_buffer[8];
+				bool is_ejected = !(ioport("META")->read() & (1 << memcard_port)); // Forcefully ejected using hotkey
+
+				if (!is_ejected && memcard_read(memcard_port, 0, nullptr)) {
+					// Check if card is inserted
+					m_status = MEMCARD_AVAILABLE;
+				} else {
+					m_status = MEMCARD_UNAVAILABLE;
+				}
+
+				if (m_status == MEMCARD_AVAILABLE && m_is_memcard_initialized) {
+					for (int i = 0; i < block_count; i++) {
+						m_status |= MEMCARD_WRITING;
+
+						if (memcard_write(memcard_port, memcard_addr + i, &m_ram[ram_addr + (i * MEMCARD_BLOCK_SIZE)])) {
+							m_status = MEMCARD_AVAILABLE;
+						} else {
+							m_status = MEMCARD_ERROR;
+							break;
+						}
+					}
+				}
+
+				*recv_buffer++ = 0x01;
+				*recv_buffer++ = 0x01;
+
+				// The game will write a block of 0xffs to block 3f immediately after inserting a memory card for the first time.
+				// I believe it's some kind of initialization, and based on the game's code, the 0xff buffer is prepared when the firmware is being sent.
+				// Based on someone else's research with real hardware, the 0xff block doesn't actually get written to the memory card.
+				m_is_memcard_initialized = true;
+
+				return 9;
+			}
+
+			return -1;
+		}
+
+		case 0x77:
+		{
+			// Controller ports
+			// Packet: e0 01 02 77 7a
+			//
+			// Only used by Guitar Freaks.
+			// This was introduced in Guitar Freaks 2nd Mix Link Kit 2, which allowed players to bring their own PS1 guitar controllers to the arcade
+			// and plug it into the machine to use as a controller instead of the normal machine's guitar controllers.
+
+			*recv_buffer++ = 0x01;
+			pad_read(0, recv_buffer);
+			pad_read(1, recv_buffer + 2);
+
+			recv_buffer += 4;
+
+			return 1;
+		}
+	}
+
+	// Command not recognized, pass it off to the base message handler
+	return -1;
 }
 
 ROM_START( k573mcr )
@@ -29,6 +471,18 @@ ROM_END
 const tiny_rom_entry *k573mcr_device::device_rom_region() const
 {
 	return ROM_NAME( k573mcr );
+}
+
+
+INPUT_PORTS_START( k573mcr_meta_controls )
+	PORT_START("META")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE1) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 1")
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_SERVICE2) PORT_TOGGLE PORT_NAME("Insert/Eject Memory Card 2")
+INPUT_PORTS_END
+
+ioport_constructor k573mcr_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME(k573mcr_meta_controls);
 }
 
 DEFINE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device, "k573mcr", "Konami 573 Memory Card Reader")

--- a/src/mame/machine/k573mcr.h
+++ b/src/mame/machine/k573mcr.h
@@ -11,6 +11,7 @@
 
 #include "bus/psx/ctlrport.h"
 #include "machine/jvsdev.h"
+#include "machine/timer.h"
 
 class k573mcr_device : public jvs_device
 {
@@ -25,6 +26,8 @@ public:
 	k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual ioport_constructor device_input_ports() const override;
+
+	DECLARE_WRITE_LINE_MEMBER(write_rxd);
 
 protected:
 	template <uint8_t First> void set_port_tags() { }
@@ -57,7 +60,8 @@ private:
 		MEMCARD_BLOCK_SIZE = 128
 	};
 
-	uint8_t controller_port_send_byte(uint32_t port, uint8_t data);
+	void controller_set_port(uint32_t port_no);
+	uint8_t controller_port_send_byte(uint8_t data);
 	bool pad_read(uint32_t port_no, uint8_t *output);
 	bool memcard_read(uint32_t port_no, uint16_t block_addr, uint8_t *output);
 	bool memcard_write(uint32_t port_no, uint16_t block_addr, uint8_t *input);
@@ -65,8 +69,10 @@ private:
 	std::unique_ptr<uint8_t[]> m_ram;
 	uint16_t m_status;
 	bool m_is_memcard_initialized;
+	uint8_t m_psx_rx_data, m_psx_rx_bit;
+	bool m_psx_clock;
 
-	required_device_array<psx_controller_port_device, 2> m_ports;
+	required_device<psxcontrollerports_device> m_controllers;
 	required_ioport m_meta;
 };
 

--- a/src/mame/machine/k573mcr.h
+++ b/src/mame/machine/k573mcr.h
@@ -67,7 +67,7 @@ private:
 	uint16_t m_status;
 	bool m_is_memcard_initialized;
 
-	required_device<psx_controller_port_device> m_ports[2];
+	required_device_array<psx_controller_port_device, 2> m_ports;
 };
 
 DECLARE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device)

--- a/src/mame/machine/k573mcr.h
+++ b/src/mame/machine/k573mcr.h
@@ -68,6 +68,7 @@ private:
 	bool m_is_memcard_initialized;
 
 	required_device_array<psx_controller_port_device, 2> m_ports;
+	required_ioport m_meta;
 };
 
 DECLARE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device)

--- a/src/mame/machine/k573mcr.h
+++ b/src/mame/machine/k573mcr.h
@@ -40,8 +40,7 @@ protected:
 	virtual uint8_t command_format_version() override;
 	virtual uint8_t jvs_standard_version() override;
 	virtual uint8_t comm_method_version() override;
-
-	virtual int device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer) override;
+	virtual int handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer) override;
 
 private:
 	enum {

--- a/src/mame/machine/k573mcr.h
+++ b/src/mame/machine/k573mcr.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:smf
+// copyright-holders:smf, windyfairy
 /*
  * Konami 573 Memory Card Reader
  *
@@ -9,19 +9,67 @@
 
 #pragma once
 
+#include "bus/psx/ctlrport.h"
+#include "machine/jvsdev.h"
 
-
-DECLARE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device)
-
-class k573mcr_device : public device_t
+class k573mcr_device : public jvs_device
 {
 public:
+	template <typename T>
+	k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&jvs_host_tag)
+		: k573mcr_device(mconfig, tag, owner, clock)
+	{
+		host.set_tag(std::forward<T>(jvs_host_tag));
+	}
+
 	k573mcr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	virtual ioport_constructor device_input_ports() const override;
+
 protected:
+	template <uint8_t First> void set_port_tags() { }
+
 	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
 
 	virtual const tiny_rom_entry *device_rom_region() const override;
+
+	// JVS device overrides
+	virtual const char *device_id() override;
+	virtual uint8_t command_format_version() override;
+	virtual uint8_t jvs_standard_version() override;
+	virtual uint8_t comm_method_version() override;
+
+	virtual int device_handle_message(const uint8_t *send_buffer, uint32_t send_size, uint8_t *&recv_buffer) override;
+
+private:
+	enum {
+		MEMCARD_UNINITIALIZED = 0x0000, // Default value, also used after writing?
+		MEMCARD_ERROR         = 0x0002,
+		MEMCARD_UNAVAILABLE   = 0x0008, // Card is not inserted
+		MEMCARD_READING       = 0x0200, // Read request is executing
+		MEMCARD_WRITING       = 0x0400, // Write request is executing
+		MEMCARD_AVAILABLE     = 0x8000  // Can be combined with MEMCARD_READING and MEMCARD_WRITING for busy state
+	};
+
+	enum {
+		RAM_SIZE = 0x400000,
+		MEMCARD_BLOCK_SIZE = 128
+	};
+
+	uint8_t controller_port_send_byte(uint32_t port, uint8_t data);
+	bool pad_read(uint32_t port_no, uint8_t *output);
+	bool memcard_read(uint32_t port_no, uint16_t block_addr, uint8_t *output);
+	bool memcard_write(uint32_t port_no, uint16_t block_addr, uint8_t *input);
+
+	std::unique_ptr<uint8_t[]> m_ram;
+	uint16_t m_status;
+	bool m_is_memcard_initialized;
+
+	required_device<psx_controller_port_device> m_ports[2];
 };
+
+DECLARE_DEVICE_TYPE(KONAMI_573_MEMORY_CARD_READER, k573mcr_device)
 
 #endif // MAME_MACHINE_K573_MCR_H


### PR DESCRIPTION
This is a software implementation of the JVS memory card reader device used by System 573. This allows for saving and loading scores in DDR games, loading custom edit chart data in DDR and Guitar Freaks games, and PS1 guitar controller inputs in Guitar Freaks games.

I've included packet captures for every implemented commands and the corresponding responses in the code for documentation purposes. If it's too much or not required then I can remove them.

The following games are affected:
```
ddr2mc2
ddr2ml
ddr2mla
ddr3mka
ddr3ma
ddr3mk
ddr3mj
ddr3mp
ddr4m
ddr4mj
ddr4ms
ddr4msj
ddr4mp
ddr4mps
ddr5m
ddrmax
ddrmax2
ddrextrm
gtrfrk3m
gtfrk3ma
gtrfrk4m
```

All of the above have been tested to make sure that the memory card and controller functionality is working. I've also tried to test as much of the other System 573 games as possible (~80 or so) to make sure nothing broke as a result of these changes.

Overview of changes:
- jvsdev: Added a custom device-specific message handler that can be overridden by devices implementing jvsdev
- k573mcr: Added documentation about the PCB layout
- k573mcr: Implemented k573mcr as a jvsdev using the custom message handler
- ksys573: Implemented registers used for JVS communication
- ksys573: Removed hacks for ddr2ml/ddr2mla that patched out the security plate errors since this PR fixes the problem