### PR TITLE
firebeat: Large refactor + initial beatmania III support

### DIFF
--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -325,11 +325,6 @@ private:
 	required_shared_ptr<uint16_t> m_waveram;
 
 	output_finder<8> m_spu_status_leds;
-
-	enum
-	{
-		TIMER_SPU_DMA
-	};
 };
 
 /*****************************************************************************/

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -1179,13 +1179,11 @@ void firebeat_bm3_state::firebeat_bm3(machine_config &config)
 
 	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_bm3_state::firebeat_bm3_map);
 
+	// beatmania III is the only game on the Firebeat platform to use 640x480
 	screen_device *screen = subdevice<screen_device>("screen");
-	if (screen != nullptr) {
-		// beatmania III is the only game on the Firebeat platform to use 640x480
-		screen->set_size(640, 480);
-		screen->set_visarea(0, 639, 0, 479);
-		screen->screen_vblank().set(FUNC(firebeat_bm3_state::bm3_vblank));
-	}
+	screen->set_size(640, 480);
+	screen->set_visarea(0, 639, 0, 479);
+	screen->screen_vblank().set(FUNC(firebeat_bm3_state::bm3_vblank));
 
 	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "hdd", nullptr, true);
 	m_spuata->irq_handler().set(FUNC(firebeat_bm3_state::spu_ata_interrupt));

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -1140,8 +1140,8 @@ TIMER_CALLBACK_MEMBER(firebeat_spu_state::spu_dma_callback)
 	// These values were picked because they roughly match real in-game footage of
 	// when sounds start playing, and more importantly to free up CPU time for the
 	// main CPU during DMAs to avoid stuttering.
-	auto next_dma_timing = attotime::from_usec(75);
-	auto dma_end_target = m_spu_ata_dma + 128;
+	auto next_dma_timing = attotime::from_usec(5);
+	auto dma_end_target = m_spu_ata_dma + 16;
 
 	while (m_spu_ata_dmarq && m_spu_ata_dma < dma_end_target)
 	{

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -1137,22 +1137,15 @@ WRITE_LINE_MEMBER(firebeat_spu_state::spu_ata_dmarq)
 
 TIMER_CALLBACK_MEMBER(firebeat_spu_state::spu_dma_callback)
 {
-	// These values were picked because they roughly match real in-game footage of
-	// when sounds start playing, and more importantly to free up CPU time for the
-	// main CPU during DMAs to avoid stuttering.
-	auto next_dma_timing = attotime::from_usec(5);
-	auto dma_end_target = m_spu_ata_dma + 16;
-
-	while (m_spu_ata_dmarq && m_spu_ata_dma < dma_end_target)
-	{
-		uint16_t data = m_spuata->read_dma();
-		m_waveram[m_wave_bank+m_spu_ata_dma] = data;
-		m_spu_ata_dma++;
-	}
+	uint16_t data = m_spuata->read_dma();
+	m_waveram[m_wave_bank+m_spu_ata_dma] = data;
+	m_spu_ata_dma++;
 
 	if (m_spu_ata_dmarq)
 	{
-		m_dma_timer->adjust(next_dma_timing);
+		// This timer adjust value was picked because
+		// it reduces stuttering issues/performance issues
+		m_dma_timer->adjust(attotime::from_nsec(350));
 	}
 	else
 	{

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -191,7 +191,6 @@ static void cdrom_config(device_t *device)
 {
 	device->subdevice<cdda_device>("cdda")->add_route(0, "^^lspeaker", 0.5);
 	device->subdevice<cdda_device>("cdda")->add_route(1, "^^rspeaker", 0.5);
-	device = device->subdevice("cdda");
 }
 
 static void dvdrom_config(device_t *device)

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -1141,7 +1141,6 @@ WRITE_LINE_MEMBER(firebeat_spu_state::spu_ata_dmarq)
 		if (m_spu_ata_dmarq)
 		{
 			m_spuata->write_dmack(ASSERT_LINE);
-			m_dma_timer->enable(true);
 			m_dma_timer->adjust(attotime::zero);
 		}
 	}

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -825,14 +825,14 @@ void firebeat_state::lamp_output_w(offs_t offset, uint32_t data, uint32_t mem_ma
 	// -------- -------- -------- xxxxxxxx   Status LEDs (active low)
 	if (ACCESSING_BITS_0_7)
 	{
-		output().set_value("status_led_0", (data & 0x01) ? 0 : 1);
-		output().set_value("status_led_1", (data & 0x02) ? 0 : 1);
-		output().set_value("status_led_2", (data & 0x04) ? 0 : 1);
-		output().set_value("status_led_3", (data & 0x08) ? 0 : 1);
-		output().set_value("status_led_4", (data & 0x10) ? 0 : 1);
-		output().set_value("status_led_5", (data & 0x20) ? 0 : 1);
-		output().set_value("status_led_6", (data & 0x40) ? 0 : 1);
-		output().set_value("status_led_7", (data & 0x80) ? 0 : 1);
+		output().set_value("status_led_0", BIT(~data, 0));
+		output().set_value("status_led_1", BIT(~data, 1));
+		output().set_value("status_led_2", BIT(~data, 2));
+		output().set_value("status_led_3", BIT(~data, 3));
+		output().set_value("status_led_4", BIT(~data, 4));
+		output().set_value("status_led_5", BIT(~data, 5));
+		output().set_value("status_led_6", BIT(~data, 6));
+		output().set_value("status_led_7", BIT(~data, 7));
 	}
 
 //  printf("lamp_output_w: %08X, %08X, %08X\n", data, offset, mem_mask);
@@ -1020,11 +1020,11 @@ void firebeat_spu_state::spu_irq_ack_w(offs_t offset, uint16_t data, uint16_t me
 {
 	if (ACCESSING_BITS_0_7)
 	{
-		if (data & 0x01)
+		if (BIT(data, 0))
 			m_audiocpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
-		if (data & 0x02)
+		if (BIT(data, 1))
 			m_audiocpu->set_input_line(INPUT_LINE_IRQ2, CLEAR_LINE);
-		if (data & 0x08)
+		if (BIT(data, 3))
 			m_audiocpu->set_input_line(INPUT_LINE_IRQ6, CLEAR_LINE);
 	}
 }
@@ -1343,25 +1343,25 @@ void firebeat_ppp_state::lamp_output_ppp_w(offs_t offset, uint32_t data, uint32_
 	// 0x00080000 Stage LED 7
 	if (ACCESSING_BITS_8_15)
 	{
-		output().set_value("left",            (data & 0x00000100) ? 1 : 0);
-		output().set_value("right",           (data & 0x00000200) ? 1 : 0);
-		output().set_value("door_lamp",       (data & 0x00000400) ? 1 : 0);
-		output().set_value("ok",              (data & 0x00000800) ? 1 : 0);
-		output().set_value("slim",            (data & 0x00008000) ? 1 : 0);
+		output().set_value("left",      BIT(data, 8));
+		output().set_value("right",     BIT(data, 9));
+		output().set_value("door_lamp", BIT(data, 10));
+		output().set_value("ok",        BIT(data, 11));
+		output().set_value("slim",      BIT(data, 15));
 	}
 	if (ACCESSING_BITS_24_31)
 	{
-		output().set_value("stage_led_0",     (data & 0x01000000) ? 1 : 0);
-		output().set_value("stage_led_1",     (data & 0x02000000) ? 1 : 0);
-		output().set_value("stage_led_2",     (data & 0x04000000) ? 1 : 0);
-		output().set_value("stage_led_3",     (data & 0x08000000) ? 1 : 0);
+		output().set_value("stage_led_0", BIT(data, 24));
+		output().set_value("stage_led_1", BIT(data, 25));
+		output().set_value("stage_led_2", BIT(data, 26));
+		output().set_value("stage_led_3", BIT(data, 27));
 	}
 	if (ACCESSING_BITS_16_23)
 	{
-		output().set_value("stage_led_4",     (data & 0x00010000) ? 1 : 0);
-		output().set_value("stage_led_5",     (data & 0x00020000) ? 1 : 0);
-		output().set_value("stage_led_6",     (data & 0x00040000) ? 1 : 0);
-		output().set_value("stage_led_7",     (data & 0x00080000) ? 1 : 0);
+		output().set_value("stage_led_4", BIT(data, 16));
+		output().set_value("stage_led_5", BIT(data, 17));
+		output().set_value("stage_led_6", BIT(data, 18));
+		output().set_value("stage_led_7", BIT(data, 19));
 	}
 }
 
@@ -1380,17 +1380,17 @@ void firebeat_ppp_state::lamp_output2_ppp_w(offs_t offset, uint32_t data, uint32
 	// 0x00000008 Top LED 7
 	if (ACCESSING_BITS_16_23)
 	{
-		output().set_value("top_led_0",       (data & 0x00010000) ? 1 : 0);
-		output().set_value("top_led_1",       (data & 0x00020000) ? 1 : 0);
-		output().set_value("top_led_2",       (data & 0x00040000) ? 1 : 0);
-		output().set_value("top_led_3",       (data & 0x00080000) ? 1 : 0);
+		output().set_value("top_led_0", BIT(data, 16));
+		output().set_value("top_led_1", BIT(data, 17));
+		output().set_value("top_led_2", BIT(data, 18));
+		output().set_value("top_led_3", BIT(data, 19));
 	}
 	if (ACCESSING_BITS_0_7)
 	{
-		output().set_value("top_led_4",       (data & 0x00000001) ? 1 : 0);
-		output().set_value("top_led_5",       (data & 0x00000002) ? 1 : 0);
-		output().set_value("top_led_6",       (data & 0x00000004) ? 1 : 0);
-		output().set_value("top_led_7",       (data & 0x00000008) ? 1 : 0);
+		output().set_value("top_led_4", BIT(data, 0));
+		output().set_value("top_led_5", BIT(data, 1));
+		output().set_value("top_led_6", BIT(data, 2));
+		output().set_value("top_led_7", BIT(data, 3));
 	}
 }
 
@@ -1405,10 +1405,10 @@ void firebeat_ppp_state::lamp_output3_ppp_w(offs_t offset, uint32_t data, uint32
 	// 0x00400000 Lamp 3
 	if (ACCESSING_BITS_16_23)
 	{
-		output().set_value("lamp_0",          (data & 0x00010000) ? 1 : 0);
-		output().set_value("lamp_1",          (data & 0x00040000) ? 1 : 0);
-		output().set_value("lamp_2",          (data & 0x00100000) ? 1 : 0);
-		output().set_value("lamp_3",          (data & 0x00400000) ? 1 : 0);
+		output().set_value("lamp_0", BIT(data, 16));
+		output().set_value("lamp_1", BIT(data, 18));
+		output().set_value("lamp_2", BIT(data, 20));
+		output().set_value("lamp_3", BIT(data, 22));
 	}
 }
 
@@ -1531,7 +1531,7 @@ void firebeat_kbm_state::midi_uart_w(offs_t offset, uint8_t data)
 
 WRITE_LINE_MEMBER(firebeat_kbm_state::midi_uart_ch0_irq_callback)
 {
-	if ((m_extend_board_irq_enable & 0x02) == 0 && state != CLEAR_LINE)
+	if (BIT(m_extend_board_irq_enable, 1) == 0 && state != CLEAR_LINE)
 	{
 		m_extend_board_irq_active |= 0x02;
 		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
@@ -1542,7 +1542,7 @@ WRITE_LINE_MEMBER(firebeat_kbm_state::midi_uart_ch0_irq_callback)
 
 WRITE_LINE_MEMBER(firebeat_kbm_state::midi_uart_ch1_irq_callback)
 {
-	if ((m_extend_board_irq_enable & 0x01) == 0 && state != CLEAR_LINE)
+	if (BIT(m_extend_board_irq_enable, 0) == 0 && state != CLEAR_LINE)
 	{
 		m_extend_board_irq_active |= 0x01;
 		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
@@ -1631,16 +1631,16 @@ void firebeat_kbm_state::lamp_output_kbm_w(offs_t offset, uint32_t data, uint32_
 
 	if (ACCESSING_BITS_24_31)
 	{
-		output().set_value("door_lamp",   (data & 0x10000000) ? 1 : 0);
-		output().set_value("start1p",     (data & 0x01000000) ? 1 : 0);
-		output().set_value("start2p",     (data & 0x02000000) ? 1 : 0);
+		output().set_value("door_lamp", BIT(data, 28));
+		output().set_value("start1p",   BIT(data, 24));
+		output().set_value("start2p",   BIT(data, 25));
 	}
 	if (ACCESSING_BITS_8_15)
 	{
-		output().set_value("lamp1",       (data & 0x00000100) ? 1 : 0);
-		output().set_value("lamp2",       (data & 0x00000200) ? 1 : 0);
-		output().set_value("lamp3",       (data & 0x00000400) ? 1 : 0);
-		output().set_value("neon",        (data & 0x00000800) ? 1 : 0);
+		output().set_value("lamp1", BIT(data, 8));
+		output().set_value("lamp2", BIT(data, 9));
+		output().set_value("lamp3", BIT(data, 10));
+		output().set_value("neon",  BIT(data, 11));
 	}
 }
 

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -773,7 +773,8 @@ void firebeat_state::extend_board_irq_w(offs_t offset, uint8_t data)
 
 uint8_t firebeat_state::input_r(offs_t offset)
 {
-	switch (offset) {
+	switch (offset)
+	{
 		case 0: return (m_io_inputs[0]->read() & 0xff);
 		case 1: return (m_io_inputs[1]->read() & 0xff);
 		case 2: return (m_io_inputs[2]->read() & 0xff);
@@ -872,9 +873,9 @@ static void comm_uart_irq_callback(running_machine &machine, int channel, int va
 
 void firebeat_state::init_lights(write32s_delegate out1, write32s_delegate out2, write32s_delegate out3)
 {
-	if(out1.isnull()) out1 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output_w));
-	if(out2.isnull()) out2 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output2_w));
-	if(out3.isnull()) out3 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output3_w));
+	if (out1.isnull()) out1 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output_w));
+	if (out2.isnull()) out2 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output2_w));
+	if (out3.isnull()) out3 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output3_w));
 
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x7d000804, 0x7d000807, out1);
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x7d000320, 0x7d000323, out2);
@@ -1161,9 +1162,12 @@ TIMER_CALLBACK_MEMBER(firebeat_spu_state::spu_dma_callback)
 		m_spu_ata_dma++;
 	}
 
-	if (m_spu_ata_dmarq) {
+	if (m_spu_ata_dmarq)
+	{
 		m_dma_timer->adjust(next_dma_timing);
-	} else {
+	}
+	else
+	{
 		m_spuata->write_dmack(CLEAR_LINE);
 		m_dma_timer->enable(false);
 	}
@@ -1260,7 +1264,8 @@ uint32_t firebeat_bm3_state::spectrum_analyzer_r(offs_t offset)
 
 uint16_t firebeat_bm3_state::sensor_r(offs_t offset)
 {
-	switch (offset) {
+	switch (offset)
+	{
 		case 0: return m_io[0]->read() | 0x0100;
 		case 1: return m_io[1]->read() | 0x0100;
 		case 2: return m_io[2]->read() | 0x0100;
@@ -1297,31 +1302,31 @@ WRITE_LINE_MEMBER(firebeat_bm3_state::bm3_vblank)
 {
 	// Patch out FDD errors since the game otherwise runs fine without it
 	// and the FDD might not be implemented for a while
-	if(strcmp(machine().system().name, "bm3") == 0)
+	if (strcmp(machine().system().name, "bm3") == 0)
 	{
 		if (m_work_ram[0x918C / 4] == 0x4809202D) m_work_ram[0x918C / 4] = 0x38600000;
 		if (m_work_ram[0x3380C / 4] == 0x4BFFFD99) m_work_ram[0x3380C / 4] = 0x38600000;
 		if (m_work_ram[0x33834 / 4] == 0x4BFFFD71) m_work_ram[0x33834 / 4] = 0x38600000;
 	}
-	else if(strcmp(machine().system().name, "bm3core") == 0)
+	else if (strcmp(machine().system().name, "bm3core") == 0)
 	{
 		if (m_work_ram[0x91E4 / 4] == 0x480A19F5) m_work_ram[0x91E4 / 4] = 0x38600000;
 		if (m_work_ram[0x37BB0 / 4] == 0x4BFFFD71) m_work_ram[0x37BB0 / 4] = 0x38600000;
 		if (m_work_ram[0x37BD8 / 4] == 0x4BFFFD49) m_work_ram[0x37BD8 / 4] = 0x38600000;
 	}
-	else if(strcmp(machine().system().name, "bm36th") == 0)
+	else if (strcmp(machine().system().name, "bm36th") == 0)
 	{
 		if (m_work_ram[0x91E4 / 4] == 0x480BC8BD) m_work_ram[0x91E4 / 4] = 0x38600000;
 		if (m_work_ram[0x451D8 / 4] == 0x4BFFFD75) m_work_ram[0x451D8 / 4] = 0x38600000;
 		if (m_work_ram[0x45200 / 4] == 0x4BFFFD4D) m_work_ram[0x45200 / 4] = 0x38600000;
 	}
-	else if(strcmp(machine().system().name, "bm37th") == 0)
+	else if (strcmp(machine().system().name, "bm37th") == 0)
 	{
 		if (m_work_ram[0x91E4 / 4] == 0x480CF62D) m_work_ram[0x91E4 / 4] = 0x38600000;
 		if (m_work_ram[0x46A58 / 4] == 0x4BFFFD45) m_work_ram[0x46A58 / 4] = 0x38600000;
 		if (m_work_ram[0x46AB8 / 4] == 0x4BFFFCE5) m_work_ram[0x46AB8 / 4] = 0x38600000;
 	}
-	else if(strcmp(machine().system().name, "bm3final") == 0)
+	else if (strcmp(machine().system().name, "bm3final") == 0)
 	{
 		if (m_work_ram[0x47F8 / 4] == 0x480CEF91) m_work_ram[0x47F8 / 4] = 0x38600000;
 		if (m_work_ram[0x3FAF4 / 4] == 0x4BFFFD59) m_work_ram[0x3FAF4 / 4] = 0x38600000;
@@ -1401,7 +1406,8 @@ void firebeat_ppp_state::firebeat_ppp_map(address_map &map)
 
 uint16_t firebeat_ppp_state::sensor_r(offs_t offset)
 {
-	switch (offset) {
+	switch (offset)
+	{
 		case 0: return m_io_sensors[0]->read() | 0x0100;
 		case 1: return m_io_sensors[1]->read() | 0x0100;
 		case 2: return m_io_sensors[2]->read() | 0x0100;
@@ -1609,7 +1615,8 @@ void firebeat_kbm_state::firebeat_kbm_map(address_map &map)
 
 uint8_t firebeat_kbm_state::keyboard_wheel_r(offs_t offset)
 {
-	switch (offset) {
+	switch (offset)
+	{
 		case 0: return m_io_wheels[0]->read(); // Keyboard Wheel (P1)
 		case 8: return m_io_wheels[1]->read(); // Keyboard Wheel (P2)
 	}

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -176,983 +176,18 @@ struct IBUTTON
 	IBUTTON_SUBKEY subkey[3];
 };
 
-
-//#define PRINT_SPU_MEM 0
-
-class firebeat_state : public driver_device
-{
-public:
-	firebeat_state(const machine_config &mconfig, device_type type, const char *tag) :
-		driver_device(mconfig, type, tag),
-		m_maincpu(*this, "maincpu"),
-		m_audiocpu(*this, "audiocpu"),
-		m_work_ram(*this, "work_ram"),
-		m_duart_midi(*this, "duart_midi"),
-		m_duart_com(*this, "duart_com"),
-		m_kbd(*this, "kbd%u", 0),
-		m_ata(*this, "ata"),
-		m_gcu(*this, "gcu%u", 0),
-		m_dpram(*this, "spuram"),
-		m_spuata(*this, "spu_ata"),
-		m_waveram(*this, "rf5c400")
-	{ }
-
-	void firebeat2(machine_config &config);
-	void firebeat(machine_config &config);
-
-	void firebeat_spu(machine_config &config);
-	void firebeat_spu_bm3(machine_config &config);
-
-	void init_ppd();
-	void init_kbm();
-	void init_ppp();
-
-protected:
-	virtual void machine_start() override;
-	virtual void machine_reset() override;
-	virtual void video_start() override;
-
-private:
-	required_device<ppc4xx_device> m_maincpu;
-	optional_device<m68000_device> m_audiocpu;
-	required_shared_ptr<uint32_t> m_work_ram;
-	optional_device<pc16552_device> m_duart_midi;
-	required_device<pc16552_device> m_duart_com;
-	optional_device_array<midi_keyboard_device, 2> m_kbd;
-	required_device<ata_interface_device> m_ata;
-	optional_device_array<k057714_device, 2> m_gcu;
-	optional_device<cy7c131_device> m_dpram;
-	optional_device<ata_interface_device> m_spuata;
-	optional_shared_ptr<uint16_t> m_waveram;
-
-	uint8_t m_extend_board_irq_enable;
-	uint8_t m_extend_board_irq_active;
-//  emu_timer *m_keyboard_timer;
-	int m_layer;
-	int m_cab_data_ptr;
-	const int * m_cur_cab_data;
-//  int m_keyboard_state[2];
-	IBUTTON m_ibutton;
-	int m_ibutton_state;
-	int m_ibutton_read_subkey_ptr;
-	uint8_t m_ibutton_subkey_data[0x40];
-
-	uint32_t m_spu_ata_dma;
-	int m_spu_ata_dmarq;
-	uint32_t m_wave_bank;
-
-	void firebeat_spu_base(machine_config &config);
-
-	uint32_t screen_update_firebeat_0(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_firebeat_1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
-	INTERRUPT_GEN_MEMBER(firebeat_interrupt);
-	uint32_t input_r(offs_t offset, uint32_t mem_mask = ~0);
-	uint32_t sensor_r(offs_t offset);
-	DECLARE_WRITE_LINE_MEMBER(ata_interrupt);
-	uint32_t ata_command_r(offs_t offset, uint32_t mem_mask = ~0);
-	void ata_command_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t ata_control_r(offs_t offset, uint32_t mem_mask = ~0);
-	void ata_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-//  uint32_t comm_uart_r(offs_t offset, uint32_t mem_mask = ~ 0);
-//  void comm_uart_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint32_t cabinet_r(offs_t offset, uint32_t mem_mask = ~0);
-	uint32_t keyboard_wheel_r(offs_t offset);
-	uint8_t midi_uart_r(offs_t offset);
-	void midi_uart_w(offs_t offset, uint8_t data);
-	uint32_t extend_board_irq_r(offs_t offset, uint32_t mem_mask = ~0);
-	void extend_board_irq_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output_kbm_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output2_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output2_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output3_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	void lamp_output3_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
-	uint16_t spu_unk_r();
-	void spu_irq_ack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void spu_220000_w(uint16_t data);
-	void spu_ata_dma_low_w(uint16_t data);
-	void spu_ata_dma_high_w(uint16_t data);
-	void spu_wavebank_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	uint16_t firebeat_waveram_r(offs_t offset);
-	void firebeat_waveram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	DECLARE_WRITE_LINE_MEMBER(spu_ata_interrupt);
-	DECLARE_WRITE_LINE_MEMBER(spu_ata_dmarq);
-//  TIMER_CALLBACK_MEMBER(keyboard_timer_callback);
-	void set_ibutton(uint8_t *data);
-	int ibutton_w(uint8_t data);
-	void security_w(uint8_t data);
-	void init_lights(write32s_delegate out1, write32s_delegate out2, write32s_delegate out3);
-	void init_firebeat();
-	void init_keyboard();
-	DECLARE_WRITE_LINE_MEMBER(sound_irq_callback);
-	DECLARE_WRITE_LINE_MEMBER(midi_uart_ch0_irq_callback);
-	DECLARE_WRITE_LINE_MEMBER(midi_uart_ch1_irq_callback);
-	DECLARE_WRITE_LINE_MEMBER(gcu0_interrupt);
-	DECLARE_WRITE_LINE_MEMBER(gcu1_interrupt);
-	static void cdrom_config(device_t *device);
-	void firebeat_map(address_map &map);
-	void firebeat_spu_map(address_map &map);
-	void firebeat2_map(address_map &map);
-	void spu_map(address_map &map);
-	void ymz280b_map(address_map &map);
-	void rf5c400_map(address_map& map);
-};
-
-
-
-
-
-
-void firebeat_state::video_start()
-{
-}
-
-uint32_t firebeat_state::screen_update_firebeat_0(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect){ return m_gcu[0]->draw(screen, bitmap, cliprect); }
-uint32_t firebeat_state::screen_update_firebeat_1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect){ return m_gcu[1]->draw(screen, bitmap, cliprect); }
-
 /*****************************************************************************/
-
-uint32_t firebeat_state::input_r(offs_t offset, uint32_t mem_mask)
+static void firebeat_ata_devices(device_slot_interface &device)
 {
-	uint32_t r = 0;
-
-	if (ACCESSING_BITS_24_31)
-	{
-		r |= (ioport("IN0")->read() & 0xff) << 24;
-	}
-	if (ACCESSING_BITS_16_23)
-	{
-		r |= (ioport("IN3")->read() & 0xff) << 16;
-	}
-	if (ACCESSING_BITS_8_15)
-	{
-		r |= (ioport("IN1")->read() & 0xff) << 8;
-	}
-	if (ACCESSING_BITS_0_7)
-	{
-		r |= (ioport("IN2")->read() & 0xff);
-	}
-
-	return r;
+	device.option_add("cdrom", ATAPI_FIXED_CDROM);
 }
 
-uint32_t firebeat_state::sensor_r(offs_t offset)
+static void firebeat_ata_devices_hdd(device_slot_interface &device)
 {
-	if (offset == 0)
-	{
-		return ioport("SENSOR1")->read() | 0x01000100;
-	}
-	else
-	{
-		return ioport("SENSOR2")->read() | 0x01000100;
-	}
+	device.option_add("hdd", IDE_HARDDISK);
 }
 
-/*****************************************************************************/
-/* ATA Interface */
-
-#define BYTESWAP16(x)   ((((x) >> 8) & 0xff) | (((x) << 8) & 0xff00))
-
-uint32_t firebeat_state::ata_command_r(offs_t offset, uint32_t mem_mask)
-{
-	uint16_t r;
-//  printf("ata_command_r: %08X, %08X\n", offset, mem_mask);
-	if (ACCESSING_BITS_16_31)
-	{
-		r = m_ata->cs0_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
-		return BYTESWAP16(r) << 16;
-	}
-	else
-	{
-		r = m_ata->cs0_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
-		return BYTESWAP16(r) << 0;
-	}
-}
-
-void firebeat_state::ata_command_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-//  printf("ata_command_w: %08X, %08X, %08X\n", data, offset, mem_mask);
-
-	if (ACCESSING_BITS_16_31)
-	{
-		m_ata->cs0_w(offset*2, BYTESWAP16((data >> 16) & 0xffff), BYTESWAP16((mem_mask >> 16) & 0xffff));
-	}
-	else
-	{
-		m_ata->cs0_w((offset*2) + 1, BYTESWAP16((data >> 0) & 0xffff), BYTESWAP16((mem_mask >> 0) & 0xffff));
-	}
-}
-
-
-uint32_t firebeat_state::ata_control_r(offs_t offset, uint32_t mem_mask)
-{
-	uint16_t r;
-//  printf("ata_control_r: %08X, %08X\n", offset, mem_mask);
-
-	if (ACCESSING_BITS_16_31)
-	{
-		r = m_ata->cs1_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
-		return BYTESWAP16(r) << 16;
-	}
-	else
-	{
-		r = m_ata->cs1_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
-		return BYTESWAP16(r) << 0;
-	}
-}
-
-void firebeat_state::ata_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	if (ACCESSING_BITS_16_31)
-	{
-		m_ata->cs1_w(offset*2, BYTESWAP16(data >> 16) & 0xffff, BYTESWAP16((mem_mask >> 16) & 0xffff));
-	}
-	else
-	{
-		m_ata->cs1_w((offset*2) + 1, BYTESWAP16(data >> 0) & 0xffff, BYTESWAP16((mem_mask >> 0) & 0xffff));
-	}
-}
-
-
-/*****************************************************************************/
-/*
-uint32_t firebeat_state::comm_uart_r(offs_t offset, uint32_t mem_mask)
-{
-    uint32_t r = 0;
-
-    if (ACCESSING_BITS_24_31)
-    {
-        r |= pc16552d_0_r((offset*4)+0) << 24;
-    }
-    if (ACCESSING_BITS_16_23)
-    {
-        r |= pc16552d_0_r((offset*4)+1) << 16;
-    }
-    if (ACCESSING_BITS_8_15)
-    {
-        r |= pc16552d_0_r((offset*4)+2) << 8;
-    }
-    if (ACCESSING_BITS_0_7)
-    {
-        r |= pc16552d_0_r((offset*4)+3) << 0;
-    }
-
-    return r;
-}
-
-void firebeat_state::comm_uart_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-    if (ACCESSING_BITS_24_31)
-    {
-        pc16552d_0_w((offset*4)+0, (data >> 24) & 0xff);
-    }
-    if (ACCESSING_BITS_16_23)
-    {
-        pc16552d_0_w((offset*4)+1, (data >> 16) & 0xff);
-    }
-    if (ACCESSING_BITS_8_15)
-    {
-        pc16552d_0_w((offset*4)+2, (data >> 8) & 0xff);
-    }
-    if (ACCESSING_BITS_0_7)
-    {
-        pc16552d_0_w((offset*4)+3, (data >> 0) & 0xff);
-    }
-}
-
-static void comm_uart_irq_callback(running_machine &machine, int channel, int value)
-{
-    // TODO
-    //m_maincpu->set_input_line(INPUT_LINE_IRQ2, ASSERT_LINE);
-}
-*/
-
-/*****************************************************************************/
-
-static const int cab_data[2] = { 0x0, 0x8 };
-static const int kbm_cab_data[2] = { 0x2, 0x8 };
-static const int ppd_cab_data[2] = { 0x1, 0x9 };
-
-uint32_t firebeat_state::cabinet_r(offs_t offset, uint32_t mem_mask)
-{
-	uint32_t r = 0;
-
-//  printf("cabinet_r: %08X, %08X\n", offset, mem_mask);
-	switch (offset)
-	{
-		case 0:
-		{
-			r = m_cur_cab_data[m_cab_data_ptr & 1] << 28;
-			m_cab_data_ptr++;
-			return r;
-		}
-		case 2:     return 0x00000000;
-		case 4:     return 0x00000000;
-	}
-
-	return 0;
-}
-
-/*****************************************************************************/
-
-uint32_t firebeat_state::keyboard_wheel_r(offs_t offset)
-{
-	if (offset == 0)        // Keyboard Wheel (P1)
-	{
-		return ioport("WHEEL_P1")->read() << 24;
-	}
-	else if (offset == 2)   // Keyboard Wheel (P2)
-	{
-		return ioport("WHEEL_P2")->read() << 24;
-	}
-
-	return 0;
-}
-
-uint8_t firebeat_state::midi_uart_r(offs_t offset)
-{
-	return m_duart_midi->read(offset >> 6);
-}
-
-void firebeat_state::midi_uart_w(offs_t offset, uint8_t data)
-{
-	m_duart_midi->write(offset >> 6, data);
-}
-
-WRITE_LINE_MEMBER(firebeat_state::midi_uart_ch0_irq_callback)
-{
-	if ((m_extend_board_irq_enable & 0x02) == 0 && state != CLEAR_LINE)
-	{
-		m_extend_board_irq_active |= 0x02;
-		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
-	}
-	else
-		m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
-}
-
-WRITE_LINE_MEMBER(firebeat_state::midi_uart_ch1_irq_callback)
-{
-	if ((m_extend_board_irq_enable & 0x01) == 0 && state != CLEAR_LINE)
-	{
-		m_extend_board_irq_active |= 0x01;
-		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
-	}
-	else
-		m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
-}
-
-/*
-static const int keyboard_notes[24] =
-{
-    0x3c,   // C1
-    0x3d,   // C1#
-    0x3e,   // D1
-    0x3f,   // D1#
-    0x40,   // E1
-    0x41,   // F1
-    0x42,   // F1#
-    0x43,   // G1
-    0x44,   // G1#
-    0x45,   // A1
-    0x46,   // A1#
-    0x47,   // B1
-    0x48,   // C2
-    0x49,   // C2#
-    0x4a,   // D2
-    0x4b,   // D2#
-    0x4c,   // E2
-    0x4d,   // F2
-    0x4e,   // F2#
-    0x4f,   // G2
-    0x50,   // G2#
-    0x51,   // A2
-    0x52,   // A2#
-    0x53,   // B2
-};
-
-TIMER_CALLBACK_MEMBER(firebeat_state::keyboard_timer_callback)
-{
-    static const int kb_uart_channel[2] = { 1, 0 };
-    static const char *const keynames[] = { "KEYBOARD_P1", "KEYBOARD_P2" };
-    int keyboard;
-    int i;
-
-    for (keyboard=0; keyboard < 2; keyboard++)
-    {
-        uint32_t kbstate = ioport(keynames[keyboard])->read();
-        int uart_channel = kb_uart_channel[keyboard];
-
-        if (kbstate != m_keyboard_state[keyboard])
-        {
-            for (i=0; i < 24; i++)
-            {
-                int kbnote = keyboard_notes[i];
-
-                if ((m_keyboard_state[keyboard] & (1 << i)) != 0 && (kbstate & (1 << i)) == 0)
-                {
-                    // key was on, now off -> send Note Off message
-                    pc16552d_rx_data(machine(), 1, uart_channel, 0x80);
-                    pc16552d_rx_data(machine(), 1, uart_channel, kbnote);
-                    pc16552d_rx_data(machine(), 1, uart_channel, 0x7f);
-                }
-                else if ((m_keyboard_state[keyboard] & (1 << i)) == 0 && (kbstate & (1 << i)) != 0)
-                {
-                    // key was off, now on -> send Note On message
-                    pc16552d_rx_data(machine(), 1, uart_channel, 0x90);
-                    pc16552d_rx_data(machine(), 1, uart_channel, kbnote);
-                    pc16552d_rx_data(machine(), 1, uart_channel, 0x7f);
-                }
-            }
-        }
-        else
-        {
-            // no messages, send Active Sense message instead
-            pc16552d_rx_data(machine(), 1, uart_channel, 0xfe);
-        }
-
-        m_keyboard_state[keyboard] = kbstate;
-    }
-}
-*/
-// Extend board IRQs
-// 0x01: MIDI UART channel 2
-// 0x02: MIDI UART channel 1
-// 0x04: ?
-// 0x08: ?
-// 0x10: ?
-// 0x20: ?
-
-uint32_t firebeat_state::extend_board_irq_r(offs_t offset, uint32_t mem_mask)
-{
-	uint32_t r = 0;
-
-	if (ACCESSING_BITS_24_31)
-	{
-		r |= (~m_extend_board_irq_active) << 24;
-	}
-
-	return r;
-}
-
-void firebeat_state::extend_board_irq_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-//  printf("extend_board_irq_w: %08X, %08X, %08X\n", data, offset, mem_mask);
-
-	if (ACCESSING_BITS_24_31)
-	{
-		m_extend_board_irq_active &= ~((data >> 24) & 0xff);
-
-		m_extend_board_irq_enable = (data >> 24) & 0xff;
-	}
-}
-
-/*****************************************************************************/
-
-void firebeat_state::lamp_output_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	// -------- -------- -------- xxxxxxxx   Status LEDs (active low)
-	if (ACCESSING_BITS_0_7)
-	{
-		output().set_value("status_led_0", (data & 0x01) ? 0 : 1);
-		output().set_value("status_led_1", (data & 0x02) ? 0 : 1);
-		output().set_value("status_led_2", (data & 0x04) ? 0 : 1);
-		output().set_value("status_led_3", (data & 0x08) ? 0 : 1);
-		output().set_value("status_led_4", (data & 0x10) ? 0 : 1);
-		output().set_value("status_led_5", (data & 0x20) ? 0 : 1);
-		output().set_value("status_led_6", (data & 0x40) ? 0 : 1);
-		output().set_value("status_led_7", (data & 0x80) ? 0 : 1);
-	}
-
-//  printf("lamp_output_w: %08X, %08X, %08X\n", data, offset, mem_mask);
-}
-
-void firebeat_state::lamp_output_kbm_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	lamp_output_w(offset, data, mem_mask);
-
-	if (ACCESSING_BITS_24_31)
-	{
-		output().set_value("door_lamp",   (data & 0x10000000) ? 1 : 0);
-		output().set_value("start1p",     (data & 0x01000000) ? 1 : 0);
-		output().set_value("start2p",     (data & 0x02000000) ? 1 : 0);
-	}
-	if (ACCESSING_BITS_8_15)
-	{
-		output().set_value("lamp1",       (data & 0x00000100) ? 1 : 0);
-		output().set_value("lamp2",       (data & 0x00000200) ? 1 : 0);
-		output().set_value("lamp3",       (data & 0x00000400) ? 1 : 0);
-		output().set_value("neon",        (data & 0x00000800) ? 1 : 0);
-	}
-}
-
-void firebeat_state::lamp_output_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	lamp_output_w(offset, data, mem_mask);
-
-	// ParaParaParadise lamps (active high)
-	// 0x00000100 Left
-	// 0x00000200 Right
-	// 0x00000400 Door Lamp
-	// 0x00000800 OK
-	// 0x00008000 Slim
-	// 0x01000000 Stage LED 0
-	// 0x02000000 Stage LED 1
-	// 0x04000000 Stage LED 2
-	// 0x08000000 Stage LED 3
-	// 0x00010000 Stage LED 4
-	// 0x00020000 Stage LED 5
-	// 0x00040000 Stage LED 6
-	// 0x00080000 Stage LED 7
-	if (ACCESSING_BITS_8_15)
-	{
-		output().set_value("left",            (data & 0x00000100) ? 1 : 0);
-		output().set_value("right",           (data & 0x00000200) ? 1 : 0);
-		output().set_value("door_lamp",       (data & 0x00000400) ? 1 : 0);
-		output().set_value("ok",              (data & 0x00000800) ? 1 : 0);
-		output().set_value("slim",            (data & 0x00008000) ? 1 : 0);
-	}
-	if (ACCESSING_BITS_24_31)
-	{
-		output().set_value("stage_led_0",     (data & 0x01000000) ? 1 : 0);
-		output().set_value("stage_led_1",     (data & 0x02000000) ? 1 : 0);
-		output().set_value("stage_led_2",     (data & 0x04000000) ? 1 : 0);
-		output().set_value("stage_led_3",     (data & 0x08000000) ? 1 : 0);
-	}
-	if (ACCESSING_BITS_16_23)
-	{
-		output().set_value("stage_led_4",     (data & 0x00010000) ? 1 : 0);
-		output().set_value("stage_led_5",     (data & 0x00020000) ? 1 : 0);
-		output().set_value("stage_led_6",     (data & 0x00040000) ? 1 : 0);
-		output().set_value("stage_led_7",     (data & 0x00080000) ? 1 : 0);
-	}
-}
-
-void firebeat_state::lamp_output2_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-//  printf("lamp_output2_w: %08X, %08X, %08X\n", data, offset, mem_mask);
-}
-
-void firebeat_state::lamp_output2_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	lamp_output2_w(offset, data, mem_mask);
-
-	// ParaParaParadise lamps (active high)
-	// 0x00010000 Top LED 0
-	// 0x00020000 Top LED 1
-	// 0x00040000 Top LED 2
-	// 0x00080000 Top LED 3
-	// 0x00000001 Top LED 4
-	// 0x00000002 Top LED 5
-	// 0x00000004 Top LED 6
-	// 0x00000008 Top LED 7
-	if (ACCESSING_BITS_16_23)
-	{
-		output().set_value("top_led_0",       (data & 0x00010000) ? 1 : 0);
-		output().set_value("top_led_1",       (data & 0x00020000) ? 1 : 0);
-		output().set_value("top_led_2",       (data & 0x00040000) ? 1 : 0);
-		output().set_value("top_led_3",       (data & 0x00080000) ? 1 : 0);
-	}
-	if (ACCESSING_BITS_0_7)
-	{
-		output().set_value("top_led_4",       (data & 0x00000001) ? 1 : 0);
-		output().set_value("top_led_5",       (data & 0x00000002) ? 1 : 0);
-		output().set_value("top_led_6",       (data & 0x00000004) ? 1 : 0);
-		output().set_value("top_led_7",       (data & 0x00000008) ? 1 : 0);
-	}
-}
-
-void firebeat_state::lamp_output3_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-//  printf("lamp_output3_w: %08X, %08X, %08X\n", data, offset, mem_mask);
-}
-
-void firebeat_state::lamp_output3_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
-{
-	lamp_output3_w(offset, data, mem_mask);
-
-	// ParaParaParadise lamps (active high)
-	// 0x00010000 Lamp 0
-	// 0x00040000 Lamp 1
-	// 0x00100000 Lamp 2
-	// 0x00400000 Lamp 3
-	if (ACCESSING_BITS_16_23)
-	{
-		output().set_value("lamp_0",          (data & 0x00010000) ? 1 : 0);
-		output().set_value("lamp_1",          (data & 0x00040000) ? 1 : 0);
-		output().set_value("lamp_2",          (data & 0x00100000) ? 1 : 0);
-		output().set_value("lamp_3",          (data & 0x00400000) ? 1 : 0);
-	}
-}
-
-/*****************************************************************************/
-
-
-/*  SPU board M68K IRQs
-
-    IRQ1: ?
-
-    IRQ2: Timer?
-
-    IRQ4: Dual-port RAM mailbox (when PPC writes to 0x3FE)
-          Handles commands from PPC (bytes 0x00 and 0x01)
-
-    IRQ6: ATA
-*/
-
-uint16_t firebeat_state::spu_unk_r()
-{
-	// dipswitches?
-
-	uint16_t r = 0;
-	r |= 0x80;      // if set, uses ATA PIO mode, otherwise DMA
-	r |= 0x01;      // enable SDRAM test
-	r |= 0x02;      // Fixes sound effects not playing
-
-	return r;
-}
-
-void firebeat_state::spu_irq_ack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	if (ACCESSING_BITS_0_7)
-	{
-		if (data & 0x01)
-			m_audiocpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
-		if (data & 0x02)
-			m_audiocpu->set_input_line(INPUT_LINE_IRQ2, CLEAR_LINE);
-		if (data & 0x08)
-			m_audiocpu->set_input_line(INPUT_LINE_IRQ6, CLEAR_LINE);
-	}
-}
-
-void firebeat_state::spu_220000_w(uint16_t data)
-{
-	// IRQ2 handler 5 sets all bits
-}
-
-void firebeat_state::spu_ata_dma_low_w(uint16_t data)
-{
-	m_spu_ata_dma = (m_spu_ata_dma & ~0xffff) | data;
-}
-
-void firebeat_state::spu_ata_dma_high_w(uint16_t data)
-{
-	m_spu_ata_dma = (m_spu_ata_dma & 0xffff) | ((uint32_t)data << 16);
-}
-
-void firebeat_state::spu_wavebank_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	m_wave_bank = data * (4 * 1024 * 1024);
-}
-
-uint16_t firebeat_state::firebeat_waveram_r(offs_t offset)
-{
-	return m_waveram[offset + m_wave_bank];
-}
-
-void firebeat_state::firebeat_waveram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
-{
-	COMBINE_DATA(&m_waveram[offset + m_wave_bank]);
-}
-
-
-WRITE_LINE_MEMBER(firebeat_state::spu_ata_dmarq)
-{
-	if (m_spuata != nullptr && m_spu_ata_dmarq != state)
-	{
-		m_spu_ata_dmarq = state;
-
-		if (m_spu_ata_dmarq)
-		{
-			m_spuata->write_dmack(ASSERT_LINE);
-
-			while (m_spu_ata_dmarq)
-			{
-				uint16_t data = m_spuata->read_dma();
-				m_waveram[m_wave_bank+m_spu_ata_dma] = data;
-				m_spu_ata_dma++;
-			}
-
-			m_spuata->write_dmack(CLEAR_LINE);
-		}
-	}
-}
-
-WRITE_LINE_MEMBER(firebeat_state::spu_ata_interrupt)
-{
-	m_audiocpu->set_input_line(INPUT_LINE_IRQ6, state);
-}
-
-/*****************************************************************************/
-
-void firebeat_state::machine_start()
-{
-	/* set conservative DRC options */
-	m_maincpu->ppcdrc_set_options(PPCDRC_COMPATIBLE_OPTIONS);
-
-	/* configure fast RAM regions for DRC */
-	m_maincpu->ppcdrc_add_fastram(0x00000000, 0x01ffffff, false, m_work_ram);
-}
-
-void firebeat_state::firebeat_map(address_map &map)
-{
-	map(0x00000000, 0x01ffffff).ram().share("work_ram");
-	map(0x70000000, 0x70000fff).rw(FUNC(firebeat_state::midi_uart_r), FUNC(firebeat_state::midi_uart_w)).umask32(0xff000000);
-	map(0x70006000, 0x70006003).w(FUNC(firebeat_state::extend_board_irq_w));
-	map(0x70008000, 0x7000800f).r(FUNC(firebeat_state::keyboard_wheel_r));
-	map(0x7000a000, 0x7000a003).r(FUNC(firebeat_state::extend_board_irq_r));
-	map(0x74000000, 0x740003ff).noprw(); // SPU shared RAM
-	map(0x7d000200, 0x7d00021f).r(FUNC(firebeat_state::cabinet_r));
-	map(0x7d000340, 0x7d000347).r(FUNC(firebeat_state::sensor_r));
-	map(0x7d000400, 0x7d000401).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write));
-	map(0x7d000800, 0x7d000803).r(FUNC(firebeat_state::input_r));
-	map(0x7d400000, 0x7d5fffff).rw("flash_main", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
-	map(0x7d800000, 0x7d9fffff).rw("flash_snd1", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
-	map(0x7da00000, 0x7dbfffff).rw("flash_snd2", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
-	map(0x7dc00000, 0x7dc0000f).rw(m_duart_com, FUNC(pc16552_device::read), FUNC(pc16552_device::write));
-	map(0x7e000000, 0x7e00003f).rw("rtc", FUNC(rtc65271_device::rtc_r), FUNC(rtc65271_device::rtc_w));
-	map(0x7e000100, 0x7e00013f).rw("rtc", FUNC(rtc65271_device::xram_r), FUNC(rtc65271_device::xram_w));
-	map(0x7e800000, 0x7e8000ff).rw(m_gcu[0], FUNC(k057714_device::read), FUNC(k057714_device::write));
-	map(0x7fe00000, 0x7fe0000f).rw(FUNC(firebeat_state::ata_command_r), FUNC(firebeat_state::ata_command_w));
-	map(0x7fe80000, 0x7fe8000f).rw(FUNC(firebeat_state::ata_control_r), FUNC(firebeat_state::ata_control_w));
-	map(0x7ff80000, 0x7fffffff).rom().region("user1", 0);       /* System BIOS */
-}
-
-void firebeat_state::firebeat_spu_map(address_map &map)
-{
-	firebeat_map(map);
-	map(0x74000000, 0x740003ff).rw(m_dpram, FUNC(cy7c131_device::right_r), FUNC(cy7c131_device::right_w)); // SPU shared RAM
-}
-
-void firebeat_state::firebeat2_map(address_map &map)
-{
-	firebeat_map(map);
-	map(0x7e800100, 0x7e8001ff).rw(m_gcu[1], FUNC(k057714_device::read), FUNC(k057714_device::write));
-}
-
-void firebeat_state::spu_map(address_map &map)
-{
-	map(0x000000, 0x07ffff).rom();
-	map(0x100000, 0x13ffff).ram();
-	map(0x200000, 0x200001).r(FUNC(firebeat_state::spu_unk_r));
-	map(0x220000, 0x220001).w(FUNC(firebeat_state::spu_220000_w));
-	map(0x230000, 0x230001).w(FUNC(firebeat_state::spu_irq_ack_w));
-	map(0x240000, 0x240003).w(FUNC(firebeat_state::spu_ata_dma_low_w)).nopr();
-	map(0x250000, 0x250003).w(FUNC(firebeat_state::spu_ata_dma_high_w)).nopr();
-	map(0x260000, 0x260001).w(FUNC(firebeat_state::spu_wavebank_w)).nopr();
-	map(0x280000, 0x2807ff).rw(m_dpram, FUNC(cy7c131_device::left_r), FUNC(cy7c131_device::left_w)).umask16(0x00ff);
-	map(0x300000, 0x30000f).rw(m_spuata, FUNC(ata_interface_device::cs0_r), FUNC(ata_interface_device::cs0_w));
-	map(0x340000, 0x34000f).rw(m_spuata, FUNC(ata_interface_device::cs1_r), FUNC(ata_interface_device::cs1_w));
-	map(0x400000, 0x400fff).rw("rf5c400", FUNC(rf5c400_device::rf5c400_r), FUNC(rf5c400_device::rf5c400_w));
-	map(0x800000, 0xffffff).rw(FUNC(firebeat_state::firebeat_waveram_r), FUNC(firebeat_state::firebeat_waveram_w));
-}
-
-void firebeat_state::ymz280b_map(address_map &map)
-{
-	map.global_mask(0x3fffff);
-	map(0x000000, 0x1fffff).r("flash_snd1", FUNC(fujitsu_29f016a_device::read));
-	map(0x200000, 0x3fffff).r("flash_snd2", FUNC(fujitsu_29f016a_device::read));
-}
-
-void firebeat_state::rf5c400_map(address_map& map)
-{
-	map(0x0000000, 0x1ffffff).ram().share("rf5c400");
-}
-
-/*****************************************************************************/
-
-WRITE_LINE_MEMBER(firebeat_state::sound_irq_callback)
-{
-}
-
-static INPUT_PORTS_START( firebeat )
-	PORT_START("IN2")
-	PORT_DIPUNKNOWN_DIPLOC( 0x01, IP_ACTIVE_LOW, "DIP SW:8" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x02, IP_ACTIVE_LOW, "DIP SW:7" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x04, IP_ACTIVE_LOW, "DIP SW:6" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x08, IP_ACTIVE_LOW, "DIP SW:5" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x10, IP_ACTIVE_LOW, "DIP SW:4" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x20, IP_ACTIVE_LOW, "DIP SW:3" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x40, IP_ACTIVE_LOW, "DIP SW:2" )
-	PORT_DIPUNKNOWN_DIPLOC( 0x80, IP_ACTIVE_LOW, "DIP SW:1" )
-
-	PORT_START("IN3")
-	PORT_BIT( 0xfc, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-	PORT_BIT( 0x03, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Fixes "FLASH RAM DATA ERROR" in some games (Mickey Tunes)
-INPUT_PORTS_END
-
-static INPUT_PORTS_START(ppp)
-	PORT_INCLUDE( firebeat )
-
-	PORT_START("IN0")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON1 )            // Left
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_BUTTON2 )            // Right
-	PORT_SERVICE_NO_TOGGLE( 0x04, IP_ACTIVE_LOW)            // Test
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START1 )             // Start / Ok
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNUSED )             // Fixes booting in PPP with certain dongle types
-	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNUSED )
-
-	PORT_START("IN1")
-	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
-
-	// ParaParaParadise has 24 sensors, grouped into groups of 3 for each sensor bar
-	// Sensors 15...23 are only used by the Korean version of PPP, which has 8 sensor bars
-
-	PORT_START("SENSOR1")
-	PORT_BIT( 0x00070000, IP_ACTIVE_HIGH, IPT_BUTTON3 )     // Sensor 0, 1, 2  (Sensor bar 1)
-	PORT_BIT( 0x00380000, IP_ACTIVE_HIGH, IPT_BUTTON4 )     // Sensor 3, 4, 5  (Sensor bar 2)
-	PORT_BIT( 0x00c00001, IP_ACTIVE_HIGH, IPT_BUTTON5 )     // Sensor 6, 7, 8  (Sensor bar 3)
-	PORT_BIT( 0x0000000e, IP_ACTIVE_HIGH, IPT_BUTTON6 )     // Sensor 9, 10,11 (Sensor bar 4)
-
-	PORT_START("SENSOR2")
-	PORT_BIT( 0x00070000, IP_ACTIVE_HIGH, IPT_BUTTON7 )     // Sensor 12,13,14 (Sensor bar 5)
-	PORT_BIT( 0x00380000, IP_ACTIVE_HIGH, IPT_BUTTON8 )     // Sensor 15,16,17 (Sensor bar 6)   (unused by PPP)
-	PORT_BIT( 0x00c00001, IP_ACTIVE_HIGH, IPT_BUTTON9 )     // Sensor 18,19,20 (Sensor bar 7)   (unused by PPP)
-	PORT_BIT( 0x0000000e, IP_ACTIVE_HIGH, IPT_BUTTON10 )    // Sensor 21,22,23 (Sensor bar 8)   (unused by PPP)
-
-INPUT_PORTS_END
-
-static INPUT_PORTS_START(kbm)
-	PORT_INCLUDE( firebeat )
-
-	PORT_START("IN0")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_START1 )             // Start P1
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_START2 )             // Start P2
-	PORT_SERVICE_NO_TOGGLE( 0x04, IP_ACTIVE_LOW)            // Test
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
-	PORT_BIT( 0xe0, IP_ACTIVE_LOW, IPT_UNUSED )
-
-	PORT_START("IN1")
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_UNKNOWN )           // e-Amusement
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN )            // e-Amusement (Keyboardmania)
-	PORT_BIT( 0xde, IP_ACTIVE_LOW, IPT_UNKNOWN )
-
-	PORT_START("WHEEL_P1")          // Keyboard modulation wheel (P1)
-	PORT_BIT( 0xff, 0x80, IPT_PADDLE ) PORT_MINMAX(0x00, 0xff) PORT_SENSITIVITY(30) PORT_KEYDELTA(10)
-
-	PORT_START("WHEEL_P2")          // Keyboard modulation wheel (P2)
-	PORT_BIT( 0xff, 0x80, IPT_PADDLE_V ) PORT_MINMAX(0x00, 0xff) PORT_SENSITIVITY(30) PORT_KEYDELTA(10)
-
-/*
-    PORT_START("KEYBOARD_P1")
-    PORT_BIT( 0x000001, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C1") PORT_CODE(KEYCODE_Q)
-    PORT_BIT( 0x000002, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C1#") PORT_CODE(KEYCODE_W)
-    PORT_BIT( 0x000004, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D1") PORT_CODE(KEYCODE_E)
-    PORT_BIT( 0x000008, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D1#") PORT_CODE(KEYCODE_R)
-    PORT_BIT( 0x000010, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 E1") PORT_CODE(KEYCODE_T)
-    PORT_BIT( 0x000020, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F1") PORT_CODE(KEYCODE_Y)
-    PORT_BIT( 0x000040, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F1#") PORT_CODE(KEYCODE_U)
-    PORT_BIT( 0x000080, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G1") PORT_CODE(KEYCODE_I)
-    PORT_BIT( 0x000100, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G1#") PORT_CODE(KEYCODE_O)
-    PORT_BIT( 0x000200, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A1") PORT_CODE(KEYCODE_A)
-    PORT_BIT( 0x000400, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A1#") PORT_CODE(KEYCODE_S)
-    PORT_BIT( 0x000800, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 B1") PORT_CODE(KEYCODE_D)
-    PORT_BIT( 0x001000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C2") PORT_CODE(KEYCODE_F)
-    PORT_BIT( 0x002000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C2#") PORT_CODE(KEYCODE_G)
-    PORT_BIT( 0x004000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D2") PORT_CODE(KEYCODE_H)
-    PORT_BIT( 0x008000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D2#") PORT_CODE(KEYCODE_J)
-    PORT_BIT( 0x010000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 E2") PORT_CODE(KEYCODE_K)
-    PORT_BIT( 0x020000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F2") PORT_CODE(KEYCODE_L)
-    PORT_BIT( 0x040000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F2#") PORT_CODE(KEYCODE_Z)
-    PORT_BIT( 0x080000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G2") PORT_CODE(KEYCODE_X)
-    PORT_BIT( 0x100000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G2#") PORT_CODE(KEYCODE_C)
-    PORT_BIT( 0x200000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A2") PORT_CODE(KEYCODE_V)
-    PORT_BIT( 0x400000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A2#") PORT_CODE(KEYCODE_B)
-    PORT_BIT( 0x800000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 B2") PORT_CODE(KEYCODE_N)
-
-    PORT_START("KEYBOARD_P2")
-    PORT_BIT( 0x000001, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C1") PORT_CODE(KEYCODE_Q)
-    PORT_BIT( 0x000002, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C1#") PORT_CODE(KEYCODE_W)
-    PORT_BIT( 0x000004, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D1") PORT_CODE(KEYCODE_E)
-    PORT_BIT( 0x000008, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D1#") PORT_CODE(KEYCODE_R)
-    PORT_BIT( 0x000010, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 E1") PORT_CODE(KEYCODE_T)
-    PORT_BIT( 0x000020, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F1") PORT_CODE(KEYCODE_Y)
-    PORT_BIT( 0x000040, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F1#") PORT_CODE(KEYCODE_U)
-    PORT_BIT( 0x000080, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G1") PORT_CODE(KEYCODE_I)
-    PORT_BIT( 0x000100, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G1#") PORT_CODE(KEYCODE_O)
-    PORT_BIT( 0x000200, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A1") PORT_CODE(KEYCODE_A)
-    PORT_BIT( 0x000400, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A1#") PORT_CODE(KEYCODE_S)
-    PORT_BIT( 0x000800, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 B1") PORT_CODE(KEYCODE_D)
-    PORT_BIT( 0x001000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C2") PORT_CODE(KEYCODE_F)
-    PORT_BIT( 0x002000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C2#") PORT_CODE(KEYCODE_G)
-    PORT_BIT( 0x004000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D2") PORT_CODE(KEYCODE_H)
-    PORT_BIT( 0x008000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D2#") PORT_CODE(KEYCODE_J)
-    PORT_BIT( 0x010000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 E2") PORT_CODE(KEYCODE_K)
-    PORT_BIT( 0x020000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F2") PORT_CODE(KEYCODE_L)
-    PORT_BIT( 0x040000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F2#") PORT_CODE(KEYCODE_Z)
-    PORT_BIT( 0x080000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G2") PORT_CODE(KEYCODE_X)
-    PORT_BIT( 0x100000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G2#") PORT_CODE(KEYCODE_C)
-    PORT_BIT( 0x200000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A2") PORT_CODE(KEYCODE_V)
-    PORT_BIT( 0x400000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A2#") PORT_CODE(KEYCODE_B)
-    PORT_BIT( 0x800000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 B2") PORT_CODE(KEYCODE_N)
-*/
-INPUT_PORTS_END
-
-static INPUT_PORTS_START(popn)
-	PORT_INCLUDE( firebeat )
-
-	PORT_START("IN0")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON1 )            // Switch 1
-	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_BUTTON2 )            // Switch 2
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON3 )            // Switch 3
-	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_BUTTON4 )            // Switch 4
-	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON5 )            // Switch 5
-	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON6 )            // Switch 6
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON7 )            // Switch 7
-	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_BUTTON8 )            // Switch 8
-
-	PORT_START("IN1")
-	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON9 )            // Switch 9
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
-	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-	PORT_SERVICE_NO_TOGGLE( 0x10, IP_ACTIVE_LOW)            // Test
-	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
-	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNKNOWN )
-
-INPUT_PORTS_END
-
-INTERRUPT_GEN_MEMBER(firebeat_state::firebeat_interrupt)
-{
-	// IRQs
-	// IRQ 0: VBlank
-	// IRQ 1: Extend board IRQ
-	// IRQ 2: Main board UART
-	// IRQ 3: SPU mailbox interrupt
-	// IRQ 4: ATA
-
-	device.execute().set_input_line(INPUT_LINE_IRQ0, ASSERT_LINE);
-}
-
-WRITE_LINE_MEMBER(firebeat_state::gcu0_interrupt)
-{
-	m_maincpu->set_input_line(INPUT_LINE_IRQ0, state);
-}
-
-WRITE_LINE_MEMBER(firebeat_state::gcu1_interrupt)
-{
-	m_maincpu->set_input_line(INPUT_LINE_IRQ0, state);
-}
-
-void firebeat_state::machine_reset()
-{
-	m_layer = 0;
-
-	m_spu_ata_dma = 0;
-	m_spu_ata_dmarq = 0;
-	m_wave_bank = 0;
-}
-
-WRITE_LINE_MEMBER( firebeat_state::ata_interrupt )
-{
-	m_maincpu->set_input_line(INPUT_LINE_IRQ4, state);
-}
-
-void firebeat_state::cdrom_config(device_t *device)
+static void cdrom_config(device_t *device)
 {
 	device->subdevice<cdda_device>("cdda")->add_route(0, "^^lspeaker", 0.5);
 	device->subdevice<cdda_device>("cdda")->add_route(1, "^^rspeaker", 0.5);
@@ -1164,10 +199,259 @@ static void dvdrom_config(device_t *device)
 	downcast<atapi_cdrom_device &>(*device).set_ultra_dma_mode(0x0102);
 }
 
-static void firebeat_ata_devices(device_slot_interface &device)
+class firebeat_state : public driver_device
 {
-	device.option_add("cdrom", ATAPI_FIXED_CDROM);
-	device.option_add("hdd", IDE_HARDDISK);
+public:
+	firebeat_state(const machine_config &mconfig, device_type type, const char *tag) :
+		driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_work_ram(*this, "work_ram"),
+		m_ata(*this, "ata"),
+		m_gcu(*this, "gcu"),
+		m_duart_com(*this, "duart_com")
+	{ }
+
+	void firebeat(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
+	uint32_t screen_update_firebeat_0(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void init_firebeat();
+
+	void firebeat_map(address_map &map);
+	void ymz280b_map(address_map &map);
+
+	void init_lights(write32s_delegate out1, write32s_delegate out2, write32s_delegate out3);
+	void lamp_output_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void lamp_output2_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void lamp_output3_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+	INTERRUPT_GEN_MEMBER(firebeat_interrupt);
+	DECLARE_WRITE_LINE_MEMBER(ata_interrupt);
+	DECLARE_WRITE_LINE_MEMBER(gcu_interrupt);
+	DECLARE_WRITE_LINE_MEMBER(sound_irq_callback);
+
+	int m_cabinet_info;
+
+	uint8_t m_extend_board_irq_enable;
+	uint8_t m_extend_board_irq_active;
+
+	required_device<ppc4xx_device> m_maincpu;
+	required_shared_ptr<uint32_t> m_work_ram;
+	required_device<ata_interface_device> m_ata;
+	required_device<k057714_device> m_gcu;
+
+private:
+	uint32_t cabinet_r(offs_t offset, uint32_t mem_mask = ~0);
+
+	void set_ibutton(uint8_t *data);
+	int ibutton_w(uint8_t data);
+	void security_w(uint8_t data);
+
+	uint32_t extend_board_irq_r(offs_t offset, uint32_t mem_mask = ~0);
+	void extend_board_irq_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+	uint32_t input_r(offs_t offset, uint32_t mem_mask = ~0);
+
+	uint32_t ata_command_r(offs_t offset, uint32_t mem_mask = ~0);
+	void ata_command_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+	uint32_t ata_control_r(offs_t offset, uint32_t mem_mask = ~0);
+	void ata_control_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+//  uint32_t comm_uart_r(offs_t offset, uint32_t mem_mask = ~ 0);
+//  void comm_uart_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+	IBUTTON m_ibutton;
+	int m_ibutton_state;
+	int m_ibutton_read_subkey_ptr;
+	uint8_t m_ibutton_subkey_data[0x40];
+
+	required_device<pc16552_device> m_duart_com;
+};
+
+class firebeat_spu_state : public firebeat_state
+{
+public:
+	firebeat_spu_state(const machine_config &mconfig, device_type type, const char *tag) :
+		firebeat_state(mconfig, type, tag),
+		m_spuata(*this, "spu_ata"),
+		m_audiocpu(*this, "audiocpu"),
+		m_dpram(*this, "spuram"),
+		m_waveram(*this, "rf5c400")
+	{ }
+
+protected:
+	void firebeat_spu_base(machine_config &config);
+	void firebeat_spu_map(address_map &map);
+	void spu_map(address_map &map);
+	void rf5c400_map(address_map& map);
+
+	virtual void machine_start() override;
+	virtual void machine_reset() override;
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
+	DECLARE_WRITE_LINE_MEMBER(spu_ata_dmarq);
+	DECLARE_WRITE_LINE_MEMBER(spu_ata_interrupt);
+	TIMER_CALLBACK_MEMBER(spu_dma_callback);
+	TIMER_DEVICE_CALLBACK_MEMBER(spu_timer_callback);
+
+	required_device<ata_interface_device> m_spuata;
+
+private:
+	uint16_t spu_unk_r();
+	void spu_status_led_w(uint16_t data);
+	void spu_irq_ack_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void spu_ata_dma_low_w(uint16_t data);
+	void spu_ata_dma_high_w(uint16_t data);
+	void spu_wavebank_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	uint16_t firebeat_waveram_r(offs_t offset);
+	void firebeat_waveram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+
+	emu_timer *m_dma_timer;
+	bool m_sync_ata_irq;
+
+	uint32_t m_spu_ata_dma;
+	int m_spu_ata_dmarq;
+	uint32_t m_wave_bank;
+
+	required_device<m68000_device> m_audiocpu;
+	required_device<cy7c131_device> m_dpram;
+	required_shared_ptr<uint16_t> m_waveram;
+
+	enum
+	{
+		TIMER_SPU_DMA
+	};
+};
+
+/*****************************************************************************/
+
+class firebeat_ppp_state : public firebeat_state
+{
+public:
+	firebeat_ppp_state(const machine_config &mconfig, device_type type, const char *tag) :
+		firebeat_state(mconfig, type, tag)
+	{ }
+
+	void firebeat_ppp(machine_config &config);
+	void init_ppd();
+	void init_ppp();
+
+private:
+	void firebeat_ppp_map(address_map &map);
+
+	uint16_t sensor_r(offs_t offset);
+
+	void lamp_output_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void lamp_output2_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+	void lamp_output3_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+};
+
+class firebeat_kbm_state : public firebeat_state
+{
+public:
+	firebeat_kbm_state(const machine_config &mconfig, device_type type, const char *tag) :
+		firebeat_state(mconfig, type, tag),
+		m_duart_midi(*this, "duart_midi"),
+		m_kbd(*this, "kbd%u", 0),
+		m_gcu_sub(*this, "gcu_sub")
+	{ }
+
+	uint32_t screen_update_firebeat_1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+
+	void init_kbm();
+	void firebeat_kbm(machine_config &config);
+
+private:
+	void firebeat_kbm_map(address_map &map);
+
+	void init_keyboard();
+
+	uint32_t keyboard_wheel_r(offs_t offset);
+	uint8_t midi_uart_r(offs_t offset);
+	void midi_uart_w(offs_t offset, uint8_t data);
+
+	void lamp_output_kbm_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+//  TIMER_CALLBACK_MEMBER(keyboard_timer_callback);
+	DECLARE_WRITE_LINE_MEMBER(midi_uart_ch0_irq_callback);
+	DECLARE_WRITE_LINE_MEMBER(midi_uart_ch1_irq_callback);
+
+//  emu_timer *m_keyboard_timer;
+//  int m_keyboard_state[2];
+
+	required_device<pc16552_device> m_duart_midi;
+	required_device_array<midi_keyboard_device, 2> m_kbd;
+	required_device<k057714_device> m_gcu_sub;
+};
+
+class firebeat_bm3_state : public firebeat_spu_state
+{
+public:
+	firebeat_bm3_state(const machine_config &mconfig, device_type type, const char *tag) :
+		firebeat_spu_state(mconfig, type, tag)
+	{ }
+
+	void firebeat_bm3(machine_config &config);
+	void init_bm3();
+
+private:
+	void firebeat_bm3_map(address_map &map);
+
+	uint32_t spectrum_analyzer_r(offs_t offset);
+	uint16_t sensor_r(offs_t offset);
+
+	// TODO: Floppy disk implementation
+	uint32_t fdd_unk_r(offs_t offset, uint32_t mem_mask = ~0);
+	void fdd_unk_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
+
+	DECLARE_WRITE_LINE_MEMBER( bm3_vblank );
+};
+
+class firebeat_popn_state : public firebeat_spu_state
+{
+public:
+	firebeat_popn_state(const machine_config &mconfig, device_type type, const char *tag) :
+		firebeat_spu_state(mconfig, type, tag)
+	{ }
+
+	void firebeat_popn(machine_config &config);
+	void init_popn();
+};
+
+/*****************************************************************************/
+
+uint32_t firebeat_state::screen_update_firebeat_0(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect){ return m_gcu->draw(screen, bitmap, cliprect); }
+uint32_t firebeat_kbm_state::screen_update_firebeat_1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect){ return m_gcu_sub->draw(screen, bitmap, cliprect); }
+
+void firebeat_state::machine_start()
+{
+	/* set conservative DRC options */
+	m_maincpu->ppcdrc_set_options(PPCDRC_COMPATIBLE_OPTIONS);
+
+	/* configure fast RAM regions for DRC */
+	m_maincpu->ppcdrc_add_fastram(0x00000000, 0x01ffffff, false, m_work_ram);
+}
+
+void firebeat_state::init_firebeat()
+{
+	uint8_t *rom = memregion("user2")->base();
+
+//  pc16552d_init(machine(), 0, 19660800, comm_uart_irq_callback, 0);     // Network UART
+
+	m_extend_board_irq_enable = 0x3f;
+	m_extend_board_irq_active = 0x00;
+
+	m_cabinet_info = 0;
+
+	m_maincpu->ppc4xx_spu_set_tx_handler(write8smo_delegate(*this, FUNC(firebeat_state::security_w)));
+
+	set_ibutton(rom);
+
+	init_lights(write32s_delegate(*this), write32s_delegate(*this), write32s_delegate(*this));
 }
 
 void firebeat_state::firebeat(machine_config &config)
@@ -1190,8 +474,8 @@ void firebeat_state::firebeat(machine_config &config)
 	/* video hardware */
 	PALETTE(config, "palette", palette_device::RGB_555);
 
-	K057714(config, m_gcu[0], 0);
-	m_gcu[0]->irq_callback().set(FUNC(firebeat_state::gcu0_interrupt));
+	K057714(config, m_gcu, 0);
+	m_gcu->irq_callback().set(FUNC(firebeat_state::gcu_interrupt));
 
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
@@ -1211,132 +495,59 @@ void firebeat_state::firebeat(machine_config &config)
 	ymz.add_route(1, "lspeaker", 1.0);
 	ymz.add_route(0, "rspeaker", 1.0);
 
-	PC16552D(config, "duart_com", 0);  // pgmd to 9600baud
-	NS16550(config, "duart_com:chan0", XTAL(19'660'800));
-	NS16550(config, "duart_com:chan1", XTAL(19'660'800));
-	PC16552D(config, "duart_midi", 0);  // in all memory maps, pgmd to 31250baud
-	ns16550_device &midi_chan0(NS16550(config, "duart_midi:chan0", XTAL(24'000'000)));
-	midi_chan0.out_int_callback().set(FUNC(firebeat_state::midi_uart_ch0_irq_callback));
-	ns16550_device &midi_chan1(NS16550(config, "duart_midi:chan1", XTAL(24'000'000)));
-	midi_chan1.out_int_callback().set(FUNC(firebeat_state::midi_uart_ch1_irq_callback));
-}
-
-void firebeat_state::firebeat2(machine_config &config)
-{
-	/* basic machine hardware */
-	PPC403GCX(config, m_maincpu, XTAL(66'000'000));
-	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_state::firebeat2_map);
-	m_maincpu->set_vblank_int("lscreen", FUNC(firebeat_state::firebeat_interrupt));
-
-	RTC65271(config, "rtc", 0);
-
-	FUJITSU_29F016A(config, "flash_main");
-	FUJITSU_29F016A(config, "flash_snd1");
-	FUJITSU_29F016A(config, "flash_snd2");
-
-	ATA_INTERFACE(config, m_ata).options(firebeat_ata_devices, "cdrom", "cdrom", true);
-	m_ata->irq_handler().set(FUNC(firebeat_state::ata_interrupt));
-	m_ata->slot(1).set_option_machine_config("cdrom", cdrom_config);
-
-	/* video hardware */
-	PALETTE(config, "palette", palette_device::RGB_555);
-
-	K057714(config, m_gcu[0], 0);
-	m_gcu[0]->irq_callback().set(FUNC(firebeat_state::gcu0_interrupt));
-
-	K057714(config, m_gcu[1], 0);
-	m_gcu[1]->irq_callback().set(FUNC(firebeat_state::gcu1_interrupt));
-
-	screen_device &lscreen(SCREEN(config, "lscreen", SCREEN_TYPE_RASTER));
-	lscreen.set_refresh_hz(60);
-	lscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	lscreen.set_size(512, 384);
-	lscreen.set_visarea(0, 511, 0, 383);
-	lscreen.set_screen_update(FUNC(firebeat_state::screen_update_firebeat_0));
-	lscreen.set_palette("palette");
-
-	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
-	rscreen.set_refresh_hz(60);
-	rscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
-	rscreen.set_size(512, 384);
-	rscreen.set_visarea(0, 511, 0, 383);
-	rscreen.set_screen_update(FUNC(firebeat_state::screen_update_firebeat_1));
-	rscreen.set_palette("palette");
-
-	/* sound hardware */
-	SPEAKER(config, "lspeaker").front_left();
-	SPEAKER(config, "rspeaker").front_right();
-
-	ymz280b_device &ymz(YMZ280B(config, "ymz", 16934400));
-	ymz.irq_handler().set(FUNC(firebeat_state::sound_irq_callback));
-	ymz.set_addrmap(0, &firebeat_state::ymz280b_map);
-	ymz.add_route(1, "lspeaker", 1.0);
-	ymz.add_route(0, "rspeaker", 1.0);
-
 	PC16552D(config, "duart_com", 0);
 	NS16550(config, "duart_com:chan0", XTAL(19'660'800));
 	NS16550(config, "duart_com:chan1", XTAL(19'660'800));
-	PC16552D(config, "duart_midi", 0);
-	ns16550_device &midi_chan0(NS16550(config, "duart_midi:chan0", XTAL(24'000'000)));
-	midi_chan0.out_int_callback().set(FUNC(firebeat_state::midi_uart_ch0_irq_callback));
-	ns16550_device &midi_chan1(NS16550(config, "duart_midi:chan1", XTAL(24'000'000)));
-	midi_chan1.out_int_callback().set(FUNC(firebeat_state::midi_uart_ch1_irq_callback));
-
-	MIDI_KBD(config, m_kbd[0], 31250).tx_callback().set(midi_chan0, FUNC(ins8250_uart_device::rx_w));
-	MIDI_KBD(config, m_kbd[1], 31250).tx_callback().set(midi_chan1, FUNC(ins8250_uart_device::rx_w));
 }
 
-void firebeat_state::firebeat_spu_base(machine_config &config)
+void firebeat_state::firebeat_map(address_map &map)
 {
-	firebeat(config);
-
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_state::firebeat_spu_map);
-
-	M68000(config, m_audiocpu, 16000000);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &firebeat_state::spu_map);
-	// This isn't correct but it's required for sounds to play.
-	// Adjusting the time will change the duration of the sound.
-	// More research is required to find a proper way to implement this.
-	m_audiocpu->set_periodic_int(FUNC(firebeat_state::irq2_line_assert), attotime::from_hz(500));
-
-	CY7C131(config, m_dpram);
-	m_dpram->intl_callback().set_inputline(m_audiocpu, INPUT_LINE_IRQ4); // address 0x3fe triggers M68K interrupt
-	m_dpram->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ3); // address 0x3ff triggers PPC interrupt
-
-	rf5c400_device &rf5c400(RF5C400(config, "rf5c400", XTAL(16'934'400)));
-	rf5c400.set_addrmap(0, &firebeat_state::rf5c400_map);
-	rf5c400.add_route(0, "lspeaker", 0.5);
-	rf5c400.add_route(1, "rspeaker", 0.5);
+	map(0x00000000, 0x01ffffff).ram().share("work_ram");
+	map(0x70006000, 0x70006003).w(FUNC(firebeat_state::extend_board_irq_w));
+	map(0x7000a000, 0x7000a003).r(FUNC(firebeat_state::extend_board_irq_r));
+	map(0x74000000, 0x740003ff).noprw(); // SPU shared RAM
+	map(0x7d000200, 0x7d00021f).r(FUNC(firebeat_state::cabinet_r));
+	map(0x7d000400, 0x7d000401).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write));
+	map(0x7d000800, 0x7d000803).r(FUNC(firebeat_state::input_r));
+	map(0x7d400000, 0x7d5fffff).rw("flash_main", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
+	map(0x7d800000, 0x7d9fffff).rw("flash_snd1", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
+	map(0x7da00000, 0x7dbfffff).rw("flash_snd2", FUNC(fujitsu_29f016a_device::read), FUNC(fujitsu_29f016a_device::write));
+	map(0x7dc00000, 0x7dc0000f).rw(m_duart_com, FUNC(pc16552_device::read), FUNC(pc16552_device::write));
+	map(0x7e000000, 0x7e00003f).rw("rtc", FUNC(rtc65271_device::rtc_r), FUNC(rtc65271_device::rtc_w));
+	map(0x7e000100, 0x7e00013f).rw("rtc", FUNC(rtc65271_device::xram_r), FUNC(rtc65271_device::xram_w));
+	map(0x7e800000, 0x7e8000ff).rw(m_gcu, FUNC(k057714_device::read), FUNC(k057714_device::write));
+	map(0x7e800100, 0x7e8001ff).noprw(); // Secondary GCU, only used by Keyboardmania but is written to during the bootloader of other games
+	map(0x7fe00000, 0x7fe0000f).rw(FUNC(firebeat_state::ata_command_r), FUNC(firebeat_state::ata_command_w));
+	map(0x7fe80000, 0x7fe8000f).rw(FUNC(firebeat_state::ata_control_r), FUNC(firebeat_state::ata_control_w));
+	map(0x7ff80000, 0x7fffffff).rom().region("user1", 0);       /* System BIOS */
 }
 
-void firebeat_state::firebeat_spu(machine_config &config)
+void firebeat_state::ymz280b_map(address_map &map)
 {
-	firebeat_spu_base(config);
-
-	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "cdrom", nullptr, true);
-	m_spuata->slot(0).set_option_machine_config("cdrom", dvdrom_config);
-	m_spuata->irq_handler().set(FUNC(firebeat_state::spu_ata_interrupt));
-	m_spuata->dmarq_handler().set(FUNC(firebeat_state::spu_ata_dmarq));
-}
-
-void firebeat_state::firebeat_spu_bm3(machine_config &config)
-{
-	firebeat_spu_base(config);
-
-	screen_device *screen = subdevice<screen_device>("screen");
-	if (screen != nullptr) {
-		// beatmania III is the only game on the Firebeat platform to use 640x480
-		screen->set_size(640, 480);
-		screen->set_visarea(0, 639, 0, 479);
-	}
-
-	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "hdd", nullptr, true);
-	m_spuata->irq_handler().set(FUNC(firebeat_state::spu_ata_interrupt));
-	m_spuata->dmarq_handler().set(FUNC(firebeat_state::spu_ata_dmarq));
+	map.global_mask(0x3fffff);
+	map(0x000000, 0x1fffff).r("flash_snd1", FUNC(fujitsu_29f016a_device::read));
+	map(0x200000, 0x3fffff).r("flash_snd2", FUNC(fujitsu_29f016a_device::read));
 }
 
 /*****************************************************************************/
+
+uint32_t firebeat_state::cabinet_r(offs_t offset, uint32_t mem_mask)
+{
+//  printf("cabinet_r: %08X, %08X\n", offset, mem_mask);
+	switch (offset)
+	{
+		case 0: return m_cabinet_info << 28;
+
+		// These never seem to be anything other than 0?
+		case 2: return 0;
+		case 4: return 0;
+	}
+
+	return 0;
+}
+
+/*****************************************************************************/
+
 /* Security dongle is a Dallas DS1411 RS232 Adapter with a DS1991 Multikey iButton */
 
 /* popn7 supports 8 different dongles:
@@ -1355,8 +566,6 @@ enum
 	DS1991_STATE_NORMAL,
 	DS1991_STATE_READ_SUBKEY
 };
-
-
 
 void firebeat_state::set_ibutton(uint8_t *data)
 {
@@ -1483,6 +692,187 @@ void firebeat_state::security_w(uint8_t data)
 
 /*****************************************************************************/
 
+// Extend board IRQs
+// 0x01: MIDI UART channel 2
+// 0x02: MIDI UART channel 1
+// 0x04: ?
+// 0x08: ?
+// 0x10: ?
+// 0x20: ?
+
+uint32_t firebeat_state::extend_board_irq_r(offs_t offset, uint32_t mem_mask)
+{
+	uint32_t r = 0;
+
+	if (ACCESSING_BITS_24_31)
+	{
+		r |= (~m_extend_board_irq_active) << 24;
+	}
+
+	return r;
+}
+
+void firebeat_state::extend_board_irq_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+//  printf("extend_board_irq_w: %08X, %08X, %08X\n", data, offset, mem_mask);
+
+	if (ACCESSING_BITS_24_31)
+	{
+		m_extend_board_irq_active &= ~((data >> 24) & 0xff);
+
+		m_extend_board_irq_enable = (data >> 24) & 0xff;
+	}
+}
+
+/*****************************************************************************/
+
+uint32_t firebeat_state::input_r(offs_t offset, uint32_t mem_mask)
+{
+	uint32_t r = 0;
+
+	if (ACCESSING_BITS_24_31)
+	{
+		r |= (ioport("IN0")->read() & 0xff) << 24;
+	}
+	if (ACCESSING_BITS_16_23)
+	{
+		r |= (ioport("IN3")->read() & 0xff) << 16;
+	}
+	if (ACCESSING_BITS_8_15)
+	{
+		r |= (ioport("IN1")->read() & 0xff) << 8;
+	}
+	if (ACCESSING_BITS_0_7)
+	{
+		r |= (ioport("IN2")->read() & 0xff);
+	}
+
+	return r;
+}
+
+/*****************************************************************************/
+/* ATA Interface */
+
+#define BYTESWAP16(x)   ((((x) >> 8) & 0xff) | (((x) << 8) & 0xff00))
+
+uint32_t firebeat_state::ata_command_r(offs_t offset, uint32_t mem_mask)
+{
+	uint16_t r;
+//  printf("ata_command_r: %08X, %08X\n", offset, mem_mask);
+	if (ACCESSING_BITS_16_31)
+	{
+		r = m_ata->cs0_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
+		return BYTESWAP16(r) << 16;
+	}
+	else
+	{
+		r = m_ata->cs0_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
+		return BYTESWAP16(r) << 0;
+	}
+}
+
+void firebeat_state::ata_command_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+//  printf("ata_command_w: %08X, %08X, %08X\n", data, offset, mem_mask);
+
+	if (ACCESSING_BITS_16_31)
+	{
+		m_ata->cs0_w(offset*2, BYTESWAP16((data >> 16) & 0xffff), BYTESWAP16((mem_mask >> 16) & 0xffff));
+	}
+	else
+	{
+		m_ata->cs0_w((offset*2) + 1, BYTESWAP16((data >> 0) & 0xffff), BYTESWAP16((mem_mask >> 0) & 0xffff));
+	}
+}
+
+
+uint32_t firebeat_state::ata_control_r(offs_t offset, uint32_t mem_mask)
+{
+	uint16_t r;
+//  printf("ata_control_r: %08X, %08X\n", offset, mem_mask);
+
+	if (ACCESSING_BITS_16_31)
+	{
+		r = m_ata->cs1_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
+		return BYTESWAP16(r) << 16;
+	}
+	else
+	{
+		r = m_ata->cs1_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
+		return BYTESWAP16(r) << 0;
+	}
+}
+
+void firebeat_state::ata_control_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	if (ACCESSING_BITS_16_31)
+	{
+		m_ata->cs1_w(offset*2, BYTESWAP16(data >> 16) & 0xffff, BYTESWAP16((mem_mask >> 16) & 0xffff));
+	}
+	else
+	{
+		m_ata->cs1_w((offset*2) + 1, BYTESWAP16(data >> 0) & 0xffff, BYTESWAP16((mem_mask >> 0) & 0xffff));
+	}
+}
+
+
+/*****************************************************************************/
+
+/*
+uint32_t firebeat_state::comm_uart_r(offs_t offset, uint32_t mem_mask)
+{
+    uint32_t r = 0;
+
+    if (ACCESSING_BITS_24_31)
+    {
+        r |= pc16552d_0_r((offset*4)+0) << 24;
+    }
+    if (ACCESSING_BITS_16_23)
+    {
+        r |= pc16552d_0_r((offset*4)+1) << 16;
+    }
+    if (ACCESSING_BITS_8_15)
+    {
+        r |= pc16552d_0_r((offset*4)+2) << 8;
+    }
+    if (ACCESSING_BITS_0_7)
+    {
+        r |= pc16552d_0_r((offset*4)+3) << 0;
+    }
+
+    return r;
+}
+
+void firebeat_state::comm_uart_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+    if (ACCESSING_BITS_24_31)
+    {
+        pc16552d_0_w((offset*4)+0, (data >> 24) & 0xff);
+    }
+    if (ACCESSING_BITS_16_23)
+    {
+        pc16552d_0_w((offset*4)+1, (data >> 16) & 0xff);
+    }
+    if (ACCESSING_BITS_8_15)
+    {
+        pc16552d_0_w((offset*4)+2, (data >> 8) & 0xff);
+    }
+    if (ACCESSING_BITS_0_7)
+    {
+        pc16552d_0_w((offset*4)+3, (data >> 0) & 0xff);
+    }
+}
+
+static void comm_uart_irq_callback(running_machine &machine, int channel, int value)
+{
+    // TODO
+    //m_maincpu->set_input_line(INPUT_LINE_IRQ2, ASSERT_LINE);
+}
+*/
+
+
+/*****************************************************************************/
+
 void firebeat_state::init_lights(write32s_delegate out1, write32s_delegate out2, write32s_delegate out3)
 {
 	if(out1.isnull()) out1 = write32s_delegate(*this, FUNC(firebeat_state::lamp_output_w));
@@ -1494,56 +884,1068 @@ void firebeat_state::init_lights(write32s_delegate out1, write32s_delegate out2,
 	m_maincpu->space(AS_PROGRAM).install_write_handler(0x7d000324, 0x7d000327, out3);
 }
 
-void firebeat_state::init_firebeat()
+void firebeat_state::lamp_output_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
-	uint8_t *rom = memregion("user2")->base();
+	// -------- -------- -------- xxxxxxxx   Status LEDs (active low)
+	if (ACCESSING_BITS_0_7)
+	{
+		output().set_value("status_led_0", (data & 0x01) ? 0 : 1);
+		output().set_value("status_led_1", (data & 0x02) ? 0 : 1);
+		output().set_value("status_led_2", (data & 0x04) ? 0 : 1);
+		output().set_value("status_led_3", (data & 0x08) ? 0 : 1);
+		output().set_value("status_led_4", (data & 0x10) ? 0 : 1);
+		output().set_value("status_led_5", (data & 0x20) ? 0 : 1);
+		output().set_value("status_led_6", (data & 0x40) ? 0 : 1);
+		output().set_value("status_led_7", (data & 0x80) ? 0 : 1);
+	}
 
-//  pc16552d_init(machine(), 0, 19660800, comm_uart_irq_callback, 0);     // Network UART
-//  pc16552d_init(machine(), 1, 24000000, midi_uart_irq_callback, 0);     // MIDI UART
+//  printf("lamp_output_w: %08X, %08X, %08X\n", data, offset, mem_mask);
+}
 
-	m_extend_board_irq_enable = 0x3f;
-	m_extend_board_irq_active = 0x00;
+void firebeat_state::lamp_output2_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+//  printf("lamp_output2_w: %08X, %08X, %08X\n", data, offset, mem_mask);
+}
 
-	m_cur_cab_data = cab_data;
+void firebeat_state::lamp_output3_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+//  printf("lamp_output3_w: %08X, %08X, %08X\n", data, offset, mem_mask);
+}
 
-	m_maincpu->ppc4xx_spu_set_tx_handler(write8smo_delegate(*this, FUNC(firebeat_state::security_w)));
+/*****************************************************************************/
 
-	set_ibutton(rom);
+INTERRUPT_GEN_MEMBER(firebeat_state::firebeat_interrupt)
+{
+	// IRQs
+	// IRQ 0: VBlank
+	// IRQ 1: Extend board IRQ
+	// IRQ 2: Main board UART
+	// IRQ 3: SPU mailbox interrupt
+	// IRQ 4: ATA
 
+	device.execute().set_input_line(INPUT_LINE_IRQ0, ASSERT_LINE);
+}
+
+WRITE_LINE_MEMBER(firebeat_state::ata_interrupt)
+{
+	m_maincpu->set_input_line(INPUT_LINE_IRQ4, state);
+}
+
+WRITE_LINE_MEMBER(firebeat_state::gcu_interrupt)
+{
+	m_maincpu->set_input_line(INPUT_LINE_IRQ0, state);
+}
+
+WRITE_LINE_MEMBER(firebeat_state::sound_irq_callback)
+{
+}
+
+/*****************************************************************************/
+
+void firebeat_spu_state::machine_start()
+{
+	m_dma_timer = timer_alloc(TIMER_SPU_DMA);
+}
+
+void firebeat_spu_state::machine_reset()
+{
+	m_spu_ata_dma = 0;
+	m_spu_ata_dmarq = 0;
+	m_wave_bank = 0;
+	m_sync_ata_irq = 0;
+}
+
+void firebeat_spu_state::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
+{
+	switch (id)
+	{
+	case TIMER_SPU_DMA:
+		spu_dma_callback(ptr, param);
+		break;
+	}
+}
+
+void firebeat_spu_state::firebeat_spu_base(machine_config &config)
+{
+	firebeat(config);
+
+	/* basic machine hardware */
+	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_spu_state::firebeat_spu_map);
+
+	M68000(config, m_audiocpu, 16000000);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &firebeat_spu_state::spu_map);
+
+	CY7C131(config, m_dpram);
+	m_dpram->intl_callback().set_inputline(m_audiocpu, INPUT_LINE_IRQ4); // address 0x3fe triggers M68K interrupt
+	m_dpram->intr_callback().set_inputline(m_maincpu, INPUT_LINE_IRQ3); // address 0x3ff triggers PPC interrupt
+
+	rf5c400_device &rf5c400(RF5C400(config, "rf5c400", XTAL(16'934'400)));
+	rf5c400.set_addrmap(0, &firebeat_spu_state::rf5c400_map);
+	rf5c400.add_route(0, "lspeaker", 0.5);
+	rf5c400.add_route(1, "rspeaker", 0.5);
+}
+
+void firebeat_spu_state::firebeat_spu_map(address_map &map)
+{
+	firebeat_map(map);
+	map(0x74000000, 0x740003ff).rw(m_dpram, FUNC(cy7c131_device::right_r), FUNC(cy7c131_device::right_w)); // SPU shared RAM
+}
+
+void firebeat_spu_state::spu_map(address_map &map)
+{
+	map(0x000000, 0x07ffff).rom();
+	map(0x100000, 0x13ffff).ram();
+	map(0x200000, 0x200001).portr("SPU_DSW");
+	map(0x220000, 0x220001).w(FUNC(firebeat_spu_state::spu_status_led_w));
+	map(0x230000, 0x230001).w(FUNC(firebeat_spu_state::spu_irq_ack_w));
+	map(0x240000, 0x240003).w(FUNC(firebeat_spu_state::spu_ata_dma_low_w)).nopr();
+	map(0x250000, 0x250003).w(FUNC(firebeat_spu_state::spu_ata_dma_high_w)).nopr();
+	map(0x260000, 0x260001).w(FUNC(firebeat_spu_state::spu_wavebank_w)).nopr();
+	map(0x280000, 0x2807ff).rw(m_dpram, FUNC(cy7c131_device::left_r), FUNC(cy7c131_device::left_w)).umask16(0x00ff);
+	map(0x300000, 0x30000f).rw(m_spuata, FUNC(ata_interface_device::cs0_r), FUNC(ata_interface_device::cs0_w));
+	map(0x340000, 0x34000f).rw(m_spuata, FUNC(ata_interface_device::cs1_r), FUNC(ata_interface_device::cs1_w));
+	map(0x400000, 0x400fff).rw("rf5c400", FUNC(rf5c400_device::rf5c400_r), FUNC(rf5c400_device::rf5c400_w));
+	map(0x800000, 0xffffff).rw(FUNC(firebeat_spu_state::firebeat_waveram_r), FUNC(firebeat_spu_state::firebeat_waveram_w));
+}
+
+void firebeat_spu_state::rf5c400_map(address_map& map)
+{
+	map(0x0000000, 0x1ffffff).ram().share("rf5c400");
+}
+
+
+/*  SPU board M68K IRQs
+
+    IRQ1: Executes all commands stored in a buffer.
+          The buffer can contain up to 8 commands.
+          This seems to be unused.
+
+    IRQ2: Executes one command stored in a different buffer from IRQ1.
+          The buffer can contain up to 8 commands.
+	      The command index counter increments after each IRQ2 call.
+		  If there is no command in the slot at the current counter then it just increments without executing a command.
+
+		  Timing matters. In particular if the speed of the IRQ 2 calls is too fast then the volume and frequency animations will be wrong.
+		  The most common issue with bad timing is keysounds will be cut off.
+		  pop'n music Animelo 2 also has an issue when playing CHA-LA HEAD CHA-LA where one of the beginning keysounds will stay on a
+		  very high pitched frequency. The lower(?) the IRQ 2 frequency, the longer the keysound stays played it seems.
+
+		  For beatmania III:
+			cmd[0] = nop
+			cmd[1] = 0x91bc -> Send stop command for all rf5c400 channels that are done playing
+			cmd[2] = 0x310a -> Error checking? Sending some kind of state to main CPU???
+			cmd[3] = 0x29c6 -> Increment a timer for each running DMA(ATA command?)
+				Each timer must count up to 0x02e8 (744) before it will move on to the next DMA, which I believe is the time out counter.
+
+				In another part of the program (0x363c for a21jca03.bin) is the following code for determining when to start and stop the DMA:
+
+				start_dma();
+				while (get_dma_timer() < dma_max_timer) {
+					if (irq6_called_flag) {
+						break;
+					}
+				}
+				end_dma();
+
+				irq6_called_flag is set only when IRQ6 is called.
+				get_dma_timer is the timer that is incremented by 0x29c6.
+			cmd[4] = 0x94de -> Animates rf5c400 channel volumes
+			cmd[5] = 0x7b2c -> Send some kind of buffer status flags to spu_status_led_w. Related to IRQ4 since commands come from PPC to set buffer data
+			cmd[6] = 0x977e -> Animates rf5c400 channel frequencies
+			cmd[7] = 0x9204 -> Sends current state of rf5c400 channels as well as a list (bitmask integer) of usable channels up to main CPU memory.
+			                   Also sends a flag to to spu_status_led_w that shows if there are available SE slots.
+							   If there are no available SE slots then it will set bit 3 to .
+
+    IRQ4: Dual-port RAM mailbox (when PPC writes to 0x3FE)
+          Handles commands from PPC (bytes 0x00 and 0x01)
+
+    IRQ6: ATA
+*/
+
+void firebeat_spu_state::spu_status_led_w(uint16_t data)
+{
+	// Verified with real hardware that the patterns match the status LEDs on the board
+
+	// Set when clearing waveram memory during initialization:
+	// uint16_t bank = ((~data) >> 6) & 3;
+	// uint16_t offset = (!!((~data) & (1 << 5))) * 8192;
+	// uint16_t verify = !!((~data) & (1 << 4)); // 0 = writing memory, 1 = verifying memory
+
+	// For IRQ2:
+	// Command 5 (0x7b2c):
+	// if buffer[4] == 0 and buffer[0] < buffer[5], it writes what buffer(thread?) is currently busy(?)
+	// There are 8 buffers/threads total
+	//
+	// Command 7 (0x9204):
+	// If all 30 SE channels are in use, bit 3 will be set to 1
+}
+
+void firebeat_spu_state::spu_irq_ack_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	if (ACCESSING_BITS_0_7)
+	{
+		if (data & 0x01)
+			m_audiocpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
+		if (data & 0x02)
+			m_audiocpu->set_input_line(INPUT_LINE_IRQ2, CLEAR_LINE);
+		if (data & 0x08)
+			m_audiocpu->set_input_line(INPUT_LINE_IRQ6, CLEAR_LINE);
+	}
+}
+
+void firebeat_spu_state::spu_ata_dma_low_w(uint16_t data)
+{
+	m_spu_ata_dma = (m_spu_ata_dma & ~0xffff) | data;
+}
+
+void firebeat_spu_state::spu_ata_dma_high_w(uint16_t data)
+{
+	m_spu_ata_dma = (m_spu_ata_dma & 0xffff) | ((uint32_t)data << 16);
+}
+
+void firebeat_spu_state::spu_wavebank_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	m_wave_bank = data * (4 * 1024 * 1024);
+}
+
+uint16_t firebeat_spu_state::firebeat_waveram_r(offs_t offset)
+{
+	return m_waveram[offset + m_wave_bank];
+}
+
+void firebeat_spu_state::firebeat_waveram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+{
+	COMBINE_DATA(&m_waveram[offset + m_wave_bank]);
+}
+
+WRITE_LINE_MEMBER(firebeat_spu_state::spu_ata_dmarq)
+{
+	if (m_spuata != nullptr && m_spu_ata_dmarq != state)
+	{
+		m_spu_ata_dmarq = state;
+
+		if (m_spu_ata_dmarq)
+		{
+			m_spuata->write_dmack(ASSERT_LINE);
+			m_dma_timer->enable(true);
+			m_dma_timer->adjust(attotime::zero);
+		}
+	}
+}
+
+TIMER_CALLBACK_MEMBER(firebeat_spu_state::spu_dma_callback)
+{
+	// These values were picked because they roughly match real in-game footage of
+	// when sounds start playing, and more importantly to free up CPU time for the
+	// main CPU during DMAs to avoid stuttering.
+	auto next_dma_timing = attotime::from_usec(75);
+	auto dma_end_target = m_spu_ata_dma + 128;
+
+	while (m_spu_ata_dmarq && m_spu_ata_dma < dma_end_target)
+	{
+		uint16_t data = m_spuata->read_dma();
+		m_waveram[m_wave_bank+m_spu_ata_dma] = data;
+		m_spu_ata_dma++;
+	}
+
+	if (m_spu_ata_dmarq) {
+		m_dma_timer->adjust(next_dma_timing);
+	} else {
+		m_spuata->write_dmack(CLEAR_LINE);
+		m_dma_timer->enable(false);
+	}
+}
+
+WRITE_LINE_MEMBER(firebeat_spu_state::spu_ata_interrupt)
+{
+	if (state == 0)
+		m_audiocpu->set_input_line(INPUT_LINE_IRQ2, state);
+
+	m_sync_ata_irq = state;
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(firebeat_spu_state::spu_timer_callback)
+{
+	if (m_sync_ata_irq)
+		m_audiocpu->set_input_line(INPUT_LINE_IRQ6, 1);
+	else
+		m_audiocpu->set_input_line(INPUT_LINE_IRQ2, 1);
+}
+
+/*****************************************************************************
+* beatmania III
+******************************************************************************/
+void firebeat_bm3_state::firebeat_bm3(machine_config &config)
+{
+	firebeat_spu_base(config);
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_bm3_state::firebeat_bm3_map);
+
+	screen_device *screen = subdevice<screen_device>("screen");
+	if (screen != nullptr) {
+		// beatmania III is the only game on the Firebeat platform to use 640x480
+		screen->set_size(640, 480);
+		screen->set_visarea(0, 639, 0, 479);
+		screen->screen_vblank().set(FUNC(firebeat_bm3_state::bm3_vblank));
+	}
+
+	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices_hdd, "hdd", nullptr, true);
+	m_spuata->irq_handler().set(FUNC(firebeat_bm3_state::spu_ata_interrupt));
+	m_spuata->dmarq_handler().set(FUNC(firebeat_bm3_state::spu_ata_dmarq));
+
+	// 500 hz seems ok for beatmania III.
+	// Any higher makes things act weird.
+	// Lower doesn't have that huge of an effect compared to pop'n? (limited tested).
+	TIMER(config, "spu_timer").configure_periodic(FUNC(firebeat_bm3_state::spu_timer_callback), attotime::from_hz(500));
+}
+
+void firebeat_bm3_state::init_bm3()
+{
+	init_firebeat();
 	init_lights(write32s_delegate(*this), write32s_delegate(*this), write32s_delegate(*this));
 }
 
-void firebeat_state::init_ppp()
+void firebeat_bm3_state::firebeat_bm3_map(address_map &map)
 {
-	init_firebeat();
-	init_lights(write32s_delegate(*this, FUNC(firebeat_state::lamp_output_ppp_w)), write32s_delegate(*this, FUNC(firebeat_state::lamp_output2_ppp_w)), write32s_delegate(*this, FUNC(firebeat_state::lamp_output3_ppp_w)));
+	firebeat_spu_map(map);
+
+	map(0x7d000330, 0x7d00033f).nopw(); // ?
+	map(0x7d000340, 0x7d00035f).r(FUNC(firebeat_bm3_state::sensor_r));
+	map(0x70001fc0, 0x70001fdf).rw(FUNC(firebeat_bm3_state::fdd_unk_r), FUNC(firebeat_bm3_state::fdd_unk_w));
+	map(0x70008000, 0x7000807f).r(FUNC(firebeat_bm3_state::spectrum_analyzer_r));
 }
 
-void firebeat_state::init_ppd()
+uint32_t firebeat_bm3_state::spectrum_analyzer_r(offs_t offset)
 {
-	init_firebeat();
-	init_lights(write32s_delegate(*this, FUNC(firebeat_state::lamp_output_ppp_w)), write32s_delegate(*this, FUNC(firebeat_state::lamp_output2_ppp_w)), write32s_delegate(*this, FUNC(firebeat_state::lamp_output3_ppp_w)));
+	// Visible in the sound test menu and most likely the spectral analyzer game skin
+	//
+	// Notes about where this could be coming from...
+	// - It's not the ST-224: Only sends audio in and out, with a MIDI in
+	// - It's not the RF5C400: There are no unimplemented registers or anything of that sort that could give this info
+	// - The memory address mapping is the same as Keyboardmania's wheel, which plugs into a connector on extend board
+	//   but there's nothing actually plugged into that spot on a beatmania III configuration, so it's not external
+	// - Any place where the audio is directed somewhere (amps, etc) does not have a way to get back to the PCBs
+	//   from what I can tell based on looking at the schematics in the beatmania III manual
+	// - I think it's probably calculated somewhere within one of the main boards (main/extend/SPU) but couldn't find any
+	//   potentially interesting chips at a glance of PCB pics
+	// - The manual does not seem to make mention of this feature *at all* much less troubleshooting it, so no leads there
 
-	m_cur_cab_data = ppd_cab_data;
+	// 6 notch spectrum analyzer
+	// No idea what frequency range each notch corresponds but it does not affect core gameplay in any way.
+	// Notch 1: 0x0c
+	// Notch 2: 0x0a
+	// Notch 3: 0x08
+	// Notch 4: 0x06
+	// Notch 5: 0x04
+	// Notch 6: 0x02
+
+	// TODO: Fill in logic (reuse vgm_visualizer in some way?)
+	// auto ch = offset & 0xf0; // 0 = Left, 1 = Right
+	auto data = 0;
+
+	return data;
 }
 
-void firebeat_state::init_keyboard()
+uint16_t firebeat_bm3_state::sensor_r(offs_t offset)
+{
+	switch (offset) {
+		case 0: return ioport("IO1")->read() | 0x0100;
+		case 1: return ioport("IO2")->read() | 0x0100;
+		case 2: return ioport("IO3")->read() | 0x0100;
+		case 3: return ioport("IO4")->read() | 0x0100;
+		case 5: return (ioport("TURNTABLE_P1")->read() >> 8) | 0x0100;
+		case 6: return (ioport("TURNTABLE_P1")->read() & 0xff) | 0x0100;
+		case 7: return (ioport("TURNTABLE_P2")->read() >> 8) | 0x0100;
+		case 8: return (ioport("TURNTABLE_P2")->read() & 0xff) | 0x0100;
+		case 9: return ioport("EFFECT1")->read() | 0x0100;
+		case 10: return ioport("EFFECT2")->read() | 0x0100;
+		case 11: return ioport("EFFECT3")->read() | 0x0100;
+		case 12: return ioport("EFFECT4")->read() | 0x0100;
+		case 13: return ioport("EFFECT5")->read() | 0x0100;
+		case 14: return ioport("EFFECT6")->read() | 0x0100;
+		case 15: return ioport("EFFECT7")->read() | 0x0100;
+	}
+
+	return 0;
+}
+
+uint32_t firebeat_bm3_state::fdd_unk_r(offs_t offset, uint32_t mem_mask)
+{
+	// printf("%s: fdd_unk_r: %08X, %08X\n", machine().describe_context().c_str(), offset, mem_mask);
+
+	return 0;
+}
+
+void firebeat_bm3_state::fdd_unk_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	// printf("%s: fdd_unk_w: %08X, %08X, %08X\n", machine().describe_context().c_str(), data, offset, mem_mask);
+}
+
+WRITE_LINE_MEMBER(firebeat_bm3_state::bm3_vblank)
+{
+	// Patch out FDD errors since the game otherwise runs fine without it
+	// and the FDD might not be implemented for a while
+	if(strcmp(machine().system().name, "bm3") == 0)
+	{
+		if (m_work_ram[0x918C / 4] == 0x4809202D) m_work_ram[0x918C / 4] = 0x38600000;
+		if (m_work_ram[0x3380C / 4] == 0x4BFFFD99) m_work_ram[0x3380C / 4] = 0x38600000;
+		if (m_work_ram[0x33834 / 4] == 0x4BFFFD71) m_work_ram[0x33834 / 4] = 0x38600000;
+	}
+	else if(strcmp(machine().system().name, "bm3core") == 0)
+	{
+		if (m_work_ram[0x91E4 / 4] == 0x480A19F5) m_work_ram[0x91E4 / 4] = 0x38600000;
+		if (m_work_ram[0x37BB0 / 4] == 0x4BFFFD71) m_work_ram[0x37BB0 / 4] = 0x38600000;
+		if (m_work_ram[0x37BD8 / 4] == 0x4BFFFD49) m_work_ram[0x37BD8 / 4] = 0x38600000;
+	}
+	else if(strcmp(machine().system().name, "bm36th") == 0)
+	{
+		if (m_work_ram[0x91E4 / 4] == 0x480BC8BD) m_work_ram[0x91E4 / 4] = 0x38600000;
+		if (m_work_ram[0x451D8 / 4] == 0x4BFFFD75) m_work_ram[0x451D8 / 4] = 0x38600000;
+		if (m_work_ram[0x45200 / 4] == 0x4BFFFD4D) m_work_ram[0x45200 / 4] = 0x38600000;
+	}
+	else if(strcmp(machine().system().name, "bm37th") == 0)
+	{
+		if (m_work_ram[0x91E4 / 4] == 0x480CF62D) m_work_ram[0x91E4 / 4] = 0x38600000;
+		if (m_work_ram[0x46A58 / 4] == 0x4BFFFD45) m_work_ram[0x46A58 / 4] = 0x38600000;
+		if (m_work_ram[0x46AB8 / 4] == 0x4BFFFCE5) m_work_ram[0x46AB8 / 4] = 0x38600000;
+	}
+	else if(strcmp(machine().system().name, "bm3final") == 0)
+	{
+		if (m_work_ram[0x47F8 / 4] == 0x480CEF91) m_work_ram[0x47F8 / 4] = 0x38600000;
+		if (m_work_ram[0x3FAF4 / 4] == 0x4BFFFD59) m_work_ram[0x3FAF4 / 4] = 0x38600000;
+		if (m_work_ram[0x3FB54 / 4] == 0x4BFFFCF9) m_work_ram[0x3FB54 / 4] = 0x38600000;
+	}
+}
+
+/*****************************************************************************
+* pop'n music
+******************************************************************************/
+void firebeat_popn_state::firebeat_popn(machine_config &config)
+{
+	firebeat_spu_base(config);
+
+	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "cdrom", nullptr, true);
+	m_spuata->slot(0).set_option_machine_config("cdrom", dvdrom_config);
+	m_spuata->irq_handler().set(FUNC(firebeat_popn_state::spu_ata_interrupt));
+	m_spuata->dmarq_handler().set(FUNC(firebeat_popn_state::spu_ata_dmarq));
+
+	// 500 hz works best for pop'n music.
+	// Any lower and sometimes you'll hear buzzing from certain keysounds, or fades take too long.
+	// Any higher and keysounds get cut short.
+	TIMER(config, "spu_timer").configure_periodic(FUNC(firebeat_popn_state::spu_timer_callback), attotime::from_hz(500));
+}
+
+void firebeat_popn_state::init_popn()
+{
+	init_firebeat();
+	init_lights(write32s_delegate(*this), write32s_delegate(*this), write32s_delegate(*this));
+}
+
+
+/*****************************************************************************
+* ParaParaParadise / ParaParaDancing
+******************************************************************************/
+void firebeat_ppp_state::firebeat_ppp(machine_config &config)
+{
+	firebeat(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_ppp_state::firebeat_ppp_map);
+}
+
+void firebeat_ppp_state::init_ppp()
+{
+	init_firebeat();
+	init_lights(write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output_ppp_w)), write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output2_ppp_w)), write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output3_ppp_w)));
+
+	m_cabinet_info = 8;
+}
+
+void firebeat_ppp_state::init_ppd()
+{
+	init_firebeat();
+	init_lights(write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output_ppp_w)), write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output2_ppp_w)), write32s_delegate(*this, FUNC(firebeat_ppp_state::lamp_output3_ppp_w)));
+
+	m_cabinet_info = 9;
+}
+
+void firebeat_ppp_state::firebeat_ppp_map(address_map &map)
+{
+	firebeat_map(map);
+	map(0x7d000340, 0x7d00035f).r(FUNC(firebeat_ppp_state::sensor_r));
+}
+
+uint16_t firebeat_ppp_state::sensor_r(offs_t offset)
+{
+	switch (offset) {
+		case 0: return ioport("SENSOR1")->read() | 0x0100;
+		case 1: return ioport("SENSOR2")->read() | 0x0100;
+		case 2: return ioport("SENSOR3")->read() | 0x0100;
+		case 3: return ioport("SENSOR4")->read() | 0x0100;
+	}
+
+	return 0;
+}
+
+void firebeat_ppp_state::lamp_output_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	lamp_output_w(offset, data, mem_mask);
+
+	// ParaParaParadise lamps (active high)
+	// 0x00000100 Left
+	// 0x00000200 Right
+	// 0x00000400 Door Lamp
+	// 0x00000800 OK
+	// 0x00008000 Slim
+	// 0x01000000 Stage LED 0
+	// 0x02000000 Stage LED 1
+	// 0x04000000 Stage LED 2
+	// 0x08000000 Stage LED 3
+	// 0x00010000 Stage LED 4
+	// 0x00020000 Stage LED 5
+	// 0x00040000 Stage LED 6
+	// 0x00080000 Stage LED 7
+	if (ACCESSING_BITS_8_15)
+	{
+		output().set_value("left",            (data & 0x00000100) ? 1 : 0);
+		output().set_value("right",           (data & 0x00000200) ? 1 : 0);
+		output().set_value("door_lamp",       (data & 0x00000400) ? 1 : 0);
+		output().set_value("ok",              (data & 0x00000800) ? 1 : 0);
+		output().set_value("slim",            (data & 0x00008000) ? 1 : 0);
+	}
+	if (ACCESSING_BITS_24_31)
+	{
+		output().set_value("stage_led_0",     (data & 0x01000000) ? 1 : 0);
+		output().set_value("stage_led_1",     (data & 0x02000000) ? 1 : 0);
+		output().set_value("stage_led_2",     (data & 0x04000000) ? 1 : 0);
+		output().set_value("stage_led_3",     (data & 0x08000000) ? 1 : 0);
+	}
+	if (ACCESSING_BITS_16_23)
+	{
+		output().set_value("stage_led_4",     (data & 0x00010000) ? 1 : 0);
+		output().set_value("stage_led_5",     (data & 0x00020000) ? 1 : 0);
+		output().set_value("stage_led_6",     (data & 0x00040000) ? 1 : 0);
+		output().set_value("stage_led_7",     (data & 0x00080000) ? 1 : 0);
+	}
+}
+
+void firebeat_ppp_state::lamp_output2_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	lamp_output2_w(offset, data, mem_mask);
+
+	// ParaParaParadise lamps (active high)
+	// 0x00010000 Top LED 0
+	// 0x00020000 Top LED 1
+	// 0x00040000 Top LED 2
+	// 0x00080000 Top LED 3
+	// 0x00000001 Top LED 4
+	// 0x00000002 Top LED 5
+	// 0x00000004 Top LED 6
+	// 0x00000008 Top LED 7
+	if (ACCESSING_BITS_16_23)
+	{
+		output().set_value("top_led_0",       (data & 0x00010000) ? 1 : 0);
+		output().set_value("top_led_1",       (data & 0x00020000) ? 1 : 0);
+		output().set_value("top_led_2",       (data & 0x00040000) ? 1 : 0);
+		output().set_value("top_led_3",       (data & 0x00080000) ? 1 : 0);
+	}
+	if (ACCESSING_BITS_0_7)
+	{
+		output().set_value("top_led_4",       (data & 0x00000001) ? 1 : 0);
+		output().set_value("top_led_5",       (data & 0x00000002) ? 1 : 0);
+		output().set_value("top_led_6",       (data & 0x00000004) ? 1 : 0);
+		output().set_value("top_led_7",       (data & 0x00000008) ? 1 : 0);
+	}
+}
+
+void firebeat_ppp_state::lamp_output3_ppp_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	lamp_output3_w(offset, data, mem_mask);
+
+	// ParaParaParadise lamps (active high)
+	// 0x00010000 Lamp 0
+	// 0x00040000 Lamp 1
+	// 0x00100000 Lamp 2
+	// 0x00400000 Lamp 3
+	if (ACCESSING_BITS_16_23)
+	{
+		output().set_value("lamp_0",          (data & 0x00010000) ? 1 : 0);
+		output().set_value("lamp_1",          (data & 0x00040000) ? 1 : 0);
+		output().set_value("lamp_2",          (data & 0x00100000) ? 1 : 0);
+		output().set_value("lamp_3",          (data & 0x00400000) ? 1 : 0);
+	}
+}
+
+
+/*****************************************************************************
+* Keyboardmania
+******************************************************************************/
+void firebeat_kbm_state::init_kbm()
+{
+	init_firebeat();
+	init_lights(write32s_delegate(*this, FUNC(firebeat_kbm_state::lamp_output_kbm_w)), write32s_delegate(*this), write32s_delegate(*this));
+	init_keyboard();
+
+//  pc16552d_init(machine(), 1, 24000000, midi_uart_irq_callback, 0);     // MIDI UART
+
+	m_cabinet_info = 2;
+}
+
+void firebeat_kbm_state::init_keyboard()
 {
 	// set keyboard timer
 //  m_keyboard_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(firebeat_state::keyboard_timer_callback),this));
 //  m_keyboard_timer->adjust(attotime::from_msec(10), 0, attotime::from_msec(10));
 }
 
-void firebeat_state::init_kbm()
+void firebeat_kbm_state::firebeat_kbm(machine_config &config)
 {
-	init_firebeat();
-	init_lights(write32s_delegate(*this, FUNC(firebeat_state::lamp_output_kbm_w)), write32s_delegate(*this), write32s_delegate(*this));
+	/* basic machine hardware */
+	PPC403GCX(config, m_maincpu, XTAL(66'000'000));
+	m_maincpu->set_addrmap(AS_PROGRAM, &firebeat_kbm_state::firebeat_kbm_map);
+	m_maincpu->set_vblank_int("lscreen", FUNC(firebeat_kbm_state::firebeat_interrupt));
 
-	init_keyboard();
+	RTC65271(config, "rtc", 0);
 
-	m_cur_cab_data = kbm_cab_data;
+	FUJITSU_29F016A(config, "flash_main");
+	FUJITSU_29F016A(config, "flash_snd1");
+	FUJITSU_29F016A(config, "flash_snd2");
+
+	ATA_INTERFACE(config, m_ata).options(firebeat_ata_devices, "cdrom", "cdrom", true);
+	m_ata->irq_handler().set(FUNC(firebeat_kbm_state::ata_interrupt));
+	m_ata->slot(1).set_option_machine_config("cdrom", cdrom_config);
+
+	/* video hardware */
+	PALETTE(config, "palette", palette_device::RGB_555);
+
+	K057714(config, m_gcu, 0);
+	m_gcu->irq_callback().set(FUNC(firebeat_kbm_state::gcu_interrupt));
+
+	K057714(config, m_gcu_sub, 0);
+	m_gcu_sub->irq_callback().set(FUNC(firebeat_kbm_state::gcu_interrupt));
+
+	screen_device &lscreen(SCREEN(config, "lscreen", SCREEN_TYPE_RASTER));
+	lscreen.set_refresh_hz(60);
+	lscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	lscreen.set_size(512, 384);
+	lscreen.set_visarea(0, 511, 0, 383);
+	lscreen.set_screen_update(FUNC(firebeat_kbm_state::screen_update_firebeat_0));
+	lscreen.set_palette("palette");
+
+	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
+	rscreen.set_refresh_hz(60);
+	rscreen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	rscreen.set_size(512, 384);
+	rscreen.set_visarea(0, 511, 0, 383);
+	rscreen.set_screen_update(FUNC(firebeat_kbm_state::screen_update_firebeat_1));
+	rscreen.set_palette("palette");
+
+	/* sound hardware */
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+
+	ymz280b_device &ymz(YMZ280B(config, "ymz", 16934400));
+	ymz.irq_handler().set(FUNC(firebeat_kbm_state::sound_irq_callback));
+	ymz.set_addrmap(0, &firebeat_kbm_state::ymz280b_map);
+	ymz.add_route(1, "lspeaker", 1.0);
+	ymz.add_route(0, "rspeaker", 1.0);
+
+	PC16552D(config, "duart_com", 0);
+	NS16550(config, "duart_com:chan0", XTAL(19'660'800));
+	NS16550(config, "duart_com:chan1", XTAL(19'660'800));
+
+	PC16552D(config, "duart_midi", 0);
+	ns16550_device &midi_chan0(NS16550(config, "duart_midi:chan0", XTAL(24'000'000)));
+	midi_chan0.out_int_callback().set(FUNC(firebeat_kbm_state::midi_uart_ch0_irq_callback));
+	ns16550_device &midi_chan1(NS16550(config, "duart_midi:chan1", XTAL(24'000'000)));
+	midi_chan1.out_int_callback().set(FUNC(firebeat_kbm_state::midi_uart_ch1_irq_callback));
+
+	MIDI_KBD(config, m_kbd[0], 31250).tx_callback().set(midi_chan1, FUNC(ins8250_uart_device::rx_w));
+	MIDI_KBD(config, m_kbd[1], 31250).tx_callback().set(midi_chan0, FUNC(ins8250_uart_device::rx_w));
 }
 
+void firebeat_kbm_state::firebeat_kbm_map(address_map &map)
+{
+	firebeat_map(map);
+	map(0x70000000, 0x70000fff).rw(FUNC(firebeat_kbm_state::midi_uart_r), FUNC(firebeat_kbm_state::midi_uart_w)).umask32(0xff000000);
+	map(0x70008000, 0x7000800f).r(FUNC(firebeat_kbm_state::keyboard_wheel_r));
+	map(0x7e800100, 0x7e8001ff).rw(m_gcu_sub, FUNC(k057714_device::read), FUNC(k057714_device::write));
+}
+
+uint32_t firebeat_kbm_state::keyboard_wheel_r(offs_t offset)
+{
+	if (offset == 0)        // Keyboard Wheel (P1)
+	{
+		return ioport("WHEEL_P1")->read() << 24;
+	}
+	else if (offset == 2)   // Keyboard Wheel (P2)
+	{
+		return ioport("WHEEL_P2")->read() << 24;
+	}
+
+	return 0;
+}
+
+uint8_t firebeat_kbm_state::midi_uart_r(offs_t offset)
+{
+	return m_duart_midi->read(offset >> 6);
+}
+
+void firebeat_kbm_state::midi_uart_w(offs_t offset, uint8_t data)
+{
+	m_duart_midi->write(offset >> 6, data);
+}
+
+WRITE_LINE_MEMBER(firebeat_kbm_state::midi_uart_ch0_irq_callback)
+{
+	if ((m_extend_board_irq_enable & 0x02) == 0 && state != CLEAR_LINE)
+	{
+		m_extend_board_irq_active |= 0x02;
+		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
+	}
+	else
+		m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
+}
+
+WRITE_LINE_MEMBER(firebeat_kbm_state::midi_uart_ch1_irq_callback)
+{
+	if ((m_extend_board_irq_enable & 0x01) == 0 && state != CLEAR_LINE)
+	{
+		m_extend_board_irq_active |= 0x01;
+		m_maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
+	}
+	else
+		m_maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
+}
+
+/*
+static const int keyboard_notes[24] =
+{
+    0x3c,   // C1
+    0x3d,   // C1#
+    0x3e,   // D1
+    0x3f,   // D1#
+    0x40,   // E1
+    0x41,   // F1
+    0x42,   // F1#
+    0x43,   // G1
+    0x44,   // G1#
+    0x45,   // A1
+    0x46,   // A1#
+    0x47,   // B1
+    0x48,   // C2
+    0x49,   // C2#
+    0x4a,   // D2
+    0x4b,   // D2#
+    0x4c,   // E2
+    0x4d,   // F2
+    0x4e,   // F2#
+    0x4f,   // G2
+    0x50,   // G2#
+    0x51,   // A2
+    0x52,   // A2#
+    0x53,   // B2
+};
+
+TIMER_CALLBACK_MEMBER(firebeat_kbm_state::keyboard_timer_callback)
+{
+    static const int kb_uart_channel[2] = { 1, 0 };
+    static const char *const keynames[] = { "KEYBOARD_P1", "KEYBOARD_P2" };
+    int keyboard;
+    int i;
+
+    for (keyboard=0; keyboard < 2; keyboard++)
+    {
+        uint32_t kbstate = ioport(keynames[keyboard])->read();
+        int uart_channel = kb_uart_channel[keyboard];
+
+        if (kbstate != m_keyboard_state[keyboard])
+        {
+            for (i=0; i < 24; i++)
+            {
+                int kbnote = keyboard_notes[i];
+
+                if ((m_keyboard_state[keyboard] & (1 << i)) != 0 && (kbstate & (1 << i)) == 0)
+                {
+                    // key was on, now off -> send Note Off message
+                    pc16552d_rx_data(machine(), 1, uart_channel, 0x80);
+                    pc16552d_rx_data(machine(), 1, uart_channel, kbnote);
+                    pc16552d_rx_data(machine(), 1, uart_channel, 0x7f);
+                }
+                else if ((m_keyboard_state[keyboard] & (1 << i)) == 0 && (kbstate & (1 << i)) != 0)
+                {
+                    // key was off, now on -> send Note On message
+                    pc16552d_rx_data(machine(), 1, uart_channel, 0x90);
+                    pc16552d_rx_data(machine(), 1, uart_channel, kbnote);
+                    pc16552d_rx_data(machine(), 1, uart_channel, 0x7f);
+                }
+            }
+        }
+        else
+        {
+            // no messages, send Active Sense message instead
+            pc16552d_rx_data(machine(), 1, uart_channel, 0xfe);
+        }
+
+        m_keyboard_state[keyboard] = kbstate;
+    }
+}
+*/
+
+void firebeat_kbm_state::lamp_output_kbm_w(offs_t offset, uint32_t data, uint32_t mem_mask)
+{
+	lamp_output_w(offset, data, mem_mask);
+
+	if (ACCESSING_BITS_24_31)
+	{
+		output().set_value("door_lamp",   (data & 0x10000000) ? 1 : 0);
+		output().set_value("start1p",     (data & 0x01000000) ? 1 : 0);
+		output().set_value("start2p",     (data & 0x02000000) ? 1 : 0);
+	}
+	if (ACCESSING_BITS_8_15)
+	{
+		output().set_value("lamp1",       (data & 0x00000100) ? 1 : 0);
+		output().set_value("lamp2",       (data & 0x00000200) ? 1 : 0);
+		output().set_value("lamp3",       (data & 0x00000400) ? 1 : 0);
+		output().set_value("neon",        (data & 0x00000800) ? 1 : 0);
+	}
+}
+
+/*****************************************************************************/
+
+static INPUT_PORTS_START( firebeat )
+	PORT_START("IN2")
+	PORT_DIPUNKNOWN_DIPLOC( 0x01, IP_ACTIVE_LOW, "DIP SW:8" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x02, IP_ACTIVE_LOW, "DIP SW:7" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x04, IP_ACTIVE_LOW, "DIP SW:6" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x08, IP_ACTIVE_LOW, "DIP SW:5" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x10, IP_ACTIVE_LOW, "DIP SW:4" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x20, IP_ACTIVE_LOW, "DIP SW:3" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x40, IP_ACTIVE_LOW, "DIP SW:2" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x80, IP_ACTIVE_LOW, "DIP SW:1" )
+
+	PORT_START("IN3")
+	PORT_BIT( 0xfc, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_BIT( 0x03, IP_ACTIVE_LOW, IPT_UNKNOWN ) // Fixes "FLASH RAM DATA ERROR" in some games (Mickey Tunes)
+INPUT_PORTS_END
+
+static INPUT_PORTS_START( firebeat_spu )
+	PORT_START("SPU_DSW")
+	PORT_DIPUNKNOWN_DIPLOC( 0x01, IP_ACTIVE_LOW, "SPU DSW:1" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x02, IP_ACTIVE_LOW, "SPU DSW:2" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x04, IP_ACTIVE_LOW, "SPU DSW:3" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x08, IP_ACTIVE_LOW, "SPU DSW:4" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x10, IP_ACTIVE_LOW, "SPU DSW:5" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x20, IP_ACTIVE_LOW, "SPU DSW:6" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x40, IP_ACTIVE_LOW, "SPU DSW:7" )
+	PORT_DIPUNKNOWN_DIPLOC( 0x80, IP_ACTIVE_LOW, "SPU DSW:8" )
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(ppp)
+	PORT_INCLUDE( firebeat )
+
+	PORT_START("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON1 )            // Left
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_BUTTON2 )            // Right
+	PORT_SERVICE_NO_TOGGLE( 0x04, IP_ACTIVE_LOW)            // Test
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_START1 )             // Start / Ok
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_UNUSED )             // Fixes booting in PPP with certain dongle types
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START("IN1")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+
+	// ParaParaParadise has 24 sensors, grouped into groups of 3 for each sensor bar
+	// Sensors 15...23 are only used by the Korean version of PPP, which has 8 sensor bars
+
+	PORT_START("SENSOR1")
+	PORT_BIT( 0x0007, IP_ACTIVE_HIGH, IPT_BUTTON3 )     // Sensor 0, 1, 2  (Sensor bar 1)
+	PORT_BIT( 0x0038, IP_ACTIVE_HIGH, IPT_BUTTON4 )     // Sensor 3, 4, 5  (Sensor bar 2)
+	PORT_BIT( 0x00c0, IP_ACTIVE_HIGH, IPT_BUTTON5 )     // Sensor 6, 7, 8  (Sensor bar 3)
+
+	PORT_START("SENSOR2")
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_BUTTON5 )     // Sensor 6, 7, 8  (Sensor bar 3)
+	PORT_BIT( 0x000e, IP_ACTIVE_HIGH, IPT_BUTTON6 )     // Sensor 9, 10,11 (Sensor bar 4)
+
+	PORT_START("SENSOR3")
+	PORT_BIT( 0x0007, IP_ACTIVE_HIGH, IPT_BUTTON7 )     // Sensor 12,13,14 (Sensor bar 5)
+	PORT_BIT( 0x0038, IP_ACTIVE_HIGH, IPT_BUTTON8 )     // Sensor 15,16,17 (Sensor bar 6)   (unused by PPP)
+	PORT_BIT( 0x00c0, IP_ACTIVE_HIGH, IPT_BUTTON9 )     // Sensor 18,19,20 (Sensor bar 7)   (unused by PPP)
+
+	PORT_START("SENSOR4")
+	PORT_BIT( 0x0001, IP_ACTIVE_HIGH, IPT_BUTTON9 )     // Sensor 18,19,20 (Sensor bar 7)   (unused by PPP)
+	PORT_BIT( 0x000e, IP_ACTIVE_HIGH, IPT_BUTTON10 )    // Sensor 21,22,23 (Sensor bar 8)   (unused by PPP)
+
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(kbm)
+	PORT_INCLUDE( firebeat )
+
+	PORT_START("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_START1 )             // Start P1
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_START2 )             // Start P2
+	PORT_SERVICE_NO_TOGGLE( 0x04, IP_ACTIVE_LOW)            // Test
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
+	PORT_BIT( 0xe0, IP_ACTIVE_LOW, IPT_UNUSED )
+
+	PORT_START("IN1")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_UNKNOWN )           // e-Amusement
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_UNKNOWN )            // e-Amusement (Keyboardmania)
+	PORT_BIT( 0xde, IP_ACTIVE_LOW, IPT_UNKNOWN )
+
+	PORT_START("WHEEL_P1")          // Keyboard modulation wheel (P1)
+	PORT_BIT( 0xff, 0x80, IPT_PADDLE ) PORT_MINMAX(0x00, 0xff) PORT_SENSITIVITY(30) PORT_KEYDELTA(10)
+
+	PORT_START("WHEEL_P2")          // Keyboard modulation wheel (P2)
+	PORT_BIT( 0xff, 0x80, IPT_PADDLE_V ) PORT_MINMAX(0x00, 0xff) PORT_SENSITIVITY(30) PORT_KEYDELTA(10)
+
+/*
+    PORT_START("KEYBOARD_P1")
+    PORT_BIT( 0x000001, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C1") PORT_CODE(KEYCODE_Q)
+    PORT_BIT( 0x000002, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C1#") PORT_CODE(KEYCODE_W)
+    PORT_BIT( 0x000004, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D1") PORT_CODE(KEYCODE_E)
+    PORT_BIT( 0x000008, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D1#") PORT_CODE(KEYCODE_R)
+    PORT_BIT( 0x000010, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 E1") PORT_CODE(KEYCODE_T)
+    PORT_BIT( 0x000020, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F1") PORT_CODE(KEYCODE_Y)
+    PORT_BIT( 0x000040, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F1#") PORT_CODE(KEYCODE_U)
+    PORT_BIT( 0x000080, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G1") PORT_CODE(KEYCODE_I)
+    PORT_BIT( 0x000100, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G1#") PORT_CODE(KEYCODE_O)
+    PORT_BIT( 0x000200, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A1") PORT_CODE(KEYCODE_A)
+    PORT_BIT( 0x000400, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A1#") PORT_CODE(KEYCODE_S)
+    PORT_BIT( 0x000800, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 B1") PORT_CODE(KEYCODE_D)
+    PORT_BIT( 0x001000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C2") PORT_CODE(KEYCODE_F)
+    PORT_BIT( 0x002000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 C2#") PORT_CODE(KEYCODE_G)
+    PORT_BIT( 0x004000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D2") PORT_CODE(KEYCODE_H)
+    PORT_BIT( 0x008000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 D2#") PORT_CODE(KEYCODE_J)
+    PORT_BIT( 0x010000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 E2") PORT_CODE(KEYCODE_K)
+    PORT_BIT( 0x020000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F2") PORT_CODE(KEYCODE_L)
+    PORT_BIT( 0x040000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 F2#") PORT_CODE(KEYCODE_Z)
+    PORT_BIT( 0x080000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G2") PORT_CODE(KEYCODE_X)
+    PORT_BIT( 0x100000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 G2#") PORT_CODE(KEYCODE_C)
+    PORT_BIT( 0x200000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A2") PORT_CODE(KEYCODE_V)
+    PORT_BIT( 0x400000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 A2#") PORT_CODE(KEYCODE_B)
+    PORT_BIT( 0x800000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P1 B2") PORT_CODE(KEYCODE_N)
+
+    PORT_START("KEYBOARD_P2")
+    PORT_BIT( 0x000001, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C1") PORT_CODE(KEYCODE_Q)
+    PORT_BIT( 0x000002, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C1#") PORT_CODE(KEYCODE_W)
+    PORT_BIT( 0x000004, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D1") PORT_CODE(KEYCODE_E)
+    PORT_BIT( 0x000008, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D1#") PORT_CODE(KEYCODE_R)
+    PORT_BIT( 0x000010, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 E1") PORT_CODE(KEYCODE_T)
+    PORT_BIT( 0x000020, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F1") PORT_CODE(KEYCODE_Y)
+    PORT_BIT( 0x000040, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F1#") PORT_CODE(KEYCODE_U)
+    PORT_BIT( 0x000080, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G1") PORT_CODE(KEYCODE_I)
+    PORT_BIT( 0x000100, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G1#") PORT_CODE(KEYCODE_O)
+    PORT_BIT( 0x000200, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A1") PORT_CODE(KEYCODE_A)
+    PORT_BIT( 0x000400, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A1#") PORT_CODE(KEYCODE_S)
+    PORT_BIT( 0x000800, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 B1") PORT_CODE(KEYCODE_D)
+    PORT_BIT( 0x001000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C2") PORT_CODE(KEYCODE_F)
+    PORT_BIT( 0x002000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 C2#") PORT_CODE(KEYCODE_G)
+    PORT_BIT( 0x004000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D2") PORT_CODE(KEYCODE_H)
+    PORT_BIT( 0x008000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 D2#") PORT_CODE(KEYCODE_J)
+    PORT_BIT( 0x010000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 E2") PORT_CODE(KEYCODE_K)
+    PORT_BIT( 0x020000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F2") PORT_CODE(KEYCODE_L)
+    PORT_BIT( 0x040000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 F2#") PORT_CODE(KEYCODE_Z)
+    PORT_BIT( 0x080000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G2") PORT_CODE(KEYCODE_X)
+    PORT_BIT( 0x100000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 G2#") PORT_CODE(KEYCODE_C)
+    PORT_BIT( 0x200000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A2") PORT_CODE(KEYCODE_V)
+    PORT_BIT( 0x400000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 A2#") PORT_CODE(KEYCODE_B)
+    PORT_BIT( 0x800000, IP_ACTIVE_HIGH, IPT_OTHER ) PORT_NAME("P2 B2") PORT_CODE(KEYCODE_N)
+*/
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(popn)
+	PORT_INCLUDE( firebeat )
+	PORT_INCLUDE( firebeat_spu )
+
+	PORT_START("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON1 )            // Switch 1
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_BUTTON2 )            // Switch 2
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_BUTTON3 )            // Switch 3
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_BUTTON4 )            // Switch 4
+	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON5 )            // Switch 5
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON6 )            // Switch 6
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_BUTTON7 )            // Switch 7
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_BUTTON8 )            // Switch 8
+
+	PORT_START("IN1")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_BUTTON9 )            // Switch 9
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_COIN1 )              // Coin
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_SERVICE_NO_TOGGLE( 0x10, IP_ACTIVE_LOW)            // Test
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_SERVICE ) PORT_NAME("Service") PORT_CODE(KEYCODE_7)      // Service
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+
+INPUT_PORTS_END
+
+static INPUT_PORTS_START(bm3)
+	PORT_INCLUDE( firebeat )
+	PORT_INCLUDE( firebeat_spu )
+
+	PORT_START("IN0")
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE) PORT_NAME(DEF_STR(Test))              // Test
+	PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_SERVICE1 ) PORT_NAME("Service")                // Service
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_SERVICE2 ) PORT_NAME("A")                      // A
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_SERVICE3 ) PORT_NAME("B")                      // B
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_BUTTON6 ) PORT_PLAYER(1) PORT_NAME("P1 Foot") // P1 Foot Pedal
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_BUTTON6 ) PORT_PLAYER(2) PORT_NAME("P2 Foot") // P2 Foot Pedal
+
+	PORT_START("IN1")
+	PORT_BIT( 0xff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+
+	PORT_START("IO1")
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(1) // P1 Button 1
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(1) // P1 Button 2
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(1) // P1 Button 3
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_PLAYER(1) // P1 Button 4
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_PLAYER(1) // P1 Button 5
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START1 )                 // P1 Start Button
+
+	PORT_START("IO2")
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_COIN1 ) // Coin sensor
+
+	PORT_START("IO3")
+	PORT_BIT( 0x0001, IP_ACTIVE_LOW, IPT_BUTTON1 ) PORT_PLAYER(2) // P2 Button 1
+	PORT_BIT( 0x0002, IP_ACTIVE_LOW, IPT_BUTTON2 ) PORT_PLAYER(2) // P2 Button 2
+	PORT_BIT( 0x0004, IP_ACTIVE_LOW, IPT_BUTTON3 ) PORT_PLAYER(2) // P2 Button 3
+	PORT_BIT( 0x0008, IP_ACTIVE_LOW, IPT_BUTTON4 ) PORT_PLAYER(2) // P2 Button 4
+	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_BUTTON5 ) PORT_PLAYER(2) // P2 Button 5
+	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_START2 )                 // P2 Start Button
+
+	PORT_START("IO4")
+	PORT_BIT( 0xffff, IP_ACTIVE_LOW, IPT_UNKNOWN )
+
+	PORT_START("TURNTABLE_P1")
+	PORT_BIT( 0x03ff, 0x00, IPT_TRACKBALL_X) PORT_PLAYER(1) PORT_NAME("Turntable") PORT_MINMAX(0x00,0x3ff) PORT_SENSITIVITY(100) PORT_KEYDELTA(15)
+
+	PORT_START("TURNTABLE_P2")
+	PORT_BIT( 0x03ff, 0x00, IPT_TRACKBALL_X) PORT_PLAYER(2) PORT_NAME("Turntable") PORT_MINMAX(0x00,0x3ff) PORT_SENSITIVITY(100) PORT_KEYDELTA(15)
+
+	PORT_START("EFFECT1")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 1") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT2")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 2") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT3")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 3") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT4")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 4") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT5")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 5") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT6")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 6") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+	PORT_START("EFFECT7")
+	PORT_BIT( 0x001f, 0x00, IPT_DIAL) PORT_NAME("Effect 7") PORT_MINMAX(0x00,0x1f) PORT_SENSITIVITY(10) PORT_KEYDELTA(1)
+
+INPUT_PORTS_END
 
 /*****************************************************************************/
 
@@ -1552,7 +1954,7 @@ ROM_START( ppp )
 	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
 
 	ROM_REGION(0xc0, "user2", 0)    // Security dongle
-	ROM_LOAD("gq977-ja", 0x00, 0xc0, BAD_DUMP CRC(55b5abdb) SHA1(d8da5bac005235480a1815bd0a79c3e8a63ebad1))
+	ROM_LOAD("gq977-ja", 0x00, 0xc0, BAD_DUMP CRC(5b17d0c7) SHA1(c2de4c0510ad6a48ad5769780a27ce80e44fb380))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "977jaa01", 0, BAD_DUMP SHA1(59c03d8eb366167feef741d42d9d8b54bfeb3c1e) )
@@ -1566,7 +1968,7 @@ ROM_START( ppp1mp )
 	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
 
 	ROM_REGION(0xc0, "user2", 0)    // Security dongle
-	ROM_LOAD( "gqa11-ja",     0x000000, 0x0000c0, CRC(2ed8e2ae) SHA1(b8c3410dab643111b2d2027068175ba018a0a67e) )
+	ROM_LOAD("gqa11-ja", 0x00, 0xc0, BAD_DUMP CRC(207a99b2) SHA1(d19788e1c377771141527660311ff84653039c32))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "a11jaa01", 0, SHA1(539ec6f1c1d198b0d6ce5543eadcbb4d9917fa42) )
@@ -1575,12 +1977,40 @@ ROM_START( ppp1mp )
 	DISK_IMAGE_READONLY( "a11jaa02", 0, SHA1(575069570cb4a2b58b199a1329d45b189a20fcc9) )
 ROM_END
 
+ROM_START( ppd )
+	ROM_REGION32_BE(0x80000, "user1", 0)
+	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
+
+	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
+	ROM_LOAD("gq977-ko", 0x00, 0xc0, BAD_DUMP CRC(b275de3c) SHA1(d23fcf0e87da2e561bc112851d26b3e78079f40a))
+
+	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
+	DISK_IMAGE_READONLY( "977kaa01", 0, BAD_DUMP SHA1(7af9f4949ffa10ea5fc18b6c88c2abc710df3cf9) )
+
+	DISK_REGION( "ata:1:cdrom" ) // audio CD-ROM
+	DISK_IMAGE_READONLY( "977kaa02", 1, SHA1(0feb5ac56269ad4a8401fcfe3bb98b01a0169177) )
+ROM_END
+
+ROM_START( ppp11 )
+	ROM_REGION32_BE(0x80000, "user1", 0)
+	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
+
+	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
+	ROM_LOAD("gq977-ja", 0x00, 0xc0, BAD_DUMP CRC(09b446c4) SHA1(54e43b69a2daeb4f6e69466152a70ce63f6267b5))
+
+	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
+	DISK_IMAGE_READONLY( "gc977jaa01", 0, SHA1(7ed1f4b55105c93fec74468436bfb1d540bce944) )
+
+	DISK_REGION( "ata:1:cdrom" ) // audio CD-ROM
+	DISK_IMAGE_READONLY( "gc977jaa02", 1, SHA1(74ce8c90575fd562807def7d561392d0f91f2bc6) )
+ROM_END
+
 ROM_START( kbm )
 	ROM_REGION32_BE(0x80000, "user1", 0)
 	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD("gq974-ja", 0x00, 0xc0, BAD_DUMP CRC(4578f29b) SHA1(faaeaf6357c1e86e898e7017566cfd2fc7ee3d6f))
+	ROM_LOAD("gq974-ja", 0x00, 0xc0, BAD_DUMP CRC(4bda8987) SHA1(9c5c89808a57aa5aeb7976a3cf3ca96e9797beea))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "974jac01", 0, BAD_DUMP SHA1(c6145d7090e44c87f71ba626620d2ae2596a75ca) )
@@ -1594,7 +2024,7 @@ ROM_START( kbm2nd )
 	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD("gca01-ja", 0x00, 0xc0, BAD_DUMP CRC(2bda339d) SHA1(031cb3f44e7a89cd62a9ba948f3d19d53a325abd))
+	ROM_LOAD("gca01-ja", 0x00, 0xc0, BAD_DUMP CRC(25784881) SHA1(99ba9456a91af3043baed2bbf72feed73df564b2))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "a01jaa01", 0, BAD_DUMP SHA1(37bc3879719b3d3c6bc8a5691abd7aa4aec87d45) )
@@ -1627,8 +2057,6 @@ ROM_START( popn4 )
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
 
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
-
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gq986jaa01", 0, SHA1(e5368ac029b0bdf29943ae66677b5521ae1176e1) )
 
@@ -1646,8 +2074,6 @@ ROM_START( popn5 )
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP( "a02jaa04.3q",  0x000000, 0x080000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683) )
 
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
-
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "a04jaa01", 0, SHA1(87136ddad1d786b4d5f04381fcbf679ab666e6c9) )
 
@@ -1660,12 +2086,10 @@ ROM_START( popn6 )
 	ROM_LOAD16_WORD_SWAP("a02jaa03.21e", 0x00000, 0x80000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gqa16-ja", 0x000000, 0x0000c0, CRC(a3393355) SHA1(6b28b972fe375e6ad0c614110c0ae3832cffccff) )
+	ROM_LOAD("gqa16-ja", 0x00, 0xc0, BAD_DUMP CRC(f2094180) SHA1(36559307f73fe4d9e21533041e8ff8f9297773ed))
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gqa16jaa01", 0, SHA1(7a7e475d06c74a273f821fdfde0743b33d566e4c) )
@@ -1679,12 +2103,10 @@ ROM_START( popn7 )
 	ROM_LOAD16_WORD_SWAP("a02jaa03.21e", 0x00000, 0x80000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD("gcb00-ja", 0x00, 0xc0, CRC(d0a58c74) SHA1(fc1d8ad2f9d16743dc10b6e61a5a88ffa9c9dd2f))
+	ROM_LOAD("gcb00-ja", 0x00, 0xc0, BAD_DUMP CRC(45223b93) SHA1(b05a260ddc3dbedc3209509b9848d2ccf2319584))
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "b00jab01", 0, SHA1(259c733ca4d30281205b46b7bf8d60c9d01aa818) )
@@ -1698,12 +2120,10 @@ ROM_START( popn8 )
 	ROM_LOAD16_WORD_SWAP("a02jaa03.21e", 0x00000, 0x80000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gqb30-ja", 0x000000, 0x0000c0, CRC(dbabb51b) SHA1(b53e971f544a654f0811e10eed40bee2e0393855) )
+	ROM_LOAD("gqb30-ja", 0x00, 0xc0, BAD_DUMP CRC(a2276ca5) SHA1(eff519ef21befa5f843f84f3b81d3397a173fe99))
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gqb30jaa01", 0, SHA1(0ff3e40e3717ce23337b3a2438bdaca01cba9e30) )
@@ -1712,17 +2132,32 @@ ROM_START( popn8 )
 	DISK_IMAGE_READONLY( "gqb30jaa02", 0, SHA1(f067d502c23efe0267aada5706f5bc7a54605942) )
 ROM_END
 
+ROM_START( popnanm )
+	ROM_REGION32_BE(0x80000, "user1", 0)
+	ROM_LOAD16_WORD_SWAP("a02jaa03.21e", 0x00000, 0x80000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599))
+
+	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
+	ROM_LOAD("gq987-ja", 0x00, 0xc0, BAD_DUMP CRC(201327bd) SHA1(461b422382cc35b0027eb5426bd94d1297b5f98c))
+
+	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
+	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
+
+	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
+	DISK_IMAGE_READONLY( "gq987jaa01", 0, SHA1(ee1f9cf480c01ef356451cec30e5303d6c433758) )
+
+	DISK_REGION( "spu_ata:0:cdrom" ) // data DVD-ROM
+	DISK_IMAGE_READONLY( "gq987jaa02", 0, SHA1(d72515bac3fcd9f28c39fa1402292009734df678) )
+ROM_END
+
 ROM_START( popnanm2 )
 	ROM_REGION32_BE(0x80000, "user1", 0)
 	ROM_LOAD16_WORD_SWAP("a02jaa03.21e", 0x00000, 0x80000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gea02-ja", 0x000000, 0x0000c0, CRC(072f8624) SHA1(e869b85a891bf7f9c870fb581a9a2ddd70810e2c) )
+	ROM_LOAD("gea02-ja", 0x00, 0xc0, BAD_DUMP CRC(ab66b22f) SHA1(7ad73a6ccca513e51b3ab96f4ecd0bdf0a6d1475))
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
 	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gea02jaa01", 0, SHA1(e81203b6812336c4d00476377193340031ef11b1) )
@@ -1731,46 +2166,67 @@ ROM_START( popnanm2 )
 	DISK_IMAGE_READONLY( "gea02jaa02", 0, SHA1(7212e399779f37a5dcb8317a8f635a3b3f620aa9) )
 ROM_END
 
-ROM_START( ppd )
+ROM_START( popnmt )
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
+	ROM_LOAD16_WORD_SWAP( "a02jaa03.21e", 0x000000, 0x080000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599) )
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD("gq977-ko", 0x00, 0xc0, BAD_DUMP CRC(ee743323) SHA1(2042e45879795557ad3cc21b37962f6bf54da60d))
+	ROM_LOAD("gq976-ja", 0x00, 0xc0, BAD_DUMP CRC(673c2478) SHA1(97e7952a503a93f5334faf1882e8b0394148cf84))
+
+	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
+	ROM_LOAD16_WORD_SWAP( "a02jaa04.3q",  0x000000, 0x080000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683) )
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
-	DISK_IMAGE_READONLY( "977kaa01", 0, BAD_DUMP SHA1(7af9f4949ffa10ea5fc18b6c88c2abc710df3cf9) )
+	DISK_IMAGE_READONLY( "976jaa01", 0, SHA1(622a9350107e9fb17609ea1a234ca35489915da7) )
 
-	DISK_REGION( "ata:1:cdrom" ) // audio CD-ROM
-	DISK_IMAGE_READONLY( "977kaa02", 1, SHA1(0feb5ac56269ad4a8401fcfe3bb98b01a0169177) )
+	DISK_REGION( "spu_ata:0:cdrom" ) // data DVD-ROM
+	DISK_IMAGE_READONLY( "976jaa02", 0, SHA1(3881bb1e4deb829ba272c541cb7d203924571f3b) )
 ROM_END
 
-ROM_START( ppp11 )
+ROM_START( popnmt2 )
+	// This is an updated version of popnmt released a few months later which has NET@MANIA
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("977jaa03.21e", 0x00000, 0x80000, CRC(7b83362a) SHA1(2857a93be58636c10a8d180dbccf2caeeaaff0e2))
+	ROM_LOAD16_WORD_SWAP( "a02jaa03.21e", 0x000000, 0x080000, CRC(43ecc093) SHA1(637df5b546cf7409dd4752dc471674fe2a046599) )
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD("gq977-ja", 0x00, 0xc0, BAD_DUMP CRC(55b5abdb) SHA1(d8da5bac005235480a1815bd0a79c3e8a63ebad1))
+	ROM_LOAD("gq976-ja", 0x00, 0xc0, BAD_DUMP CRC(673c2478) SHA1(97e7952a503a93f5334faf1882e8b0394148cf84))
+
+	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
+	ROM_LOAD16_WORD_SWAP( "a02jaa04.3q",  0x000000, 0x080000, CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683) )
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
-	DISK_IMAGE_READONLY( "gc977jaa01", 0, SHA1(7ed1f4b55105c93fec74468436bfb1d540bce944) )
+	DISK_IMAGE_READONLY( "976jba01", 0, SHA1(f8a70ca0718dc222cebbef238b5954494503d315) )
 
-	DISK_REGION( "ata:1:cdrom" ) // audio CD-ROM
-	DISK_IMAGE_READONLY( "gc977jaa02", 1, SHA1(74ce8c90575fd562807def7d561392d0f91f2bc6) )
+	DISK_REGION( "spu_ata:0:cdrom" ) // data DVD-ROM
+	DISK_IMAGE_READONLY( "976jaa02", 0, SHA1(3881bb1e4deb829ba272c541cb7d203924571f3b) )
 ROM_END
 
-// Beatmania III has a different BIOS and SPU program, and they aren't dumped yet
+ROM_START( bm3 )
+	ROM_REGION32_BE(0x80000, "user1", 0)
+	ROM_LOAD16_WORD_SWAP("972maina01.21e", 0x00000, 0x80000, CRC(9de35bfd) SHA1(57290e0015ea24fa46efdfe1e8299003b7754a3b))
+
+	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
+	ROM_LOAD( "gq972-jc", 0x000000, 0x0000c0, BAD_DUMP CRC(25003a96) SHA1(6c9cca4eba6f4334d3fb04744b2929c801b710c0) )
+
+	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
+	ROM_LOAD16_WORD_SWAP("972spua01.3q", 0x00000, 0x80000, CRC(308dbcff) SHA1(87d11eb3e28cb4f3a8f88e3c57a28809dc429ccd))
+
+	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
+	DISK_IMAGE_READONLY( "gc97201", 0, SHA1(216ced68f2082bf891dc3e89fb0663f559cc4915) )
+
+	DISK_REGION( "spu_ata:0:hdd:image" ) // HDD
+	DISK_IMAGE_READONLY( "gc97202", 0, SHA1(84049bab473d29eca3c6d536956ef20ae410967d) )
+ROM_END
+
 ROM_START( bm3core )
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, BAD_DUMP CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))     // boots with KBM BIOS
+	ROM_LOAD16_WORD_SWAP("972maina01.21e", 0x00000, 0x80000, CRC(9de35bfd) SHA1(57290e0015ea24fa46efdfe1e8299003b7754a3b))
 
 	ROM_REGION(0xc8, "user2", ROMREGION_ERASE00)    // Security dongle
 	ROM_LOAD( "gca05-jc.bin", 0x00, 0xc8, CRC(a4c67c80) SHA1(a87609052fa879116350564353df7f5b70ef3ae5) )
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
-	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, BAD_DUMP CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("972spua01.3q", 0x00000, 0x80000, CRC(308dbcff) SHA1(87d11eb3e28cb4f3a8f88e3c57a28809dc429ccd))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "a05jca01", 0, SHA1(b89eced8a1325b087e3f875d1a643bebe9bad5c0) )
@@ -1781,15 +2237,13 @@ ROM_END
 
 ROM_START( bm36th )
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, BAD_DUMP CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))     // boots with KBM BIOS
+	ROM_LOAD16_WORD_SWAP("972maina01.21e", 0x00000, 0x80000, CRC(9de35bfd) SHA1(57290e0015ea24fa46efdfe1e8299003b7754a3b))
 
-	ROM_REGION(0xc8, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gca21-jc", 0x000000, 0x0000c8, NO_DUMP )
+	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
+	ROM_LOAD( "gca21-jc", 0x000000, 0x0000c0, BAD_DUMP CRC(5cf45b41) SHA1(14f9ff701df79c621d47d20fe3e6b8b579975a1e) )
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
-	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, BAD_DUMP CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("a21jca03.3q", 0x00000, 0x80000, CRC(98ea367a) SHA1(f0b72bdfbba4d265e7b08d606cd82424947d97b9))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "a21jca01", 0, SHA1(d1b888379cc0b2c2ab58fa2c5be49258043c3ea1) )
@@ -1800,15 +2254,13 @@ ROM_END
 
 ROM_START( bm37th )
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, BAD_DUMP CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))     // boots with KBM BIOS
+	ROM_LOAD16_WORD_SWAP("972maina01.21e", 0x00000, 0x80000, CRC(9de35bfd) SHA1(57290e0015ea24fa46efdfe1e8299003b7754a3b))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gcb07-jc", 0x000000, 0x0000c0, CRC(16115b6a) SHA1(dcb2a3346973941a946b2cdfd31a5a761f666ca3) )
+	ROM_LOAD( "gcb07-jc", 0x000000, 0x0000c0, BAD_DUMP CRC(18b32076) SHA1(6f5a44a0c2ed033bc00e73e95f9fbd8301719054) )
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
-	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, BAD_DUMP CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("a21jca03.3q", 0x00000, 0x80000, CRC(98ea367a) SHA1(f0b72bdfbba4d265e7b08d606cd82424947d97b9))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gcb07jca01", 0, SHA1(f906379bdebee314e2ca97c7756259c8c25897fd) )
@@ -1819,15 +2271,13 @@ ROM_END
 
 ROM_START( bm3final )
 	ROM_REGION32_BE(0x80000, "user1", 0)
-	ROM_LOAD16_WORD_SWAP("974a03.21e", 0x00000, 0x80000, BAD_DUMP CRC(ef9a932d) SHA1(6299d3b9823605e519dbf1f105b59a09197df72f))     // boots with KBM BIOS
+	ROM_LOAD16_WORD_SWAP("972maina01.21e", 0x00000, 0x80000, CRC(9de35bfd) SHA1(57290e0015ea24fa46efdfe1e8299003b7754a3b))
 
 	ROM_REGION(0xc0, "user2", ROMREGION_ERASE00)    // Security dongle
-	ROM_LOAD( "gcc01-jc", 0x000000, 0x0000c0, CRC(9c49fed8) SHA1(212b87c1d25763117611ffb2a36ed568d429d2f4) )
+	ROM_LOAD( "gcc01-jc", 0x000000, 0x0000c0, BAD_DUMP CRC(92eb85c4) SHA1(4cab9c20d072c00a61583731c37aa7fab61857c5) )
 
 	ROM_REGION(0x80000, "audiocpu", 0)          // SPU 68K program
-	ROM_LOAD16_WORD_SWAP("a02jaa04.3q", 0x00000, 0x80000, BAD_DUMP CRC(8c6000dd) SHA1(94ab2a66879839411eac6c673b25143d15836683))
-
-	ROM_REGION16_LE(0x1000000, "rf5c400", ROMREGION_ERASE00)
+	ROM_LOAD16_WORD_SWAP("a21jca03.3q", 0x00000, 0x80000, CRC(98ea367a) SHA1(f0b72bdfbba4d265e7b08d606cd82424947d97b9))
 
 	DISK_REGION( "ata:0:cdrom" ) // program CD-ROM
 	DISK_IMAGE_READONLY( "gcc01jca01", 0, SHA1(3e7af83670d791591ad838823422959987f7aab9) )
@@ -1841,20 +2291,27 @@ ROM_END
 
 /*****************************************************************************/
 
-GAME(  2000, ppp,      0,   firebeat,         ppp,  firebeat_state, init_ppp, ROT0,   "Konami",  "ParaParaParadise", MACHINE_NOT_WORKING)
-GAME(  2000, ppd,      0,   firebeat,         ppp,  firebeat_state, init_ppd, ROT0,   "Konami",  "ParaParaDancing", MACHINE_NOT_WORKING)
-GAME(  2000, ppp11,    0,   firebeat,         ppp,  firebeat_state, init_ppp, ROT0,   "Konami",  "ParaParaParadise v1.1", MACHINE_NOT_WORKING)
-GAME(  2000, ppp1mp,   ppp, firebeat,         ppp,  firebeat_state, init_ppp, ROT0,   "Konami",  "ParaParaParadise 1st Mix Plus", MACHINE_NOT_WORKING)
-GAMEL( 2000, kbm,      0,   firebeat2,        kbm,  firebeat_state, init_kbm, ROT270, "Konami",  "Keyboardmania", MACHINE_NOT_WORKING, layout_firebeat)
-GAMEL( 2000, kbm2nd,   0,   firebeat2,        kbm,  firebeat_state, init_kbm, ROT270, "Konami",  "Keyboardmania 2nd Mix", MACHINE_NOT_WORKING, layout_firebeat)
-GAMEL( 2001, kbm3rd,   0,   firebeat2,        kbm,  firebeat_state, init_kbm, ROT270, "Konami",  "Keyboardmania 3rd Mix", MACHINE_NOT_WORKING, layout_firebeat)
-GAME(  2000, popn4,    0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music 4", MACHINE_NOT_WORKING)
-GAME(  2000, popn5,    0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music 5", MACHINE_NOT_WORKING)
-GAME(  2001, popn6,    0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music 6", MACHINE_NOT_WORKING)
-GAME(  2001, popn7,    0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music 7", MACHINE_NOT_WORKING)
-GAME(  2001, popnanm2, 0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music Animelo 2", MACHINE_NOT_WORKING)
-GAME(  2002, popn8,    0,   firebeat_spu,     popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Pop'n Music 8", MACHINE_NOT_WORKING)
-GAME(  2000, bm3core,  0,   firebeat_spu_bm3, popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Beatmania III Append Core Remix", MACHINE_NOT_WORKING)
-GAME(  2001, bm36th,   0,   firebeat_spu_bm3, popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Beatmania III Append 6th Mix", MACHINE_NOT_WORKING)
-GAME(  2002, bm37th,   0,   firebeat_spu_bm3, popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Beatmania III Append 7th Mix", MACHINE_NOT_WORKING)
-GAME(  2003, bm3final, 0,   firebeat_spu_bm3, popn, firebeat_state, init_ppp, ROT0,   "Konami",  "Beatmania III The Final", MACHINE_NOT_WORKING)
+GAME( 2000, ppp,    0,   firebeat_ppp, ppp, firebeat_ppp_state, init_ppp, ROT0, "Konami", "ParaParaParadise", MACHINE_NOT_WORKING )
+GAME( 2000, ppd,    0,   firebeat_ppp, ppp, firebeat_ppp_state, init_ppd, ROT0, "Konami", "ParaParaDancing", MACHINE_NOT_WORKING )
+GAME( 2000, ppp11,  0,   firebeat_ppp, ppp, firebeat_ppp_state, init_ppp, ROT0, "Konami", "ParaParaParadise v1.1", MACHINE_NOT_WORKING )
+GAME( 2000, ppp1mp, ppp, firebeat_ppp, ppp, firebeat_ppp_state, init_ppp, ROT0, "Konami", "ParaParaParadise 1st Mix Plus", MACHINE_NOT_WORKING )
+
+GAMEL( 2000, kbm,    0, firebeat_kbm, kbm, firebeat_kbm_state, init_kbm, ROT270, "Konami", "Keyboardmania", MACHINE_NOT_WORKING, layout_firebeat )
+GAMEL( 2000, kbm2nd, 0, firebeat_kbm, kbm, firebeat_kbm_state, init_kbm, ROT270, "Konami", "Keyboardmania 2nd Mix", MACHINE_NOT_WORKING, layout_firebeat )
+GAMEL( 2001, kbm3rd, 0, firebeat_kbm, kbm, firebeat_kbm_state, init_kbm, ROT270, "Konami", "Keyboardmania 3rd Mix", MACHINE_NOT_WORKING, layout_firebeat )
+
+GAME( 2000, popn4,    0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music 4", MACHINE_NOT_WORKING )
+GAME( 2000, popn5,    0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music 5", MACHINE_NOT_WORKING )
+GAME( 2001, popn6,    0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music 6", MACHINE_NOT_WORKING )
+GAME( 2001, popn7,    0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music 7", MACHINE_NOT_WORKING )
+GAME( 2002, popn8,    0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music 8", MACHINE_NOT_WORKING )
+GAME( 2000, popnmt,   0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music Mickey Tunes", MACHINE_NOT_WORKING )
+GAME( 2000, popnmt2,  popnmt, firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music Mickey Tunes!", MACHINE_NOT_WORKING )
+GAME( 2000, popnanm,  0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music Animelo", MACHINE_NOT_WORKING )
+GAME( 2001, popnanm2, 0,      firebeat_popn, popn, firebeat_popn_state, init_popn, ROT0, "Konami", "Pop'n Music Animelo 2", MACHINE_NOT_WORKING )
+
+GAME( 2000, bm3,      0, firebeat_bm3, bm3, firebeat_bm3_state, init_bm3, ROT0, "Konami", "Beatmania III", MACHINE_NOT_WORKING )
+GAME( 2000, bm3core,  0, firebeat_bm3, bm3, firebeat_bm3_state, init_bm3, ROT0, "Konami", "Beatmania III Append Core Remix", MACHINE_NOT_WORKING )
+GAME( 2001, bm36th,   0, firebeat_bm3, bm3, firebeat_bm3_state, init_bm3, ROT0, "Konami", "Beatmania III Append 6th Mix", MACHINE_NOT_WORKING )
+GAME( 2002, bm37th,   0, firebeat_bm3, bm3, firebeat_bm3_state, init_bm3, ROT0, "Konami", "Beatmania III Append 7th Mix", MACHINE_NOT_WORKING )
+GAME( 2003, bm3final, 0, firebeat_bm3, bm3, firebeat_bm3_state, init_bm3, ROT0, "Konami", "Beatmania III The Final", MACHINE_NOT_WORKING )

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -180,10 +180,6 @@ struct IBUTTON
 static void firebeat_ata_devices(device_slot_interface &device)
 {
 	device.option_add("cdrom", ATAPI_FIXED_CDROM);
-}
-
-static void firebeat_ata_devices_hdd(device_slot_interface &device)
-{
 	device.option_add("hdd", IDE_HARDDISK);
 }
 
@@ -1188,9 +1184,10 @@ void firebeat_bm3_state::firebeat_bm3(machine_config &config)
 		screen->screen_vblank().set(FUNC(firebeat_bm3_state::bm3_vblank));
 	}
 
-	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices_hdd, "hdd", nullptr, true);
+	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "hdd", nullptr, true);
 	m_spuata->irq_handler().set(FUNC(firebeat_bm3_state::spu_ata_interrupt));
 	m_spuata->dmarq_handler().set(FUNC(firebeat_bm3_state::spu_ata_dmarq));
+	m_spuata->slot(0).set_fixed(true);
 
 	// 500 hz seems ok for beatmania III.
 	// Any higher makes things act weird.
@@ -1324,9 +1321,10 @@ void firebeat_popn_state::firebeat_popn(machine_config &config)
 	firebeat_spu_base(config);
 
 	ATA_INTERFACE(config, m_spuata).options(firebeat_ata_devices, "cdrom", nullptr, true);
-	m_spuata->slot(0).set_option_machine_config("cdrom", dvdrom_config);
 	m_spuata->irq_handler().set(FUNC(firebeat_popn_state::spu_ata_interrupt));
 	m_spuata->dmarq_handler().set(FUNC(firebeat_popn_state::spu_ata_dmarq));
+	m_spuata->slot(0).set_option_machine_config("cdrom", dvdrom_config);
+	m_spuata->slot(0).set_fixed(true);
 
 	// 500 hz works best for pop'n music.
 	// Any lower and sometimes you'll hear buzzing from certain keysounds, or fades take too long.
@@ -1511,6 +1509,7 @@ void firebeat_kbm_state::firebeat_kbm(machine_config &config)
 	ATA_INTERFACE(config, m_ata).options(firebeat_ata_devices, "cdrom", "cdrom", true);
 	m_ata->irq_handler().set(FUNC(firebeat_kbm_state::ata_interrupt));
 	m_ata->slot(1).set_option_machine_config("cdrom", cdrom_config);
+	m_ata->slot(1).set_fixed(true);
 
 	/* video hardware */
 	PALETTE(config, "palette", palette_device::RGB_555);

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -290,7 +290,6 @@ public:
 protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
-	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 	virtual void device_resolve_objects() override;
 
 	void firebeat_spu_base(machine_config &config);
@@ -942,7 +941,7 @@ WRITE_LINE_MEMBER(firebeat_state::sound_irq_callback)
 
 void firebeat_spu_state::machine_start()
 {
-	m_dma_timer = timer_alloc(TIMER_SPU_DMA);
+	m_dma_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(firebeat_spu_state::spu_dma_callback), this));
 }
 
 void firebeat_spu_state::machine_reset()
@@ -951,16 +950,6 @@ void firebeat_spu_state::machine_reset()
 	m_spu_ata_dmarq = 0;
 	m_wave_bank = 0;
 	m_sync_ata_irq = 0;
-}
-
-void firebeat_spu_state::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
-{
-	switch (id)
-	{
-	case TIMER_SPU_DMA:
-		spu_dma_callback(ptr, param);
-		break;
-	}
 }
 
 void firebeat_spu_state::device_resolve_objects()

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -205,7 +205,8 @@ public:
 		m_ata(*this, "ata"),
 		m_gcu(*this, "gcu"),
 		m_duart_com(*this, "duart_com"),
-		m_status_leds(*this, "status_led_%u", 0U)
+		m_status_leds(*this, "status_led_%u", 0U),
+		m_io_inputs(*this, "IN%u", 0U)
 	{ }
 
 	void firebeat(machine_config &config);
@@ -270,6 +271,8 @@ private:
 	required_device<pc16552_device> m_duart_com;
 
 	output_finder<8> m_status_leds;
+
+	required_ioport_array<4> m_io_inputs;
 };
 
 class firebeat_spu_state : public firebeat_state
@@ -344,7 +347,8 @@ public:
 		m_cab_led_right(*this, "right"),
 		m_cab_led_door_lamp(*this, "door_lamp"),
 		m_cab_led_ok(*this, "ok"),
-		m_cab_led_slim(*this, "slim")
+		m_cab_led_slim(*this, "slim"),
+		m_io_sensors(*this, "SENSOR%u", 1U)
 	{ }
 
 	void firebeat_ppp(machine_config &config);
@@ -370,6 +374,8 @@ private:
 	output_finder<> m_cab_led_door_lamp;
 	output_finder<> m_cab_led_ok;
 	output_finder<> m_cab_led_slim;
+
+	required_ioport_array<4> m_io_sensors;
 };
 
 class firebeat_kbm_state : public firebeat_state
@@ -384,7 +390,8 @@ public:
 		m_cab_led_door_lamp(*this, "door_lamp"),
 		m_cab_led_start1p(*this, "start1p"),
 		m_cab_led_start2p(*this, "start2p"),
-		m_lamp_neon(*this, "neon")
+		m_lamp_neon(*this, "neon"),
+		m_io_wheels(*this, "WHEEL_P%u", 1U)
 	{ }
 
 	uint32_t screen_update_firebeat_1(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
@@ -421,13 +428,18 @@ private:
 	output_finder<> m_cab_led_start1p;
 	output_finder<> m_cab_led_start2p;
 	output_finder<> m_lamp_neon;
+
+	required_ioport_array<2> m_io_wheels;
 };
 
 class firebeat_bm3_state : public firebeat_spu_state
 {
 public:
 	firebeat_bm3_state(const machine_config &mconfig, device_type type, const char *tag) :
-		firebeat_spu_state(mconfig, type, tag)
+		firebeat_spu_state(mconfig, type, tag),
+		m_io(*this, "IO%u", 1U),
+		m_io_turntables(*this, "TURNTABLE_P%u", 1U),
+		m_io_effects(*this, "EFFECT%u", 1U)
 	{ }
 
 	void firebeat_bm3(machine_config &config);
@@ -444,6 +456,10 @@ private:
 	void fdd_unk_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 
 	DECLARE_WRITE_LINE_MEMBER( bm3_vblank );
+
+	required_ioport_array<4> m_io;
+	required_ioport_array<2> m_io_turntables;
+	required_ioport_array<7> m_io_effects;
 };
 
 class firebeat_popn_state : public firebeat_spu_state
@@ -759,10 +775,10 @@ void firebeat_state::extend_board_irq_w(offs_t offset, uint8_t data)
 uint8_t firebeat_state::input_r(offs_t offset)
 {
 	switch (offset) {
-		case 0: return (ioport("IN0")->read() & 0xff);
-		case 1: return (ioport("IN1")->read() & 0xff);
-		case 2: return (ioport("IN2")->read() & 0xff);
-		case 3: return (ioport("IN3")->read() & 0xff);
+		case 0: return (m_io_inputs[0]->read() & 0xff);
+		case 1: return (m_io_inputs[1]->read() & 0xff);
+		case 2: return (m_io_inputs[2]->read() & 0xff);
+		case 3: return (m_io_inputs[3]->read() & 0xff);
 	}
 
 	return 0;
@@ -1246,21 +1262,21 @@ uint32_t firebeat_bm3_state::spectrum_analyzer_r(offs_t offset)
 uint16_t firebeat_bm3_state::sensor_r(offs_t offset)
 {
 	switch (offset) {
-		case 0: return ioport("IO1")->read() | 0x0100;
-		case 1: return ioport("IO2")->read() | 0x0100;
-		case 2: return ioport("IO3")->read() | 0x0100;
-		case 3: return ioport("IO4")->read() | 0x0100;
-		case 5: return (ioport("TURNTABLE_P1")->read() >> 8) | 0x0100;
-		case 6: return (ioport("TURNTABLE_P1")->read() & 0xff) | 0x0100;
-		case 7: return (ioport("TURNTABLE_P2")->read() >> 8) | 0x0100;
-		case 8: return (ioport("TURNTABLE_P2")->read() & 0xff) | 0x0100;
-		case 9: return ioport("EFFECT1")->read() | 0x0100;
-		case 10: return ioport("EFFECT2")->read() | 0x0100;
-		case 11: return ioport("EFFECT3")->read() | 0x0100;
-		case 12: return ioport("EFFECT4")->read() | 0x0100;
-		case 13: return ioport("EFFECT5")->read() | 0x0100;
-		case 14: return ioport("EFFECT6")->read() | 0x0100;
-		case 15: return ioport("EFFECT7")->read() | 0x0100;
+		case 0: return m_io[0]->read() | 0x0100;
+		case 1: return m_io[1]->read() | 0x0100;
+		case 2: return m_io[2]->read() | 0x0100;
+		case 3: return m_io[3]->read() | 0x0100;
+		case 5: return (m_io_turntables[0]->read() >> 8) | 0x0100;
+		case 6: return (m_io_turntables[0]->read() & 0xff) | 0x0100;
+		case 7: return (m_io_turntables[1]->read() >> 8) | 0x0100;
+		case 8: return (m_io_turntables[1]->read() & 0xff) | 0x0100;
+		case 9: return m_io_effects[0]->read() | 0x0100;
+		case 10: return m_io_effects[1]->read() | 0x0100;
+		case 11: return m_io_effects[2]->read() | 0x0100;
+		case 12: return m_io_effects[3]->read() | 0x0100;
+		case 13: return m_io_effects[4]->read() | 0x0100;
+		case 14: return m_io_effects[5]->read() | 0x0100;
+		case 15: return m_io_effects[6]->read() | 0x0100;
 	}
 
 	return 0;
@@ -1387,10 +1403,10 @@ void firebeat_ppp_state::firebeat_ppp_map(address_map &map)
 uint16_t firebeat_ppp_state::sensor_r(offs_t offset)
 {
 	switch (offset) {
-		case 0: return ioport("SENSOR1")->read() | 0x0100;
-		case 1: return ioport("SENSOR2")->read() | 0x0100;
-		case 2: return ioport("SENSOR3")->read() | 0x0100;
-		case 3: return ioport("SENSOR4")->read() | 0x0100;
+		case 0: return m_io_sensors[0]->read() | 0x0100;
+		case 1: return m_io_sensors[1]->read() | 0x0100;
+		case 2: return m_io_sensors[2]->read() | 0x0100;
+		case 3: return m_io_sensors[3]->read() | 0x0100;
 	}
 
 	return 0;
@@ -1595,8 +1611,8 @@ void firebeat_kbm_state::firebeat_kbm_map(address_map &map)
 uint8_t firebeat_kbm_state::keyboard_wheel_r(offs_t offset)
 {
 	switch (offset) {
-		case 0: return ioport("WHEEL_P1")->read(); // Keyboard Wheel (P1)
-		case 8: return ioport("WHEEL_P2")->read(); // Keyboard Wheel (P2)
+		case 0: return m_io_wheels[0]->read(); // Keyboard Wheel (P1)
+		case 8: return m_io_wheels[1]->read(); // Keyboard Wheel (P2)
 	}
 
 	return 0;

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -158,6 +158,7 @@ Keyboard Mania 2nd Mix - dongle, program CD, audio CD
 #include "emupal.h"
 #include "screen.h"
 #include "speaker.h"
+#include "osdcomm.h"
 
 #include "firebeat.lh"
 
@@ -748,21 +749,19 @@ uint32_t firebeat_state::input_r(offs_t offset, uint32_t mem_mask)
 /*****************************************************************************/
 /* ATA Interface */
 
-#define BYTESWAP16(x)   ((((x) >> 8) & 0xff) | (((x) << 8) & 0xff00))
-
 uint32_t firebeat_state::ata_command_r(offs_t offset, uint32_t mem_mask)
 {
 	uint16_t r;
 //  printf("ata_command_r: %08X, %08X\n", offset, mem_mask);
 	if (ACCESSING_BITS_16_31)
 	{
-		r = m_ata->cs0_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
-		return BYTESWAP16(r) << 16;
+		r = m_ata->cs0_r(offset*2, swapendian_int16((mem_mask >> 16) & 0xffff));
+		return swapendian_int16(r) << 16;
 	}
 	else
 	{
-		r = m_ata->cs0_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
-		return BYTESWAP16(r) << 0;
+		r = m_ata->cs0_r((offset*2) + 1, swapendian_int16((mem_mask >> 0) & 0xffff));
+		return swapendian_int16(r) << 0;
 	}
 }
 
@@ -772,11 +771,11 @@ void firebeat_state::ata_command_w(offs_t offset, uint32_t data, uint32_t mem_ma
 
 	if (ACCESSING_BITS_16_31)
 	{
-		m_ata->cs0_w(offset*2, BYTESWAP16((data >> 16) & 0xffff), BYTESWAP16((mem_mask >> 16) & 0xffff));
+		m_ata->cs0_w(offset*2, swapendian_int16((data >> 16) & 0xffff), swapendian_int16((mem_mask >> 16) & 0xffff));
 	}
 	else
 	{
-		m_ata->cs0_w((offset*2) + 1, BYTESWAP16((data >> 0) & 0xffff), BYTESWAP16((mem_mask >> 0) & 0xffff));
+		m_ata->cs0_w((offset*2) + 1, swapendian_int16((data >> 0) & 0xffff), swapendian_int16((mem_mask >> 0) & 0xffff));
 	}
 }
 
@@ -788,13 +787,13 @@ uint32_t firebeat_state::ata_control_r(offs_t offset, uint32_t mem_mask)
 
 	if (ACCESSING_BITS_16_31)
 	{
-		r = m_ata->cs1_r(offset*2, BYTESWAP16((mem_mask >> 16) & 0xffff));
-		return BYTESWAP16(r) << 16;
+		r = m_ata->cs1_r(offset*2, swapendian_int16((mem_mask >> 16) & 0xffff));
+		return swapendian_int16(r) << 16;
 	}
 	else
 	{
-		r = m_ata->cs1_r((offset*2) + 1, BYTESWAP16((mem_mask >> 0) & 0xffff));
-		return BYTESWAP16(r) << 0;
+		r = m_ata->cs1_r((offset*2) + 1, swapendian_int16((mem_mask >> 0) & 0xffff));
+		return swapendian_int16(r) << 0;
 	}
 }
 
@@ -802,11 +801,11 @@ void firebeat_state::ata_control_w(offs_t offset, uint32_t data, uint32_t mem_ma
 {
 	if (ACCESSING_BITS_16_31)
 	{
-		m_ata->cs1_w(offset*2, BYTESWAP16(data >> 16) & 0xffff, BYTESWAP16((mem_mask >> 16) & 0xffff));
+		m_ata->cs1_w(offset*2, swapendian_int16(data >> 16) & 0xffff, swapendian_int16((mem_mask >> 16) & 0xffff));
 	}
 	else
 	{
-		m_ata->cs1_w((offset*2) + 1, BYTESWAP16(data >> 0) & 0xffff, BYTESWAP16((mem_mask >> 0) & 0xffff));
+		m_ata->cs1_w((offset*2) + 1, swapendian_int16(data >> 0) & 0xffff, swapendian_int16((mem_mask >> 0) & 0xffff));
 	}
 }
 

--- a/src/mame/drivers/firebeat.cpp
+++ b/src/mame/drivers/firebeat.cpp
@@ -489,7 +489,6 @@ void firebeat_state::machine_start()
 
 void firebeat_state::device_resolve_objects()
 {
-	printf("Called firebeat_state::device_resolve_objects\n");
 	m_status_leds.resolve();
 }
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -13767,6 +13767,7 @@ finalizrb                       // bootleg
 fireball                        //
 
 @source:firebeat.cpp
+bm3                             // GQ972 (c) 2000 (Japan)
 bm36th                          // GCA21 (c) 2001 (Japan)
 bm37th                          // GCB07 (c) 2002 (Japan JCA)
 bm3core                         // GCA05 (c) 2000 (Japan)
@@ -13779,6 +13780,9 @@ popn5                           // GCA04 (c) 2000 (Japan)
 popn6                           // GQA16 (c) 2001 (Japan)
 popn7                           // GCB00 (c) 2001 (Japan)
 popn8                           // GQB30 (c) 2002 (Japan)
+popnmt                          // GQ976 (c) 2000 (Japan)
+popnmt2                         // GQ976 (c) 2000 (Japan)
+popnanm                         // GQ987 (c) 2000 (Japan)
 popnanm2                        // GEA02 (c) 2001 (Japan)
 ppd                             // GQ977 (c) 2000 (Korea)
 ppp                             // GQ977 (c) 2000 (Japan)

--- a/src/mame/video/k057714.h
+++ b/src/mame/video/k057714.h
@@ -34,7 +34,10 @@ protected:
 	virtual void device_reset() override;
 
 private:
-	enum { VRAM_SIZE = 0x2000000 };
+	enum {
+		VRAM_SIZE = 0x2000000,
+		VRAM_SIZE_HALF = 0x2000000 / 2
+	};
 
 	void execute_command(uint32_t *cmd);
 	void execute_display_list(uint32_t addr);


### PR DESCRIPTION
This is a large refactor of the Firebeat driver as discussed in #7693 so please forgive me for the huge PR with a meaningless diff. I've tried to make note of anything below that I've changed during the refactoring that wasn't just structural refactoring.

All games on the Firebeat platform except those with missing HDD data (`bm36th` and `bm3core`) have been tested to make sure they are still booting into gameplay and inputs responding as expected.

All of the required new ROMs for this PR have been sent to `code ( at ) mamedev`.

NOTE: Even with this PR, pop'n music *will not* boot as-is currently due to lack of support for the DVD CHDs. The CHDs are made as HDD CHDs which can't be loaded by the CD-ROM emulation code. The pop'n music games will work if you extract the raw data from the existing CHDs and rebuild them using `chdman createcd` but that is just a workaround. I will try to fix this in a future PR.

NOTE 2: RTC initialization for pop'n music, `bm3`, and `bm3core` are locked behind a randomly generated password for which you were supposed to call Konami to get a password that corresponds to your dongle serial ID + seed. This is not a bug, it's a feature (thanks Konami). You will need to use a tool I made to generate the required passwords.

Source code: https://github.com/987123879113/firebeatrtc
Web version: https://987123879113.github.io/firebeatrtc/

Ideally there should be a way to include a clean initialized RTC file in the ROM dumps so as to not require everyone to input a password but I couldn't find a way to do that with the RTC65271 so that's on hold for now.

---

Changelog:
- firebeat: Refactored entire monolith `firebeat_state` into (hopefully) logical components based on machine configurations. The Firebeat system is highly modular and each individual game has its own machine configuration, sometimes with the same boards being populated differently between games. I attempted to recreate that in the code so that only the components that are required for each game are loaded. 
Also discussed in #7693, in the future I will look at splitting the SPU code off into its own machine to be shared with Twinkle because the two have nearly identical SPUs but that will be for another PR.
- firebeat: Rewrote `cabinet_r` register
Every game treats this a little differently so the initial value needs to be set based on cabinet type, which includes whether the machine is an overseas or Japanese machine, a rental or a purchase machine, and some other bits to determine actual machine type.
The values picked have all been checked by debugging the games to verify happy paths without requiring any additional hacks. These values are also tied to the specific dongle used in some cases which is why "normal" type dongles have been provided to replace all of the old non-"normal" type dongles (see below for more details).


- firebeat SPU: Changed dipswitch register to use dipswitch inputs instead of a function because the dipswitches are accessible on the board
- firebeat SPU: Added documentation for unknown parts of SPU code (IRQs 1 and 2, register 0x220000)
- firebeat SPU: Added attempt to ease blocking issues between audio CPU and main CPU during DMAs.
DMA handling is done entirely by the audio CPU. It's expected that the audio CPU can perform DMAs asynchronously apart from the main CPU in order to refill the BGM sound buffer while songs are being played.
The existing DMA code from my previous PR works as a bare minimum implementation but will block during large DMAs (size >= 0x1000000) which are frequent in beatmania III and pop'n music.


- firebeat ParaParaParadise/beatmania III: `sensor_r` has been changed from a 32-bit register to 16-bit based on the way beatmania III reads the turntable's values as two separate 16-bit values (upper and lower). The appropriate changes were made to PPP's sensor inputs and tested to make sure inputs still worked.


- firebeat Keyboardmania: Swapped keyboard inputs to match I/O test menu (P1 should be left screen, P2 should be right screen now)


- firebeat beatmania III: Added new game: `bm3` added as `MACHINE_NOT_WORKING`
- firebeat beatmania III: Added proper SPUs/ROMs for all beatmania III games
- firebeat beatmania III: Added basic I/O emulation. Does not support Zoom ST-224 effects board or FDD.
- firebeat beatmania III: A hack (similar to what was used until recently in System 573 for `ddr2ml`/`ddr2mla` security plate errors) was added to bypass the FDD errors in all beatmania III games. The FDD only adds saving and loading scores and will otherwise run without errors if it's patched out. The patches have been tested on all beatmania III games. The patches will be removed when FDD emulation is implemented enough that the games can be loaded without the patches. 


- firebeat pop'n music: Added new games: `popnmt`, `popnmt2`, `popnanm` added as `MACHINE_NOT_WORKING`


- firebeat ROMs: Replaced/added dongles for the following games
    - `ppp`
    - `ppd`
    - `ppp1mp`
    - `ppp11`
    - `kbm`
    - `kbm2nd`
    - `popn6`
    - `popn7`
    - `popn8`
    - `popnanm2`
    - `bm36th`
    - `bm37th`
    - `bm3final`

    All of the replacement dongles are generated through a tool, not dumped from security keys. All generated dongles have also been marked as BAD_DUMP to be sure that they don't get mixed up with real dongles. All dongles have been tested to make sure they boot in-game as expected.

    A large majority of the previous dongles dongles were also manually generated instead of dumped from the real security keys. The reason the old ones needed to be replaced is because the dongle type used by the old dongles was often the wrong one (service or manufacture type instead of a normal dongle) which in some cases caused the game to not load properly or in a way that it would not normally on real hardware with real dongles. There are legit dongle dumps in MAME already (`kbm3rd`, `popn4`, `popn5`, `bm3core`) which were used as references to generate as accurate as possible dongles. The main differences being the serial number and the lack of 8 bytes at the end of each file, which are not used at all during emulation, also data which the previous fake dongles lacked. An easy way to tell apart the fake from real dongle dumps is the fakes are 0xc0 bytes in size while real are 0xc8 bytes in size.

Other:
- k057714: Adjusted transparency blend mode based on new info from beatmania III
- k057714: Fixed some crashes (divide by zero, out of bounds)
- k057714: Clear vram between resets
