### PR TITLE
Reinstated RI Handler

### DIFF
--- a/src/devices/bus/cpc/cpc_rs232.cpp
+++ b/src/devices/bus/cpc/cpc_rs232.cpp
@@ -52,7 +52,7 @@ void cpc_rs232_device::device_add_mconfig(machine_config &config)
 	m_rs232->rxd_handler().set(m_dart, FUNC(z80dart_device::rxa_w));
 	m_rs232->dcd_handler().set(m_dart, FUNC(z80dart_device::dcda_w));
 	m_rs232->cts_handler().set(m_dart, FUNC(z80dart_device::ctsa_w));
-//  m_rs232->ri_handler().set(m_dart, FUNC(z80dart_device::ria_w));
+	m_rs232->ri_handler().set(m_dart, FUNC(z80dart_device::ria_w));
 
 	// pass-through
 	cpc_expansion_slot_device &exp(CPC_EXPANSION_SLOT(config, "exp", DERIVED_CLOCK(1, 1), cpc_exp_cards, nullptr));


### PR DESCRIPTION

The COMMSTAR ROM software won't run due to the ring indicator bit 4 of the DART RR0 being high when it's expected to be 0. 

If line 55 is uncommented bit 4 is low as expected and the software runs.

I've tried a few different pieces of mid 80's comms software and all is good.

Reading between the lines of forum posts back in 2014. It seems that the z80 dart emulation has been improved since then and I think now's the time to reinstate that line. 

The routine in cpc_ser/COMMSTAR1.ROM that reads the z80 dart RR0 are:

```
               LD      BC,&FADD                ;;F102:   ...     01 DD FA
                LD      A,&18                   ;;F105:   >.      3E 18
                OUT     (C),A                   ;;F107:   .y      ED 79
                LD      A,&10                   ;;F109:   >.      3E 10
                OUT     (C),A                   ;;F10B:   .y      ED 79
                LD      A,&00                   ;;F10D:   >.      3E 00
                OUT     (C),A                   ;;F10F:   .y      ED 79
                IN      E,(C)                   ;;F111:   .X      ED 58.  --- READ REGISTER 0 Expecting 6C getting 7C
                LD      A,&56                   ;;F113:   >V      3E 56
                AND     E                       ;;F115:   .       A3
                CP      &44                     ;;F116:   .D      FE 44 -- replace with &56 to work with &7C
                LD      A,E                     ;;F118:   {       7B
                SCF                             ;;F119:   7       37
                CCF                             ;;F11A:   ?       3F
                RET     NZ                      ;;F11B:   .       C0 
```
