### PR TITLE
Apple IIgs - don't flag "p" as a keypad character

### DIFF
--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -2437,7 +2437,11 @@ u8 apple2gs_state::c000_r(offs_t offset)
 				{
 					ret |= 0x10;
 				}
-				else if (m_lastchar >= 0x32 && m_lastchar <= 0x3f)
+				else if (m_lastchar >= 0x32 && m_lastchar <= 0x37)
+				{
+					ret |= 0x10;
+				}
+				else if (m_lastchar >= 0x3c && m_lastchar <= 0x3f)
 				{
 					ret |= 0x10;
 				}


### PR DESCRIPTION
'p' (0x39) is incorrectly being flagged as a keypad character. This also applies to `, [, and ].

The keypad flag causes some programs (Spectrum, for example) to treat 'p' as a function key since all function/extended keys are encoded via their raw ADB code and the keypad bit.
