### PR TITLE
mame: dist.mak: add missing tools executables

### DIFF
--- a/dist.mak
+++ b/dist.mak
@@ -101,7 +101,7 @@ MAINBIN := $(TARGET)$(MAINBINARCH)$(MAINBINVARIANT)
 BINDIR := build/$(PROJECTTYPE)/bin/$(BUILDARCH)/$(BUILDVARIANT)
 STAGEDIR := build/release/$(BUILDARCH)/$(BUILDVARIANT)/$(TARGET)
 
-BINARIES = $(MAINBIN) castool chdman floptool imgtool jedutil ldresample ldverify nltool nlwav romcmp unidasm
+BINARIES = $(MAINBIN) aueffectutil castool chdman floptool imgtool jedutil ldresample ldverify nltool nlwav pngcmp regrep romcmp split srcclean testkeys unidasm
 SIMPLE_DIRS := ctrlr docs/legal docs/man docs/swlist hash ini/examples ini/presets
 LOCALISATIONS := $(wildcard language/*/*.mo)
 COPIED_FILES := COPYING uismall.bdf roms/dir.txt $(foreach DIR,$(SIMPLE_DIRS),$(wildcard $(DIR)/*)) language/LICENSE language/README.md $(LOCALISATIONS)


### PR DESCRIPTION
Trivial change, adding missing tools executables to the list of binaries.

Tracked by issue:
[mame: dist.mak: some tools executables missing](https://github.com/mamedev/mame/issues/7672)
