### PR TITLE
Unbreak aarch64 and arm builds

### DIFF
--- a/makefile
+++ b/makefile
@@ -371,14 +371,6 @@ ifndef NOASM
 endif
 endif
 
-ifeq ($(findstring arm,$(UNAME)),arm)
-ARCHITECTURE :=
-endif
-
-ifeq ($(findstring aarch64,$(UNAME)),aarch64)
-ARCHITECTURE :=
-endif
-
 ifeq ($(findstring ppc,$(UNAME)),ppc)
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
@@ -392,12 +384,14 @@ endif
 endif
 
 ifeq ($(findstring arm,$(UNAME)),arm)
+ARCHITECTURE :=
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
 endif
 endif
 
 ifeq ($(findstring aarch64,$(UNAME)),aarch64)
+ARCHITECTURE :=
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
 endif

--- a/makefile
+++ b/makefile
@@ -371,6 +371,14 @@ ifndef NOASM
 endif
 endif
 
+ifeq ($(findstring arm,$(UNAME)),arm)
+ARCHITECTURE :=
+endif
+
+ifeq ($(findstring aarch64,$(UNAME)),aarch64)
+ARCHITECTURE :=
+endif
+
 ifeq ($(findstring ppc,$(UNAME)),ppc)
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1


### PR DESCRIPTION
This fixes arm build breakage introduced by 6e1bbe8be89349038995df2aaa4f11019439e39e.