### PR TITLE
Change "mame64" to "mame" in docs

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -66,11 +66,13 @@ executable (for example you could call it ``mame-here`` )::
     exec ./mame
 
 You should be able to use any text editor.  If you have a choice of file format
-or line ending style, choose UNIX. Once you've created the file, you need to
-mark it as executable.  You can do this by opening a Terminal window,
-typing **chmod a+x** followed by a space, dragging the file you created onto
-the window (this causes Terminal to insert the full escaped path to the file),
-and then ensuring the Terminal window is active and hitting **Return**
+or line ending style, choose UNIX. This assumes you're using a 64-bit release
+build of MAME, but if you aren't you just need to change ``mame`` to the name
+of your MAME executable (e.g. mamed, mamep, mamedp).  Once you've created the
+file, you need to mark it as executable.  You can do this by opening a Terminal
+window, typing **chmod a+x** followed by a space, dragging the file you created
+onto the window (this causes Terminal to insert the full escaped path to the
+file), and then ensuring the Terminal window is active and hitting **Return**
 (or **Enter**) on your keyboard.  You can close the Terminal window after doing
 this.  Now if you double-click the script in the Finder, it will open a
 Terminal window, set the working directory to the location of the script

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -63,20 +63,18 @@ executable (for example you could call it ``mame-here`` )::
 
     #!/bin/sh
     cd "`dirname "$0"`"
-    exec ./mame64
+    exec ./mame
 
 You should be able to use any text editor.  If you have a choice of file format
-or line ending style, choose UNIX.  This assumes you're using a 64-bit release
-build of MAME, but if you aren't you just need to change ``mame64`` to the name
-of your MAME executable.  Once you've created the file, you need to mark is as
-executable.  You can do this by opening a Terminal window, typing **chmod a+x**
-followed by a space, dragging the file you created onto the window (this causes
-Terminal to insert the full escaped path to the file), and then ensuring the
-Terminal window is active and hitting **Return** (or **Enter**) on your
-keyboard.  You can close the Terminal window after doing this.  Now if you
-double-click the script in the Finder, it will open a Terminal window, set the
-working directory to the location of the script (i.e. the folder containing
-MAME), and then start MAME.
+or line ending style, choose UNIX. Once you've created the file, you need to
+mark it as executable.  You can do this by opening a Terminal window,
+typing **chmod a+x** followed by a space, dragging the file you created onto
+the window (this causes Terminal to insert the full escaped path to the file),
+and then ensuring the Terminal window is active and hitting **Return**
+(or **Enter**) on your keyboard.  You can close the Terminal window after doing
+this.  Now if you double-click the script in the Finder, it will open a
+Terminal window, set the working directory to the location of the script
+(i.e. the folder containing MAME), and then start MAME.
 
 
 Core Verbs
@@ -101,7 +99,7 @@ Core Verbs
     Example:
         .. code-block:: bash
 
-            mame64 -help
+            mame -help
 
 .. _mame-commandline-validate:
 
@@ -119,7 +117,7 @@ Core Verbs
     Example:
         .. code-block:: bash
 
-            mame64 -validate
+            mame -validate
             Driver ace100 (file apple2.cpp): 1 errors, 0 warnings
             Errors:
             Software List device 'flop525_orig': apple2_flop_orig.xml: Errors parsing software list:
@@ -149,7 +147,7 @@ Configuration Verbs
     Example:
         .. code-block:: bash
 
-            mame64 -createconfig
+            mame -createconfig
 
 .. _mame-commandline-showconfig:
 
@@ -191,7 +189,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 -listcrc puckman > list.txt
+            mame -listcrc puckman > list.txt
 
     This creates (or overwrites the existing file if already there) ``list.txt``
     and fills the file with the results of **-listcrc puckman**.  In other
@@ -214,7 +212,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 galaxian -listxml
+            mame galaxian -listxml
             <?xml version="1.0"?>
             <!DOCTYPE mame [
             <!ELEMENT mame (machine+)>
@@ -238,7 +236,7 @@ overwritten.
 
 .. Tip:: Output from this command is typically more useful if redirected to
          an output file. For instance, doing
-         **mame64 -listxml galaxian > galax.xml** will make ``galax.xml`` or
+         **mame -listxml galaxian > galax.xml** will make ``galax.xml`` or
          overwrite any existing data in the file with the results of
          **-listxml**; this will allow you to view it in a text editor or parse
          it with external tools.
@@ -250,7 +248,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 -listfull galaxian*
+            mame -listfull galaxian*
             Name:             Description:
             galaxian          "Galaxian (Namco set 1)"
             galaxiana         "Galaxian (Namco set 2)"
@@ -279,7 +277,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 galaga -listsource
+            mame galaga -listsource
             galaga           galaga.cpp
 
 .. _mame-commandline-listclones:
@@ -294,14 +292,14 @@ overwritten.
     Example 1:
         .. code-block:: bash
 
-            mame64 pacman -listclones
+            mame pacman -listclones
             Name:            Clone of:
             pacman           puckman
 
     Example 2:
         .. code-block:: bash
 
-            mame64 puckman -listclones
+            mame puckman -listclones
             Name:            Clone of:
             abscam           puckman
             bucaner          puckman
@@ -321,7 +319,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 galaxian -listbrothers
+            mame galaxian -listbrothers
             Source file:         Name:            Parent:
             galaxian.cpp         amidar
             galaxian.cpp         amidar1          amidar
@@ -342,7 +340,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 playch10 -listcrc
+            mame playch10 -listcrc
             d52fa07a pch1-c__8t_e-2.8t                      playch10                PlayChoice-10 BIOS
             503ee8b1 pck1-c.8t                              playch10                PlayChoice-10 BIOS
             123ffa37 pch1-c_8te.8t                          playch10                PlayChoice-10 BIOS
@@ -375,7 +373,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 neogeo -listroms
+            mame neogeo -listroms
             ROMs required for driver "neogeo".
             Name                                   Size Checksum
             sp-s2.sp1                            131072 CRC(9036d879) SHA1(4f5ed7105b7128794654ce82b51723e16e389543)
@@ -397,7 +395,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 armorap -listsamples
+            mame armorap -listsamples
             Samples required for driver "armorap".
             loexp
             jeepfire
@@ -418,7 +416,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 gradius -verifyroms
+            mame gradius -verifyroms
             romset gradius [nemesis] is good
             1 romsets found, 1 were OK.
 
@@ -434,7 +432,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 armorap -verifysamples
+            mame armorap -verifysamples
             sampleset armorap [armora] is good
             1 samplesets found, 1 were OK.
 
@@ -455,7 +453,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 unknown.rom -romident
+            mame unknown.rom -romident
             Identifying unknown.rom....
             unknown.rom         = 456-a07.17l           gradius    Gradius (Japan, ROM version)
 
@@ -474,7 +472,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 apple2e -listdevices
+            mame apple2e -listdevices
             Driver apple2e (Apple //e):
                <root>                         Apple //e
                  a2bus                        Apple II Bus
@@ -506,7 +504,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 apple2e -listslots
+            mame apple2e -listslots
             SYSTEM           SLOT NAME        SLOT OPTIONS     SLOT DEVICE NAME
             ---------------- ---------------- ---------------- ----------------------------
             apple2e          sl1              4play            4play Joystick Card (rev. B)
@@ -536,7 +534,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 coco3 -listmedia
+            mame coco3 -listmedia
             SYSTEM           MEDIA NAME       (brief)    IMAGE FILE EXTENSIONS SUPPORTED
             ---------------- --------------------------- -------------------------------
             coco3            cassette         (cass)     .wav  .cas
@@ -557,7 +555,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 coco3 -listsoftware
+            mame coco3 -listsoftware
             <?xml version="1.0"?>
             <!DOCTYPE softwarelists [
             <!ELEMENT softwarelists (softwarelist*)>
@@ -594,7 +592,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 coco3 -verifysoftware
+            mame coco3 -verifysoftware
             romset coco_cart:7cardstd is good
             coco_cart:amazing: a mazing world of malcom mortar (1987)(26-3160)(zct systems).rom (16384 bytes) - NEEDS REDUMP
             romset coco_cart:amazing is best available
@@ -613,7 +611,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 -getsoftlist apple2_flop_orig
+            mame -getsoftlist apple2_flop_orig
             <?xml version="1.0"?>
             <!DOCTYPE softwarelists [
             <!ELEMENT softwarelists (softwarelist*)>
@@ -648,7 +646,7 @@ overwritten.
     Example:
         .. code-block:: bash
 
-            mame64 -verifysoftlist apple2_flop_orig
+            mame -verifysoftlist apple2_flop_orig
             romset apple2_flop_orig:agentusa is good
             romset apple2_flop_orig:airheart is good
             romset apple2_flop_orig:aplpanic is good
@@ -681,7 +679,7 @@ OSD-related Options
     Example:
         .. code-block:: bash
 
-            mame64 ibm5150 -uimodekey DEL
+            mame ibm5150 -uimodekey DEL
 
 .. _mame-commandline-uifontprovider:
 
@@ -724,7 +722,7 @@ OSD-related Options
 Example:
     .. code-block:: bash
 
-        mame64 ajax -uifontprovider dwrite
+        mame ajax -uifontprovider dwrite
 
 .. _mame-commandline-keyboardprovider:
 
@@ -776,7 +774,7 @@ Example:
 Example:
     .. code-block:: bash
 
-        mame64 c64 -keyboardprovider win32
+        mame c64 -keyboardprovider win32
 
 .. _mame-commandline-mouseprovider:
 
@@ -824,7 +822,7 @@ Example:
 Example:
     .. code-block:: bash
 
-        mame64 indy_4610 -mouseprovider win32
+        mame indy_4610 -mouseprovider win32
 
 .. _mame-commandline-lightgunprovider:
 
@@ -871,7 +869,7 @@ Example:
 Example:
     .. code-block:: bash
 
-        mame64 lethalen -lightgunprovider x11
+        mame lethalen -lightgunprovider x11
 
 .. _mame-commandline-joystickprovider:
 
@@ -912,7 +910,7 @@ Example:
 Example:
     .. code-block:: bash
 
-        mame64 mk2 -joystickprovider winhybrid
+        mame mk2 -joystickprovider winhybrid
 
 .. Tip:: On Windows, winhybrid is likely to give the best experience by
          supporting both XInput and DirectInput controllers.
@@ -930,7 +928,7 @@ OSD CLI Options
     Example:
         .. code-block:: bash
 
-            mame64 -listmidi
+            mame -listmidi
             MIDI input ports:
 
             MIDI output ports:
@@ -946,13 +944,13 @@ OSD CLI Options
     Example 1:
         .. code-block:: bash
 
-            mame64 -listnetwork
+            mame -listnetwork
             No network adapters were found
 
     Example 2:
         .. code-block:: bash
 
-            mame64 -listnetwork
+            mame -listnetwork
             Available network adapters:
                 Local Area Connection
 
@@ -978,7 +976,7 @@ OSD Output Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -output console
+            mame asteroid -output console
             led0 = 1
             led0 = 0
             ...
@@ -1021,7 +1019,7 @@ Configuration Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2ee -noreadconfig -sl6 diskii -sl7 cffa2 -hard1 TotalReplay.2mg
+            mame apple2ee -noreadconfig -sl6 diskii -sl7 cffa2 -hard1 TotalReplay.2mg
 
 
 Core Search Path Options
@@ -1038,7 +1036,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -homepath c:\mame\lua
+            mame -homepath c:\mame\lua
 
 .. _mame-commandline-rompath:
 
@@ -1053,7 +1051,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -rompath c:\mame\roms;c:\roms\another
+            mame -rompath c:\mame\roms;c:\roms\another
 
 .. _mame-commandline-hashpath:
 
@@ -1068,7 +1066,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -hashpath c:\mame\hash;c:\roms\softlists
+            mame -hashpath c:\mame\hash;c:\roms\softlists
 
 .. _mame-commandline-samplepath:
 
@@ -1083,7 +1081,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -samplepath c:\mame\samples;c:\roms\samples
+            mame -samplepath c:\mame\samples;c:\roms\samples
 
 .. _mame-commandline-artpath:
 
@@ -1098,7 +1096,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -artpath c:\mame\artwork;c:\emu\shared-artwork
+            mame -artpath c:\mame\artwork;c:\emu\shared-artwork
 
 .. _mame-commandline-ctrlrpath:
 
@@ -1113,7 +1111,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -ctrlrpath c:\mame\ctrlr;c:\emu\controllers
+            mame -ctrlrpath c:\mame\ctrlr;c:\emu\controllers
 
 .. _mame-commandline-inipath:
 
@@ -1142,7 +1140,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -inipath c:\users\thisuser\documents\mameini
+            mame -inipath c:\users\thisuser\documents\mameini
 
 .. _mame-commandline-fontpath:
 
@@ -1157,7 +1155,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -fontpath c:\mame\;c:\emu\artwork\mamefonts
+            mame -fontpath c:\mame\;c:\emu\artwork\mamefonts
 
 .. _mame-commandline-cheatpath:
 
@@ -1172,7 +1170,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -cheatpath c:\mame\cheat;c:\emu\cheats
+            mame -cheatpath c:\mame\cheat;c:\emu\cheats
 
 .. _mame-commandline-crosshairpath:
 
@@ -1187,7 +1185,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -crosshairpath c:\mame\crsshair;c:\emu\artwork\crosshairs
+            mame -crosshairpath c:\mame\crsshair;c:\emu\artwork\crosshairs
 
 .. _mame-commandline-pluginspath:
 
@@ -1201,7 +1199,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -pluginspath c:\mame\plugins;c:\emu\lua
+            mame -pluginspath c:\mame\plugins;c:\emu\lua
 
 .. _mame-commandline-languagepath:
 
@@ -1216,7 +1214,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -languagepath c:\mame\language;c:\emu\mame-languages
+            mame -languagepath c:\mame\language;c:\emu\mame-languages
 
 .. _mame-commandline-swpath:
 
@@ -1230,7 +1228,7 @@ Core Search Path Options
     Example:
         .. code-block:: bash
 
-            mame64 -swpath c:\mame\software;c:\emu\mydisks
+            mame -swpath c:\mame\software;c:\emu\mydisks
 
 
 Core Output Directory Options
@@ -1253,7 +1251,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -cfg_directory c:\mame\cfg
+            mame -cfg_directory c:\mame\cfg
 
 .. _mame-commandline-nvramdirectory:
 
@@ -1271,7 +1269,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -nvram_directory c:\mame\nvram
+            mame -nvram_directory c:\mame\nvram
 
 .. _mame-commandline-inputdirectory:
 
@@ -1288,7 +1286,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -input_directory c:\mame\inp
+            mame -input_directory c:\mame\inp
 
 .. _mame-commandline-statedirectory:
 
@@ -1305,7 +1303,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -state_directory c:\mame\sta
+            mame -state_directory c:\mame\sta
 
 .. _mame-commandline-snapshotdirectory:
 
@@ -1321,7 +1319,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -snapshot_directory c:\mame\snap
+            mame -snapshot_directory c:\mame\snap
 
 .. _mame-commandline-diffdirectory:
 
@@ -1340,7 +1338,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -diff_directory c:\mame\diff
+            mame -diff_directory c:\mame\diff
 
 .. _mame-commandline-commentdirectory:
 
@@ -1357,7 +1355,7 @@ Core Output Directory Options
     Example:
         .. code-block:: bash
 
-            mame64 -comment_directory c:\mame\comments
+            mame -comment_directory c:\mame\comments
 
 
 Core State/Playback Options
@@ -1382,7 +1380,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 -norewind
+            mame -norewind
 
 .. _mame-commandline-rewindcapacity:
 
@@ -1397,7 +1395,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 -rewind_capacity 30
+            mame -rewind_capacity 30
 
 .. _mame-commandline-state:
 
@@ -1409,7 +1407,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 -state 1
+            mame -state 1
 
 .. _mame-commandline-noautosave:
 
@@ -1425,7 +1423,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 -autosave
+            mame -autosave
 
 .. _mame-commandline-playback:
 
@@ -1440,7 +1438,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -playback worldrecord
+            mame pacman -playback worldrecord
 
 .. Tip:: You may experience desync in playback if the configuration, NVRAM, and
          memory card files don't match the original; this is why it is suggested
@@ -1460,7 +1458,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -playback worldrecord -exit_after_playback
+            mame pacman -playback worldrecord -exit_after_playback
 
 .. _mame-commandline-record:
 
@@ -1475,7 +1473,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -record worldrecord
+            mame pacman -record worldrecord
 
 .. Tip:: You may experience desync in playback if the configuration, NVRAM, and
          memory card files don't match the original; this is why it is suggested
@@ -1496,7 +1494,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -record worldrecord -record_timecode
+            mame pacman -record worldrecord -record_timecode
 
 .. _mame-commandline-mngwrite:
 
@@ -1513,7 +1511,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -mngwrite pacman-video
+            mame pacman -mngwrite pacman-video
 
 .. _mame-commandline-aviwrite:
 
@@ -1533,7 +1531,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -playback worldrecord -exit_after_playback -aviwrite worldrecord
+            mame pacman -playback worldrecord -exit_after_playback -aviwrite worldrecord
 
 .. _mame-commandline-wavwrite:
 
@@ -1549,7 +1547,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -wavewrite pacsounds
+            mame pacman -wavewrite pacsounds
 
 **-snapname** *<name>*
 
@@ -1574,21 +1572,21 @@ Core State/Playback Options
     Example 1:
         .. code-block:: bash
 
-            mame64 robby -snapname foo\%g%i
+            mame robby -snapname foo\%g%i
 
         Snapshots will be saved as ``snaps\foo\robby0000.png``, ``snaps\foo\robby0001.png`` and so on.
 
     Example 2:
         .. code-block:: bash
 
-            mame64 nes -cart robby -snapname %g\%d_cart
+            mame nes -cart robby -snapname %g\%d_cart
 
         Snapshots will be saved as ``snaps\nes\robby.png``.
 
     Example 3:
         .. code-block:: bash
 
-            mame64 c64 -flop1 robby -snapname %g\%d_flop1/%i
+            mame c64 -flop1 robby -snapname %g\%d_flop1/%i
 
         Snapshots will be saved as ``snaps\c64\robby\0000.png``.
 
@@ -1607,7 +1605,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -snapsize 1920x1080
+            mame pacman -snapsize 1920x1080
 
 .. Tip:: -snapsize does not automatically rotate if the system is vertically
          oriented, so for vertical systems you'll want to swap the width and
@@ -1639,7 +1637,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 wrecking -snapview cocktail
+            mame wrecking -snapview cocktail
 
 
 .. _mame-commandline-nosnapbilinear:
@@ -1654,7 +1652,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -nosnapbilinear
+            mame pacman -nosnapbilinear
 
 .. _mame-commandline-statename:
 
@@ -1677,19 +1675,19 @@ Core State/Playback Options
     Example 1:
         .. code-block:: bash
 
-            mame64 robby -statename foo\%g
+            mame robby -statename foo\%g
             All save states will be stored inside sta\foo\robby\
 
     Example 2:
         .. code-block:: bash
 
-            mame64 nes -cart robby -statename %g/%d_cart
+            mame nes -cart robby -statename %g/%d_cart
             All save states will be stored inside sta\nes\robby\
 
     Example 3:
         .. code-block:: bash
 
-            mame64 c64 -flop1 robby -statename %g/%d_flop1
+            mame c64 -flop1 robby -statename %g/%d_flop1
             All save states will be stored inside sta\c64\robby\
 
 .. Tip:: Note that even on Microsoft Windows, you should use ``/`` as your
@@ -1717,7 +1715,7 @@ Core State/Playback Options
     Example:
         .. code-block:: bash
 
-            mame64 neogeo -burnin
+            mame neogeo -burnin
 
 
 Core Performance Options
@@ -1736,7 +1734,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius4 -autoframeskip
+            mame gradius4 -autoframeskip
 
 .. _mame-commandline-frameskip:
 
@@ -1753,7 +1751,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius4 -frameskip 2
+            mame gradius4 -frameskip 2
 
 .. _mame-commandline-secondstorun:
 
@@ -1770,7 +1768,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -seconds_to_run 60
+            mame pacman -seconds_to_run 60
 
 .. _mame-commandline-nothrottle:
 
@@ -1788,7 +1786,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -nothrottle
+            mame pacman -nothrottle
 
 .. _mame-commandline-nosleep:
 
@@ -1805,7 +1803,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius 4 -nosleep
+            mame gradius 4 -nosleep
 
 .. _mame-commandline-speed:
 
@@ -1824,7 +1822,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -speed 1.25
+            mame pacman -speed 1.25
 
 .. _mame-commandline-norefreshspeed:
 
@@ -1842,7 +1840,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -refreshspeed
+            mame pacman -refreshspeed
 
 .. _mame-commandline-numprocessors:
 
@@ -1858,7 +1856,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius4 -numprocessors 2
+            mame gradius4 -numprocessors 2
 
 .. _mame-commandline-bench:
 
@@ -1872,7 +1870,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius4 -bench 300
+            mame gradius4 -bench 300
 
 .. _mame-commandline-lowlatency:
 
@@ -1889,7 +1887,7 @@ Core Performance Options
     Example:
         .. code-block:: bash
 
-            mame64 bgaregga -lowlatency
+            mame bgaregga -lowlatency
 
 
 Core Rotation Options
@@ -1910,7 +1908,7 @@ Core Rotation Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -norotate
+            mame pacman -norotate
 
 .. _mame-commandline-noror:
 
@@ -1930,12 +1928,12 @@ Core Rotation Options
     Example 1:
         .. code-block:: bash
 
-            mame64 pacman -ror
+            mame pacman -ror
 
     Example 2:
         .. code-block:: bash
 
-            mame64 pacman -rol
+            mame pacman -rol
 
 
 .. _mame-commandline-noautoror:
@@ -1956,12 +1954,12 @@ Core Rotation Options
     Example 1:
         .. code-block:: bash
 
-            mame64 pacman -autoror
+            mame pacman -autoror
 
     Example 2:
         .. code-block:: bash
 
-            mame64 pacman -autorol
+            mame pacman -autorol
 
 .. Tip:: If you have a display that can be rotated, **-autorol** or
          **-autoror** will allow you to get a larger display for both horizontal
@@ -1984,12 +1982,12 @@ Core Rotation Options
     Example 1:
         .. code-block:: bash
 
-            mame64 -flipx pacman
+            mame -flipx pacman
 
     Example 2:
         .. code-block:: bash
 
-            mame64 -flipy suprmrio
+            mame -flipy suprmrio
 
 
 Core Video Options
@@ -2037,7 +2035,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius3 -video bgfx
+            mame gradius3 -video bgfx
 
 .. _mame-commandline-numscreens:
 
@@ -2056,12 +2054,12 @@ Core Video Options
     Example 1:
         .. code-block:: bash
 
-            mame64 darius -numscreens 3
+            mame darius -numscreens 3
 
     Example 2:
         .. code-block:: bash
 
-            mame64 pc_cntra -numscreens 2
+            mame pc_cntra -numscreens 2
 
 .. _mame-commandline-window:
 
@@ -2074,7 +2072,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 coco3 -window
+            mame coco3 -window
 
 .. _mame-commandline-maximize:
 
@@ -2092,7 +2090,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2e -window -nomaximize
+            mame apple2e -window -nomaximize
 
 .. _mame-commandline-keepaspect:
 
@@ -2127,7 +2125,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 sf2ua -nokeepaspect
+            mame sf2ua -nokeepaspect
 
 .. _mame-commandline-waitvsync:
 
@@ -2166,7 +2164,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 gradius2 -waitvsync
+            mame gradius2 -waitvsync
 
 .. _mame-commandline-syncrefresh:
 
@@ -2188,7 +2186,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 mk -syncrefresh
+            mame mk -syncrefresh
 
 **-prescale** *<amount>*
 
@@ -2207,7 +2205,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -video d3d -prescale 3
+            mame pacman -video d3d -prescale 3
 
 .. _mame-commandline-filter:
 
@@ -2229,7 +2227,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -nofilter
+            mame pacman -nofilter
 
 .. _mame-commandline-unevenstretch:
 
@@ -2243,7 +2241,7 @@ Core Video Options
     Example:
         .. code-block:: bash
 
-            mame64 dkong -nounevenstretch
+            mame dkong -nounevenstretch
 
 
 Core Full Screen Options
@@ -2268,7 +2266,7 @@ Core Full Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 kof97 -video d3d -switchres -resolution 1280x1024
+            mame kof97 -video d3d -switchres -resolution 1280x1024
 
 
 Core Per-Window Options
@@ -2305,12 +2303,12 @@ Core Per-Window Options
     Example 1:
         .. code-block:: bash
 
-            mame64 pc_cntra -numscreens 2 -screen0 \\.\DISPLAY1 -screen1 \\.\DISPLAY2
+            mame pc_cntra -numscreens 2 -screen0 \\.\DISPLAY1 -screen1 \\.\DISPLAY2
 
     Example 2:
         .. code-block:: bash
 
-            mame64 darius -numscreens 3 -screen0 \\.\DISPLAY1 -screen1 \\.\DISPLAY3 -screen2 \\.\DISPLAY2
+            mame darius -numscreens 3 -screen0 \\.\DISPLAY1 -screen1 \\.\DISPLAY3 -screen2 \\.\DISPLAY2
 
 .. Tip:: Using **-verbose** will tell you which displays you have on your
          system, where they are connected, and what their current resolutions
@@ -2349,12 +2347,12 @@ Core Per-Window Options
     Example 1:
         .. code-block:: bash
 
-            mame64 contra -aspect 16:9
+            mame contra -aspect 16:9
 
     Example 2:
         .. code-block:: bash
 
-            mame64 pc_cntra -numscreens 2 -aspect0 16:9 -aspect1 5:4
+            mame pc_cntra -numscreens 2 -aspect0 16:9 -aspect1 5:4
 
 
 .. _mame-commandline-resolution:
@@ -2392,7 +2390,7 @@ Core Per-Window Options
     Example:
         .. code-block:: bash
 
-            mame64 pc_cntra -numscreens 2 -resolution0 1920x1080 -resolution1 1280x1024
+            mame pc_cntra -numscreens 2 -resolution0 1920x1080 -resolution1 1280x1024
 
 .. _mame-commandline-view:
 
@@ -2433,7 +2431,7 @@ Core Per-Window Options
     Example:
         .. code-block:: bash
 
-            mame64 contra -view native
+            mame contra -view native
 
 
 Core Artwork Options
@@ -2453,7 +2451,7 @@ Core Artwork Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -artwork_crop
+            mame pacman -artwork_crop
 
 .. Tip:: **-artwork_crop** is great for widescreen displays. You will get a
          full-sized system display and the artwork will fill the empty space on
@@ -2470,7 +2468,7 @@ Core Artwork Options
     Example:
         .. code-block:: bash
 
-            mame64 coco -fallback_artwork suprmrio
+            mame coco -fallback_artwork suprmrio
 
 .. Tip:: You can use **fallback_artwork <artwork name>** in
          ``horizontal.ini`` and ``vertical.ini`` to specify different
@@ -2486,7 +2484,7 @@ Core Artwork Options
     Example:
         .. code-block:: bash
 
-            mame64 galaga -override_artwork puckman
+            mame galaga -override_artwork puckman
 
 
 Core Screen Options
@@ -2507,7 +2505,7 @@ Core Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -brightness 0.5
+            mame pacman -brightness 0.5
 
 .. _mame-commandline-contrast:
 
@@ -2524,7 +2522,7 @@ Core Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -contrast 0.5
+            mame pacman -contrast 0.5
 
 .. _mame-commandline-gamma:
 
@@ -2544,7 +2542,7 @@ Core Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -gamma 0.8
+            mame pacman -gamma 0.8
 
 .. _mame-commandline-pausebrightness:
 
@@ -2557,7 +2555,7 @@ Core Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -pause_brightness 0.33
+            mame pacman -pause_brightness 0.33
 
 .. _mame-commandline-effect:
 
@@ -2580,7 +2578,7 @@ Core Screen Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -effect scanlines
+            mame pacman -effect scanlines
 
 
 Core Vector Options
@@ -2598,7 +2596,7 @@ Core Vector Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -beam_width_min 0.1
+            mame asteroid -beam_width_min 0.1
 
 .. _mame-commandline-beamwidthmax:
 
@@ -2612,7 +2610,7 @@ Core Vector Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -beam_width_max 2
+            mame asteroid -beam_width_max 2
 
 .. _mame-commandline-beamintensityweight:
 
@@ -2628,7 +2626,7 @@ Core Vector Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -beam_intensity_weight 0.5
+            mame asteroid -beam_intensity_weight 0.5
 
 .. _mame-commandline-beamdotsize:
 
@@ -2645,7 +2643,7 @@ Core Vector Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -beam_dot_size 2
+            mame asteroid -beam_dot_size 2
 
 .. _mame-commandline-flicker:
 
@@ -2660,7 +2658,7 @@ Core Vector Options
     Example:
         .. code-block:: bash
 
-            mame64 asteroid -flicker 0.15
+            mame asteroid -flicker 0.15
 
 
 Core Video OpenGL Debugging Options
@@ -2721,7 +2719,7 @@ Core Video OpenGL GLSL Options
     Example:
         .. code-block:: bash
 
-            mame64 galaxian -gl_glsl
+            mame galaxian -gl_glsl
 
 .. _mame-commandline-glglslfilter:
 
@@ -2737,7 +2735,7 @@ Core Video OpenGL GLSL Options
     Example:
         .. code-block:: bash
 
-            mame64 galaxian -gl_glsl -gl_glsl_filter 0
+            mame galaxian -gl_glsl -gl_glsl_filter 0
 
 .. _mame-commandline-glslshadermame:
 
@@ -2756,7 +2754,7 @@ Core Video OpenGL GLSL Options
     Example:
         .. code-block:: bash
 
-            mame64 suprmrio -gl_glsl -glsl_shader_mame0 NTSC/NTSC_chain -glsl_shader_mame1 CRT-geom/CRT-geom
+            mame suprmrio -gl_glsl -glsl_shader_mame0 NTSC/NTSC_chain -glsl_shader_mame1 CRT-geom/CRT-geom
 
 .. _mame-commandline-glslshaderscreen:
 
@@ -2776,7 +2774,7 @@ Core Video OpenGL GLSL Options
     Example:
         .. code-block:: bash
 
-            mame64 suprmrio -gl_glsl -glsl_shader_screen0 gaussx -glsl_shader_screen1 gaussy -glsl_shader_screen2 CRT-geom-halation
+            mame suprmrio -gl_glsl -glsl_shader_screen0 gaussx -glsl_shader_screen1 gaussy -glsl_shader_screen2 CRT-geom-halation
 
 
 .. _mame-commandline-glglslvidattr:
@@ -2791,7 +2789,7 @@ Core Video OpenGL GLSL Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -gl_glsl -gl_glsl_vid_attr off
+            mame pacman -gl_glsl -gl_glsl_vid_attr off
 
 Core Sound Options
 ------------------
@@ -2809,7 +2807,7 @@ Core Sound Options
     Example:
         .. code-block:: bash
 
-            mame64 galaga -samplerate 44100
+            mame galaga -samplerate 44100
 
 .. _mame-commandline-nosamples:
 
@@ -2822,7 +2820,7 @@ Core Sound Options
     Example:
         .. code-block:: bash
 
-            mame64 qbert -nosamples
+            mame qbert -nosamples
 
 .. _mame-commandline-volume:
 
@@ -2837,7 +2835,7 @@ Core Sound Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -volume -30
+            mame pacman -volume -30
 
 .. _mame-commandline-sound:
 
@@ -2860,7 +2858,7 @@ Core Sound Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -sound portaudio
+            mame pacman -sound portaudio
 
 .. list-table:: Supported sound subsystems per-platform
     :header-rows: 0
@@ -2913,7 +2911,7 @@ Core Sound Options
     Example:
         .. code-block:: bash
 
-            mame64 galaga -audio_latency 1
+            mame galaga -audio_latency 1
 
 
 Core Input Options
@@ -2936,7 +2934,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 suprmrio -coin_lockout
+            mame suprmrio -coin_lockout
 
 .. _mame-commandline-ctrlr:
 
@@ -2951,7 +2949,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 dkong -ctrlr xarcade
+            mame dkong -ctrlr xarcade
 
 .. _mame-commandline-nomouse:
 
@@ -2966,7 +2964,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 centiped -mouse
+            mame centiped -mouse
 
 .. _mame-commandline-nojoystick:
 
@@ -2982,7 +2980,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 mappy -joystick
+            mame mappy -joystick
 
 .. _mame-commandline-nolightgun:
 
@@ -2997,7 +2995,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 lethalen -lightgun
+            mame lethalen -lightgun
 
 .. _mame-commandline-nomultikeyboard:
 
@@ -3015,7 +3013,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 sf2ceua -multikey
+            mame sf2ceua -multikey
 
 .. _mame-commandline-nomultimouse:
 
@@ -3032,7 +3030,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 warlords -multimouse
+            mame warlords -multimouse
 
 .. _mame-commandline-nosteadykey:
 
@@ -3050,7 +3048,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 sf2ua -steadykey
+            mame sf2ua -steadykey
 
 .. _mame-commandline-uiactive:
 
@@ -3063,7 +3061,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2e -ui_active
+            mame apple2e -ui_active
 
 .. _mame-commandline-nooffscreenreload:
 
@@ -3081,7 +3079,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 lethalen -offscreen_reload
+            mame lethalen -offscreen_reload
 
 .. _mame-commandline-joystickmap:
 
@@ -3233,7 +3231,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 sinistar -joystick_deadzone 0.45
+            mame sinistar -joystick_deadzone 0.45
 
 .. _mame-commandline-joysticksaturation:
 
@@ -3250,7 +3248,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 sinistar -joystick_saturation 1.0
+            mame sinistar -joystick_saturation 1.0
 
 .. _mame-commandline-natural:
 
@@ -3284,7 +3282,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 coco2 -natural
+            mame coco2 -natural
 
 .. _mame-commandline-joystickcontradictory:
 
@@ -3298,7 +3296,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 pc_smb -joystick_contradictory
+            mame pc_smb -joystick_contradictory
 
 .. _mame-commandline-coinimpulse:
 
@@ -3312,7 +3310,7 @@ Core Input Options
     Example:
         .. code-block:: bash
 
-            mame64 contra -coin_impulse 1
+            mame contra -coin_impulse 1
 
 
 Core Input Automatic Enable Options
@@ -3360,7 +3358,7 @@ Core Input Automatic Enable Options
     Example:
         .. code-block:: bash
 
-            mame64 sbrkout -paddle_device mouse
+            mame sbrkout -paddle_device mouse
 
 .. Tip:: Note that these controls override the values of **-[no]mouse**,
          **-[no]joystick**, etc.
@@ -3381,7 +3379,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 polepos -verbose
+            mame polepos -verbose
 
 .. Tip:: IMPORTANT: When reporting bugs to MAMEdev, please run with **-verbose**
          and include the resulting information.
@@ -3403,7 +3401,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 mappy -oslog
+            mame mappy -oslog
 
 .. _mame-commandline-log:
 
@@ -3418,12 +3416,12 @@ Debugging Options
     Example 1:
         .. code-block:: bash
 
-            mame64 qbert -log
+            mame qbert -log
 
     Example 2:
         .. code-block:: bash
 
-            mame64 qbert -oslog -log
+            mame qbert -oslog -log
 
 .. _mame-commandline-debug:
 
@@ -3438,7 +3436,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 indy_4610 -debug
+            mame indy_4610 -debug
 
 .. _mame-commandline-debugscript:
 
@@ -3452,7 +3450,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 galaga -debugscript testscript.txt
+            mame galaga -debugscript testscript.txt
 
 .. _mame-commandline-updateinpause:
 
@@ -3467,7 +3465,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 indy_4610 -update_in_pause
+            mame indy_4610 -update_in_pause
 
 .. _mame-commandline-watchdog:
 
@@ -3485,7 +3483,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 ibm_5150 -watchdog 30
+            mame ibm_5150 -watchdog 30
 
 .. _mame-commandline-debuggerfont:
 
@@ -3500,7 +3498,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 marble -debug -debugger_font "Comic Sans MS"
+            mame marble -debug -debugger_font "Comic Sans MS"
 
 .. _mame-commandline-debuggerfontsize:
 
@@ -3515,7 +3513,7 @@ Debugging Options
     Example:
         .. code-block:: bash
 
-            mame64 marble -debug -debugger_font "Comic Sans MS" -debugger_font_size 16
+            mame marble -debug -debugger_font "Comic Sans MS" -debugger_font_size 16
 
 
 Core Communication Options
@@ -3534,7 +3532,7 @@ Core Communication Options
     Example:
         .. code-block:: bash
 
-            mame64 arescue -comm_localhost 192.168.1.2
+            mame arescue -comm_localhost 192.168.1.2
 
 .. _mame-commandline-commlocalport:
 
@@ -3548,7 +3546,7 @@ Core Communication Options
     Example:
         .. code-block:: bash
 
-            mame64 arescue -comm_localhost 192.168.1.2 -comm_localport 30100
+            mame arescue -comm_localhost 192.168.1.2 -comm_localport 30100
 
 .. _mame-commandline-commremotehost:
 
@@ -3563,7 +3561,7 @@ Core Communication Options
     Example:
         .. code-block:: bash
 
-            mame64 arescue -comm_remotehost 192.168.1.2
+            mame arescue -comm_remotehost 192.168.1.2
 
 .. _mame-commandline-commremoteport:
 
@@ -3577,7 +3575,7 @@ Core Communication Options
     Example:
         .. code-block:: bash
 
-            mame64 arescue -comm_remotehost 192.168.1.2 -comm_remoteport 30100
+            mame arescue -comm_remotehost 192.168.1.2 -comm_remoteport 30100
 
 .. _mame-commandline-commframesync:
 
@@ -3590,7 +3588,7 @@ Core Communication Options
     Example:
         .. code-block:: bash
 
-            mame64 arescue -comm_remotehost 192.168.1.3 -comm_remoteport 30100 -comm_framesync
+            mame arescue -comm_remotehost 192.168.1.3 -comm_remoteport 30100 -comm_framesync
 
 
 Core Misc Options
@@ -3607,7 +3605,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 ironfort -nodrc
+            mame ironfort -nodrc
 
 .. _mame-commandline-drcusec:
 
@@ -3620,7 +3618,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 ironfort -drc_use_c
+            mame ironfort -drc_use_c
 
 .. _mame-commandline-drcloguml:
 
@@ -3633,7 +3631,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 ironfort -drc_log_uml
+            mame ironfort -drc_log_uml
 
 .. _mame-commandline-drclognative:
 
@@ -3646,7 +3644,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 ironfort -drc_log_native
+            mame ironfort -drc_log_native
 
 .. _mame-commandline-bios:
 
@@ -3661,7 +3659,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 mslug -bios unibios33
+            mame mslug -bios unibios33
 
 .. _mame-commandline-cheat:
 
@@ -3679,7 +3677,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 dkong -cheat
+            mame dkong -cheat
 
 .. _mame-commandline-skipgameinfo:
 
@@ -3692,7 +3690,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 samsho5 -skip_gameinfo
+            mame samsho5 -skip_gameinfo
 
 .. _mame-commandline-uifont:
 
@@ -3708,7 +3706,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 -uifont "Comic Sans MS"
+            mame -uifont "Comic Sans MS"
 
 .. _mame-commandline-ui:
 
@@ -3721,7 +3719,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 -ui simple
+            mame -ui simple
 
 .. _mame-commandline-ramsize:
 
@@ -3732,7 +3730,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 coco -ramsize 16K
+            mame coco -ramsize 16K
 
 .. _mame-commandline-confirmquit:
 
@@ -3746,7 +3744,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 pacman -confirm_quit
+            mame pacman -confirm_quit
 
 .. _mame-commandline-uimouse:
 
@@ -3761,7 +3759,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 -ui_mouse
+            mame -ui_mouse
 
 **-language** *<language>*
 
@@ -3770,7 +3768,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 -language Japanese
+            mame -language Japanese
 
 .. _mame-commandline-nvramsave:
 
@@ -3786,7 +3784,7 @@ Core Misc Options
     Example:
         .. code-block:: bash
 
-            mame64 galaga88 -nonvram_save
+            mame galaga88 -nonvram_save
 
 
 Scripting Options
@@ -3805,7 +3803,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 c64 -autoboot_delay 5 -autoboot_command "load """$""",8,1\n"
+            mame c64 -autoboot_delay 5 -autoboot_command "load """$""",8,1\n"
 
 .. _mame-commandline-autobootdelay:
 
@@ -3816,7 +3814,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 c64 -autoboot_delay 5 -autoboot_command "load """$""",8,1\n"
+            mame c64 -autoboot_delay 5 -autoboot_command "load """$""",8,1\n"
 
 .. _mame-commandline-autobootscript:
 
@@ -3827,7 +3825,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 ibm5150 -autoboot_script myscript.lua
+            mame ibm5150 -autoboot_script myscript.lua
 
 .. _mame-commandline-console:
 
@@ -3840,7 +3838,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 ibm5150 -console
+            mame ibm5150 -console
 
 .. _mame-commandline-plugins:
 
@@ -3853,7 +3851,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2e -plugins
+            mame apple2e -plugins
 
 .. _mame-commandline-plugin:
 
@@ -3864,7 +3862,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 alcon -plugin cheat,discord,autofire
+            mame alcon -plugin cheat,discord,autofire
 
 .. _mame-commandline-noplugin:
 
@@ -3875,7 +3873,7 @@ Scripting Options
     Example:
         .. code-block:: bash
 
-            mame64 alcon -noplugin cheat
+            mame alcon -noplugin cheat
 
 
 HTTP Server Options
@@ -3891,7 +3889,7 @@ HTTP Server Options
     Example:
         .. code-block:: bash
 
-            mame64 -http
+            mame -http
 
 .. _mame-commandline-httpport:
 
@@ -3904,7 +3902,7 @@ HTTP Server Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2 -http -http_port 6502
+            mame apple2 -http -http_port 6502
 
 .. _mame-commandline-httproot:
 
@@ -3917,7 +3915,7 @@ HTTP Server Options
     Example:
         .. code-block:: bash
 
-            mame64 apple2 -http -http_port 6502 -http_root c:\users\me\appleweb\root
+            mame apple2 -http -http_port 6502 -http_root c:\users\me\appleweb\root
 
 
 PortAudio Options
@@ -3934,7 +3932,7 @@ PortAudio Options
     Example 1:
         .. code-block:: bash
 
-            mame64 -sound portaudio -verbose
+            mame -sound portaudio -verbose
             Attempting load of mame.ini
             ...
             PortAudio: API MME has 20 devices
@@ -3977,7 +3975,7 @@ PortAudio Options
     Example 2:
         .. code-block:: bash
 
-            mame64 suprmrio -sound portaudio -pa_api "Windows WASAPI"
+            mame suprmrio -sound portaudio -pa_api "Windows WASAPI"
 
 .. _mame-commandline-pa-device:
 
@@ -3991,7 +3989,7 @@ PortAudio Options
     Example:
         .. code-block:: bash
 
-            mame64 suprmrio -sound portaudio -pa_api "Windows WASAPI" -pa_device "NX-EDG27 (NVIDIA High Definition Audio)"
+            mame suprmrio -sound portaudio -pa_api "Windows WASAPI" -pa_device "NX-EDG27 (NVIDIA High Definition Audio)"
 
 .. _mame-commandline-pa-latency:
 
@@ -4008,4 +4006,4 @@ PortAudio Options
     Example:
         .. code-block:: bash
 
-            mame64 suprmrio -sound portaudio -pa_api "Windows WASAPI" -pa_device "NX-EDG27 (NVIDIA High Definition Audio)" -pa_latency 0.20
+            mame suprmrio -sound portaudio -pa_api "Windows WASAPI" -pa_device "NX-EDG27 (NVIDIA High Definition Audio)" -pa_latency 0.20

--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -71,7 +71,7 @@ building MAME on a 64-bit system.  Instructions may need to be adjusted for
   window management, audio/video output, font rendering, etc.  If you want to
   use the portable SDL (Simple DirectMedia Layer) interfaces instead, you can
   add **OSD=sdl** to the make options.  The main emulator binary will have an
-  ``sdl`` prefix prepended (e.g. ``sdlmame64.exe`` or ``sdlmame.exe``).  You
+  ``sdl`` prefix prepended (e.g. ``sdlmame.exe`` or ``sdlmame.exe``).  You
   will need to install the MSYS2 packages for SDL 2 version 2.0.3 or later.
 * By default, MAME will include the native Windows debugger.  To also include
   the portable Qt debugger, add **USE_QTDEBUG=1** to the make options.  You

--- a/docs/source/initialsetup/compilingmame.rst
+++ b/docs/source/initialsetup/compilingmame.rst
@@ -71,7 +71,7 @@ building MAME on a 64-bit system.  Instructions may need to be adjusted for
   window management, audio/video output, font rendering, etc.  If you want to
   use the portable SDL (Simple DirectMedia Layer) interfaces instead, you can
   add **OSD=sdl** to the make options.  The main emulator binary will have an
-  ``sdl`` prefix prepended (e.g. ``sdlmame.exe`` or ``sdlmame.exe``).  You
+  ``sdl`` prefix prepended (e.g. ``sdlmame.exe``).  You
   will need to install the MSYS2 packages for SDL 2 version 2.0.3 or later.
 * By default, MAME will include the native Windows debugger.  To also include
   the portable Qt debugger, add **USE_QTDEBUG=1** to the make options.  You

--- a/docs/source/techspecs/layout_script.rst
+++ b/docs/source/techspecs/layout_script.rst
@@ -21,7 +21,7 @@ Layout scripting requires the layout plugin to be enabled.  For example, to run
 BWB Double Take with the Lua script in the layout enabled, you might use this
 command::
 
-    mame64 -plugins -plugin layout v4dbltak
+    mame -plugins -plugin layout v4dbltak
 
 If you may want to add the settings to enable the layout plugin to an INI file
 to save having to enable it every time you start a system.

--- a/docs/source/usingmame/usingmame.rst
+++ b/docs/source/usingmame/usingmame.rst
@@ -19,7 +19,7 @@ will load the USA version of Metroid for the Nintendo Entertainment System.
 Alternatively, you could start MAME with
 
 	**mame.exe nes**
-	
+
 and choose the *software list* from the cartridge slot. From there, you could pick any softlist-compatible software you have in your roms folders. Please note that many older dumps of cartridges and discs may either be bad or require renaming to match up to the softlist in order to work in this way.
 
 
@@ -66,7 +66,7 @@ gives you a (quite long) list of available configuration options for MAME. These
 
 creates a brand new **mame.ini** file, with default configuration settings. Notice that mame.ini is basically a plain text file, hence you can open it with any text editor (e.g. Notepad, Emacs or TextEdit) and configure every option you need. However, no particular tweaks are needed to start, so you can basically leave most of the options unaltered.
 
-If you execute **mame64 -createconfig** when you already have an existing mame.ini from a previous MAME version, MAME automatically updates the pre-existing mame.ini by copying changed options into it.
+If you execute **mame -createconfig** when you already have an existing mame.ini from a previous MAME version, MAME automatically updates the pre-existing mame.ini by copying changed options into it.
 
 
 Once you are more confident with MAME options, you may want to configure a bit more your setup. In this case, keep in mind the order in which options are read; see :ref:`advanced-multi-CFG` for details.


### PR DESCRIPTION
Need a specific review on compilingmame.rst line 205, though.