### PR TITLE
fmtowns_cd.xml: 16 new dumps, 13 replacements, 6 missing floppies added

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -32,7 +32,6 @@ Airwave Adventure                                             Toshiba EMI       
 Aishuu to Netsujou no Chouwa                                  Fujitsu                           1995/4     CD
 Akiko Gold                                                    Fairytale (Red Zone)              1995/1     SET(CD+FD)
 Alice in Wonderland                                           DynEd Japan                       1993/3     SET(CD+FD)
-* Alice no Yakata 3 CD                                        Alice Soft                        1995/6     CD
 Amour Ver. 1.0                                                Kozu System                       1989/11    SET(CD+FD)
 AniVox Eiken 3-4-kyuu Hatsuon-Accent Ban                      Unity                             1992/6     SET(CD+FD)
 Anne no Tea Party                                             Dennou Shoukai                    1993/6     CD
@@ -81,7 +80,7 @@ Collector D                                                   D.O.              
 Computer Zukan: Shokubutsu-hen CD-ROM-ban                     Ratio International               1991/12    CD
 Config Rom                                                    Glams                             1995/12    CD
 Cover Girls Vol. 1                                            Janis                             1994/2     CD
-Crayonnage                                                    CSK Research Institute (CRI)      1991/8     SET(CD+FD)
+* Crayonnage                                                  CSK Research Institute (CRI)      1991/8     SET(CD+FD)
 CRI Postman                                                   CSK Research Institute (CRI)      1990/3     CD
 CRI StacCard                                                  CSK Research Institute (CRI)      1991/5     SET(CD+FD)
 C-Trace Towns                                                 Cast                              1989/6     CD
@@ -115,7 +114,6 @@ Den V3.0                                                      Fujitsu           
 Diamond Players                                               Wolf Team                         1993/6     SET(CD+FD)
 Dick                                                          Amorphous                         1996/1     CD
 Digital Pinup Girls Vol. 2                                    Transpegasus Limited              1993/6     CD
-* Doki Doki Vacation                                          Cocktail Soft                     1995/3     SET(CD+FD)
 Do-Re-Mi Canvas                                               Tokyo Shoseki                     1994/12    CD
 Dragon Souseiki                                               Basho House                       1993/12    CD
 Drive Simulator Home Navi                                     Fujitsu Ten                       1994/8     SET(CD+FD)
@@ -158,8 +156,6 @@ Eigo de Eigo ni Tsuyoku Naru 8                                Infortech         
 Eigo de Eigo ni Tsuyoku Naru 9                                Infortech                         1990/4     CD
 Eikan wa Kimi ni 3: Koukou Yakyuu Zenkoku Taikai              Artdink                           1993/8     SET(CD+FD)
 Ei-wa-doku-ro Denki Jutsugo Daijiten                          Ohmsha                            1990/4     CD
-Engage Errands 2: Kouki wo Niau Mono                          Ponytail Soft                     1995/5     CD
-Engage Errands: Miwaku no Shito-tachi                         Ponytail Soft                     1995/4     CD
 English in Dream                                              SofMedia                          1990/6     CD
 Enkaiou Ver. 3: Chikyuu Saidai no Kessen                      Dennou Shoukai                    1993/12    CD
 Euphony 2 / MTR V1.1                                          Fujitsu                           1992/11    CD
@@ -262,8 +258,7 @@ Hyper Media NHK Zoku Kiso Eigo: Dai-2-kan                     CSK Research Insti
 * Hyper Media NHK Zoku Kiso Eigo: Dai-3-kan                   CSK Research Institute (CRI)      1991/9     SET(CD+FD)
 Hyper Note                                                    Datt Japan                        1991/12    SET(CD+FD)
 Hyper Photo DB                                                Fujitsu                           1993/9     CD
-* Hyper Planet for Marty                                      Datt Japan                        1993/6     SET(CD+FD)
-Hyper Planet Shiki Vol. 2: Utsukushii Fuyu no Seiza Hen       Datt Japan                        1993/12    CD
+* Hyper Planet Shiki Vol. 2: Utsukushii Fuyu no Seiza Hen     Datt Japan                        1993/12    CD
 Hyper Planet Shiki Vol. 3: Uraraka na Haru no Seiza Hen       Datt Japan                        1994/4     CD
 Hyper Planet Shiki Vol. 4: Fukamari Yuku Aki no Seiza Hen     Datt Japan                        1994/11    CD
 Hyper Touhouku Kikou                                          Nanken Koubou                     1991/12    SET(CD+FD)
@@ -310,7 +305,6 @@ Kazu ya Kimi Tashizan / Hikizan Hen                           Media Art         
 Kenkyuusha Readers Eiwa CD-ROM                                Fujitsu                           1993/2     CD
 Kerokero Keroppi to Origami no Tabibito                       Fujitsu Parex                     1995/7     CD
 Kid Pix Companion                                             Fujitsu Parex                     1995/3     CD
-Kikai Jikake no Marian                                        Janis                             1994/8     CD
 Kikou Shidan 2                                                Artdink                           1993/3     SET(CD+FD)
 Kitty Town no Nakama-tachi: Tanoshii Seikatsuka               Fujitsu Parex                     1995/10    CD
 Komaki Naomi                                                  Janis                             1994/2     CD
@@ -321,7 +315,6 @@ Kousoku Choujin                                               Foster            
 Kusuriyubi no Kyoukasho                                       Active                            1996/4     CD
 Kyouiku & FM Towns Vol. 1                                     Fujitsu                           ?          CD
 Kyouiku & FM Towns Vol. 4                                     Fujitsu                           ?          CD
-* L'Empereur                                                  Koei                              1991/1     SET(CD+FD)
 Let's go 1-1                                                  DynEd Japan                       1995/7     SET(CD+FD)
 Let's go 1-2                                                  DynEd Japan                       1995/7     SET(CD+FD)
 Let's go 2-1                                                  DynEd Japan                       1995/7     SET(CD+FD)
@@ -335,7 +328,6 @@ LiveMorph V1.1                                                Fujitsu           
 LiveMovie V1.1                                                Fujitsu                           1992/12    CD
 LiveMovie V2.1                                                Fujitsu                           1994/3     CD
 * Lodoss-tou Senki 2: Goshiki no Maryuu                       MAC                               1994/6     SET(CD+FD)
-Lua                                                           Inter Heart                       1993/6     CD
 M Talk                                                        Fujitsu Office Kiki               1993/6     CD
 Manami no Dokomade Iku no?                                    Wendy Magazine                    1995/5     CD
 Manami: Ai to Koukan no Hibi                                  Fairytale (Red Zone)              1995/10    SET(CD+FD)
@@ -361,7 +353,6 @@ Monster Planet 2255                                           Nihon Media Progra
 Moon Crystal                                                  Orange House                      1992/6     ?
 Moonlight Energy                                              Inter Heart                       1992/12    CD
 Mori no Ninkimono                                             Fujitsu Social Science Laboratory 1993/12    CD
-* Ms. Detective File #1: Iwami Ginzan Satsujin Jiken (Marty compatible)   Data West                         1992/9     CD×02
 Multimedia Nihon no Rekishi Dai-1-Shou: Kariya-ryou no Kurashi  Tokyo Shoseki                     ?          CD
 Multimedia Nihon no Rekishi Dai-2-Shou: Kome-zukuri no Mura kara Kofun no Kuni e    Tokyo Shoseki                     1995/4     CD
 Multimedia Seikatsuka: Ikimono to Otomodachi Dai-2-shuu       Tokyo Shoseki                     1995/4     CD
@@ -384,7 +375,6 @@ MyTown for FM Towns 3-nensei-you                              Fujitsu           
 MyTown for FM Towns 4-nensei-you                              Fujitsu                           1995/11    CD
 Nandemo Illust Eigo Jiten                                     SofMedia                          1990/6     CD
 Nandemo Illust Eigo Jiten 2                                   SofMedia                          1990/7     CD
-Naru Mahjong                                                  Libido                            1995/4     CD
 Nazonazo Meiro Daibouken: Pyoko-tan no Chie Asobi Ehon        Nanken Koubou                     1991/9     CD
 Nazoraa 1-nen                                                 Infortech                         1993/4     SET(CD+FD)
 Nazoraa 2-nen                                                 Infortech                         1993/4     SET(CD+FD)
@@ -426,7 +416,6 @@ Nihongo Nyuumon Dai-2-kan                                     Infortech         
 Nihongo Nyuumon Dai-3-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-4-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-5-kan                                     Infortech                         1991/4     CD
-Nijiiro Denshoku Musume                                       ISC                               1994/8     CD
 * Nobunaga no Yabou: Sengoku Gun'yuuden                       Koei                              1989/12    SET(CD+FD)
 * Nobunaga no Yabou: Tenshouki                                Koei                              1995/3     SET(CD+FD)
 Nooch: Abakareta Inbou                                        Bombee Bonbon                     1992/11    ?
@@ -446,7 +435,6 @@ Populous 2 Expert                                             Imagineer         
 Powers of Ten                                                 Datt Japan                        1995/10    CD
 Present                                                       Orange House                      1991/6     ?
 Primary Health Care System                                    Raison                            1990/9     CD
-Princess Danger                                               Janis                             1996/4     CD
 Private Slave                                                 Raccoon                           1993/8     SET(CD+FD)
 Psychic Detective Series Vol. 1: Invitation: Kage kara no Shoutaijou (Remake)   Data West                         1993/11    SET(CD+FD)
 Psychic Detective Series Vol. 2: Memories (Remake)            Data West                         1994/4     SET(CD+FD)
@@ -455,7 +443,7 @@ Psychic Detective Series Vol. 4: Orgel (Remake)               Data West         
 Psychic Detective Series Vol. 5: Nightmare (Remake)           Data West                         1995/4     SET(CD+FD)
 Pyoko-tan no Niji no Shima: Nanairo no Ninjin wo Sagase       Nanken Koubou                     1994/3     CD
 Q2 ROM Magazine - Soukangou                                   Disinfectant                      1993/5     CD
-Queen of Duellist Gaiden + Gaiden Alpha                       Agumix                            1994/3     CD
+Queen of Duellist Gaiden + Gaiden Alpha Light                 Agumix                            1994/4     CD
 Quiz de Let's Go!                                             Great                             1993/3     ?
 Rakuraku Sozai Vol. 1                                         Fujitsu                           1995/3     CD
 Reijou Monogatari                                             Inter Heart                       1995/4     CD
@@ -475,9 +463,7 @@ S-DAPS Demo CD [DWDC4922]                                     Data West         
 Saishin American Idiom Jiten                                  Sanshusha                         1990/2     CD
 Saishin Igaku Daijiten CD-ROM                                 Fujitsu                           1990/5     CD
 Saishin Igaku Daijiten Standard-ban CD-ROM                    Fujitsu                           1993/2     CD
-* Samurai Spirits                                             Japan Home Video (JHV)            1995/9     SET(CD+FD)
 * Sangokushi III                                              Koei                              1992/6     SET(CD+FD)
-* Sangokushi IV                                               Koei                              1994/6     SET(CD+FD)
 Sanseido Word Hunter Multi CD-ROM Jiten                       Fujitsu                           1991/10    CD
 School Accessory Illust-hen V1.0                              Fujitsu                           1993/2     CD
 School Navi Nihon no Rekishi CD: Heian, Kamakura              Unitybell                         1995/8     CD
@@ -494,7 +480,6 @@ Seikatsu Simulation: Watashi no Machi                         Gakushuu Kenkyuush
 Seikatsuka 1-nen: Asobou Mitsukeyou                           Uchida Youkou                     1994/4     CD
 Seikatsuka 2-nen: Wakuwaku Tanken                             Uchida Youkou                     1994/5     CD
 Sekai no Ohanashi                                             Gyousei                           1992/5     CD
-* Sensual Angels                                              Japan Home Video (JHV)            1994/1     SET(CD+FD)
 Sexy in the Hawaii: Nice Gal Hawaii Ban                       Birdy Soft                        1994/12    CD
 Sexy PK 2 World Cup Ban                                       Birdy Soft                        1995/6     CD
 Sexy PK World Cup Ban                                         Birdy Soft                        1995/6     CD
@@ -538,7 +523,6 @@ Sunshine 1-nen                                                Uchida Youkou     
 Sunshine 2-nen                                                Uchida Youkou                     1993/7     CD
 Super Kakitaoshi                                              Nikkonren Kikaku                  1993/?     SET(CD+FD)
 Super Zurukamashi                                             Nikkonren Kikaku                  1993/?     SET(CD+FD)
-Tactical Tank Corps DX                                        GAM                               1995/2     SET(CD+FD)
 Taiken Shiyou! Marty Channel 2                                Fujitsu                           1993/6     CD×02
 Takken Ou                                                     Techno Business                   1994/10    CD
 Tamashii no Mon: Dante "Shinkyoku" yori                       Koei                              1993/6     SET(CD+FD)
@@ -549,7 +533,6 @@ Teata -vision- (V1.0-1.3)                                     Nanken Koubou     
 Teitoku no Ketsudan                                           Koei                              1990/4     SET(CD+FD)
 Tender Light Vol. 1                                           Fujitsu                           1994/3     CD
 Tensai Kyuutei Ongaku no Kanade                               Fujitsu                           1992/12    CD
-Tensen Nyannyan                                               Ponytail Soft                     1994/9     CD
 Tenshi-tachi no Gogo 3: Bangai-hen Hanseiban                  JAST                              1993/3     ?
 Tenshi-tachi no Gogo Collection 2                             JAST                              1995/11    CD
 Tenshi-tachi no Gogo V: Nerawareta Tenshi                     JAST                              1992/12    ?
@@ -632,11 +615,8 @@ Wedding Plan                                                  Computer System   
 Wellness Yoga                                                 Fujitsu Personal Computer Systems 1995/4     CD
 Wetpaint Towns                                                Wave Train                        1990/9     CD
 What's a Computer? V1.2 Nyuumon Computer Yougo Kaisetsu       Fujitsu                           1993/7     SET(CD+FD)
-Winning Post                                                  Koei                              1993/5     SET(CD+FD)
 Winter Wonderland                                             Raison                            1990/12    CD
 Woman's Memory                                                Human Interface                   1991/4     CD
-Wonpara Wars                                                  Mink                              1995/2     CD
-Wonpara Wars II                                               Mink                              1995/4     CD
 Yacht & Cruiser System                                        Raison                            1989/11    CD
 Yasashii Chuugokugo                                           SofMedia                          1990/12    CD
 Yellows                                                       Digital Rogue                     1994/12    CD
@@ -1871,6 +1851,38 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Due to a misprint, the floppy disks were physically labeled as "V2.1L11", but their internal version number is V1.2L11 -->
+	<software name="airwar1211" cloneof="airwar21">
+		<!--
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Fujitsu Air Warrior V1.2L11 (Japan) (En,Ja) (Track 1).bin" size="20815200" crc="6b411171" sha1="c8e7b617f68d4f94d264695f0d33415cc0068176"/>
+		<rom name="Fujitsu Air Warrior V1.2L11 (Japan) (En,Ja) (Track 2).bin" size="22226400" crc="d1ca055a" sha1="80959a10c25efae67c38f62bf6710026974f2073"/>
+		<rom name="Fujitsu Air Warrior V1.2L11 (Japan) (En,Ja).cue" size="256" crc="f55960a1" sha1="565036dfc66563ed99be18d06c163569136c5cfd"/>
+		-->
+		<description>Air Warrior V1.2L11</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-0109B"/>
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="FM Towns-you System Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="fujitsu_air_warrior_v1.2l11_fmtowns.hdm" size="1261568" crc="78bdbda9" sha1="295f8c47497f8bb86fbb26cc957c8ddfbb205000" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Marty-you System Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="fujitsu_air_warrior_v1.2l11_marty.hdm" size="1261568" crc="68c7efca" sha1="93c9db6bb8d0dbce9c7a15e86ba0f9fcf46c6c69" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="fujitsu air warrior v1.2l11 (japan) (en,ja)" sha1="d3c67fc7fce2e6a8bb9c3605923bdef4e7293e56" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Missing a floppy disk -->
 	<software name="airwar12" supported="no" cloneof="airwar21">
 		<!--
@@ -1934,7 +1946,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="alice2">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / wiggy2k (floppy)
 		<rom name="Alice no Yakata CD II (Japan) (Track 1).bin" size="73735200" crc="51911d6b" sha1="49621ea47c6cf8be8eb411c12128f96a5a4a656c"/>
 		<rom name="Alice no Yakata CD II (Japan) (Track 2).bin" size="514046064" crc="ff8e6ee1" sha1="6107967a7d9d559cb82379232a0c109f3dce915d"/>
 		<rom name="Alice no Yakata CD II (Japan) (Track 3).bin" size="173913936" crc="e942cb93" sha1="61d8ae5a21cc18da40d5b56e30b9da6e67d37898"/>
@@ -1947,6 +1959,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="アリスの館2" />
 		<info name="release" value="199210xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="alice_no_yakata_2.hdm" size="1261568" crc="1d587e12" sha1="202e99a83a4fd29d3efeb982c806f3670cf7974c" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="alice no yakata cd ii (japan)" sha1="d4224974ab42d6ac9b1dc999e77dd4513005aaae" />
@@ -2925,7 +2943,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="biblemas">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / wiggy2k (floppy)
 		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 1).bin" size="6138720" crc="8e6dc685" sha1="693cbebcc53e11d04d2f8875b00924bd681f906a"/>
 		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 2).bin" size="66919104" crc="874fea90" sha1="f3bdb9dd10fb083c6bcd9c5cd0c40321018886d2"/>
 		<rom name="Bible Master - Crash of the BlleotRutz (Japan) (Track 3).bin" size="3229296" crc="2431323a" sha1="d5f451dddd0430333383a63dc477c65572e082f3"/>
@@ -2944,7 +2962,7 @@ User/save disks that can be created from the game itself are not included.
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="bible master (system disk).hdm" size="1261568" crc="f264d93e" sha1="b7939c12ab503fcddb1ad828e7c546cf21987b0c" offset="000000" />
+				<rom name="bible master (system disk).hdm" size="1261568" crc="6c6415bc" sha1="8338b813203ba455285334a127f938f2f56de672" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -3266,11 +3284,14 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="bublbobl">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Bubble Bobble.ccd" size="1706" crc="77649d33" sha1="8fa449d3a1fddc19d921e46ca7eaff6cbd0b11d6"/>
-		<rom name="Bubble Bobble.cue" size="272" crc="b70b3fda" sha1="31442377e23ffdc857c7310f4cc86a97cc41b9c1"/>
-		<rom name="Bubble Bobble.img" size="165251520" crc="032401b8" sha1="3838dac8a169ea134d8cd1dd9e97171455f00239"/>
-		<rom name="Bubble Bobble.sub" size="6744960" crc="6b14e001" sha1="43b5ece3c5436dcf6a8b13d2c3596486bef235fa"/>
+		Origin: redump.org
+		<rom name="Bubble Bobble (Japan) (Track 1).bin" size="10231200" crc="d46e2266" sha1="4429f72e2df37d5023b981537dc284368809d28a"/>
+		<rom name="Bubble Bobble (Japan) (Track 2).bin" size="6597360" crc="cbbdf9c6" sha1="7bce4849f42e44188dbfefe7e080a72f951f5dc0"/>
+		<rom name="Bubble Bobble (Japan) (Track 3).bin" size="20191920" crc="7fa71ce7" sha1="ab25d80a6e535631d2ab26dfdd5ec8f7f2631ba3"/>
+		<rom name="Bubble Bobble (Japan) (Track 4).bin" size="47922000" crc="75493687" sha1="6526a13ddad1c94b7a49ebc258223f0cdc73d8fb"/>
+		<rom name="Bubble Bobble (Japan) (Track 5).bin" size="29423520" crc="d518698c" sha1="5dcedb22ad1c3b67db4f7a69f95eb65557050edd"/>
+		<rom name="Bubble Bobble (Japan) (Track 6).bin" size="50885520" crc="6195036d" sha1="9fe5b8c75ebb7dbebfee4da232e39a46c0b88b91"/>
+		<rom name="Bubble Bobble (Japan).cue" size="672" crc="b7f599e9" sha1="7b0e3be3a0bb80579969972e3ffa2d0503c69f64"/>
 		-->
 		<description>Bubble Bobble</description>
 		<year>1990</year>
@@ -3281,7 +3302,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="bubble bobble" sha1="6832299e67d17aca22d0ec2265b78d6e42336e30" />
+				<disk name="bubble bobble (japan)" sha1="fa749f0cc3d0fa9e4946b5dce2a6b62a5bebeba6" />
 			</diskarea>
 		</part>
 	</software>
@@ -3652,7 +3673,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Works only on the 386SX-based models (Marty & UX). Probably an emulation bug, but it needs to be confirmed on real hardware. -->
+	<!-- Works only on the FM Towns Marty. Probably an emulation bug (the Marty didn't even exist in 1991), but it needs to be confirmed on real hardware. -->
 	<software name="chasehqd" supported="partial">
 		<!--
 		Origin: redump.org
@@ -3839,6 +3860,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="crayonag" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Crayonnage (Japan).bin" size="16758000" crc="cb51cda4" sha1="1c0b6918600de38d3dae32faff2e60aba719aebc"/>
+		<rom name="Crayonnage (Japan).cue" size="107" crc="27dfbe15" sha1="ab02af69fad40c9904f47283d384a75a73ab6b5e"/>
+		-->
+		<description>Crayonnage</description>
+		<year>1991</year>
+		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-203"/>
+		<info name="alt_title" value="クレヨナージュ" />
+		<info name="release" value="199108xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="crayonnage (japan)" sha1="3a689ef44a3b308e80d963a52a40b36c01b3f63d" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="criss">
 		<!--
 		Origin: redump.org
@@ -3857,9 +3898,10 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- The CD is self-bootable, but the floppy disk contains an updated version of the executable file -->
 	<software name="crystalr">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cherokee (floppy)
 		<rom name="Crystal Rinal - Ouma no Meikyuu (Japan) (Track 01).bin" size="155387232" crc="e9d753bb" sha1="95760fd81e87c248119294e34a8c8c474e59cc85"/>
 		<rom name="Crystal Rinal - Ouma no Meikyuu (Japan) (Track 02).bin" size="32634000" crc="f8dd74fa" sha1="40208e1a19f20d571ee8f9aa4daf89383254b419"/>
 		<rom name="Crystal Rinal - Ouma no Meikyuu (Japan) (Track 03).bin" size="19756800" crc="a5bf0924" sha1="3e21eb540c8f6c59eb3e15ee251b2c21d8e27ba3"/>
@@ -3888,6 +3930,11 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="クリスタルリナール －逢魔の迷宮－" />
 		<info name="release" value="199408xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="crystal_rinal.hdm" size="1261568" crc="c1ce9e3e" sha1="33a14ab80dcbb22d1c55ce7886aff91f089b92d2" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="crystal rinal - ouma no meikyuu (japan)" sha1="4e5d63dff3da55ca2137c1388b332c56a648bad4" />
@@ -4824,10 +4871,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="dokivact" supported="no">
+	<software name="dokivact">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / wiggy2k (floppy)
 		<rom name="Doki Doki Vacation - Kirameku Kisetsu no Naka de (Japan) (Track 01).bin" size="20815200" crc="c3adc522" sha1="b525f593242ec3b938898b71632ef772b06d4479"/>
 		<rom name="Doki Doki Vacation - Kirameku Kisetsu no Naka de (Japan) (Track 02).bin" size="38808000" crc="531ccb78" sha1="0c53ada3b630fede7fb58ab578fc71ef85210ce6"/>
 		<rom name="Doki Doki Vacation - Kirameku Kisetsu no Naka de (Japan) (Track 03).bin" size="35809200" crc="fc73593f" sha1="47e412d4ade866654cd962f8cd3e0b67ecdd4542"/>
@@ -4849,6 +4895,12 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>カクテル・ソフト (Cocktail Soft)</publisher>
 		<info name="serial" value="HMG-109 / IDES-030"/>
 		<info name="alt_title" value="Ｄｏｋｉ　Ｄｏｋｉ　バケーション　～きらめく季節の中で～" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="doki_doki_vacation_disk_a.hdm" size="1261568" crc="4ac3ba75" sha1="21996fd03ddf22159a7552f99fd622c251d2a935" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="doki doki vacation - kirameku kisetsu no naka de (japan)" sha1="d6d454e713b10c3f8ab8076a4fde4ededfc2cdbf" />
@@ -5132,11 +5184,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="drgnflam">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="AD&amp;D Dragons of Flame.ccd" size="3425" crc="5f83ae7c" sha1="a0798177f037f9d914bb44d272b724d53f1a95a9"/>
-		<rom name="AD&amp;D Dragons of Flame.cue" size="637" crc="0b598265" sha1="e2615041bf52504c62a1c3b73cc22eb2f8e62676"/>
-		<rom name="AD&amp;D Dragons of Flame.img" size="296787120" crc="ee6a5f5c" sha1="c2d2033ee6a1977d3a7a92e15a1e92e5b35248c0"/>
-		<rom name="AD&amp;D Dragons of Flame.sub" size="12113760" crc="6e6729b6" sha1="623322ad86a5a0ef51b0c59eee9716c28561defb"/>
+		Origin: redump.org
+		<rom name="Dragons of Flame (Japan) (Track 01).bin" size="52214400" crc="c55fcca4" sha1="d229a9ba95fb8d5b592d0b44388cd83872c6a157"/>
+		<rom name="Dragons of Flame (Japan) (Track 02).bin" size="3575040" crc="e6499c30" sha1="40a394d87042663d0d76cf322d8781e812a2d70b"/>
+		<rom name="Dragons of Flame (Japan) (Track 03).bin" size="13636896" crc="56910f61" sha1="8b5bfb89f411c9795dda4e4d8b464f47414f2784"/>
+		<rom name="Dragons of Flame (Japan) (Track 04).bin" size="11176704" crc="2305d2f8" sha1="147503d638f8f172e86d763787a691e28d61d5eb"/>
+		<rom name="Dragons of Flame (Japan) (Track 05).bin" size="19909680" crc="ef6e9da0" sha1="ef9fdc0b1923827f7666471232a2d993dfdd4e19"/>
+		<rom name="Dragons of Flame (Japan) (Track 06).bin" size="22191120" crc="887d60d4" sha1="d406d8f00fc123842df60bfd8c269b296d18bf80"/>
+		<rom name="Dragons of Flame (Japan) (Track 08).bin" size="10678080" crc="c903e242" sha1="5fc9c7adebac913e67075c16f999efba751d8ea0"/>
+		<rom name="Dragons of Flame (Japan) (Track 09).bin" size="17722320" crc="03c15625" sha1="0900bcd8cdb6fed3737e5855b0f9302cbd839dcc"/>
+		<rom name="Dragons of Flame (Japan) (Track 10).bin" size="27330240" crc="0c020db7" sha1="56d677214182202dbfb2cc982e3d09610b17cf01"/>
+		<rom name="Dragons of Flame (Japan) (Track 11).bin" size="15193920" crc="836170bb" sha1="7b39729fd07fcacf80849ea66c00bb5d467b06ee"/>
+		<rom name="Dragons of Flame (Japan) (Track 12).bin" size="18357360" crc="2864ec29" sha1="5ea0c9c00a2d1e7001a711126e4925a05f10cdb3"/>
+		<rom name="Dragons of Flame (Japan) (Track 13).bin" size="20528256" crc="21acf860" sha1="77670f7126b6901c7b1ee69cab765964a33aa50e"/>
+		<rom name="Dragons of Flame (Japan) (Track 14).bin" size="23990400" crc="9888f973" sha1="8d7458381deceb812d6a10690fbec12e691970f9"/>
+		<rom name="Dragons of Flame (Japan) (Track 15).bin" size="19702704" crc="3bc9f46b" sha1="0e5d2c7a9afbf03c211d014d8daa676ec8a06223"/>
+		<rom name="Dragons of Flame (Japan).cue" size="1767" crc="7e003f93" sha1="04286683d48e6634f819e3b050f56f30a9c0817d"/>
 		-->
 		<description>Dragons of Flame</description>
 		<year>1992</year>
@@ -5147,7 +5210,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ad&amp;d dragons of flame" sha1="0e0fed376b4882c338e9d4510b377c8f9318df67" />
+				<disk name="dragons of flame (japan)" sha1="503ff24e5edd5979e1e12eb402efa2c103d25e9a" />
 			</diskarea>
 		</part>
 	</software>
@@ -5708,6 +5771,31 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="emit1d">
+		<!--
+		Origin: redump.org
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 1).bin" size="10233552" crc="7bed86c9" sha1="3da47725fec989c1754044d94d9d15c6501c03d8"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 2).bin" size="28927248" crc="8ff55a69" sha1="64411dedf1e20f24e231fceb2f9b1f6f30726b57"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 3).bin" size="9349200" crc="7f075b18" sha1="78e76829c525a00be43c6c3075173c11c4c642b4"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 4).bin" size="2998800" crc="6968e464" sha1="715c8849aff6a33377723c5e0b5fb18b50bd8f1b"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 5).bin" size="2998800" crc="5be2ebe8" sha1="ee74a2c6c6099879c67b5d731013c4c4e4efcec3"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 6).bin" size="3704400" crc="75d392f6" sha1="576c6936122cf9c77ed94a45f73d148f00d652b2"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo) (Track 7).bin" size="62269200" crc="1bdbcafa" sha1="104742a4bc47f683d5e8e44d698df25edbc0a961"/>
+		<rom name="Emit Vol. 1 - Toki no Maigo (Japan) (Demo).cue" size="957" crc="c09f4a83" sha1="d5c8a291bc367a611a9bb12af7416ec2a2ea5578"/>
+		-->
+		<description>Emit Vol. 1 - Toki no Maigo (Demo)</description>
+		<year>1994</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMF-904"/>
+		<info name="alt_title" value="エミット Vol. 1 時の迷子" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="emit vol. 1 - toki no maigo (japan) (demo)" sha1="e7613bfaee8c5fb76427a89e1d21d243949d22ee" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="emit2">
 		<!--
 		Origin: redump.org
@@ -5808,6 +5896,52 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="l'empereur (japan)" sha1="6fd271652eae89b4879a468319cfee2f19ef5216" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="engerrnd">
+		<!--
+		Origin: redump.org
+		<rom name="Engage Errands - Miwaku no Shito-tachi (Japan).bin" size="11830560" crc="9b67dee3" sha1="8444dd607590423db9c13012d279b3896585447e"/>
+		<rom name="Engage Errands - Miwaku no Shito-tachi (Japan).cue" size="135" crc="fb2c3e0f" sha1="6b3df2776a482c76ee3b9f55744ac1a847c5040d"/>
+		-->
+		<description>Engage Errands - Miwaku no Shito-tachi</description>
+		<year>1995</year>
+		<publisher>ポニーテールソフト (Ponytail Soft)</publisher>
+		<info name="serial" value="MTC-1126"/>
+		<info name="alt_title" value="エンゲージ・エランス　～魅惑の使徒たち～" />
+		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="engage errands - miwaku no shito-tachi (japan)" sha1="bb0414297d57a64167a398bbc22a3ad833a71d4d" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- The CD is self-bootable, but the floppy disk contains an updated version of the executable file -->
+	<software name="engerrn2">
+		<!--
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Engage Errands II - Kouki o Ninau Mono (Japan).bin" size="19004160" crc="7a60ea81" sha1="67232291a1f1f7b3fcc5b501dab2f068354c8eec"/>
+		<rom name="Engage Errands II - Kouki o Ninau Mono (Japan).cue" size="135" crc="faf6336b" sha1="ad9755086ca732408f17df7aacaa84085d39ed6a"/>
+		-->
+		<description>Engage Errands II - Hikari o Ninau Mono</description>
+		<year>1995</year>
+		<publisher>ポニーテールソフト (Ponytail Soft)</publisher>
+		<info name="alt_title" value="エンゲージ・エランスⅡ　～光輝を担うもの～" /> <!-- ひかり is written in furigana above 光輝 -->
+		<info name="release" value="199505xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="修正ディスク / Shuusei Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="engage_errands_2.hdm" size="1261568" crc="be2392d0" sha1="b78c26c423cf98bf35b84ba5a1c9b26228ab8306" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="engage errands ii - kouki o ninau mono (japan)" sha1="27e608f9663dd7afdf10cb7a35eb277d7c31b7a5" />
 			</diskarea>
 		</part>
 	</software>
@@ -6190,16 +6324,83 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="excd94s">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Exciting CD &apos;94 Summer (Disc 1).ccd" size="5479" crc="a51fb439" sha1="957993172f60a86a9bcd481fbda9efd348c0ba1b"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 1).cue" size="2033" crc="8de56a87" sha1="6f3b558517e470d4c4e19ff4c6375a17146f75cc"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 1).img" size="691664400" crc="1771c174" sha1="499249e9985b25e5b2b02d07643dc55ca5c4baa7"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 1).sub" size="28231200" crc="b0e6ecb7" sha1="caca6c04dd591723e5bf2755450d1afcc2d447e1"/>
-
-		<rom name="Exciting CD &apos;94 Summer (Disc 2).ccd" size="7406" crc="03a62802" sha1="5cc0465062b55d7568e0cf9ccfc4b4c46a562970"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 2).cue" size="2801" crc="f63873f3" sha1="1eba13d1e7aae0b6689f91d26380a6490c28c881"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 2).img" size="648606336" crc="0a827aa5" sha1="740b481174dd408848930a920fa6a3c5e0750649"/>
-		<rom name="Exciting CD &apos;94 Summer (Disc 2).sub" size="26473728" crc="5a4cfd35" sha1="beecfc8b991f2d5d03316beb18ac85765904f511"/>
+		Origin: redump.org
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 01).bin" size="189630000" crc="2a7a2dae" sha1="de1a6c5950fec3ad9dcc8c324cb60813e72c7910"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 02).bin" size="1764000" crc="411bc78f" sha1="3ec3c5083a82c957c7776beddfdf43d83b3d690c"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 03).bin" size="1764000" crc="d66de7c1" sha1="370f93115884acbc268ccb461eac6cf3bc1fc2d6"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 04).bin" size="8467200" crc="92a24578" sha1="68f65c4ceefc714314e0a8b3af342e7cdc84158d"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 05).bin" size="17287200" crc="42dba316" sha1="7f8b11cf17e7eb36fb727367e2682e1432baf21d"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 06).bin" size="7408800" crc="83b3b09f" sha1="2696372db7e2f0b2806bd5258f6e8168a41dbad4"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 07).bin" size="21344400" crc="d4289071" sha1="b057610a423a8dd8d959abf72d1d4016ba4aa08c"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 08).bin" size="10584000" crc="96b51b7b" sha1="dc08f3f200b48a036d82edfac2817b85e9e29a3b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 09).bin" size="20286000" crc="971983b9" sha1="0e29841d0bb4367ba8b7e65b4e37db1997a313c9"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 10).bin" size="14288400" crc="e657eb7f" sha1="b243793b0bc28d06a2f928d3694807e345e3fdc5"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 11).bin" size="1764000" crc="e7887563" sha1="923937048d6b3fe908cbe4115a099a3b7a195d0b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 12).bin" size="1764000" crc="e7887563" sha1="923937048d6b3fe908cbe4115a099a3b7a195d0b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 13).bin" size="1764000" crc="e7887563" sha1="923937048d6b3fe908cbe4115a099a3b7a195d0b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 14).bin" size="1764000" crc="e7887563" sha1="923937048d6b3fe908cbe4115a099a3b7a195d0b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 15).bin" size="21873600" crc="567b035d" sha1="6d947e0beabc4a135eb4f01e8e485d8f6a6a15a2"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 16).bin" size="17287200" crc="2f1c9b2e" sha1="afd9b1d66156da3e48a1e98c1776bf829fc76dc6"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 17).bin" size="15170400" crc="974cbd14" sha1="574183cddddc6df77d734e4082073ba566070292"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 18).bin" size="22755600" crc="c558458d" sha1="00fe204432c80d972e5e88b4140fc714ca1b95ab"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 19).bin" size="7585200" crc="486c2985" sha1="bd4d60998afe6325dfadf27c0f51ab979344f67d"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 20).bin" size="10407600" crc="a655832d" sha1="52c19b7cae9aa3f6cc9f6eb2759df593f56efbd8"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 21).bin" size="16758000" crc="e910104d" sha1="5f83cf0f7f13958b6b6391e7f555f3eef601f3c9"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 22).bin" size="21168000" crc="c65f1a2c" sha1="c9d009dfe9bf080a450fe921563c459c4499f96f"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 23).bin" size="21344400" crc="bbb80f27" sha1="dbe8df76c2c01036d5a398cfc1729a375278f440"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 24).bin" size="21873600" crc="7ccc762f" sha1="26f37f847e7f422c6c60b12f16d6f049ba6ee85f"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 25).bin" size="10936800" crc="d786ed68" sha1="ea3b156235b3554b5d522054f83c811a3fc3188e"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 26).bin" size="47980800" crc="efeafc15" sha1="72834dde37f2421234ba5cb2bfc5e6c0f096c1a8"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 27).bin" size="63680400" crc="e85fa906" sha1="3dcfab8ecb5683a9bb86781ee60ecb6f6ac67582"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 28).bin" size="8932896" crc="4560b76c" sha1="a1f58a3c3ab1728155dc82ed7bb7c67cee110708"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 29).bin" size="16475760" crc="54bd67c2" sha1="09149ee46baeea70a8cd08c12c30fbd663f75d15"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 30).bin" size="15610224" crc="49ccd42a" sha1="98a6597020109e5925b59a1f96ca49f0593f51c0"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1) (Track 31).bin" size="51943920" crc="1309e890" sha1="96ce4349e3fcf15990e60007e87721bba2bdf263"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 1).cue" size="4136" crc="a9bc5c7e" sha1="c59c296ac1cafdfa129d4fca681c2e20f17fd11c"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 01).bin" size="253834896" crc="41576a4b" sha1="890d9106e104c507b707aad9d3a0605cf0d5a50c"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 02).bin" size="3904320" crc="5f9a4e58" sha1="21df976c1b49439fd08c7de17bee773869882fa0"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 03).bin" size="7408800" crc="d51db24b" sha1="b794909355cc33d3b00eb18b556de9755fed01c4"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 04).bin" size="1357104" crc="d9c72c0c" sha1="3d171ebbe062e6b628de94758025869bbb54ce1b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 05).bin" size="18870096" crc="a4e7a4b8" sha1="d5f43df22f4526deebc45bbd04ddb58c772f06ad"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 06).bin" size="18863040" crc="3dadf234" sha1="585bc2b2f2e85ed443706907d37ff461f03735ad"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 07).bin" size="1357104" crc="ad01b7c5" sha1="bb857c745c4a25bb467f8fe926f5ad192b07225d"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 08).bin" size="1364160" crc="7863fc1c" sha1="1586628f8b1ec1f26c470b164a137274f91764c2"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 09).bin" size="1364160" crc="50341964" sha1="7cc55364718f4c079d61acf458f4bf16bc8f0d67"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 10).bin" size="1359456" crc="0604867d" sha1="c492f74ff58e745b2750a7fdeed0c3dcb0e427e0"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 11).bin" size="1364160" crc="1e7301c7" sha1="1a8885c1136e997ac56514e94ee50ca031280e8d"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 12).bin" size="1357104" crc="065d8c7a" sha1="6376d9faad0e41aa53dfbe31200743528abfeb36"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 13).bin" size="1364160" crc="c92aee3a" sha1="945cf4031c575dbe2f8b5c06ba04cd785bbde6b0"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 14).bin" size="1364160" crc="be94c300" sha1="0abaacee38cb13038e23d86ea31917a18d2d3f91"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 15).bin" size="28572096" crc="158944fe" sha1="228427cd1042dfdb3081608939ab9743cc5fb3c0"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 16).bin" size="1357104" crc="00a222ed" sha1="4de5391551987e2d2ffd4e13b69f21c8c1e08a84"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 17).bin" size="1364160" crc="f32ae4cd" sha1="e23eadeebf638432f4a21b86b5dce135c56dc1ef"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 18).bin" size="1364160" crc="156ac019" sha1="9575db5a0960dced79619a8dae42d8119bd5e275"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 19).bin" size="1359456" crc="e8805d6c" sha1="8d1015696c16be0f3a0c63d32d0e5ca2d3c38eaf"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 20).bin" size="1364160" crc="6b502423" sha1="6e11037e9bdfa859414328da4f4d2e036d8940a3"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 21).bin" size="1357104" crc="ea7e43db" sha1="83f220e627aa91d7d713d062ca4407caa9051d62"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 22).bin" size="1364160" crc="a1f56d9f" sha1="aa1580c4c4aba484d1de3a0ae8087d5b51f1bedc"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 23).bin" size="1364160" crc="3b9b0864" sha1="a8d3a1b1f3714e35ae9d9535614d682c6fd8c861"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 24).bin" size="1164240" crc="2463f630" sha1="cb6f7d703440feec4b6710f81716c3cf75944ab9"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 25).bin" size="1171296" crc="7fed2e61" sha1="1c5a4fbc6fc2fdcf7daf2ca9b37bf20806120148"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 26).bin" size="1168944" crc="4eedc57f" sha1="fa89c51c35211ab007b2f4bb46044bea269e445b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 27).bin" size="1512336" crc="4b8c1f63" sha1="e738fb2dc6584d1e773d8763fb2676f01b3202d7"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 28).bin" size="1168944" crc="3d8e4296" sha1="9df1726d3da2470168dcbaaaf3e9fa77c735112a"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 29).bin" size="1164240" crc="51a34782" sha1="ade32139cb4b60e24af9bf00172d61efbce1f59b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 30).bin" size="1171296" crc="d8bd2464" sha1="2761889f2d4c4cdb0c4ce085891e31e312185d8a"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 31).bin" size="34684944" crc="fa2c7663" sha1="cc49e83b83f059cddcc72f7fab4dd60aa6340a9b"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 32).bin" size="43542576" crc="d1b8bee9" sha1="b09d64a3bed4d45954eab77873d07b70ea9c6e1c"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 33).bin" size="1415904" crc="f6d0396b" sha1="4c38a9ec23f3804041211cfefb147915402200be"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 34).bin" size="1587600" crc="0133b29a" sha1="400b376820040a8737674b1078fd6127ad79b2e1"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 35).bin" size="1587600" crc="0133b29a" sha1="400b376820040a8737674b1078fd6127ad79b2e1"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 36).bin" size="8820000" crc="24b02850" sha1="fa3221930c2e17cb3cdb40d030fc0443a9528dac"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 37).bin" size="70383600" crc="6c230326" sha1="aa46d77a4dbb4e546b00b8c5da171a2cd6b81ce6"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 38).bin" size="12348000" crc="e31a5e7a" sha1="aa83672faa1147df386aad6ab2526f1a1aa42928"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 39).bin" size="40219200" crc="67c9f133" sha1="f9b98a36556747374c45116cf99fa8d0089abdd1"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 40).bin" size="12877200" crc="2212c58d" sha1="81f3bf0465db6d8861bbce671e84b9bc39c63443"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 41).bin" size="2123856" crc="791f1cf7" sha1="608801180a2d8ab187845c6652ee533a3e51a479"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 42).bin" size="4743984" crc="f57668a3" sha1="e15fe168f3e697c715693325ff0439f40e0bb60e"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2) (Track 43).bin" size="51151296" crc="f50abe3b" sha1="33dc46fd0927d4aec3a5d47d2760d893ac690499"/>
+		<rom name="Exciting CD '94 Summer (Japan) (Disc 2).cue" size="5744" crc="43260fbc" sha1="6865b7e67a2e0d89fa09da95e780ddb97ffdbef1"/>
 		-->
 		<description>Exciting CD '94 Summer</description>
 		<year>1994</year>
@@ -6208,12 +6409,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="exciting cd '94 summer (disc 1)" sha1="267497e6ea4ee286e702d5525f141585bdef0f7f" />
+				<disk name="exciting cd '94 summer (japan) (disc 1)" sha1="029b2743d0b9abdb0c6657c1dfd817b00ed54f82" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="exciting cd '94 summer (disc 2)" sha1="5b00b3a5d1134ec82fbfab4bc107aa5b708b33ea" />
+				<disk name="exciting cd '94 summer (japan) (disc 2)" sha1="88c91991075e6897102e80ea53186700a67c5959" />
 			</diskarea>
 		</part>
 	</software>
@@ -7089,18 +7290,28 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Works only on the 386SX-based models (Marty & UX). Probably an emulation bug, but it needs to be confirmed on real hardware. -->
 	<software name="funnybee">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Uchuu Kaitou Funny Bee.ccd" size="2647" crc="864414f0" sha1="7086713452aeb61b31ff7efa5b8cc7b58652e82e"/>
-		<rom name="Uchuu Kaitou Funny Bee.cue" size="872" crc="0a714915" sha1="6ad59ff897fd70e9ac77799881f5706c59d50f81"/>
-		<rom name="Uchuu Kaitou Funny Bee.img" size="537577824" crc="30449030" sha1="5a0f7d90aa6f72e1052db350116ef2b3de0fc768"/>
-		<rom name="Uchuu Kaitou Funny Bee.sub" size="21941952" crc="cc407142" sha1="3e59fb03d94d96576676afaa6e5e2d0da845aacb"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 01).bin" size="12223344" crc="bb663ea8" sha1="3576a56d4613bf2194d5d4e954c40ff6bec93e8d"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 02).bin" size="42900480" crc="9aaf94e8" sha1="9442989734a67eced4c344d7f02ce35ae75c7f4a"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 03).bin" size="43758960" crc="c633d2ea" sha1="fa35bfed08ad45187710c7aace2078834ad54e9a"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 04).bin" size="53402160" crc="93e8d405" sha1="1517db9e77ef2a6f0f7e293b7fe65e71885ae94d"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 05).bin" size="48498240" crc="75043e46" sha1="eae6d54945e01bb8fe1c40ac35f274e28532517c"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 06).bin" size="43664880" crc="1c68fd3f" sha1="74ffd2c58fb1ce23a9ee22d5920e06c9acc790bd"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 07).bin" size="42959280" crc="bbf17522" sha1="c86c47e632b740ea4b07da2b69be82c33f7ebce4"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 08).bin" size="45769920" crc="5412b2fc" sha1="1029ada98e00ec490631acdd7ba0682340ce7e9b"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 09).bin" size="46428480" crc="1d62a3ca" sha1="9cedfd498b71233e74c7d43a2b9149d17600c717"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 10).bin" size="56313936" crc="234c18fa" sha1="bbc9c565d1fcb9f63547db27594d9e03f027b41e"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 11).bin" size="68113920" crc="7c31b730" sha1="11b9ecbd2364689a8f085902d279e2cbfb896779"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 12).bin" size="16010064" crc="0ecbd527" sha1="2a7d4846d6e11abe754e8ae0da206a4a30adb901"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan) (Track 13).bin" size="17534160" crc="de32cd71" sha1="081176f415d4ecd81436213617efca6afd94e7b8"/>
+		<rom name="Uchuu Kaitou Funny Bee (Japan).cue" size="1607" crc="8cb1c1ef" sha1="f0265ac3bf49b39a241e4480c8963e967447d522"/>
 		-->
 		<description>Uchuu Kaitou Funny Bee</description>
 		<year>1994</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="ALS-0008"/>
 		<info name="alt_title" value="宇宙怪盗ファニービー" />
 		<info name="release" value="199409xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -7110,7 +7321,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="uchuu kaitou funny bee" sha1="da9c5874aaeccbf120ab9593a63a7aa1f87b4b27" />
+				<disk name="uchuu kaitou funny bee (japan)" sha1="6ea67120a66e1153f648fab8008d3a14fe7de5a0" />
 			</diskarea>
 		</part>
 	</software>
@@ -7451,19 +7662,43 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="gametec2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Game Technopolis Super Collection 2.bin" size="681082752" crc="5fddd52a" sha1="b85ef1c3f348d449616c4548069bcd64af0d9b9d"/>
-		<rom name="Game Technopolis Super Collection 2.cue" size="1106" crc="c14df5b5" sha1="59bc42f86f80b4e7736d7a15637c7d5b6f5cf755"/>
+		Origin: redump.org
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 01).bin" size="31399200" crc="2cd547fb" sha1="e1dd27ed0d44f0dc0eb3f7ca58ec22938a99239b"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 02).bin" size="38810352" crc="974e47cf" sha1="6508c726750d30d09a79e82281c3fb3b2577c677"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 03).bin" size="34927200" crc="ba3502f5" sha1="107d6f97ebf10410137c8cab93d18c91016c2c6d"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 04).bin" size="17816400" crc="a803006d" sha1="4de9e7061a8bfc76b8a01cbebf4769044c39208f"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 05).bin" size="21520800" crc="61ec86f3" sha1="d70a1a1393560efce37ae018ea267417f74a4b3c"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 06).bin" size="23814000" crc="2634c094" sha1="99a04c7248a28385b48bc6e4340c0265181cc2c4"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 07).bin" size="20991600" crc="1cf06303" sha1="83fb55e2b3955a8638b2ed1c96a44d44ebbb52bb"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 08).bin" size="26460000" crc="13528b38" sha1="83fcd45f1afcf0e516d4a1c9ebd91d1f5a341724"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 09).bin" size="27342000" crc="eddbb0b2" sha1="64eb0892816b17d0ca178fc293cec78f39f7cdcf"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 10).bin" size="20815200" crc="d8d26f16" sha1="b61aa4e074b9bd1ec92b9ca6a669784004869c4a"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 11).bin" size="35103600" crc="4fb36857" sha1="99df39dc2ac6e6171af883f5127bf66ec5dfbd92"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 12).bin" size="39337200" crc="8bd0617d" sha1="248f9214045affe00245aaa531e25e415b717786"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 13).bin" size="18169200" crc="91bcc187" sha1="b481c2b50af8f2410a9aa1d7dc8b039b78b5feb5"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 14).bin" size="18874800" crc="4968eac9" sha1="8ccb770729e7244e2d525cd4f99da1d646d16952"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 15).bin" size="13406400" crc="b46af4ba" sha1="cdfbf28744449b8ad851bb94c4e2d51275be88bf"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 16).bin" size="9702000" crc="3737abe8" sha1="388fa9590be478a6d9fbf95475116d05d24cefa4"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 17).bin" size="12524400" crc="c9a51f93" sha1="84c0e92cdd7dc5ee2abbba8176deb777b1422194"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 18).bin" size="14994000" crc="d9c11456" sha1="73d3d83ba2251db6a0780c673d7c505fd4f015dc"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 19).bin" size="9702000" crc="e4223e75" sha1="a5f3e5c8fe5ab15415c87617c5c7b2be2f96f7fa"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 20).bin" size="15523200" crc="1c8fa3a5" sha1="fb7751da34c4c48659a6bb572968a43ee737e732"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 21).bin" size="12877200" crc="d6efdb40" sha1="9a20cb8ccf7087df7960aeb3c0eab80f6e257ba9"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 22).bin" size="9702000" crc="1dd3b65a" sha1="540f4f2e528dcaa85291c5080e333bf8f3e8fd6f"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 23).bin" size="17992800" crc="219ea0d3" sha1="87af8d2d13869a07bb123f13ced3c18e476b50f2"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 24).bin" size="38808000" crc="26273d37" sha1="00450c07f509884c2a0a4d66a9b6d2a91a89808e"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan) (Track 25).bin" size="150822000" crc="3eb9643a" sha1="f4f5f09e20e8d14180c90a745191cb970dd84c1a"/>
+		<rom name="Super Collection 2 - Game Technopolis (IV - Tesera &amp; Hatsukoi Monogatari +) (Japan).cue" size="4455" crc="77dca0f4" sha1="63886889430a22299ccd7430fc4807a5e99af060"/>
 		-->
 		<description>Game Technopolis Super Collection 2</description>
 		<year>1993</year>
 		<publisher>徳間書店インターメディア (Tokuma Shoten Intermedia)</publisher>
-		<info name="serial" value="HME-184"/>
+		<info name="serial" value="HME-184 / FMSC0020"/>
 		<info name="alt_title" value="GAMEテクノポリス スーパーコレクション2" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="game technopolis super collection 2" sha1="71e1cb211ed1055086162de74fd265498a986546" />
+				<disk name="super collection 2 - game technopolis (iv - tesera &amp; hatsukoi monogatari +) (japan)" sha1="67df75ed63d50d428ea0ca844ac68c9ee98a06b2" />
 			</diskarea>
 		</part>
 	</software>
@@ -8291,11 +8526,24 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="heartron">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Heart de Ron!!.ccd" size="3628" crc="a428fd6e" sha1="204ffda9db3f38f27bfc8e344adf8fc4674ccf5e"/>
-		<rom name="Heart de Ron!!.cue" size="670" crc="f899c966" sha1="17156fe0adbffeae8e3f8cc2a3f74ce69fe4f72f"/>
-		<rom name="Heart de Ron!!.img" size="439953360" crc="ed1e3f58" sha1="746444998a41a1d722b09a6cecd0097a1c909cdb"/>
-		<rom name="Heart de Ron!!.sub" size="17957280" crc="5de2c580" sha1="84abf50f739bb620c2171029e5564aa6210ec7f9"/>
+		Origin: redump.org
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 01).bin" size="35625744" crc="00debf8b" sha1="10b1709bc44f6ee24497ffd6573bad335a93cc3a"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 02).bin" size="4852176" crc="4dde7b2a" sha1="be37cff09dfedf3ef4f2ab62378a10d331cd21a3"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 03).bin" size="17823456" crc="333c23b2" sha1="6e195f6ff0591efc1247bb258b2bb19bf08fa76f"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 04).bin" size="38982048" crc="94cdaab1" sha1="2b4bf7579a8599c750c17c2e8c283f4b4b89932f"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 05).bin" size="35797440" crc="d34deb1b" sha1="cba788feb8170ce331a8a1516cf42097ee8096e3"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 06).bin" size="31864896" crc="d1d2e3f4" sha1="3b206921798a2ed694e7a8895471e297a5fd66c0"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 07).bin" size="22393392" crc="4f5bcb93" sha1="3d5e759fc8ee6035b73e5c94801bcc5a2d213f44"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 08).bin" size="25942560" crc="9a128c4f" sha1="115201742cff122b5339807dad0b2c486a6da1bd"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 09).bin" size="40285056" crc="7b76c46b" sha1="5df7d3d521a0f92e4d7bb24d4c257d863b2cd4d5"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 10).bin" size="36893472" crc="22d83ae1" sha1="85e2b5fcd81d20c4f887e93c8a8c5272ce33053a"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 11).bin" size="29545824" crc="52d11511" sha1="09b7ba7ee418126cf290e36843068fe9745e002d"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 12).bin" size="15509088" crc="ae036e4e" sha1="5247506efc5505d94f9e97ebe2121f29d2e33566"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 13).bin" size="19650960" crc="aa8064e0" sha1="68efcb7e8eb5ec66d77b9b9ebd576e265a437c18"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 14).bin" size="36794688" crc="53a3f442" sha1="8f6fbf14fb2f28bf659eb2b2ec8373b962cdc752"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 15).bin" size="22753248" crc="3d87f13e" sha1="647679bff12271140d65f995eb36c77dc7be1da0"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan) (Track 16).bin" size="25239312" crc="b2c1a6fa" sha1="ad4731cfa9c74050495e97a9bb59f78277d05092"/>
+		<rom name="Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!! (Japan).cue" size="2268" crc="a8a47b53" sha1="8b3012d9b6f1ab953f698d68c8bf7c2cb87e8c87"/>
 		-->
 		<description>Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!!</description>
 		<year>1995</year>
@@ -8305,7 +8553,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="heart de ron" sha1="1c95cf153e055068b71f8fd6fffe760d1ddd2ac0" />
+				<disk name="zen nihon bishoujo mahjong senshuken taikai - heart de ron (japan)" sha1="44ab329b41b6fe0051aa31c20ebe492bca7f0de2" />
 			</diskarea>
 		</part>
 	</software>
@@ -8787,10 +9035,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="hyplanetm" cloneof="hyplanet" supported="no">
+	<software name="hyplanetm" cloneof="hyplanet">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cherokee (floppy)
 		<rom name="Hyper Planet for Marty (Japan) (Track 01).bin" size="31399200" crc="fa8d4e60" sha1="4ce3a39ecb3d8e6b12fee82649e1cadaafed91ec"/>
 		<rom name="Hyper Planet for Marty (Japan) (Track 02).bin" size="63527520" crc="2a2f71d9" sha1="ced27f97193ef361f2c8d926c2fa36b809dde645"/>
 		<rom name="Hyper Planet for Marty (Japan) (Track 03).bin" size="68871264" crc="3c47268b" sha1="6041a5645681ab161eca3d0b21272c7a375cb00f"/>
@@ -8814,6 +9061,12 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ダットジャパン (Datt Japan)</publisher>
 		<info name="serial" value="HME-139"/>
 		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="hyper_planet_marty.hdm" size="1261568" crc="bff17a79" sha1="139be75e703aefe0a3eb1131967de02e1af559e7" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper planet for marty (japan)" sha1="9cb884c64bcd1c2cff35fea66cf1e6503150a551" />
@@ -8893,6 +9146,43 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper planet shiki vol. 1 (japan)" sha1="2b0df49f5183f5502776d514515b6be254d742b3" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Dumped from a physically damaged disc, it only affects some of the audio tracks (7 and 11) but a redump is needed -->
+	<software name="hyplanets2">
+		<!--
+		Origin: private dump (Maddog)
+		<rom name="Hyper Planet Shiki Vol 2.cue" size="1529" crc="6b0ee345" sha1="2057dcd9739f1cb80d0d84bc7f2310856291dc9e"/>
+		<rom name="Track01.bin" size="20815200" crc="629a63e0" sha1="1f17367785da47a68b7d53c855a6995259d9af17"/>
+		<rom name="Track02.bin" size="47971392" crc="7f41d59d" sha1="ae07f9ac01e974b5df503071031954e8f011c12f"/>
+		<rom name="Track03.bin" size="87200400" crc="e276ca15" sha1="85919ef4e330bb290b621014b801dd3006288976"/>
+		<rom name="Track04.bin" size="72794400" crc="b9771b20" sha1="eac0afde1e7922af99ed779ca115d4c3ce096f53"/>
+		<rom name="Track05.bin" size="84876624" crc="b56453f3" sha1="047d512f8a9dcc3dd413d570ced8d9736b04bb8f"/>
+		<rom name="Track06.bin" size="71331456" crc="9e08a1cd" sha1="f7601f566c41f70f79809d2ff344e40b780734c1"/>
+		<rom name="Track07.bin" size="66279360" crc="71a3a2ff" sha1="878b844d1938350b5c5ff9266939b0bba01fd023"/>
+		<rom name="Track08.bin" size="55272000" crc="12dc9116" sha1="edc9bff5c4e3cb21bee7d934e064c9c94fd49b74"/>
+		<rom name="Track09.bin" size="31293360" crc="21c1d265" sha1="8837ff6ad4db066e304dd134daa63a17a59dea80"/>
+		<rom name="Track10.bin" size="34449744" crc="4cc03069" sha1="c07fc277f0631417d7f8a98ea9306cd8de921020"/>
+		<rom name="Track11.bin" size="56165760" crc="a7bbe6e4" sha1="f5894ee751b89f9fa1831018a1bb3064676f511e"/>
+		<rom name="Track12.bin" size="18140976" crc="650c9b0f" sha1="2b630ff3e86d989da78f687babbcb5b9ce4ac476"/>
+		<rom name="Track13.bin" size="19690944" crc="6240d916" sha1="cd0e982f8fb642e6c79de1f88a21e8b2823d0289"/>
+		<rom name="Track14.bin" size="20445936" crc="0d64bcc9" sha1="c05d52f3f25eb877fe4b0d75b5b652bd8c2b5647"/>
+		<rom name="Track15.bin" size="18686640" crc="fd10137f" sha1="414ca25d1656dd56af56147b5944f97d64d7f92a"/>
+		<rom name="Track16.bin" size="26601120" crc="72073dac" sha1="f94048252b279b42d8b038c1e918b62ca423a2b7"/>
+		<rom name="Track17.bin" size="54825120" crc="0ff85fa0" sha1="a39638049a9d3d49af57610ccec5b2f193f87fe7"/>
+		-->
+		<description>Hyper Planet Shiki Vol. 2</description>
+		<year>1993</year>
+		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HME-702"/>
+		<info name="alt_title" value="ハイパー・プラネット四季ＶＯＬ．２" />
+		<info name="release" value="199312xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper planet shiki vol 2" sha1="f09dfbb993eefbfed217f91518ff6d0337b65e2d" status="baddump" />
 			</diskarea>
 		</part>
 	</software>
@@ -9593,21 +9883,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="janjaka">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Jan Jaka Jan.ccd" size="767" crc="05177487" sha1="f3fbe3b3f55d386c241dc3b73588e73a23143932"/>
-		<rom name="Jan Jaka Jan.cue" size="76" crc="2b222e3a" sha1="c644734dfc32d7f9955728f745add6273a8e3a10"/>
-		<rom name="Jan Jaka Jan.img" size="10231200" crc="13668fd4" sha1="09906f6471fa9705ca9331584d0b271272bd554c"/>
-		<rom name="Jan Jaka Jan.sub" size="417600" crc="7d23400c" sha1="e7e6965b1646a9816d0afb825da57b202c537e09"/>
+		Origin: redump.org
+		<rom name="Jan Jaka Jan (Japan).bin" size="10231200" crc="67d1d7e4" sha1="c64d41a0697e989be2dda9ec339a71431b212303"/>
+		<rom name="Jan Jaka Jan (Japan).cue" size="86" crc="9fba1c2d" sha1="8f1fda4a3a580a8b7caa521d88fd209370c104c7"/>
 		-->
 		<description>Jan Jaka Jan</description>
 		<year>1992</year>
 		<publisher>エルフ (Elf)</publisher>
-		<info name="serial" value="HMD-206"/>
+		<info name="serial" value="HMD-206 / AOBA-15"/>
 		<info name="alt_title" value="雀ジャカ雀" />
 		<info name="release" value="199301xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jan jaka jan" sha1="eff72281e9c2867ddc2940386f4bcca2c1d1af54" />
+				<disk name="jan jaka jan (japan)" sha1="ab5100758d1f378f2e1b5451247847be983e1df4" />
 			</diskarea>
 		</part>
 	</software>
@@ -10088,20 +10376,27 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="kigen">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Kigen.bin" size="133005600" crc="f7e06793" sha1="51462a9ae88c7ad0546622ca94f5fae9c0259bea"/>
-		<rom name="Kigen.cue" size="379" crc="90afe3a2" sha1="9bef33cecf72c9b888303fe8f1f9ce36c4959562"/>
+		Origin: redump.org
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 1).bin" size="10231200" crc="8ea11047" sha1="44c82cc23a0902803c602125078692aa83e0ff82"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 2).bin" size="16052400" crc="f9291b33" sha1="f08df008271e1d900c59c27de36b207a93abfabc"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 3).bin" size="12348000" crc="fa23523b" sha1="e9688951caba8088e19617aede112e7975367712"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 4).bin" size="12700800" crc="96c445e5" sha1="5c18c79aed1b068afa3d27d47786a9455ae64447"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 5).bin" size="25930800" crc="7337bf10" sha1="c536227577404ea867801415e55308211271f18d"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 6).bin" size="7408800" crc="26304ac4" sha1="d0e172af2e40cdf0e1969ad90738c9171f53ed44"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 7).bin" size="23637600" crc="3b68a7b8" sha1="421c40891a6c5ee0ed292667f95350d0c2693b6b"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan) (Track 8).bin" size="25048800" crc="30d8fb7d" sha1="2f796ffe8b68c20ce986917beb227de01ac3c9be"/>
+		<rom name="Kigen - Kagayaki no Hasha (Japan).cue" size="998" crc="78b00275" sha1="07ba483747360f1ef423fcff1c78ed8be795c2d9"/>
 		-->
 		<description>Kigen - Kagayaki no Hasha</description>
 		<year>1992</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
-		<info name="serial" value="HMD-122"/>
+		<info name="serial" value="HMD-122 / MTC-1010"/>
 		<info name="alt_title" value="ＫＩＧＥＮ 輝きの覇者" />
 		<info name="release" value="199205xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kigen" sha1="3df8b6bb0c3ee6797f784c349a1ca40efb13dac8" />
+				<disk name="kigen - kagayaki no hasha (japan)" sha1="96234871427347ced00af0d3290b431c9404d430" />
 			</diskarea>
 		</part>
 	</software>
@@ -10220,6 +10515,28 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="kiwame ii" sha1="b3bcb4e8f1de660e8669b5d34b3802d238e7bc9f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Windows / Mac / FM Towns hybrid -->
+	<software name="kjmarian">
+		<!--
+		Origin: private dump (rockleevk)
+		<rom name="IMAGE.CCD" size="777" crc="f5e8d4dc" sha1="aaecd6eabc9b1bf0c95e8e2b005fc58ccf8253c4"/>
+		<rom name="IMAGE.cue" size="69" crc="02599f28" sha1="152366092283279915a12175200e2a1e2bdd5f55"/>
+		<rom name="IMAGE.img" size="151494672" crc="787bd2eb" sha1="5002a837851725fbe6f1cce0b66dddccd8c3a0e9"/>
+		<rom name="IMAGE.sub" size="6183456" crc="9dc484ad" sha1="66aa398af49f199e45ba5a220d548090dc390c68"/>
+		-->
+		<description>Kikai Jikake no Marian</description>
+		<year>1994</year>
+		<publisher>ジャニス (Janis)</publisher>
+		<info name="alt_title" value="機械じかけのマリアン" />
+		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 8 MB RAM and TownsOS V2.1 L40 or later"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="kjmarian" sha1="3cd9d330f7e32a53b5a65d85a7cbbd573763b84f" />
 			</diskarea>
 		</part>
 	</software>
@@ -10644,8 +10961,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Works only on the 386SX-based models (Marty & UX). Confirmed to work on a real Model 2. -->
-	<software name="ktiger" supported="partial">
+	<software name="ktiger">
 		<!--
 		Origin: Tokugawa Corporate Forums (wushu)
 		<rom name="Tiger.bin" size="757692096" crc="131e7221" sha1="e300709315d53e06fdc64eed31159da25d68e357"/>
@@ -10711,7 +11027,209 @@ User/save disks that can be created from the game itself are not included.
 	</software>
 
 	<!-- Runs too fast -->
+	<!--
+	    The reprint doesn't have any actual changes in the game files, but the ECC "intermediate field" of the
+	    data sectors (which is normally all zeroes) has some unknown data, and the audio tracks contain different data
+	    (not just offset, but completely different) that doesn't seem to result in any audible differences.
+	-->
 	<software name="lastarmg" supported="partial">
+		<!--
+		Origin: redump.org
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 01).bin" size="11313120" crc="17bffcea" sha1="351e0e8ce329426458e8cb01744184632313dd22"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 02).bin" size="14782320" crc="6d0b8491" sha1="cef25e78020184139ea2875944d09090206ffd40"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 03).bin" size="4480560" crc="cb2e09bd" sha1="720941f482dff037451ca9ff5a862f895bfd9192"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 04).bin" size="1046640" crc="bc916ee1" sha1="de313bf0884d9a5b8985f45788741b34e5b57003"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 05).bin" size="97819680" crc="43b5d048" sha1="71d904462f6950bffc705042982da01fbf5fbf00"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 06).bin" size="5162640" crc="3c759e9f" sha1="3584ae4183c7ab417489d8ea0e535101b6d1e180"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 07).bin" size="2892960" crc="937e51d7" sha1="a632b81ed4997a9e6a62c2ec7490769562114918"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 08).bin" size="1446480" crc="80602efb" sha1="4dfc6e61f1e9fa901c135903a95452ea8394660a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 09).bin" size="14453040" crc="5a8f9d5c" sha1="c66df10329bece142722c74711c206d7b9b5d39d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 10).bin" size="13688640" crc="84209077" sha1="b99d1944d10ddd3cb184b55f6cd1740a532f7fd3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 11).bin" size="13923840" crc="d6bafeee" sha1="595949d0dbfc05bf91d9fccddb9d48d4137eec68"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 12).bin" size="27459600" crc="e88e325e" sha1="ccf6eadfc74a1ee489b27b2098752766bff9fc08"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 13).bin" size="8314320" crc="0922e6c5" sha1="e720a241011d044f320499b54e1d49704eeea83e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 14).bin" size="8549520" crc="fe3e95da" sha1="57a126bbec8b62bc0ee80d236b3b439ebffc68c0"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 15).bin" size="7738080" crc="030edcce" sha1="597d1e81338c3c42f57385ff16c983f8b7aa2d95"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 16).bin" size="5797680" crc="473f10c3" sha1="c95299a8c49c530f40b68c8737c793117959607a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 17).bin" size="4163040" crc="25ee175f" sha1="15a9da6fad26d95477330821651c896140b6c4a9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 18).bin" size="1481760" crc="82230fc3" sha1="478ab11e7371bcf84dfe1e6c18e50afb6ccecac3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 19).bin" size="7444080" crc="66304380" sha1="07bdb31009b86680e72fbe9a8b5c8a07b2b41b1e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 20).bin" size="7244160" crc="eb8accbf" sha1="d0d3b5963a2a44ca8e3a6947fb568100fd182f90"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 21).bin" size="7114800" crc="877b1b9b" sha1="d83e6222856565ce3628191f9f0639749e26c120"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 22).bin" size="24437280" crc="cbf2422d" sha1="0fb05462780562957fd15c0d9bb02c4c435cc348"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 23).bin" size="5280240" crc="fd86b40a" sha1="038f29121e1cc2718b5370465e3386966f2ed57d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 24).bin" size="20791680" crc="ac24601f" sha1="3deb25e289ac289cb0fd9beab72d6e9bd83c45c8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 25).bin" size="12759600" crc="09dd0546" sha1="760a8e09f2e6b66a87dc3f776ee35c7544e3511e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 26).bin" size="12936000" crc="67abbd63" sha1="0a5a21fb6f6c5a7bac94112d9465476eb3160746"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 27).bin" size="5127360" crc="04b77a94" sha1="c66c77089ce6e4fcfc5f2589960741a37edaf3c7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 28).bin" size="6373920" crc="3b69c9ad" sha1="e68595f47243ed969ecf36739309eab11ec46f66"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 29).bin" size="6879600" crc="82c1e570" sha1="73de2bbd7f644d1af34ddb8fbda59959f2f933e9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 30).bin" size="2916480" crc="ee1ec26d" sha1="0179313837af150fbe5569bc6ac6c89592585bb1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 31).bin" size="1411200" crc="379ac41e" sha1="4d5709d1ebbf8586d1c70a4e167a1d101bc181de"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 32).bin" size="2140320" crc="76bf0df3" sha1="9d16d8dec7d620f4defa718e3387f4dbb7dc9535"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 33).bin" size="1740480" crc="6a3c9650" sha1="d1e8e5bd402882a9bd5288bb0b8233d59eedaf34"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 34).bin" size="2399040" crc="9fc16d86" sha1="673cb506172f1297231b4bc0be987ef68bbf4e8c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 35).bin" size="3610320" crc="e661e819" sha1="b99b51afbc461d0ea259aff7faf3bf90a5671291"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 36).bin" size="3986640" crc="6585aa9b" sha1="cfb059fe5c37c4b06e078f9c9b26e2fc5d9341c4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 37).bin" size="2328480" crc="c3badcb8" sha1="0d562013821975a558d127938e41d5d0a0eaa9de"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 38).bin" size="3292800" crc="eabaab90" sha1="fbf9b81fd1c1b8eec3dac1a3533e048830378f05"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 39).bin" size="2904720" crc="4a564dbd" sha1="59292d889318c9658273525603fde9c17c0a3887"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 40).bin" size="5103840" crc="0b70c893" sha1="e9feaf54db68aa6b613078b94bdd581ba35f14d5"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 41).bin" size="5480160" crc="722f64d6" sha1="0d52576ad40177100e460bad02af7cfc53f94933"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 42).bin" size="4492320" crc="dadd26d9" sha1="cc2f81d2907b3c247481309945df92e0cfd06583"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 43).bin" size="15511440" crc="0fed7a84" sha1="fdabdea4adb9ed12b58170026bc6f7603a10e408"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 44).bin" size="19768560" crc="abcbbec2" sha1="6b3b9ecdf51017806868b4a9188d97b89fb793b5"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 45).bin" size="19239360" crc="c4819ce3" sha1="cf126684a5e966eb200a3a186c3a8140c1dbecfe"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 46).bin" size="2199120" crc="dda6f2dc" sha1="a66edf30abd794f478139ad1a729f3d435917b7f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 47).bin" size="9572640" crc="a398bc7b" sha1="568acf7a1fdc414339be581e41ca0edaffbeff2e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 48).bin" size="2528400" crc="61dad60b" sha1="6bb14e19e5f17ab35101b8b41916eda184cfe05a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 49).bin" size="2293200" crc="176c5c02" sha1="4cd0500c7c0fce4848865549fe2558908b8dc9c2"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 50).bin" size="3222240" crc="80ffa729" sha1="15efc9574ef9c1d70c5c2685360f7a9762f8bb53"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 51).bin" size="11454240" crc="a83444e5" sha1="ccad6d169db83a848dca90cbeb3ee9f59a8ffe6d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 52).bin" size="35938560" crc="13464987" sha1="ca2c9595373cc4f8dbf528096d39d02e8394cf8b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 53).bin" size="34492080" crc="88f1c11c" sha1="15d95e0f59a9a7cde3b28b9ca49d6b0c65f7a1bb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 54).bin" size="36126720" crc="cef4b916" sha1="bd6072f1c8f6777a16565eaa16488c770225cc17"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 55).bin" size="4386480" crc="945487fc" sha1="f740830b4b4b8fcdd42339799cbe739ab9d070fd"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 56).bin" size="8573040" crc="b4f2b9fb" sha1="be27a147c5f4b6d8fdd8b818189649de5dd9dc98"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 57).bin" size="8502480" crc="8c1d79fb" sha1="707b2650ad2c333aace0b2c11c8b9a32c1d62ce4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease) (Track 58).bin" size="9537360" crc="02b227c4" sha1="15c8a149c723db43e13efaad8e53d2c54e6b5732"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Rerelease).cue" size="8798" crc="360725d4" sha1="1f371f3aed06717142b215a944a3a47da9ace515"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 01).bin" size="10748640" crc="e37b41b3" sha1="2bb992bb89a2820c6b6eabce2527e15e436af599"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 02).bin" size="14617680" crc="8dc1613f" sha1="11e9d6888ca0db238fc3d3b4191ecb39ea37c7ad"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 03).bin" size="4515840" crc="c5f7369a" sha1="234b12a5f51cdca37cfa8a417bafb514b00bffee"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 04).bin" size="987840" crc="84cd4776" sha1="5bb42fcd2fbb79bba02c90294a43b8cfa0425cce"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 05).bin" size="6326880" crc="3ba2daee" sha1="8b45f183b19d9c6808201f08f66287e3b4778701"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 06).bin" size="5750640" crc="2f0ca62f" sha1="bfcac2642e6449c487651c8139ce173377cff319"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 07).bin" size="5821200" crc="3d2cf945" sha1="93e4b870505e3f77e29276525ae3d99b2e336b70"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 08).bin" size="1646400" crc="b7d3b0dc" sha1="ae66a2d6dfac3b147a91eb2d2882d862588ccf8f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 09).bin" size="12112800" crc="d6147aa2" sha1="fd20895a7d5cda3fbd0f740a0c0df35e4ee27880"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 10).bin" size="11842320" crc="f5b2dbde" sha1="27e81d656466f8358bc551f6a2cd7645809cf0f8"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 11).bin" size="11948160" crc="154df993" sha1="a4746247052fc566e2018b2ad219ecc5fd62f597"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 12).bin" size="28118160" crc="d04ba0b2" sha1="88e1e0ca1309e4c9419c236b8b4ad014fd1c3c8a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 13).bin" size="18298560" crc="0b1b6715" sha1="e28194ce0c5694331b2f3efde944977d0598be88"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 14).bin" size="12536160" crc="cf284ae3" sha1="435274c98727bbe1cfb9dd6c0c60cffb55ce00a6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 15).bin" size="19145280" crc="ab94581b" sha1="e00fafc3fe641eed50f01827f2355cc2d9e7d884"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 16).bin" size="20297760" crc="f6ac48e6" sha1="a12321167afd87f46f47b204e466f2e51985ad8f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 17).bin" size="14311920" crc="b031e793" sha1="bd067480c1fcdb53d67ef2ad4befcac1a5b03880"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 18).bin" size="18004560" crc="b9f101b8" sha1="38c032ee314c6d261d8dad6a40a413b95b57f86f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 19).bin" size="20544720" crc="4862745b" sha1="a8b871f67de8d7bd77f931de59aae49a931c5467"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 20).bin" size="11501280" crc="e88765ea" sha1="04517e614fb1ce8f242e4c0318a690815d60b23d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 21).bin" size="23567040" crc="d5c58f0e" sha1="db89cdaaec88f80689caebab9ad1a390d857746a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 22).bin" size="11418960" crc="2958af10" sha1="6b99348fb304f4a12a6f3824d02af0dc1504162b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 23).bin" size="12148080" crc="ead9b3b0" sha1="7cd07bf4928b4405bb2bdf3ae8976550f92819e1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 24).bin" size="10619280" crc="478b5494" sha1="73df31ede854c068e99a979ebbd67d5eecbcb433"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 25).bin" size="3739680" crc="88950ce9" sha1="65b5e9774dd3117ff6f6f67c9a6e70289e827a8e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 26).bin" size="2928240" crc="cfcb1024" sha1="e14f64fc4c88e60576b470b7afa39c481e789d49"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 27).bin" size="8737680" crc="768dfeef" sha1="8ded38f7d584b154e7cbfcee0bdd32f6daa41cca"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 28).bin" size="2622480" crc="cc79cb0d" sha1="86b81929d64fd2f1f2f9e1ed1eaa1151193dbe88"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 29).bin" size="6303360" crc="139c70c0" sha1="9cbea4014a011434be7d8bd0628e24f0f2053837"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 30).bin" size="9478560" crc="806fbd20" sha1="e1d2a5874947d5b61adde7c66f9422a920c5ff96"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 31).bin" size="19415760" crc="379e5ec0" sha1="ffa0b1a5b828312818708346746b963c32ccb821"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 32).bin" size="19650960" crc="45237107" sha1="5eac9c47f43a06a1350f4388aaa14b106fde8479"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 33).bin" size="16287600" crc="a289e0d9" sha1="79680a3d258ed72a7e0a8d60b2f713c39216088f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 34).bin" size="2175600" crc="b50981fd" sha1="b9f7ae70ed3ff5e1d9d78f0cfb7119fe03f2b4a4"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 35).bin" size="2551920" crc="3870ca0a" sha1="12d2b4bbfb3602ff6ec97ebf5b0f5baf2475fd6d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 36).bin" size="2105040" crc="741e2daf" sha1="17ee9a172153ba79eb47ea1458fca2c7cf6c88d3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 37).bin" size="2316720" crc="d43e7258" sha1="de575a56950d68aecb82c77f09e9b39a2eee980c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 38).bin" size="2751840" crc="f466888b" sha1="a18ecc4fe59e7df2bc88e0b9b6a9be45dcc635c3"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 39).bin" size="2128560" crc="8fd98834" sha1="d9a4896f3aca870a0d3f8a333e1e5169b1e9593e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 40).bin" size="5103840" crc="3c44a80e" sha1="efca6751ee72de4cbfa2eace54eb31f0b1a5c4bf"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 41).bin" size="4833360" crc="fabbd1fd" sha1="149c12457f2c3dd872dfde2462b56efc0d2faf6f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 42).bin" size="5033280" crc="736dd69c" sha1="d33734439500f4953c4192deeb8a63aef1702494"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 43).bin" size="21179760" crc="0595ba7d" sha1="e5e8dee3e5273ca564f95ac95eb471c088b3017c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 44).bin" size="6491520" crc="16762eef" sha1="ea769b562b90a472dfc689b0b1d4550513a9918f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 45).bin" size="7197120" crc="f981daa2" sha1="7055c3dfd4b43e82d834e7cd755581d24a74ffcb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 46).bin" size="7632240" crc="dbc80a5c" sha1="040e79cdb2a196aefbb18ad6e358a9dced41242e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 47).bin" size="5633040" crc="55389381" sha1="e5f43d9335125b3c9ec5f09802a68ab3a13b9526"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease) (Track 48).bin" size="92739360" crc="0beada11" sha1="9a2f05ae0cef274bf81ccaec1e3f496430bd4e58"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc B) (Rerelease).cue" size="7278" crc="35514ec8" sha1="7dd5eba2dce0bbe2a803639860d62e6d38d2c2ad"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 01).bin" size="10748640" crc="604ac0a0" sha1="3a86d2383d9b280cd422c2f9f5629f49d333682c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 02).bin" size="14605920" crc="104f629a" sha1="93d28bba396f92201fcf9319214b469a452963ab"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 03).bin" size="4468800" crc="07bd2bce" sha1="cffb50514edafe21f1713cfd92dd5bd66220ef20"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 04).bin" size="1070160" crc="f5990857" sha1="931905a532d292b303c893d6a559b471cd0a2fee"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 05).bin" size="16816800" crc="f0a1f957" sha1="3725edd9afe4ec15ab9c9db2b3c47a4bac6f2183"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 06).bin" size="14958720" crc="e82f593d" sha1="9e4b7f05a52f03c8cd9a2306d7cd26695378f260"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 07).bin" size="21120960" crc="a8a5bf6d" sha1="8f9cb3018b7c84490977e5619498ba7085b17599"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 08).bin" size="1458240" crc="fb5b1635" sha1="12f365bf3eb71d5630f145dbc26788ab010102f5"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 09).bin" size="21273840" crc="870c22d6" sha1="c4982e856984f17096820d8b21b4eb4d0c5b3a9a"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 10).bin" size="27894720" crc="0109db6a" sha1="dc8d2c35523fe17f91e90537dd1fd772d65f5ffa"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 11).bin" size="11583600" crc="6d001125" sha1="9c829d1ed26754e44ccd6159e3245bad5caee340"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 12).bin" size="5127360" crc="97421d02" sha1="c2377dd2982546aa943e4743e08bfc58e1a4186f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 13).bin" size="27541920" crc="12be9129" sha1="9b6b38117527049370af7f9d251e18927cdd1279"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 14).bin" size="7232400" crc="d65fd225" sha1="17190a479308369a1a582582e7705ad2916a673b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 15).bin" size="4539360" crc="a62a120c" sha1="295d8b067f5946ca1d91940ffae129cb48885d25"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 16).bin" size="24754800" crc="edadcd47" sha1="7fc6ee1f2883d5e2c8e95e2e78236387fbf7503f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 17).bin" size="6444480" crc="245126d7" sha1="62c380b5f534f7d1889daa521cac9505bcc97161"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 18).bin" size="4950960" crc="09c75515" sha1="900e1b6adf7c61bda10f706babe8545818aeead7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 19).bin" size="19897920" crc="756edba7" sha1="52a6ecea33f8c59c762d1c0d297f097e1b1d2374"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 20).bin" size="6209280" crc="5ce9b994" sha1="705e8c44a63d4834735f0f5e69562a3c91d6d0f1"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 21).bin" size="6585600" crc="e8e2f548" sha1="670f139cf5cc7cb8f0e1e2b03d1594fa5b7cc593"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 22).bin" size="18051600" crc="95e39577" sha1="d857ef5b69f2034f79b0ce0b72b884143a02b3ec"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 23).bin" size="6221040" crc="ced44c97" sha1="2a3e841bad92c01754a505cc1793040a37d8c199"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 24).bin" size="7655760" crc="3ad21d98" sha1="ccd7307379af65b51d03b97894b40215c59131d9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 25).bin" size="9866640" crc="03e5a718" sha1="202725961547bd9554ee060437f5e493e0b7f12e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 26).bin" size="9866640" crc="149b9c8e" sha1="a75f1cf46572902d425e89a479cbb232d9111b9e"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 27).bin" size="10395840" crc="8387c325" sha1="f000d585df5b98bcb3e92502ed55a7f02d6322a9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 28).bin" size="10125360" crc="ea21aa3e" sha1="599841b04b137822cfa86a549a368eaf198d9f59"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 29).bin" size="6691440" crc="6c48a6e0" sha1="84a5f0237ea309e0ced1480ad01cffb2d9182083"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 30).bin" size="4351200" crc="9f5b54e9" sha1="2f5d6ad6dd2e1773d44be06bfde11b95eccc284f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 31).bin" size="25284000" crc="35fa734e" sha1="b181bd210d4d29f18f98394653c97873a8aa60dd"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 32).bin" size="15335040" crc="d3c1a8f7" sha1="1ba4db46279d20019cfe9bc708523a470802f6a9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 33).bin" size="14841120" crc="e1f7c3bf" sha1="565b33f4a7c731428339e2cf6e382fc42c8b2f1d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 34).bin" size="15182160" crc="3820e0fb" sha1="09c009286fb8bdc8badbe37d202f5fee1cfac1a0"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 35).bin" size="5915280" crc="ff7e8710" sha1="0928d0d5bbc4564acbe6f375aca0c93574a87866"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 36).bin" size="3328080" crc="e2c837ad" sha1="6bd849f14a2c9489d3755eaaca9ef3c244862f3c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 37).bin" size="49462560" crc="0f0c7b99" sha1="b910590e812cceb9632da6ba19c0d7b30463d204"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 38).bin" size="8490720" crc="c48ec613" sha1="9636e9673ff1979a6cf7753bf2fd9a6bbe337e0b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 39).bin" size="2046240" crc="bf8d06bb" sha1="4bb23c696b0d6cd0e7ca1910cebe0a4b54294565"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 40).bin" size="16957920" crc="c79c81ac" sha1="808f051ddba01d45dc1aa524a1b0e7cf941b147b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 41).bin" size="16675680" crc="b75e76c4" sha1="1dee95d46b8181af3007525acbc586bfc4be8b8f"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 42).bin" size="19650960" crc="636a9872" sha1="20ffa73d60ab43f952ea300ed2e7d555f88d23ff"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 43).bin" size="15158640" crc="f37dce66" sha1="252a49721bf9e504f261694896a8807a27a3bc91"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 44).bin" size="4903920" crc="8e05ff6b" sha1="1fbfa0226a62d212e0b4ac629adc13ef30be56ad"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 45).bin" size="5327280" crc="bfef0996" sha1="b03e8c45a2c9aa558df6cca78afa72a592c9842c"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 46).bin" size="6503280" crc="3bddd10e" sha1="07f4f2545bf373d59259712b7eea5b682298cb61"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 47).bin" size="14476560" crc="d8177145" sha1="aa8896eb4a52e1bdf287fdafc35a5c5cb78083ef"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 48).bin" size="19051200" crc="15fd6330" sha1="a67c087653ddb880137991da27558a002fabeac6"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 49).bin" size="12089280" crc="3216ed1c" sha1="60dada635411f07c73d99b043db2f3e7ce1d8ee9"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 50).bin" size="12700800" crc="4497da8f" sha1="2cf2baa1a993a6fdba10f9640e70fab4be23c94d"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 51).bin" size="12371520" crc="993d7ca4" sha1="dc88c9b0064c1102ca25834bb0a488eed4012bcb"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 52).bin" size="24919440" crc="22edcdfe" sha1="dfc467c5f032b65c4abd8d104137755ea2a13587"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 53).bin" size="25201680" crc="e2ec7739" sha1="f5604e6015752e5da3eda59ff412e4491019afed"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 54).bin" size="25295760" crc="a706a975" sha1="b6fa4427178c57ce25e19ce71b776d12ddf73b47"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 55).bin" size="12818400" crc="b68435e9" sha1="5683055d8d500bb9476338aecc6cb3622e17ff82"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 56).bin" size="16334640" crc="ef3208f7" sha1="cb09819b6833b1ed533d084e5a2164dbc19ac6d7"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 57).bin" size="16440480" crc="778ba165" sha1="52194864a4dd7a46ae0535bb85e82d4be62e3126"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease) (Track 58).bin" size="16993200" crc="d42bcc51" sha1="50bb1a1595c255e3048d4fa65ae75024654b2d0b"/>
+		<rom name="Last Armageddon - CD Special (Japan) (Disc C) (Rerelease).cue" size="8798" crc="4b9710ba" sha1="019c81800a1a3cb7729a9f0d7cd071eecf7755b3"/>
+		-->
+		<description>Last Armageddon CD Special (Selon reprint)</description>
+		<year>1989</year>
+		<publisher>ブレイングレイ (Brain Grey)</publisher>
+		<info name="serial" value="HMA-207 / SW-002"/>
+		<info name="alt_title" value="ラスト・ハルマゲドン CDスペシャル" />
+		<info name="release" value="198907xx" />
+		<part name="cdrom1" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc A"/>
+			<diskarea name="cdrom">
+				<disk name="last armageddon - cd special (japan) (disc a) (rerelease)" sha1="c42a5e1cca558d42962621a59a3437a581f9b443" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc B"/>
+			<diskarea name="cdrom">
+				<disk name="last armageddon - cd special (japan) (disc b) (rerelease)" sha1="6654bf0972622ba355bb4241310bd46ba3ea12a4" />
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="fmt_cdrom">
+			<feature name="part_id" value="Disc C"/>
+			<diskarea name="cdrom">
+				<disk name="last armageddon - cd special (japan) (disc c) (rerelease)" sha1="8b1ecfa89210b1cbad90eefaee4e9c33056565ae" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="lastarmgo" cloneof="lastarmg" supported="partial">
 		<!--
 		Origin: redump.org
 		<rom name="Last Armageddon - CD Special (Japan) (Disc A) (Track 01).bin" size="11308416" crc="406550a5" sha1="3be67ec6d4da8c0c34d8be3f1ba05f28a38cbc13"/>
@@ -11330,11 +11848,15 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="lodoss">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Record of Lodoss War - Haiiro no Majo.ccd" size="1713" crc="0b3685ac" sha1="08b860697c30d1cbede2a82fab23d87eceeac9cf"/>
-		<rom name="Record of Lodoss War - Haiiro no Majo.cue" size="526" crc="076a8d66" sha1="471e24b85ae1ef3f206f992905c28d8a86adf89c"/>
-		<rom name="Record of Lodoss War - Haiiro no Majo.img" size="119636832" crc="fd25dfb0" sha1="543bb5edea022390cda6fc90ef84db8fc63e1848"/>
-		<rom name="Record of Lodoss War - Haiiro no Majo.sub" size="4883136" crc="1405c0ea" sha1="c6fdd87b5ebce3e307b3d2216dba57867f2a2059"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 01).bin" size="5604816" crc="184c9936" sha1="4ace66aa7eb220e89d509d460da2308f68c0c687"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 02).bin" size="17437728" crc="3f565f8c" sha1="d20d9110e7900477dafa8ba7fef96c66b9a7089f"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 03).bin" size="20450640" crc="fbd82c26" sha1="78bb82aa7ddb233e2a4e6b0326638088c2d4712e"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 04).bin" size="24456096" crc="705c1468" sha1="d2eccc5493d26ae6ef11593237b2c58ca14b0e3f"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 05).bin" size="12068112" crc="e80f6aa0" sha1="27fb89893812c3457940795c4fe9dbe5fa7251a3"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 06).bin" size="38384640" crc="878be648" sha1="5b7b481812d1108fc93484532aa5e16a643692cc"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan) (Track 07).bin" size="1234800" crc="d42c677c" sha1="37276f79e8923d659b24ed3ab916b9191e89f5c6"/>
+		<rom name="Record of Lodoss War - Lodoss-tou Senki - Haiiro no Majo (Japan).cue" size="1111" crc="dcfae385" sha1="a810afb4311c7ef8ec1b515ac452273e41378821"/>
 		-->
 		<description>Record of Lodoss War - Haiiro no Majo</description>
 		<year>1994</year>
@@ -11350,7 +11872,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="record of lodoss war - haiiro no majo" sha1="7479e561eaf9a60468b924c3b822173710c37f47" />
+				<disk name="record of lodoss war - lodoss-tou senki - haiiro no majo (japan)" sha1="8630fd1bf0644650697cc6366301ffa144b58481" />
 			</diskarea>
 		</part>
 	</software>
@@ -11499,13 +12021,130 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="lua">
+		<!--
+		Origin: redump.org
+		<rom name="Lua (Japan) (Track 01).bin" size="10231200" crc="bd509023" sha1="db686b4fc0dadcba6852b0eda3673f36b11e045f"/>
+		<rom name="Lua (Japan) (Track 02).bin" size="34927200" crc="cb181210" sha1="df9ec61d5da6b4552a00566cf012096e4721de36"/>
+		<rom name="Lua (Japan) (Track 03).bin" size="43394400" crc="25c2e549" sha1="b87b08b015c903e14267d6214de2e4e8d086a464"/>
+		<rom name="Lua (Japan) (Track 04).bin" size="29811600" crc="7aa373a6" sha1="0736c818466dab75d769167f2012ed8f1a3a1df0"/>
+		<rom name="Lua (Japan) (Track 05).bin" size="25930800" crc="e175e4e8" sha1="b375d628e83e78bd165d724ca022e98b9ef66709"/>
+		<rom name="Lua (Japan) (Track 06).bin" size="39337200" crc="ee2dc20b" sha1="3669c21def657ec7933de353d73b31b86d019565"/>
+		<rom name="Lua (Japan) (Track 07).bin" size="25754400" crc="867d6082" sha1="e5b2786c1c7db2c5f096cf011170e54f8d89ca1c"/>
+		<rom name="Lua (Japan) (Track 08).bin" size="25048800" crc="db136fa8" sha1="ec9b857615c07ff31b4e3416a6d74aa0edd3bfb0"/>
+		<rom name="Lua (Japan) (Track 09).bin" size="38808000" crc="e436ade6" sha1="c552fc72c550ed9c90b0f87aaaac32aff8dd23c5"/>
+		<rom name="Lua (Japan) (Track 10).bin" size="23990400" crc="e9cc85b0" sha1="29058781383fab880900aad16e03a5c9f8666480"/>
+		<rom name="Lua (Japan) (Track 11).bin" size="35280000" crc="cafdf7f3" sha1="2de496ac89a46f36881ffd2bb276edd71030e442"/>
+		<rom name="Lua (Japan) (Track 12).bin" size="11289600" crc="de044138" sha1="99206f29c012e9de306baa88767632120ab6288a"/>
+		<rom name="Lua (Japan) (Track 13).bin" size="20286000" crc="1c440722" sha1="e903b984f20123bc7c537107172e43ac6993d592"/>
+		<rom name="Lua (Japan) (Track 14).bin" size="34750800" crc="d4cebd98" sha1="0e9dce3dd4045fd285070e1578a2f5271c31c947"/>
+		<rom name="Lua (Japan) (Track 15).bin" size="10584000" crc="ca13d267" sha1="ceddc9092c78c68b8bfae09bd89366ef028465aa"/>
+		<rom name="Lua (Japan) (Track 16).bin" size="26989200" crc="cac5d30f" sha1="6c09ebb532cc48f4cf632f57950c41cabe983bb5"/>
+		<rom name="Lua (Japan) (Track 17).bin" size="14288400" crc="0e3f4b5c" sha1="3d38585f64c3456e636ef07e215fd4440eb5a94b"/>
+		<rom name="Lua (Japan) (Track 18).bin" size="11642400" crc="a5a95822" sha1="6448f03687cfd97b627e23782b0ce0179d099e90"/>
+		<rom name="Lua (Japan) (Track 19).bin" size="13582800" crc="6ae1c1df" sha1="3226ab760df3506513b8f4499ccbb4e6de4498cd"/>
+		<rom name="Lua (Japan).cue" size="1996" crc="2f64eb64" sha1="e63f5507301b7cdc3c67ebd8a2d300e4319e6234"/>
+		-->
+		<description>Lua</description>
+		<year>1993</year>
+		<publisher>インターハート (Inter Heart)</publisher>
+		<info name="serial" value="HME-203"/>
+		<info name="alt_title" value="ルア" />
+		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="lua (japan)" sha1="61fe651d6384547936dad8865b961288bc82abc8" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="lupin3">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Lupin III - Hong Kong no Mashu.ccd" size="16155" crc="45af8f84" sha1="9b7f6d6d57110437f04b10e39adf2534d133358b"/>
-		<rom name="Lupin III - Hong Kong no Mashu.cue" size="3326" crc="c8f43998" sha1="91ba9179610271e5d30d68f67b0816eb61e3ab52"/>
-		<rom name="Lupin III - Hong Kong no Mashu.img" size="341315184" crc="7fbe9b86" sha1="810defb7503665f185c868dc24e4eca2647f108a"/>
-		<rom name="Lupin III - Hong Kong no Mashu.sub" size="13931232" crc="31cd1f8d" sha1="1a6cbbae19217e1150190c8e60b4d920256609b6"/>
+		Origin: redump.org
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 01).bin" size="52567200" crc="e8bcb252" sha1="0aa822bfd53b55583ae1ae30175b53d64eec7bf8"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 02).bin" size="24394944" crc="bec4a2ae" sha1="52e04761820abe9a161f70b6fb18a47e257c0899"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 03).bin" size="5569536" crc="2dcbf291" sha1="d932d5489e633ee802f403d81cd8bf5135e585af"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 04).bin" size="6785520" crc="19ef9c83" sha1="689015502a7d188e41aa5f40d6fd86f6662603e5"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 05).bin" size="2916480" crc="a5460115" sha1="2627ebc4e9ed3e9cda3118c1d8b623369ffe8048"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 06).bin" size="3121104" crc="64eac3a9" sha1="921ffc7897ec60b7360e6744157d652ae514d8e3"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 07).bin" size="3186960" crc="26343692" sha1="19311c68e353bd6b1ba37cf50604f3cbbc8312bb"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 08).bin" size="4104240" crc="5eaf75bc" sha1="3d973a0fc238da0db816703674dfe74c6c362ff8"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 09).bin" size="2488416" crc="82ac3ef7" sha1="4d78bbbb65a82ebb10aa11062f185213de614416"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 10).bin" size="1234800" crc="ca5d339c" sha1="e0369cb9e92d66d9aeefffdb47c16bab03f2189d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 11).bin" size="1234800" crc="dc7ad541" sha1="238d4d390fc08dbe2cf5aa313741ef82158045b4"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 12).bin" size="1234800" crc="c6bf3f15" sha1="f67d7a2cc0348ba95f09a3c31258d929e3077565"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 13).bin" size="2827104" crc="d20272b7" sha1="1e615e8beb4aaa807c128e6197e27b9a364d53c9"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 14).bin" size="3845520" crc="776f2f92" sha1="8a93dd558d60bfac88abf958cb8d8c7a9d1c2614"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 15).bin" size="2940000" crc="afe79141" sha1="54f5a9b537c3bc709056917bf73de1184cbd816b"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 16).bin" size="2641296" crc="c431556b" sha1="08c15d02326e3246dc751bb89549b95a4a829f39"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 17).bin" size="2121504" crc="1bbca814" sha1="fc32f5152e107d273cbd29977c1b20a41d613a61"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 18).bin" size="6627936" crc="667f26c6" sha1="055df811f99d7621bdd2196735841128c9ea4ec4"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 19).bin" size="2093280" crc="7abcff88" sha1="fdf82bb95e932e4495bc631af983011c479ea0c8"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 20).bin" size="1858080" crc="0b180d4b" sha1="54f4d4250d3798f49223bb1e04379e2b0f83e479"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 21).bin" size="1434720" crc="b8fac292" sha1="9cd630a27700948133e0a9d68a96a8da717a7729"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 22).bin" size="1470000" crc="072cebe2" sha1="75ddc15042bea521f1c634eb374ef7c9a64066bb"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 23).bin" size="2627184" crc="97beeda6" sha1="c4b289d0f991850f681f23711ed7d1ed4bbcb81c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 24).bin" size="2500176" crc="e81016d5" sha1="f86edd6a0e490b8d4bcbdc5f8505716113037d3d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 25).bin" size="2391984" crc="faa44b13" sha1="4cf3d1a1812f2239b8ec0746bf3d48f80150f8f8"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 26).bin" size="1658160" crc="cfffc733" sha1="fcd4e009fbba9a00549804398cda4153e90ee7c7"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 27).bin" size="2041536" crc="031dfe71" sha1="e25c79539d731a43d3c57628af18bfc2603848d4"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 28).bin" size="2497824" crc="dd3ceb02" sha1="7d3b1ccab7b7c45582598ed6146608b6f16879e1"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 29).bin" size="1764000" crc="6122d7ab" sha1="c87f4e83174d8c47bdea933ec494322691e14384"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 30).bin" size="3076416" crc="2f95340b" sha1="32e40b0e5d00cc42325e88b7bc23f627aa8d3429"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 31).bin" size="2163840" crc="c502f6cd" sha1="4b8828837aac810fe667d202855cbe73a8da62c4"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 32).bin" size="1646400" crc="26ead7be" sha1="f775695120eb5ab7b2157aae2d23de2234e2bec0"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 33).bin" size="1281840" crc="45510e9d" sha1="c42caf70304305a96d7ca24737530c8bef2cbd86"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 34).bin" size="1493520" crc="21d82da1" sha1="05e98418b9cbe734a535624b3b68dd9babcd1d80"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 35).bin" size="2027424" crc="c1cbffa0" sha1="65107be1e8148889d687f0f7ab8a19ec7c925ab9"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 36).bin" size="2257920" crc="4fd27c4b" sha1="f0169158deabfc39435fadb6938bf2088fe05c6f"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 37).bin" size="1411200" crc="5ebc4ceb" sha1="30cc4204a3a672e58a4dee4cb325da7637f41bd1"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 38).bin" size="2206176" crc="25597909" sha1="90fe2a1ac51d0d534cda07af5eadf49e0783c426"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 39).bin" size="2297904" crc="467446c1" sha1="fac1c546ee3d1f158ef304c1e4337e20fe954f9b"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 40).bin" size="2128560" crc="e3aebe44" sha1="a69ca7cb02dc201aecd691f3c460896e04601bfc"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 41).bin" size="1858080" crc="10b8c1ba" sha1="1797ad7a40a8d9450f7f4fe4e2b40741e75212bc"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 42).bin" size="1787520" crc="3c4699a6" sha1="a3a4fc3a8935085299b17edc1543ef05691ec2ce"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 43).bin" size="1928640" crc="11a738b0" sha1="759255c5e5ea7289fcbe36871ba0673adc5542ff"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 44).bin" size="2363760" crc="cff9fe08" sha1="aaedf39b4734fc889a3b464acb2e2a4aa52a4eb9"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 45).bin" size="1858080" crc="58801950" sha1="ee5a09bb4e859ac47d5d05276e8c007d5dff1c0c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 46).bin" size="1905120" crc="83cf175b" sha1="0936e085bfdfbcbd1626b834aef1743ce6fb5cc9"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 47).bin" size="1641696" crc="91c88428" sha1="02e537bab66db8ee29ab820181f7c275452cdcb6"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 48).bin" size="3257520" crc="2dcb9e92" sha1="8adaef34af5c710278af35b11c5bfd7a1ae524f2"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 49).bin" size="2380224" crc="20c10afa" sha1="5435d0b553d4b2d01a661e1e247c76af8e08a183"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 50).bin" size="2347296" crc="f75cc889" sha1="b25c070960bcd96e37e5cf9887a1a2ce7eb003c5"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 51).bin" size="1575840" crc="ffdc082d" sha1="c56497897417c874e1da5dc7b6ff6c0677f780ed"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 52).bin" size="1375920" crc="205f21bf" sha1="15d8bb505a47859945cc443c7bd4bb17c3e47788"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 53).bin" size="2493120" crc="aa40c4eb" sha1="2252623feebd4a4a01c37407d184b3a2f7830202"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 54).bin" size="1387680" crc="b8b1b8fb" sha1="e31d64a8ced10cfddf550f31be01c7ad10259992"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 55).bin" size="3038784" crc="b6911a3a" sha1="0f9ee9349f94c5b9f5b5c86d36631eba39daaea6"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 56).bin" size="1794576" crc="8c020541" sha1="5e459f20439b7df173a264cd45cc826183537474"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 57).bin" size="1434720" crc="e5173a36" sha1="2c0f6e0df38ec24f1a0964389809c4659ceaf63d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 58).bin" size="2881200" crc="ce3081c7" sha1="e158a00d92ef134a757469963b168ba56f5da804"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 59).bin" size="2387280" crc="02b92fd4" sha1="a082bb62f31c9573b4a696dba4cdfe7f1d9519a4"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 60).bin" size="3810240" crc="ae604645" sha1="03f8a91701b528042f9c3a66d5b2ca866e799b9c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 61).bin" size="2740080" crc="24526deb" sha1="ff092016af4ed100e0b2e1186534ea3caac73fa8"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 62).bin" size="2368464" crc="b6b53b9f" sha1="96f7529611c893b8b14f8c4fa25425b830eaab8b"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 63).bin" size="1822800" crc="22726845" sha1="980281a87f1db55b9d5e327f768a61e5d08f09d6"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 64).bin" size="3563280" crc="156fe311" sha1="29038acebecf1d1b0be4f84dc873757a17536b3b"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 65).bin" size="1987440" crc="6038ebc5" sha1="c2ccb23c9034390586d63158561b3457e19ac90c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 66).bin" size="2441376" crc="850ff883" sha1="7f3e239fc6b92d945657f098a41241ad85e3914d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 67).bin" size="1599360" crc="f3ce08a4" sha1="3fc3a25338d8aa0fc1dfe7901d1f94c977902047"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 68).bin" size="2638944" crc="6890efd7" sha1="8ca6069513730d6b0251751e813a3dc276dd5b2d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 69).bin" size="23602320" crc="1d77fe77" sha1="b43b3063ad3d1075672b01e494a85ca62901044c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 70).bin" size="17792880" crc="f4f39d2d" sha1="0ae628d8c5666e71d4a4ee5ad62a323dd367932c"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 71).bin" size="15753696" crc="eeb6e704" sha1="51cb893ffe688235aefd25a02a6a5f705926111f"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 72).bin" size="6731424" crc="ad21e73f" sha1="1b558d6c5f29d3def69cab8919bb17a58edc0c7d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 73).bin" size="24632496" crc="ee2c27cb" sha1="cde183ba207266fbdaf9a860851e515eb7bba366"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 74).bin" size="1340640" crc="13244faf" sha1="5b2bc0d2ae75d00c23f239b2ef4104110dcf056a"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 75).bin" size="1234800" crc="a27ab13e" sha1="987c6ca3155394eeda8a43e73be2f8c0f06a5bb3"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 76).bin" size="1740480" crc="20daa22b" sha1="503bc0e442c189d195e06666a55073119acc2b9a"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 77).bin" size="2474304" crc="954ec397" sha1="6c611464a9d6d919f4100c6d2893c1c607f843cb"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 78).bin" size="1375920" crc="ad44fbd4" sha1="ef54d3aaf0c6dd4630af50597a99667841a1ce0a"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 79).bin" size="2387280" crc="130bbad4" sha1="8e83c80bdb8c68d4ff15edb114a0fa3a95f0876b"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 80).bin" size="1418256" crc="bf1023f1" sha1="669dc132d46c6036ef4f01d7a9ffd7107884faf9"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 81).bin" size="1815744" crc="95ab7a8e" sha1="f9d4328c56f1c6c7252d5008fbb9a7c8da218ba1"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan) (Track 82).bin" size="2175600" crc="c326e91d" sha1="931388e6f18ca35cba09c91e7eaab8b2d526099d"/>
+		<rom name="Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni (Japan).cue" size="14622" crc="6693fd19" sha1="b4be7ed8becaea4b4f19bedf363efd4ff3baa9ba"/>
 		-->
 		<description>Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni</description>
 		<year>1990</year>
@@ -11516,7 +12155,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lupin iii - hong kong no mashu" sha1="c42ff4f7d772bf8a7d5b33ae64e5b8d0dfa7e956" />
+				<disk name="lupin sansei - hong kong no mashu - fukushuu wa meikyuu no hate ni (japan)" sha1="a0775c92949572b83f242d917d56f1e15d92fe7b" />
 			</diskarea>
 		</part>
 	</software>
@@ -12718,11 +13357,9 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Hangs while playing FMV -->
 	<software name="mmorph" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Megamorph.ccd" size="784" crc="b10bc2c6" sha1="8760ed5e880d3466fdbd2c538d62959e7f581f92"/>
-		<rom name="Megamorph.cue" size="75" crc="cbb0f514" sha1="f9721cf34f18f4a01fd926f75477d4bb733f086d"/>
-		<rom name="Megamorph.img" size="412423200" crc="3c1d16e8" sha1="225128e91047b91cc564bd30215e0d1dc2eeb040"/>
-		<rom name="Megamorph.sub" size="16833600" crc="993f36a6" sha1="8157ee33297f5e1881a888162a9a0a838f2b4417"/>
+		Origin: redump.org
+		<rom name="MegaMorph (Japan).bin" size="412423200" crc="3c1d16e8" sha1="225128e91047b91cc564bd30215e0d1dc2eeb040"/>
+		<rom name="MegaMorph (Japan).cue" size="106" crc="88496dca" sha1="ba2fe632577450fa8b4de2e1b6dbdc7fcb837d17"/>
 		-->
 		<description>Megamorph</description>
 		<year>1994</year>
@@ -12732,7 +13369,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="megamorph" sha1="59e30f6ce0c8cb62b22afe383ffcf7450910a612" />
+				<disk name="megamorph (japan)" sha1="c8fa442563a5ee2d3656c421cdedd18b09d7582b" />
 			</diskarea>
 		</part>
 	</software>
@@ -12974,10 +13611,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="msdet1m" cloneof="msdet1" supported="no">
+	<software name="msdet1m" cloneof="msdet1">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cherokee (floppy)
 		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 1).bin" size="473692800" crc="94b7e859" sha1="7f44d047146dfd282abf05dc92e5b9db2eb582ff"/>
 		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 2).bin" size="57240624" crc="e46efbbc" sha1="b0bda4091b22c7eda443b102d1c2f1271c87567a"/>
 		<rom name="Ms. Detective File 1 - Iwami Ginzan Satsujin Jiken (Japan) (FM Towns Marty) (Track 3).bin" size="5992896" crc="7d0d6658" sha1="f36b48802dd13cfb4c27058455c21915ed395db0"/>
@@ -12990,6 +13626,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="DWFS3009"/>
 		<info name="alt_title" value="Ms.DETECTIVE ファイル#1 「石見銀山殺人事件」" />
 		<info name="release" value="199209xx" />
+		<info name="usage" value="Requires an FM Towns Marty. Won't run on any other models."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="ms_detective_1_marty.hdm" size="1261568" crc="3e70fc8c" sha1="05d3f256874fec6deccf8f3a4f80d143182f3846" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="ms. detective file 1 - iwami ginzan satsujin jiken (japan) (fm towns marty)" sha1="fff0bea9c41f0fca097db68988596abcc5787ce9" />
@@ -13307,6 +13949,26 @@ User/save disks that can be created from the game itself are not included.
 			<feature name="part_id" value="Disk C - The Fortress"/>
 			<diskarea name="cdrom">
 				<disk name="fushigi no umi no nadia - the secret of blue water (japan) (disc c) (the fortress)" sha1="115527f2778eb55e6638c9e9d84760ae968d6a21" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="narumj">
+		<!--
+		Origin: redump.org
+		<rom name="Naru Mahjong (Japan).bin" size="17578848" crc="5913dd89" sha1="f3057d80312fcc02cba6275c1cae725576c3fd98"/>
+		<rom name="Naru Mahjong (Japan).cue" size="109" crc="ac3dea2a" sha1="eb666969028f8358a7af7562a9ff3d8205a4e5fd"/>
+		-->
+		<description>Naru Mahjong</description>
+		<year>1995</year>
+		<publisher>リビドー (Libido)</publisher>
+		<info name="serial" value="MTC-1133"/>
+		<info name="alt_title" value="なる麻雀" />
+		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="naru mahjong (japan)" sha1="62aca8dba3128971632900c87fa6ef1fefe3e1b3" />
 			</diskarea>
 		</part>
 	</software>
@@ -14208,6 +14870,52 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no yachou (japan) (fm towns marty rerelease)" sha1="9a80cea927db8de8105afc18d15ce592047fe118" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="nijiiro">
+		<!--
+		Origin: redump.org
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 01).bin" size="29058960" crc="2643293b" sha1="cb9af1afc9d37de6c66f36361965f9a2d47f7515"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 02).bin" size="22165248" crc="3517d48d" sha1="1b6da1aaec4a51affd47209b2f7e35b60886378a"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 03).bin" size="22144080" crc="e6bd78bb" sha1="be667dd72e253c0dd769161d267f26565cef181a"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 04).bin" size="22607424" crc="ff7067fc" sha1="61a90596e888afe7826af6f067fb11d1e241d9ff"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 05).bin" size="22619184" crc="afbfd419" sha1="314749177ee7da6640c2c4d22bb1581c09f8cff0"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 06).bin" size="22426320" crc="f911151d" sha1="7c7d5c57e607df1a7af12999466967de9ce10d82"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 07).bin" size="22285200" crc="d555c16b" sha1="fa2436f2ec477c898ca7fc7d061843c85648cba5"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 08).bin" size="22148784" crc="838253e5" sha1="88233f851cbff4f5c036fd6410787bc55aa40a25"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 09).bin" size="22395744" crc="cfd38163" sha1="eab08f648b85386b3e25b3a1ed246d1bcb0db5c6"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 10).bin" size="16974384" crc="327e72bb" sha1="a163bf9166c2ab60bb9ab300955d90b07e85c337"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 11).bin" size="16962624" crc="df1402ff" sha1="a51ef739fe896ce2ca90286d7d804a874583bd89"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 12).bin" size="16903824" crc="76469178" sha1="e397e1d5ccc4821f9813035ca881cf4153bda374"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 13).bin" size="16758000" crc="37d39806" sha1="9eb8bb989c43b793062c1f22d1ceca50f48e6391"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 14).bin" size="16781520" crc="a8f3abd6" sha1="19bd18605a3a942d20988d9b9139a3aee945a7e0"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 15).bin" size="17052000" crc="684459c0" sha1="40fec58e1a45abe2f05cb593886298bc0ddb7a32"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 16).bin" size="17103744" crc="641679a5" sha1="6f9ad3d0484a2234097a3531fb3550557b072eae"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 17).bin" size="22336944" crc="c29484a0" sha1="d9e72b921767732ed12b335ffcbd46e9cb1700f3"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 18).bin" size="22289904" crc="28ff8a8e" sha1="9a76db790b7bf41ccb8c0dafcc96dd1ee7f7ee97"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 19).bin" size="27706560" crc="fc7b493e" sha1="dea7958fae8af33b611e690880f592b39377155c"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 20).bin" size="22301664" crc="a756b6e1" sha1="77a28777264695c07b3187ce69f2649a6bc58569"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 21).bin" size="11776464" crc="ac90ce40" sha1="fb6fd58a779708af83f0bdd06f363b1821f10694"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 22).bin" size="17310720" crc="61a95dca" sha1="c305cf0eee9ea90f757533104664edb371f67090"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 23).bin" size="12030480" crc="8d3aedce" sha1="c499889fed5b71a51e0e877b96b3945fe834004c"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 24).bin" size="1575840" crc="460f8361" sha1="49e60bca1a90b9afe2159b0492a0c1f407783a82"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 25).bin" size="31956624" crc="b78fdc48" sha1="2613ecfc6e7568083cbc38f1b27cd29d1177b8f0"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 26).bin" size="31980144" crc="d51c5f12" sha1="21a81336d64bb4bca0cd1d7a982d164744c5ccce"/>
+		<rom name="Nijiiro Denshoku Musume (Japan) (Track 27).bin" size="32022480" crc="621dc6e8" sha1="52a70b2d637166262fc11aeb0caa606f2ffe672d"/>
+		<rom name="Nijiiro Denshoku Musume (Japan).cue" size="3407" crc="41f345f1" sha1="3c6200e7a2a15c9b3aad3e5f77782139260638cc"/>
+		-->
+		<description>Nijiiro Denshoku Musume</description>
+		<year>1994</year>
+		<publisher>ISC</publisher>
+		<info name="serial" value="MTC-1104"/>
+		<info name="alt_title" value="虹色電飾娘" />
+		<info name="release" value="199408xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nijiiro denshoku musume (japan)" sha1="98b891e326d6743344367d87003fa314f2a295f5" />
 			</diskarea>
 		</part>
 	</software>
@@ -15270,6 +15978,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="presence (japan)" sha1="2a67dfc67b6b8b93a900bb13d3958a4f95f927b0" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Windows / Mac / FM Towns hybrid -->
+	<software name="prindang">
+		<!--
+		Origin: private dump (rockleevk)
+		<rom name="princess.bin" size="151492320" crc="a4e8caf8" sha1="d06e97b90de334ceb7c7130888fdcc3c8341b925"/>
+		<rom name="princess.cue" size="74" crc="4a02bd44" sha1="f77ee67ae7b783375adf0dcd2d76fb15acbe6e10"/>
+		-->
+		<description>Princess Danger</description>
+		<year>1996</year>
+		<publisher>ジャニス (Janis)</publisher>
+		<info name="alt_title" value="ぷりんせすでんじゃあ" />
+		<info name="release" value="199604xx" />
+		<info name="usage" value="Requires 4 MB RAM and TownsOS V2.1 L40 or later"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="princess" sha1="708a7d71b5e44285f2b63dc511af9417f550491f" />
 			</diskarea>
 		</part>
 	</software>
@@ -16452,10 +17180,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="sangoku4" supported="no">
+	<software name="sangoku4">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / akira_2020 (floppy)
 		<rom name="Sangokushi IV (Japan) (Track 01).bin" size="10231200" crc="9a2fbc22" sha1="5f33db7b5044d24ea337755b438b4edace4ead73"/>
 		<rom name="Sangokushi IV (Japan) (Track 02).bin" size="59505600" crc="53161c66" sha1="05abc71faac8cfee1a39adac38a7a1a9e9f04f25"/>
 		<rom name="Sangokushi IV (Japan) (Track 03).bin" size="32598720" crc="a8840727" sha1="3fe89a236da56b828b92724102f2b5e07cd0986d"/>
@@ -16476,6 +17203,11 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="HMF-139"/>
 		<info name="alt_title" value="三国志Ⅳ" />
 		<info name="release" value="199406xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="sangokushi_4.hdm" size="1261568" crc="ef3e8441" sha1="fc1c9db8be644d413c1a6ef0ada6d3f37bf80676" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sangokushi iv (japan)" sha1="49dc6daa29837edd705cf281d57030f3d7a22aee" />
@@ -16787,10 +17519,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="sensangl" supported="no">
+	<software name="sensangl">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cherokee (floppy)
 		<rom name="Sensual Angels (Japan).bin" size="609814800" crc="51c1024b" sha1="763a11dbed4e1396c0cdfe3389c09036a68c381f"/>
 		<rom name="Sensual Angels (Japan).cue" size="88" crc="fbaff388" sha1="75bf916d032b5bc5890c8c75aa680cd4c4719274"/>
 		-->
@@ -16800,6 +17531,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="DWDC3813 / DI-001"/>
 		<info name="alt_title" value="センシャル・エンジェル" />
 		<info name="release" value="199401xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="sensual_angels.hdm" size="1261568" crc="18190c59" sha1="bb996d3d071d85e286b69deb7273f04df66b2d53" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sensual angels (japan)" sha1="7aa87b214723ccdd40d1183183c6e51cd77929a7" />
@@ -18669,6 +19406,26 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="tankcpdx">
+		<!--
+		Origin: redump.org
+		<rom name="Tactical Tank Corps DX (Japan).bin" size="11830560" crc="1a9536ec" sha1="fdca2487d0ef75e49541c2ebcd6c294d3307ddff"/>
+		<rom name="Tactical Tank Corps DX (Japan).cue" size="119" crc="c363d772" sha1="f7811c11982eb95a3df2ceff7fee1c6514af6260"/>
+		-->
+		<description>Tactical Tank Corps DX</description>
+		<year>1995</year>
+		<publisher>ジーエーエム (GAM)</publisher>
+		<info name="serial" value="MTC-1119"/>
+		<info name="alt_title" value="タクティカル・タンク・コープスＤＸ" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="tactical tank corps dx (japan)" sha1="0368abb67c94bb397bfd2fc6c6d97dd3aa7d90b0" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="tatsuou">
 		<!--
 		Origin: redump.org
@@ -18860,6 +19617,25 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="tensen">
+		<!--
+		Origin: redump.org
+		<rom name="Tensen Nyannyan (Japan).bin" size="8674176" crc="28fe9ca1" sha1="e6e31bbe61ae27d2ba4a23ced5c363f9f2f8efd5"/>
+		<rom name="Tensen Nyannyan (Japan).cue" size="112" crc="db5d455d" sha1="122d263d47c5d0772ce144295d45b044fdfd958a"/>
+		-->
+		<description>Tensen Nyannyan</description>
+		<year>1994</year>
+		<publisher>ポニーテールソフト (Ponytail Soft)</publisher>
+		<info name="alt_title" value="天仙娘々" />
+		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="tensen nyannyan (japan)" sha1="6a1aa881097b03f65a2abe467f71c13c216df651" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="terra">
 		<!--
 		Origin: redump.org
@@ -18984,13 +19760,24 @@ User/save disks that can be created from the game itself are not included.
 	</software>
 
 	<!-- Sound issues with FMV playback -->
+	<!-- PC-9821 / DOS/V / FM Towns hybrid -->
 	<software name="horde" supported="partial">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Horde.ccd" size="3063" crc="72d2dad6" sha1="4cce603c4e734e24bdf1c92c69e77e4d9e67f869"/>
-		<rom name="The Horde.cue" size="545" crc="3d6563a0" sha1="3bb73919091305cc9c3f97f633e199f3014a510c"/>
-		<rom name="The Horde.img" size="594475056" crc="9051c6ae" sha1="891ebf3a54d3cbc90f19eca53937ea2fe58ec771"/>
-		<rom name="The Horde.sub" size="24264288" crc="3f5c25df" sha1="382903ea64069ae6c8755fe664ad5dade291ac60"/>
+		Origin: redump.org
+		<rom name="Horde, The (Japan) (Track 01).bin" size="281717856" crc="73721dfb" sha1="0b753964b7283a092928f8d5700a32a9729cedca"/>
+		<rom name="Horde, The (Japan) (Track 02).bin" size="34574400" crc="e0f167a9" sha1="4c9066f9bb72da1552638526d4cf8f801b601670"/>
+		<rom name="Horde, The (Japan) (Track 03).bin" size="22226400" crc="a792a8f0" sha1="b145cbeb83e981b724ef5c2aa02d33f67b520552"/>
+		<rom name="Horde, The (Japan) (Track 04).bin" size="33163200" crc="daec7246" sha1="216dc4558cfd1f09d08d02f8328407c0c1cb3166"/>
+		<rom name="Horde, The (Japan) (Track 05).bin" size="22402800" crc="ddb0edac" sha1="4f85104654bb55e42359e8270f105dbd97917bc2"/>
+		<rom name="Horde, The (Japan) (Track 06).bin" size="32457600" crc="a5441176" sha1="c8488464d17fcef8ba3f6ce375a0aacfa03e1081"/>
+		<rom name="Horde, The (Japan) (Track 07).bin" size="13935600" crc="e5951b8b" sha1="29d52bca0c86bf6fab3beedb2e63f01710d1d31a"/>
+		<rom name="Horde, The (Japan) (Track 08).bin" size="21873600" crc="8ca59661" sha1="912b000348d8dc09cc95320313503dea254d10f6"/>
+		<rom name="Horde, The (Japan) (Track 09).bin" size="22755600" crc="02ba42bf" sha1="d719799a7335025e8545b06a5429be35706b8541"/>
+		<rom name="Horde, The (Japan) (Track 10).bin" size="34574400" crc="0480e090" sha1="57eec18e628d7831978f7c03fb628a6207316f41"/>
+		<rom name="Horde, The (Japan) (Track 11).bin" size="24696000" crc="f5099eb8" sha1="85be72692bcb87ae1cb894ff951a3df765a1e355"/>
+		<rom name="Horde, The (Japan) (Track 12).bin" size="25048800" crc="b933af1c" sha1="0bc9e73054f1182e23735ad35a60b618276b3786"/>
+		<rom name="Horde, The (Japan) (Track 13).bin" size="25048800" crc="73b1c9f4" sha1="6b9a293824d3fa9fe62de6c681dc3850c0d9e6c5"/>
+		<rom name="Horde, The (Japan).cue" size="1451" crc="89c39237" sha1="afae4fee774ec36ec6bb01099e7346f0bcbdb0fb"/>
 		-->
 		<description>The Horde</description>
 		<year>1995</year>
@@ -19000,7 +19787,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires HDD installation, 4 MB RAM and a 486 CPU"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the horde" sha1="53b6f886fafc5e532583c7ccd85774d73608c4ca" />
+				<disk name="horde, the (japan)" sha1="32e962e4cf040fc2552e7ac647a6553973f2d4a5" />
 			</diskarea>
 		</part>
 	</software>
@@ -20364,11 +21151,9 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="wakoku">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Wakoku Seiha Den.ccd" size="769" crc="e3eef86d" sha1="3290f0e3ed6ce9265d0d77cb13be6c43a9ed2a5d"/>
-		<rom name="Wakoku Seiha Den.cue" size="80" crc="c6973696" sha1="40c4fa261b55dc4ecb396e76c9ed9301de873e60"/>
-		<rom name="Wakoku Seiha Den.img" size="10228848" crc="768685d5" sha1="07896849fae030641bd726eb18a8ec6c588ef455"/>
-		<rom name="Wakoku Seiha Den.sub" size="417504" crc="632a643c" sha1="fc7ab5135b4fdf57bec8567e45fd9827a2b466fd"/>
+		Origin: redump.org
+		<rom name="Wakoku Seihaden (Japan).bin" size="10231200" crc="06c1c3a4" sha1="da5dc179dd01d0bb89a0077fb4ea1f49338042b8"/>
+		<rom name="Wakoku Seihaden (Japan).cue" size="89" crc="305851cc" sha1="a95f09576d2f40de9390a150fa678915a9ac0666"/>
 		-->
 		<description>Wakoku Seiha Den</description>
 		<year>1994</year>
@@ -20379,7 +21164,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wakoku seiha den" sha1="c678cf3231d465243e898f81259032635bc7aaf5" />
+				<disk name="wakoku seihaden (japan)" sha1="d1f93565348ded22ef097950436df2d44190be74" />
 			</diskarea>
 		</part>
 	</software>
@@ -20569,6 +21354,43 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="winpost">
+		<!--
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Winning Post (Japan) (Track 01).bin" size="10231200" crc="331669c4" sha1="1cb0bc4df89ae22a5f6de1ea76778f36b0c5d4d9"/>
+		<rom name="Winning Post (Japan) (Track 02).bin" size="4410000" crc="6275903e" sha1="4ad2dd098efa6cf81903f1ad7dc4e8eb06700925"/>
+		<rom name="Winning Post (Japan) (Track 03).bin" size="4057200" crc="4c2097cc" sha1="32e5b727cd6be1a677172f19b5596fdb3b54dcb2"/>
+		<rom name="Winning Post (Japan) (Track 04).bin" size="3351600" crc="1ec4fc81" sha1="85055c8e36a38388a95777c44a72e2689ebe0c19"/>
+		<rom name="Winning Post (Japan) (Track 05).bin" size="3351600" crc="a9b0a7e4" sha1="4deda4b9347aac209386fce00888c133181755fc"/>
+		<rom name="Winning Post (Japan) (Track 06).bin" size="3175200" crc="cae18b9a" sha1="10386e50a6f132f4d49bda1d26f94b602e13361b"/>
+		<rom name="Winning Post (Japan) (Track 07).bin" size="2469600" crc="f87be767" sha1="d5a2ea4b13d860e4965d401c22674dae3b40c6dd"/>
+		<rom name="Winning Post (Japan) (Track 08).bin" size="3528000" crc="07f98a39" sha1="f6be58a31128eaf11c03172706dfa954137daf74"/>
+		<rom name="Winning Post (Japan) (Track 09).bin" size="7761600" crc="12d2b668" sha1="e4c9183e96e2a7615045af8619babb1b5e3130f5"/>
+		<rom name="Winning Post (Japan) (Track 10).bin" size="8114400" crc="8bc2250a" sha1="7220562b6b0c255577b7967e310a349a532743a9"/>
+		<rom name="Winning Post (Japan) (Track 11).bin" size="8643600" crc="6a752bc7" sha1="d4b33e2e4a5cd541b098165b8180a2a7900c63c7"/>
+		<rom name="Winning Post (Japan) (Track 12).bin" size="7408800" crc="d1c2b2cb" sha1="b15fb436a58a1d360e161b05944cf8cbe6d75ad8"/>
+		<rom name="Winning Post (Japan) (Track 13).bin" size="5292000" crc="bd84235d" sha1="b256e595bf435397f94ee191bc733f515a36838f"/>
+		<rom name="Winning Post (Japan) (Track 14).bin" size="33516000" crc="7ee3caaf" sha1="85b5ae8fa8657764b5513aafc40719a24212f83f"/>
+		<rom name="Winning Post (Japan).cue" size="1615" crc="1a897e97" sha1="b47247f6fdb075e441167dc5f78f67c995d46cc1"/>
+		-->
+		<description>Winning Post</description>
+		<year>1993</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HME-135 / KN10381040"/>
+		<info name="release" value="199305xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="winning_post.hdm" size="1261568" crc="839cf8d5" sha1="2a9f89106e318ac122b2f05d036c81bf8d391121" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="winning post (japan)" sha1="77e25807c7f10373e4f4c4eb5a02e7b6275fb5d9" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="wizardr5">
 		<!--
 		Origin: redump.org
@@ -20720,6 +21542,26 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="wrestle angels special" sha1="8411c536a37c0a59f42831c906c5d39c19b86df4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="wonpara">
+		<!--
+		Origin: redump.org
+		<rom name="WonPara Wars (Japan).bin" size="20815200" crc="d7037e54" sha1="2bf1ee22ef49ac33598534731112fc11715bc484"/>
+		<rom name="WonPara Wars (Japan).cue" size="109" crc="3281421c" sha1="d356e096da3ebcf55c295c4ea1c4c7cf75b3e972"/>
+		-->
+		<description>WonPara Wars</description>
+		<year>1995</year>
+		<publisher>ミンク (Mink)</publisher>
+		<info name="serial" value="HMG-105"/>
+		<info name="alt_title" value="ＷＯＮＰＡＲＡウォーズ" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="wonpara wars (japan)" sha1="c5131185ad3dbeeb18b847485ca3b95b914ccac3" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
In addition to everything below:

- Added a floppy disk included with Crystal Rinal [cherokee]
- Replaced the Bible Master floppy disk with a cleaner copy [wiggy2k]

New working software list additions
-----------------------------------

Air Warrior V1.2L11 [redump.org, wiggy2k]
Emit Vol. 1 - Toki no Maigo (Demo) [redump.org]
Engage Errands - Miwaku no Shito-tachi [redump.org]
Engage Errands II - Hikari o Ninau Mono [redump.org, wiggy2k]
Hyper Planet Shiki Vol. 2 [Maddog]
Kikai Jikake no Marian [rockleevk]
Last Armageddon CD Special (Selon reprint) [redump.org]
Lua [redump.org]
Naru Mahjong [redump.org]
Nijiiro Denshoku Musume [redump.org]
Princess Danger [rockleevk]
Tactical Tank Corps DX [redump.org]
Tensen Nyannyan [redump.org]
Winning Post [redump.org]
WonPara Wars [redump.org]

New not working software list additions
---------------------------------------

Crayonnage [redump.org]

Replaced software list items
----------------------------

Bubble Bobble [redump.org]
Dragons of Flame [redump.org]
Exciting CD '94 Summer [redump.org]
Game Technopolis Super Collection 2 [redump.org]
Jan Jaka Jan [redump.org]
Kigen - Kagayaki no Hasha [redump.org]
Lupin Sansei - Hong Kong no Mashu - Fukushuu wa Meikyuu no Hate ni [redump.org]
Megamorph [redump.org]
Record of Lodoss War - Haiiro no Majo [redump.org]
The Horde [redump.org]
Uchuu Kaitou Funny Bee [redump.org]
Wakoku Seiha Den [redump.org]
Zen Nihon Bishoujo Mahjong Senshuken Taikai - Heart de Ron!!
[redump.org]

Software list items promoted to working
---------------------------------------

Alice no Yakata CD II [wiggy2k]
Doki Doki Vacation - Kirameku Kisetsu no Naka de [wiggy2k]
Hyper Planet for Marty [cherokee]
Ms. Detective File #1 - Iwami Ginzan Satsujin Jiken (FM Towns Marty version) [cherokee]
Sangokushi IV [akira_2020]
Sensual Angels [cherokee]