### PR TITLE
raiden_ms.cpp: sound improvements

### DIFF
--- a/src/mame/drivers/raiden_ms.cpp
+++ b/src/mame/drivers/raiden_ms.cpp
@@ -349,7 +349,7 @@ u8 raiden_ms_state::sound_status_r()
 void raiden_ms_state::adpcm_w(u8 data)
 {
 	m_audio_select = BIT(data, 7);
-	m_soundbank->set_entry(m_audio_select);
+	m_soundbank->set_entry(m_audio_select ? 1 : 0);
 	m_msm->reset_w(BIT(data, 4));
 
 	m_adpcm_data = data & 0xf;

--- a/src/mame/drivers/raiden_ms.cpp
+++ b/src/mame/drivers/raiden_ms.cpp
@@ -278,6 +278,7 @@ private:
 	u8 m_adpcm_data;
 
 	void unk_snd_dffx_w(offs_t offset, u8 data);
+	void soundlatch_w(u8 data);
 
 	DECLARE_WRITE_LINE_MEMBER(vblank_irq);
 
@@ -375,6 +376,12 @@ void raiden_ms_state::unk_snd_dffx_w(offs_t offset, u8 data)
 
 }
 
+void raiden_ms_state::soundlatch_w(u8 data)
+{
+	m_soundlatch[0]->clear_w(data);
+	m_soundlatch[1]->clear_w(data);
+}
+
 void raiden_ms_state::audio_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom();
@@ -385,7 +392,7 @@ void raiden_ms_state::audio_map(address_map &map)
 	// area 0xdff0-5 is never ever readback, applying a RAM mirror causes sound to go significantly worse,
 	// what they are even for?  (offset select bankswitch rather than data select?)
 	map(0xdff0, 0xdff7).w(FUNC(raiden_ms_state::unk_snd_dffx_w));
-	map(0xdff8, 0xdff8).rw(m_soundlatch[1], FUNC(generic_latch_8_device::read), FUNC(generic_latch_8_device::clear_w));
+	map(0xdff8, 0xdff8).r(m_soundlatch[1], FUNC(generic_latch_8_device::read)).w(FUNC(raiden_ms_state::soundlatch_w));
 	map(0xdff9, 0xdff9).r(m_soundlatch[0], FUNC(generic_latch_8_device::read));
 	map(0xe000, 0xe003).w(FUNC(raiden_ms_state::ym_w));
 	map(0xe008, 0xe009).r(m_ym1, FUNC(ym2203_device::read));


### PR DESCRIPTION
This couple of commits fixes up main-to-sound-CPU communication and a few details of YM and ADPCM writes from the sound CPU so that music and sound effect playback get triggered correctly.

The FM audio still doesn't sound _great_, but it's at least functional.