### PR TITLE
completely unsafe Naomi threading hack

### DIFF
--- a/src/mame/video/powervr2.h
+++ b/src/mame/video/powervr2.h
@@ -203,6 +203,12 @@ public:
 	uint32_t softreset_r();
 	void softreset_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	void startrender_w(address_space &space, uint32_t data);
+	void startrender_real_w(address_space &space);
+
+	osd_work_queue *m_work_queue;
+	osd_work_item *m_render_request;
+	static void *blit_request_callback(void *param, int threadid);
+
 	uint32_t param_base_r();
 	void param_base_w(offs_t offset, uint32_t data, uint32_t mem_mask = ~0);
 	uint32_t region_base_r();


### PR DESCRIPTION
Clearing out some old stuff from my HDDs.  This is from when I added the SH4 recompiler.

I wanted to see if Crazy Taxi ran at 100% speed if the video was threaded (it does) however the code is crude as it can possible be, 100% unsafe and will lock up MAME frequently, forcing you to kill the program.

Note, this also makes it kinda obvious that most Naomi stuff really isn't running at 100% speed even when it claims to be, and also the audio CPU dies quite often too.

This is not for inclusion, but put it here in a draft PR, maybe somebody can thread the driver properly, because full speed does seem realistic for a good number of games on a high end i7.