### PR TITLE
viper: Add new dongles for ppp2nd (JAA), add new game ppp2nda (AAA) as MACHINE_NOT_WORKING, and add ppp2nd/a IO

### DIFF
--- a/src/mame/drivers/viper.cpp
+++ b/src/mame/drivers/viper.cpp
@@ -2501,9 +2501,21 @@ ROM_START(ppp2nd)
 	VIPER_BIOS
 
 	ROM_REGION(0x28, "ds2430", ROMREGION_ERASE00)       /* DS2430 */
-	ROM_LOAD("ds2430.u3", 0x00, 0x28, BAD_DUMP CRC(f1511505) SHA1(ed7cd9b2763b3e377df9663943160f9871f65105))
+	ROM_LOAD("ds2430.u3", 0x00, 0x28, BAD_DUMP CRC(ef0e7caa) SHA1(02fef7465445d33f0288c49a8998a2759ad70823))
 	// byte 0x1e (0) JAA (1) AAA
 	// byte 0x1f (1) rental
+
+	ROM_REGION(0x2000, "m48t58", ROMREGION_ERASE00)     /* M48T58 Timekeeper NVRAM */
+
+	DISK_REGION( "ata:0:hdd:image" )
+	DISK_IMAGE( "ppp2nd", 0, SHA1(b8b90483d515c83eac05ffa617af19612ea990b0))
+ROM_END
+
+ROM_START(ppp2nda)
+	VIPER_BIOS
+
+	ROM_REGION(0x28, "ds2430", ROMREGION_ERASE00)       /* DS2430 */
+	ROM_LOAD("ds2430-aaa.u3", 0x00, 0x28, BAD_DUMP CRC(76906d8f) SHA1(ceea4addc881975cfd6b8e2283b9aecb6080bd99))
 
 	ROM_REGION(0x2000, "m48t58", ROMREGION_ERASE00)     /* M48T58 Timekeeper NVRAM */
 
@@ -3065,7 +3077,8 @@ ROM_END
 /* Viper BIOS */
 GAME(1999, kviper,    0,         viper,    viper,   viper_state, init_viper,    ROT0,  "Konami", "Konami Viper BIOS", MACHINE_IS_BIOS_ROOT)
 
-GAME(2001, ppp2nd,    kviper,    viper,   ppp2nd,   viper_state, init_viperhd,  ROT0,  "Konami", "ParaParaParadise 2nd Mix", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
+GAME(2001, ppp2nd,    kviper,    viper,   ppp2nd,   viper_state, init_viperhd,  ROT0,  "Konami", "ParaParaParadise 2nd Mix (JAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
+GAME(2001, ppp2nda,   ppp2nd,    viper,   ppp2nd,   viper_state, init_viperhd,  ROT0,  "Konami", "ParaParaParadise 2nd Mix (AAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
 
 GAME(2001, boxingm,   kviper,    viper,  boxingm,   viper_state, init_vipercf,  ROT0,  "Konami", "Boxing Mania: Ashita no Joe (ver JAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
 GAME(2000, code1d,    kviper,    viper,    viper,   viper_state, init_vipercf,  ROT0,  "Konami", "Code One Dispatch (ver D)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)

--- a/src/mame/drivers/viper.cpp
+++ b/src/mame/drivers/viper.cpp
@@ -77,7 +77,7 @@
     - needs a proper way to dump security dongles, anything but p9112 has placeholder ROM for ds2430.
 
     Game status:
-        ppp2nd              POST: "NO SECURITY ERROR"
+        ppp2nd              Boots in-game, no sound or DVD support, crashes when going into song selection screen
         boxingm             Goes to attract mode when ran with memory card check. Coins up.
         code1d,b            RTC self check bad
         gticlub2,ea         Attract mode works. Coins up. Hangs in car selection.

--- a/src/mame/drivers/viper.cpp
+++ b/src/mame/drivers/viper.cpp
@@ -389,6 +389,7 @@ public:
 	}
 
 	void viper(machine_config &config);
+	void viper_ppp(machine_config &config);
 
 	void init_viper();
 	void init_vipercf();
@@ -444,6 +445,7 @@ private:
 	uint32_t m_mpc8240_regs[256/4];
 
 	void viper_map(address_map &map);
+	void viper_ppp_map(address_map &map);
 
 	TIMER_CALLBACK_MEMBER(epic_global_timer_callback);
 	TIMER_CALLBACK_MEMBER(ds2430_timer_callback);
@@ -2127,6 +2129,12 @@ void viper_state::viper_map(address_map &map)
 	map(0xfff00000, 0xfff3ffff).rom().region("user1", 0);       // Boot ROM
 }
 
+void viper_state::viper_ppp_map(address_map &map)
+{
+	viper_map(map);
+	map(0xff400200, 0xff40023f).r(FUNC(viper_state::ppp_sensor_r));
+}
+
 /*****************************************************************************/
 
 READ_LINE_MEMBER(viper_state::ds2430_unk_r)
@@ -2470,6 +2478,12 @@ void viper_state::viper(machine_config &config)
 	M48T58(config, "m48t58", 0);
 }
 
+void viper_state::viper_ppp(machine_config &config)
+{
+	viper(config);
+	m_maincpu->set_addrmap(AS_PROGRAM, &viper_state::viper_ppp_map);
+}
+
 /*****************************************************************************/
 
 void viper_state::init_viper()
@@ -2492,12 +2506,6 @@ void viper_state::init_vipercf()
 	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0xff200000, 0xff200fff, read64s_delegate(*this, FUNC(viper_state::cf_card_r)), write64s_delegate(*this, FUNC(viper_state::cf_card_w)));
 
 	m_maincpu->space(AS_PROGRAM).install_readwrite_handler(0xff300000, 0xff300fff, read64s_delegate(*this, FUNC(viper_state::unk_serial_r)), write64s_delegate(*this, FUNC(viper_state::unk_serial_w)));
-}
-
-void viper_state::init_viperppp()
-{
-	init_viperhd();
-	m_maincpu->space(AS_PROGRAM).install_read_handler(0xff400200, 0xff40023f, read16sm_delegate(*this, FUNC(viper_state::ppp_sensor_r)));
 }
 
 uint16_t viper_state::ppp_sensor_r(offs_t offset)
@@ -3116,8 +3124,8 @@ ROM_END
 /* Viper BIOS */
 GAME(1999, kviper,    0,         viper,    viper,   viper_state, init_viper,    ROT0,  "Konami", "Konami Viper BIOS", MACHINE_IS_BIOS_ROOT)
 
-GAME(2001, ppp2nd,    kviper,    viper,   ppp2nd,   viper_state, init_viperppp, ROT0,  "Konami", "ParaParaParadise 2nd Mix (JAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
-GAME(2001, ppp2nda,   ppp2nd,    viper,   ppp2nd,   viper_state, init_viperppp, ROT0,  "Konami", "ParaParaParadise 2nd Mix (AAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
+GAME(2001, ppp2nd,    kviper,    viper_ppp, ppp2nd, viper_state, init_viperhd,  ROT0,  "Konami", "ParaParaParadise 2nd Mix (JAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
+GAME(2001, ppp2nda,   ppp2nd,    viper_ppp, ppp2nd, viper_state, init_viperhd,  ROT0,  "Konami", "ParaParaParadise 2nd Mix (AAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
 
 GAME(2001, boxingm,   kviper,    viper,  boxingm,   viper_state, init_vipercf,  ROT0,  "Konami", "Boxing Mania: Ashita no Joe (ver JAA)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)
 GAME(2000, code1d,    kviper,    viper,    viper,   viper_state, init_vipercf,  ROT0,  "Konami", "Code One Dispatch (ver D)", MACHINE_NOT_WORKING|MACHINE_NO_SOUND)

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -41627,6 +41627,7 @@ p911j                           // 2001
 p911kc                          // 2001
 p911uc                          // 2001
 ppp2nd                          // 2001
+ppp2nda                         // 2001
 sogeki                          // 2001
 sscopefh                        // 2002
 sscopex                         // 2001


### PR DESCRIPTION
Previously this game would error out immediately with a security check error due to the placeholder `ds2430.u3`. I've generated working dongles that will allow the games to boot as retail (non-rental type cabinet) JAA (Japan region) and AAA (Asia region) region codes. These are generated (not real dumps) so they are both still marked as `BAD_DUMP` to be sure. `ppp2nda` uses the same data as `ppp2nd` except the dongle tells it to boot AAA region instead of JAA. JAA will be in Japanese, AAA will be in English. Since it is the only way to play in English I included it as a separate game entry.

Sensor mappings worked the same as Firebeat so I just copied those over and added the read handler. I gave it a quick test in-game and all buttons including the sensors respond as expected in the I/O test menu now.

Sound and the external DVD player does not work so these games are still unplayable.

Edit: Just to be clear, there may be differences in the HDD on a real AAA dump but that's an unknown for now. It can be updated in the future if someone does dump one from an AAA machine eventually.