### PR TITLE
Eliminate ARRAY_LENGTH template in favor of C++17's std::size

### DIFF
--- a/src/devices/bus/arcadia/slot.cpp
+++ b/src/devices/bus/arcadia/slot.cpp
@@ -119,7 +119,7 @@ static int arcadia_get_pcb_id(const char *slot)
 #if 0
 static const char *arcadia_get_slot(int type)
 {
-	for (int i = 0; i < ARRAY_LENGTH(slot_list); i++)
+	for (int i = 0; i < std::size(slot_list); i++)
 	{
 		if (slot_list[i].pcb_id == type)
 			return slot_list[i].slot_option;

--- a/src/devices/bus/gameboy/gb_slot.cpp
+++ b/src/devices/bus/gameboy/gb_slot.cpp
@@ -476,7 +476,7 @@ bool gb_cart_slot_device_base::is_mbc1col_game(const uint8_t *ROM, uint32_t len)
 		"SUPERCHINESE 123"
 	};
 
-	const uint8_t rows = ARRAY_LENGTH(internal_names);
+	const uint8_t rows = std::size(internal_names);
 
 	for (uint8_t i = 0x00; i < rows; ++i) {
 		if (0 == memcmp(&ROM[0x134], &internal_names[i][0], name_length))
@@ -803,10 +803,10 @@ void gb_cart_slot_device_base::internal_header_logging(uint8_t *ROM, uint32_t le
 	logerror("\tRAM Size:         %d kB [0x%02X]\n", ramsize[ROM[0x0149] & 0x07], ROM[0x0149]);
 	logerror("\tLicense code:     0x%02X%02X\n", ROM[0x0145], ROM[0x0144] );
 	tmp = (ROM[0x014b] << 8) + ROM[0x014a];
-	for (i = 0; i < ARRAY_LENGTH(companies); i++)
+	for (i = 0; i < std::size(companies); i++)
 		if (tmp == companies[i].code)
 			break;
-	logerror("\tManufacturer ID:  0x%02X [%s]\n", tmp, (i < ARRAY_LENGTH(companies)) ? companies[i].name : "?");
+	logerror("\tManufacturer ID:  0x%02X [%s]\n", tmp, (i < std::size(companies)) ? companies[i].name : "?");
 	logerror("\tVersion Number:   0x%02X\n", ROM[0x014c]);
 	logerror("\tComplement Check: 0x%02X\n", ROM[0x014d]);
 	logerror("\tChecksum:         0x%04X\n", ((ROM[0x014e] << 8) + ROM[0x014f]));

--- a/src/devices/bus/gio64/newport.cpp
+++ b/src/devices/bus/gio64/newport.cpp
@@ -86,7 +86,7 @@ void xmap9_device::device_reset()
 	m_cursor_cmap = 0;
 	m_popup_cmap = 0;
 	m_mode_table_idx = 0;
-	memset(m_mode_table, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_mode_table));
+	std::fill(std::begin(m_mode_table), std::end(m_mode_table), 0);
 }
 
 void xmap9_device::serialize(FILE *file)
@@ -233,7 +233,7 @@ void cmap_device::device_reset()
 {
 	m_status = 8;
 	m_palette_idx = 0;
-	memset(m_palette, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_palette));
+	std::fill(std::begin(m_palette), std::end(m_palette), 0);
 }
 
 void cmap_device::serialize(FILE *file)

--- a/src/devices/bus/ieee488/c2040fdc.cpp
+++ b/src/devices/bus/ieee488/c2040fdc.cpp
@@ -220,7 +220,7 @@ bool c2040_fdc_device::write_next_bit(bool bit, const attotime &limit)
 	if(etime > limit)
 		return true;
 
-	if(bit && cur_live.write_position < ARRAY_LENGTH(cur_live.write_buffer))
+	if(bit && cur_live.write_position < std::size(cur_live.write_buffer))
 		cur_live.write_buffer[cur_live.write_position++] = cur_live.tm - m_period;
 
 	if (LOG) logerror("%s write bit %u (%u)\n", cur_live.tm.as_string(), cur_live.bit_counter, bit);

--- a/src/devices/bus/intellec4/intellec4.cpp
+++ b/src/devices/bus/intellec4/intellec4.cpp
@@ -127,7 +127,7 @@ void univ_bus_device::device_start()
 
 unsigned univ_bus_device::add_card(device_univ_card_interface &card)
 {
-	for (unsigned i = 0; ARRAY_LENGTH(m_cards) > i; ++i)
+	for (unsigned i = 0; std::size(m_cards) > i; ++i)
 	{
 		if (!m_cards[i])
 		{
@@ -135,12 +135,12 @@ unsigned univ_bus_device::add_card(device_univ_card_interface &card)
 			return i;
 		}
 	}
-	throw emu_fatalerror("univ_bus_device: maximum number of cards (%u) exceeded\n", unsigned(ARRAY_LENGTH(m_cards)));
+	throw emu_fatalerror("univ_bus_device: maximum number of cards (%u) exceeded\n", unsigned(std::size(m_cards)));
 }
 
 void univ_bus_device::set_test(unsigned index, int state)
 {
-	assert(ARRAY_LENGTH(m_cards) >= index);
+	assert(std::size(m_cards) >= index);
 	bool const changed(bool(state) != !BIT(m_test, index));
 	if (changed)
 	{
@@ -150,10 +150,10 @@ void univ_bus_device::set_test(unsigned index, int state)
 		else
 			m_test |= u16(1U) << index;
 
-		if ((ARRAY_LENGTH(m_cards) != index) && !(other & ~(u16(1U) << ARRAY_LENGTH(m_cards))))
+		if ((std::size(m_cards) != index) && !(other & ~(u16(1U) << std::size(m_cards))))
 			m_test_out_cb(state);
 
-		for (unsigned card = 0U; (ARRAY_LENGTH(m_cards) > card) && m_cards[card]; ++card)
+		for (unsigned card = 0U; (std::size(m_cards) > card) && m_cards[card]; ++card)
 		{
 			if ((index != card) && !(other & ~(u16(1U) << index)))
 				m_cards[card]->test_in(state);
@@ -163,7 +163,7 @@ void univ_bus_device::set_test(unsigned index, int state)
 
 void univ_bus_device::set_stop(unsigned index, int state)
 {
-	assert(ARRAY_LENGTH(m_cards) >= index);
+	assert(std::size(m_cards) >= index);
 	bool const changed(bool(state) != !BIT(m_stop, index));
 	if (changed)
 	{
@@ -173,10 +173,10 @@ void univ_bus_device::set_stop(unsigned index, int state)
 		else
 			m_stop |= u16(1U) << index;
 
-		if ((ARRAY_LENGTH(m_cards) != index) && !(other & ~(u16(1U) << ARRAY_LENGTH(m_cards))))
+		if ((std::size(m_cards) != index) && !(other & ~(u16(1U) << std::size(m_cards))))
 			m_stop_out_cb(state);
 
-		for (unsigned card = 0U; (ARRAY_LENGTH(m_cards) > card) && m_cards[card]; ++card)
+		for (unsigned card = 0U; (std::size(m_cards) > card) && m_cards[card]; ++card)
 		{
 			if ((index != card) && !(other & ~(u16(1U) << index)))
 				m_cards[card]->stop_in(state);
@@ -186,7 +186,7 @@ void univ_bus_device::set_stop(unsigned index, int state)
 
 void univ_bus_device::set_reset_4002(unsigned index, int state)
 {
-	assert(ARRAY_LENGTH(m_cards) >= index);
+	assert(std::size(m_cards) >= index);
 	bool const changed(bool(state) != !BIT(m_reset_4002, index));
 	if (changed)
 	{
@@ -196,10 +196,10 @@ void univ_bus_device::set_reset_4002(unsigned index, int state)
 		else
 			m_reset_4002 |= u16(1U) << index;
 
-		if ((ARRAY_LENGTH(m_cards) != index) && !(other & ~(u16(1U) << ARRAY_LENGTH(m_cards))))
+		if ((std::size(m_cards) != index) && !(other & ~(u16(1U) << std::size(m_cards))))
 			m_reset_4002_out_cb(state);
 
-		for (unsigned card = 0U; (ARRAY_LENGTH(m_cards) > card) && m_cards[card]; ++card)
+		for (unsigned card = 0U; (std::size(m_cards) > card) && m_cards[card]; ++card)
 		{
 			if ((index != card) && !(other & ~(u16(1U) << index)))
 				m_cards[card]->reset_4002_in(state);
@@ -209,7 +209,7 @@ void univ_bus_device::set_reset_4002(unsigned index, int state)
 
 void univ_bus_device::set_user_reset(unsigned index, int state)
 {
-	assert(ARRAY_LENGTH(m_cards) > index);
+	assert(std::size(m_cards) > index);
 	bool const changed(bool(state) != !BIT(m_user_reset, index));
 	if (changed)
 	{
@@ -222,7 +222,7 @@ void univ_bus_device::set_user_reset(unsigned index, int state)
 		if (!other)
 			m_user_reset_out_cb(state);
 
-		for (unsigned card = 0U; (ARRAY_LENGTH(m_cards) > card) && m_cards[card]; ++card)
+		for (unsigned card = 0U; (std::size(m_cards) > card) && m_cards[card]; ++card)
 		{
 			if ((index != card) && !(other & ~(u16(1U) << index)))
 				m_cards[card]->user_reset_in(state);

--- a/src/devices/bus/intellec4/intellec4.h
+++ b/src/devices/bus/intellec4/intellec4.h
@@ -168,17 +168,17 @@ public:
 
 	// input lines
 	DECLARE_WRITE_LINE_MEMBER(sync_in);
-	DECLARE_WRITE_LINE_MEMBER(test_in) {set_test(ARRAY_LENGTH(m_cards), state); }
-	DECLARE_WRITE_LINE_MEMBER(stop_in) {set_stop(ARRAY_LENGTH(m_cards), state); }
+	DECLARE_WRITE_LINE_MEMBER(test_in) {set_test(std::size(m_cards), state); }
+	DECLARE_WRITE_LINE_MEMBER(stop_in) {set_stop(std::size(m_cards), state); }
 	DECLARE_WRITE_LINE_MEMBER(stop_acknowledge_in);
 	DECLARE_WRITE_LINE_MEMBER(cpu_reset_in);
-	DECLARE_WRITE_LINE_MEMBER(reset_4002_in) { set_reset_4002(ARRAY_LENGTH(m_cards), state); }
+	DECLARE_WRITE_LINE_MEMBER(reset_4002_in) { set_reset_4002(std::size(m_cards), state); }
 
 	// output lines
-	DECLARE_READ_LINE_MEMBER(test_out) const        { return (m_test        & ~(u16(1U) << ARRAY_LENGTH(m_cards))) ? 0 : 1; }
-	DECLARE_READ_LINE_MEMBER(stop_out) const        { return (m_stop        & ~(u16(1U) << ARRAY_LENGTH(m_cards))) ? 0 : 1; }
-	DECLARE_READ_LINE_MEMBER(reset_4002_out) const  { return (m_reset_4002  & ~(u16(1U) << ARRAY_LENGTH(m_cards))) ? 0 : 1; }
-	DECLARE_READ_LINE_MEMBER(user_reset_out) const  { return (m_user_reset  & ~(u16(1U) << ARRAY_LENGTH(m_cards))) ? 0 : 1; }
+	DECLARE_READ_LINE_MEMBER(test_out) const        { return (m_test        & ~(u16(1U) << std::size(m_cards))) ? 0 : 1; }
+	DECLARE_READ_LINE_MEMBER(stop_out) const        { return (m_stop        & ~(u16(1U) << std::size(m_cards))) ? 0 : 1; }
+	DECLARE_READ_LINE_MEMBER(reset_4002_out) const  { return (m_reset_4002  & ~(u16(1U) << std::size(m_cards))) ? 0 : 1; }
+	DECLARE_READ_LINE_MEMBER(user_reset_out) const  { return (m_user_reset  & ~(u16(1U) << std::size(m_cards))) ? 0 : 1; }
 
 protected:
 	// device_t implementation

--- a/src/devices/bus/lpci/i82439tx.cpp
+++ b/src/devices/bus/lpci/i82439tx.cpp
@@ -145,7 +145,7 @@ uint32_t i82439tx_device::pci_read(pci_bus_device *pcibus, int function, int off
 		case 0xF4:
 		case 0xF8:
 		case 0xFC:
-			assert(((offset - 0x50) / 4) >= 0 && ((offset - 0x50) / 4) < ARRAY_LENGTH(m_regs));
+			assert(((offset - 0x50) / 4) >= 0 && ((offset - 0x50) / 4) < std::size(m_regs));
 			result = m_regs[(offset - 0x50) / 4];
 			break;
 
@@ -294,7 +294,7 @@ void i82439tx_device::pci_write(pci_bus_device *pcibus, int function, int offset
 		case 0xF4:
 		case 0xF8:
 		case 0xFC:
-			assert(((offset - 0x50) / 4) >= 0 && ((offset - 0x50) / 4) < ARRAY_LENGTH(m_regs));
+			assert(((offset - 0x50) / 4) >= 0 && ((offset - 0x50) / 4) < std::size(m_regs));
 			COMBINE_DATA(&m_regs[(offset - 0x50) / 4]);
 			break;
 

--- a/src/devices/bus/lpci/pci.cpp
+++ b/src/devices/bus/lpci/pci.cpp
@@ -237,7 +237,7 @@ void pci_bus_device::add_sibling(pci_bus_device *sibling, int busnum)
 
 void pci_bus_device::remap(int space_id, offs_t start, offs_t end)
 {
-	for (int i = 0; i < ARRAY_LENGTH(m_devtag); i++)
+	for (int i = 0; i < std::size(m_devtag); i++)
 	{
 		if (m_device[i] != nullptr)
 			m_device[i]->remap(space_id, start, end);
@@ -272,7 +272,7 @@ void pci_bus_device::device_start()
 
 	char id[3];
 	/* find all our devices */
-	for (int i = 0; i < ARRAY_LENGTH(m_devtag); i++)
+	for (int i = 0; i < std::size(m_devtag); i++)
 	{
 		sprintf(id, "%d", i);
 		pci_connector_device *conn = downcast<pci_connector_device *>(subdevice(id));

--- a/src/devices/bus/m5/slot.cpp
+++ b/src/devices/bus/m5/slot.cpp
@@ -120,7 +120,7 @@ static const m5_slot slot_list[] =
 
 static int m5_get_pcb_id(const char *slot)
 {
-	for (int i = 0; i < ARRAY_LENGTH(slot_list); i++)
+	for (int i = 0; i < std::size(slot_list); i++)
 	{
 		if (!strcmp(slot_list[i].slot_option, slot))
 			return slot_list[i].pcb_id;
@@ -131,7 +131,7 @@ static int m5_get_pcb_id(const char *slot)
 
 static const char *m5_get_slot(int type)
 {
-	for (int i = 0; i < ARRAY_LENGTH(slot_list); i++)
+	for (int i = 0; i < std::size(slot_list); i++)
 	{
 		if (slot_list[i].pcb_id == type)
 			return slot_list[i].slot_option;

--- a/src/devices/bus/megadrive/svp.cpp
+++ b/src/devices/bus/megadrive/svp.cpp
@@ -369,8 +369,8 @@ void md_rom_svp_device::set_bank_to_rom(const char *banktag, uint32_t offset)
 
 void md_rom_svp_device::device_start()
 {
-	memset(m_pmac_read, 0, ARRAY_LENGTH(m_pmac_read));
-	memset(m_pmac_write, 0, ARRAY_LENGTH(m_pmac_write));
+	std::fill(std::begin(m_pmac_read), std::end(m_pmac_read), 0);
+	std::fill(std::begin(m_pmac_write), std::end(m_pmac_write), 0);
 	m_pmc.d = 0;
 	m_pmc.w.l = 0;
 	m_pmc.w.h = 0;

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -291,9 +291,7 @@ static const nes_mmc mmc_list[] =
 
 const nes_mmc *nes_mapper_lookup( int mapper )
 {
-	int i;
-
-	for (i = 0; i < ARRAY_LENGTH(mmc_list); i++)
+	for (int i = 0; i < std::size(mmc_list); i++)
 	{
 		if (mmc_list[i].iNesMapper == mapper)
 			return &mmc_list[i];

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -276,8 +276,8 @@ inline void device_nes_cart_interface::update_prg_banks(int prg_bank_start, int 
 	for (int prg_bank = prg_bank_start; prg_bank <= prg_bank_end; prg_bank++)
 	{
 		assert(prg_bank >= 0);
-		assert(prg_bank < ARRAY_LENGTH(m_prg_bank));
-		assert(prg_bank < ARRAY_LENGTH(m_prg_bank_mem));
+		assert(prg_bank < std::size(m_prg_bank));
+		assert(prg_bank < std::size(m_prg_bank_mem));
 
 		m_prg_bank_mem[prg_bank]->set_entry(m_prg_bank[prg_bank]);
 	}

--- a/src/devices/bus/nes/nes_unif.hxx
+++ b/src/devices/bus/nes/nes_unif.hxx
@@ -158,8 +158,7 @@ static const unif unif_list[] =
 
 const unif *nes_unif_lookup( const char *board )
 {
-	int i;
-	for (i = 0; i < ARRAY_LENGTH(unif_list); i++)
+	for (int i = 0; i < std::size(unif_list); i++)
 	{
 		if (!core_stricmp(unif_list[i].board, board))
 			return &unif_list[i];

--- a/src/devices/bus/nes_ctrl/bcbattle.cpp
+++ b/src/devices/bus/nes_ctrl/bcbattle.cpp
@@ -119,7 +119,7 @@ void nes_bcbattle_device::device_reset()
 	m_transmitting = 0;
 	m_cur_bit = 0;
 	m_cur_byte = 0;
-	memset(m_current_barcode, 0, ARRAY_LENGTH(m_current_barcode));
+	std::fill(std::begin(m_current_barcode), std::end(m_current_barcode), 0);
 }
 
 

--- a/src/devices/bus/nubus/nubus_image.cpp
+++ b/src/devices/bus/nubus/nubus_image.cpp
@@ -264,7 +264,7 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 	filectx.curcmd = data;
 	switch (data) {
 	case kFileCmdGetDir:
-		strncpy(filectx.filename, filectx.curdir.c_str(), ARRAY_LENGTH(filectx.filename));
+		strncpy(filectx.filename, filectx.curdir.c_str(), std::size(filectx.filename));
 		break;
 	case kFileCmdSetDir:
 		if ((filectx.filename[0] == '/') || (filectx.filename[0] == '$')) {
@@ -281,7 +281,7 @@ void nubus_image_device::file_cmd_w(uint32_t data)
 		if (filectx.dirp) {
 			osd::directory::entry const *const dp = filectx.dirp->read();
 			if (dp) {
-				strncpy(filectx.filename, dp->name, ARRAY_LENGTH(filectx.filename));
+				strncpy(filectx.filename, dp->name, std::size(filectx.filename));
 			} else {
 				std::fill(std::begin(filectx.filename), std::end(filectx.filename), '\0');
 			}

--- a/src/devices/bus/snes/snes_slot.cpp
+++ b/src/devices/bus/snes/snes_slot.cpp
@@ -1372,7 +1372,7 @@ void base_sns_cart_slot_device::internal_header_logging(uint8_t *ROM, uint32_t l
 
 	logerror( "\tSize:          %d megabits [%d]\n", 1 << (ROM[hilo_mode + 0x17] - 7), ROM[hilo_mode + 0x17]);
 	logerror( "\tSRAM:          %d kilobits [%d]\n", ROM[hilo_mode + 0x18] * 8, ROM[hilo_mode + 0x18] );
-	if (ROM[hilo_mode + 0x19] < ARRAY_LENGTH(countries))
+	if (ROM[hilo_mode + 0x19] < std::size(countries))
 		logerror( "\tCountry:       %s [%d]\n", countries[ROM[hilo_mode + 0x19]], ROM[hilo_mode + 0x19]);
 	else
 		logerror( "\tCountry:       Unknown [%d]\n", ROM[hilo_mode + 0x19]);

--- a/src/devices/bus/snes_ctrl/bcbattle.cpp
+++ b/src/devices/bus/snes_ctrl/bcbattle.cpp
@@ -121,7 +121,7 @@ void snes_bcbattle_device::device_reset()
 	m_transmitting = 0;
 	m_cur_bit = 0;
 	m_cur_byte = 0;
-	memset(m_current_barcode, 0, ARRAY_LENGTH(m_current_barcode));
+	std::fill(std::begin(m_current_barcode), std::end(m_current_barcode), 0);
 }
 
 

--- a/src/devices/bus/vectrex/slot.cpp
+++ b/src/devices/bus/vectrex/slot.cpp
@@ -111,7 +111,7 @@ static const vectrex_slot slot_list[] =
 #if 0
 static int vectrex_get_pcb_id(const char *slot)
 {
-	for (int i = 0; i < ARRAY_LENGTH(slot_list); i++)
+	for (int i = 0; i < std::size(slot_list); i++)
 	{
 		if (!strcmp(slot_list[i].slot_option, slot))
 			return slot_list[i].pcb_id;

--- a/src/devices/bus/vme/vme_fccpu20.cpp
+++ b/src/devices/bus/vme/vme_fccpu20.cpp
@@ -504,8 +504,8 @@ uint32_t vme_fccpu20_device::bootvect_r(offs_t offset)
 void vme_fccpu20_device::bootvect_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOG("%s\n", FUNCNAME);
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] &= ~mem_mask;
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] |= (data & mem_mask);
+	m_sysram[offset % std::size(m_sysram)] &= ~mem_mask;
+	m_sysram[offset % std::size(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcoming accesses to masking RAM until reset.
 }
 

--- a/src/devices/bus/vme/vme_hcpu30.cpp
+++ b/src/devices/bus/vme/vme_hcpu30.cpp
@@ -156,8 +156,8 @@ uint32_t vme_hcpu30_card_device::bootvect_r(offs_t offset)
 void vme_hcpu30_card_device::bootvect_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	LOG("%s\n", FUNCNAME);
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] &= ~mem_mask;
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] |= (data & mem_mask);
+	m_sysram[offset % std::size(m_sysram)] &= ~mem_mask;
+	m_sysram[offset % std::size(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcoming accesses to masking RAM until reset.
 }
 

--- a/src/devices/bus/vtech/memexp/floppy.cpp
+++ b/src/devices/bus/vtech/memexp/floppy.cpp
@@ -191,7 +191,7 @@ void vtech_floppy_controller_device::latch_w(uint8_t data)
 		}
 	}
 	if(!(m_latch & 0x40) && (diff & 0x20)) {
-		if(m_write_position == ARRAY_LENGTH(m_write_buffer)) {
+		if(m_write_position == std::size(m_write_buffer)) {
 			update_latching_inverter();
 			flush_writes(true);
 		}

--- a/src/devices/cpu/arm7/arm7drc.hxx
+++ b/src/devices/cpu/arm7/arm7drc.hxx
@@ -95,7 +95,7 @@ void arm7_cpu_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_impstate.regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_impstate.regmap); regnum++)
 		if (m_impstate.regmap[regnum].is_int_register())
 			UML_DMOV(block, uml::ireg(m_impstate.regmap[regnum].ireg() - uml::REG_I0), uml::mem(&m_r[regnum]));
 }
@@ -110,7 +110,7 @@ void arm7_cpu_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_impstate.regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_impstate.regmap); regnum++)
 		if (m_impstate.regmap[regnum].is_int_register())
 			UML_DMOV(block, uml::mem(&m_r[regnum]), uml::ireg(m_impstate.regmap[regnum].ireg() - uml::REG_I0));
 }
@@ -251,7 +251,7 @@ void arm7_cpu_device::arm7drc_set_options(uint32_t options)
 
 void arm7_cpu_device::arm7drc_add_fastram(offs_t start, offs_t end, uint8_t readonly, void *base)
 {
-	if (m_impstate.fastram_select < ARRAY_LENGTH(m_impstate.fastram))
+	if (m_impstate.fastram_select < std::size(m_impstate.fastram))
 	{
 		m_impstate.fastram[m_impstate.fastram_select].start = start;
 		m_impstate.fastram[m_impstate.fastram_select].end = end;
@@ -268,7 +268,7 @@ void arm7_cpu_device::arm7drc_add_fastram(offs_t start, offs_t end, uint8_t read
 
 void arm7_cpu_device::arm7drc_add_hotspot(offs_t pc, uint32_t opcode, uint32_t cycles)
 {
-	if (m_impstate.hotspot_select < ARRAY_LENGTH(m_impstate.hotspot))
+	if (m_impstate.hotspot_select < std::size(m_impstate.hotspot))
 	{
 		m_impstate.hotspot[m_impstate.hotspot_select].pc = pc;
 		m_impstate.hotspot[m_impstate.hotspot_select].opcode = opcode;

--- a/src/devices/cpu/cosmac/cosmac.cpp
+++ b/src/devices/cpu/cosmac/cosmac.cpp
@@ -528,8 +528,8 @@ void cosmac_device::device_reset()
 	m_df = 0;
 	m_p = 0;
 
-	for (int i = 0; i < ARRAY_LENGTH(m_r); i++)
-		m_r[i] = machine().rand() & 0xffff;
+	for (uint16_t &r : m_r)
+		r = machine().rand() & 0xffff;
 }
 
 

--- a/src/devices/cpu/drcbec.cpp
+++ b/src/devices/cpu/drcbec.cpp
@@ -528,7 +528,7 @@ int drcbe_c::execute(code_handle &entry)
 				newinst = (const drcbec_instruction *)m_hash.get_codeptr(PARAM0, PARAM1);
 				if (newinst == nullptr)
 				{
-					assert(sp < ARRAY_LENGTH(callstack));
+					assert(sp < std::size(callstack));
 					m_state.exp = PARAM1;
 					newinst = (const drcbec_instruction *)inst[2].handle->codeptr();
 					callstack[sp++] = inst;
@@ -562,7 +562,7 @@ int drcbe_c::execute(code_handle &entry)
 				[[fallthrough]];
 
 			case MAKE_OPCODE_SHORT(OP_CALLH, 4, 0):
-				assert(sp < ARRAY_LENGTH(callstack));
+				assert(sp < std::size(callstack));
 				newinst = (const drcbec_instruction *)inst[0].handle->codeptr();
 				assert_in_cache(m_cache, newinst);
 				callstack[sp++] = inst + OPCODE_GET_PWORDS(opcode);
@@ -587,7 +587,7 @@ int drcbe_c::execute(code_handle &entry)
 				[[fallthrough]];
 
 			case MAKE_OPCODE_SHORT(OP_EXH, 4, 0):
-				assert(sp < ARRAY_LENGTH(callstack));
+				assert(sp < std::size(callstack));
 				newinst = (const drcbec_instruction *)inst[0].handle->codeptr();
 				assert_in_cache(m_cache, newinst);
 				m_state.exp = PARAM1;

--- a/src/devices/cpu/drcbeut.cpp
+++ b/src/devices/cpu/drcbeut.cpp
@@ -276,7 +276,7 @@ void drc_map_variables::block_end(drcuml_block &block)
 			// build a mask of changed variables
 			int numchanged = 0;
 			uint32_t varmask = 0;
-			for (int varnum = 0; varnum < ARRAY_LENGTH(changed); varnum++)
+			for (int varnum = 0; varnum < std::size(changed); varnum++)
 				if (changed[varnum])
 				{
 					changed[varnum] = false;
@@ -298,7 +298,7 @@ void drc_map_variables::block_end(drcuml_block &block)
 			*dest++ = (codedelta << 16) | (varmask << 4) | numchanged;
 
 			// now output updated variable values
-			for (int varnum = 0; varnum < ARRAY_LENGTH(changed); varnum++)
+			for (int varnum = 0; varnum < std::size(changed); varnum++)
 				if ((varmask >> varnum) & 1)
 					*dest++ = curvalue[varnum];
 

--- a/src/devices/cpu/drcbex64.cpp
+++ b/src/devices/cpu/drcbex64.cpp
@@ -654,7 +654,7 @@ drcbe_x64::drcbe_x64(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 	m_near.drcmap_get_value = (x86code *)&drc_map_variables::static_get_value;
 
 	// build the flags map
-	for (int entry = 0; entry < ARRAY_LENGTH(m_near.flagsmap); entry++)
+	for (int entry = 0; entry < std::size(m_near.flagsmap); entry++)
 	{
 		uint8_t flags = 0;
 		if (entry & 0x001) flags |= FLAG_C;
@@ -664,7 +664,7 @@ drcbe_x64::drcbe_x64(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		if (entry & 0x800) flags |= FLAG_V;
 		m_near.flagsmap[entry] = flags;
 	}
-	for (int entry = 0; entry < ARRAY_LENGTH(m_near.flagsunmap); entry++)
+	for (int entry = 0; entry < std::size(m_near.flagsunmap); entry++)
 	{
 		uint64_t flags = 0;
 		if (entry & FLAG_C) flags |= 0x001;
@@ -873,7 +873,7 @@ void drcbe_x64::generate(drcuml_block &block, const instruction *instlist, uint3
 	for (int inum = 0; inum < numinst; inum++)
 	{
 		const instruction &inst = instlist[inum];
-		assert(inst.opcode() < ARRAY_LENGTH(s_opcode_table));
+		assert(inst.opcode() < std::size(s_opcode_table));
 
 		// must remain in scope until output
 		std::string dasm;
@@ -1883,7 +1883,7 @@ void drcbe_x64::op_save(Assembler &a, const instruction &inst)
 
 	// copy integer registers
 	int regoffs = offsetof(drcuml_machine_state, r);
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.r); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.r); regnum++)
 	{
 		if (int_register_map[regnum] != 0)
 			a.mov(ptr(rcx, regoffs + 8 * regnum), Gpq(regnum));
@@ -1896,7 +1896,7 @@ void drcbe_x64::op_save(Assembler &a, const instruction &inst)
 
 	// copy FP registers
 	regoffs = offsetof(drcuml_machine_state, f);
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.f); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.f); regnum++)
 	{
 		if (float_register_map[regnum] != 0)
 			a.movsd(ptr(rcx, regoffs + 8 * regnum), Xmm(regnum));
@@ -1927,7 +1927,7 @@ void drcbe_x64::op_restore(Assembler &a, const instruction &inst)
 
 	// copy integer registers
 	int regoffs = offsetof(drcuml_machine_state, r);
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.r); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.r); regnum++)
 	{
 		if (int_register_map[regnum] != 0)
 			a.mov(Gpq(regnum), ptr(rcx, regoffs + 8 * regnum));
@@ -1940,7 +1940,7 @@ void drcbe_x64::op_restore(Assembler &a, const instruction &inst)
 
 	// copy FP registers
 	regoffs = offsetof(drcuml_machine_state, f);
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.f); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.f); regnum++)
 	{
 		if (float_register_map[regnum] != 0)
 			a.movsd(Xmm(regnum), ptr(rcx, regoffs + 8 * regnum));

--- a/src/devices/cpu/drcbex86.cpp
+++ b/src/devices/cpu/drcbex86.cpp
@@ -538,7 +538,7 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		m_reshi(0)
 {
 	// compute hi pointers for each register
-	for (int regnum = 0; regnum < ARRAY_LENGTH(int_register_map); regnum++)
+	for (int regnum = 0; regnum < std::size(int_register_map); regnum++)
 		if (int_register_map[regnum] != 0)
 		{
 			m_reglo[int_register_map[regnum]] = &m_state.r[regnum].w.l;
@@ -546,7 +546,7 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		}
 
 	// build the flags map (static but it doesn't hurt to regenerate it)
-	for (int entry = 0; entry < ARRAY_LENGTH(flags_map); entry++)
+	for (int entry = 0; entry < std::size(flags_map); entry++)
 	{
 		uint8_t flags = 0;
 		if (entry & 0x001) flags |= FLAG_C;
@@ -556,7 +556,7 @@ drcbe_x86::drcbe_x86(drcuml_state &drcuml, device_t &device, drc_cache &cache, u
 		if (entry & 0x800) flags |= FLAG_V;
 		flags_map[entry] = flags;
 	}
-	for (int entry = 0; entry < ARRAY_LENGTH(flags_unmap); entry++)
+	for (int entry = 0; entry < std::size(flags_unmap); entry++)
 	{
 		uint32_t flags = 0;
 		if (entry & FLAG_C) flags |= 0x001;
@@ -712,7 +712,7 @@ void drcbe_x86::reset()
 	a.mov(ptr(ecx, offsetof(drcuml_machine_state, fmod)), al);                          // mov    state->fmod,al
 	a.mov(eax, MABS(&m_state.exp));                                                     // mov    eax,[exp]
 	a.mov(ptr(ecx, offsetof(drcuml_machine_state, exp)), eax);                          // mov    state->exp,eax
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.r); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.r); regnum++)
 	{
 		uintptr_t regoffsl = (uintptr_t)&((drcuml_machine_state *)nullptr)->r[regnum].w.l;
 		uintptr_t regoffsh = (uintptr_t)&((drcuml_machine_state *)nullptr)->r[regnum].w.h;
@@ -726,7 +726,7 @@ void drcbe_x86::reset()
 		a.mov(eax, MABS(&m_state.r[regnum].w.h));
 		a.mov(ptr(ecx, regoffsh), eax);
 	}
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.f); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.f); regnum++)
 	{
 		uintptr_t regoffsl = (uintptr_t)&((drcuml_machine_state *)nullptr)->f[regnum].s.l;
 		uintptr_t regoffsh = (uintptr_t)&((drcuml_machine_state *)nullptr)->f[regnum].s.h;
@@ -740,7 +740,7 @@ void drcbe_x86::reset()
 	// generate a restore subroutine
 	m_restore = dst + a.offset();
 	a.bind(a.newNamedLabel("restore"));
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.r); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.r); regnum++)
 	{
 		uintptr_t regoffsl = (uintptr_t)&((drcuml_machine_state *)nullptr)->r[regnum].w.l;
 		uintptr_t regoffsh = (uintptr_t)&((drcuml_machine_state *)nullptr)->r[regnum].w.h;
@@ -754,7 +754,7 @@ void drcbe_x86::reset()
 		a.mov(eax, ptr(ecx, regoffsh));
 		a.mov(MABS(&m_state.r[regnum].w.h), eax);
 	}
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_state.f); regnum++)
+	for (int regnum = 0; regnum < std::size(m_state.f); regnum++)
 	{
 		uintptr_t regoffsl = (uintptr_t)&((drcuml_machine_state *)nullptr)->f[regnum].s.l;
 		uintptr_t regoffsh = (uintptr_t)&((drcuml_machine_state *)nullptr)->f[regnum].s.h;
@@ -843,7 +843,7 @@ void drcbe_x86::generate(drcuml_block &block, const instruction *instlist, uint3
 	for (int inum = 0; inum < numinst; inum++)
 	{
 		const instruction &inst = instlist[inum];
-		assert(inst.opcode() < ARRAY_LENGTH(s_opcode_table));
+		assert(inst.opcode() < std::size(s_opcode_table));
 
 		// must remain in scope until output
 		std::string dasm;

--- a/src/devices/cpu/drcuml.cpp
+++ b/src/devices/cpu/drcuml.cpp
@@ -704,10 +704,10 @@ static void validate_backend(drcuml_state *drcuml)
 
 	// iterate over test entries
 	printf("Backend validation....\n");
-	for (tnum = 31; tnum < ARRAY_LENGTH(bevalidate_test_list); tnum++)
+	for (tnum = 31; tnum < std::size(bevalidate_test_list); tnum++)
 	{
 		const bevalidate_test *test = &bevalidate_test_list[tnum];
-		parameter param[ARRAY_LENGTH(test->param)];
+		parameter param[std::size(test->param)];
 		char mnemonic[20], *dst;
 		const char *src;
 
@@ -726,7 +726,7 @@ static void validate_backend(drcuml_state *drcuml)
 				*dst++ = *src;
 		}
 		*dst = 0;
-		printf("Executing test %d/%d (%s)", tnum + 1, (int)ARRAY_LENGTH(bevalidate_test_list), mnemonic);
+		printf("Executing test %d/%d (%s)", tnum + 1, (int)std::size(bevalidate_test_list), mnemonic);
 
 		// reset parameter list and iterate
 		memset(param, 0, sizeof(param));
@@ -750,7 +750,7 @@ static void bevalidate_iterate_over_params(drcuml_state *drcuml, uml::code_handl
 	drcuml_ptype ptype;
 
 	// if no parameters, execute now
-	if (pnum >= ARRAY_LENGTH(opinfo->param) || opinfo->param[pnum].typemask == PTYPES_NONE)
+	if (pnum >= std::size(opinfo->param) || opinfo->param[pnum].typemask == PTYPES_NONE)
 	{
 		bevalidate_iterate_over_flags(drcuml, handles, test, paramlist);
 		return;
@@ -838,7 +838,7 @@ static void bevalidate_iterate_over_flags(drcuml_state *drcuml, uml::code_handle
 
 static void bevalidate_execute(drcuml_state *drcuml, uml::code_handle **handles, const bevalidate_test *test, const parameter *paramlist, uint8_t flagmask)
 {
-	parameter params[ARRAY_LENGTH(test->param)];
+	parameter params[std::size(test->param)];
 	drcuml_machine_state istate, fstate;
 	instruction testinst;
 	drcuml_block *block;
@@ -846,7 +846,7 @@ static void bevalidate_execute(drcuml_state *drcuml, uml::code_handle **handles,
 	int numparams;
 
 	// allocate memory for parameters
-	parammem = (uint64_t *)drcuml->cache->alloc_near(sizeof(uint64_t) * (ARRAY_LENGTH(test->param) + 1));
+	parammem = (uint64_t *)drcuml->cache->alloc_near(sizeof(uint64_t) * (std::size(test->param) + 1));
 
 	// flush the cache
 	drcuml->reset();
@@ -888,7 +888,7 @@ static void bevalidate_execute(drcuml_state *drcuml, uml::code_handle **handles,
 	}
 	testinst = block->inst[block->nextinst - 1];
 	UML_HANDLE(block, handles[2]);
-	UML_GETFLGS(block, MEM(&parammem[ARRAY_LENGTH(test->param)]), flagmask);
+	UML_GETFLGS(block, MEM(&parammem[std::size(test->param)]), flagmask);
 	UML_SAVE(block, &fstate);
 	UML_EXIT(block, IMM(0));
 
@@ -899,10 +899,10 @@ static void bevalidate_execute(drcuml_state *drcuml, uml::code_handle **handles,
 	drcuml->execute(*handles[0]);
 
 	// verify the results
-	bevalidate_verify_state(drcuml, &istate, &fstate, test, *(uint32_t *)&parammem[ARRAY_LENGTH(test->param)], params, &testinst, handles[1]->code, handles[2]->code, flagmask);
+	bevalidate_verify_state(drcuml, &istate, &fstate, test, *(uint32_t *)&parammem[std::size(test->param)], params, &testinst, handles[1]->code, handles[2]->code, flagmask);
 
 	// free memory
-	drcuml->cache->dealloc(parammem, sizeof(uint64_t) * (ARRAY_LENGTH(test->param) + 1));
+	drcuml->cache->dealloc(parammem, sizeof(uint64_t) * (std::size(test->param) + 1));
 }
 
 
@@ -922,14 +922,14 @@ static void bevalidate_initialize_random_state(drcuml_state *drcuml, drcuml_bloc
 	state->exp = machine.rand();
 
 	// initialize integer registers to random values
-	for (regnum = 0; regnum < ARRAY_LENGTH(state->r); regnum++)
+	for (regnum = 0; regnum < std::size(state->r); regnum++)
 	{
 		state->r[regnum].w.h = machine.rand();
 		state->r[regnum].w.l = machine.rand();
 	}
 
 	// initialize float registers to random values
-	for (regnum = 0; regnum < ARRAY_LENGTH(state->f); regnum++)
+	for (regnum = 0; regnum < std::size(state->f); regnum++)
 	{
 		*(uint32_t *)&state->f[regnum].s.h = machine.rand();
 		*(uint32_t *)&state->f[regnum].s.l = machine.rand();
@@ -950,14 +950,14 @@ static void bevalidate_initialize_random_state(drcuml_state *drcuml, drcuml_bloc
 static int bevalidate_populate_state(drcuml_block *block, drcuml_machine_state *state, const bevalidate_test *test, const parameter *paramlist, parameter *params, uint64_t *parammem)
 {
 	const opcode_info *opinfo = opcode_info_table[test->opcode()];
-	int numparams = ARRAY_LENGTH(test->param);
+	int numparams = std::size(test->param);
 	int pnum;
 
 	// copy flags as-is
 	state->flags = test->iflags;
 
 	// iterate over parameters
-	for (pnum = 0; pnum < ARRAY_LENGTH(test->param); pnum++)
+	for (pnum = 0; pnum < std::size(test->param); pnum++)
 	{
 		int psize = effective_test_psize(opinfo, pnum, test->size, test->param);
 		parameter *curparam = &params[pnum];
@@ -1046,7 +1046,7 @@ static int bevalidate_verify_state(drcuml_state *drcuml, const drcuml_machine_st
 	}
 
 	// check destination parameters
-	for (pnum = 0; pnum < ARRAY_LENGTH(test->param); pnum++)
+	for (pnum = 0; pnum < std::size(test->param); pnum++)
 		if (opinfo->param[pnum].output & PIO_OUT)
 		{
 			int psize = effective_test_psize(opinfo, pnum, test->size, test->param);
@@ -1094,14 +1094,14 @@ static int bevalidate_verify_state(drcuml_state *drcuml, const drcuml_machine_st
 		}
 
 	// check source integer parameters for unexpected alterations
-	for (regnum = 0; regnum < ARRAY_LENGTH(state->r); regnum++)
+	for (regnum = 0; regnum < std::size(state->r); regnum++)
 		if (ireg[regnum] == 0 && istate->r[regnum].d != state->r[regnum].d)
 			errend += sprintf(errend, "  Register i%d ... result:%08X%08X  originally:%08X%08X\n", regnum,
 								(uint32_t)(state->r[regnum].d >> 32), (uint32_t)state->r[regnum].d,
 								(uint32_t)(istate->r[regnum].d >> 32), (uint32_t)istate->r[regnum].d);
 
 	// check source float parameters for unexpected alterations
-	for (regnum = 0; regnum < ARRAY_LENGTH(state->f); regnum++)
+	for (regnum = 0; regnum < std::size(state->f); regnum++)
 		if (freg[regnum] == 0 && *(uint64_t *)&istate->f[regnum].d != *(uint64_t *)&state->f[regnum].d)
 			errend += sprintf(errend, "  Register f%d ... result:%08X%08X  originally:%08X%08X\n", regnum,
 								(uint32_t)(*(uint64_t *)&state->f[regnum].d >> 32), (uint32_t)*(uint64_t *)&state->f[regnum].d,

--- a/src/devices/cpu/dsp16/dsp16fe.cpp
+++ b/src/devices/cpu/dsp16/dsp16fe.cpp
@@ -564,9 +564,9 @@ bool dsp16_device_base::frontend::describe_do(opcode_desc &desc, u16 op)
 	m_cache_cycles = cycles;
 	m_cache_last_cycles = cycles + (romcycles - cachecycles);
 	m_cache_flags = desc.flags & (OPFLAG_READS_MEMORY | OPFLAG_WRITES_MEMORY);
-	std::copy_n(desc.regin, ARRAY_LENGTH(desc.regin), m_cache_regin);
-	std::copy_n(desc.regout, ARRAY_LENGTH(desc.regout), m_cache_regout);
-	std::copy_n(desc.regreq, ARRAY_LENGTH(desc.regreq), m_cache_regreq);
+	std::copy_n(desc.regin, std::size(desc.regin), m_cache_regin);
+	std::copy_n(desc.regout, std::size(desc.regout), m_cache_regout);
+	std::copy_n(desc.regreq, std::size(desc.regreq), m_cache_regreq);
 	m_cache_valid = true;
 	desc.cycles += (2U - romcycles) + ((k - 1) * cycles) + (romcycles - cachecycles);
 	return true;
@@ -589,9 +589,9 @@ bool dsp16_device_base::frontend::describe_redo(opcode_desc &desc, u16 op)
 	{
 		desc.cycles += ((k - 1) * m_cache_cycles) + m_cache_last_cycles;
 		desc.flags |= m_cache_flags;
-		std::copy_n(m_cache_regin, ARRAY_LENGTH(desc.regin), desc.regin);
-		std::copy_n(m_cache_regout, ARRAY_LENGTH(desc.regout), desc.regout);
-		std::copy_n(m_cache_regreq, ARRAY_LENGTH(desc.regreq), desc.regreq);
+		std::copy_n(m_cache_regin, std::size(desc.regin), desc.regin);
+		std::copy_n(m_cache_regout, std::size(desc.regout), desc.regout);
+		std::copy_n(m_cache_regreq, std::size(desc.regreq), desc.regreq);
 		return true;
 	}
 }

--- a/src/devices/cpu/dspp/dsppdrc.cpp
+++ b/src/devices/cpu/dspp/dsppdrc.cpp
@@ -94,7 +94,7 @@ registers
 inline void dspp_device::load_fast_iregs(drcuml_block &block)
 {
 #if 0 // TODO
-	for (uint32_t regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (uint32_t regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -115,7 +115,7 @@ void dspp_device::save_fast_iregs(drcuml_block &block)
 #if 0 // TODO
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{

--- a/src/devices/cpu/i386/i386dasm.cpp
+++ b/src/devices/cpu/i386/i386dasm.cpp
@@ -2847,7 +2847,7 @@ void i386_disassembler::decode_opcode(std::ostream &stream, const I386_OPCODE *o
 
 		case GROUP:
 			handle_modrm(modrm_string, base_pc, pc, opcodes);
-			for( i=0; i < ARRAY_LENGTH(group_op_table); i++ ) {
+			for( i=0; i < std::size(group_op_table); i++ ) {
 				if( strcmp(op->mnemonic, group_op_table[i].mnemonic) == 0 ) {
 					if (op->flags & GROUP_MOD)
 						decode_opcode(stream, &group_op_table[i].opcode[MODRM_MOD()], op1, base_pc, pc, opcodes);

--- a/src/devices/cpu/i8085/i8085.cpp
+++ b/src/devices/cpu/i8085/i8085.cpp
@@ -502,7 +502,7 @@ void i8085a_cpu_device::execute_set_input(int irqline, int state)
 	}
 
 	/* remaining sources are level triggered */
-	else if (irqline < ARRAY_LENGTH(m_irq_state))
+	else if (irqline < std::size(m_irq_state))
 		m_irq_state[irqline] = state;
 }
 

--- a/src/devices/cpu/m6502/m6500_1.cpp
+++ b/src/devices/cpu/m6502/m6500_1.cpp
@@ -171,7 +171,7 @@ void m6500_1_device::device_reset()
 
 	m_cr = 0x00U;
 
-	for (unsigned i = 0; ARRAY_LENGTH(m_port_buf) > i; ++i)
+	for (unsigned i = 0; std::size(m_port_buf) > i; ++i)
 	{
 		if (0xffU != m_port_buf[i])
 			m_port_out_cb[i](m_port_buf[i] = 0xffU);

--- a/src/devices/cpu/m6809/6x09dasm.cpp
+++ b/src/devices/cpu/m6809/6x09dasm.cpp
@@ -808,7 +808,7 @@ const m6x09_base_disassembler::opcodeinfo m6x09_disassembler::m6x09_opcodes[] =
 // ======================> m6x09_disassembler
 
 m6x09_disassembler::m6x09_disassembler(m6x09_instruction_level level, const char teregs[16][4])
-	: m6x09_base_disassembler(m6x09_opcodes, ARRAY_LENGTH(m6x09_opcodes), level)
+	: m6x09_base_disassembler(m6x09_opcodes, std::size(m6x09_opcodes), level)
 	, m_teregs(*reinterpret_cast<const std::array<std::array<char, 4>, 16> *>(teregs))
 {
 }
@@ -1237,7 +1237,7 @@ const m6x09_base_disassembler::opcodeinfo konami_disassembler::konami_opcodes[] 
 
 // ======================> konami_disassembler
 
-konami_disassembler::konami_disassembler() : m6x09_base_disassembler(konami_opcodes, ARRAY_LENGTH(konami_opcodes), M6x09_GENERAL)
+konami_disassembler::konami_disassembler() : m6x09_base_disassembler(konami_opcodes, std::size(konami_opcodes), M6x09_GENERAL)
 {
 }
 

--- a/src/devices/cpu/mb86235/mb86235drc.cpp
+++ b/src/devices/cpu/mb86235/mb86235drc.cpp
@@ -189,7 +189,7 @@ inline void mb86235_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -207,7 +207,7 @@ void mb86235_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{

--- a/src/devices/cpu/mips/mips1.cpp
+++ b/src/devices/cpu/mips/mips1.cpp
@@ -160,7 +160,7 @@ void mips1core_device_base::device_start()
 	state_add(MIPS1_PC,                   "PC",        m_pc);
 	state_add(MIPS1_COP0 + COP0_Status,   "SR",        m_cop0[COP0_Status]);
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_r); i++)
+	for (unsigned i = 0; i < std::size(m_r); i++)
 		state_add(MIPS1_R0 + i, util::string_format("R%d", i).c_str(), m_r[i]);
 
 	state_add(MIPS1_HI, "HI", m_hi);
@@ -751,17 +751,17 @@ void mips1core_device_base::generate_exception(u32 exception, bool refill)
 			{
 			case 1049: // msgsys
 				LOGMASKED(LOG_RISCOS, "asid %d syscall msgsys:%s() (%s)\n",
-					asid, (m_r[5] < ARRAY_LENGTH(msg_syscalls)) ? msg_syscalls[m_r[5]] : "unknown", machine().describe_context());
+					asid, (m_r[5] < std::size(msg_syscalls)) ? msg_syscalls[m_r[5]] : "unknown", machine().describe_context());
 				break;
 
 			case 1052: // shmsys
 				LOGMASKED(LOG_RISCOS, "asid %d syscall shmsys:%s() (%s)\n",
-					asid, (m_r[5] < ARRAY_LENGTH(shm_syscalls)) ? shm_syscalls[m_r[5]] : "unknown", machine().describe_context());
+					asid, (m_r[5] < std::size(shm_syscalls)) ? shm_syscalls[m_r[5]] : "unknown", machine().describe_context());
 				break;
 
 			case 1053: // semsys
 				LOGMASKED(LOG_RISCOS, "asid %d syscall semsys:%s() (%s)\n",
-					asid, (m_r[5] < ARRAY_LENGTH(sem_syscalls)) ? sem_syscalls[m_r[5]] : "unknown", machine().describe_context());
+					asid, (m_r[5] < std::size(sem_syscalls)) ? sem_syscalls[m_r[5]] : "unknown", machine().describe_context());
 				break;
 
 			case 2151: // bsd_sysmips
@@ -773,7 +773,7 @@ void mips1core_device_base::generate_exception(u32 exception, bool refill)
 					break;
 
 				default:
-					if ((m_r[5] > 0x100) && (m_r[5] - 0x100) < ARRAY_LENGTH(mips_syscalls))
+					if ((m_r[5] > 0x100) && (m_r[5] - 0x100) < std::size(mips_syscalls))
 						LOGMASKED(LOG_RISCOS, "asid %d syscall bsd_sysmips:%s() (%s)\n",
 							asid, mips_syscalls[m_r[5] - 0x100], machine().describe_context());
 					else
@@ -784,7 +784,7 @@ void mips1core_device_base::generate_exception(u32 exception, bool refill)
 				break;
 
 			default:
-				if ((m_r[4] > 2000) && (m_r[4] - 2000 < ARRAY_LENGTH(bsd_syscalls)) && bsd_syscalls[m_r[4] - 2000])
+				if ((m_r[4] > 2000) && (m_r[4] - 2000 < std::size(bsd_syscalls)) && bsd_syscalls[m_r[4] - 2000])
 					LOGMASKED(LOG_RISCOS, "asid %d syscall bsd_%s() (%s)\n",
 						asid, bsd_syscalls[m_r[4] - 2000], machine().describe_context());
 				else
@@ -833,7 +833,7 @@ void mips1core_device_base::generate_exception(u32 exception, bool refill)
 			break;
 
 		default:
-			if ((m_r[2] > 1000) && (m_r[2] - 1000 < ARRAY_LENGTH(sysv_syscalls)) && sysv_syscalls[m_r[2] - 1000])
+			if ((m_r[2] > 1000) && (m_r[2] - 1000 < std::size(sysv_syscalls)) && sysv_syscalls[m_r[2] - 1000])
 				LOGMASKED(LOG_RISCOS, "asid %d syscall %s() (%s)\n", asid, sysv_syscalls[m_r[2] - 1000], machine().describe_context());
 			else
 				LOGMASKED(LOG_RISCOS, "asid %d syscall unknown %d (%s)\n", asid, m_r[2], machine().describe_context());
@@ -1245,7 +1245,7 @@ void mips1_device_base::device_start()
 	if (m_fcr0)
 	{
 		state_add(MIPS1_FCR31, "FCSR", m_fcr31);
-		for (unsigned i = 0; i < ARRAY_LENGTH(m_f); i++)
+		for (unsigned i = 0; i < std::size(m_f); i++)
 			state_add(MIPS1_F0 + i, util::string_format("F%d", i * 2).c_str(), m_f[i]);
 	}
 
@@ -1267,7 +1267,7 @@ void mips1_device_base::device_reset()
 	m_reset_time = total_cycles();
 
 	// initialize tlb mru index with identity mapping
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_tlb); i++)
+	for (unsigned i = 0; i < std::size(m_tlb); i++)
 	{
 		m_tlb_mru[TRANSLATE_READ][i] = i;
 		m_tlb_mru[TRANSLATE_WRITE][i] = i;
@@ -1979,7 +1979,7 @@ bool mips1_device_base::memory_translate(int spacenum, int intention, offs_t &ad
 	bool refill = !BIT(address, 31);
 	bool modify = false;
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_tlb); i++)
+	for (unsigned i = 0; i < std::size(m_tlb); i++)
 	{
 		unsigned const index = mru[i];
 		u32 const *const entry = m_tlb[index];

--- a/src/devices/cpu/mips/mips3drc.cpp
+++ b/src/devices/cpu/mips/mips3drc.cpp
@@ -120,7 +120,7 @@ inline void mips3_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 		if (m_regmap[regnum].is_int_register())
 			UML_DMOV(block, ireg(m_regmap[regnum].ireg() - REG_I0), mem(&m_core->r[regnum]));
 }
@@ -135,7 +135,7 @@ inline void mips3_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 		if (m_regmap[regnum].is_int_register())
 			UML_DMOV(block, mem(&m_core->r[regnum]), ireg(m_regmap[regnum].ireg() - REG_I0));
 }
@@ -174,7 +174,7 @@ void mips3_device::clear_fastram(uint32_t select_start)
 
 void mips3_device::add_fastram(offs_t start, offs_t end, uint8_t readonly, void *base)
 {
-	if (m_fastram_select < ARRAY_LENGTH(m_fastram))
+	if (m_fastram_select < std::size(m_fastram))
 	{
 		m_fastram[m_fastram_select].start = start;
 		m_fastram[m_fastram_select].end = end;
@@ -197,7 +197,7 @@ void mips3_device::add_fastram(offs_t start, offs_t end, uint8_t readonly, void 
 void mips3_device::mips3drc_add_hotspot(offs_t pc, uint32_t opcode, uint32_t cycles)
 {
 	if (!allow_drc()) return;
-	if (m_hotspot_select < ARRAY_LENGTH(m_hotspot))
+	if (m_hotspot_select < std::size(m_hotspot))
 	{
 		m_hotspot[m_hotspot_select].pc = pc;
 		m_hotspot[m_hotspot_select].opcode = opcode;

--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -225,7 +225,7 @@ void r4000_base_device::device_reset()
 	m_cp0[CP0_WatchHi] = 0;
 
 	// initialize tlb mru index with identity mapping
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_tlb); i++)
+	for (unsigned i = 0; i < std::size(m_tlb); i++)
 	{
 		m_tlb_mru[TRANSLATE_READ][i] = i;
 		m_tlb_mru[TRANSLATE_WRITE][i] = i;
@@ -1411,10 +1411,10 @@ u64 r4000_base_device::cp0_get(unsigned const reg)
 		{
 			u8 const wired = m_cp0[CP0_Wired] & 0x3f;
 
-			if (wired < ARRAY_LENGTH(m_tlb))
-				return ((total_cycles() - m_cp0_timer_zero) % (ARRAY_LENGTH(m_tlb) - wired) + wired) & 0x3f;
+			if (wired < std::size(m_tlb))
+				return ((total_cycles() - m_cp0_timer_zero) % (std::size(m_tlb) - wired) + wired) & 0x3f;
 			else
-				return ARRAY_LENGTH(m_tlb) - 1;
+				return std::size(m_tlb) - 1;
 		}
 		break;
 
@@ -1525,7 +1525,7 @@ void r4000_base_device::cp0_tlbr()
 {
 	u8 const index = m_cp0[CP0_Index] & 0x3f;
 
-	if (index < ARRAY_LENGTH(m_tlb))
+	if (index < std::size(m_tlb))
 	{
 		tlb_entry const &entry = m_tlb[index];
 
@@ -1538,7 +1538,7 @@ void r4000_base_device::cp0_tlbr()
 
 void r4000_base_device::cp0_tlbwi(u8 const index)
 {
-	if (index < ARRAY_LENGTH(m_tlb))
+	if (index < std::size(m_tlb))
 	{
 		tlb_entry &entry = m_tlb[index];
 
@@ -1563,9 +1563,9 @@ void r4000_base_device::cp0_tlbwi(u8 const index)
 void r4000_base_device::cp0_tlbwr()
 {
 	u8 const wired = m_cp0[CP0_Wired] & 0x3f;
-	u8 const unwired = ARRAY_LENGTH(m_tlb) - wired;
+	u8 const unwired = std::size(m_tlb) - wired;
 
-	u8 const index = (unwired > 0) ? ((total_cycles() - m_cp0_timer_zero) % unwired + wired) & 0x3f : (ARRAY_LENGTH(m_tlb) - 1);
+	u8 const index = (unwired > 0) ? ((total_cycles() - m_cp0_timer_zero) % unwired + wired) & 0x3f : (std::size(m_tlb) - 1);
 
 	cp0_tlbwi(index);
 }
@@ -1573,7 +1573,7 @@ void r4000_base_device::cp0_tlbwr()
 void r4000_base_device::cp0_tlbp()
 {
 	m_cp0[CP0_Index] = 0x80000000;
-	for (u8 index = 0; index < ARRAY_LENGTH(m_tlb); index++)
+	for (u8 index = 0; index < std::size(m_tlb); index++)
 	{
 		tlb_entry const &entry = m_tlb[index];
 
@@ -3615,7 +3615,7 @@ r4000_base_device::translate_result r4000_base_device::translate(int intention, 
 
 	bool invalid = false;
 	bool modify = false;
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_tlb); i++)
+	for (unsigned i = 0; i < std::size(m_tlb); i++)
 	{
 		unsigned const index = mru[i];
 		tlb_entry const &entry = m_tlb[index];

--- a/src/devices/cpu/nec/necdasm.cpp
+++ b/src/devices/cpu/nec/necdasm.cpp
@@ -1414,7 +1414,7 @@ void nec_disassembler::decode_opcode(std::ostream &stream, const NEC_I386_OPCODE
 
 		case GROUP:
 			handle_modrm( pc_base, pc, params );
-			for( i=0; i < ARRAY_LENGTH(group_op_table); i++ ) {
+			for( i=0; i < std::size(group_op_table); i++ ) {
 				if( strcmp(op->mnemonic, group_op_table[i].mnemonic) == 0 )
 				{
 					decode_opcode( stream, &group_op_table[i].opcode[MODRM_REG1], op1, pc_base, pc, opcodes, params );

--- a/src/devices/cpu/powerpc/ppccom.cpp
+++ b/src/devices/cpu/powerpc/ppccom.cpp
@@ -1919,7 +1919,7 @@ void ppc_device::ppccom_execute_mfdcr()
 	/* default handling */
 	if (m_dcr_read_func.isnull()) {
 		osd_printf_debug("DCR %03X read\n", m_core->param0);
-		if (m_core->param0 < ARRAY_LENGTH(m_dcr))
+		if (m_core->param0 < std::size(m_dcr))
 			m_core->param1 = m_dcr[m_core->param0];
 		else
 			m_core->param1 = 0;
@@ -2011,7 +2011,7 @@ void ppc_device::ppccom_execute_mtdcr()
 	/* default handling */
 	if (m_dcr_write_func.isnull()) {
 		osd_printf_debug("DCR %03X write = %08X\n", m_core->param0, m_core->param1);
-		if (m_core->param0 < ARRAY_LENGTH(m_dcr))
+		if (m_core->param0 < std::size(m_dcr))
 			m_dcr[m_core->param0] = m_core->param1;
 	} else {
 		m_dcr_write_func(m_core->param0,m_core->param1);
@@ -2662,7 +2662,7 @@ void ppc_device::ppc4xx_spu_rx_data(uint8_t data)
 	uint32_t new_rxin;
 
 	/* fail if we are going to overflow */
-	new_rxin = (m_spu.rxin + 1) % ARRAY_LENGTH(m_spu.rxbuffer);
+	new_rxin = (m_spu.rxin + 1) % std::size(m_spu.rxbuffer);
 	if (new_rxin == m_spu.rxout)
 		fatalerror("ppc4xx_spu_rx_data: buffer overrun!\n");
 
@@ -2741,7 +2741,7 @@ TIMER_CALLBACK_MEMBER( ppc_device::ppc4xx_spu_callback )
 
 			/* consume the byte and advance the out pointer */
 			rxbyte = m_spu.rxbuffer[m_spu.rxout];
-			m_spu.rxout = (m_spu.rxout + 1) % ARRAY_LENGTH(m_spu.rxbuffer);
+			m_spu.rxout = (m_spu.rxout + 1) % std::size(m_spu.rxbuffer);
 
 			/* if we're not full, copy data to the buffer and update the line status */
 			if (!(m_spu.regs[SPU4XX_LINE_STATUS] & 0x80))
@@ -2784,7 +2784,7 @@ uint8_t ppc4xx_device::ppc4xx_spu_r(offs_t offset)
 			break;
 
 		default:
-			if (offset < ARRAY_LENGTH(m_spu.regs))
+			if (offset < std::size(m_spu.regs))
 				result = m_spu.regs[offset];
 			break;
 	}
@@ -2848,7 +2848,7 @@ void ppc4xx_device::ppc4xx_spu_w(offs_t offset, uint8_t data)
 			break;
 
 		default:
-			if (offset < ARRAY_LENGTH(m_spu.regs))
+			if (offset < std::size(m_spu.regs))
 				m_spu.regs[offset] = data;
 			break;
 	}

--- a/src/devices/cpu/powerpc/ppcdrc.cpp
+++ b/src/devices/cpu/powerpc/ppcdrc.cpp
@@ -118,7 +118,7 @@ inline void ppc_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -137,7 +137,7 @@ void ppc_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -149,7 +149,7 @@ void ppc_device::save_fast_iregs(drcuml_block &block)
 
 inline void ppc_device::load_fast_fregs(drcuml_block &block)
 {
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_fdregmap); regnum++)
+	for (int regnum = 0; regnum < std::size(m_fdregmap); regnum++)
 	{
 		if (m_fdregmap[regnum].is_float_register())
 		{
@@ -160,7 +160,7 @@ inline void ppc_device::load_fast_fregs(drcuml_block &block)
 
 void ppc_device::save_fast_fregs(drcuml_block &block)
 {
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_fdregmap); regnum++)
+	for (int regnum = 0; regnum < std::size(m_fdregmap); regnum++)
 	{
 		if (m_fdregmap[regnum].is_float_register())
 		{
@@ -268,7 +268,7 @@ void ppc_device::ppcdrc_set_options(uint32_t options)
 
 void ppc_device::ppcdrc_add_fastram(offs_t start, offs_t end, uint8_t readonly, void *base)
 {
-	if (m_fastram_select < ARRAY_LENGTH(m_fastram))
+	if (m_fastram_select < std::size(m_fastram))
 	{
 		m_fastram[m_fastram_select].start = start;
 		m_fastram[m_fastram_select].end = end;
@@ -285,7 +285,7 @@ void ppc_device::ppcdrc_add_fastram(offs_t start, offs_t end, uint8_t readonly, 
 
 void ppc_device::ppcdrc_add_hotspot(offs_t pc, uint32_t opcode, uint32_t cycles)
 {
-	if (m_hotspot_select < ARRAY_LENGTH(m_hotspot))
+	if (m_hotspot_select < std::size(m_hotspot))
 	{
 		m_hotspot[m_hotspot_select].pc = pc;
 		m_hotspot[m_hotspot_select].opcode = opcode;

--- a/src/devices/cpu/romp/romp.cpp
+++ b/src/devices/cpu/romp/romp.cpp
@@ -63,7 +63,7 @@ void romp_device::device_start()
 	state_add(ROMP_SCR + ICS,  "ICS",  m_scr[ICS]);
 	state_add(ROMP_SCR + CS,   "CS",   m_scr[CS]);
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_gpr); i++)
+	for (unsigned i = 0; i < std::size(m_gpr); i++)
 		state_add(ROMP_GPR + i, util::string_format("R%d", i).c_str(), m_gpr[i]);
 
 	// register state for saving

--- a/src/devices/cpu/rsp/rspdrc.cpp
+++ b/src/devices/cpu/rsp/rspdrc.cpp
@@ -91,7 +91,7 @@ inline void rsp_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 		if (m_regmap[regnum].is_int_register())
 			UML_MOV(block, ireg(m_regmap[regnum].ireg() - REG_I0), mem(&m_rsp_state->r[regnum]));
 }
@@ -106,7 +106,7 @@ inline void rsp_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 		if (m_regmap[regnum].is_int_register())
 			UML_MOV(block, mem(&m_rsp_state->r[regnum]), ireg(m_regmap[regnum].ireg() - REG_I0));
 }

--- a/src/devices/cpu/sh/sh.cpp
+++ b/src/devices/cpu/sh/sh.cpp
@@ -2009,7 +2009,7 @@ void cfunc_printf_probe(void *param) { ((sh_common_execution *)param)->func_prin
 
 void sh_common_execution::sh2drc_add_fastram(offs_t start, offs_t end, uint8_t readonly, void *base)
 {
-	if (m_fastram_select < ARRAY_LENGTH(m_fastram))
+	if (m_fastram_select < std::size(m_fastram))
 	{
 		m_fastram[m_fastram_select].start = start;
 		m_fastram[m_fastram_select].end = end;
@@ -2051,7 +2051,7 @@ void sh_common_execution::alloc_handle(uml::code_handle *&handleptr, const char 
 
 void sh_common_execution::load_fast_iregs(drcuml_block &block)
 {
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (int regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -2068,7 +2068,7 @@ void sh_common_execution::load_fast_iregs(drcuml_block &block)
 
 void sh_common_execution::save_fast_iregs(drcuml_block &block)
 {
-	for (int regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (int regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -4293,6 +4293,6 @@ void sh_common_execution::sh2drc_add_pcflush(offs_t address)
 {
 	if (!allow_drc()) return;
 
-	if (m_pcfsel < ARRAY_LENGTH(m_pcflushes))
+	if (m_pcfsel < std::size(m_pcflushes))
 		m_pcflushes[m_pcfsel++] = address;
 }

--- a/src/devices/cpu/sharc/sharc.cpp
+++ b/src/devices/cpu/sharc/sharc.cpp
@@ -470,8 +470,6 @@ void adsp21062_device::external_dma_write(uint32_t address, uint64_t data)
 
 void adsp21062_device::device_start()
 {
-	int saveindex;
-
 	m_core = (sharc_internal_state *)m_cache.alloc_near(sizeof(sharc_internal_state));
 	memset(m_core, 0, sizeof(sharc_internal_state));
 
@@ -672,8 +670,8 @@ void adsp21062_device::device_start()
 	m_core->fp1 = 1.0f;
 
 	save_item(NAME(m_core->pc));
-	save_pointer(NAME(&m_core->r[0].r), ARRAY_LENGTH(m_core->r));
-	save_pointer(NAME(&m_core->reg_alt[0].r), ARRAY_LENGTH(m_core->reg_alt));
+	save_pointer(NAME(&m_core->r[0].r), std::size(m_core->r));
+	save_pointer(NAME(&m_core->reg_alt[0].r), std::size(m_core->reg_alt));
 	save_item(NAME(m_core->mrf));
 	save_item(NAME(m_core->mrb));
 
@@ -709,18 +707,15 @@ void adsp21062_device::device_start()
 	save_item(NAME(m_core->dag2_alt.b));
 	save_item(NAME(m_core->dag2_alt.l));
 
-	for (saveindex = 0; saveindex < ARRAY_LENGTH(m_core->dma); saveindex++)
-	{
-		save_item(NAME(m_core->dma[saveindex].control), saveindex);
-		save_item(NAME(m_core->dma[saveindex].int_index), saveindex);
-		save_item(NAME(m_core->dma[saveindex].int_modifier), saveindex);
-		save_item(NAME(m_core->dma[saveindex].int_count), saveindex);
-		save_item(NAME(m_core->dma[saveindex].chain_ptr), saveindex);
-		save_item(NAME(m_core->dma[saveindex].gen_purpose), saveindex);
-		save_item(NAME(m_core->dma[saveindex].ext_index), saveindex);
-		save_item(NAME(m_core->dma[saveindex].ext_modifier), saveindex);
-		save_item(NAME(m_core->dma[saveindex].ext_count), saveindex);
-	}
+	save_item(STRUCT_MEMBER(m_core->dma, control));
+	save_item(STRUCT_MEMBER(m_core->dma, int_index));
+	save_item(STRUCT_MEMBER(m_core->dma, int_modifier));
+	save_item(STRUCT_MEMBER(m_core->dma, int_count));
+	save_item(STRUCT_MEMBER(m_core->dma, chain_ptr));
+	save_item(STRUCT_MEMBER(m_core->dma, gen_purpose));
+	save_item(STRUCT_MEMBER(m_core->dma, ext_index));
+	save_item(STRUCT_MEMBER(m_core->dma, ext_modifier));
+	save_item(STRUCT_MEMBER(m_core->dma, ext_count));
 
 	save_item(NAME(m_core->mode1));
 	save_item(NAME(m_core->mode2));
@@ -737,11 +732,8 @@ void adsp21062_device::device_start()
 	save_item(NAME(m_core->syscon));
 	save_item(NAME(m_core->sysstat));
 
-	for (saveindex = 0; saveindex < ARRAY_LENGTH(m_core->status_stack); saveindex++)
-	{
-		save_item(NAME(m_core->status_stack[saveindex].mode1), saveindex);
-		save_item(NAME(m_core->status_stack[saveindex].astat), saveindex);
-	}
+	save_item(STRUCT_MEMBER(m_core->status_stack, mode1));
+	save_item(STRUCT_MEMBER(m_core->status_stack, astat));
 	save_item(NAME(m_core->status_stkp));
 
 	save_item(NAME(m_core->px));
@@ -754,19 +746,16 @@ void adsp21062_device::device_start()
 	save_item(NAME(m_core->irq_pending));
 	save_item(NAME(m_core->active_irq_num));
 
-	for (saveindex = 0; saveindex < ARRAY_LENGTH(m_core->dma_op); saveindex++)
-	{
-		save_item(NAME(m_core->dma_op[saveindex].src), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].dst), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].chain_ptr), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].src_modifier), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].dst_modifier), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].src_count), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].dst_count), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].pmode), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].chained_direction), saveindex);
-		save_item(NAME(m_core->dma_op[saveindex].active), saveindex);
-	}
+	save_item(STRUCT_MEMBER(m_core->dma_op, src));
+	save_item(STRUCT_MEMBER(m_core->dma_op, dst));
+	save_item(STRUCT_MEMBER(m_core->dma_op, chain_ptr));
+	save_item(STRUCT_MEMBER(m_core->dma_op, src_modifier));
+	save_item(STRUCT_MEMBER(m_core->dma_op, dst_modifier));
+	save_item(STRUCT_MEMBER(m_core->dma_op, src_count));
+	save_item(STRUCT_MEMBER(m_core->dma_op, dst_count));
+	save_item(STRUCT_MEMBER(m_core->dma_op, pmode));
+	save_item(STRUCT_MEMBER(m_core->dma_op, chained_direction));
+	save_item(STRUCT_MEMBER(m_core->dma_op, active));
 
 	save_item(NAME(m_core->dma_status));
 

--- a/src/devices/cpu/sharc/sharcdrc.cpp
+++ b/src/devices/cpu/sharc/sharcdrc.cpp
@@ -263,7 +263,7 @@ inline void adsp21062_device::load_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{
@@ -282,7 +282,7 @@ void adsp21062_device::save_fast_iregs(drcuml_block &block)
 {
 	int regnum;
 
-	for (regnum = 0; regnum < ARRAY_LENGTH(m_regmap); regnum++)
+	for (regnum = 0; regnum < std::size(m_regmap); regnum++)
 	{
 		if (m_regmap[regnum].is_int_register())
 		{

--- a/src/devices/cpu/sparc/sparc.cpp
+++ b/src/devices/cpu/sparc/sparc.cpp
@@ -49,7 +49,7 @@ sparc_base_device::sparc_base_device(const machine_config &mconfig, device_type 
 	m_debugger_config = address_space_config("debug", ENDIANNESS_BIG, 32, 32);
 	for (int i = 0; i < 0x10; i++)
 	{
-		snprintf(asi_buf, ARRAY_LENGTH(asi_buf), "asi%X", i);
+		snprintf(asi_buf, std::size(asi_buf), "asi%X", i);
 		m_asi_config[i] = address_space_config(asi_buf, ENDIANNESS_BIG, 32, 32);
 	}
 }
@@ -417,7 +417,7 @@ void sparc_base_device::device_reset()
 	m_fp_exception = 0;
 	m_fp_exception_pending = 0;
 	m_fpr_pending = 0;
-	m_pending_fpr = ARRAY_LENGTH(m_fpr);
+	m_pending_fpr = std::size(m_fpr);
 	m_fpu_sequence_err = 0;
 	m_cp_disabled = 0;
 	m_cp_exception = 0;
@@ -4834,7 +4834,7 @@ inline void sparc_base_device::execute_step()
 			m_fpr_pending--;
 			if (!m_fpr_pending)
 			{
-				m_pending_fpr = ARRAY_LENGTH(m_fpr);
+				m_pending_fpr = std::size(m_fpr);
 				if (m_fp_exception_pending)
 				{
 					m_fp_exception_pending = false;

--- a/src/devices/cpu/tms32031/tms32031.cpp
+++ b/src/devices/cpu/tms32031/tms32031.cpp
@@ -432,7 +432,7 @@ tms32032_device::tms32032_device(const machine_config &mconfig, const char *tag,
 tms3203x_device::~tms3203x_device()
 {
 #if (TMS_3203X_LOG_OPCODE_USAGE)
-	for (int i = 0; i < ARRAY_LENGTH(m_hits); i++)
+	for (int i = 0; i < std::size(m_hits); i++)
 		if (m_hits[i] != 0)
 			printf("%10d - %03X.%X\n", m_hits[i], i / 4, i % 4);
 #endif

--- a/src/devices/cpu/tms34010/tms34010.cpp
+++ b/src/devices/cpu/tms34010/tms34010.cpp
@@ -755,7 +755,7 @@ void tms340x0_device::device_start()
 	save_item(NAME(m_convmp));
 	save_item(NAME(m_pixelshift));
 	save_item(NAME(m_gfxcycles));
-	save_pointer(NAME(&m_regs[0].reg), ARRAY_LENGTH(m_regs));
+	save_pointer(NAME(&m_regs[0].reg), std::size(m_regs));
 
 	set_icountptr(m_icount);
 }

--- a/src/devices/cpu/tms9900/tms9995.cpp
+++ b/src/devices/cpu/tms9900/tms9995.cpp
@@ -383,7 +383,7 @@ void tms9995_device::state_string_export(const device_state_entry &entry, std::s
 {
 	static char const statestr[] = "LAECOPX-----IIII";
 	char flags[17];
-	memset(flags, 0x00, ARRAY_LENGTH(flags));
+	std::fill(std::begin(flags), std::end(flags), 0x00);
 	uint16_t val = 0x8000;
 	if (entry.index()==STATE_GENFLAGS)
 	{

--- a/src/devices/cpu/uml.cpp
+++ b/src/devices/cpu/uml.cpp
@@ -766,7 +766,7 @@ void uml::instruction::validate()
 	}
 
 	// make sure we aren't missing any parameters
-	if (m_numparams < ARRAY_LENGTH(opinfo.param))
+	if (m_numparams < std::size(opinfo.param))
 		assert(opinfo.param[m_numparams].typemask == 0);
 #endif // MAME_DEBUG
 }

--- a/src/devices/cpu/unsp/unsp.cpp
+++ b/src/devices/cpu/unsp/unsp.cpp
@@ -309,7 +309,7 @@ void unsp_20_device::device_start()
 
 void unsp_device::device_reset()
 {
-	for (int i = 0; i < ARRAY_LENGTH(m_core->m_r); i++)
+	for (int i = 0; i < std::size(m_core->m_r); i++)
 	{
 		if (i < m_numregs)
 			m_core->m_r[i] = 0;

--- a/src/devices/imagedev/cassette.cpp
+++ b/src/devices/imagedev/cassette.cpp
@@ -364,7 +364,7 @@ std::string cassette_image_device::call_display()
 		cassette_state uistate = get_state() & CASSETTE_MASK_UISTATE;
 
 		// choose which frame of the animation we are at
-		int n = (int(position) / ANIMATION_FPS) % ARRAY_LENGTH(shapes);
+		int n = (int(position) / ANIMATION_FPS) % std::size(shapes);
 
 		// play or record
 		const char *status_icon = (uistate == CASSETTE_PLAY)

--- a/src/devices/imagedev/flopdrv.cpp
+++ b/src/devices/imagedev/flopdrv.cpp
@@ -456,7 +456,7 @@ image_init_result legacy_floppy_image_device::internal_floppy_device_load(bool i
 	return image_init_result::PASS;
 
 error:
-	for (i = 0; i < ARRAY_LENGTH(errmap); i++)
+	for (i = 0; i < std::size(errmap); i++)
 	{
 		if (err == errmap[i].ferr)
 			seterror(errmap[i].ierr, errmap[i].message);

--- a/src/devices/machine/53c810.cpp
+++ b/src/devices/machine/53c810.cpp
@@ -723,7 +723,7 @@ unsigned lsi53c810_device::lsi53c810_dasm(char *buf, uint32_t pc)
 		buf += sprintf(buf, "%s ", op_mnemonic);
 		need_cojunction = false;
 
-		for (i = 0; i < ARRAY_LENGTH(flags); i++)
+		for (i = 0; i < std::size(flags); i++)
 		{
 			if (op & flags[i].flag)
 			{

--- a/src/devices/machine/64h156.cpp
+++ b/src/devices/machine/64h156.cpp
@@ -197,7 +197,7 @@ bool c64h156_device::write_next_bit(bool bit, const attotime &limit)
 	if(etime > limit)
 		return true;
 
-	if(bit && cur_live.write_position < ARRAY_LENGTH(cur_live.write_buffer))
+	if(bit && cur_live.write_position < std::size(cur_live.write_buffer))
 		cur_live.write_buffer[cur_live.write_position++] = cur_live.tm - m_period;
 
 	LOG("%s write bit %u (%u)\n", cur_live.tm.as_string(), cur_live.bit_counter, bit);

--- a/src/devices/machine/68307tmu.cpp
+++ b/src/devices/machine/68307tmu.cpp
@@ -152,7 +152,7 @@ uint16_t m68307_cpu_device::m68307_timer::read_tcn(uint16_t mem_mask, int which)
 
 void m68307_cpu_device::m68307_timer::write_ter(uint16_t data, uint16_t mem_mask, int which)
 {
-	assert(which >= 0 && which < ARRAY_LENGTH(singletimer));
+	assert(which >= 0 && which < std::size(singletimer));
 	single_timer* tptr = &singletimer[which];
 	if (data & 0x2)
 	{
@@ -167,7 +167,7 @@ void m68307_cpu_device::m68307_timer::write_ter(uint16_t data, uint16_t mem_mask
 void m68307_cpu_device::m68307_timer::write_tmr(uint16_t data, uint16_t mem_mask, int which)
 {
 	m68307_cpu_device* m68k = parent;
-	assert(which >= 0 && which < ARRAY_LENGTH(singletimer));
+	assert(which >= 0 && which < std::size(singletimer));
 	single_timer* tptr = &singletimer[which];
 
 	COMBINE_DATA(&tptr->regs[m68307TIMER_TMR]);
@@ -216,7 +216,7 @@ void m68307_cpu_device::m68307_timer::write_tmr(uint16_t data, uint16_t mem_mask
 
 void m68307_cpu_device::m68307_timer::write_trr(uint16_t data, uint16_t mem_mask, int which)
 {
-	assert(which >= 0 && which < ARRAY_LENGTH(singletimer));
+	assert(which >= 0 && which < std::size(singletimer));
 	single_timer* tptr = &singletimer[which];
 
 	COMBINE_DATA(&tptr->regs[m68307TIMER_TRR]);
@@ -248,7 +248,7 @@ void m68307_cpu_device::m68307_timer::reset()
 
 bool m68307_cpu_device::m68307_timer::timer_int_pending(int which) const
 {
-	assert(which >= 0 && which < ARRAY_LENGTH(singletimer));
+	assert(which >= 0 && which < std::size(singletimer));
 	const single_timer* tptr = &singletimer[which];
 
 	return BIT(tptr->regs[m68307TIMER_TER], 1) && BIT(tptr->regs[m68307TIMER_TMR], 4);

--- a/src/devices/machine/am2901b.cpp
+++ b/src/devices/machine/am2901b.cpp
@@ -216,13 +216,13 @@ void am2901b_device::disassemble()
 	};
 
 	char dasm_buf[64];
-	int buf_idx = snprintf(dasm_buf, ARRAY_LENGTH(dasm_buf), "%s %s", s_func_table[(m_i >> 3) & 7], s_dst_table[(m_i >> 6) & 7]);
+	int buf_idx = snprintf(dasm_buf, std::size(dasm_buf), "%s %s", s_func_table[(m_i >> 3) & 7], s_dst_table[(m_i >> 6) & 7]);
 	while (buf_idx < 12)
 	{
 		dasm_buf[buf_idx] = ' ';
 		buf_idx++;
 	}
-	snprintf(dasm_buf + buf_idx, ARRAY_LENGTH(dasm_buf) - 12, "%c,%c", s_r_table[m_i & 7], s_s_table[m_i & 7]);
+	snprintf(dasm_buf + buf_idx, std::size(dasm_buf) - 12, "%c,%c", s_r_table[m_i & 7], s_s_table[m_i & 7]);
 
 	LOG("%s: %s\n", machine().describe_context(), dasm_buf);
 }

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -629,7 +629,7 @@ bool amiga_fdc_device::pll_t::write_next_bit(bool bit, attotime &tm, floppy_imag
 		uint16_t pre_counter = counter;
 		counter += increment;
 		if(bit && !(pre_counter & 0x400) && (counter & 0x400))
-			if(write_position < ARRAY_LENGTH(write_buffer))
+			if(write_position < std::size(write_buffer))
 				write_buffer[write_position++] = etime;
 		slot++;
 		tm = etime;

--- a/src/devices/machine/appldriv.cpp
+++ b/src/devices/machine/appldriv.cpp
@@ -233,7 +233,7 @@ static uint8_t apple525_process_byte(device_t *img, int write_value)
 	}
 
 	disk->position++;
-	disk->position %= ARRAY_LENGTH(disk->track_data);
+	disk->position %= std::size(disk->track_data);
 
 	/* when writing; save the current track after every full sector write */
 	if ((write_value >= 0) && ((disk->position % APPLE2_NIBBLE_SIZE) == 0))

--- a/src/devices/machine/eepromser.cpp
+++ b/src/devices/machine/eepromser.cpp
@@ -331,7 +331,7 @@ void eeprom_serial_base_device::set_state(eeprom_state newstate)
 		{ STATE_WAIT_FOR_COMPLETION, "WAIT_FOR_COMPLETION" },
 	};
 	const char *newstate_string = "UNKNOWN";
-	for (int index = 0; index < ARRAY_LENGTH(s_state_names); index++)
+	for (int index = 0; index < std::size(s_state_names); index++)
 		if (s_state_names[index].state == newstate)
 			newstate_string = s_state_names[index].string;
 	LOG2("New state: %s\n", newstate_string);
@@ -484,7 +484,7 @@ void eeprom_serial_base_device::execute_command()
 		{ COMMAND_ERASEALL, "Execute command:ERASEALL\n" },
 	};
 	const char *command_string = s_command_names[0].string;
-	for (int index = 0; index < ARRAY_LENGTH(s_command_names); index++)
+	for (int index = 0; index < std::size(s_command_names); index++)
 		if (s_command_names[index].command == m_command)
 			command_string = s_command_names[index].string;
 	LOG1(command_string, m_address);
@@ -565,7 +565,7 @@ void eeprom_serial_base_device::execute_write_command()
 		{ COMMAND_WRITEALL, "Execute write command: WRITEALL (%X) = 0x%X\n" },
 	};
 	const char *command_string = "UNKNOWN";
-	for (int index = 0; index < ARRAY_LENGTH(s_command_names); index++)
+	for (int index = 0; index < std::size(s_command_names); index++)
 		if (s_command_names[index].command == m_command)
 			command_string = s_command_names[index].string;
 	LOG1(command_string, m_address, m_shift_register);
@@ -807,7 +807,7 @@ void eeprom_serial_x24c44_device::execute_command()
 		{ COMMAND_COPY_RAM_TO_EEPROM, "Execute command:COPY_RAM_TO_EEPROM\n" },
 	};
 	const char *command_string = s_command_names[0].string;
-	for (int index = 0; index < ARRAY_LENGTH(s_command_names); index++)
+	for (int index = 0; index < std::size(s_command_names); index++)
 		if (s_command_names[index].command == m_command)
 			command_string = s_command_names[index].string;
 	LOG1(command_string, m_address);

--- a/src/devices/machine/fdc_pll.cpp
+++ b/src/devices/machine/fdc_pll.cpp
@@ -127,7 +127,7 @@ bool fdc_pll_t::write_next_bit(bool bit, attotime &tm, floppy_image_device *flop
 	if(etime > limit)
 		return true;
 
-	if(bit && write_position < ARRAY_LENGTH(write_buffer))
+	if(bit && write_position < std::size(write_buffer))
 		write_buffer[write_position++] = ctime + period/2;
 
 	tm = etime;

--- a/src/devices/machine/gt64xxx.cpp
+++ b/src/devices/machine/gt64xxx.cpp
@@ -243,10 +243,8 @@ void gt64xxx_device::device_start()
 	save_item(NAME(m_cpu_stalled_mem_mask));
 	save_item(NAME(m_prev_addr));
 	save_item(NAME(m_reg));
-	for (int i = 0; i < ARRAY_LENGTH(m_timer); i++) {
-		save_item(NAME(m_timer[i].active), i);
-		save_item(NAME(m_timer[i].count), i);
-	}
+	save_item(STRUCT_MEMBER(m_timer, active));
+	save_item(STRUCT_MEMBER(m_timer, count));
 	save_item(NAME(m_dma_active));
 	// m_ram[4]
 	save_pointer(NAME(m_ram[0].data()), m_simm_size[0] / 4);

--- a/src/devices/machine/i8279.cpp
+++ b/src/devices/machine/i8279.cpp
@@ -298,7 +298,7 @@ void i8279_device::timer_mainloop()
 	{
 		u8 rl = m_in_rl_cb(0) ^ 0xff;     // inverted
 		u8 addr = m_scanner & 7;
-		assert(addr < ARRAY_LENGTH(m_s_ram));
+		assert(addr < std::size(m_s_ram));
 
 		// see if key still down from last time
 		u8 keys_down = rl & ~m_s_ram[addr];
@@ -444,7 +444,7 @@ u8 i8279_device::data_r()
 	if (sensor_mode)
 	{
 	// read sensor ram
-		assert(m_s_ram_ptr < ARRAY_LENGTH(m_s_ram));
+		assert(m_s_ram_ptr < std::size(m_s_ram));
 		data = m_s_ram[m_s_ram_ptr];
 		if (!machine().side_effects_disabled())
 		{

--- a/src/devices/machine/keyboard.ipp
+++ b/src/devices/machine/keyboard.ipp
@@ -106,8 +106,8 @@ void device_matrix_keyboard_interface<ROW_COUNT>::typematic_stop()
 template <uint8_t ROW_COUNT>
 TIMER_CALLBACK_MEMBER(device_matrix_keyboard_interface<ROW_COUNT>::scan_row)
 {
-	assert(m_next_row < ARRAY_LENGTH(m_key_rows));
-	assert(m_next_row < ARRAY_LENGTH(m_key_states));
+	assert(m_next_row < std::size(m_key_rows));
+	assert(m_next_row < std::size(m_key_states));
 
 	will_scan_row(m_next_row);
 
@@ -128,7 +128,7 @@ TIMER_CALLBACK_MEMBER(device_matrix_keyboard_interface<ROW_COUNT>::scan_row)
 		}
 	}
 
-	m_next_row = (m_next_row + 1) % ARRAY_LENGTH(m_key_rows);
+	m_next_row = (m_next_row + 1) % std::size(m_key_rows);
 	if (m_next_row == 0)
 		scan_complete();
 }

--- a/src/devices/machine/laserdsc.cpp
+++ b/src/devices/machine/laserdsc.cpp
@@ -201,7 +201,7 @@ uint32_t laserdisc_device::screen_update(screen_device &screen, bitmap_rgb32 &bi
 		}
 
 		// swap to the next bitmap
-		m_overindex = (m_overindex + 1) % ARRAY_LENGTH(m_overbitmap);
+		m_overindex = (m_overindex + 1) % std::size(m_overbitmap);
 	}
 	return 0;
 }
@@ -870,7 +870,7 @@ laserdisc_device::frame_data &laserdisc_device::current_frame()
 	// determine the most recent live set of frames
 	frame_data *frame = &m_frame[m_videoindex];
 	if (frame->m_numfields < 2)
-		frame = &m_frame[(m_videoindex + ARRAY_LENGTH(m_frame) - 1) % ARRAY_LENGTH(m_frame)];
+		frame = &m_frame[(m_videoindex + std::size(m_frame) - 1) % std::size(m_frame)];
 	return *frame;
 }
 
@@ -906,7 +906,7 @@ void laserdisc_device::read_track_data()
 	if ((vbidata.line1718 & VBI_MASK_CAV_PICTURE) == VBI_CODE_CAV_PICTURE)
 	{
 		if (frame->m_numfields >= 2)
-			m_videoindex = (m_videoindex + 1) % ARRAY_LENGTH(m_frame);
+			m_videoindex = (m_videoindex + 1) % std::size(m_frame);
 		frame = &m_frame[m_videoindex];
 		frame->m_numfields = 0;
 	}

--- a/src/devices/machine/ldv1000.cpp
+++ b/src/devices/machine/ldv1000.cpp
@@ -392,7 +392,7 @@ uint8_t pioneer_ldv1000_device::z80_decoder_display_port_r(offs_t offset)
 		if (m_portselect == 4)
 		{
 			m_vbiready = false;
-			result = m_vbi[m_vbiindex++ % ARRAY_LENGTH(m_vbi)];
+			result = m_vbi[m_vbiindex++ % std::size(m_vbi)];
 		}
 	}
 	return result;

--- a/src/devices/machine/ldvp931.cpp
+++ b/src/devices/machine/ldvp931.cpp
@@ -233,7 +233,7 @@ void philips_22vp931_device::device_timer(emu_timer &timer, device_timer_id id, 
 			m_fromcontroller_pending = true;
 
 			// track the commands for debugging purposes
-			if (m_cmdcount < ARRAY_LENGTH(m_cmdbuf))
+			if (m_cmdcount < std::size(m_cmdbuf))
 			{
 				m_cmdbuf[m_cmdcount++ % 3] = param;
 				if (LOG_COMMANDS && m_cmdcount % 3 == 0)

--- a/src/devices/machine/ns32081.cpp
+++ b/src/devices/machine/ns32081.cpp
@@ -108,7 +108,7 @@ void ns32081_device::device_start()
 void ns32081_device::device_reset()
 {
 	m_fsr = 0;
-	std::fill_n(&m_f[0], ARRAY_LENGTH(m_f), 0);
+	std::fill(std::begin(m_f), std::end(m_f), 0);
 
 	m_state = IDLE;
 }

--- a/src/devices/machine/nscsi_bus.cpp
+++ b/src/devices/machine/nscsi_bus.cpp
@@ -544,7 +544,7 @@ bool nscsi_full_device::scsi_command_done(uint8_t command, uint8_t length)
 
 nscsi_full_device::control *nscsi_full_device::buf_control_push()
 {
-	if(buf_control_wpos == int(ARRAY_LENGTH(buf_control)))
+	if(buf_control_wpos == int(std::size(buf_control)))
 		throw emu_fatalerror("%s: buf_control overflow\n", tag());
 
 	control *c = buf_control + buf_control_wpos;

--- a/src/devices/machine/pci.cpp
+++ b/src/devices/machine/pci.cpp
@@ -104,9 +104,7 @@ void pci_device::device_start()
 	bank_count = 0;
 	bank_reg_count = 0;
 
-	for (int i = 0; i < ARRAY_LENGTH(bank_infos); i++) {
-		save_item(NAME(bank_infos[i].adr), i);
-	}
+	save_item(STRUCT_MEMBER(bank_infos, adr));
 	save_item(NAME(command));
 	save_item(NAME(command_mask));
 	save_item(NAME(status));

--- a/src/devices/machine/pckeybrd.cpp
+++ b/src/devices/machine/pckeybrd.cpp
@@ -315,10 +315,10 @@ void pc_keyboard_device::device_start()
 	save_item(NAME(m_on));
 	save_item(NAME(m_head));
 	save_item(NAME(m_tail));
-	save_pointer(NAME(m_queue), ARRAY_LENGTH(m_queue));
-	save_pointer(NAME(m_make), ARRAY_LENGTH(m_make));
+	save_item(NAME(m_queue));
+	save_item(NAME(m_make));
 
-	memset(m_make, 0, sizeof(m_make));
+	std::fill(std::begin(m_make), std::end(m_make), 0);
 
 	machine().natkeyboard().configure(
 		ioport_queue_chars_delegate(&pc_keyboard_device::queue_chars, this),
@@ -383,7 +383,7 @@ void pc_keyboard_device::queue_insert(uint8_t data)
 
 	m_queue[m_head] = data;
 	m_head++;
-	m_head %= ARRAY_LENGTH(m_queue);
+	m_head %= std::size(m_queue);
 }
 
 
@@ -392,7 +392,7 @@ int pc_keyboard_device::queue_size(void)
 	int queue_size;
 	queue_size = m_head - m_tail;
 	if (queue_size < 0)
-		queue_size += ARRAY_LENGTH(m_queue);
+		queue_size += std::size(m_queue);
 	return queue_size;
 }
 
@@ -626,7 +626,7 @@ uint8_t pc_keyboard_device::read()
 		logerror("read(): Keyboard Read 0x%02x\n",data);
 
 	m_tail++;
-	m_tail %= ARRAY_LENGTH(m_queue);
+	m_tail %= std::size(m_queue);
 	return data;
 }
 

--- a/src/devices/machine/rtc4543.cpp
+++ b/src/devices/machine/rtc4543.cpp
@@ -268,7 +268,7 @@ READ_LINE_MEMBER( rtc4543_device::data_r )
 
 void rtc4543_device::load_bit(int reg)
 {
-	assert(reg < ARRAY_LENGTH(m_regs));
+	assert(reg < std::size(m_regs));
 	int bit = m_curbit & 7;
 
 	// reload data?
@@ -289,7 +289,7 @@ void rtc4543_device::load_bit(int reg)
 
 void rtc4543_device::store_bit(int reg)
 {
-	assert(reg < ARRAY_LENGTH(m_regs));
+	assert(reg < std::size(m_regs));
 	int bit = m_curbit & 7;
 
 	m_regs[reg] &= ~(1 << bit);

--- a/src/devices/machine/s3c24xx.hxx
+++ b/src/devices/machine/s3c24xx.hxx
@@ -1919,7 +1919,7 @@ void S3C24_CLASS_NAME::s3c24xx_gpio_w(offs_t offset, uint32_t data, uint32_t mem
 
 uint32_t S3C24_CLASS_NAME::s3c24xx_memcon_r(offs_t offset, uint32_t mem_mask)
 {
-	assert(offset < ARRAY_LENGTH(m_memcon.regs.data));
+	assert(offset < std::size(m_memcon.regs.data));
 	uint32_t data = m_memcon.regs.data[offset];
 	LOGMASKED(LOG_MEMCON, "%s: memcon read: %08x = %08x & %08x\n", machine().describe_context(), S3C24XX_BASE_MEMCON + (offset << 2), data, mem_mask);
 	return data;

--- a/src/devices/machine/sa1110.cpp
+++ b/src/devices/machine/sa1110.cpp
@@ -429,7 +429,7 @@ void sa1110_periphs_device::rcv_complete()
 void sa1110_periphs_device::tra_complete()
 {
 	m_uart_regs.tx_fifo_count--;
-	m_uart_regs.tx_fifo_read_idx = (m_uart_regs.tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_uart_regs.tx_fifo);
+	m_uart_regs.tx_fifo_read_idx = (m_uart_regs.tx_fifo_read_idx + 1) % std::size(m_uart_regs.tx_fifo);
 	m_uart_regs.utsr1 |= (1 << UTSR1_TNF_BIT);
 
 	if (m_uart_regs.tx_fifo_count)
@@ -463,7 +463,7 @@ void sa1110_periphs_device::uart_update_eif_status()
 	bool has_error = false;
 	for (int i = 0; i < 4 && i < m_uart_regs.rx_fifo_count; i++)
 	{
-		const int read_idx = (m_uart_regs.rx_fifo_read_idx + i) % ARRAY_LENGTH(m_uart_regs.rx_fifo);
+		const int read_idx = (m_uart_regs.rx_fifo_read_idx + i) % std::size(m_uart_regs.rx_fifo);
 		if (m_uart_regs.rx_fifo[read_idx] & 0x700)
 		{
 			has_error = true;
@@ -485,7 +485,7 @@ void sa1110_periphs_device::uart_update_eif_status()
 
 void sa1110_periphs_device::uart_write_receive_fifo(uint16_t data_and_flags)
 {
-	if (m_uart_regs.rx_fifo_count >= ARRAY_LENGTH(m_uart_regs.rx_fifo))
+	if (m_uart_regs.rx_fifo_count >= std::size(m_uart_regs.rx_fifo))
 		return;
 	if (!BIT(m_uart_regs.utcr[3], UTCR3_RXE_BIT))
 		return;
@@ -493,7 +493,7 @@ void sa1110_periphs_device::uart_write_receive_fifo(uint16_t data_and_flags)
 	// fill FIFO entry
 	m_uart_regs.rx_fifo[m_uart_regs.rx_fifo_write_idx] = data_and_flags;
 	m_uart_regs.rx_fifo_count++;
-	m_uart_regs.rx_fifo_write_idx = (m_uart_regs.rx_fifo_write_idx + 1) % ARRAY_LENGTH(m_uart_regs.rx_fifo);
+	m_uart_regs.rx_fifo_write_idx = (m_uart_regs.rx_fifo_write_idx + 1) % std::size(m_uart_regs.rx_fifo);
 
 	// update error flags
 	uart_update_eif_status();
@@ -507,7 +507,7 @@ uint8_t sa1110_periphs_device::uart_read_receive_fifo()
 	const uint8_t data = m_uart_regs.rx_fifo[m_uart_regs.rx_fifo_read_idx];
 	if (m_uart_regs.rx_fifo_count)
 	{
-		m_uart_regs.rx_fifo_read_idx = (m_uart_regs.rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_uart_regs.rx_fifo);
+		m_uart_regs.rx_fifo_read_idx = (m_uart_regs.rx_fifo_read_idx + 1) % std::size(m_uart_regs.rx_fifo);
 		m_uart_regs.rx_fifo_count--;
 		if (m_uart_regs.rx_fifo_count)
 		{
@@ -545,7 +545,7 @@ void sa1110_periphs_device::uart_check_rx_fifo_service()
 
 void sa1110_periphs_device::uart_write_transmit_fifo(uint8_t data)
 {
-	if (m_uart_regs.tx_fifo_count >= ARRAY_LENGTH(m_uart_regs.tx_fifo))
+	if (m_uart_regs.tx_fifo_count >= std::size(m_uart_regs.tx_fifo))
 		return;
 	if (!BIT(m_uart_regs.utcr[3], UTCR3_TXE_BIT))
 		return;
@@ -560,7 +560,7 @@ void sa1110_periphs_device::uart_write_transmit_fifo(uint8_t data)
 	// fill FIFO entry
 	m_uart_regs.tx_fifo[m_uart_regs.tx_fifo_write_idx] = data;
 	m_uart_regs.tx_fifo_count++;
-	m_uart_regs.tx_fifo_write_idx = (m_uart_regs.tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_uart_regs.tx_fifo);
+	m_uart_regs.tx_fifo_write_idx = (m_uart_regs.tx_fifo_write_idx + 1) % std::size(m_uart_regs.tx_fifo);
 
 	// update FIFO-service interrupt
 	uart_check_tx_fifo_service();
@@ -568,7 +568,7 @@ void sa1110_periphs_device::uart_write_transmit_fifo(uint8_t data)
 
 void sa1110_periphs_device::uart_check_tx_fifo_service()
 {
-	if (m_uart_regs.tx_fifo_count < ARRAY_LENGTH(m_uart_regs.tx_fifo))
+	if (m_uart_regs.tx_fifo_count < std::size(m_uart_regs.tx_fifo))
 		m_uart_regs.utsr1 |= (1 << UTSR1_TNF_BIT);
 	else
 		m_uart_regs.utsr1 &= ~(1 << UTSR1_TNF_BIT);
@@ -808,7 +808,7 @@ TIMER_CALLBACK_MEMBER(sa1110_periphs_device::mcp_audio_tx_callback)
 	if (m_mcp_regs.audio_tx_fifo_count)
 	{
 		m_mcp_regs.audio_tx_fifo_count--;
-		m_mcp_regs.audio_tx_fifo_read_idx = (m_mcp_regs.audio_tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_mcp_regs.audio_tx_fifo);
+		m_mcp_regs.audio_tx_fifo_read_idx = (m_mcp_regs.audio_tx_fifo_read_idx + 1) % std::size(m_mcp_regs.audio_tx_fifo);
 
 		m_mcp_regs.mcsr &= ~(1 << MCSR_ATU_BIT);
 		m_mcp_irqs->in_w<MCP_AUDIO_UNDERRUN>(0);
@@ -833,7 +833,7 @@ TIMER_CALLBACK_MEMBER(sa1110_periphs_device::mcp_telecom_tx_callback)
 	if (m_mcp_regs.telecom_tx_fifo_count)
 	{
 		m_mcp_regs.telecom_tx_fifo_count--;
-		m_mcp_regs.telecom_tx_fifo_read_idx = (m_mcp_regs.telecom_tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_mcp_regs.telecom_tx_fifo);
+		m_mcp_regs.telecom_tx_fifo_read_idx = (m_mcp_regs.telecom_tx_fifo_read_idx + 1) % std::size(m_mcp_regs.telecom_tx_fifo);
 
 		m_mcp_regs.mcsr &= ~(1 << MCSR_TTU_BIT);
 		m_mcp_irqs->in_w<MCP_TELECOM_UNDERRUN>(0);
@@ -853,7 +853,7 @@ uint16_t sa1110_periphs_device::mcp_read_audio_fifo()
 	if (m_mcp_regs.audio_rx_fifo_count)
 	{
 		m_mcp_regs.audio_rx_fifo_count--;
-		m_mcp_regs.audio_rx_fifo_read_idx = (m_mcp_regs.audio_rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_mcp_regs.audio_rx_fifo);
+		m_mcp_regs.audio_rx_fifo_read_idx = (m_mcp_regs.audio_rx_fifo_read_idx + 1) % std::size(m_mcp_regs.audio_rx_fifo);
 
 		const bool half_full = m_mcp_regs.audio_rx_fifo_count >= 4;
 		m_mcp_regs.mcsr &= ~(1 << MCSR_ARS_BIT);
@@ -878,7 +878,7 @@ uint16_t sa1110_periphs_device::mcp_read_telecom_fifo()
 	if (m_mcp_regs.telecom_rx_fifo_count)
 	{
 		m_mcp_regs.telecom_rx_fifo_count--;
-		m_mcp_regs.telecom_rx_fifo_read_idx = (m_mcp_regs.telecom_rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_mcp_regs.telecom_rx_fifo);
+		m_mcp_regs.telecom_rx_fifo_read_idx = (m_mcp_regs.telecom_rx_fifo_read_idx + 1) % std::size(m_mcp_regs.telecom_rx_fifo);
 
 		const bool half_full = m_mcp_regs.telecom_rx_fifo_count >= 4;
 		m_mcp_regs.mcsr &= ~(1 << MCSR_TRS_BIT);
@@ -935,14 +935,14 @@ void sa1110_periphs_device::mcp_set_enabled(bool enabled)
 
 void sa1110_periphs_device::mcp_audio_tx_fifo_push(const uint16_t value)
 {
-	if (m_mcp_regs.audio_rx_fifo_count == ARRAY_LENGTH(m_mcp_regs.audio_tx_fifo))
+	if (m_mcp_regs.audio_rx_fifo_count == std::size(m_mcp_regs.audio_tx_fifo))
 		return;
 
 	m_mcp_regs.audio_tx_fifo[m_mcp_regs.audio_tx_fifo_write_idx] = value;
-	m_mcp_regs.audio_rx_fifo_write_idx = (m_mcp_regs.audio_tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_mcp_regs.audio_tx_fifo);
+	m_mcp_regs.audio_rx_fifo_write_idx = (m_mcp_regs.audio_tx_fifo_write_idx + 1) % std::size(m_mcp_regs.audio_tx_fifo);
 	m_mcp_regs.audio_rx_fifo_count++;
 
-	if (m_mcp_regs.audio_tx_fifo_count == ARRAY_LENGTH(m_mcp_regs.audio_tx_fifo))
+	if (m_mcp_regs.audio_tx_fifo_count == std::size(m_mcp_regs.audio_tx_fifo))
 		m_mcp_regs.mcsr &= ~(1 << MCSR_ANF_BIT);
 
 	if (m_mcp_regs.audio_tx_fifo_count >= 4)
@@ -961,14 +961,14 @@ void sa1110_periphs_device::mcp_audio_tx_fifo_push(const uint16_t value)
 
 void sa1110_periphs_device::mcp_telecom_tx_fifo_push(const uint16_t value)
 {
-	if (m_mcp_regs.telecom_rx_fifo_count == ARRAY_LENGTH(m_mcp_regs.telecom_tx_fifo))
+	if (m_mcp_regs.telecom_rx_fifo_count == std::size(m_mcp_regs.telecom_tx_fifo))
 		return;
 
 	m_mcp_regs.telecom_tx_fifo[m_mcp_regs.telecom_tx_fifo_write_idx] = value;
-	m_mcp_regs.telecom_rx_fifo_write_idx = (m_mcp_regs.telecom_tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_mcp_regs.telecom_tx_fifo);
+	m_mcp_regs.telecom_rx_fifo_write_idx = (m_mcp_regs.telecom_tx_fifo_write_idx + 1) % std::size(m_mcp_regs.telecom_tx_fifo);
 	m_mcp_regs.telecom_rx_fifo_count++;
 
-	if (m_mcp_regs.telecom_tx_fifo_count == ARRAY_LENGTH(m_mcp_regs.telecom_tx_fifo))
+	if (m_mcp_regs.telecom_tx_fifo_count == std::size(m_mcp_regs.telecom_tx_fifo))
 		m_mcp_regs.mcsr &= ~(1 << MCSR_TNF_BIT);
 
 	if (m_mcp_regs.audio_tx_fifo_count >= 4)
@@ -1156,7 +1156,7 @@ TIMER_CALLBACK_MEMBER(sa1110_periphs_device::ssp_tx_callback)
 		const uint16_t data = m_ssp_regs.tx_fifo[m_ssp_regs.tx_fifo_read_idx];
 		m_ssp_out(data);
 
-		m_ssp_regs.tx_fifo_read_idx = (m_ssp_regs.tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_ssp_regs.tx_fifo);
+		m_ssp_regs.tx_fifo_read_idx = (m_ssp_regs.tx_fifo_read_idx + 1) % std::size(m_ssp_regs.tx_fifo);
 		m_ssp_regs.tx_fifo_count--;
 
 		m_ssp_regs.sssr |= (1 << SSSR_TNF_BIT);
@@ -1169,7 +1169,7 @@ void sa1110_periphs_device::ssp_update_enable_state()
 {
 	if (BIT(m_ssp_regs.sscr0, SSCR0_SSE_BIT))
 	{
-		if (m_ssp_regs.tx_fifo_count != ARRAY_LENGTH(m_ssp_regs.tx_fifo))
+		if (m_ssp_regs.tx_fifo_count != std::size(m_ssp_regs.tx_fifo))
 			m_ssp_regs.sssr |= (1 << SSSR_TNF_BIT);
 		else
 			m_ssp_regs.sssr &= ~(1 << SSSR_TNF_BIT);
@@ -1227,10 +1227,10 @@ void sa1110_periphs_device::ssp_update_rx_level()
 
 void sa1110_periphs_device::ssp_rx_fifo_push(const uint16_t data)
 {
-	if (m_ssp_regs.rx_fifo_count < ARRAY_LENGTH(m_ssp_regs.rx_fifo))
+	if (m_ssp_regs.rx_fifo_count < std::size(m_ssp_regs.rx_fifo))
 	{
 		m_ssp_regs.rx_fifo[m_ssp_regs.rx_fifo_write_idx] = data;
-		m_ssp_regs.rx_fifo_write_idx = (m_ssp_regs.rx_fifo_write_idx + 1) % ARRAY_LENGTH(m_ssp_regs.rx_fifo);
+		m_ssp_regs.rx_fifo_write_idx = (m_ssp_regs.rx_fifo_write_idx + 1) % std::size(m_ssp_regs.rx_fifo);
 		m_ssp_regs.rx_fifo_count++;
 
 		m_ssp_regs.sssr |= (1 << SSSR_RNE_BIT);
@@ -1249,13 +1249,13 @@ void sa1110_periphs_device::ssp_update_tx_level()
 
 void sa1110_periphs_device::ssp_tx_fifo_push(const uint16_t data)
 {
-	if (m_ssp_regs.tx_fifo_count < ARRAY_LENGTH(m_ssp_regs.tx_fifo))
+	if (m_ssp_regs.tx_fifo_count < std::size(m_ssp_regs.tx_fifo))
 	{
 		m_ssp_regs.tx_fifo[m_ssp_regs.tx_fifo_write_idx] = data;
-		m_ssp_regs.tx_fifo_write_idx = (m_ssp_regs.tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_ssp_regs.tx_fifo);
+		m_ssp_regs.tx_fifo_write_idx = (m_ssp_regs.tx_fifo_write_idx + 1) % std::size(m_ssp_regs.tx_fifo);
 		m_ssp_regs.tx_fifo_count++;
 
-		if (m_ssp_regs.tx_fifo_count != ARRAY_LENGTH(m_ssp_regs.tx_fifo))
+		if (m_ssp_regs.tx_fifo_count != std::size(m_ssp_regs.tx_fifo))
 			m_ssp_regs.sssr |= (1 << SSSR_TNF_BIT);
 		else
 			m_ssp_regs.sssr &= ~(1 << SSSR_TNF_BIT);
@@ -1274,7 +1274,7 @@ uint16_t sa1110_periphs_device::ssp_rx_fifo_pop()
 	uint16_t data = m_ssp_regs.rx_fifo[m_ssp_regs.rx_fifo_read_idx];
 	if (m_ssp_regs.rx_fifo_count)
 	{
-		m_ssp_regs.rx_fifo_read_idx = (m_ssp_regs.rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_ssp_regs.rx_fifo);
+		m_ssp_regs.rx_fifo_read_idx = (m_ssp_regs.rx_fifo_read_idx + 1) % std::size(m_ssp_regs.rx_fifo);
 		m_ssp_regs.rx_fifo_count--;
 
 		if (m_ssp_regs.rx_fifo_count == 0)
@@ -2464,15 +2464,15 @@ void sa1110_periphs_device::device_reset()
 	m_udc_regs.udcsr = 0;
 
 	// init ICP
-	memset(m_icp_regs.uart.utcr, 0, sizeof(uint32_t) * 4);
+	std::fill_n(&m_icp_regs.uart.utcr[0], 4, 0);
 	m_icp_regs.uart.utsr0 = 0;
 	m_icp_regs.uart.utsr1 = 0;
-	memset(m_icp_regs.uart.rx_fifo, 0, sizeof(uint16_t) * 12);
+	std::fill_n(&m_icp_regs.uart.rx_fifo[0], 12, 0);
 	m_icp_regs.uart.rx_fifo_read_idx = 0;
 	m_icp_regs.uart.rx_fifo_write_idx = 0;
 	m_icp_regs.uart.rx_fifo_count = 0;
 	m_icp_regs.uart_rx_timer->adjust(attotime::never);
-	memset(m_icp_regs.uart.tx_fifo, 0, 8);
+	std::fill_n(&m_icp_regs.uart.tx_fifo[0], 8, 0);
 	m_icp_regs.uart.tx_fifo_read_idx = 0;
 	m_icp_regs.uart.tx_fifo_write_idx = 0;
 	m_icp_regs.uart.tx_fifo_count = 0;
@@ -2484,26 +2484,26 @@ void sa1110_periphs_device::device_reset()
 	m_icp_regs.hssp.hscr1 = 0;
 	m_icp_regs.hssp.hssr0 = 0;
 	m_icp_regs.hssp.hssr1 = 0;
-	memset(m_icp_regs.hssp.rx_fifo, 0, sizeof(uint16_t) * 8);
+	std::fill_n(&m_icp_regs.hssp.rx_fifo[0], 4, 0);
 	m_icp_regs.hssp.rx_fifo_read_idx = 0;
 	m_icp_regs.hssp.rx_fifo_write_idx = 0;
 	m_icp_regs.hssp.rx_fifo_count = 0;
 	m_icp_regs.hssp.rx_timer->adjust(attotime::never);
-	memset(m_icp_regs.hssp.tx_fifo, 0, sizeof(uint16_t) * 8);
+	std::fill_n(&m_icp_regs.hssp.tx_fifo[0], 12, 0);
 	m_icp_regs.hssp.tx_fifo_read_idx = 0;
 	m_icp_regs.hssp.tx_fifo_write_idx = 0;
 	m_icp_regs.hssp.tx_fifo_count = 0;
 	m_icp_regs.hssp.tx_timer->adjust(attotime::never);
 
 	// init UART3
-	memset(m_uart_regs.utcr, 0, sizeof(uint32_t) * 4);
+	std::fill_n(&m_uart_regs.utcr[0], 4, 0);
 	m_uart_regs.utsr0 = 0;
 	m_uart_regs.utsr1 = 0;
-	memset(m_uart_regs.rx_fifo, 0, sizeof(uint16_t) * 12);
+	std::fill_n(&m_uart_regs.rx_fifo[0], 12, 0);
 	m_uart_regs.rx_fifo_read_idx = 0;
 	m_uart_regs.rx_fifo_write_idx = 0;
 	m_uart_regs.rx_fifo_count = 0;
-	memset(m_uart_regs.tx_fifo, 0, 8);
+	std::fill_n(&m_uart_regs.tx_fifo[0], 8, 0);
 	m_uart_regs.tx_fifo_read_idx = 0;
 	m_uart_regs.tx_fifo_write_idx = 0;
 	m_uart_regs.tx_fifo_count = 0;
@@ -2517,20 +2517,20 @@ void sa1110_periphs_device::device_reset()
 	m_mcp_regs.mccr1 = 0;
 	m_mcp_regs.mcdr2 = 0;
 	m_mcp_regs.mcsr = (1 << MCSR_ANF_BIT) | (1 << MCSR_TNF_BIT);
-	memset(m_mcp_regs.audio_rx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_mcp_regs.audio_rx_fifo));
+	std::fill(std::begin(m_mcp_regs.audio_rx_fifo), std::end(m_mcp_regs.audio_rx_fifo), 0);
 	m_mcp_regs.audio_rx_fifo_read_idx = 0;
 	m_mcp_regs.audio_rx_fifo_write_idx = 0;
 	m_mcp_regs.audio_rx_fifo_count = 0;
-	memset(m_mcp_regs.audio_tx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_mcp_regs.audio_tx_fifo));
+	std::fill(std::begin(m_mcp_regs.audio_tx_fifo), std::end(m_mcp_regs.audio_tx_fifo), 0);
 	m_mcp_regs.audio_tx_fifo_read_idx = 0;
 	m_mcp_regs.audio_tx_fifo_write_idx = 0;
 	m_mcp_regs.audio_tx_fifo_count = 0;
 	m_mcp_regs.audio_tx_timer->adjust(attotime::never);
-	memset(m_mcp_regs.telecom_rx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_mcp_regs.telecom_rx_fifo));
+	std::fill(std::begin(m_mcp_regs.telecom_rx_fifo), std::end(m_mcp_regs.telecom_rx_fifo), 0);
 	m_mcp_regs.telecom_rx_fifo_read_idx = 0;
 	m_mcp_regs.telecom_rx_fifo_write_idx = 0;
 	m_mcp_regs.telecom_rx_fifo_count = 0;
-	memset(m_mcp_regs.telecom_tx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_mcp_regs.telecom_tx_fifo));
+	std::fill(std::begin(m_mcp_regs.telecom_tx_fifo), std::end(m_mcp_regs.telecom_tx_fifo), 0);
 	m_mcp_regs.telecom_tx_fifo_read_idx = 0;
 	m_mcp_regs.telecom_tx_fifo_write_idx = 0;
 	m_mcp_regs.telecom_tx_fifo_count = 0;
@@ -2540,19 +2540,19 @@ void sa1110_periphs_device::device_reset()
 	m_ssp_regs.sscr0 = 0;
 	m_ssp_regs.sscr1 = 0;
 	m_ssp_regs.sssr = (1 << SSSR_TNF_BIT);
-	memset(m_ssp_regs.rx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_ssp_regs.rx_fifo));
+	std::fill(std::begin(m_ssp_regs.rx_fifo), std::end(m_ssp_regs.rx_fifo), 0);
 	m_ssp_regs.rx_fifo_read_idx = 0;
 	m_ssp_regs.rx_fifo_write_idx = 0;
 	m_ssp_regs.rx_fifo_count = 0;
 	m_ssp_regs.rx_timer->adjust(attotime::never);
-	memset(m_ssp_regs.tx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_ssp_regs.tx_fifo));
+	std::fill(std::begin(m_ssp_regs.tx_fifo), std::end(m_ssp_regs.tx_fifo), 0);
 	m_ssp_regs.tx_fifo_read_idx = 0;
 	m_ssp_regs.tx_fifo_write_idx = 0;
 	m_ssp_regs.tx_fifo_count = 0;
 	m_ssp_regs.tx_timer->adjust(attotime::never);
 
 	// init OS timers
-	memset(m_ostmr_regs.osmr, 0, sizeof(uint32_t) * 4);
+	std::fill_n(&m_ostmr_regs.osmr[0], 4, 0);
 	m_ostmr_regs.ower = 0;
 	m_ostmr_regs.ossr = 0;
 	m_ostmr_regs.oier = 0;
@@ -2570,7 +2570,13 @@ void sa1110_periphs_device::device_reset()
 	m_rtc_regs.tick_timer->adjust(attotime::from_seconds(1), 0, attotime::from_seconds(1));
 
 	// init power regs
-	memset(&m_power_regs, 0, sizeof(m_power_regs));
+	m_power_regs.pmcr = 0;
+	m_power_regs.pssr = 0;
+	m_power_regs.pspr = 0;
+	m_power_regs.pwer = 0;
+	m_power_regs.pcfr = 0;
+	m_power_regs.ppcr = 0;
+	m_power_regs.pgsr = 0;
 	m_power_regs.posr = 1; // flag oscillator OK
 
 	// init PPC regs
@@ -2581,17 +2587,34 @@ void sa1110_periphs_device::device_reset()
 	m_ppc_regs.ppfr = 0x0007f001;
 
 	// init DMA regs
-	for (int channel = 0; channel < 6; channel++)
+	for (dma_regs &regs : m_dma_regs)
 	{
-		m_dma_regs[channel].ddar = 0;
-		m_dma_regs[channel].dsr = 0;
-		memset(m_dma_regs[channel].dbs, 0, sizeof(uint32_t) * 2);
-		memset(m_dma_regs[channel].dbt, 0, sizeof(uint32_t) * 2);
+		regs.ddar = 0;
+		regs.dsr = 0;
+		std::fill_n(&regs.dbs[0], 2, 0);
+		std::fill_n(&regs.dbt[0], 2, 0);
 	}
-	// bulk-init other registers
+
 	m_rcsr = 0x00000001; // indicate hardware reset
-	memset(&m_gpio_regs, 0, sizeof(m_gpio_regs));
-	memset(&m_intc_regs, 0, sizeof(m_intc_regs));
+
+	m_gpio_regs.gplr = 0;
+	m_gpio_regs.gpdr = 0;
+	m_gpio_regs.grer = 0;
+	m_gpio_regs.gfer = 0;
+	m_gpio_regs.gedr = 0;
+	m_gpio_regs.gafr = 0;
+	m_gpio_regs.any_edge_mask = 0;
+	m_gpio_regs.output_latch = 0;
+	m_gpio_regs.input_latch = 0;
+	m_gpio_regs.alt_output_latch = 0;
+	m_gpio_regs.alt_input_latch = 0;
+
+	m_intc_regs.icip = 0;
+	m_intc_regs.icmr = 0;
+	m_intc_regs.iclr = 0;
+	m_intc_regs.iccr = 0;
+	m_intc_regs.icfp = 0;
+	m_intc_regs.icpr = 0;
 
 	uart_check_rx_fifo_service();
 	uart_check_tx_fifo_service();

--- a/src/devices/machine/sa1111.cpp
+++ b/src/devices/machine/sa1111.cpp
@@ -478,7 +478,7 @@ TIMER_CALLBACK_MEMBER(sa1111_device::audio_tx_dma_callback)
 {
 	const uint32_t buf = BIT(m_audio_regs.sadtcs, SADTCS_TBIU_BIT);
 	const uint32_t remaining = m_audio_regs.sadtcc >> 2;
-	const uint32_t avail = ARRAY_LENGTH(m_audio_regs.tx_fifo) - m_audio_regs.tx_fifo_count;
+	const uint32_t avail = std::size(m_audio_regs.tx_fifo) - m_audio_regs.tx_fifo_count;
 	if (remaining == 0 || avail == 0)
 		return;
 
@@ -655,12 +655,12 @@ void sa1111_device::audio_start_rx_dma(const uint32_t buf)
 void sa1111_device::audio_update_tx_fifo_levels()
 {
 	uint32_t &status = BIT(m_sbi_regs.skcr, SKCR_SACMDSL_BIT) ? m_audio_regs.sasr1 : m_audio_regs.sasr0;
-	if (m_audio_regs.tx_fifo_count < ARRAY_LENGTH(m_audio_regs.tx_fifo))
+	if (m_audio_regs.tx_fifo_count < std::size(m_audio_regs.tx_fifo))
 		status |= (1 << SASR_TNF_BIT);
 	else
 		status &= ~(1 << SASR_TNF_BIT);
 
-	const uint32_t tfl = ((m_audio_regs.tx_fifo_count == ARRAY_LENGTH(m_audio_regs.tx_fifo)) ? (m_audio_regs.tx_fifo_count - 1) : m_audio_regs.tx_fifo_count);
+	const uint32_t tfl = ((m_audio_regs.tx_fifo_count == std::size(m_audio_regs.tx_fifo)) ? (m_audio_regs.tx_fifo_count - 1) : m_audio_regs.tx_fifo_count);
 	status &= ~SASR_TFL_MASK;
 	status |= (tfl << SASR_TFL_BIT);
 
@@ -685,7 +685,7 @@ void sa1111_device::audio_update_rx_fifo_levels()
 	else
 		status &= ~(1 << SASR_RNE_BIT);
 
-	const uint32_t rfl = ((m_audio_regs.rx_fifo_count == ARRAY_LENGTH(m_audio_regs.rx_fifo)) ? (m_audio_regs.rx_fifo_count - 1) : m_audio_regs.rx_fifo_count);
+	const uint32_t rfl = ((m_audio_regs.rx_fifo_count == std::size(m_audio_regs.rx_fifo)) ? (m_audio_regs.rx_fifo_count - 1) : m_audio_regs.rx_fifo_count);
 	status &= ~SASR_RFL_MASK;
 	status |= (rfl << SASR_RFL_BIT);
 
@@ -713,10 +713,10 @@ void sa1111_device::audio_update_busy_flag()
 
 void sa1111_device::audio_tx_fifo_push(uint32_t data)
 {
-	if (m_audio_regs.tx_fifo_count < ARRAY_LENGTH(m_audio_regs.tx_fifo))
+	if (m_audio_regs.tx_fifo_count < std::size(m_audio_regs.tx_fifo))
 	{
 		m_audio_regs.tx_fifo[m_audio_regs.tx_fifo_write_idx] = data;
-		m_audio_regs.tx_fifo_write_idx = (m_audio_regs.tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_audio_regs.tx_fifo);
+		m_audio_regs.tx_fifo_write_idx = (m_audio_regs.tx_fifo_write_idx + 1) % std::size(m_audio_regs.tx_fifo);
 		m_audio_regs.tx_fifo_count++;
 		audio_update_tx_fifo_levels();
 		if (m_audio_regs.tx_timer->remaining() == attotime::never)
@@ -734,7 +734,7 @@ uint32_t sa1111_device::audio_tx_fifo_pop()
 	if (m_audio_regs.tx_fifo_count > 0)
 	{
 		const uint32_t data = m_audio_regs.tx_fifo[m_audio_regs.tx_fifo_read_idx];
-		m_audio_regs.tx_fifo_read_idx = (m_audio_regs.tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_audio_regs.tx_fifo);
+		m_audio_regs.tx_fifo_read_idx = (m_audio_regs.tx_fifo_read_idx + 1) % std::size(m_audio_regs.tx_fifo);
 		m_audio_regs.tx_fifo_count--;
 		audio_update_tx_fifo_levels();
 		if (m_audio_regs.tx_fifo_count == 0)
@@ -754,10 +754,10 @@ uint32_t sa1111_device::audio_tx_fifo_pop()
 
 void sa1111_device::audio_rx_fifo_push(uint32_t data)
 {
-	if (m_audio_regs.rx_fifo_count < ARRAY_LENGTH(m_audio_regs.rx_fifo))
+	if (m_audio_regs.rx_fifo_count < std::size(m_audio_regs.rx_fifo))
 	{
 		m_audio_regs.rx_fifo[m_audio_regs.rx_fifo_write_idx] = data;
-		m_audio_regs.rx_fifo_write_idx = (m_audio_regs.rx_fifo_write_idx + 1) % ARRAY_LENGTH(m_audio_regs.rx_fifo);
+		m_audio_regs.rx_fifo_write_idx = (m_audio_regs.rx_fifo_write_idx + 1) % std::size(m_audio_regs.rx_fifo);
 		m_audio_regs.rx_fifo_count++;
 		audio_update_rx_fifo_levels();
 	}
@@ -774,7 +774,7 @@ uint32_t sa1111_device::audio_rx_fifo_pop()
 	if (m_audio_regs.rx_fifo_count > 0)
 	{
 		const uint32_t data = m_audio_regs.rx_fifo[m_audio_regs.rx_fifo_read_idx];
-		m_audio_regs.rx_fifo_read_idx = (m_audio_regs.rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_audio_regs.rx_fifo);
+		m_audio_regs.rx_fifo_read_idx = (m_audio_regs.rx_fifo_read_idx + 1) % std::size(m_audio_regs.rx_fifo);
 		m_audio_regs.rx_fifo_count--;
 		audio_update_rx_fifo_levels();
 		return data;
@@ -1247,7 +1247,7 @@ TIMER_CALLBACK_MEMBER(sa1111_device::ssp_tx_callback)
 		const uint16_t data = m_ssp_regs.tx_fifo[m_ssp_regs.tx_fifo_read_idx];
 		m_ssp_out(data);
 
-		m_ssp_regs.tx_fifo_read_idx = (m_ssp_regs.tx_fifo_read_idx + 1) % ARRAY_LENGTH(m_ssp_regs.tx_fifo);
+		m_ssp_regs.tx_fifo_read_idx = (m_ssp_regs.tx_fifo_read_idx + 1) % std::size(m_ssp_regs.tx_fifo);
 		m_ssp_regs.tx_fifo_count--;
 
 		m_ssp_regs.sspsr |= (1 << SSPSR_TNF_BIT);
@@ -1265,7 +1265,7 @@ void sa1111_device::ssp_update_enable_state()
 		const uint32_t tft = (m_ssp_regs.sspsr & SSPCR1_TFT_MASK) >> SSPCR1_TFT_BIT;
 		const uint32_t rft = (m_ssp_regs.sspsr & SSPCR1_RFT_MASK) >> SSPCR1_RFT_BIT;
 
-		if (tfl != (ARRAY_LENGTH(m_ssp_regs.tx_fifo) - 1))
+		if (tfl != (std::size(m_ssp_regs.tx_fifo) - 1))
 			m_ssp_regs.sspsr |= (1 << SSPSR_TNF_BIT);
 		else
 			m_ssp_regs.sspsr &= ~(1 << SSPSR_TNF_BIT);
@@ -1328,10 +1328,10 @@ void sa1111_device::ssp_update_rx_level()
 
 void sa1111_device::ssp_rx_fifo_push(const uint16_t data)
 {
-	if (m_ssp_regs.rx_fifo_count < ARRAY_LENGTH(m_ssp_regs.rx_fifo))
+	if (m_ssp_regs.rx_fifo_count < std::size(m_ssp_regs.rx_fifo))
 	{
 		m_ssp_regs.rx_fifo[m_ssp_regs.rx_fifo_write_idx] = data;
-		m_ssp_regs.rx_fifo_write_idx = (m_ssp_regs.rx_fifo_write_idx + 1) % ARRAY_LENGTH(m_ssp_regs.rx_fifo);
+		m_ssp_regs.rx_fifo_write_idx = (m_ssp_regs.rx_fifo_write_idx + 1) % std::size(m_ssp_regs.rx_fifo);
 		m_ssp_regs.rx_fifo_count++;
 
 		m_ssp_regs.sspsr |= (1 << SSPSR_RNE_BIT);
@@ -1355,13 +1355,13 @@ void sa1111_device::ssp_update_tx_level()
 
 void sa1111_device::ssp_tx_fifo_push(const uint16_t data)
 {
-	if (m_ssp_regs.tx_fifo_count < ARRAY_LENGTH(m_ssp_regs.tx_fifo))
+	if (m_ssp_regs.tx_fifo_count < std::size(m_ssp_regs.tx_fifo))
 	{
 		m_ssp_regs.tx_fifo[m_ssp_regs.tx_fifo_write_idx] = data;
-		m_ssp_regs.tx_fifo_write_idx = (m_ssp_regs.tx_fifo_write_idx + 1) % ARRAY_LENGTH(m_ssp_regs.tx_fifo);
+		m_ssp_regs.tx_fifo_write_idx = (m_ssp_regs.tx_fifo_write_idx + 1) % std::size(m_ssp_regs.tx_fifo);
 		m_ssp_regs.tx_fifo_count++;
 
-		if (m_ssp_regs.tx_fifo_count != ARRAY_LENGTH(m_ssp_regs.tx_fifo))
+		if (m_ssp_regs.tx_fifo_count != std::size(m_ssp_regs.tx_fifo))
 			m_ssp_regs.sspsr |= (1 << SSPSR_TNF_BIT);
 		else
 			m_ssp_regs.sspsr &= ~(1 << SSPSR_TNF_BIT);
@@ -1375,7 +1375,7 @@ uint16_t sa1111_device::ssp_rx_fifo_pop()
 	uint16_t data = m_ssp_regs.rx_fifo[m_ssp_regs.rx_fifo_read_idx];
 	if (m_ssp_regs.rx_fifo_count)
 	{
-		m_ssp_regs.rx_fifo_read_idx = (m_ssp_regs.rx_fifo_read_idx + 1) % ARRAY_LENGTH(m_ssp_regs.rx_fifo);
+		m_ssp_regs.rx_fifo_read_idx = (m_ssp_regs.rx_fifo_read_idx + 1) % std::size(m_ssp_regs.rx_fifo);
 		m_ssp_regs.rx_fifo_count--;
 
 		if (m_ssp_regs.rx_fifo_count == 0)
@@ -2112,11 +2112,11 @@ void sa1111_device::device_reset()
 	m_sk_regs.skpen1 = 0;
 	m_sk_regs.skpwm1 = 0;
 
-	memset(m_usb_regs.ohci, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_usb_regs.ohci));
+	std::fill(std::begin(m_usb_regs.ohci), std::end(m_usb_regs.ohci), 0);
 	m_usb_regs.status = 0;
 	m_usb_regs.reset = (1 << USBRST_FHR_BIT) | (1 << USBRST_FIR_BIT);
 	m_usb_regs.int_test = 0;
-	memset(m_usb_regs.fifo, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_usb_regs.fifo));
+	std::fill(std::begin(m_usb_regs.fifo), std::end(m_usb_regs.fifo), 0);
 
 	m_audio_regs.sacr0 = (0x7 << SACR0_RFTH_BIT) | (0x7 << SACR0_TFTH_BIT);
 	m_audio_regs.sacr1 = 0;
@@ -2130,23 +2130,23 @@ void sa1111_device::device_reset()
 	m_audio_regs.acsar = 0;
 	m_audio_regs.acsdr = 0;
 	m_audio_regs.sadtcs = 0;
-	memset(m_audio_regs.sadts, 0, sizeof(uint32_t) * 2);
-	memset(m_audio_regs.sadtc, 0, sizeof(uint32_t) * 2);
+	std::fill_n(&m_audio_regs.sadts[0], 2, 0);
+	std::fill_n(&m_audio_regs.sadtc[0], 2, 0);
 	m_audio_regs.sadta = 0;
 	m_audio_regs.sadtcc = 0;
 	m_audio_regs.sadrcs = 0;
-	memset(m_audio_regs.sadrs, 0, sizeof(uint32_t) * 2);
-	memset(m_audio_regs.sadrc, 0, sizeof(uint32_t) * 2);
+	std::fill_n(&m_audio_regs.sadrs[0], 2, 0);
+	std::fill_n(&m_audio_regs.sadrc[0], 2, 0);
 	m_audio_regs.sadra = 0;
 	m_audio_regs.sadrcc = 0;
 	m_audio_regs.saitr = 0;
-	memset(m_audio_regs.rx_fifo, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_audio_regs.rx_fifo));
+	std::fill(std::begin(m_audio_regs.rx_fifo), std::end(m_audio_regs.rx_fifo), 0);
 	m_audio_regs.rx_fifo_read_idx = 0;
 	m_audio_regs.rx_fifo_write_idx = 0;
 	m_audio_regs.rx_fifo_count = 0;
 	m_audio_regs.rx_timer->adjust(attotime::never);
 	m_audio_regs.rx_dma_timer->adjust(attotime::never);
-	memset(m_audio_regs.tx_fifo, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_audio_regs.tx_fifo));
+	std::fill(std::begin(m_audio_regs.tx_fifo), std::end(m_audio_regs.tx_fifo), 0);
 	m_audio_regs.tx_fifo_read_idx = 0;
 	m_audio_regs.tx_fifo_write_idx = 0;
 	m_audio_regs.tx_fifo_count = 0;
@@ -2157,35 +2157,43 @@ void sa1111_device::device_reset()
 	m_ssp_regs.sspcr1 = (0x7 << SSPCR1_RFT_BIT) | (0x7 << SSPCR1_TFT_BIT);
 	m_ssp_regs.sspsr = 0;
 	m_ssp_regs.sspitr = 0;
-	memset(m_ssp_regs.rx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_ssp_regs.rx_fifo));
+	std::fill(std::begin(m_ssp_regs.rx_fifo), std::end(m_ssp_regs.rx_fifo), 0);
 	m_ssp_regs.rx_fifo_read_idx = 0;
 	m_ssp_regs.rx_fifo_write_idx = 0;
 	m_ssp_regs.rx_fifo_count = 0;
 	m_ssp_regs.rx_timer->adjust(attotime::never);
-	memset(m_ssp_regs.tx_fifo, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_ssp_regs.tx_fifo));
+	std::fill(std::begin(m_ssp_regs.tx_fifo), std::end(m_ssp_regs.tx_fifo), 0);
 	m_ssp_regs.tx_fifo_read_idx = 0;
 	m_ssp_regs.tx_fifo_write_idx = 0;
 	m_ssp_regs.tx_fifo_count = 0;
 	m_ssp_regs.tx_timer->adjust(attotime::never);
 
-	memset(&m_track_regs, 0, sizeof(ps2_regs));
-	memset(&m_mouse_regs, 0, sizeof(ps2_regs));
+	for (ps2_regs &regs : { std::ref(m_track_regs), std::ref(m_mouse_regs) })
+	{
+		regs.kbdcr = 0;
+		regs.kbdstat = 0;
+		regs.kbddata_tx = 0;
+		regs.kbddata_rx = 0;
+		regs.kbdclkdiv = 0;
+		regs.kbdprecnt = 0;
+		regs.kbditr = 0;
+	}
 
-	memset(m_gpio_regs.ddr, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.ddr));
-	memset(m_gpio_regs.level, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.level));
-	memset(m_gpio_regs.sdr, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.sdr));
-	memset(m_gpio_regs.ssr, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.ssr));
-	memset(m_gpio_regs.out_latch, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.out_latch));
-	memset(m_gpio_regs.in_latch, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_gpio_regs.in_latch));
+	std::fill(std::begin(m_gpio_regs.ddr), std::end(m_gpio_regs.ddr), 0);
+	std::fill(std::begin(m_gpio_regs.level), std::end(m_gpio_regs.level), 0);
+	std::fill(std::begin(m_gpio_regs.sdr), std::end(m_gpio_regs.sdr), 0);
+	std::fill(std::begin(m_gpio_regs.ssr), std::end(m_gpio_regs.ssr), 0);
+	std::fill(std::begin(m_gpio_regs.out_latch), std::end(m_gpio_regs.out_latch), 0);
+	std::fill(std::begin(m_gpio_regs.in_latch), std::end(m_gpio_regs.in_latch), 0);
 
-	memset(m_intc_regs.inttest, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.inttest));
-	memset(m_intc_regs.inten, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.inten));
-	memset(m_intc_regs.intpol, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.intpol));
+	std::fill(std::begin(m_intc_regs.inttest), std::end(m_intc_regs.inttest), 0);
+	std::fill(std::begin(m_intc_regs.inten), std::end(m_intc_regs.inten), 0);
+	std::fill(std::begin(m_intc_regs.intpol), std::end(m_intc_regs.intpol), 0);
 	m_intc_regs.inttstsel = 0;
-	memset(m_intc_regs.intstat, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.intstat));
-	memset(m_intc_regs.wake_en, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.wake_en));
-	memset(m_intc_regs.wake_pol, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.wake_pol));
-	memset(m_intc_regs.intraw, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_intc_regs.intraw));
+	std::fill(std::begin(m_intc_regs.intstat), std::end(m_intc_regs.intstat), 0);
+	std::fill(std::begin(m_intc_regs.wake_en), std::end(m_intc_regs.wake_en), 0);
+	std::fill(std::begin(m_intc_regs.wake_pol), std::end(m_intc_regs.wake_pol), 0);
+	std::fill(std::begin(m_intc_regs.intraw), std::end(m_intc_regs.intraw), 0);
 
 	m_card_regs.pccr = 0;
 	m_card_regs.pcssr = 0;

--- a/src/devices/machine/scc2698b.cpp
+++ b/src/devices/machine/scc2698b.cpp
@@ -404,7 +404,7 @@ void scc2698b_device::device_reset()
 
 void scc2698b_device::write_line_tx(int port, int value)
 {
-	if ((0 <= port) && (ARRAY_LENGTH(write_tx) > port))
+	if ((0 <= port) && (std::size(write_tx) > port))
 		write_tx[port](value);
 	else
 		logerror("Unsupported port %d in write_line_tx\n", port);
@@ -412,7 +412,7 @@ void scc2698b_device::write_line_tx(int port, int value)
 
 void scc2698b_device::write_line_mpp1(int port, int value)
 {
-	if ((0 <= port) && (ARRAY_LENGTH(write_mpp1) > port))
+	if ((0 <= port) && (std::size(write_mpp1) > port))
 		write_mpp1[port](value);
 	else
 		logerror("Unsupported port %d in write_line_mpp1\n", port);
@@ -420,7 +420,7 @@ void scc2698b_device::write_line_mpp1(int port, int value)
 
 void scc2698b_device::write_line_mpp2(int port, int value)
 {
-	if ((0 <= port) && (ARRAY_LENGTH(write_mpp2) > port))
+	if ((0 <= port) && (std::size(write_mpp2) > port))
 		write_mpp2[port](value);
 	else
 		logerror("Unsupported port %d in write_line_mpp2\n", port);
@@ -428,7 +428,7 @@ void scc2698b_device::write_line_mpp2(int port, int value)
 
 void scc2698b_device::write_line_mpo(int port, int value)
 {
-	if ((0 <= port) && (ARRAY_LENGTH(write_mpo) > port))
+	if ((0 <= port) && (std::size(write_mpo) > port))
 		write_mpo[port](value);
 	else
 		logerror("Unsupported port %d in write_line_mpo\n", port);

--- a/src/devices/machine/sensorboard.cpp
+++ b/src/devices/machine/sensorboard.cpp
@@ -127,7 +127,7 @@ void sensorboard_device::device_start()
 	m_upointer = 0;
 	m_ufirst = 0;
 	m_ulast = 0;
-	m_usize = ARRAY_LENGTH(m_history);
+	m_usize = std::size(m_history);
 
 	// register for savestates
 	save_item(NAME(m_nosensors));

--- a/src/devices/machine/spg2xx_io.cpp
+++ b/src/devices/machine/spg2xx_io.cpp
@@ -179,7 +179,7 @@ void spg2xx_io_device::device_start()
 
 void spg2xx_io_device::device_reset()
 {
-	memset(m_io_regs, 0, 0x100 * sizeof(uint16_t));
+	std::fill_n(&m_io_regs[0], 0x100, 0);
 
 	m_timer_a_preload = 0;
 	m_timer_b_preload = 0;
@@ -190,7 +190,7 @@ void spg2xx_io_device::device_reset()
 	m_io_regs[REG_PRNG1] = 0x1418;
 	m_io_regs[REG_PRNG2] = 0x1658;
 
-	memset(m_uart_rx_fifo, 0, ARRAY_LENGTH(m_uart_rx_fifo));
+	std::fill(std::begin(m_uart_rx_fifo), std::end(m_uart_rx_fifo), 0);
 	m_uart_rx_fifo_start = 0;
 	m_uart_rx_fifo_end = 0;
 	m_uart_rx_fifo_count = 0;
@@ -198,14 +198,14 @@ void spg2xx_io_device::device_reset()
 	m_uart_tx_irq = false;
 	m_uart_rx_irq = false;
 
-	memset(m_spi_tx_fifo, 0, ARRAY_LENGTH(m_spi_tx_fifo));
+	std::fill(std::begin(m_spi_tx_fifo), std::end(m_spi_tx_fifo), 0);
 	m_spi_tx_fifo_start = 0;
 	m_spi_tx_fifo_end = 0;
 	m_spi_tx_fifo_count = 0;
 	m_spi_tx_buf = 0x00;
 	m_spi_tx_bit = 8;
 
-	memset(m_spi_rx_fifo, 0, ARRAY_LENGTH(m_spi_rx_fifo));
+	std::fill(std::begin(m_spi_rx_fifo), std::end(m_spi_rx_fifo), 0);
 	m_spi_rx_fifo_start = 0;
 	m_spi_rx_fifo_end = 0;
 	m_spi_rx_fifo_count = 0;
@@ -214,7 +214,7 @@ void spg2xx_io_device::device_reset()
 
 	m_spi_rate = 0;
 
-	memset(m_extint, 0, sizeof(bool) * 2);
+	std::fill_n(&m_extint[0], 2, false);
 
 	m_4khz_timer->adjust(attotime::from_hz(4096), 0, attotime::from_hz(4096));
 
@@ -252,7 +252,7 @@ void spg2xx_io_device::uart_rx(uint8_t data)
 	if (BIT(m_io_regs[REG_UART_CTRL], 6))
 	{
 		m_uart_rx_fifo[m_uart_rx_fifo_end] = data;
-		m_uart_rx_fifo_end = (m_uart_rx_fifo_end + 1) % ARRAY_LENGTH(m_uart_rx_fifo);
+		m_uart_rx_fifo_end = (m_uart_rx_fifo_end + 1) % std::size(m_uart_rx_fifo);
 		m_uart_rx_fifo_count++;
 		if (m_uart_rx_timer->remaining() == attotime::never)
 			m_uart_rx_timer->adjust(attotime::from_ticks(BIT(m_io_regs[REG_UART_CTRL], 5) ? 11 : 10, m_uart_baud_rate));
@@ -535,7 +535,7 @@ uint16_t spg2xx_io_device::io_extended_r(offs_t offset)
 					LOGMASKED(LOG_UART, "%s: Remaining count %d, value %02x\n", machine().describe_context(), m_uart_rx_fifo_count, m_uart_rx_fifo[m_uart_rx_fifo_start]);
 					m_io_regs[REG_UART_RXBUF] = m_uart_rx_fifo[m_uart_rx_fifo_start];
 					val = m_io_regs[REG_UART_RXBUF];
-					m_uart_rx_fifo_start = (m_uart_rx_fifo_start + 1) % ARRAY_LENGTH(m_uart_rx_fifo);
+					m_uart_rx_fifo_start = (m_uart_rx_fifo_start + 1) % std::size(m_uart_rx_fifo);
 					m_uart_rx_fifo_count--;
 
 					if (m_uart_rx_fifo_count == 0)

--- a/src/devices/machine/wd_fdc.cpp
+++ b/src/devices/machine/wd_fdc.cpp
@@ -2540,7 +2540,7 @@ bool wd_fdc_digital_device_base::digital_pll_t::write_next_bit(bool bit, attotim
 		uint16_t pre_counter = counter;
 		counter += increment;
 		if(bit && !(pre_counter & 0x400) && (counter & 0x400))
-			if(write_position < ARRAY_LENGTH(write_buffer))
+			if(write_position < std::size(write_buffer))
 				write_buffer[write_position++] = etime;
 		slot++;
 		tm = etime;

--- a/src/devices/machine/z80sio.cpp
+++ b/src/devices/machine/z80sio.cpp
@@ -506,7 +506,7 @@ int z80sio_device::z80daisy_irq_state()
 
 	// loop over all interrupt sources
 	int state = 0;
-	for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+	for (int i = 0; std::size(m_int_state) > i; ++i)
 	{
 		// if we're servicing a request, don't indicate more interrupts
 		if (m_int_state[prio[i]] & Z80_DAISY_IEO)
@@ -531,7 +531,7 @@ int z80sio_device::z80daisy_irq_ack()
 
 	// loop over all interrupt sources
 	int const *const prio = interrupt_priorities();
-	for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+	for (int i = 0; std::size(m_int_state) > i; ++i)
 	{
 		// find the first channel with an interrupt requested
 		if (m_int_state[prio[i]] & Z80_DAISY_INT)
@@ -597,7 +597,7 @@ int i8274_device::z80daisy_irq_ack()
 	{
 		// loop over all interrupt sources
 		int const *const prio = interrupt_priorities();
-		for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+		for (int i = 0; std::size(m_int_state) > i; ++i)
 		{
 			// find the first channel with an interrupt requested
 			if (m_int_state[prio[i]] & Z80_DAISY_INT)
@@ -711,7 +711,7 @@ void z80sio_device::return_from_interrupt()
 {
 	// loop over all interrupt sources
 	int const *const prio = interrupt_priorities();
-	for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+	for (int i = 0; std::size(m_int_state) > i; ++i)
 	{
 		// find the first channel with an interrupt requested
 		if (m_int_state[prio[i]] & (Z80_DAISY_IEO))
@@ -741,7 +741,7 @@ uint8_t z80sio_device::read_vector()
 	// modify vector for highest-priority pending interrupt
 	int const *const prio = interrupt_priorities();
 	vec &= 0xf1U;
-	for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+	for (int i = 0; std::size(m_int_state) > i; ++i)
 	{
 		if (m_int_state[prio[i]] & Z80_DAISY_INT)
 		{
@@ -797,7 +797,7 @@ uint8_t i8274_device::read_vector()
 
 	// modify vector for highest-priority pending interrupt
 	int const *const prio = interrupt_priorities();
-	for (int i = 0; ARRAY_LENGTH(m_int_state) > i; ++i)
+	for (int i = 0; std::size(m_int_state) > i; ++i)
 	{
 		if (m_int_state[prio[i]] & Z80_DAISY_INT)
 		{

--- a/src/devices/machine/z8536.cpp
+++ b/src/devices/machine/z8536.cpp
@@ -748,7 +748,7 @@ void cio_base_device::external_port_w(int port, int bit, int state)
 	case PORT_A:
 	case PORT_B:
 		{
-		assert((PORT_A_DATA_DIRECTION + (port << 3)) >= 0 && (PORT_A_DATA_DIRECTION + (port << 3)) < ARRAY_LENGTH(m_register));
+		assert((PORT_A_DATA_DIRECTION + (port << 3)) >= 0 && (PORT_A_DATA_DIRECTION + (port << 3)) < std::size(m_register));
 		u8 ddr = m_register[PORT_A_DATA_DIRECTION + (port << 3)];
 
 		if (!BIT(ddr, bit)) return;

--- a/src/devices/sound/nile.cpp
+++ b/src/devices/sound/nile.cpp
@@ -94,7 +94,7 @@ void nile_device::sound_stream_update(sound_stream &stream, std::vector<read_str
 
 	lsptr=leptr=0;
 
-	sound_assert(outputs[0].samples() * 2 < ARRAY_LENGTH(mix));
+	sound_assert(outputs[0].samples() * 2 < std::size(mix));
 	std::fill_n(&mix[0], outputs[0].samples()*2, 0);
 
 	for (v = 0; v < NILE_VOICES; v++)

--- a/src/devices/sound/spu_tables.cpp
+++ b/src/devices/sound/spu_tables.cpp
@@ -617,7 +617,7 @@ spu_device::reverb_preset spu_device::reverb_presets[]=
 
 float spu_device::get_linear_rate(const int n)
 {
-	static constexpr int num_linear_rates=ARRAY_LENGTH(linear_rate);
+	static constexpr int num_linear_rates=std::size(linear_rate);
 	if (n>=num_linear_rates) return 0.0f;
 	return linear_rate[n]*freq_multiplier;
 }
@@ -630,7 +630,7 @@ float spu_device::get_linear_rate_neg_phase(const int n)
 
 float spu_device::get_pos_exp_rate(const int n)
 {
-	static constexpr int num_pos_exp_rates=ARRAY_LENGTH(pos_exp_rate);
+	static constexpr int num_pos_exp_rates=std::size(pos_exp_rate);
 	if (n>=num_pos_exp_rates) return 0.0f;
 	return pos_exp_rate[n]*freq_multiplier;
 }
@@ -643,7 +643,7 @@ float spu_device::get_pos_exp_rate_neg_phase(const int n)
 
 float spu_device::get_neg_exp_rate(const int n)
 {
-	static constexpr int num_neg_exp_rates=ARRAY_LENGTH(neg_exp_rate);
+	static constexpr int num_neg_exp_rates=std::size(neg_exp_rate);
 	if (n>=num_neg_exp_rates) return 0.0f;
 	return -neg_exp_rate[n]*freq_multiplier;
 }
@@ -666,14 +666,14 @@ float spu_device::get_sustain_level(const int n)
 
 float spu_device::get_linear_release_rate(const int n)
 {
-	static constexpr int num_linear_release_rates=ARRAY_LENGTH(linear_release_rate);
+	static constexpr int num_linear_release_rates=std::size(linear_release_rate);
 	if (n>=num_linear_release_rates) return 0.0f;
 	return linear_release_rate[n]*freq_multiplier;
 }
 
 float spu_device::get_exp_release_rate(const int n)
 {
-	static constexpr int num_exp_release_rates=ARRAY_LENGTH(exp_release_rate);
+	static constexpr int num_exp_release_rates=std::size(exp_release_rate);
 	if (n>=num_exp_release_rates) return 0.0f;
 	return exp_release_rate[n]*freq_multiplier;
 }

--- a/src/devices/sound/ym2413.cpp
+++ b/src/devices/sound/ym2413.cpp
@@ -1605,52 +1605,47 @@ void ym2413_device::device_start()
 	save_item(NAME(inst_tab));
 	save_item(NAME(address));
 
-	for (int chnum = 0; chnum < ARRAY_LENGTH(P_CH); chnum++)
+	save_item(STRUCT_MEMBER(P_CH, block_fnum));
+	save_item(STRUCT_MEMBER(P_CH, fc));
+	save_item(STRUCT_MEMBER(P_CH, ksl_base));
+	save_item(STRUCT_MEMBER(P_CH, kcode));
+	save_item(STRUCT_MEMBER(P_CH, sus));
+
+	for (int chnum = 0; chnum < std::size(P_CH); chnum++)
 	{
-		OPLL_CH *ch = &P_CH[chnum];
+		OPLL_CH &ch = P_CH[chnum];
 
-		save_item(NAME(ch->block_fnum), chnum);
-		save_item(NAME(ch->fc), chnum);
-		save_item(NAME(ch->ksl_base), chnum);
-		save_item(NAME(ch->kcode), chnum);
-		save_item(NAME(ch->sus), chnum);
-
-		for (int slotnum = 0; slotnum < ARRAY_LENGTH(ch->SLOT); slotnum++)
-		{
-			OPLL_SLOT *sl = &ch->SLOT[slotnum];
-
-			save_item(NAME(sl->ar), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->dr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->rr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->KSR), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->ksl), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->ksr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->mul), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->phase), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->freq), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->fb_shift), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->op1_out), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_type), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->state), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->TL), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->TLL), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->volume), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->sl), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sh_dp), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sel_dp), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sh_ar), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sel_ar), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sh_dr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sel_dr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sh_rr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sel_rr), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sh_rs), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->eg_sel_rs), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->key), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->AMmask), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->vib), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-			save_item(NAME(sl->wavetable), chnum * ARRAY_LENGTH(ch->SLOT) + slotnum);
-		}
+		save_item(STRUCT_MEMBER(ch.SLOT, ar), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, dr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, rr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, KSR), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, ksl), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, ksr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, mul), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, phase), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, freq), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, fb_shift), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, op1_out), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_type), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, state), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, TL), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, TLL), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, volume), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, sl), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sh_dp), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sel_dp), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sh_ar), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sel_ar), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sh_dr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sel_dr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sh_rr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sel_rr), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sh_rs), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, eg_sel_rs), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, key), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, AMmask), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, vib), chnum);
+		save_item(STRUCT_MEMBER(ch.SLOT, wavetable), chnum);
 	}
 }
 

--- a/src/devices/video/gb_lcd.cpp
+++ b/src/devices/video/gb_lcd.cpp
@@ -429,15 +429,12 @@ void dmg_ppu_device::common_start()
 	save_item(NAME(m_next_state));
 	save_item(NAME(m_old_curline));
 
-	for (int i = 0; i < ARRAY_LENGTH(m_layer); i++)
-	{
-		save_item(NAME(m_layer[i].enabled), i);
-		save_item(NAME(m_layer[i].xindex), i);
-		save_item(NAME(m_layer[i].xshift), i);
-		save_item(NAME(m_layer[i].xstart), i);
-		save_item(NAME(m_layer[i].xend), i);
-		save_item(NAME(m_layer[i].bgline), i);
-	}
+	save_item(STRUCT_MEMBER(m_layer, enabled));
+	save_item(STRUCT_MEMBER(m_layer, xindex));
+	save_item(STRUCT_MEMBER(m_layer, xshift));
+	save_item(STRUCT_MEMBER(m_layer, xstart));
+	save_item(STRUCT_MEMBER(m_layer, xend));
+	save_item(STRUCT_MEMBER(m_layer, bgline));
 
 	save_item(NAME(m_line.tile_cycle));
 	save_item(NAME(m_line.tile_count));
@@ -465,16 +462,13 @@ void dmg_ppu_device::common_start()
 	save_item(NAME(m_line.window_enable));
 	save_item(NAME(m_line.window_enable_index));
 	save_item(NAME(m_line.window_should_trigger));
-	for (int i = 0; i < ARRAY_LENGTH(m_line.sprite); i++)
-	{
-		save_item(NAME(m_line.sprite[i].enabled), i);
-		save_item(NAME(m_line.sprite[i].x), i);
-		save_item(NAME(m_line.sprite[i].y), i);
-		save_item(NAME(m_line.sprite[i].pattern), i);
-		save_item(NAME(m_line.sprite[i].flags), i);
-		save_item(NAME(m_line.sprite[i].tile_plane_0), i);
-		save_item(NAME(m_line.sprite[i].tile_plane_1), i);
-	}
+	save_item(STRUCT_MEMBER(m_line.sprite, enabled));
+	save_item(STRUCT_MEMBER(m_line.sprite, x));
+	save_item(STRUCT_MEMBER(m_line.sprite, y));
+	save_item(STRUCT_MEMBER(m_line.sprite, pattern));
+	save_item(STRUCT_MEMBER(m_line.sprite, flags));
+	save_item(STRUCT_MEMBER(m_line.sprite, tile_plane_0));
+	save_item(STRUCT_MEMBER(m_line.sprite, tile_plane_1));
 	save_item(NAME(m_frame_window_active));
 }
 
@@ -1034,14 +1028,14 @@ void dmg_ppu_device::check_start_of_window()
 	}
 
 	// 4 makes most tests pass
-	m_line.window_start_y[(m_line.window_start_y_index + 4) % ARRAY_LENGTH(m_line.window_start_y)] = WNDPOSY;
+	m_line.window_start_y[(m_line.window_start_y_index + 4) % std::size(m_line.window_start_y)] = WNDPOSY;
 	// 2-4 makes most tests pass
-	m_line.window_start_x[(m_line.window_start_y_index + 4) % ARRAY_LENGTH(m_line.window_start_x)] = WNDPOSX;
-	m_line.window_start_y_index = (m_line.window_start_y_index + 1) % ARRAY_LENGTH(m_line.window_start_y);
+	m_line.window_start_x[(m_line.window_start_y_index + 4) % std::size(m_line.window_start_x)] = WNDPOSX;
+	m_line.window_start_y_index = (m_line.window_start_y_index + 1) % std::size(m_line.window_start_y);
 
 	// 3 makes most tests pass
-	m_line.window_enable[(m_line.window_enable_index + 3) % ARRAY_LENGTH(m_line.window_enable)] = LCDCONT;
-	m_line.window_enable_index = (m_line.window_enable_index + 1) % ARRAY_LENGTH(m_line.window_enable);
+	m_line.window_enable[(m_line.window_enable_index + 3) % std::size(m_line.window_enable)] = LCDCONT;
+	m_line.window_enable_index = (m_line.window_enable_index + 1) % std::size(m_line.window_enable);
 
 	if (!m_line.starting && m_line.tile_cycle < 8)
 	{
@@ -1545,7 +1539,7 @@ void sgb_ppu_device::update_scanline(uint32_t cycles_to_go)
 				while (i > 0)
 				{
 					/* Figure out which palette we're using */
-					assert(((m_end_x - i) >> 3) >= 0 && ((m_end_x - i) >> 3) < ARRAY_LENGTH(m_sgb_pal_map));
+					assert(((m_end_x - i) >> 3) >= 0 && ((m_end_x - i) >> 3) < std::size(m_sgb_pal_map));
 					sgb_palette = m_sgb_pal_map[(m_end_x - i) >> 3][m_current_line >> 3] << 2;
 
 					while ((m_layer[l].xshift < 8) && i)
@@ -2209,13 +2203,13 @@ void dmg_ppu_device::update_state()
 				break;
 
 			case GB_LCD_STATE_LYXX_M3:      /* Switch to mode 3 */
-				for (int i = 0; i < ARRAY_LENGTH(m_line.window_start_y); i++)
+				for (int i = 0; i < std::size(m_line.window_start_y); i++)
 				{
 					m_line.window_start_y[i] = WNDPOSY;
 					m_line.window_start_x[i] = WNDPOSX;
 				}
 				m_line.window_start_y_index = 0;
-				for (int i = 0; i < ARRAY_LENGTH(m_line.window_enable); i++)
+				for (int i = 0; i < std::size(m_line.window_enable); i++)
 				{
 					m_line.window_enable[i] = LCDCONT;
 				}
@@ -2640,13 +2634,13 @@ void cgb_ppu_device::update_state()
 				break;
 
 			case GB_LCD_STATE_LYXX_M3:      /* Switch to mode 3 */
-				for (int i = 0; i < ARRAY_LENGTH(m_line.window_start_y); i++)
+				for (int i = 0; i < std::size(m_line.window_start_y); i++)
 				{
 					m_line.window_start_y[i] = WNDPOSY;
 					m_line.window_start_x[i] = WNDPOSX;
 				}
 				m_line.window_start_y_index = 0;
-				for (int i = 0; i < ARRAY_LENGTH(m_line.window_enable); i++)
+				for (int i = 0; i < std::size(m_line.window_enable); i++)
 				{
 					m_line.window_enable[i] = LCDCONT;
 				}

--- a/src/devices/video/gba_lcd.cpp
+++ b/src/devices/video/gba_lcd.cpp
@@ -1577,7 +1577,7 @@ uint32_t gba_lcd_device::video_r(offs_t offset, uint32_t mem_mask)
 		break;
 	}
 
-	if (offset >= ARRAY_LENGTH(reg_names) / 2)
+	if (offset >= std::size(reg_names) / 2)
 		throw emu_fatalerror("gba_lcd_device::video_r: Not enough register names in gba_lcd_device");
 
 	if (ACCESSING_BITS_0_15)
@@ -1593,7 +1593,7 @@ void gba_lcd_device::video_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 {
 	COMBINE_DATA(&m_regs[offset]);
 
-	if (offset >= ARRAY_LENGTH(reg_names) / 2)
+	if (offset >= std::size(reg_names) / 2)
 		throw emu_fatalerror("gba_lcd_device::video_w: Not enough register names in gba_lcd_device");
 
 	if (ACCESSING_BITS_0_15)

--- a/src/devices/video/i8244.cpp
+++ b/src/devices/video/i8244.cpp
@@ -591,7 +591,7 @@ void i8244_device::char_pixel(u8 index, int x, int y, u8 pixel, u16 color, bitma
 void i8244_device::draw_major(int scanline, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// quad objects
-	for (int i = ARRAY_LENGTH(m_vdc.s.quad) - 1; i >= 0; i--)
+	for (int i = std::size(m_vdc.s.quad) - 1; i >= 0; i--)
 	{
 		int y = m_vdc.s.quad[i].single[0].y;
 		if (is_ntsc() && y < 0xe)
@@ -605,7 +605,7 @@ void i8244_device::draw_major(int scanline, bitmap_ind16 &bitmap, const rectangl
 		{
 			int x = (m_vdc.s.quad[i].single[0].x + 5) * 2;
 
-			for (int j = 0; j < ARRAY_LENGTH(m_vdc.s.quad[0].single); j++, x += 16)
+			for (int j = 0; j < std::size(m_vdc.s.quad[0].single); j++, x += 16)
 			{
 				int offset = (m_vdc.s.quad[i].single[j].ptr | ((m_vdc.s.quad[i].single[j].color & 0x01) << 8)) + (y >> 1) + ((scanline - y) >> 1);
 
@@ -617,7 +617,7 @@ void i8244_device::draw_major(int scanline, bitmap_ind16 &bitmap, const rectangl
 	}
 
 	// regular foreground objects
-	for (int i = ARRAY_LENGTH(m_vdc.s.foreground) - 1; i >= 0; i--)
+	for (int i = std::size(m_vdc.s.foreground) - 1; i >= 0; i--)
 	{
 		int y = m_vdc.s.foreground[i].y;
 		if (is_ntsc() && y < 0xe)
@@ -642,7 +642,7 @@ void i8244_device::draw_major(int scanline, bitmap_ind16 &bitmap, const rectangl
 void i8244_device::draw_minor(int scanline, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	// minor system (sprites)
-	for (int i = ARRAY_LENGTH(m_vdc.s.sprites) - 1; i >= 0; i--)
+	for (int i = std::size(m_vdc.s.sprites) - 1; i >= 0; i--)
 	{
 		int y = m_vdc.s.sprites[i].y;
 		int height = 8;

--- a/src/devices/video/i82730.cpp
+++ b/src/devices/video/i82730.cpp
@@ -256,7 +256,7 @@ void i82730_device::execute_command()
 	uint8_t command = read_byte(m_cbp + 1);
 	uint16_t tmp;
 
-	if (VERBOSE_COMMANDS && command < ARRAY_LENGTH(s_command_names))
+	if (VERBOSE_COMMANDS && command < std::size(s_command_names))
 		logerror("%s('%s'): executing command: %s [cbp = %08x]\n", shortname(), basetag(), s_command_names[command], m_cbp);
 
 	tmp = read_word(m_cbp + 2);

--- a/src/devices/video/jangou_blitter.cpp
+++ b/src/devices/video/jangou_blitter.cpp
@@ -92,7 +92,7 @@ void jangou_blitter_device::device_start()
 
 void jangou_blitter_device::device_reset()
 {
-	memset(m_pen_data, 0, ARRAY_LENGTH(m_pen_data));
+	std::fill(std::begin(m_pen_data), std::end(m_pen_data), 0);
 	m_bltflip = false;
 	m_src_addr = 0;
 }

--- a/src/devices/video/mc6847.cpp
+++ b/src/devices/video/mc6847.cpp
@@ -555,7 +555,7 @@ mc6847_base_device::mc6847_base_device(const machine_config &mconfig, device_typ
 {
 	m_palette = s_palette;
 
-	for (int i = 0; i < ARRAY_LENGTH(s_palette); i++)
+	for (int i = 0; i < std::size(s_palette); i++)
 	{
 		m_bw_palette[i] = black_and_white(s_palette[i]);
 	}
@@ -693,7 +693,7 @@ void mc6847_base_device::record_scanline_res(int scanline, int32_t start_pos, in
 			{
 				// update values
 				//assert(current_sample_count >= 0);
-				assert(current_sample_count < ARRAY_LENGTH(m_data[scanline].m_mode));
+				assert(current_sample_count < std::size(m_data[scanline].m_mode));
 				update_value(&m_data[scanline].m_mode[current_sample_count], simplify_mode(data, m_mode));
 				update_value(&m_data[scanline].m_data[current_sample_count], data);
 				current_sample_count++;
@@ -948,7 +948,7 @@ mc6847_friend_device::character_map::character_map(const uint8_t *text_fontdata,
 		m_stripes[i] = ~(i / 12);
 
 	// loop through all modes
-	for (mode = 0; mode < ARRAY_LENGTH(m_entries); mode++)
+	for (mode = 0; mode < std::size(m_entries); mode++)
 	{
 		const uint8_t *fontdata;
 		uint8_t character_mask;

--- a/src/devices/video/mc6847.h
+++ b/src/devices/video/mc6847.h
@@ -107,7 +107,7 @@ protected:
 				uint8_t character = data[i];
 
 				// based on the mode, determine which entry to use
-				const entry *e = &m_entries[mode % ARRAY_LENGTH(m_entries)];
+				const entry *e = &m_entries[mode % std::size(m_entries)];
 
 				// identify the character in the font data
 				const uint8_t *font_character = e->m_fontdata + (character & e->m_character_mask) * 12;

--- a/src/devices/video/nt7534.cpp
+++ b/src/devices/video/nt7534.cpp
@@ -331,7 +331,7 @@ void nt7534_device::data_write(uint8_t data)
 
 	LOG("RAM write %x %x '%c'\n", m_page*132 + m_column, m_dr, isprint(m_dr) ? m_dr : '.');
 
-	if (m_page*132 + m_column < ARRAY_LENGTH(m_ddram))
+	if (m_page*132 + m_column < std::size(m_ddram))
 		m_ddram[m_page*132 + m_column] = m_dr;
 
 	if (m_column < 131)
@@ -342,7 +342,7 @@ void nt7534_device::data_write(uint8_t data)
 
 uint8_t nt7534_device::data_read()
 {
-	if (m_page*132 + m_column >= ARRAY_LENGTH(m_ddram))
+	if (m_page*132 + m_column >= std::size(m_ddram))
 		return 0;
 
 	uint8_t data = m_ddram[m_page*132 + m_column];

--- a/src/devices/video/poly.h
+++ b/src/devices/video/poly.h
@@ -341,7 +341,7 @@ poly_manager<BaseType, ObjectData, MaxParams, MaxPolys>::~poly_manager()
 {
 	// accumulate stats over the entire collection
 	int conflicts = 0, resolved = 0;
-	for (int i = 0; i < ARRAY_LENGTH(m_conflicts); i++)
+	for (int i = 0; i < std::size(m_conflicts); i++)
 	{
 		conflicts += m_conflicts[i];
 		resolved += m_resolved[i];

--- a/src/devices/video/polylgcy.cpp
+++ b/src/devices/video/polylgcy.cpp
@@ -360,8 +360,8 @@ void poly_free(legacy_poly_manager *poly)
 {
 #if KEEP_STATISTICS
 {
-	int i, conflicts = 0, resolved = 0;
-	for (i = 0; i < ARRAY_LENGTH(poly->conflicts); i++)
+	int conflicts = 0, resolved = 0;
+	for (int i = 0; i < std::size(poly->conflicts); i++)
 	{
 		conflicts += poly->conflicts[i];
 		resolved += poly->resolved[i];

--- a/src/devices/video/pwm.cpp
+++ b/src/devices/video/pwm.cpp
@@ -84,9 +84,10 @@ void pwm_display_device::device_start()
 	}
 
 	// initialize
-	std::fill_n(m_rowdata, ARRAY_LENGTH(m_rowdata), 0);
-	std::fill_n(m_rowdata_prev, ARRAY_LENGTH(m_rowdata_prev), 0);
-	std::fill_n(*m_bri, ARRAY_LENGTH(m_bri) * ARRAY_LENGTH(m_bri[0]), 0.0);
+	std::fill(std::begin(m_rowdata), std::end(m_rowdata), 0);
+	std::fill(std::begin(m_rowdata_prev), std::end(m_rowdata_prev), 0);
+	for (auto &bri : m_bri)
+		std::fill(std::begin(bri), std::end(bri), 0.0);
 
 	m_frame_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(pwm_display_device::frame_tick),this));
 	m_update_time = machine().time();
@@ -215,7 +216,7 @@ void pwm_display_device::update()
 
 void pwm_display_device::schedule_frame()
 {
-	std::fill_n(*m_acc, m_height * ARRAY_LENGTH(m_acc[0]), attotime::zero);
+	std::fill_n(*m_acc, m_height * std::size(m_acc[0]), attotime::zero);
 
 	m_framerate = m_framerate_set;
 	m_frame_timer->adjust(m_framerate);

--- a/src/devices/video/pwm.h
+++ b/src/devices/video/pwm.h
@@ -21,7 +21,7 @@ public:
 	pwm_display_device &set_refresh(attotime duration) { m_framerate_set = duration; return *this; } // time between each outputs refresh
 	pwm_display_device &set_interpolation(double factor) { m_interpolation = factor; return *this; } // frame interpolation (0.0 - 1.0)
 	pwm_display_device &set_segmask(u64 digits, u64 mask); // mask for multi-state outputs, eg. 7seg led
-	pwm_display_device &reset_segmask() { std::fill_n(m_segmask, ARRAY_LENGTH(m_segmask), 0); return *this; }
+	pwm_display_device &reset_segmask() { std::fill(std::begin(m_segmask), std::end(m_segmask), 0); return *this; }
 	pwm_display_device &set_bri_levels(double l0, double l1 = 1.0, double l2 = 1.0, double l3 = 1.0); // brightness threshold per level (0.0 - 1.0)
 	pwm_display_device &set_bri_minimum(u8 i) { m_level_min = i; return *this; } // minimum level index for element to be considered "on"
 	pwm_display_device &set_bri_maximum(double b) { m_level_max = b; return *this; } // maximum brightness level, 0.0 for auto
@@ -31,7 +31,7 @@ public:
 	auto output_a() { return m_output_a_cb.bind(); }
 	auto output_digit() { return m_output_digit_cb.bind(); }
 
-	void reset_bri_levels() { std::fill_n(m_levels, ARRAY_LENGTH(m_levels), 1.0); }
+	void reset_bri_levels() { std::fill(std::begin(m_levels), std::end(m_levels), 1.0); }
 	void set_bri_one(u8 i, double level) { m_levels[i] = level; }
 	void segmask_one(u8 y, u64 mask) { m_segmask[y] = mask; }
 

--- a/src/devices/video/snes_ppu.cpp
+++ b/src/devices/video/snes_ppu.cpp
@@ -251,15 +251,12 @@ void snes_ppu_device::device_start()
 		}
 	}
 
-	for (int i = 0; i < ARRAY_LENGTH(m_scanlines); i++)
-	{
-		save_item(NAME(m_scanlines[i].enable), i);
-		save_item(NAME(m_scanlines[i].clip), i);
-		save_item(NAME(m_scanlines[i].buffer), i);
-		save_item(NAME(m_scanlines[i].priority), i);
-		save_item(NAME(m_scanlines[i].layer), i);
-		save_item(NAME(m_scanlines[i].blend_exception), i);
-	}
+	save_item(STRUCT_MEMBER(m_scanlines, enable));
+	save_item(STRUCT_MEMBER(m_scanlines, clip));
+	save_item(STRUCT_MEMBER(m_scanlines, buffer));
+	save_item(STRUCT_MEMBER(m_scanlines, priority));
+	save_item(STRUCT_MEMBER(m_scanlines, layer));
+	save_item(STRUCT_MEMBER(m_scanlines, blend_exception));
 
 	save_item(STRUCT_MEMBER(m_layer, window1_enabled));
 	save_item(STRUCT_MEMBER(m_layer, window1_invert));
@@ -283,8 +280,7 @@ void snes_ppu_device::device_start()
 	save_item(STRUCT_MEMBER(m_layer, mosaic_counter));
 	save_item(STRUCT_MEMBER(m_layer, mosaic_offset));
 
-	for (int i = 0; i < ARRAY_LENGTH(m_clipmasks); i++)
-		save_item(NAME(m_clipmasks[i]), i);
+	save_item(NAME(m_clipmasks));
 
 	save_item(NAME(m_oam.address));
 	save_item(NAME(m_oam.base_address));

--- a/src/devices/video/stvvdp2.cpp
+++ b/src/devices/video/stvvdp2.cpp
@@ -6198,7 +6198,7 @@ int saturn_state::get_vcounter( void )
 		return (vcount & ~1) | (m_screen->frame_number() & 1);
 
 	/* docs says << 1, but according to HW tests it's a typo. */
-	assert((vcount & 0x1ff) < ARRAY_LENGTH(true_vcount));
+	assert((vcount & 0x1ff) < std::size(true_vcount));
 	return (true_vcount[vcount & 0x1ff][STV_VDP2_VRES]); // Non-interlace
 }
 

--- a/src/devices/video/tms34061.cpp
+++ b/src/devices/video/tms34061.cpp
@@ -182,7 +182,7 @@ void tms34061_device::register_w(offs_t offset, u8 data)
 		screen().update_partial(screen().vpos());
 
 	/* store the hi/lo half */
-	if (regnum < ARRAY_LENGTH(m_regs))
+	if (regnum < std::size(m_regs))
 	{
 		if (offset & 0x02)
 			m_regs[regnum] = (m_regs[regnum] & 0x00ff) | (data << 8);
@@ -248,7 +248,7 @@ u8 tms34061_device::register_r(offs_t offset)
 	u16 result;
 
 	/* extract the correct portion of the register */
-	if (regnum < ARRAY_LENGTH(m_regs))
+	if (regnum < std::size(m_regs))
 		result = m_regs[regnum];
 	else
 		result = 0xffff;

--- a/src/devices/video/vic4567.cpp
+++ b/src/devices/video/vic4567.cpp
@@ -317,7 +317,7 @@ void vic3_device::device_start()
 
 void vic3_device::device_reset()
 {
-	memset(m_reg, 0, ARRAY_LENGTH(m_reg));
+	std::fill(std::begin(m_reg), std::end(m_reg), 0);
 
 	m_on = 1;
 
@@ -355,8 +355,8 @@ void vic3_device::device_reset()
 	m_lastline = 0;
 	m_rasterline = 0;
 
-	memset(m_shift, 0, ARRAY_LENGTH(m_shift));
-	memset(m_multi_collision, 0, ARRAY_LENGTH(m_multi_collision));
+	std::fill(std::begin(m_shift), std::end(m_shift), 0);
+	std::fill(std::begin(m_multi_collision), std::end(m_multi_collision), 0);
 
 	for (int i = 0; i < 256; i++)
 	{

--- a/src/devices/video/voodoo.cpp
+++ b/src/devices/video/voodoo.cpp
@@ -1141,11 +1141,11 @@ void voodoo_device::tmu_state::init(uint8_t vdt, tmu_shared_state &share, voodoo
 void voodoo_device::voodoo_postload()
 {
 	fbi.clut_dirty = true;
-	for (int index = 0; index < ARRAY_LENGTH(tmu); index++)
+	for (tmu_state &tm : tmu)
 	{
-		tmu[index].regdirty = true;
-		for (int subindex = 0; subindex < ARRAY_LENGTH(tmu[index].ncc); subindex++)
-			tmu[index].ncc[subindex].dirty = true;
+		tm.regdirty = true;
+		for (tmu_state::ncc_table &ncc : tm.ncc)
+			ncc.dirty = true;
 	}
 
 	/* recompute video memory to get the FBI FIFO base recomputed */
@@ -1160,7 +1160,7 @@ void voodoo_device::init_save_state(voodoo_device *vd)
 
 	/* register states: core */
 	vd->save_item(NAME(vd->extra_cycles));
-	vd->save_pointer(NAME(&vd->reg[0].u), ARRAY_LENGTH(vd->reg));
+	vd->save_pointer(NAME(&vd->reg[0].u), std::size(vd->reg));
 	vd->save_item(NAME(vd->alt_regmap));
 
 	/* register states: pci */
@@ -1264,7 +1264,7 @@ void voodoo_device::init_save_state(voodoo_device *vd)
 	vd->save_item(NAME(vd->fbi.clut));
 
 	/* register states: tmu */
-	for (int index = 0; index < ARRAY_LENGTH(vd->tmu); index++)
+	for (int index = 0; index < std::size(vd->tmu); index++)
 	{
 		tmu_state *tmu = &vd->tmu[index];
 		if (tmu->ram == nullptr)
@@ -4872,7 +4872,7 @@ u8 voodoo_banshee_device::banshee_vga_r(offs_t offset)
 	{
 		/* attribute access */
 		case 0x3c0:
-			if (banshee.vga[0x3c1 & 0x1f] < ARRAY_LENGTH(banshee.att))
+			if (banshee.vga[0x3c1 & 0x1f] < std::size(banshee.att))
 				result = banshee.att[banshee.vga[0x3c1 & 0x1f]];
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_att_r(%X)\n", machine().describe_context(), banshee.vga[0x3c1 & 0x1f]);
@@ -4893,7 +4893,7 @@ u8 voodoo_banshee_device::banshee_vga_r(offs_t offset)
 
 		/* Sequencer access */
 		case 0x3c5:
-			if (banshee.vga[0x3c4 & 0x1f] < ARRAY_LENGTH(banshee.seq))
+			if (banshee.vga[0x3c4 & 0x1f] < std::size(banshee.seq))
 				result = banshee.seq[banshee.vga[0x3c4 & 0x1f]];
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_seq_r(%X)\n", machine().describe_context(), banshee.vga[0x3c4 & 0x1f]);
@@ -4916,7 +4916,7 @@ u8 voodoo_banshee_device::banshee_vga_r(offs_t offset)
 
 		/* Graphics controller access */
 		case 0x3cf:
-			if (banshee.vga[0x3ce & 0x1f] < ARRAY_LENGTH(banshee.gc))
+			if (banshee.vga[0x3ce & 0x1f] < std::size(banshee.gc))
 				result = banshee.gc[banshee.vga[0x3ce & 0x1f]];
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_gc_r(%X)\n", machine().describe_context(), banshee.vga[0x3ce & 0x1f]);
@@ -4924,7 +4924,7 @@ u8 voodoo_banshee_device::banshee_vga_r(offs_t offset)
 
 		/* CRTC access */
 		case 0x3d5:
-			if (banshee.vga[0x3d4 & 0x1f] < ARRAY_LENGTH(banshee.crtc))
+			if (banshee.vga[0x3d4 & 0x1f] < std::size(banshee.crtc))
 				result = banshee.crtc[banshee.vga[0x3d4 & 0x1f]];
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_crtc_r(%X)\n", machine().describe_context(), banshee.vga[0x3d4 & 0x1f]);
@@ -5440,7 +5440,7 @@ void voodoo_banshee_device::banshee_vga_w(offs_t offset, u8 data)
 			}
 			else
 			{
-				if (banshee.vga[0x3c1 & 0x1f] < ARRAY_LENGTH(banshee.att))
+				if (banshee.vga[0x3c1 & 0x1f] < std::size(banshee.att))
 					banshee.att[banshee.vga[0x3c1 & 0x1f]] = data;
 				if (LOG_REGISTERS)
 					logerror("%s:banshee_att_w(%X) = %02X\n", machine().describe_context(), banshee.vga[0x3c1 & 0x1f], data);
@@ -5450,7 +5450,7 @@ void voodoo_banshee_device::banshee_vga_w(offs_t offset, u8 data)
 
 		/* Sequencer access */
 		case 0x3c5:
-			if (banshee.vga[0x3c4 & 0x1f] < ARRAY_LENGTH(banshee.seq))
+			if (banshee.vga[0x3c4 & 0x1f] < std::size(banshee.seq))
 				banshee.seq[banshee.vga[0x3c4 & 0x1f]] = data;
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_seq_w(%X) = %02X\n", machine().describe_context(), banshee.vga[0x3c4 & 0x1f], data);
@@ -5458,7 +5458,7 @@ void voodoo_banshee_device::banshee_vga_w(offs_t offset, u8 data)
 
 		/* Graphics controller access */
 		case 0x3cf:
-			if (banshee.vga[0x3ce & 0x1f] < ARRAY_LENGTH(banshee.gc))
+			if (banshee.vga[0x3ce & 0x1f] < std::size(banshee.gc))
 				banshee.gc[banshee.vga[0x3ce & 0x1f]] = data;
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_gc_w(%X) = %02X\n", machine().describe_context(), banshee.vga[0x3ce & 0x1f], data);
@@ -5466,7 +5466,7 @@ void voodoo_banshee_device::banshee_vga_w(offs_t offset, u8 data)
 
 		/* CRTC access */
 		case 0x3d5:
-			if (banshee.vga[0x3d4 & 0x1f] < ARRAY_LENGTH(banshee.crtc))
+			if (banshee.vga[0x3d4 & 0x1f] < std::size(banshee.crtc))
 				banshee.crtc[banshee.vga[0x3d4 & 0x1f]] = data;
 			if (LOG_REGISTERS)
 				logerror("%s:banshee_crtc_w(%X) = %02X\n", machine().describe_context(), banshee.vga[0x3d4 & 0x1f], data);
@@ -5840,7 +5840,6 @@ int32_t voodoo_device::fastfill(voodoo_device *vd)
 	uint16_t dithermatrix[16];
 	uint16_t *drawbuf = nullptr;
 	uint32_t pixels = 0;
-	int extnum, x, y;
 
 	/* if we're not clearing either, take no time */
 	if (!FBZMODE_RGB_BUFFER_MASK(vd->reg[fbzMode].u) && !FBZMODE_AUX_BUFFER_MASK(vd->reg[fbzMode].u))
@@ -5866,11 +5865,11 @@ int32_t voodoo_device::fastfill(voodoo_device *vd)
 		}
 
 		/* determine the dither pattern */
-		for (y = 0; y < 4; y++)
+		for (int y = 0; y < 4; y++)
 		{
 			DECLARE_DITHER_POINTERS_NO_DITHER_VAR;
 			COMPUTE_DITHER_POINTERS_NO_DITHER_VAR(vd->reg[fbzMode].u, y);
-			for (x = 0; x < 4; x++)
+			for (int x = 0; x < 4; x++)
 			{
 				int r = vd->reg[color1].rgb.r;
 				int g = vd->reg[color1].rgb.g;
@@ -5885,14 +5884,13 @@ int32_t voodoo_device::fastfill(voodoo_device *vd)
 	/* fill in a block of extents */
 	extents[0].startx = sx;
 	extents[0].stopx = ex;
-	for (extnum = 1; extnum < ARRAY_LENGTH(extents); extnum++)
-		extents[extnum] = extents[0];
+	std::fill(std::begin(extents) + 1, std::end(extents), extents[0]);
 
 	/* iterate over blocks of extents */
-	for (y = sy; y < ey; y += ARRAY_LENGTH(extents))
+	for (int y = sy; y < ey; y += std::size(extents))
 	{
 		poly_extra_data *extra = (poly_extra_data *)poly_get_extra_data(vd->poly);
-		int count = (std::min)(ey - y, int(ARRAY_LENGTH(extents)));
+		int count = (std::min)(ey - y, int(std::size(extents)));
 
 		extra->device = vd;
 		memcpy(extra->dither, dithermatrix, sizeof(extra->dither));

--- a/src/emu/bookkeeping.cpp
+++ b/src/emu/bookkeeping.cpp
@@ -157,7 +157,7 @@ void bookkeeping_manager::config_save(config_type cfg_type, util::xml::data_node
 
 void bookkeeping_manager::coin_counter_w(int num, int on)
 {
-	if (num >= ARRAY_LENGTH(m_coin_count))
+	if (num >= std::size(m_coin_count))
 		return;
 
 	/* Count it only if the data has changed from 0 to non-zero */
@@ -174,7 +174,7 @@ void bookkeeping_manager::coin_counter_w(int num, int on)
 
 int bookkeeping_manager::coin_counter_get_count(int num)
 {
-	if (num >= ARRAY_LENGTH(m_coin_count))
+	if (num >= std::size(m_coin_count))
 		return 0;
 	return m_coin_count[num];
 }
@@ -186,7 +186,7 @@ int bookkeeping_manager::coin_counter_get_count(int num)
 
 void bookkeeping_manager::coin_lockout_w(int num,int on)
 {
-	if (num >= ARRAY_LENGTH(m_coinlockedout))
+	if (num >= std::size(m_coinlockedout))
 		return;
 	m_coinlockedout[num] = on;
 }
@@ -199,7 +199,7 @@ void bookkeeping_manager::coin_lockout_w(int num,int on)
 
 int bookkeeping_manager::coin_lockout_get_state(int num)
 {
-	if (num >= ARRAY_LENGTH(m_coinlockedout))
+	if (num >= std::size(m_coinlockedout))
 		return false;
 	return m_coinlockedout[num];
 }
@@ -212,6 +212,6 @@ int bookkeeping_manager::coin_lockout_get_state(int num)
 
 void bookkeeping_manager::coin_lockout_global_w(int on)
 {
-	for (int i = 0; i < ARRAY_LENGTH(m_coinlockedout); i++)
+	for (int i = 0; i < std::size(m_coinlockedout); i++)
 		coin_lockout_w(i, on);
 }

--- a/src/emu/crsshair.cpp
+++ b/src/emu/crsshair.cpp
@@ -172,7 +172,7 @@ void render_crosshair::set_default_bitmap()
 
 void render_crosshair::create_bitmap()
 {
-	rgb_t color = m_player < ARRAY_LENGTH(crosshair_colors) ? crosshair_colors[m_player] : rgb_t::white();
+	rgb_t color = m_player < std::size(crosshair_colors) ? crosshair_colors[m_player] : rgb_t::white();
 
 	// if we have a bitmap and texture for this player, kill it
 	if (!m_bitmap)

--- a/src/emu/debug/debugcmd.cpp
+++ b/src/emu/debug/debugcmd.cpp
@@ -3820,7 +3820,7 @@ void debugger_commands::execute_symlist(int ref, const std::vector<std::string> 
 		if (!entry.second->is_function())
 		{
 			namelist[count++] = entry.second->name();
-			if (count >= ARRAY_LENGTH(namelist))
+			if (count >= std::size(namelist))
 				break;
 		}
 	}

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -1380,7 +1380,7 @@ offs_t device_debug::history_pc(int index) const
 		index = 0;
 	if (index <= -HISTORY_SIZE)
 		index = -HISTORY_SIZE + 1;
-	return m_pc_history[(m_pc_history_index + ARRAY_LENGTH(m_pc_history) - 1 + index) % ARRAY_LENGTH(m_pc_history)];
+	return m_pc_history[(m_pc_history_index + std::size(m_pc_history) - 1 + index) % std::size(m_pc_history)];
 }
 
 

--- a/src/emu/debug/debughlp.cpp
+++ b/src/emu/debug/debughlp.cpp
@@ -1637,7 +1637,7 @@ const char *debug_get_help(const char *tag)
 	size_t taglen = strlen(tag);
 
 	/* find a match */
-	for (i = 0; i < ARRAY_LENGTH(static_help_list); i++)
+	for (i = 0; i < std::size(static_help_list); i++)
 		if (!core_strnicmp(static_help_list[i].tag, tag, taglen))
 		{
 			foundcount++;
@@ -1659,7 +1659,7 @@ const char *debug_get_help(const char *tag)
 
 	/* otherwise, indicate ambiguous help */
 	msglen = sprintf(ambig_message, "Ambiguous help request, did you mean:\n");
-	for (i = 0; i < ARRAY_LENGTH(static_help_list); i++)
+	for (i = 0; i < std::size(static_help_list); i++)
 		if (!core_strnicmp(static_help_list[i].tag, tag, taglen))
 			msglen += sprintf(&ambig_message[msglen], "  help %s?\n", static_help_list[i].tag);
 	return ambig_message;

--- a/src/emu/debug/dvbpoints.cpp
+++ b/src/emu/debug/dvbpoints.cpp
@@ -217,7 +217,7 @@ void debug_view_breakpoints::view_update()
 	gather_breakpoints();
 
 	// Set the view region so the scroll bars update
-	m_total.x = tableBreaks[ARRAY_LENGTH(tableBreaks) - 1];
+	m_total.x = tableBreaks[std::size(tableBreaks) - 1];
 	m_total.y = m_buffer.size() + 1;
 	if (m_total.y < 10)
 		m_total.y = 10;
@@ -225,7 +225,7 @@ void debug_view_breakpoints::view_update()
 	// Draw
 	debug_view_char     *dest = &m_viewdata[0];
 	util::ovectorstream linebuf;
-	linebuf.reserve(ARRAY_LENGTH(tableBreaks) - 1);
+	linebuf.reserve(std::size(tableBreaks) - 1);
 
 	// Header
 	if (m_visible.y > 0)

--- a/src/emu/debug/dvwpoints.cpp
+++ b/src/emu/debug/dvwpoints.cpp
@@ -239,7 +239,7 @@ void debug_view_watchpoints::view_update()
 	gather_watchpoints();
 
 	// Set the view region so the scroll bars update
-	m_total.x = tableBreaks[ARRAY_LENGTH(tableBreaks) - 1];
+	m_total.x = tableBreaks[std::size(tableBreaks) - 1];
 	m_total.y = m_buffer.size() + 1;
 	if (m_total.y < 10)
 		m_total.y = 10;
@@ -247,7 +247,7 @@ void debug_view_watchpoints::view_update()
 	// Draw
 	debug_view_char     *dest = &m_viewdata[0];
 	util::ovectorstream linebuf;
-	linebuf.reserve(ARRAY_LENGTH(tableBreaks) - 1);
+	linebuf.reserve(std::size(tableBreaks) - 1);
 
 	// Header
 	if (m_visible.y > 0)

--- a/src/emu/diexec.cpp
+++ b/src/emu/diexec.cpp
@@ -416,7 +416,7 @@ void device_execute_interface::interface_post_start()
 	device().save_item(STRUCT_MEMBER(m_input, m_curstate));
 
 	// fill in the input states and IRQ callback information
-	for (int line = 0; line < ARRAY_LENGTH(m_input); line++)
+	for (int line = 0; line < std::size(m_input); line++)
 		m_input[line].start(*this, line);
 }
 
@@ -679,7 +679,7 @@ if (TEMPLOG) printf("setline(%s,%d,%d,%d)\n", m_execute->device().tag(), m_linen
 
 	// if we're full of events, flush the queue and log a message
 	int event_index = m_qindex++;
-	if (event_index >= ARRAY_LENGTH(m_queue))
+	if (event_index >= std::size(m_queue))
 	{
 		m_qindex--;
 		empty_event_queue(nullptr,0);
@@ -688,7 +688,7 @@ if (TEMPLOG) printf("setline(%s,%d,%d,%d)\n", m_execute->device().tag(), m_linen
 	}
 
 	// enqueue the event
-	if (event_index < ARRAY_LENGTH(m_queue))
+	if (event_index < std::size(m_queue))
 	{
 		if (vector == USE_STORED_VECTOR)
 			vector = m_stored_vector;

--- a/src/emu/diimage.cpp
+++ b/src/emu/diimage.cpp
@@ -130,17 +130,16 @@ void device_image_interface::interface_config_complete()
 
 
 //-------------------------------------------------
-//  find_device_type - search trough list of
+//  find_device_type - search through list of
 //  device types to extract data
 //-------------------------------------------------
 
 const image_device_type_info *device_image_interface::find_device_type(iodevice_t type)
 {
-	int i;
-	for (i = 0; i < ARRAY_LENGTH(device_image_interface::m_device_info_array); i++)
+	for (const image_device_type_info &info : m_device_info_array)
 	{
-		if (m_device_info_array[i].m_type == type)
-			return &m_device_info_array[i];
+		if (info.m_type == type)
+			return &info;
 	}
 	return nullptr;
 }
@@ -172,11 +171,10 @@ const char *device_image_interface::device_brieftypename(iodevice_t type)
 
 iodevice_t device_image_interface::device_typeid(const char *name)
 {
-	int i;
-	for (i = 0; i < ARRAY_LENGTH(device_image_interface::m_device_info_array); i++)
+	for (const image_device_type_info &info : m_device_info_array)
 	{
-		if (!core_stricmp(name, m_device_info_array[i].m_name) || !core_stricmp(name, m_device_info_array[i].m_shortname))
-			return m_device_info_array[i].m_type;
+		if (!core_stricmp(name, info.m_name) || !core_stricmp(name, info.m_shortname))
+			return info.m_type;
 	}
 	return (iodevice_t)-1;
 }
@@ -333,7 +331,7 @@ void device_image_interface::message(const char *format, ...)
 
 	/* format the message */
 	va_start(args, format);
-	vsnprintf(buffer, ARRAY_LENGTH(buffer), format, args);
+	vsnprintf(buffer, std::size(buffer), format, args);
 	va_end(args);
 
 	/* display the popup for a standard amount of time */

--- a/src/emu/dipalette.cpp
+++ b/src/emu/dipalette.cpp
@@ -491,7 +491,7 @@ void device_palette_interface::configure_rgb_shadows(int mode, float factor)
 	assert(m_format != BITMAP_FORMAT_IND16);
 
 	// verify the shadow table
-	assert(mode >= 0 && mode < ARRAY_LENGTH(m_shadow_tables));
+	assert(mode >= 0 && mode < std::size(m_shadow_tables));
 	shadow_table_data &stable = m_shadow_tables[mode];
 	assert(stable.base != nullptr);
 

--- a/src/emu/diserial.h
+++ b/src/emu/diserial.h
@@ -201,8 +201,8 @@ protected:
 	virtual void tra_complete() override
 	{
 		assert(!m_empty || (m_head == m_tail));
-		assert(m_head < ARRAY_LENGTH(m_fifo));
-		assert(m_tail < ARRAY_LENGTH(m_fifo));
+		assert(m_head < std::size(m_fifo));
+		assert(m_tail < std::size(m_fifo));
 
 		if (!m_empty)
 		{
@@ -227,8 +227,8 @@ protected:
 	void transmit_byte(u8 byte)
 	{
 		assert(!m_empty || (m_head == m_tail));
-		assert(m_head < ARRAY_LENGTH(m_fifo));
-		assert(m_tail < ARRAY_LENGTH(m_fifo));
+		assert(m_head < std::size(m_fifo));
+		assert(m_tail < std::size(m_fifo));
 
 		if (m_empty && is_transmit_register_empty())
 		{

--- a/src/emu/distate.cpp
+++ b/src/emu/distate.cpp
@@ -337,12 +337,12 @@ std::string device_state_entry::format(const char *string, bool maxout) const
 				if (width == 0)
 					throw emu_fatalerror("Width required for %%u formats\n");
 				hitnonzero = false;
-				while (leadzero && width > ARRAY_LENGTH(k_decimal_divisor))
+				while (leadzero && width > std::size(k_decimal_divisor))
 				{
 					dest.append(" ");
 					width--;
 				}
-				for (int digitnum = ARRAY_LENGTH(k_decimal_divisor) - 1; digitnum >= 0; digitnum--)
+				for (int digitnum = std::size(k_decimal_divisor) - 1; digitnum >= 0; digitnum--)
 				{
 					int digit = (result >= k_decimal_divisor[digitnum]) ? (result / k_decimal_divisor[digitnum]) % 10 : 0;
 					if (digit != 0)

--- a/src/emu/emucore.h
+++ b/src/emu/emucore.h
@@ -80,9 +80,6 @@ using util::iabs;
 using util::string_format;
 
 
-// genf is a generic function pointer; cast function pointers to this instead of void *
-typedef void genf(void);
-
 // pen_t is used to represent pixel values in bitmaps
 typedef u32 pen_t;
 

--- a/src/emu/fileio.cpp
+++ b/src/emu/fileio.cpp
@@ -719,12 +719,12 @@ osd_file::error emu_file::attempt_zipped()
 {
 	typedef util::archive_file::error (*open_func)(const std::string &filename, util::archive_file::ptr &result);
 	char const *const suffixes[] = { ".zip", ".7z" };
-	open_func const open_funcs[ARRAY_LENGTH(suffixes)] = { &util::archive_file::open_zip, &util::archive_file::open_7z };
+	open_func const open_funcs[std::size(suffixes)] = { &util::archive_file::open_zip, &util::archive_file::open_7z };
 
 	// loop over archive types
 	std::string const savepath(m_fullpath);
 	std::string filename;
-	for (unsigned i = 0; i < ARRAY_LENGTH(suffixes); i++, m_fullpath = savepath, filename.clear())
+	for (unsigned i = 0; i < std::size(suffixes); i++, m_fullpath = savepath, filename.clear())
 	{
 		// loop over directory parts up to the start of filename
 		while (1)

--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -668,7 +668,7 @@ bool input_manager::code_pressed_once(input_code code)
 	// look for the code in the memory
 	bool curvalue = code_pressed(code);
 	int empty = -1;
-	for (int memnum = 0; memnum < ARRAY_LENGTH(m_switch_memory); memnum++)
+	for (int memnum = 0; memnum < std::size(m_switch_memory); memnum++)
 	{
 		// were we previous pressed on the last time through here?
 		if (m_switch_memory[memnum] == code)
@@ -876,7 +876,7 @@ input_code input_manager::code_from_token(std::string_view _token)
 	// copy the token and break it into pieces
 	std::string token[6];
 	int numtokens = 0;
-	while (numtokens < ARRAY_LENGTH(token))
+	while (numtokens < std::size(token))
 	{
 		// make a token up to the next underscore
 		std::string_view::size_type score = _token.find('_');
@@ -1327,7 +1327,7 @@ bool input_manager::map_device_to_controller(const devicemap_table_type *devicem
 		std::string token[2];
 		int numtokens = 0;
 		std::string_view _token = controllername;
-		while (numtokens < ARRAY_LENGTH(token))
+		while (numtokens < std::size(token))
 		{
 			// make a token up to the next underscore
 			std::string_view::size_type score = _token.find('_');

--- a/src/emu/ioport.cpp
+++ b/src/emu/ioport.cpp
@@ -633,7 +633,7 @@ ioport_field::ioport_field(ioport_port &port, ioport_type type, ioport_value def
 	for (input_seq_type seqtype = SEQ_TYPE_STANDARD; seqtype < SEQ_TYPE_TOTAL; ++seqtype)
 		m_seq[seqtype].set_default();
 
-	for (int i = 0; i < ARRAY_LENGTH(m_chars); i++)
+	for (int i = 0; i < std::size(m_chars); i++)
 		std::fill(std::begin(m_chars[i]), std::end(m_chars[i]), char32_t(0));
 
 	// for DIP switches and configs, look for a default value from the owner
@@ -782,11 +782,11 @@ ioport_type_class ioport_field::type_class() const noexcept
 
 std::vector<char32_t> ioport_field::keyboard_codes(int which) const
 {
-	if (which >= ARRAY_LENGTH(m_chars))
+	if (which >= std::size(m_chars))
 		throw emu_fatalerror("Tried to access keyboard_code with out-of-range index %d\n", which);
 
 	std::vector<char32_t> result;
-	for (int i = 0; i < ARRAY_LENGTH(m_chars[which]) && m_chars[which][i] != 0; i++)
+	for (int i = 0; i < std::size(m_chars[which]) && m_chars[which][i] != 0; i++)
 		result.push_back(m_chars[which][i]);
 
 	return result;
@@ -3012,12 +3012,9 @@ const char *ioport_configurer::string_from_token(const char *string)
 #if false // Set true, If you want to take care missing-token or wrong-sorting
 
 	// otherwise, scan the list for a matching string and return it
-	{
-	int index;
-	for (index = 0; index < ARRAY_LENGTH(input_port_default_strings); index++)
+	for (int index = 0; index < std::size(input_port_default_strings); index++)
 		if (input_port_default_strings[index].id == uintptr_t(string))
 			return input_port_default_strings[index].string;
-	}
 	return "(Unknown Default)";
 
 #else
@@ -3096,10 +3093,10 @@ ioport_configurer& ioport_configurer::field_alloc(ioport_type type, ioport_value
 
 ioport_configurer& ioport_configurer::field_add_char(std::initializer_list<char32_t> charlist)
 {
-	for (int index = 0; index < ARRAY_LENGTH(m_curfield->m_chars); index++)
+	for (int index = 0; index < std::size(m_curfield->m_chars); index++)
 		if (m_curfield->m_chars[index][0] == 0)
 		{
-			const size_t char_count = ARRAY_LENGTH(m_curfield->m_chars[index]);
+			const size_t char_count = std::size(m_curfield->m_chars[index]);
 			assert(charlist.size() > 0 && charlist.size() <= char_count);
 
 			for (size_t i = 0; i < char_count; i++)
@@ -3782,7 +3779,7 @@ std::string ioport_manager::input_type_to_token(ioport_type type, int player)
 input_seq_type ioport_manager::token_to_seq_type(const char *string)
 {
 	// look up the string in the table of possible sequence types and return the index
-	for (int seqindex = 0; seqindex < ARRAY_LENGTH(seqtypestrings); seqindex++)
+	for (int seqindex = 0; seqindex < std::size(seqtypestrings); seqindex++)
 		if (!core_stricmp(string, seqtypestrings[seqindex]))
 			return input_seq_type(seqindex);
 	return SEQ_TYPE_INVALID;

--- a/src/emu/natkeyboard.cpp
+++ b/src/emu/natkeyboard.cpp
@@ -1066,7 +1066,7 @@ const char_info *char_info::find(char32_t target)
 {
 	// perform a simple binary search to find the proper alternate
 	int low = 0;
-	int high = ARRAY_LENGTH(charinfo);
+	int high = std::size(charinfo);
 	while (high > low)
 	{
 		int middle = (high + low) / 2;
@@ -1096,7 +1096,7 @@ bool validate_natural_keyboard_statics(void)
     const char_info *ci;
 
     // check to make sure that charinfo is in order
-    for (i = 0; i < ARRAY_LENGTH(charinfo); i++)
+    for (i = 0; i < std::size(charinfo); i++)
     {
         if (last_char >= charinfo[i].ch)
         {
@@ -1107,7 +1107,7 @@ bool validate_natural_keyboard_statics(void)
     }
 
     // check to make sure that I can look up everything on alternate_charmap
-    for (i = 0; i < ARRAY_LENGTH(charinfo); i++)
+    for (i = 0; i < std::size(charinfo); i++)
     {
         ci = char_info::find(charinfo[i].ch);
         if (ci != &charinfo[i])

--- a/src/emu/profiler.h
+++ b/src/emu/profiler.h
@@ -117,7 +117,7 @@ private:
 	ATTR_FORCE_INLINE void real_start(profile_type type)
 	{
 		// fail if we overflow
-		if (m_filoptr >= &m_filo[ARRAY_LENGTH(m_filo) - 1])
+		if (m_filoptr >= &m_filo[std::size(m_filo) - 1])
 			throw emu_fatalerror("Profiler FILO overflow (type = %d)\n", type);
 
 		// get current tick count

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -442,7 +442,7 @@ void render_texture::get_scaled(u32 dwidth, u32 dheight, render_texinfo &texinfo
 		// is it a size we already have?
 		scaled_texture *scaled = nullptr;
 		int scalenum;
-		for (scalenum = 0; scalenum < ARRAY_LENGTH(m_scaled); scalenum++)
+		for (scalenum = 0; scalenum < std::size(m_scaled); scalenum++)
 		{
 			scaled = &m_scaled[scalenum];
 
@@ -452,12 +452,12 @@ void render_texture::get_scaled(u32 dwidth, u32 dheight, render_texinfo &texinfo
 		}
 
 		// did we get one?
-		if (scalenum == ARRAY_LENGTH(m_scaled))
+		if (scalenum == std::size(m_scaled))
 		{
 			int lowest = -1;
 
 			// didn't find one -- take the entry with the lowest seqnum
-			for (scalenum = 0; scalenum < ARRAY_LENGTH(m_scaled); scalenum++)
+			for (scalenum = 0; scalenum < std::size(m_scaled); scalenum++)
 				if ((lowest == -1 || m_scaled[scalenum].seqid < m_scaled[lowest].seqid) && !primlist.has_reference(m_scaled[scalenum].bitmap.get()))
 					lowest = scalenum;
 			if (-1 == lowest)
@@ -697,7 +697,7 @@ const rgb_t *render_container::bcg_lookup_table(int texformat, u32 &out_length, 
 		case TEXFORMAT_RGB32:
 		case TEXFORMAT_ARGB32:
 		case TEXFORMAT_YUY16:
-			out_length = ARRAY_LENGTH(m_bcglookup256);
+			out_length = std::size(m_bcglookup256);
 			return m_bcglookup256;
 
 		default:
@@ -1318,7 +1318,7 @@ render_primitive_list &render_target::get_primitives()
 
 	// switch to the next primitive list
 	render_primitive_list &list = m_primlist[m_listindex];
-	m_listindex = (m_listindex + 1) % ARRAY_LENGTH(m_primlist);
+	m_listindex = (m_listindex + 1) % std::size(m_primlist);
 	list.acquire_lock();
 
 	// free any previous primitives

--- a/src/emu/rendfont.cpp
+++ b/src/emu/rendfont.cpp
@@ -478,7 +478,7 @@ inline render_font::glyph &render_font::get_char(char32_t chnum)
 	static glyph dummy_glyph;
 
 	unsigned const page(chnum / 256);
-	if (page >= ARRAY_LENGTH(m_glyphs))
+	if (page >= std::size(m_glyphs))
 	{
 		if ((0 <= m_defchar) && (chnum != m_defchar))
 			return get_char(m_defchar);
@@ -1292,7 +1292,7 @@ bool render_font::load_bdf()
 			{
 				LOG("render_font::load_bdf: ignoring character with negative x advance\n");
 			}
-			else if ((256 * ARRAY_LENGTH(m_glyphs)) <= encoding)
+			else if ((256 * std::size(m_glyphs)) <= encoding)
 			{
 				LOG("render_font::load_bdf: ignoring character with encoding outside range\n");
 			}
@@ -1505,7 +1505,7 @@ bool render_font::save_cached(const char *filename, u64 length, u32 hash)
 
 		// loop over all characters
 		bdc_table_entry table_entry(chartable.empty() ? nullptr : &chartable[0]);
-		for (unsigned chnum = 0; chnum < (256 * ARRAY_LENGTH(m_glyphs)); chnum++)
+		for (unsigned chnum = 0; chnum < (256 * std::size(m_glyphs)); chnum++)
 		{
 			if (m_glyphs[chnum / 256] && (0 < m_glyphs[chnum / 256][chnum % 256].width))
 			{

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -218,7 +218,7 @@ void software_list_device::display_matches(const machine_config &config, const c
 	{
 		// get the top 16 approximate matches for the selected device interface (i.e. only carts for cartslot, etc.)
 		const software_info *matches[16] = { nullptr };
-		swlistdev.find_approx_matches(name, ARRAY_LENGTH(matches), matches, interface);
+		swlistdev.find_approx_matches(name, std::size(matches), matches, interface);
 
 		// if we found some, print them
 		if (matches[0] != nullptr)

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -105,7 +105,7 @@ void stream_buffer::set_sample_rate(u32 rate, bool resample)
 	// voice when jumping off the edge in Q*Bert; without this extra effort
 	// it is crackly and/or glitchy at times
 	sample_t buffer[64];
-	int buffered_samples = std::min(m_sample_rate, std::min(rate, u32(ARRAY_LENGTH(buffer))));
+	int buffered_samples = std::min(m_sample_rate, std::min(rate, u32(std::size(buffer))));
 
 	// if the new rate is lower, downsample into our holding buffer;
 	// otherwise just copy into our holding buffer for later upsampling
@@ -203,12 +203,12 @@ void stream_buffer::flush_wav()
 
 	// iterate over chunks for conversion
 	s16 buffer[1024];
-	for (int samplebase = 0; samplebase < view.samples(); samplebase += ARRAY_LENGTH(buffer))
+	for (int samplebase = 0; samplebase < view.samples(); samplebase += std::size(buffer))
 	{
 		// clamp to the buffer size
 		int cursamples = view.samples() - samplebase;
-		if (cursamples > ARRAY_LENGTH(buffer))
-			cursamples = ARRAY_LENGTH(buffer);
+		if (cursamples > std::size(buffer))
+			cursamples = std::size(buffer);
 
 		// convert and fill
 		for (int sampindex = 0; sampindex < cursamples; sampindex++)

--- a/src/emu/uiinput.cpp
+++ b/src/emu/uiinput.cpp
@@ -138,11 +138,11 @@ bool ui_input_manager::push_event(ui_event evt)
 	}
 
 	// is the queue filled up?
-	if ((m_events_end + 1) % ARRAY_LENGTH(m_events) == m_events_start)
+	if ((m_events_end + 1) % std::size(m_events) == m_events_start)
 		return false;
 
 	m_events[m_events_end++] = evt;
-	m_events_end %= ARRAY_LENGTH(m_events);
+	m_events_end %= std::size(m_events);
 	return true;
 }
 
@@ -156,7 +156,7 @@ bool ui_input_manager::pop_event(ui_event *evt)
 	if (m_events_start != m_events_end)
 	{
 		*evt = m_events[m_events_start++];
-		m_events_start %= ARRAY_LENGTH(m_events);
+		m_events_start %= std::size(m_events);
 		return true;
 	}
 	else

--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -1844,7 +1844,7 @@ void validity_checker::validate_dip_settings(ioport_field &field)
 	if (coin_error)
 	{
 		output_via_delegate(OSD_OUTPUT_CHANNEL_ERROR, "   Note proper coin sort order should be:\n");
-		for (int entry = 0; entry < ARRAY_LENGTH(coin_list); entry++)
+		for (int entry = 0; entry < std::size(coin_list); entry++)
 			if (coin_list[entry])
 				output_via_delegate(OSD_OUTPUT_CHANNEL_ERROR, "      %s\n", ioport_string_from_index(__input_string_coinage_start + entry));
 	}

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -296,7 +296,7 @@ int cli_frontend::execute(std::vector<std::string> &args)
 			// get the top 16 approximate matches
 			driver_enumerator drivlist(m_options);
 			int matches[16];
-			drivlist.find_approximate_matches(m_options.attempted_system_name(), ARRAY_LENGTH(matches), matches);
+			drivlist.find_approximate_matches(m_options.attempted_system_name(), std::size(matches), matches);
 
 			// work out how wide the titles need to be
 			int titlelen(0);

--- a/src/frontend/mame/ui/custui.cpp
+++ b/src/frontend/mame/ui/custui.cpp
@@ -125,7 +125,7 @@ void menu_custom_ui::handle()
 			}
 			else if (menu_event->iptkey == IPT_UI_SELECT)
 			{
-				std::vector<std::string> s_sel(ARRAY_LENGTH(HIDE_STATUS));
+				std::vector<std::string> s_sel(std::size(HIDE_STATUS));
 				std::transform(std::begin(HIDE_STATUS), std::end(HIDE_STATUS), s_sel.begin(), [](auto &s) { return _(s); });
 				menu::stack_push<menu_selector>(
 						ui(), container(), std::move(s_sel), ui_globals::panels_status,
@@ -985,7 +985,7 @@ void menu_palette_sel::handle()
 
 void menu_palette_sel::populate(float &customtop, float &custombottom)
 {
-	for (unsigned x = 0; x < ARRAY_LENGTH(s_palette); ++x)
+	for (unsigned x = 0; x < std::size(s_palette); ++x)
 		item_append(_(s_palette[x].first), s_palette[x].second, FLAG_COLOR_BOX, (void *)(uintptr_t)(x + 1));
 
 	item_append(menu_item_type::SEPARATOR);

--- a/src/frontend/mame/ui/inifile.cpp
+++ b/src/frontend/mame/ui/inifile.cpp
@@ -99,7 +99,7 @@ void inifile_manager::init_category(std::string &&filename, emu_file &file)
 	categoryindex index;
 	char rbuf[MAX_CHAR_INFO];
 	std::string name;
-	while (file.gets(rbuf, ARRAY_LENGTH(rbuf)))
+	while (file.gets(rbuf, std::size(rbuf)))
 	{
 		if ('[' == rbuf[0])
 		{
@@ -143,7 +143,7 @@ bool favorite_manager::favorite_compare::operator()(ui_software_info const &lhs,
 		return true;
 	}
 
-	return 0 > std::strncmp(lhs.driver->name, rhs.driver->name, ARRAY_LENGTH(lhs.driver->name));
+	return 0 > std::strncmp(lhs.driver->name, rhs.driver->name, std::size(lhs.driver->name));
 }
 
 bool favorite_manager::favorite_compare::operator()(ui_software_info const &lhs, game_driver const &rhs) const
@@ -153,7 +153,7 @@ bool favorite_manager::favorite_compare::operator()(ui_software_info const &lhs,
 	if (!lhs.startempty)
 		return false;
 	else
-		return 0 > std::strncmp(lhs.driver->name, rhs.name, ARRAY_LENGTH(rhs.name));
+		return 0 > std::strncmp(lhs.driver->name, rhs.name, std::size(rhs.name));
 }
 
 bool favorite_manager::favorite_compare::operator()(game_driver const &lhs, ui_software_info const &rhs) const
@@ -163,7 +163,7 @@ bool favorite_manager::favorite_compare::operator()(game_driver const &lhs, ui_s
 	if (!rhs.startempty)
 		return true;
 	else
-		return 0 > std::strncmp(lhs.name, rhs.driver->name, ARRAY_LENGTH(lhs.name));
+		return 0 > std::strncmp(lhs.name, rhs.driver->name, std::size(lhs.name));
 }
 
 bool favorite_manager::favorite_compare::operator()(ui_software_info const &lhs, running_software_key const &rhs) const
@@ -182,7 +182,7 @@ bool favorite_manager::favorite_compare::operator()(ui_software_info const &lhs,
 	else if (lhs.shortname > std::get<2>(rhs))
 		return false;
 	else
-		return 0 > std::strncmp(lhs.driver->name, std::get<0>(rhs).name, ARRAY_LENGTH(lhs.driver->name));
+		return 0 > std::strncmp(lhs.driver->name, std::get<0>(rhs).name, std::size(lhs.driver->name));
 }
 
 bool favorite_manager::favorite_compare::operator()(running_software_key const &lhs, ui_software_info const &rhs) const
@@ -201,7 +201,7 @@ bool favorite_manager::favorite_compare::operator()(running_software_key const &
 	else if (std::get<2>(lhs) > rhs.shortname)
 		return false;
 	else
-		return 0 > std::strncmp(std::get<0>(lhs).name, rhs.driver->name, ARRAY_LENGTH(rhs.driver->name));
+		return 0 > std::strncmp(std::get<0>(lhs).name, rhs.driver->name, std::size(rhs.driver->name));
 }
 
 

--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -653,7 +653,7 @@ void menu_select_game::build_available_list()
 		char const *src;
 
 		// build a name for it
-		for (src = dir->name; *src != 0 && *src != '.' && dst < &drivername[ARRAY_LENGTH(drivername) - 1]; ++src)
+		for (src = dir->name; *src != 0 && *src != '.' && dst < &drivername[std::size(drivername) - 1]; ++src)
 			*dst++ = tolower(uint8_t(*src));
 
 		*dst = 0;

--- a/src/frontend/mame/ui/simpleselgame.cpp
+++ b/src/frontend/mame/ui/simpleselgame.cpp
@@ -84,7 +84,7 @@ void simple_menu_select_game::build_driver_list()
 		const char *src;
 
 		// build a name for it
-		for (src = dir->name; *src != 0 && *src != '.' && dst < &drivername[ARRAY_LENGTH(drivername) - 1]; src++)
+		for (src = dir->name; *src != 0 && *src != '.' && dst < &drivername[std::size(drivername) - 1]; src++)
 			*dst++ = tolower((uint8_t)*src);
 		*dst = 0;
 
@@ -366,7 +366,7 @@ void simple_menu_select_game::custom_render(void *selectedref, float top, float 
 		tempbuf[line++] = string_format("%s %s", emulator_info::get_appname(), build_version);
 
 		// output message
-		while (line < ARRAY_LENGTH(tempbuf))
+		while (line < std::size(tempbuf))
 		{
 			if (!(*s == 0 || *s == '\n'))
 				tempbuf[line].push_back(*s);

--- a/src/frontend/mame/ui/sndmenu.cpp
+++ b/src/frontend/mame/ui/sndmenu.cpp
@@ -29,7 +29,7 @@ menu_sound_options::menu_sound_options(mame_ui_manager &mui, render_container &c
 	m_sound = (strcmp(options.sound(), OSDOPTVAL_NONE) && strcmp(options.sound(), "0"));
 	m_samples = mui.machine().options().samples();
 
-	int total = ARRAY_LENGTH(m_sound_rate);
+	int total = std::size(m_sound_rate);
 
 	for (m_cur_rates = 0; m_cur_rates < total; m_cur_rates++)
 		if (m_sample_rate == m_sound_rate[m_cur_rates])
@@ -92,7 +92,7 @@ void menu_sound_options::handle()
 			}
 			else if (menu_event->iptkey == IPT_UI_SELECT)
 			{
-				int total = ARRAY_LENGTH(m_sound_rate);
+				int total = std::size(m_sound_rate);
 				std::vector<std::string> s_sel(total);
 				for (int index = 0; index < total; index++)
 					s_sel[index] = std::to_string(m_sound_rate[index]);
@@ -128,7 +128,7 @@ void menu_sound_options::handle()
 
 void menu_sound_options::populate(float &customtop, float &custombottom)
 {
-	uint32_t arrow_flags = get_arrow_flags(uint16_t(0), uint16_t(ARRAY_LENGTH(m_sound_rate) - 1), m_cur_rates);
+	uint32_t arrow_flags = get_arrow_flags(uint16_t(0), uint16_t(std::size(m_sound_rate) - 1), m_cur_rates);
 	m_sample_rate = m_sound_rate[m_cur_rates];
 
 	// add options items

--- a/src/frontend/mame/ui/toolbar.ipp
+++ b/src/frontend/mame/ui/toolbar.ipp
@@ -113,7 +113,7 @@ uint32_t const toolbar_bitmap_bmp[][1024] = {
 	}
 };
 
-#define UI_TOOLBAR_BUTTONS    (ARRAY_LENGTH(toolbar_bitmap_bmp))
+#define UI_TOOLBAR_BUTTONS    (std::size(toolbar_bitmap_bmp))
 
 } // anonymous namespace
 } // namespace ui

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -210,7 +210,7 @@ void mame_ui_manager::init()
 				draw_text_box(container, messagebox_text, ui::text_layout::LEFT, 0.5f, 0.5f, colors().background_color());
 				return 0;
 			});
-	m_non_char_keys_down = std::make_unique<uint8_t[]>((ARRAY_LENGTH(non_char_keys) + 7) / 8);
+	m_non_char_keys_down = std::make_unique<uint8_t[]>((std::size(non_char_keys) + 7) / 8);
 	m_mouse_show = machine().system().flags & machine_flags::CLICKABLE_ARTWORK ? true : false;
 
 	// request notification callbacks
@@ -981,11 +981,6 @@ bool mame_ui_manager::is_menu_active(void)
 void mame_ui_manager::process_natural_keyboard()
 {
 	ui_event event;
-	int i, pressed;
-	input_item_id itemid;
-	input_code code;
-	uint8_t *key_down_ptr;
-	uint8_t key_down_mask;
 
 	// loop while we have interesting events
 	while (machine().ui_input().pop_event(&event))
@@ -996,18 +991,18 @@ void mame_ui_manager::process_natural_keyboard()
 	}
 
 	// process natural keyboard keys that don't get UI_EVENT_CHARs
-	for (i = 0; i < ARRAY_LENGTH(non_char_keys); i++)
+	for (int i = 0; i < std::size(non_char_keys); i++)
 	{
 		// identify this keycode
-		itemid = non_char_keys[i];
-		code = machine().input().code_from_itemid(itemid);
+		input_item_id itemid = non_char_keys[i];
+		input_code code = machine().input().code_from_itemid(itemid);
 
 		// ...and determine if it is pressed
-		pressed = machine().input().code_pressed(code);
+		bool pressed = machine().input().code_pressed(code);
 
 		// figure out whey we are in the key_down map
-		key_down_ptr = &m_non_char_keys_down[i / 8];
-		key_down_mask = 1 << (i % 8);
+		uint8_t *key_down_ptr = &m_non_char_keys_down[i / 8];
+		uint8_t key_down_mask = 1 << (i % 8);
 
 		if (pressed && !(*key_down_ptr & key_down_mask))
 		{

--- a/src/frontend/mame/ui/utils.cpp
+++ b/src/frontend/mame/ui/utils.cpp
@@ -1672,7 +1672,7 @@ machine_filter::ptr machine_filter::create(type n, machine_filter_data const &da
 machine_filter::ptr machine_filter::create(emu_file &file, machine_filter_data const &data, unsigned indent)
 {
 	char buffer[MAX_CHAR_INFO];
-	if (!file.gets(buffer, ARRAY_LENGTH(buffer)))
+	if (!file.gets(buffer, std::size(buffer)))
 		return nullptr;
 
 	// split it into a key/value or bail
@@ -1780,7 +1780,7 @@ software_filter::ptr software_filter::create(type n, software_filter_data const 
 software_filter::ptr software_filter::create(emu_file &file, software_filter_data const &data, unsigned indent)
 {
 	char buffer[MAX_CHAR_INFO];
-	if (!file.gets(buffer, ARRAY_LENGTH(buffer)))
+	if (!file.gets(buffer, std::size(buffer)))
 		return nullptr;
 
 	// split it into a key/value or bail

--- a/src/lib/formats/ap2_dsk.cpp
+++ b/src/lib/formats/ap2_dsk.cpp
@@ -67,7 +67,7 @@ static const uint8_t *get_untranslate6_map(void)
 	if (!map_inited)
 	{
 		memset(map, 0xff, sizeof(map));
-		for (i = 0; i < ARRAY_LENGTH(translate6); i++)
+		for (i = 0; i < std::size(translate6); i++)
 			map[translate6[i]] = i;
 		map_inited = 1;
 	}

--- a/src/lib/formats/ap_dsk35.cpp
+++ b/src/lib/formats/ap_dsk35.cpp
@@ -225,7 +225,7 @@ int apple35_sectors_per_track(floppy_image_legacy *image, int track)
 	int sectors;
 
 	assert(track >= 0);
-	assert(track < ARRAY_LENGTH(apple35_tracklen_800kb));
+	assert(track < std::size(apple35_tracklen_800kb));
 
 	if (get_apple35_tag(image)->is_1440k)
 		sectors = 18;
@@ -454,7 +454,7 @@ static uint32_t apple35_get_offset(floppy_image_legacy *floppy, int head, int tr
 
 	tag = get_apple35_tag(floppy);
 
-	if (track >= ARRAY_LENGTH(apple35_tracklen_800kb))
+	if (track >= std::size(apple35_tracklen_800kb))
 		return ~0;
 	if (head >= tag->sides)
 		return ~0;
@@ -616,7 +616,7 @@ static floperr_t apple35_read_track(floppy_image_legacy *floppy, int head, int t
 
 	tag = get_apple35_tag(floppy);
 
-	if (track >= ARRAY_LENGTH(apple35_tracklen_800kb))
+	if (track >= std::size(apple35_tracklen_800kb))
 		return FLOPPY_ERROR_SEEKERROR;
 	if (offset != 0)
 		return FLOPPY_ERROR_UNSUPPORTED;
@@ -628,7 +628,7 @@ static floperr_t apple35_read_track(floppy_image_legacy *floppy, int head, int t
 	for (sector = 0; sector < sector_count; sector++)
 	{
 		/* read the sector */
-		err = apple35_read_sector_td(floppy, head, track, sector, sector_data, ARRAY_LENGTH(sector_data));
+		err = apple35_read_sector_td(floppy, head, track, sector, sector_data, std::size(sector_data));
 		if (err)
 		{
 			return err;
@@ -636,7 +636,7 @@ static floperr_t apple35_read_track(floppy_image_legacy *floppy, int head, int t
 
 		sony_nibblize35(sector_data, nibble_data, checksum);
 
-		for (i = 0; i < ARRAY_LENGTH(blk1); i++)
+		for (i = 0; i < std::size(blk1); i++)
 			sony_filltrack((uint8_t*)buffer, buflen, &pos, blk1[i]);
 
 		sum = (track ^ sector ^ side ^ tag->format_byte) & 0x3F;
@@ -647,18 +647,18 @@ static floperr_t apple35_read_track(floppy_image_legacy *floppy, int head, int t
 		sony_filltrack((uint8_t*)buffer, buflen, &pos, diskbytes[tag->format_byte]);
 		sony_filltrack((uint8_t*)buffer, buflen, &pos, diskbytes[sum]);
 
-		for (i = 0; i < ARRAY_LENGTH(blk2); i++)
+		for (i = 0; i < std::size(blk2); i++)
 			sony_filltrack((uint8_t*)buffer, buflen, &pos, blk2[i]);
 
 		sony_filltrack((uint8_t*)buffer, buflen, &pos, diskbytes[sector]);
 
-		for (i = 0; i < ARRAY_LENGTH(nibble_data); i++)
+		for (i = 0; i < std::size(nibble_data); i++)
 			sony_filltrack((uint8_t*)buffer, buflen, &pos, diskbytes[nibble_data[i]]);
 
 		for (i = 3; i >= 0; i--)
 			sony_filltrack((uint8_t*)buffer, buflen, &pos, diskbytes[checksum[i]]);
 
-		for (i = 0; i < ARRAY_LENGTH(blk3); i++)
+		for (i = 0; i < std::size(blk3); i++)
 			sony_filltrack((uint8_t*)buffer, buflen, &pos, blk3[i]);
 	}
 
@@ -681,7 +681,7 @@ static floperr_t apple35_write_track(floppy_image_legacy *floppy, int head, int 
 
 	tag = get_apple35_tag(floppy);
 
-	if (track >= ARRAY_LENGTH(apple35_tracklen_800kb))
+	if (track >= std::size(apple35_tracklen_800kb))
 		return FLOPPY_ERROR_SEEKERROR;
 	if (offset != 0)
 		return FLOPPY_ERROR_UNSUPPORTED;
@@ -756,7 +756,7 @@ static floperr_t apple35_write_track(floppy_image_legacy *floppy, int head, int 
 			continue;
 		j++;
 
-		for (i = 0; i < ARRAY_LENGTH(nibble_data); i++)
+		for (i = 0; i < std::size(nibble_data); i++)
 		{
 			nibble_data[i] = rev_diskbytes[sony_fetchtrack((uint8_t*)buffer, buflen, &pos)];
 			j++;
@@ -778,7 +778,7 @@ static floperr_t apple35_write_track(floppy_image_legacy *floppy, int head, int 
 			sony_denibblize35(sector_data, nibble_data, checksum);
 
 			/* write the sector */
-			err = apple35_write_sector_td(floppy, head, track, sector, sector_data, ARRAY_LENGTH(sector_data), 0);
+			err = apple35_write_sector_td(floppy, head, track, sector, sector_data, std::size(sector_data), 0);
 			if (err)
 				return err;
 

--- a/src/lib/formats/cassimg.cpp
+++ b/src/lib/formats/cassimg.cpp
@@ -94,12 +94,12 @@ const int8_t *choose_wave(const cassette_image::Modulation &modulation, size_t &
 
 	if (modulation.flags & cassette_image::MODULATION_SINEWAVE)
 	{
-		wave_bytes_length = ARRAY_LENGTH(sine_wave);
+		wave_bytes_length = std::size(sine_wave);
 		return sine_wave;
 	}
 	else
 	{
-		wave_bytes_length = ARRAY_LENGTH(square_wave);
+		wave_bytes_length = std::size(square_wave);
 		return square_wave;
 	}
 }

--- a/src/lib/formats/cassimg.h
+++ b/src/lib/formats/cassimg.h
@@ -14,7 +14,6 @@
 
 #include "ioprocs.h"
 
-#include "coretmpl.h"
 #include "osdcore.h"
 
 #include <memory>

--- a/src/lib/formats/flopimg.cpp
+++ b/src/lib/formats/flopimg.cpp
@@ -876,7 +876,7 @@ const char *floppy_error(floperr_t err)
 		"Required parameter not specified"
 	};
 
-	if ((err < 0) || (err >= ARRAY_LENGTH(error_messages)))
+	if ((err < 0) || (err >= std::size(error_messages)))
 		return nullptr;
 	return error_messages[err];
 }

--- a/src/lib/formats/p2000t_cas.cpp
+++ b/src/lib/formats/p2000t_cas.cpp
@@ -3,6 +3,8 @@
 
 #include "p2000t_cas.h"
 
+#include "coretmpl.h" // BIT
+
 #include <cassert>
 #include <ostream>
 
@@ -294,7 +296,7 @@ static cassette_image::error p2000t_cas_load(cassette_image *cassette)
 
 		// Insert sync header.. 0xAA, 0x00, 0x00, 0xAA
 		CHR(p2000t_silence(cassette, &time_idx, P2000_BOB_GAP));
-		CHR(p2000t_put_bytes(cassette, &time_idx, &unused, BLOCK_MARK, ARRAY_LENGTH(BLOCK_MARK)));
+		CHR(p2000t_put_bytes(cassette, &time_idx, &unused, BLOCK_MARK, std::size(BLOCK_MARK)));
 		CHR(p2000t_silence(cassette, &time_idx, P2000_MARK_GAP));
 
 		// Insert data block

--- a/src/lib/formats/pc_dsk.cpp
+++ b/src/lib/formats/pc_dsk.cpp
@@ -48,7 +48,7 @@ static floperr_t pc_dsk_compute_geometry(floppy_image_legacy *floppy, struct bas
 	memset(geometry, 0, sizeof(*geometry));
 	size = floppy_image_size(floppy);
 
-	for (i = 0; i < ARRAY_LENGTH(disk_sizes); i++)
+	for (i = 0; i < std::size(disk_sizes); i++)
 	{
 		if (disk_sizes[i].image_size == size)
 		{

--- a/src/lib/util/chd.cpp
+++ b/src/lib/util/chd.cpp
@@ -1626,7 +1626,7 @@ chd_error chd_file::codec_configure(chd_codec_type codec, int param, void *confi
 	try
 	{
 		// find the codec and call its configuration
-		for (int codecnum = 0; codecnum < ARRAY_LENGTH(m_compression); codecnum++)
+		for (int codecnum = 0; codecnum < std::size(m_compression); codecnum++)
 			if (m_compression[codecnum] == codec)
 			{
 				m_decompressor[codecnum]->configure(param, config);
@@ -2453,7 +2453,7 @@ chd_error chd_file::open_common(bool writeable)
 void chd_file::create_open_common()
 {
 	// verify the compression types and initialize the codecs
-	for (int decompnum = 0; decompnum < ARRAY_LENGTH(m_compression); decompnum++)
+	for (int decompnum = 0; decompnum < std::size(m_compression); decompnum++)
 	{
 		m_decompressor[decompnum] = chd_codec_list::new_decompressor(m_compression[decompnum], *this);
 		if (m_decompressor[decompnum] == nullptr && m_compression[decompnum] != 0)
@@ -3071,7 +3071,7 @@ void *chd_file_compressor::async_compress_hunk_static(void *param, int threadid)
 void chd_file_compressor::async_compress_hunk(work_item &item, int threadid)
 {
 	// use our thread's codec
-	assert(threadid < ARRAY_LENGTH(m_codecs));
+	assert(threadid < std::size(m_codecs));
 	item.m_codecs = m_codecs[threadid];
 
 	// compute CRC-16 and SHA-1 hashes
@@ -3278,7 +3278,7 @@ uint64_t chd_file_compressor::hashmap::find(util::crc16_t crc16, util::sha1_t sh
 void chd_file_compressor::hashmap::add(uint64_t itemnum, util::crc16_t crc16, util::sha1_t sha1)
 {
 	// add to the appropriate map
-	if (m_block_list->m_nextalloc == ARRAY_LENGTH(m_block_list->m_array))
+	if (m_block_list->m_nextalloc == std::size(m_block_list->m_array))
 		m_block_list = new entry_block(m_block_list);
 	entry_t *entry = &m_block_list->m_array[m_block_list->m_nextalloc++];
 	entry->m_itemnum = itemnum;

--- a/src/lib/util/chdcodec.cpp
+++ b/src/lib/util/chdcodec.cpp
@@ -622,7 +622,7 @@ chd_compressor_group::chd_compressor_group(chd_file &chd, uint32_t compressor_li
 #endif
 {
 	// verify the compression types and initialize the codecs
-	for (int codecnum = 0; codecnum < ARRAY_LENGTH(m_compressor); codecnum++)
+	for (int codecnum = 0; codecnum < std::size(m_compressor); codecnum++)
 	{
 		m_compressor[codecnum] = nullptr;
 		if (compressor_list[codecnum] != CHD_CODEC_NONE)
@@ -663,7 +663,7 @@ int8_t chd_compressor_group::find_best_compressor(const uint8_t *src, uint8_t *c
 	// determine best compression technique
 	complen = m_hunkbytes;
 	int8_t compression = -1;
-	for (int codecnum = 0; codecnum < ARRAY_LENGTH(m_compressor); codecnum++)
+	for (int codecnum = 0; codecnum < std::size(m_compressor); codecnum++)
 		if (m_compressor[codecnum] != nullptr)
 		{
 			// attempt to compress, swallowing errors

--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -462,7 +462,7 @@ int core_text_file::getc()
 		{
 			// place the new character in the ring buffer
 			m_back_char_head = 0;
-			m_back_char_tail = utf8_from_uchar(m_back_chars, ARRAY_LENGTH(m_back_chars), uchar);
+			m_back_char_tail = utf8_from_uchar(m_back_chars, std::size(m_back_chars), uchar);
 			//assert(file->back_char_tail != -1);
 		}
 	}
@@ -473,7 +473,7 @@ int core_text_file::getc()
 	else
 	{
 		result = m_back_chars[m_back_char_head++];
-		m_back_char_head %= ARRAY_LENGTH(m_back_chars);
+		m_back_char_head %= std::size(m_back_chars);
 	}
 
 	return result;
@@ -488,7 +488,7 @@ int core_text_file::getc()
 int core_text_file::ungetc(int c)
 {
 	m_back_chars[m_back_char_tail++] = char(c);
-	m_back_char_tail %= ARRAY_LENGTH(m_back_chars);
+	m_back_char_tail %= std::size(m_back_chars);
 	return c;
 }
 
@@ -577,7 +577,7 @@ int core_text_file::puts(std::string_view s)
 			*pconvbuf++ = ch;
 
 		// if we overflow, break into chunks
-		if (pconvbuf >= convbuf + ARRAY_LENGTH(convbuf) - 10)
+		if (pconvbuf >= convbuf + std::size(convbuf) - 10)
 		{
 			count += write(convbuf, pconvbuf - convbuf);
 			pconvbuf = convbuf;

--- a/src/lib/util/coretmpl.h
+++ b/src/lib/util/coretmpl.h
@@ -535,6 +535,16 @@ std::basic_string_view<CharT, Traits> buf_to_string_view(basic_ovectorstream<Cha
 }
 
 
+// For declaring an array of the same dimensions as another array (including multi-dimensional arrays)
+template <typename T, typename U> struct equivalent_array_or_type { typedef T type; };
+template <typename T, typename U, std::size_t N> struct equivalent_array_or_type<T, U[N]> { typedef typename equivalent_array_or_type<T, U>::type type[N]; };
+template <typename T, typename U> using equivalent_array_or_type_t = typename equivalent_array_or_type<T, U>::type;
+template <typename T, typename U> struct equivalent_array { };
+template <typename T, typename U, std::size_t N> struct equivalent_array<T, U[N]> { typedef equivalent_array_or_type_t<T, U> type[N]; };
+template <typename T, typename U> using equivalent_array_t = typename equivalent_array<T, U>::type;
+#define EQUIVALENT_ARRAY(a, T) util::equivalent_array_t<T, std::remove_reference_t<decltype(a)> >
+
+
 template <typename E>
 using enable_enum_t = typename std::enable_if_t<std::is_enum<E>::value, typename std::underlying_type_t<E> >;
 

--- a/src/lib/util/flac.cpp
+++ b/src/lib/util/flac.cpp
@@ -10,7 +10,7 @@
 
 #include "flac.h"
 
-#include "osdcomm.h"
+#include "corefile.h"
 
 #include <cassert>
 #include <new>
@@ -129,7 +129,7 @@ bool flac_encoder::encode_interleaved(const int16_t *samples, uint32_t samples_p
 		// process in batches of 2k samples
 		FLAC__int32 converted_buffer[2048];
 		FLAC__int32 *dest = converted_buffer;
-		uint32_t cur_samples = (std::min<size_t>)(ARRAY_LENGTH(converted_buffer) / num_channels, samples_per_channel);
+		uint32_t cur_samples = (std::min<size_t>)(std::size(converted_buffer) / num_channels, samples_per_channel);
 
 		// convert a buffers' worth
 		for (uint32_t sampnum = 0; sampnum < cur_samples; sampnum++)
@@ -162,7 +162,7 @@ bool flac_encoder::encode(int16_t *const *samples, uint32_t samples_per_channel,
 		// process in batches of 2k samples
 		FLAC__int32 converted_buffer[2048];
 		FLAC__int32 *dest = converted_buffer;
-		uint32_t cur_samples = (std::min<size_t>)(ARRAY_LENGTH(converted_buffer) / num_channels, samples_per_channel);
+		uint32_t cur_samples = (std::min<size_t>)(std::size(converted_buffer) / num_channels, samples_per_channel);
 
 		// convert a buffers' worth
 		for (uint32_t sampnum = 0; sampnum < cur_samples; sampnum++, srcindex++)
@@ -464,7 +464,7 @@ bool flac_decoder::decode(int16_t **samples, uint32_t num_samples, bool swap_end
 {
 	// make sure we don't have too many channels
 	int chans = channels();
-	if (chans > ARRAY_LENGTH(m_uncompressed_start))
+	if (chans > std::size(m_uncompressed_start))
 		return false;
 
 	// configure the uncompressed buffer

--- a/src/lib/util/flac.h
+++ b/src/lib/util/flac.h
@@ -13,14 +13,16 @@
 
 #pragma once
 
-#include "corefile.h"
-
 #include <FLAC/all.h>
+
+#include <cstdint>
 
 
 //**************************************************************************
 //  TYPE DEFINITIONS
 //**************************************************************************
+
+namespace util { class core_file; }
 
 // ======================> flac_encoder
 
@@ -64,18 +66,18 @@ private:
 	// internal state
 	FLAC__StreamEncoder *   m_encoder;              // actual encoder
 	util::core_file *       m_file;                 // output file
-	uint32_t                  m_compressed_offset;    // current offset with the compressed stream
+	uint32_t                m_compressed_offset;    // current offset with the compressed stream
 	FLAC__byte *            m_compressed_start;     // start of compressed data
-	uint32_t                  m_compressed_length;    // length of the compressed stream
-
+	uint32_t                m_compressed_length;    // length of the compressed stream
+	
 	// parameters
-	uint32_t                  m_sample_rate;          // sample rate
-	uint8_t                   m_channels;             // number of channels
-	uint32_t                  m_block_size;           // block size
+	uint32_t                m_sample_rate;          // sample rate
+	uint8_t                 m_channels;             // number of channels
+	uint32_t                m_block_size;           // block size
 
 	// header stripping
 	bool                    m_strip_metadata;       // strip the metadata?
-	uint32_t                  m_ignore_bytes;         // how many bytes to ignore when writing
+	uint32_t                m_ignore_bytes;         // how many bytes to ignore when writing
 	bool                    m_found_audio;          // have we hit the audio yet?
 };
 

--- a/src/lib/util/options.cpp
+++ b/src/lib/util/options.cpp
@@ -12,7 +12,6 @@
 
 #include "corefile.h"
 #include "corestr.h"
-#include "osdcomm.h"
 
 #include <locale>
 #include <string>
@@ -732,7 +731,7 @@ void core_options::parse_ini_file(util::core_file &inifile, int priority, bool i
 
 	// loop over lines in the file
 	char buffer[4096];
-	while (inifile.gets(buffer, ARRAY_LENGTH(buffer)) != nullptr)
+	while (inifile.gets(buffer, std::size(buffer)) != nullptr)
 	{
 		// find the extent of the name
 		char *optionname;

--- a/src/lib/util/plaparse.cpp
+++ b/src/lib/util/plaparse.cpp
@@ -12,8 +12,6 @@
 
 #include "plaparse.h"
 
-#include "osdcomm.h"
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -214,11 +212,11 @@ static bool process_field(jed_data *data, const uint8_t **src, const uint8_t *sr
 
 	// find keyword
 	char dest[0x10];
-	memset(dest, 0, ARRAY_LENGTH(dest));
+	memset(dest, 0, sizeof(dest));
 	const uint8_t *seek = *src;
 	int destptr = 0;
 
-	while (seek < srcend && isalpha(*seek) && destptr < ARRAY_LENGTH(dest) - 1)
+	while (seek < srcend && isalpha(*seek) && destptr < sizeof(dest) - 1)
 	{
 		dest[destptr] = tolower(*seek);
 		seek++;

--- a/src/lib/util/png.cpp
+++ b/src/lib/util/png.cpp
@@ -123,7 +123,7 @@ private:
 	png_error process(std::list<image_data_chunk> const &idata)
 	{
 		// do some basic checks for unsupported images
-		if (!pnginfo.bit_depth || (ARRAY_LENGTH(samples) <= pnginfo.color_type) || !samples[pnginfo.color_type])
+		if (!pnginfo.bit_depth || (std::size(samples) <= pnginfo.color_type) || !samples[pnginfo.color_type])
 			return png_error::UNSUPPORTED_FORMAT; // unknown colour format
 		if ((0 != pnginfo.interlace_method) && (1 != pnginfo.interlace_method))
 			return png_error::UNSUPPORTED_FORMAT; // unknown interlace method
@@ -474,7 +474,7 @@ public:
 		// do some basic checks for unsupported images
 		if ((8 > pnginfo.bit_depth) || (pnginfo.bit_depth % 8))
 			return png_error::UNSUPPORTED_FORMAT; // only do multiples of 8bps here - expand lower bit depth first
-		if ((ARRAY_LENGTH(samples) <= pnginfo.color_type) || !samples[pnginfo.color_type])
+		if ((std::size(samples) <= pnginfo.color_type) || !samples[pnginfo.color_type])
 			return png_error::UNSUPPORTED_FORMAT; // unknown colour sample format
 		if ((0 != pnginfo.interlace_method) && (1 != pnginfo.interlace_method))
 			return png_error::UNSUPPORTED_FORMAT; // unknown interlace method
@@ -721,7 +721,7 @@ public:
 
 	static png_error verify_header(core_file &fp)
 	{
-		EQUIVALENT_ARRAY(PNG_SIGNATURE, std::uint8_t) signature;
+		std::uint8_t signature[sizeof(PNG_SIGNATURE)];
 
 		// read 8 bytes
 		if (fp.read(signature, sizeof(signature)) != sizeof(signature))

--- a/src/lib/util/pool.cpp
+++ b/src/lib/util/pool.cpp
@@ -14,8 +14,8 @@
 #include "osdcomm.h"
 
 #include <cstdarg>
-#include <cstddef>
 #include <cstdlib>
+#include <iterator>
 
 
 /***************************************************************************
@@ -35,7 +35,7 @@
 struct objtype_entry
 {
 	objtype_entry *     next;
-	uint32_t              type;
+	uint32_t            type;
 	const char *        friendly;
 	void                (*destructor)(void *, size_t);
 };
@@ -296,7 +296,7 @@ void *pool_object_add_file_line(object_pool *pool, object_type _type, void *obje
 		pool->blocklist = block;
 
 		/* add all entries to the free list */
-		for (entrynum = 0; entrynum < ARRAY_LENGTH(block->entry); entrynum++)
+		for (entrynum = 0; entrynum < std::size(block->entry); entrynum++)
 		{
 			block->entry[entrynum].next = pool->freelist;
 			pool->freelist = &block->entry[entrynum];
@@ -615,8 +615,8 @@ bool test_memory_pools()
 	/* some heavier stress tests */
 	for (i = 0; i < 512; i++)
 	{
-		ptrs[i % ARRAY_LENGTH(ptrs)] = pool_realloc_lib(pool,
-			ptrs[i % ARRAY_LENGTH(ptrs)], rand() % 1000);
+		ptrs[i % std::size(ptrs)] = pool_realloc_lib(pool,
+			ptrs[i % std::size(ptrs)], rand() % 1000);
 	}
 
 	pool_free_lib(pool);

--- a/src/lib/util/unicode.cpp
+++ b/src/lib/util/unicode.cpp
@@ -384,7 +384,7 @@ int utf8_from_uchar(char *utf8string, size_t count, char32_t uchar)
 std::string utf8_from_uchar(char32_t uchar)
 {
 	char buffer[UTF8_CHAR_MAX];
-	auto len = utf8_from_uchar(buffer, ARRAY_LENGTH(buffer), uchar);
+	auto len = utf8_from_uchar(buffer, std::size(buffer), uchar);
 	return std::string(buffer, len);
 }
 

--- a/src/mame/audio/meadows.cpp
+++ b/src/mame/audio/meadows.cpp
@@ -37,9 +37,9 @@ SAMPLES_START_CB_MEMBER(meadows_state::meadows_sh_start)
 	m_latched_0c01 = m_latched_0c02 = m_latched_0c03 = 0;
 
 	m_samples->set_volume(0,0);
-	m_samples->start_raw(0,waveform,ARRAY_LENGTH(waveform),m_freq1,true);
+	m_samples->start_raw(0,waveform,std::size(waveform),m_freq1,true);
 	m_samples->set_volume(1,0);
-	m_samples->start_raw(1,waveform,ARRAY_LENGTH(waveform),m_freq2,true);
+	m_samples->start_raw(1,waveform,std::size(waveform),m_freq2,true);
 }
 
 /************************************/

--- a/src/mame/audio/svis_snd.cpp
+++ b/src/mame/audio/svis_snd.cpp
@@ -62,7 +62,7 @@ void svision_sound_device::sound_stream_update(sound_stream &stream, std::vector
 	{
 		s32 lsum = 0;
 		s32 rsum = 0;
-		for (int j = 0; j < ARRAY_LENGTH(m_channel); j++)
+		for (int j = 0; j < std::size(m_channel); j++)
 		{
 			CHANNEL &channel(m_channel[j]);
 			if (channel.size != 0)

--- a/src/mame/drivers/a2600.cpp
+++ b/src/mame/drivers/a2600.cpp
@@ -226,7 +226,7 @@ static const rectangle visarea[4] = {
 
 void a2600_base_state::a2600_tia_vsync_callback(uint16_t data)
 {
-	for ( int i = 0; i < ARRAY_LENGTH(supported_screen_heights); i++ )
+	for ( int i = 0; i < std::size(supported_screen_heights); i++ )
 	{
 		if ( data >= supported_screen_heights[i] - 3 && data <= supported_screen_heights[i] + 3 )
 		{
@@ -241,7 +241,7 @@ void a2600_base_state::a2600_tia_vsync_callback(uint16_t data)
 
 void a2600_base_state::a2600_tia_vsync_callback_pal(uint16_t data)
 {
-	for ( int i = 0; i < ARRAY_LENGTH(supported_screen_heights); i++ )
+	for ( int i = 0; i < std::size(supported_screen_heights); i++ )
 	{
 		if ( data >= supported_screen_heights[i] - 3 && data <= supported_screen_heights[i] + 3 )
 		{

--- a/src/mame/drivers/a7800.cpp
+++ b/src/mame/drivers/a7800.cpp
@@ -1387,7 +1387,7 @@ void a7800_state::a7800_ntsc(machine_config &config)
 	m_screen->set_screen_update("maria", FUNC(atari_maria_device::screen_update));
 	m_screen->set_palette("palette");
 
-	PALETTE(config, "palette", FUNC(a7800_state::a7800_palette), ARRAY_LENGTH(a7800_colors));
+	PALETTE(config, "palette", FUNC(a7800_state::a7800_palette), std::size(a7800_colors));
 
 	ATARI_MARIA(config, m_maria, 0);
 	m_maria->set_dmacpu_tag(m_maincpu);

--- a/src/mame/drivers/apexc.cpp
+++ b/src/mame/drivers/apexc.cpp
@@ -377,7 +377,7 @@ void apexc_state::apexc(machine_config &config)
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_apexc);
 
-	PALETTE(config, m_palette, FUNC(apexc_state::apexc_palette), ARRAY_LENGTH(palette_table));
+	PALETTE(config, m_palette, FUNC(apexc_state::apexc_palette), std::size(palette_table));
 
 	APEXC_CYLINDER(config, m_cylinder);
 	APEXC_TAPE_PUNCHER(config, m_tape_puncher);

--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -929,7 +929,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2gs_state::ay3600_repeat)
 
 u8 apple2gs_state::adb_read_memory(u32 address)
 {
-	if (address < ARRAY_LENGTH(m_adb_memory))
+	if (address < std::size(m_adb_memory))
 		return m_adb_memory[address];
 	else
 		return 0x00;
@@ -937,7 +937,7 @@ u8 apple2gs_state::adb_read_memory(u32 address)
 
 void apple2gs_state::adb_write_memory(u32 address, u8 data)
 {
-	if (address < ARRAY_LENGTH(m_adb_memory))
+	if (address < std::size(m_adb_memory))
 		m_adb_memory[address] = data;
 }
 
@@ -953,7 +953,7 @@ void apple2gs_state::adb_set_config(u8 b1, u8 b2, u8 b3)
 
 void apple2gs_state::adb_post_response(const u8 *bytes, size_t length)
 {
-	assert(length < ARRAY_LENGTH(m_adb_response_bytes));
+	assert(length < std::size(m_adb_response_bytes));
 	memcpy(m_adb_response_bytes, bytes, length);
 
 	m_adb_state = ADBSTATE_INRESPONSE;
@@ -1261,7 +1261,7 @@ void apple2gs_state::adb_write_datareg(u8 data)
 			break;
 
 		case ADBSTATE_INCOMMAND:
-			assert(m_adb_command_pos < ARRAY_LENGTH(m_adb_command_bytes));
+			assert(m_adb_command_pos < std::size(m_adb_command_bytes));
 //          printf("ADB param %02x\n", data);
 			m_adb_command_bytes[m_adb_command_pos++] = data;
 			break;

--- a/src/mame/drivers/arcadia.cpp
+++ b/src/mame/drivers/arcadia.cpp
@@ -491,7 +491,7 @@ void arcadia_state::arcadia(machine_config &config)
 	m_screen->set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_arcadia);
-	PALETTE(config, m_palette, FUNC(arcadia_state::palette_init), ARRAY_LENGTH(arcadia_palette), 8);
+	PALETTE(config, m_palette, FUNC(arcadia_state::palette_init), std::size(arcadia_palette), 8);
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
@@ -795,10 +795,10 @@ void arcadia_state::init_arcadia()
 		};
 #if 1
 		FILE *f = fopen("chartest.bin","wb");
-		fwrite(prog, ARRAY_LENGTH(prog), sizeof(prog[0]), f);
+		fwrite(prog, std::size(prog), sizeof(prog[0]), f);
 		fclose(f);
 #endif
-		for (int i = 0; i < ARRAY_LENGTH(prog); i++) rom[i] = prog[i];
+		for (int i = 0; i < std::size(prog); i++) rom[i] = prog[i];
 
 	}
 #endif

--- a/src/mame/drivers/atari400.cpp
+++ b/src/mame/drivers/atari400.cpp
@@ -1119,7 +1119,7 @@ static const uint8_t atari_colors[256*3] =
 /* Initialise the palette */
 void a400_state::a400_palette(palette_device &palette) const
 {
-	for (unsigned i = 0; i < ARRAY_LENGTH(atari_colors) / 3; i++)
+	for (unsigned i = 0; i < std::size(atari_colors) / 3; i++)
 		palette.set_pen_color(i, atari_colors[i * 3], atari_colors[i * 3 + 1], atari_colors[i * 3 + 2]);
 }
 /******************************************************************
@@ -2103,7 +2103,7 @@ void a400_state::atari_common_nodac(machine_config &config)
 	m_screen->set_screen_update("antic", FUNC(antic_device::screen_update));
 	m_screen->set_palette("palette");
 
-	PALETTE(config, "palette", FUNC(a400_state::a400_palette), ARRAY_LENGTH(atari_colors) / 3);
+	PALETTE(config, "palette", FUNC(a400_state::a400_palette), std::size(atari_colors) / 3);
 
 	PIA6821(config, m_pia, 0);
 	m_pia->readpa_handler().set_ioport("djoy_0_1");

--- a/src/mame/drivers/attache.cpp
+++ b/src/mame/drivers/attache.cpp
@@ -345,8 +345,8 @@ uint32_t attache_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 
 		for(uint8_t x=0;x<(bitmap.width()-1)/8;x++)  // columns
 		{
-			assert(((y*128)+x) >= 0 && ((y*128)+x) < ARRAY_LENGTH(m_char_ram));
-			assert(((vy*128)+x) >= 0 && ((vy*128)+x) < ARRAY_LENGTH(m_char_ram));
+			assert(((y*128)+x) >= 0 && ((y*128)+x) < std::size(m_char_ram));
+			assert(((vy*128)+x) >= 0 && ((vy*128)+x) < std::size(m_char_ram));
 			uint8_t ch = m_char_ram[(vy*128)+x];
 			pen_t fg = m_palette->pen(m_attr_ram[(vy*128)+x] & 0x08 ? 2 : 1); // brightness
 			if(m_attr_ram[(vy*128)+x] & 0x10) // double-size

--- a/src/mame/drivers/bmcbowl.cpp
+++ b/src/mame/drivers/bmcbowl.cpp
@@ -312,9 +312,9 @@ void bmcbowl_state::machine_reset()
 	for (int i = 0; i < m_stats_ram.bytes()/2; i++)
 		m_stats_ram[i] = 0xffff;
 
-	init_stats(bmc_nv1,ARRAY_LENGTH(bmc_nv1),0);
-	init_stats(bmc_nv2,ARRAY_LENGTH(bmc_nv2),0x3b0/2);
-	init_stats(bmc_nv3,ARRAY_LENGTH(bmc_nv3),0xfe2/2);
+	init_stats(bmc_nv1,std::size(bmc_nv1),0);
+	init_stats(bmc_nv2,std::size(bmc_nv2),0x3b0/2);
+	init_stats(bmc_nv3,std::size(bmc_nv3),0xfe2/2);
 #endif
 }
 

--- a/src/mame/drivers/busicom.cpp
+++ b/src/mame/drivers/busicom.cpp
@@ -81,9 +81,9 @@ void busicom_state::printer_w(uint8_t data)
 
 	if (BIT(data, 3))
 	{
-		for (u8 j = 0; j < (ARRAY_LENGTH(m_printer_line) - 1); j++)
+		for (u8 j = 0; j < (std::size(m_printer_line) - 1); j++)
 			std::copy(std::begin(m_printer_line[j + 1]), std::end(m_printer_line[j + 1]), std::begin(m_printer_line[j]));
-		std::copy_n(&m_printer_line_color[1], ARRAY_LENGTH(m_printer_line_color) - 1, &m_printer_line_color[0]);
+		std::copy_n(&m_printer_line_color[1], std::size(m_printer_line_color) - 1, &m_printer_line_color[0]);
 
 		std::fill(std::begin(m_printer_line[10]), std::end(m_printer_line[10]), 0);
 		m_printer_line_color[10] = 0;
@@ -226,7 +226,7 @@ void busicom_state::machine_reset()
 	m_keyboard_shifter = 0;
 	m_printer_shifter = 0;
 
-	for (int i = 0; i < ARRAY_LENGTH(m_printer_line); i++)
+	for (int i = 0; i < std::size(m_printer_line); i++)
 		std::fill(std::begin(m_printer_line[i]), std::end(m_printer_line[i]), 0);
 	std::fill(std::begin(m_printer_line_color), std::end(m_printer_line_color), 0);
 }

--- a/src/mame/drivers/clickstart.cpp
+++ b/src/mame/drivers/clickstart.cpp
@@ -186,7 +186,7 @@ void clickstart_state::machine_reset()
 	m_mouse_dx = 0;
 	m_mouse_dy = 0;
 
-	memset(m_uart_tx_fifo, 0, ARRAY_LENGTH(m_uart_tx_fifo));
+	std::fill(std::begin(m_uart_tx_fifo), std::end(m_uart_tx_fifo), 0);
 	m_uart_tx_fifo_start = 0;
 	m_uart_tx_fifo_end = 0;
 	m_uart_tx_fifo_count = 0;
@@ -219,19 +219,19 @@ void clickstart_state::handle_uart_tx()
 		return;
 
 	m_maincpu->uart_rx(m_uart_tx_fifo[m_uart_tx_fifo_start]);
-	m_uart_tx_fifo_start = (m_uart_tx_fifo_start + 1) % ARRAY_LENGTH(m_uart_tx_fifo);
+	m_uart_tx_fifo_start = (m_uart_tx_fifo_start + 1) % std::size(m_uart_tx_fifo);
 	m_uart_tx_fifo_count--;
 }
 
 void clickstart_state::uart_tx_fifo_push(uint8_t value)
 {
-	if (m_uart_tx_fifo_count >= ARRAY_LENGTH(m_uart_tx_fifo))
+	if (m_uart_tx_fifo_count >= std::size(m_uart_tx_fifo))
 	{
 		logerror("Warning: Trying to push too much data onto the mouse Tx FIFO, data will be lost.\n");
 	}
 
 	m_uart_tx_fifo[m_uart_tx_fifo_end] = value;
-	m_uart_tx_fifo_end = (m_uart_tx_fifo_end + 1) % ARRAY_LENGTH(m_uart_tx_fifo);
+	m_uart_tx_fifo_end = (m_uart_tx_fifo_end + 1) % std::size(m_uart_tx_fifo);
 	m_uart_tx_fifo_count++;
 }
 

--- a/src/mame/drivers/dai.cpp
+++ b/src/mame/drivers/dai.cpp
@@ -210,7 +210,7 @@ void dai_state::dai(machine_config &config)
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_dai);
-	PALETTE(config, m_palette, FUNC(dai_state::dai_palette), ARRAY_LENGTH(s_palette));
+	PALETTE(config, m_palette, FUNC(dai_state::dai_palette), std::size(s_palette));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/ddenlovr.cpp
+++ b/src/mame/drivers/ddenlovr.cpp
@@ -9701,7 +9701,7 @@ MACHINE_RESET_MEMBER(ddenlovr_state,ddenlovr)
 	m_quiz365_protection[0] = 0;
 	m_quiz365_protection[1] = 0;
 
-	memset(m_palram, 0, ARRAY_LENGTH(m_palram));
+	std::fill(std::begin(m_palram), std::end(m_palram), 0);
 
 	m_blitter_irq_handler(1);
 }

--- a/src/mame/drivers/dgn_beta.cpp
+++ b/src/mame/drivers/dgn_beta.cpp
@@ -320,7 +320,7 @@ void dgn_beta_state::dgnbeta(machine_config &config)
 	screen.set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
 
 	GFXDECODE(config, "gfxdecode", m_palette, gfx_dgnbeta);
-	PALETTE(config, m_palette, FUNC(dgn_beta_state::dgn_beta_palette), ARRAY_LENGTH(dgnbeta_pens));
+	PALETTE(config, m_palette, FUNC(dgn_beta_state::dgn_beta_palette), std::size(dgnbeta_pens));
 
 	/* PIA 0 at $FC20-$FC23 I46 */
 	PIA6821(config, m_pia_0, 0);

--- a/src/mame/drivers/dynax.cpp
+++ b/src/mame/drivers/dynax.cpp
@@ -4162,7 +4162,7 @@ MACHINE_RESET_MEMBER(dynax_state,dynax)
 	m_gekisha_val[0] = 0;
 	m_gekisha_val[1] = 0;
 
-	memset(m_palette_ram, 0, ARRAY_LENGTH(m_palette_ram));
+	std::fill(std::begin(m_palette_ram), std::end(m_palette_ram), 0);
 }
 
 MACHINE_START_MEMBER(dynax_state,hjingi)

--- a/src/mame/drivers/fccpu30.cpp
+++ b/src/mame/drivers/fccpu30.cpp
@@ -428,8 +428,8 @@ uint32_t cpu30_state::bootvect_r(offs_t offset){
 
 void cpu30_state::bootvect_w(offs_t offset, uint32_t data, uint32_t mem_mask){
 	LOG("%s\n", FUNCNAME);
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] &= ~mem_mask;
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] |= (data & mem_mask);
+	m_sysram[offset % std::size(m_sysram)] &= ~mem_mask;
+	m_sysram[offset % std::size(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcoming accesses to masking RAM until reset.
 }
 

--- a/src/mame/drivers/flicker.cpp
+++ b/src/mame/drivers/flicker.cpp
@@ -306,7 +306,7 @@ WRITE_LINE_MEMBER(flicker_state::cm_ram1_w)
 	{
 		m_mux_col = m_ram0_output;
 		m_digits[m_mux_col] = led_digits[m_rom0_output];
-		if (ARRAY_LENGTH(lamp_matrix) > m_mux_col)
+		if (std::size(lamp_matrix) > m_mux_col)
 		{
 			if (lamp_matrix[m_mux_col][0])
 				output().set_value(lamp_matrix[m_mux_col][0], BIT(m_rom1_output, 0));

--- a/src/mame/drivers/funworld.cpp
+++ b/src/mame/drivers/funworld.cpp
@@ -8402,7 +8402,7 @@ void chinatow_state::init_rcdino4()
 	decrypt_rcdino4(rom, memregion("maincpu")->bytes(), memregion("gfx1")->base(), memregion("gfx1")->bytes(), memregion( "gfx1" )->base());
 
 	int j = 0;
-	for (int i = 0x40; i < (0x40 + ARRAY_LENGTH(rcdino4_keys40));)
+	for (int i = 0x40; i < (0x40 + std::size(rcdino4_keys40));)
 	{
 		uint8_t key = rcdino4_keys40[i - 0x40];
 
@@ -8492,10 +8492,10 @@ void chinatow_state::init_rcdino4()
 
 		j &= 0xff;
 
-		do {} while (((++i - 0x81) < ARRAY_LENGTH(rcdino4_keys80))
+		do {} while (((++i - 0x81) < std::size(rcdino4_keys80))
 				&& !rcdino4_keys80[i - 0x81]);
 
-		if ((i - 0x81) == ARRAY_LENGTH(rcdino4_keys80))
+		if ((i - 0x81) == std::size(rcdino4_keys80))
 		{
 			break;
 		}

--- a/src/mame/drivers/gaiden.cpp
+++ b/src/mame/drivers/gaiden.cpp
@@ -194,7 +194,7 @@ void gaiden_state::wildfang_protection_w(offs_t offset, uint16_t data, uint16_t 
 				break;
 			case 0x20:  /* low 4 bits of jump code */
 				m_jumpcode |= data & 0x0f;
-				if (m_jumpcode >= ARRAY_LENGTH(wildfang_jumppoints))
+				if (m_jumpcode >= std::size(wildfang_jumppoints))
 				{
 					logerror("unknown jumpcode %02x\n", m_jumpcode);
 					m_jumpcode = 0;

--- a/src/mame/drivers/gameking.cpp
+++ b/src/mame/drivers/gameking.cpp
@@ -299,7 +299,7 @@ void gameking_state::gameking(machine_config &config)
 	screen.set_screen_update(FUNC(gameking_state::screen_update_gameking));
 	screen.set_palette(m_palette);
 
-	PALETTE(config, m_palette, FUNC(gameking_state::gameking_palette), ARRAY_LENGTH(gameking_pens));
+	PALETTE(config, m_palette, FUNC(gameking_state::gameking_palette), std::size(gameking_pens));
 
 	/* sound hardware */
 	SPEAKER(config, "speaker").front_center();

--- a/src/mame/drivers/gba.cpp
+++ b/src/mame/drivers/gba.cpp
@@ -727,7 +727,7 @@ uint32_t gba_state::gba_io_r(offs_t offset, uint32_t mem_mask)
 			break;
 	}
 
-//  assert_always(offset < ARRAY_LENGTH(reg_names) / 2, "Not enough register names in gba_state");
+//  assert_always(offset < std::size(reg_names) / 2, "Not enough register names in gba_state");
 
 	if (ACCESSING_BITS_0_15)
 	{
@@ -749,7 +749,7 @@ void gba_state::gba_io_w(offs_t offset, uint32_t data, uint32_t mem_mask)
 
 	COMBINE_DATA(&m_regs[offset]);
 
-//  assert_always(offset < ARRAY_LENGTH(reg_names) / 2, "Not enough register names in gba_state");
+//  assert_always(offset < std::size(reg_names) / 2, "Not enough register names in gba_state");
 
 	if (ACCESSING_BITS_0_15)
 	{

--- a/src/mame/drivers/gimix.cpp
+++ b/src/mame/drivers/gimix.cpp
@@ -721,7 +721,7 @@ offs_t gimix_state::os9_dasm_override(std::ostream &stream, offs_t pc, const uti
 	if ((opcodes.r8(pc) == 0x10) && (opcodes.r8(pc+1) == 0x3F))
 	{
 		call = opcodes.r8(pc+2);
-		if ((call < ARRAY_LENGTH(os9syscalls)) && (os9syscalls[call] != nullptr))
+		if ((call < std::size(os9syscalls)) && (os9syscalls[call] != nullptr))
 		{
 			util::stream_format(stream, "OS9   %s", os9syscalls[call]);
 			result = 3;

--- a/src/mame/drivers/gmaster.cpp
+++ b/src/mame/drivers/gmaster.cpp
@@ -135,7 +135,7 @@ void gmaster_state::gmaster_io_w(offs_t offset, uint8_t data)
 			break;
 		case 1:
 			m_video.delayed = false;
-			if (m_video.x < ARRAY_LENGTH(m_video.pixels[0])) // continental galaxy flutlicht
+			if (m_video.x < std::size(m_video.pixels[0])) // continental galaxy flutlicht
 			{
 				m_video.pixels[m_video.y][m_video.x] = data;
 			}
@@ -280,9 +280,9 @@ void gmaster_state::gmaster_palette(palette_device &palette) const
 
 uint32_t gmaster_state::screen_update_gmaster(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
-	for (int y = 0; y < ARRAY_LENGTH(m_video.pixels); y++)
+	for (int y = 0; y < std::size(m_video.pixels); y++)
 	{
-		for (int x = 0; x < ARRAY_LENGTH(m_video.pixels[0]); x++)
+		for (int x = 0; x < std::size(m_video.pixels[0]); x++)
 		{
 			uint8_t const d = m_video.pixels[y][x];
 
@@ -339,7 +339,7 @@ void gmaster_state::gmaster(machine_config &config)
 	screen.set_screen_update(FUNC(gmaster_state::screen_update_gmaster));
 	screen.set_palette("palette");
 
-	PALETTE(config, "palette", FUNC(gmaster_state::gmaster_palette), ARRAY_LENGTH(gmaster_pens));
+	PALETTE(config, "palette", FUNC(gmaster_state::gmaster_palette), std::size(gmaster_pens));
 
 	SPEAKER(config, "mono").front_center();
 	SPEAKER_SOUND(config, m_speaker).add_route(0, "mono", 0.50);

--- a/src/mame/drivers/gunpey.cpp
+++ b/src/mame/drivers/gunpey.cpp
@@ -712,7 +712,7 @@ void state_s::set_o(unsigned char v)
 	assert(oy < 256);
 
 	unsigned char a = v;
-	for (int i = 0; i < ARRAY_LENGTH(colour); i++)
+	for (int i = 0; i < std::size(colour); i++)
 	{
 		unsigned char b = colour[i];
 		colour[i] = a;

--- a/src/mame/drivers/hk68v10.cpp
+++ b/src/mame/drivers/hk68v10.cpp
@@ -281,8 +281,8 @@ uint16_t hk68v10_state::bootvect_r(offs_t offset){
 
 void hk68v10_state::bootvect_w(offs_t offset, uint16_t data, uint16_t mem_mask){
 	LOG (("%s offset %08x, mask %08x, data %04x\n", FUNCNAME, offset, mem_mask, data));
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] &= ~mem_mask;
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] |= (data & mem_mask);
+	m_sysram[offset % std::size(m_sysram)] &= ~mem_mask;
+	m_sysram[offset % std::size(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcoming accesses to masking RAM until reset.
 }
 

--- a/src/mame/drivers/homelab.cpp
+++ b/src/mame/drivers/homelab.cpp
@@ -690,7 +690,7 @@ QUICKLOAD_LOAD_MEMBER(homelab_state::quickload_cb)
 
 	while((ch = image.fgetc()))
 	{
-		if (i >= (ARRAY_LENGTH(pgmname) - 1))
+		if (i >= (std::size(pgmname) - 1))
 		{
 			image.seterror(IMAGE_ERROR_INVALIDIMAGE, "File name too long");
 			image.message(" File name too long");
@@ -731,7 +731,7 @@ QUICKLOAD_LOAD_MEMBER(homelab_state::quickload_cb)
 		if (image.fread(&ch, 1) != 1)
 		{
 			char message[512];
-			snprintf(message, ARRAY_LENGTH(message), "%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
+			snprintf(message, std::size(message), "%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
 			image.seterror(IMAGE_ERROR_INVALIDIMAGE, message);
 			image.message("%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
 			return image_init_result::FAIL;

--- a/src/mame/drivers/jalmah.cpp
+++ b/src/mame/drivers/jalmah.cpp
@@ -1509,7 +1509,7 @@ uint16_t jalmah_state::urashima_mcu_r()
 	int res;
 
 	res = resp[m_respcount++];
-	if (m_respcount >= ARRAY_LENGTH(resp)) m_respcount = 0;
+	if (m_respcount >= std::size(resp)) m_respcount = 0;
 
 //  logerror("%s: mcu_r %02x\n",machine().dscribe_context(),res);
 
@@ -1568,7 +1568,7 @@ uint16_t jalmah_state::daireika_mcu_r()
 	int res;
 
 	res = resp[m_respcount++];
-	if (m_respcount >= ARRAY_LENGTH(resp)) m_respcount = 0;
+	if (m_respcount >= std::size(resp)) m_respcount = 0;
 
 //  logerror("%s: mcu_r %02x\n",machine().describe_context(),res);
 
@@ -1636,7 +1636,7 @@ uint16_t jalmah_state::mjzoomin_mcu_r()
 	int res;
 
 	res = resp[m_respcount++];
-	if (m_respcount >= ARRAY_LENGTH(resp)) m_respcount = 0;
+	if (m_respcount >= std::size(resp)) m_respcount = 0;
 
 //  logerror("%04x: mcu_r %02x\n",machine().describe_context(),res);
 
@@ -1689,7 +1689,7 @@ uint16_t jalmah_state::kakumei_mcu_r()
 	int res;
 
 	res = resp[m_respcount++];
-	if (m_respcount >= ARRAY_LENGTH(resp)) m_respcount = 0;
+	if (m_respcount >= std::size(resp)) m_respcount = 0;
 
 //  popmessage("%s: mcu_r %02x",machine().describe_context(),res);
 
@@ -1710,7 +1710,7 @@ uint16_t jalmah_state::suchiesp_mcu_r()
 	int res;
 
 	res = resp[m_respcount++];
-	if (m_respcount >= ARRAY_LENGTH(resp)) m_respcount = 0;
+	if (m_respcount >= std::size(resp)) m_respcount = 0;
 
 //  popmessage("%s: mcu_r %02x",machine().describe_context(),res);
 

--- a/src/mame/drivers/laser3k.cpp
+++ b/src/mame/drivers/laser3k.cpp
@@ -967,7 +967,7 @@ void laser3k_state::laser3k(machine_config &config)
 	m_screen->set_screen_update(FUNC(laser3k_state::screen_update));
 	m_screen->set_palette("palette");
 
-	PALETTE(config, "palette", FUNC(laser3k_state::laser3k_palette), ARRAY_LENGTH(laser3k_pens));
+	PALETTE(config, "palette", FUNC(laser3k_state::laser3k_palette), std::size(laser3k_pens));
 
 	/* memory banking */
 	ADDRESS_MAP_BANK(config, "bank0").set_map(&laser3k_state::banks_map).set_options(ENDIANNESS_LITTLE, 8, 32, 0x4000);

--- a/src/mame/drivers/ldplayer.cpp
+++ b/src/mame/drivers/ldplayer.cpp
@@ -345,8 +345,8 @@ void ldplayer_state::machine_reset()
 
 void pr8210_state::add_command(uint8_t command)
 {
-	m_command_buffer[m_command_buffer_in++ % ARRAY_LENGTH(m_command_buffer)] = (command & 0x1f) | 0x20;
-	m_command_buffer[m_command_buffer_in++ % ARRAY_LENGTH(m_command_buffer)] = 0x00 | 0x20;
+	m_command_buffer[m_command_buffer_in++ % std::size(m_command_buffer)] = (command & 0x1f) | 0x20;
+	m_command_buffer[m_command_buffer_in++ % std::size(m_command_buffer)] = 0x00 | 0x20;
 }
 
 
@@ -376,7 +376,7 @@ void pr8210_state::device_timer(emu_timer &timer, device_timer_id id, int param,
 			// if we're out of bits, queue up the next command
 			else if (bitsleft == 0 && m_command_buffer_in != m_command_buffer_out)
 			{
-				data = m_command_buffer[m_command_buffer_out++ % ARRAY_LENGTH(m_command_buffer)];
+				data = m_command_buffer[m_command_buffer_out++ % std::size(m_command_buffer)];
 				bitsleft = 12;
 			}
 			m_bit_timer->adjust(duration, (bitsleft << 16) | data);
@@ -416,7 +416,7 @@ void pr8210_state::execute_command(int command)
 	{
 		case CMD_SCAN_REVERSE:
 			if (m_command_buffer_in == m_command_buffer_out ||
-				m_command_buffer_in == (m_command_buffer_out + 1) % ARRAY_LENGTH(m_command_buffer))
+				m_command_buffer_in == (m_command_buffer_out + 1) % std::size(m_command_buffer))
 			{
 				add_command(0x1c);
 				m_playing = true;
@@ -435,7 +435,7 @@ void pr8210_state::execute_command(int command)
 
 		case CMD_FAST_REVERSE:
 			if (m_command_buffer_in == m_command_buffer_out ||
-				m_command_buffer_in == (m_command_buffer_out + 1) % ARRAY_LENGTH(m_command_buffer))
+				m_command_buffer_in == (m_command_buffer_out + 1) % std::size(m_command_buffer))
 			{
 				add_command(0x0c);
 				m_playing = true;
@@ -444,7 +444,7 @@ void pr8210_state::execute_command(int command)
 
 		case CMD_SCAN_FORWARD:
 			if (m_command_buffer_in == m_command_buffer_out ||
-				m_command_buffer_in == (m_command_buffer_out + 1) % ARRAY_LENGTH(m_command_buffer))
+				m_command_buffer_in == (m_command_buffer_out + 1) % std::size(m_command_buffer))
 			{
 				add_command(0x08);
 				m_playing = true;
@@ -463,7 +463,7 @@ void pr8210_state::execute_command(int command)
 
 		case CMD_FAST_FORWARD:
 			if (m_command_buffer_in == m_command_buffer_out ||
-				m_command_buffer_in == (m_command_buffer_out + 1) % ARRAY_LENGTH(m_command_buffer))
+				m_command_buffer_in == (m_command_buffer_out + 1) % std::size(m_command_buffer))
 			{
 				add_command(0x10);
 				m_playing = true;

--- a/src/mame/drivers/liberate.cpp
+++ b/src/mame/drivers/liberate.cpp
@@ -733,7 +733,7 @@ MACHINE_START_MEMBER(liberate_state,liberate)
 
 MACHINE_RESET_MEMBER(liberate_state,liberate)
 {
-	memset(m_io_ram, 0, ARRAY_LENGTH(m_io_ram));
+	std::fill(std::begin(m_io_ram), std::end(m_io_ram), 0);
 
 	m_background_disable = 0;
 	m_background_color = 0;

--- a/src/mame/drivers/lviv.cpp
+++ b/src/mame/drivers/lviv.cpp
@@ -453,7 +453,7 @@ void lviv_state::lviv(machine_config &config)
 	m_screen->set_screen_update(FUNC(lviv_state::screen_update));
 	m_screen->set_palette(m_palette);
 
-	PALETTE(config, m_palette, FUNC(lviv_state::lviv_palette), ARRAY_LENGTH(s_palette));
+	PALETTE(config, m_palette, FUNC(lviv_state::lviv_palette), std::size(s_palette));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/mediagx.cpp
+++ b/src/mame/drivers/mediagx.cpp
@@ -950,7 +950,7 @@ void mediagx_state::report_speedups()
 
 void mediagx_state::install_speedups(const speedup_entry *entries, int count)
 {
-	assert(count < ARRAY_LENGTH(s_speedup_handlers));
+	assert(count < std::size(s_speedup_handlers));
 
 	m_speedup_table = entries;
 	m_speedup_count = count;
@@ -984,7 +984,7 @@ void mediagx_state::init_a51site4()
 	init_mediagx();
 
 #if SPEEDUP_HACKS
-	install_speedups(a51site4_speedups, ARRAY_LENGTH(a51site4_speedups));
+	install_speedups(a51site4_speedups, std::size(a51site4_speedups));
 #endif
 }
 

--- a/src/mame/drivers/mvme147.cpp
+++ b/src/mame/drivers/mvme147.cpp
@@ -290,8 +290,8 @@ uint32_t mvme147_state::bootvect_r(offs_t offset){
 }
 
 void mvme147_state::bootvect_w(offs_t offset, uint32_t data, uint32_t mem_mask){
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] &= ~mem_mask;
-	m_sysram[offset % ARRAY_LENGTH(m_sysram)] |= (data & mem_mask);
+	m_sysram[offset % std::size(m_sysram)] &= ~mem_mask;
+	m_sysram[offset % std::size(m_sysram)] |= (data & mem_mask);
 	m_sysrom = &m_sysram[0]; // redirect all upcoming accesses to masking RAM until reset.
 }
 

--- a/src/mame/drivers/nc.cpp
+++ b/src/mame/drivers/nc.cpp
@@ -297,8 +297,8 @@ void nc_state::nc_refresh_memory_bank_config(int bank)
 	int mem_bank;
 	char bank1[20];
 	char bank5[20];
-	snprintf(bank1,ARRAY_LENGTH(bank1),"bank%d",bank+1);
-	snprintf(bank5,ARRAY_LENGTH(bank5),"bank%d",bank+5);
+	snprintf(bank1,std::size(bank1),"bank%d",bank+1);
+	snprintf(bank5,std::size(bank5),"bank%d",bank+5);
 
 	mem_type = (m_memory_config[bank]>>6) & 0x03;
 	mem_bank = m_memory_config[bank] & 0x03f;

--- a/src/mame/drivers/news_38xx.cpp
+++ b/src/mame/drivers/news_38xx.cpp
@@ -273,7 +273,7 @@ void news_38xx_state::int_check()
 	static int const int_line[] = { INPUT_LINE_IRQ7, INPUT_LINE_IRQ4, INPUT_LINE_IRQ3 };
 	static u8 const int_mask[] = { 0x80, 0x78, 0x07 };
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_int_state); i++)
+	for (unsigned i = 0; i < std::size(m_int_state); i++)
 	{
 		bool const int_state = m_intst & m_inten & int_mask[i];
 

--- a/src/mame/drivers/news_68k.cpp
+++ b/src/mame/drivers/news_68k.cpp
@@ -277,7 +277,7 @@ void news_68k_state::int_check()
 	static int const int_line[] = { INPUT_LINE_IRQ3, INPUT_LINE_IRQ4 };
 	static u8 const int_mask[] = { 0x71, 0x8e };
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_int_state); i++)
+	for (unsigned i = 0; i < std::size(m_int_state); i++)
 	{
 		bool const int_state = m_intst & int_mask[i];
 

--- a/src/mame/drivers/news_r3k.cpp
+++ b/src/mame/drivers/news_r3k.cpp
@@ -333,7 +333,7 @@ void news_r3k_state::int_check()
 	static int const int_line[] = { INPUT_LINE_IRQ0, INPUT_LINE_IRQ1, INPUT_LINE_IRQ2, INPUT_LINE_IRQ4 };
 	static u16 const int_mask[] = { 0x001f, 0x00e0, 0x1f00, 0xe000 };
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_int_state); i++)
+	for (unsigned i = 0; i < std::size(m_int_state); i++)
 	{
 		bool const int_state = m_intst & m_inten & int_mask[i];
 

--- a/src/mame/drivers/nightgal.cpp
+++ b/src/mame/drivers/nightgal.cpp
@@ -780,7 +780,7 @@ void nightgal_state::machine_reset()
 	m_z80_latch = 0;
 	m_mux_data = 0;
 
-	memset(m_blit_raw_data, 0, ARRAY_LENGTH(m_blit_raw_data));
+	std::fill(std::begin(m_blit_raw_data), std::end(m_blit_raw_data), 0);
 }
 
 void nightgal_state::royalqn(machine_config &config)

--- a/src/mame/drivers/palm_dbg.hxx
+++ b/src/mame/drivers/palm_dbg.hxx
@@ -1154,7 +1154,7 @@ static const char *lookup_trap(uint16_t opcode)
 
 	int i;
 
-	for (i = 0; i < ARRAY_LENGTH(traps); i++)
+	for (i = 0; i < std::size(traps); i++)
 	{
 		if (traps[i].trap == opcode)
 			return traps[i].name;

--- a/src/mame/drivers/pdp1.cpp
+++ b/src/mame/drivers/pdp1.cpp
@@ -1825,7 +1825,7 @@ void pdp1_state::pdp1(machine_config &config)
 	PDP1_CYLINDER(config, m_parallel_drum);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_pdp1);
-	PALETTE(config, m_palette, FUNC(pdp1_state::pdp1_palette), total_colors_needed + ARRAY_LENGTH(pdp1_pens), total_colors_needed);
+	PALETTE(config, m_palette, FUNC(pdp1_state::pdp1_palette), total_colors_needed + std::size(pdp1_pens), total_colors_needed);
 }
 
 /*

--- a/src/mame/drivers/psikyosh.cpp
+++ b/src/mame/drivers/psikyosh.cpp
@@ -432,12 +432,12 @@ P1KEY11  29|30  P2KEY11
 
 		// HACK: read IPT_START1 from "INPUTS" to avoid listing it twice or having two independent STARTs listed
 		u32 const start_depressed = ~value & 0x01000000;
-		keys |= start_depressed ? 1 << (ARRAY_LENGTH(key_codes) - 1) : 0; // and bung it in at the end
+		keys |= start_depressed ? 1 << (std::size(key_codes) - 1) : 0; // and bung it in at the end
 
 		value |= 0xFFFF0000; // set top word
 		do {
 			// since we can't handle multiple keys, just return the first one depressed
-			if ((keys & which_key) && (count < ARRAY_LENGTH(key_codes)))
+			if ((keys & which_key) && (count < std::size(key_codes)))
 			{
 				value &= ~((u32)(key_codes[count]) << 16); // mask in selected word as IP_ACTIVE_LOW
 				break;

--- a/src/mame/drivers/psion5.cpp
+++ b/src/mame/drivers/psion5.cpp
@@ -88,7 +88,7 @@ void psion5mx_state::machine_start()
 
 void psion5mx_state::machine_reset()
 {
-	memset(m_memcfg, 0, sizeof(uint32_t) * ARRAY_LENGTH(m_memcfg));
+	std::fill(std::begin(m_memcfg), std::end(m_memcfg), 0);
 	m_dramcfg = 0;
 
 	m_timers[0]->adjust(attotime::never);
@@ -107,7 +107,7 @@ void psion5mx_state::machine_reset()
 	m_ssi_read_counter = 0;
 	m_kbd_scan = 0;
 
-	memset(m_ports, 0, ARRAY_LENGTH(m_ports));
+	std::fill(std::begin(m_ports), std::end(m_ports), 0);
 
 	m_periodic->adjust(attotime::from_hz(64), 0, attotime::from_hz(64));
 

--- a/src/mame/drivers/seibuspi.cpp
+++ b/src/mame/drivers/seibuspi.cpp
@@ -1233,7 +1233,7 @@ CUSTOM_INPUT_MEMBER(seibuspi_state::ejanhs_encode)
 	static const u8 encoding[] = { 6, 5, 4, 3, 2, 7 };
 	ioport_value state = ~m_key[N]->read();
 
-	for (int bit = 0; bit < ARRAY_LENGTH(encoding); bit++)
+	for (int bit = 0; bit < std::size(encoding); bit++)
 		if (state & (1 << bit))
 			return encoding[bit];
 	return 0;

--- a/src/mame/drivers/skydiver.cpp
+++ b/src/mame/drivers/skydiver.cpp
@@ -118,9 +118,9 @@ static constexpr unsigned colortable_source[] =
 void skydiver_state::skydiver_palette(palette_device &palette) const
 {
 	constexpr rgb_t colors[]{ rgb_t::black(), rgb_t::white(), rgb_t(0xa0, 0xa0, 0xa0) }; // black, white, grey
-	for (unsigned i = 0; i < ARRAY_LENGTH(colortable_source); i++)
+	for (unsigned i = 0; i < std::size(colortable_source); i++)
 	{
-		assert(colortable_source[i] < ARRAY_LENGTH(colors));
+		assert(colortable_source[i] < std::size(colors));
 		palette.set_pen_color(i, colors[colortable_source[i]]);
 	}
 }
@@ -378,7 +378,7 @@ void skydiver_state::skydiver(machine_config &config)
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_skydiver);
-	PALETTE(config, m_palette, FUNC(skydiver_state::skydiver_palette), ARRAY_LENGTH(colortable_source));
+	PALETTE(config, m_palette, FUNC(skydiver_state::skydiver_palette), std::size(colortable_source));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/spcforce.cpp
+++ b/src/mame/drivers/spcforce.cpp
@@ -264,7 +264,7 @@ static constexpr int COLORTABLE_SOURCE[] =
 
 void spcforce_state::spcforce_palette(palette_device &palette) const
 {
-	for (int i = 0; i < ARRAY_LENGTH(COLORTABLE_SOURCE); i++)
+	for (int i = 0; i < std::size(COLORTABLE_SOURCE); i++)
 	{
 		int const data = COLORTABLE_SOURCE[i];
 		rgb_t const color = rgb_t(pal1bit(data >> 0), pal1bit(data >> 1), pal1bit(data >> 2));
@@ -311,7 +311,7 @@ void spcforce_state::spcforce(machine_config &config)
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_spcforce);
-	PALETTE(config, m_palette, FUNC(spcforce_state::spcforce_palette), ARRAY_LENGTH(COLORTABLE_SOURCE));
+	PALETTE(config, m_palette, FUNC(spcforce_state::spcforce_palette), std::size(COLORTABLE_SOURCE));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/superdq.cpp
+++ b/src/mame/drivers/superdq.cpp
@@ -170,7 +170,6 @@ void superdq_state::superdq_videoram_w(offs_t offset, uint8_t data)
 
 void superdq_state::superdq_io_w(uint8_t data)
 {
-	int             i;
 	static const uint8_t black_color_entries[] = {7,15,16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
 
 	if ( data & 0x40 ) /* bit 6 = irqack */
@@ -181,7 +180,7 @@ void superdq_state::superdq_io_w(uint8_t data)
 
 	m_color_bank = ( data & 2 ) ? 1 : 0;
 
-	for( i = 0; i < ARRAY_LENGTH( black_color_entries ); i++ )
+	for (int i = 0; i < std::size(black_color_entries); i++)
 	{
 		int index = black_color_entries[i];
 		if (data & 0x80)

--- a/src/mame/drivers/supracan.cpp
+++ b/src/mame/drivers/supracan.cpp
@@ -1968,11 +1968,11 @@ void supracan_state::machine_reset()
 	m_soundcpu_irq_enable = 0;
 	m_soundcpu_irq_source = 0;
 	m_sound_cpu_shift_ctrl = 0;
-	memset(m_sound_cpu_shift_regs, 0, ARRAY_LENGTH(m_sound_cpu_shift_regs));
-	memset(m_latched_controls, 0, sizeof(uint16_t) * ARRAY_LENGTH(m_latched_controls));
+	std::fill(std::begin(m_sound_cpu_shift_regs), std::end(m_sound_cpu_shift_regs), 0);
+	std::fill(std::begin(m_latched_controls), std::end(m_latched_controls), 0);
 	m_sound_status = 0;
 	m_sound_reg_addr = 0;
-	memset(m_sound_regs, 0, ARRAY_LENGTH(m_sound_regs));
+	std::fill(std::begin(m_sound_regs), std::end(m_sound_regs), 0);
 
 	m_soundcpu->set_input_line(INPUT_LINE_HALT, ASSERT_LINE);
 

--- a/src/mame/drivers/svision.cpp
+++ b/src/mame/drivers/svision.cpp
@@ -527,7 +527,7 @@ void svision_state::svision(machine_config &config)
 	m_screen->set_palette(m_palette);
 	m_screen->screen_vblank().set(FUNC(svision_state::frame_int_w));
 
-	PALETTE(config, m_palette, FUNC(svision_state::svision_palette), ARRAY_LENGTH(svision_pens));
+	PALETTE(config, m_palette, FUNC(svision_state::svision_palette), std::size(svision_pens));
 }
 
 void svision_state::svisions(machine_config &config)

--- a/src/mame/drivers/tecnbras.cpp
+++ b/src/mame/drivers/tecnbras.cpp
@@ -79,7 +79,7 @@ void tecnbras_state::print_column_w(offs_t offset, uint8_t data)
 {
 	int const x = m_xcoord + offset;
 	int const ch = x / 5;
-	if (ch < ARRAY_LENGTH(m_digit)) {
+	if (ch < std::size(m_digit)) {
 		int const row = x % 5;
 		for (int i = 0; i < 7; i++) {
 			m_digit[ch][i] &= ~(1 << row);
@@ -101,7 +101,7 @@ void tecnbras_state::machine_start()
 		std::fill(std::begin(elem), std::end(elem), 0);
 
 #if 0
-	for (int x = 0; x < ARRAY_LENGTH(m_digit); x++)
+	for (int x = 0; x < std::size(m_digit); x++)
 		for (int y = 0; y < 7; y++)
 			m_dmds[(x * 7) + y] = y;
 #endif

--- a/src/mame/drivers/ti89.cpp
+++ b/src/mame/drivers/ti89.cpp
@@ -488,8 +488,8 @@ void ti68k_state::machine_reset()
 	m_lcd_height = 0;
 	m_lcd_on = 0;
 	m_lcd_contrast = 0;
-	memset(m_io_hw1, 0, ARRAY_LENGTH(m_io_hw1) * sizeof(uint16_t));
-	memset(m_io_hw2, 0, ARRAY_LENGTH(m_io_hw2) * sizeof(uint16_t));
+	std::fill(std::begin(m_io_hw1), std::end(m_io_hw1), 0);
+	std::fill(std::begin(m_io_hw2), std::end(m_io_hw2), 0);
 	m_timer_on = 0;
 	m_timer_mask = 0xf;
 	m_timer_val = 0;

--- a/src/mame/drivers/tutor.cpp
+++ b/src/mame/drivers/tutor.cpp
@@ -304,13 +304,13 @@ uint8_t tutor_state::key_r(offs_t offset)
 	char port[12];
 	uint8_t value;
 
-	snprintf(port, ARRAY_LENGTH(port), "LINE%d", (offset & 0x007e) >> 3);
+	snprintf(port, std::size(port), "LINE%d", (offset & 0x007e) >> 3);
 	value = ioport(port)->read();
 
 	/* hack for ports overlapping with joystick */
 	if (offset >= 32 && offset < 48)
 	{
-		snprintf(port, ARRAY_LENGTH(port), "LINE%d_alt", (offset & 0x007e) >> 3);
+		snprintf(port, std::size(port), "LINE%d_alt", (offset & 0x007e) >> 3);
 		value |= ioport(port)->read();
 	}
 

--- a/src/mame/drivers/vegas.cpp
+++ b/src/mame/drivers/vegas.cpp
@@ -519,7 +519,7 @@ void vegas_state::machine_reset()
 	m_dcs->reset_w(1);
 
 	// Clear CPU IO registers
-	memset(m_cpuio_data, 0, ARRAY_LENGTH(m_cpuio_data));
+	std::fill(std::begin(m_cpuio_data), std::end(m_cpuio_data), 0);
 	// Clear SIO registers
 	reset_sio();
 	m_duart_irq_state = 0;

--- a/src/mame/drivers/vis.cpp
+++ b/src/mame/drivers/vis.cpp
@@ -538,7 +538,7 @@ void vis_vga_device::vga_w(offs_t offset, uint8_t data)
 			break;
 		case 0x05:
 		case 0x25:
-			assert(vga.crtc.index < ARRAY_LENGTH(m_crtc_regs));
+			assert(vga.crtc.index < std::size(m_crtc_regs));
 			m_crtc_regs[vga.crtc.index] = data;
 			switch(vga.crtc.index)
 			{

--- a/src/mame/drivers/wpc_dot.cpp
+++ b/src/mame/drivers/wpc_dot.cpp
@@ -257,7 +257,7 @@ uint32_t wpc_dot_state::screen_update(screen_device &screen, bitmap_rgb32 &bitma
 		{
 			for(uint8_t bit=0;bit<8;bit++)  // bits
 			{
-				assert(offset >= 0 && offset < ARRAY_LENGTH(m_dmdram));
+				assert(offset >= 0 && offset < std::size(m_dmdram));
 				uint32_t col;
 				if(m_dmdram[offset] & (1<<bit))
 					col = rgb_t(0xff,0xaa,0x00);

--- a/src/mame/drivers/x07.cpp
+++ b/src/mame/drivers/x07.cpp
@@ -893,7 +893,7 @@ void x07_state::printer_w()
 
 inline uint8_t x07_state::kb_get_index(uint8_t char_code)
 {
-	for(uint8_t i=0 ; i< ARRAY_LENGTH(x07_keycodes); i++)
+	for(uint8_t i=0 ; i< std::size(x07_keycodes); i++)
 		if (x07_keycodes[i].codes[0] == char_code)
 			return i;
 

--- a/src/mame/includes/saitek_stratos.h
+++ b/src/mame/includes/saitek_stratos.h
@@ -44,7 +44,7 @@ protected:
 	output_finder<4, 16, 4> m_out_lcd;
 
 	// common handlers
-	void clear_lcd() { std::fill_n(m_lcd_data, ARRAY_LENGTH(m_lcd_data), 0); }
+	void clear_lcd() { std::fill(std::begin(m_lcd_data), std::end(m_lcd_data), 0); }
 	void update_lcd();
 	void power_off();
 	void set_cpu_freq();

--- a/src/mame/machine/amstrad.cpp
+++ b/src/mame/machine/amstrad.cpp
@@ -313,7 +313,7 @@ The Amstrad Plus has a 4096 colour palette
 
 void amstrad_state::amstrad_plus_palette(palette_device &palette) const
 {
-	palette.set_pen_colors(0, amstrad_palette, ARRAY_LENGTH(amstrad_palette) / 3); // FIXME: isn't this overwritten by the loop?
+	palette.set_pen_colors(0, amstrad_palette, std::size(amstrad_palette) / 3); // FIXME: isn't this overwritten by the loop?
 	for (int i = 0; i < 0x1000; i++)
 	{
 		int const g = ( i >> 8 ) & 0x0f;

--- a/src/mame/machine/bebox.cpp
+++ b/src/mame/machine/bebox.cpp
@@ -206,15 +206,15 @@ void bebox_state::bebox_crossproc_interrupts_w(offs_t offset, uint64_t data, uin
 		{ 0x08000000, 0, 0, 0/*PPC_INPUT_LINE_TLBISYNC*/ },
 		{ 0x04000000, 1, 0, 0/*PPC_INPUT_LINE_TLBISYNC*/ }
 	};
-	int i, line;
 	uint32_t old_crossproc_interrupts = m_crossproc_interrupts;
 
 	bebox_mbreg32_w(&m_crossproc_interrupts, data, mem_mask);
 
-	for (i = 0; i < ARRAY_LENGTH(crossproc_map); i++)
+	for (int i = 0; i < std::size(crossproc_map); i++)
 	{
 		if ((old_crossproc_interrupts ^ m_crossproc_interrupts) & crossproc_map[i].mask)
 		{
+			int line;
 			if (m_crossproc_interrupts & crossproc_map[i].mask)
 				line = crossproc_map[i].active_high ? ASSERT_LINE : CLEAR_LINE;
 			else
@@ -306,7 +306,7 @@ void bebox_state::bebox_set_irq_bit(unsigned int interrupt_bit, int val)
 	if (LOG_INTERRUPTS)
 	{
 		/* make sure that we don't shoot ourself in the foot */
-		if ((interrupt_bit >= ARRAY_LENGTH(interrupt_names)) || !interrupt_names[interrupt_bit])
+		if ((interrupt_bit >= std::size(interrupt_names)) || !interrupt_names[interrupt_bit])
 			throw emu_fatalerror("bebox_state::bebox_set_irq_bit: Raising invalid interrupt");
 
 		logerror("bebox_set_irq_bit(): pc[0]=0x%08x pc[1]=0x%08x %s interrupt #%u (%s)\n",

--- a/src/mame/machine/bfm_sc45_helper.cpp
+++ b/src/mame/machine/bfm_sc45_helper.cpp
@@ -215,7 +215,7 @@ int find_input_strings(running_machine &machine)
 
 					//if (pos <= 5)
 					{
-						assert(pos >= 0 && pos < ARRAY_LENGTH(sc4inputs[port]));
+						assert(pos >= 0 && pos < std::size(sc4inputs[port]));
 						if (sc4inputs[port][pos].used == false)
 						{
 							sc4inputs[port][pos].used = true;
@@ -614,9 +614,9 @@ int find_lamp_strings(running_machine &machine)
 		{
 			char tempname2[64];
 
-			if (pos == 0) snprintf(tempname2, ARRAY_LENGTH(tempname2), "%stop", tempname);
-			if (pos == 1) snprintf(tempname2, ARRAY_LENGTH(tempname2), "%smid", tempname);
-			if (pos == 2) snprintf(tempname2, ARRAY_LENGTH(tempname2), "%sbot", tempname);
+			if (pos == 0) snprintf(tempname2, std::size(tempname2), "%stop", tempname);
+			if (pos == 1) snprintf(tempname2, std::size(tempname2), "%smid", tempname);
+			if (pos == 2) snprintf(tempname2, std::size(tempname2), "%sbot", tempname);
 
 
 			for (auto & lamp : lamps)

--- a/src/mame/machine/coco.cpp
+++ b/src/mame/machine/coco.cpp
@@ -1275,7 +1275,7 @@ offs_t coco_state::os9_dasm_override(std::ostream &stream, offs_t pc, const util
 	if ((opcodes.r8(pc) == 0x10) && (opcodes.r8(pc+1) == 0x3F))
 	{
 		call = opcodes.r8(pc+2);
-		if ((call < ARRAY_LENGTH(os9syscalls)) && (os9syscalls[call] != nullptr))
+		if ((call < std::size(os9syscalls)) && (os9syscalls[call] != nullptr))
 		{
 			util::stream_format(stream, "OS9   %s", os9syscalls[call]);
 			result = 3;

--- a/src/mame/machine/decocass_tape.cpp
+++ b/src/mame/machine/decocass_tape.cpp
@@ -91,7 +91,7 @@ void decocass_tape_device::device_start()
 		if (m_tape_data[offs] != 0)
 			break;
 	numblocks = ((offs | 0xff) + 1) / 256;
-	assert(numblocks < ARRAY_LENGTH(m_crc16));
+	assert(numblocks < std::size(m_crc16));
 
 	/* compute the total length */
 	m_numclocks = REGION_BOT_GAP_END_CLOCK + numblocks * BYTE_BLOCK_TOTAL * 16 + REGION_BOT_GAP_END_CLOCK;

--- a/src/mame/machine/etna.cpp
+++ b/src/mame/machine/etna.cpp
@@ -54,8 +54,8 @@ void etna_device::device_reset()
 
 	m_pending_ints = 0;
 
-	memset(m_regs, 0, ARRAY_LENGTH(m_regs));
-	memset(m_prom, 0, ARRAY_LENGTH(m_prom));
+	std::fill(std::begin(m_regs), std::end(m_regs), 0);
+	std::fill(std::begin(m_prom), std::end(m_prom), 0);
 
 	// defaults expected by the touchscreen code
 	m_prom[0x0a] = 20;
@@ -237,7 +237,7 @@ WRITE_LINE_MEMBER(etna_device::eeprom_clk_in)
 			if (m_prom_addr_count == 10)
 			{
 				LOGMASKED(LOG_PROM, "PROM Address: %03x\n", m_prom_addr);
-				uint16_t byte_addr = (m_prom_addr << 1) % ARRAY_LENGTH(m_prom);
+				uint16_t byte_addr = (m_prom_addr << 1) % std::size(m_prom);
 				m_prom_value = m_prom[byte_addr] | (m_prom[byte_addr + 1] << 8);
 				LOGMASKED(LOG_PROM, "PROM Value: %04x\n", m_prom_value);
 			}

--- a/src/mame/machine/fddebug.cpp
+++ b/src/mame/machine/fddebug.cpp
@@ -571,7 +571,7 @@ static void set_default_key_params(running_machine &machine)
 	int keynum;
 
 	/* look for a matching game and set the key appropriately */
-	for (keynum = 0; keynum < ARRAY_LENGTH(default_keys); keynum++)
+	for (keynum = 0; keynum < std::size(default_keys); keynum++)
 		if (strcmp(machine.system().name, default_keys[keynum].gamename) == 0)
 		{
 			fd1094_global = default_keys[keynum].global;
@@ -1873,8 +1873,8 @@ static uint32_t reconstruct_base_seed(int keybaseaddr, uint32_t startseed)
 	{
 		seed = seed * 0x29;
 		seed += seed << 16;
-		window[index++ % ARRAY_LENGTH(window)] = seed;
-	} while (((startseed ^ seed) & 0x3fffff) != 0 || index < ARRAY_LENGTH(window));
+		window[index++ % std::size(window)] = seed;
+	} while (((startseed ^ seed) & 0x3fffff) != 0 || index < std::size(window));
 
 	/* when we break, we have overshot */
 	index--;
@@ -1882,10 +1882,10 @@ static uint32_t reconstruct_base_seed(int keybaseaddr, uint32_t startseed)
 	/* back up to where we would have been at address 3 */
 	index -= keybaseaddr - 3;
 	if (index < 0)
-		index += ARRAY_LENGTH(window);
+		index += std::size(window);
 
 	/* return the value from the window at that location */
-	return window[index % ARRAY_LENGTH(window)] & 0x3fffff;
+	return window[index % std::size(window)] & 0x3fffff;
 }
 
 
@@ -2095,7 +2095,7 @@ static void build_optable(running_machine &machine)
 	}
 
 	/* now iterate over entries in our intruction table */
-	for (inum = 0; inum < ARRAY_LENGTH(instr_table); inum++)
+	for (inum = 0; inum < std::size(instr_table); inum++)
 	{
 		const char *bitstring = instr_table[inum].bitstring;
 		const char *eastring = instr_table[inum].eastring;

--- a/src/mame/machine/imm6_76.cpp
+++ b/src/mame/machine/imm6_76.cpp
@@ -50,9 +50,9 @@ void intel_imm6_76_device::device_start()
 
 image_init_result intel_imm6_76_device::call_load()
 {
-	if (length() != ARRAY_LENGTH(m_data))
+	if (length() != std::size(m_data))
 		return image_init_result::FAIL;
-	else if (fread(m_data, ARRAY_LENGTH(m_data)) != ARRAY_LENGTH(m_data))
+	else if (fread(m_data, std::size(m_data)) != std::size(m_data))
 		return image_init_result::FAIL;
 	else
 		return image_init_result::PASS;
@@ -61,7 +61,7 @@ image_init_result intel_imm6_76_device::call_load()
 image_init_result intel_imm6_76_device::call_create(int format_type, util::option_resolution *format_options)
 {
 	std::fill(std::begin(m_data), std::end(m_data), 0U);
-	if (fwrite(m_data, ARRAY_LENGTH(m_data)) != ARRAY_LENGTH(m_data))
+	if (fwrite(m_data, std::size(m_data)) != std::size(m_data))
 		return image_init_result::FAIL;
 	else
 		return image_init_result::PASS;
@@ -72,7 +72,7 @@ void intel_imm6_76_device::call_unload()
 	if (!is_readonly())
 	{
 		fseek(0, SEEK_SET);
-		fwrite(m_data, ARRAY_LENGTH(m_data));
+		fwrite(m_data, std::size(m_data));
 	}
 	std::fill(std::begin(m_data), std::end(m_data), 0U);
 }

--- a/src/mame/machine/mac.cpp
+++ b/src/mame/machine/mac.cpp
@@ -2334,7 +2334,7 @@ const char *lookup_trap(uint16_t opcode)
 
 	int i;
 
-	for (i = 0; i < ARRAY_LENGTH(traps); i++)
+	for (i = 0; i < std::size(traps); i++)
 	{
 		if (traps[i].trap == opcode)
 			return traps[i].name;
@@ -2431,7 +2431,7 @@ void mac_state::mac_tracetrap(const char *cpu_name_local, int addr, int trap)
 		csCode = *((uint16_t*) (mem + a0 + 26));
 		sprintf(s->state().state_int(" ioVRefNum=%i ioCRefNum=%i csCode=%i", ioVRefNum, ioCRefNum, csCode);
 
-		for (i = 0; i < ARRAY_LENGTH(cscodes); i++)
+		for (i = 0; i < std::size(cscodes); i++)
 		{
 			if (cscodes[i].csCode == csCode)
 			{
@@ -2467,7 +2467,7 @@ void mac_state::mac_tracetrap(const char *cpu_name_local, int addr, int trap)
 
 	case 0xa815:    /* _SCSIDispatch */
 		i = *((uint16_t*) (mem + a7));
-		if (i < ARRAY_LENGTH(scsisels))
+		if (i < std::size(scsisels))
 			if (scsisels[i])
 				sprintf(s, " (%s)", scsisels[i]);
 		break;

--- a/src/mame/machine/rosetta.cpp
+++ b/src/mame/machine/rosetta.cpp
@@ -860,7 +860,7 @@ u8 rosetta_device::compute_ecc(u32 const data) const
 {
 	u8 result = 0;
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(ecc_bits); i++)
+	for (unsigned i = 0; i < std::size(ecc_bits); i++)
 		result ^= BIT(data, 31 - i) ? ecc_bits[i] : 0;
 
 	return result;
@@ -872,7 +872,7 @@ unsigned rosetta_device::check_ecc(u32 &data, u8 const ecc) const
 
 	if (error)
 	{
-		for (unsigned i = 0; i < ARRAY_LENGTH(ecc_bits); i++)
+		for (unsigned i = 0; i < std::size(ecc_bits); i++)
 		{
 			if (error == ecc_bits[i])
 			{

--- a/src/mame/machine/sorcerer.cpp
+++ b/src/mame/machine/sorcerer.cpp
@@ -613,7 +613,6 @@ QUICKLOAD_LOAD_MEMBER(sorcerer_state::quickload_cb)
 
 		if (((start_address == 0x1d5) || (execute_address == 0xc858)) && (space.read_byte(0xdffa) == 0xc3))
 		{
-			u8 i;
 			static const u8 data[]={
 				0xcd, 0x26, 0xc4,   // CALL C426    ;set up other pointers
 				0x21, 0xd4, 1,      // LD HL,01D4   ;start of program address (used by C689)
@@ -621,7 +620,7 @@ QUICKLOAD_LOAD_MEMBER(sorcerer_state::quickload_cb)
 				0xc3, 0x89, 0xc6    // JP C689  ;run program
 			};
 
-			for (i = 0; i < ARRAY_LENGTH(data); i++)
+			for (u8 i = 0; i < std::size(data); i++)
 				space.write_byte(0xf01f + i, data[i]);
 
 			if (!autorun)

--- a/src/mame/machine/taitoio.cpp
+++ b/src/mame/machine/taitoio.cpp
@@ -185,7 +185,7 @@ u8 tc0040ioc_device::portreg_r()
 
 void tc0040ioc_device::portreg_w(u8 data)
 {
-	if (m_port < ARRAY_LENGTH(m_regs))
+	if (m_port < std::size(m_regs))
 		m_regs[m_port] = data;
 	switch (m_port)
 	{

--- a/src/mame/machine/z80bin.cpp
+++ b/src/mame/machine/z80bin.cpp
@@ -30,7 +30,7 @@ image_init_result z80bin_load_file(device_image_interface &image, address_space 
 
 		if (ch != '\0')
 		{
-			if (i >= (ARRAY_LENGTH(pgmname) - 1))
+			if (i >= (std::size(pgmname) - 1))
 			{
 				image.seterror(IMAGE_ERROR_INVALIDIMAGE, "File name too long");
 				image.message(" File name too long");
@@ -65,7 +65,7 @@ image_init_result z80bin_load_file(device_image_interface &image, address_space 
 		j = (start_addr + i) & 0xffff;
 		if (image.fread(&data, 1) != 1)
 		{
-			snprintf(message, ARRAY_LENGTH(message), "%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
+			snprintf(message, std::size(message), "%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
 			image.seterror(IMAGE_ERROR_INVALIDIMAGE, message);
 			image.message("%s: Unexpected EOF while writing byte to %04X", pgmname, (unsigned) j);
 			return image_init_result::FAIL;

--- a/src/mame/video/911_vdt.cpp
+++ b/src/mame/video/911_vdt.cpp
@@ -106,10 +106,10 @@ static const unsigned short vdt911_pens[] =
 */
 void vdt911_device::vdt911_palette(palette_device &palette) const
 {
-	for (int i = 0; i < ARRAY_LENGTH(vdt911_colors); i++)
+	for (int i = 0; i < std::size(vdt911_colors); i++)
 		palette.set_indirect_color(i, vdt911_colors[i]);
 
-	for (int i = 0; i < ARRAY_LENGTH(vdt911_pens); i++)
+	for (int i = 0; i < std::size(vdt911_pens); i++)
 		palette.set_pen_indirect(i, vdt911_pens[i]);
 }
 
@@ -804,7 +804,7 @@ void vdt911_device::device_add_mconfig(machine_config &config)
 	SPEAKER(config, "speaker").front_center();
 	BEEP(config, m_beeper, 3250).add_route(ALL_OUTPUTS, "speaker", 0.50);
 
-	PALETTE(config, "palette", FUNC(vdt911_device::vdt911_palette), ARRAY_LENGTH(vdt911_pens), ARRAY_LENGTH(vdt911_colors));
+	PALETTE(config, "palette", FUNC(vdt911_device::vdt911_palette), std::size(vdt911_pens), std::size(vdt911_colors));
 }
 
 ioport_constructor vdt911_device::device_input_ports() const

--- a/src/mame/video/apple2.cpp
+++ b/src/mame/video/apple2.cpp
@@ -1451,13 +1451,13 @@ static const rgb_t apple2_palette[] =
 
 void a2_video_device::init_palette()
 {
-	for (int i = 0; i < ARRAY_LENGTH(apple2_palette); i++)
+	for (int i = 0; i < std::size(apple2_palette); i++)
 		set_pen_color(i, apple2_palette[i]);
 }
 
 uint32_t a2_video_device::palette_entries() const
 {
-	return ARRAY_LENGTH(apple2_palette);
+	return std::size(apple2_palette);
 }
 
 uint32_t a2_video_device::screen_update_GS(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)

--- a/src/mame/video/darkmist.cpp
+++ b/src/mame/video/darkmist.cpp
@@ -71,7 +71,7 @@ void darkmist_state::darkmist_palette(palette_device &palette) const
 			{ &m_spr_clut[0], 0x40 },
 			{ &m_tx_clut[0], 0xc0 } };
 
-	for (unsigned plane = 0; ARRAY_LENGTH(planes) > plane; ++plane)
+	for (unsigned plane = 0; std::size(planes) > plane; ++plane)
 	{
 		for (unsigned i = 0; 0x100 > i; ++i)
 		{

--- a/src/mame/video/firetrk.cpp
+++ b/src/mame/video/firetrk.cpp
@@ -34,7 +34,7 @@ void firetrk_state::firetrk_palette(palette_device &palette)
 
 	m_color1_mask = m_color2_mask = 0;
 
-	for (int i = 0; i < ARRAY_LENGTH(colortable_source); i++)
+	for (int i = 0; i < std::size(colortable_source); i++)
 	{
 		uint8_t color = colortable_source[i];
 
@@ -93,7 +93,7 @@ void firetrk_state::montecar_palette(palette_device &palette)
 
 	m_color1_mask = m_color2_mask = 0;
 
-	for (int i = 0; i < ARRAY_LENGTH(colortable_source); i++)
+	for (int i = 0; i < std::size(colortable_source); i++)
 	{
 		uint8_t color = colortable_source[i];
 
@@ -105,8 +105,8 @@ void firetrk_state::montecar_palette(palette_device &palette)
 		prom_to_palette(i, color_prom[0x100 + colortable_source[i]]);
 	}
 
-	palette.set_pen_color(ARRAY_LENGTH(colortable_source) + 0, rgb_t::black());
-	palette.set_pen_color(ARRAY_LENGTH(colortable_source) + 1, rgb_t::white());
+	palette.set_pen_color(std::size(colortable_source) + 0, rgb_t::black());
+	palette.set_pen_color(std::size(colortable_source) + 1, rgb_t::white());
 }
 
 

--- a/src/mame/video/gaelco3d.cpp
+++ b/src/mame/video/gaelco3d.cpp
@@ -170,7 +170,7 @@ void gaelco3d_state::gaelco3d_renderer::render_poly(screen_device &screen, uint3
 
 	/* extract vertices */
 	data = 0;
-	for (vertnum = 0; vertnum < ARRAY_LENGTH(vert) && !IS_POLYEND(data); vertnum++)
+	for (vertnum = 0; vertnum < std::size(vert) && !IS_POLYEND(data); vertnum++)
 	{
 		/* extract vertex data */
 		data = polydata[13 + vertnum * 2];

--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -154,13 +154,13 @@ void gime_device::device_start(void)
 	m_gime_clock_timer = timer_alloc(TIMER_GIME_CLOCK);
 
 	// setup banks
-	assert(ARRAY_LENGTH(m_read_banks) == ARRAY_LENGTH(m_write_banks));
-	for (int i = 0; i < ARRAY_LENGTH(m_read_banks); i++)
+	assert(std::size(m_read_banks) == std::size(m_write_banks));
+	for (int i = 0; i < std::size(m_read_banks); i++)
 	{
 		char buffer[8];
-		snprintf(buffer, ARRAY_LENGTH(buffer), "rbank%d", i);
+		snprintf(buffer, std::size(buffer), "rbank%d", i);
 		m_read_banks[i] = machine().root_device().membank(buffer);
-		snprintf(buffer, ARRAY_LENGTH(buffer), "wbank%d", i);
+		snprintf(buffer, std::size(buffer), "wbank%d", i);
 		m_write_banks[i] = machine().root_device().membank(buffer);
 	}
 
@@ -180,8 +180,8 @@ void gime_device::device_start(void)
 	update_composite_palette();
 
 	// set up save states
-	save_pointer(NAME(m_gime_registers), ARRAY_LENGTH(m_gime_registers));
-	save_pointer(NAME(m_mmu), ARRAY_LENGTH(m_mmu));
+	save_item(NAME(m_gime_registers));
+	save_item(NAME(m_mmu));
 	save_item(NAME(m_sam_state));
 	save_item(NAME(m_ff22_value));
 	save_item(NAME(m_interrupt_value));
@@ -506,7 +506,7 @@ inline void gime_device::update_memory(void)
 void gime_device::update_memory(int bank)
 {
 	// choose bank
-	assert((bank >= 0) && (bank < ARRAY_LENGTH(m_read_banks)) && (bank < ARRAY_LENGTH(m_write_banks)));
+	assert((bank >= 0) && (bank < std::size(m_read_banks)) && (bank < std::size(m_write_banks)));
 	memory_bank *read_bank = m_read_banks[bank];
 	memory_bank *write_bank = m_write_banks[bank];
 
@@ -1036,10 +1036,10 @@ inline void gime_device::write_palette_register(offs_t offset, uint8_t data)
 		if (m_palette_rotated_position_used)
 		{
 			/* identify the new position */
-			uint16_t new_palette_rotated_position = (m_palette_rotated_position + 1) % ARRAY_LENGTH(m_palette_rotated);
+			uint16_t new_palette_rotated_position = (m_palette_rotated_position + 1) % std::size(m_palette_rotated);
 
 			/* copy the palette */
-			for (int i = 0; i < ARRAY_LENGTH(m_palette_rotated[0]); i++)
+			for (int i = 0; i < std::size(m_palette_rotated[0]); i++)
 				m_palette_rotated[new_palette_rotated_position][i] = m_palette_rotated[m_palette_rotated_position][i];
 
 			/* and advance */

--- a/src/mame/video/k054156_k054157_k056832.cpp
+++ b/src/mame/video/k054156_k054157_k056832.cpp
@@ -1069,7 +1069,7 @@ void k056832_device::word_w(offs_t offset, u16 data, u16 mem_mask)
 
 void k056832_device::b_word_w(offs_t offset, u16 data, u16 mem_mask)
 {
-	assert(offset < ARRAY_LENGTH(m_regsb));
+	assert(offset < std::size(m_regsb));
 	COMBINE_DATA(&m_regsb[offset]);
 }
 

--- a/src/mame/video/lordgun.cpp
+++ b/src/mame/video/lordgun.cpp
@@ -145,7 +145,7 @@ float lordgun_crosshair_mapper(ioport_field *field, float linear_value)
 {
 	int x = linear_value - 0x3c;
 
-	if ( (x < 0) || (x > ARRAY_LENGTH(lordgun_gun_x_table)) )
+	if ( (x < 0) || (x > std::size(lordgun_gun_x_table)) )
 		x = 0;
 
 	return lordgun_gun_x_table[x] * 1.0f / 0x1BF;
@@ -157,7 +157,7 @@ void lordgun_state::lorddgun_calc_gun_scr(int i)
 
 	int x = ioport(gunnames[i])->read() - 0x3c;
 
-	if ( (x < 0) || (x > ARRAY_LENGTH(lordgun_gun_x_table)) )
+	if ( (x < 0) || (x > std::size(lordgun_gun_x_table)) )
 		x = 0;
 
 	m_gun[i].scr_x = lordgun_gun_x_table[x];

--- a/src/mame/video/midzeus.cpp
+++ b/src/mame/video/midzeus.cpp
@@ -1466,14 +1466,14 @@ void midzeus_state::log_waveram(uint32_t length_and_base)
 	for (i = 0; i < numoctets; i++)
 		checksum += ptr[i*2] + ptr[i*2+1];
 
-	for (i = 0; i < ARRAY_LENGTH(recent_entries); i++)
+	for (i = 0; i < std::size(recent_entries); i++)
 		if (recent_entries[i].lab == length_and_base && recent_entries[i].checksum == checksum)
 		{
 			foundit = true;
 			break;
 		}
 
-	if (i == ARRAY_LENGTH(recent_entries))
+	if (i == std::size(recent_entries))
 		i--;
 	if (i != 0)
 	{

--- a/src/mame/video/namcos22.cpp
+++ b/src/mame/video/namcos22.cpp
@@ -261,7 +261,7 @@ void namcos22_renderer::poly3d_drawquad(screen_device &screen, bitmap_rgb32 &bit
 		}
 
 		clipverts = zclip_if_less(4, v, clipv, 4, 10.0f);
-		assert(clipverts <= ARRAY_LENGTH(clipv));
+		assert(clipverts <= std::size(clipv));
 		if (clipverts < 3)
 			return;
 

--- a/src/mame/video/nemesis.cpp
+++ b/src/mame/video/nemesis.cpp
@@ -262,7 +262,7 @@ void nemesis_state::video_start()
 	m_foreground->set_scroll_rows(256);
 
 	memset(m_charram, 0, m_charram.bytes());
-	memset(m_blank_tile, 0, ARRAY_LENGTH(m_blank_tile));
+	std::fill(std::begin(m_blank_tile), std::end(m_blank_tile), 0);
 
 	/* Set up save state */
 	machine().save().register_postload(save_prepost_delegate(FUNC(nemesis_state::nemesis_postload), this));

--- a/src/mame/video/pocketc.cpp
+++ b/src/mame/video/pocketc.cpp
@@ -29,10 +29,10 @@ const int pocketc_state::colortable[8][2] =
 
 void pocketc_state::pocketc_palette(palette_device &palette) const
 {
-	for (int i = 0; i < ARRAY_LENGTH(indirect_palette); i++)
+	for (int i = 0; i < std::size(indirect_palette); i++)
 		palette.set_indirect_color(i, indirect_palette[i]);
 
-	for (int i = 0; i < ARRAY_LENGTH(colortable); i++)
+	for (int i = 0; i < std::size(colortable); i++)
 	{
 		palette.set_pen_indirect(i*2,   colortable[i][0]);
 		palette.set_pen_indirect(i*2+1, colortable[i][1]);

--- a/src/mame/video/sega16sp.cpp
+++ b/src/mame/video/sega16sp.cpp
@@ -41,7 +41,7 @@ sega_16bit_sprite_device::sega_16bit_sprite_device(const machine_config &mconfig
 	, m_flip(false)
 {
 	// default to 1:1 bank mapping
-	for (int bank = 0; bank < ARRAY_LENGTH(m_bank); bank++)
+	for (int bank = 0; bank < std::size(m_bank); bank++)
 		m_bank[bank] = bank;
 }
 

--- a/src/mame/video/sgi_ge5.cpp
+++ b/src/mame/video/sgi_ge5.cpp
@@ -342,17 +342,17 @@ void sgi_ge5_device::execute_run()
 					 */
 					if (space(1).read_dword(0x50b) == 0x004d0003)
 					{
-						if (token < ARRAY_LENGTH(token_puc))
+						if (token < std::size(token_puc))
 							string = token_puc[token];
 					}
 					else if (space(1).read_dword(0x50d) == 0x004d0005
 						|| space(1).read_dword(0x536) == 0x12345678
 						|| space(1).read_dword(0x540) == 0x12345678)
 					{
-						if (token < ARRAY_LENGTH(token_gl))
+						if (token < std::size(token_gl))
 							string = token_gl[token];
 					}
-					else if (token < ARRAY_LENGTH(token_diag))
+					else if (token < std::size(token_diag))
 						string = token_diag[token];
 
 					if (string)

--- a/src/mame/video/sgi_re2.cpp
+++ b/src/mame/video/sgi_re2.cpp
@@ -71,7 +71,7 @@ void sgi_re2_device::device_start()
 	m_dram = std::make_unique<u32[]>(1280 * 1024);
 
 	// save state
-	for (unsigned i = 0; i < ARRAY_LENGTH(m_reg); i++)
+	for (unsigned i = 0; i < std::size(m_reg); i++)
 		if (regmask[i])
 			save_item(m_reg[i], regname[i]);
 

--- a/src/mame/video/starshp1.cpp
+++ b/src/mame/video/starshp1.cpp
@@ -37,7 +37,7 @@ void starshp1_state::starshp1_palette(palette_device &palette) const
 		5, 7        // 0x11        - circle
 	};
 
-	for (unsigned i = 0; i < ARRAY_LENGTH(colortable_source); i++)
+	for (unsigned i = 0; i < std::size(colortable_source); i++)
 		palette.set_pen_indirect(i, colortable_source[i]);
 }
 

--- a/src/mame/video/stic.cpp
+++ b/src/mame/video/stic.cpp
@@ -1314,7 +1314,7 @@ void stic_device::write(offs_t offset, uint16_t data)
 			break;
 	}
 
-	if (offset < ARRAY_LENGTH(m_stic_registers))
+	if (offset < std::size(m_stic_registers))
 		m_stic_registers[offset] = data;
 }
 

--- a/src/mame/video/vc4000.cpp
+++ b/src/mame/video/vc4000.cpp
@@ -574,7 +574,7 @@ INTERRUPT_GEN_MEMBER(vc4000_state::vc4000_video_line)
 {
 	uint8_t collision[400]={0}; // better alloca or gcc feature of non constant long automatic arrays
 	const rectangle &visarea = m_screen->visible_area();
-	assert(ARRAY_LENGTH(collision) >= m_screen->width());
+	assert(std::size(collision) >= m_screen->width());
 
 	m_video.line++;
 	if (m_irq_pause) m_irq_pause++;

--- a/src/osd/modules/debugger/win/editwininfo.cpp
+++ b/src/osd/modules/debugger/win/editwininfo.cpp
@@ -185,7 +185,7 @@ LRESULT editwin_info::edit_proc(UINT message, WPARAM wparam, LPARAM lparam)
 				case 13: // carriage return
 					{
 						// fetch the text
-						SendMessage(m_editwnd, WM_GETTEXT, WPARAM(ARRAY_LENGTH(buffer)), LPARAM(buffer));
+						SendMessage(m_editwnd, WM_GETTEXT, WPARAM(std::size(buffer)), LPARAM(buffer));
 
 						// add to the history if it's not a repeat of the last one
 						if (buffer[0] && (m_history.empty() || _tcscmp(buffer, m_history[0].c_str())))

--- a/src/osd/modules/file/winrtfile.cpp
+++ b/src/osd/modules/file/winrtfile.cpp
@@ -350,7 +350,7 @@ osd_file::error osd_get_full_path(std::string &dst, std::string const &path)
 
 	// canonicalize the path
 	TCHAR buffer[MAX_PATH];
-	if (!GetFullPathName(t_path.c_str(), ARRAY_LENGTH(buffer), buffer, nullptr))
+	if (!GetFullPathName(t_path.c_str(), std::size(buffer), buffer, nullptr))
 		return win_error_to_file_error(GetLastError());
 
 	// convert the result back to UTF-8

--- a/src/osd/modules/font/font_osx.cpp
+++ b/src/osd/modules/font/font_osx.cpp
@@ -241,8 +241,8 @@ private:
 bool font_osx::get_font_families(std::string const &font_path, std::vector<std::pair<std::string, std::string> > &result)
 {
 	CFStringRef keys[] = { kCTFontCollectionRemoveDuplicatesOption };
-	std::uintptr_t values[ARRAY_LENGTH(keys)] = { 1 };
-	CFDictionaryRef const options = CFDictionaryCreate(kCFAllocatorDefault, (void const **)keys, (void const **)values, ARRAY_LENGTH(keys), &kCFTypeDictionaryKeyCallBacks, nullptr);
+	std::uintptr_t values[std::size(keys)] = { 1 };
+	CFDictionaryRef const options = CFDictionaryCreate(kCFAllocatorDefault, (void const **)keys, (void const **)values, std::size(keys), &kCFTypeDictionaryKeyCallBacks, nullptr);
 	CTFontCollectionRef const collection = CTFontCollectionCreateFromAvailableFonts(nullptr);
 	CFRelease(options);
 	if (!collection) return false;

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -161,7 +161,7 @@ bool osd_font_sdl::get_bitmap(char32_t chnum, bitmap_argb32 &bitmap, std::int32_
 {
 	SDL_Color const fcol = { 0xff, 0xff, 0xff };
 	char ustr[16];
-	ustr[utf8_from_uchar(ustr, ARRAY_LENGTH(ustr), chnum)] = '\0';
+	ustr[utf8_from_uchar(ustr, std::size(ustr), chnum)] = '\0';
 	std::unique_ptr<SDL_Surface, void (*)(SDL_Surface *)> const drawsurf(TTF_RenderUTF8_Solid(m_font.get(), ustr, fcol), &SDL_FreeSurface);
 
 	// was nothing returned?

--- a/src/osd/modules/font/font_windows.cpp
+++ b/src/osd/modules/font/font_windows.cpp
@@ -86,7 +86,7 @@ bool osd_font_windows::open(std::string const &font_path, std::string const &_na
 
 	// copy in the face name
 	osd::text::tstring face = osd::text::to_tstring(name);
-	_tcsncpy(logfont.lfFaceName, face.c_str(), ARRAY_LENGTH(logfont.lfFaceName));
+	_tcsncpy(logfont.lfFaceName, face.c_str(), std::size(logfont.lfFaceName));
 	logfont.lfFaceName[sizeof(logfont.lfFaceName) / sizeof(TCHAR)-1] = 0;
 
 	// create the font
@@ -201,7 +201,7 @@ bool osd_font_windows::get_bitmap(char32_t chnum, bitmap_argb32 &bitmap, int32_t
 
 		// now draw the character
 		char16_t tempchar[UTF16_CHAR_MAX];
-		UINT const count = INT(utf16_from_uchar(tempchar, ARRAY_LENGTH(tempchar), chnum));
+		UINT const count = INT(utf16_from_uchar(tempchar, std::size(tempchar), chnum));
 		SetTextColor(dummyDC, RGB(0xff, 0xff, 0xff));
 		SetBkColor(dummyDC, RGB(0x00, 0x00, 0x00));
 		ExtTextOutW(dummyDC, 50 + abc.abcA, 50, ETO_OPAQUE, nullptr, reinterpret_cast<LPCWSTR>(tempchar), count, nullptr);

--- a/src/osd/modules/input/input_common.cpp
+++ b/src/osd/modules/input/input_common.cpp
@@ -193,7 +193,7 @@ key_trans_entry keyboard_trans_table::s_default_table[] =
 keyboard_trans_table::keyboard_trans_table()
 {
 	m_table = s_default_table;
-	m_table_size = ARRAY_LENGTH(s_default_table);
+	m_table_size = std::size(s_default_table);
 }
 #else
 keyboard_trans_table::keyboard_trans_table()

--- a/src/osd/modules/input/input_common.h
+++ b/src/osd/modules/input/input_common.h
@@ -547,7 +547,7 @@ int generic_axis_get_state(void *device_internal, void *item_internal)
 inline static const char *default_button_name(int which)
 {
 	static char buffer[20];
-	snprintf(buffer, ARRAY_LENGTH(buffer), "B%d", which);
+	snprintf(buffer, std::size(buffer), "B%d", which);
 	return buffer;
 }
 
@@ -558,7 +558,7 @@ inline static const char *default_button_name(int which)
 inline static const char *default_pov_name(int which)
 {
 	static char buffer[20];
-	snprintf(buffer, ARRAY_LENGTH(buffer), "POV%d", which);
+	snprintf(buffer, std::size(buffer), "POV%d", which);
 	return buffer;
 }
 

--- a/src/osd/modules/input/input_dinput.cpp
+++ b/src/osd/modules/input/input_dinput.cpp
@@ -312,7 +312,7 @@ public:
 			std::string name;
 
 			// generate/fetch the name
-			snprintf(defname, ARRAY_LENGTH(defname), "Scan%03d", keynum);
+			snprintf(defname, std::size(defname), "Scan%03d", keynum);
 			name = device_item_name(devinfo, keynum, defname, nullptr);
 
 			// add the item to the device

--- a/src/osd/modules/input/input_dinput.h
+++ b/src/osd/modules/input/input_dinput.h
@@ -173,7 +173,7 @@ public:
 		char guid_string[37];
 
 		snprintf(
-			guid_string, ARRAY_LENGTH(guid_string),
+			guid_string, std::size(guid_string),
 			"%08lx-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
 			guid.Data1, guid.Data2, guid.Data3,
 			guid.Data4[0], guid.Data4[1], guid.Data4[2],

--- a/src/osd/modules/input/input_rawinput.cpp
+++ b/src/osd/modules/input/input_rawinput.cpp
@@ -82,7 +82,7 @@ public:
 	std::wstring enum_key(int index) const
 	{
 		WCHAR keyname[256];
-		DWORD namelen = ARRAY_LENGTH(keyname);
+		DWORD namelen = std::size(keyname);
 		if (RegEnumKeyEx(m_key, index, keyname, &namelen, nullptr, nullptr, nullptr, nullptr) == ERROR_SUCCESS)
 			return std::wstring(keyname, namelen);
 		else
@@ -653,8 +653,8 @@ protected:
 			WCHAR keyname[100];
 
 			// generate the name
-			if (GetKeyNameTextW(((keynum & 0x7f) << 16) | ((keynum & 0x80) << 17), keyname, ARRAY_LENGTH(keyname)) == 0)
-				_snwprintf(keyname, ARRAY_LENGTH(keyname), L"Scan%03d", keynum);
+			if (GetKeyNameTextW(((keynum & 0x7f) << 16) | ((keynum & 0x80) << 17), keyname, std::size(keyname)) == 0)
+				_snwprintf(keyname, std::size(keyname), L"Scan%03d", keynum);
 			std::string name = osd::text::from_wstring(keyname);
 
 			// add the item to the device

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -786,7 +786,7 @@ public:
 			static_cast<int>(SDL_TEXTINPUT)
 		};
 
-		sdl_event_manager::instance().subscribe(event_types, ARRAY_LENGTH(event_types), this);
+		sdl_event_manager::instance().subscribe(event_types, std::size(event_types), this);
 
 		sdl_keyboard_device *devinfo;
 
@@ -921,7 +921,7 @@ public:
 			static_cast<int>(SDL_MOUSEWHEEL)
 		};
 
-		sdl_event_manager::instance().subscribe(event_types, ARRAY_LENGTH(event_types), this);
+		sdl_event_manager::instance().subscribe(event_types, std::size(event_types), this);
 
 		sdl_mouse_device *devinfo;
 		char defname[20];
@@ -1148,7 +1148,7 @@ public:
 			static_cast<int>(SDL_JOYBUTTONUP)
 		};
 
-		sdl_event_manager::instance().subscribe(event_types, ARRAY_LENGTH(event_types), this);
+		sdl_event_manager::instance().subscribe(event_types, std::size(event_types), this);
 
 		osd_printf_verbose("Joystick: End initialization\n");
 	}
@@ -1182,7 +1182,7 @@ private:
 			// only map place holders if there were mappings specified
 			if (devmap->initialized)
 			{
-				snprintf(tempname, ARRAY_LENGTH(tempname), "NC%d", index);
+				snprintf(tempname, std::size(tempname), "NC%d", index);
 				m_sixaxis_mode
 					? devicelist()->create_device<sdl_sixaxis_joystick_device>(machine, tempname, guid_str, *this)
 					: devicelist()->create_device<sdl_joystick_device>(machine, tempname, guid_str, *this);

--- a/src/osd/modules/input/input_uwp.cpp
+++ b/src/osd/modules/input/input_uwp.cpp
@@ -246,7 +246,7 @@ internal:
 			char temp[256];
 			if (keyname == nullptr)
 			{
-				snprintf(temp, ARRAY_LENGTH(temp), "Scan%03d", keynum);
+				snprintf(temp, std::size(temp), "Scan%03d", keynum);
 				keyname = temp;
 			}
 

--- a/src/osd/modules/input/input_win32.cpp
+++ b/src/osd/modules/input/input_win32.cpp
@@ -83,8 +83,8 @@ public:
 			TCHAR keyname[100];
 
 			// generate the name
-			if (GetKeyNameText(((keynum & 0x7f) << 16) | ((keynum & 0x80) << 17), keyname, ARRAY_LENGTH(keyname)) == 0)
-				_sntprintf(keyname, ARRAY_LENGTH(keyname), TEXT("Scan%03d"), keynum);
+			if (GetKeyNameText(((keynum & 0x7f) << 16) | ((keynum & 0x80) << 17), keyname, std::size(keyname)) == 0)
+				_sntprintf(keyname, std::size(keyname), TEXT("Scan%03d"), keynum);
 			std::string name = osd::text::from_tstring(keyname);
 
 			// add the item to the device

--- a/src/osd/modules/input/input_x11.cpp
+++ b/src/osd/modules/input/input_x11.cpp
@@ -540,7 +540,7 @@ public:
 			// register ourself to handle events from event manager
 			int event_types[] = { motion_type, button_press_type, button_release_type };
 			osd_printf_verbose("Events types to register: motion:%d, press:%d, release:%d\n", motion_type, button_press_type, button_release_type);
-			x11_event_manager::instance().subscribe(event_types, ARRAY_LENGTH(event_types), this);
+			x11_event_manager::instance().subscribe(event_types, std::size(event_types), this);
 		}
 
 		osd_printf_verbose("Lightgun: End initialization\n");
@@ -604,7 +604,7 @@ private:
 		{
 			if (m_lightgun_map.initialized)
 			{
-				snprintf(tempname, ARRAY_LENGTH(tempname), "NC%d", index);
+				snprintf(tempname, std::size(tempname), "NC%d", index);
 				return devicelist()->create_device<x11_lightgun_device>(machine, tempname, tempname, *this);
 			} else
 				return nullptr;

--- a/src/osd/modules/lib/osdlib_macosx.cpp
+++ b/src/osd/modules/lib/osdlib_macosx.cpp
@@ -67,7 +67,7 @@ void osd_break_into_debugger(const char *message)
 	struct kinfo_proc info;
 	info.kp_proc.p_flag = 0;
 	std::size_t infosz = sizeof(info);
-	sysctl(mib, ARRAY_LENGTH(mib), &info, &infosz, nullptr, 0);
+	sysctl(mib, std::size(mib), &info, &infosz, nullptr, 0);
 	if (info.kp_proc.p_flag & P_TRACED)
 	{
 		printf("MAME exception: %s\n", message);

--- a/src/osd/osdcomm.h
+++ b/src/osd/osdcomm.h
@@ -13,11 +13,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 
-#include <array>
-#include <cstdint>
 #include <type_traits>
 
 
@@ -80,19 +79,6 @@ using s64 = std::int64_t;
 constexpr uint64_t concat_64(uint32_t hi, uint32_t lo) { return (uint64_t(hi) << 32) | uint32_t(lo); }
 constexpr uint32_t extract_64hi(uint64_t val) { return uint32_t(val >> 32); }
 constexpr uint32_t extract_64lo(uint64_t val) { return uint32_t(val); }
-
-// Highly useful template for compile-time knowledge of an array size
-template <typename T, size_t N> constexpr size_t ARRAY_LENGTH(T (&)[N]) { return N;}
-template <typename T, size_t N> constexpr size_t ARRAY_LENGTH(std::array<T, N> const &) { return N; }
-
-// For declaring an array of the same dimensions as another array (including multi-dimensional arrays)
-template <typename T, typename U> struct equivalent_array_or_type { typedef T type; };
-template <typename T, typename U, std::size_t N> struct equivalent_array_or_type<T, U[N]> { typedef typename equivalent_array_or_type<T, U>::type type[N]; };
-template <typename T, typename U> using equivalent_array_or_type_t = typename equivalent_array_or_type<T, U>::type;
-template <typename T, typename U> struct equivalent_array { };
-template <typename T, typename U, std::size_t N> struct equivalent_array<T, U[N]> { typedef equivalent_array_or_type_t<T, U> type[N]; };
-template <typename T, typename U> using equivalent_array_t = typename equivalent_array<T, U>::type;
-#define EQUIVALENT_ARRAY(a, T) equivalent_array_t<T, std::remove_reference_t<decltype(a)> >
 
 // Macros for normalizing data into big or little endian formats
 constexpr uint16_t swapendian_int16(uint16_t val) { return (val << 8) | (val >> 8); }

--- a/src/osd/windows/winmain.cpp
+++ b/src/osd/windows/winmain.cpp
@@ -97,7 +97,7 @@ public:
 		char buffer[2048];
 		if (channel == OSD_OUTPUT_CHANNEL_ERROR)
 		{
-			vsnprintf(buffer, ARRAY_LENGTH(buffer), msg, args);
+			vsnprintf(buffer, std::size(buffer), msg, args);
 
 			std::wstring wcbuffer(osd::text::to_wstring(buffer));
 			std::wstring wcappname(osd::text::to_wstring(emulator_info::get_appname()));
@@ -107,7 +107,7 @@ public:
 		}
 		else if (channel == OSD_OUTPUT_CHANNEL_VERBOSE)
 		{
-			vsnprintf(buffer, ARRAY_LENGTH(buffer), msg, args);
+			vsnprintf(buffer, std::size(buffer), msg, args);
 			std::wstring wcbuffer = osd::text::to_wstring(buffer);
 			OutputDebugString(wcbuffer.c_str());
 
@@ -421,7 +421,7 @@ void MameMainApp::Run()
 	GetModuleFileNameA(nullptr, exe_path, MAX_PATH);
 	char* args[3] = { exe_path, (char*)"-verbose", (char*)"-mouse" };
 
-	DWORD result = emulator_info::start_frontend(*m_options.get(), *m_osd.get(), ARRAY_LENGTH(args), args);
+	DWORD result = emulator_info::start_frontend(*m_options.get(), *m_osd.get(), std::size(args), args);
 	osd_output::pop(&winerror);
 }
 

--- a/src/osd/windows/winutf8.cpp
+++ b/src/osd/windows/winutf8.cpp
@@ -108,7 +108,7 @@ std::string win_get_window_text_utf8(HWND window)
 	{
 		TCHAR t_buffer[256];
 		auto title = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->Title;
-		wcsncpy(t_buffer, title->Data(), ARRAY_LENGTH(t_buffer));
+		wcsncpy(t_buffer, title->Data(), std::size(t_buffer));
 		return osd::text::from_tstring(t_buffer);
 	}
 #endif

--- a/src/tools/chdman.cpp
+++ b/src/tools/chdman.cpp
@@ -504,8 +504,8 @@ public:
 				uint32_t samples = (uint64_t(m_info.rate) * uint64_t(effframe + 1) * uint64_t(1000000) + m_info.fps_times_1million - 1) / uint64_t(m_info.fps_times_1million) - first_sample;
 
 				// loop over channels and read the samples
-				int channels = unsigned((std::min<std::size_t>)(m_info.channels, ARRAY_LENGTH(m_audio)));
-				EQUIVALENT_ARRAY(m_audio, int16_t *) samplesptr;
+				int channels = unsigned((std::min<std::size_t>)(m_info.channels, std::size(m_audio)));
+				int16_t *samplesptr[std::size(m_audio)];
 				for (int chnum = 0; chnum < channels; chnum++)
 				{
 					// read the sound samples
@@ -886,7 +886,7 @@ static int print_help(const std::string &argv0, const command_description &desc,
 	// print usage for this command
 	printf("Usage:\n");
 	printf("   %s %s [options], where valid options are:\n", argv0.c_str(), desc.name);
-	for (int valid = 0; valid < ARRAY_LENGTH(desc.valid_options); valid++)
+	for (int valid = 0; valid < std::size(desc.valid_options); valid++)
 	{
 		// determine whether we are required
 		const char *option = desc.valid_options[valid];
@@ -1527,8 +1527,8 @@ static void do_info(parameters_map &params)
 						codec = CHD_CODEC_MINI + 1 + comptype;
 						break;
 					}
-			if (codec > ARRAY_LENGTH(compression_types))
-				codec = ARRAY_LENGTH(compression_types) - 1;
+			if (codec >= std::size(compression_types))
+				codec = std::size(compression_types) - 1;
 
 			// count stats
 			compression_types[codec]++;
@@ -1538,7 +1538,7 @@ static void do_info(parameters_map &params)
 		printf("\n");
 		printf("     Hunks  Percent  Name\n");
 		printf("----------  -------  ------------------------------------\n");
-		for (int comptype = 0; comptype < ARRAY_LENGTH(compression_types); comptype++)
+		for (int comptype = 0; comptype < std::size(compression_types); comptype++)
 			if (compression_types[comptype] != 0)
 			{
 				// determine the name
@@ -1847,7 +1847,7 @@ static void do_create_hd(parameters_map &params)
 	{
 		uint32_t id = parse_number(template_str->second->c_str());
 
-		if (id >= ARRAY_LENGTH(s_hd_templates))
+		if (id >= std::size(s_hd_templates))
 			report_error(1, "Template '%d' is invalid\n", id);
 
 		cylinders = s_hd_templates[id].cylinders;
@@ -2668,7 +2668,7 @@ static void do_extract_ld(parameters_map &params)
 		avconfig.video = &avvideo;
 		avconfig.maxsamples = max_samples_per_frame;
 		avconfig.actsamples = &actsamples;
-		for (int chnum = 0; chnum < ARRAY_LENGTH(audio_data); chnum++)
+		for (int chnum = 0; chnum < std::size(audio_data); chnum++)
 		{
 			audio_data[chnum].resize(std::max(1U,max_samples_per_frame));
 			avconfig.audio[chnum] = &audio_data[chnum][0];
@@ -2928,7 +2928,7 @@ static void do_list_templates(parameters_map &params)
 	printf("ID  Manufacturer  Model           Cylinders  Heads  Sectors  Sector Size  Total Size\n");
 	printf("------------------------------------------------------------------------------------\n");
 
-	for (int id = 0; id < ARRAY_LENGTH(s_hd_templates); id++)
+	for (int id = 0; id < std::size(s_hd_templates); id++)
 	{
 		printf("%2d  %-13s %-15s %9d  %5d  %7d  %11d  %7d MB\n",
 			id,
@@ -2990,7 +2990,7 @@ int CLIB_DECL main(int argc, char *argv[])
 
 				// iterate over valid options
 				int valid;
-				for (valid = 0; valid < ARRAY_LENGTH(desc.valid_options); valid++)
+				for (valid = 0; valid < std::size(desc.valid_options); valid++)
 				{
 					// reduce to the option name
 					const char *validname = desc.valid_options[valid];
@@ -3001,10 +3001,10 @@ int CLIB_DECL main(int argc, char *argv[])
 
 					// find the matching option description
 					int optnum;
-					for (optnum = 0; optnum < ARRAY_LENGTH(s_options); optnum++)
+					for (optnum = 0; optnum < std::size(s_options); optnum++)
 						if (strcmp(s_options[optnum].name, validname) == 0)
 							break;
-					assert(optnum != ARRAY_LENGTH(s_options));
+					assert(optnum != std::size(s_options));
 
 					// do we match?
 					const option_description &odesc = s_options[optnum];
@@ -3028,12 +3028,12 @@ int CLIB_DECL main(int argc, char *argv[])
 				}
 
 				// if not valid, error
-				if (valid == ARRAY_LENGTH(desc.valid_options))
+				if (valid == std::size(desc.valid_options))
 					return print_help(args[0], desc, "Option not valid for this command");
 			}
 
 			// make sure we got all our required parameters
-			for (int valid = 0; valid < ARRAY_LENGTH(desc.valid_options); valid++)
+			for (int valid = 0; valid < std::size(desc.valid_options); valid++)
 			{
 				const char *validname = desc.valid_options[valid];
 				if (validname == nullptr)

--- a/src/tools/floptool.cpp
+++ b/src/tools/floptool.cpp
@@ -131,7 +131,7 @@ void CLIB_DECL ATTR_PRINTF(1,2) logerror(const char *format, ...)
 	va_end(arg);
 }
 
-enum { FORMAT_COUNT = ARRAY_LENGTH(floppy_formats) };
+static constexpr size_t FORMAT_COUNT = std::size(floppy_formats);
 
 static floppy_image_format_t *formats[FORMAT_COUNT];
 static std::vector<uint32_t> variants;

--- a/src/tools/imgtool/filtbas.cpp
+++ b/src/tools/imgtool/filtbas.cpp
@@ -207,7 +207,7 @@ static imgtoolerr_t basic_writefile(const basictokens *tokens,
 			if ((c == '\r') || (c == '\n'))
 				break;
 
-			if (pos <= ARRAY_LENGTH(buf) - 1)
+			if (pos <= std::size(buf) - 1)
 			{
 				buf[pos++] = c;
 			}
@@ -2943,8 +2943,8 @@ static const char *const basic_100[] = /* "BASIC 10.0" - supported by c65 & clon
 
 static const basictoken_tableent cocobas_tokenents[] =
 {
-	{ 0x00, 0x80,   cocobas_statements, ARRAY_LENGTH(cocobas_statements) },
-	{ 0xff, 0x80,   cocobas_functions,  ARRAY_LENGTH(cocobas_functions) }
+	{ 0x00, 0x80,   cocobas_statements, std::size(cocobas_statements) },
+	{ 0xff, 0x80,   cocobas_functions,  std::size(cocobas_functions) }
 };
 
 static const basictokens cocobas_tokens =
@@ -2955,7 +2955,7 @@ static const basictokens cocobas_tokens =
 	{0xFF, 0x00, 0x00},
 	true,
 	cocobas_tokenents,
-	ARRAY_LENGTH(cocobas_tokenents)
+	std::size(cocobas_tokenents)
 };
 
 static imgtoolerr_t cocobas_readfile(imgtool::partition &partition, const char *filename,
@@ -2989,8 +2989,8 @@ void filter_cocobas_getinfo(uint32_t state, union filterinfo *info)
 
 static const basictoken_tableent dragonbas_tokenents[] =
 {
-	{ 0x00, 0x80,   dragonbas_statements,   ARRAY_LENGTH(dragonbas_statements) },
-	{ 0xff, 0x80,   dragonbas_functions,    ARRAY_LENGTH(dragonbas_functions) }
+	{ 0x00, 0x80,   dragonbas_statements,   std::size(dragonbas_statements) },
+	{ 0xff, 0x80,   dragonbas_functions,    std::size(dragonbas_functions) }
 };
 
 static const basictokens dragonbas_tokens =
@@ -3001,7 +3001,7 @@ static const basictokens dragonbas_tokens =
 	{0x55, 0x01, 0x24, 0x01, 0x00, 0x2A, 0x8B, 0x8D, 0xAA},
 	true,
 	dragonbas_tokenents,
-	ARRAY_LENGTH(dragonbas_tokenents)
+	std::size(dragonbas_tokenents)
 };
 
 static imgtoolerr_t dragonbas_readfile(imgtool::partition &partition, const char *filename,
@@ -3035,7 +3035,7 @@ void filter_dragonbas_getinfo(uint32_t state, union filterinfo *info)
 
 static const basictoken_tableent vzbas_tokenents[] =
 {
-	{ 0x00, 0x80,   vzbas,  ARRAY_LENGTH(vzbas) }
+	{ 0x00, 0x80,   vzbas,  std::size(vzbas) }
 };
 
 
@@ -3048,7 +3048,7 @@ static const basictokens vzbas_tokens =
 	{0x00},
 	false,
 	vzbas_tokenents,
-	ARRAY_LENGTH(vzbas_tokenents)
+	std::size(vzbas_tokenents)
 };
 
 static imgtoolerr_t vzbas_readfile(imgtool::partition &partition, const char *filename,
@@ -3082,8 +3082,8 @@ void filter_vzbas_getinfo(uint32_t state, union filterinfo *info)
 
 static const basictoken_tableent bml3bas_tokenents[] =
 {
-	{ 0x00, 0x80,   bml3bas_statements, ARRAY_LENGTH(bml3bas_statements) },
-	{ 0xff, 0x80,   bml3bas_functions,  ARRAY_LENGTH(bml3bas_functions) }
+	{ 0x00, 0x80,   bml3bas_statements, std::size(bml3bas_statements) },
+	{ 0xff, 0x80,   bml3bas_functions,  std::size(bml3bas_functions) }
 };
 
 static const basictokens bml3bas_tokens =
@@ -3094,7 +3094,7 @@ static const basictokens bml3bas_tokens =
 	{0xFF, 0x00, 0x00},
 	true,
 	bml3bas_tokenents,
-	ARRAY_LENGTH(bml3bas_tokenents)
+	std::size(bml3bas_tokenents)
 };
 
 static imgtoolerr_t bml3bas_readfile(imgtool::partition &partition, const char *filename,

--- a/src/tools/imgtool/imgterrs.cpp
+++ b/src/tools/imgtool/imgterrs.cpp
@@ -10,7 +10,7 @@
 
 #include "imgtool.h"
 #include "imgterrs.h"
-#include "osdcomm.h"
+#include <iterator>
 
 static const char *const msgs[] =
 {
@@ -50,6 +50,6 @@ const char *imgtool_error(imgtoolerr_t err)
 {
 	err = (imgtoolerr_t)(ERRORCODE(err) - 1);
 	assert(err >= 0);
-	assert(err < ARRAY_LENGTH(msgs));
+	assert(err < std::size(msgs));
 	return msgs[err];
 }

--- a/src/tools/imgtool/imgtool.cpp
+++ b/src/tools/imgtool/imgtool.cpp
@@ -937,7 +937,7 @@ char *imgtool_temp_str(void)
 {
 	static int index;
 	static char temp_string_pool[32][256];
-	return temp_string_pool[index++ % ARRAY_LENGTH(temp_string_pool)];
+	return temp_string_pool[index++ % std::size(temp_string_pool)];
 }
 
 
@@ -1603,7 +1603,7 @@ imgtoolerr_t imgtool::partition::get_chain_string(const char *path, char *buffer
 	chain[0].block = ~0;
 	last_block = chain[0].block;
 
-	err = get_chain(path, chain, ARRAY_LENGTH(chain));
+	err = get_chain(path, chain, std::size(chain));
 	if (err)
 		return err;
 
@@ -2362,7 +2362,7 @@ imgtoolerr_t imgtool::directory::get_next(imgtool_dirent &ent)
 		{
 			return imgtoolerr_t(IMGTOOLERR_BADFILENAME);
 		}
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", new_fname.c_str());
+		snprintf(ent.filename, std::size(ent.filename), "%s", new_fname.c_str());
 	}
 
 	// don't trust the module!

--- a/src/tools/imgtool/main.cpp
+++ b/src/tools/imgtool/main.cpp
@@ -97,7 +97,7 @@ static int parse_options(int argc, char *argv[], int minunnamed, int maxunnamed,
 				if (*fork)
 					goto optionalreadyspecified;
 
-				snprintf(buf, ARRAY_LENGTH(buf), "%s", value);
+				snprintf(buf, std::size(buf), "%s", value);
 				*fork = buf;
 			}
 			else
@@ -564,7 +564,7 @@ static int cmd_identify(const struct command *c, int argc, char *argv[])
 	imgtoolerr_t err;
 	int i;
 
-	err = imgtool::image::identify_file(argv[0], modules, ARRAY_LENGTH(modules));
+	err = imgtool::image::identify_file(argv[0], modules, std::size(modules));
 	if (err)
 	{
 		reporterror(err, c, nullptr, argv[0], nullptr, nullptr, nullptr);
@@ -895,7 +895,7 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 	{
 		/* figure out what command they are running, and run it */
-		for (i = 0; i < ARRAY_LENGTH(cmds); i++)
+		for (i = 0; i < std::size(cmds); i++)
 		{
 			c = &cmds[i];
 			if (!core_stricmp(c->name, argv[1]))
@@ -934,7 +934,7 @@ int main(int argc, char *argv[])
 
 	// Usage
 	util::stream_format(std::wcerr, L"imgtool - Generic image manipulation tool for use with MAME\n\n");
-	for (i = 0; i < ARRAY_LENGTH(cmds); i++)
+	for (i = 0; i < std::size(cmds); i++)
 	{
 		writeusage(std::wcerr, (i == 0), &cmds[i], argv);
 	}

--- a/src/tools/imgtool/modules.cpp
+++ b/src/tools/imgtool/modules.cpp
@@ -29,8 +29,6 @@ static void (*const modules[])(const imgtool_class *imgclass, uint32_t state, un
 /* step 3: declare imgtool_create_canonical_library() */
 imgtoolerr_t imgtool_create_canonical_library(bool omit_untested, std::unique_ptr<imgtool::library> &library)
 {
-	size_t i;
-
 	/* list of modules that we drop */
 	static const char *const irrelevant_modules[] =
 	{
@@ -42,14 +40,12 @@ imgtoolerr_t imgtool_create_canonical_library(bool omit_untested, std::unique_pt
 		return IMGTOOLERR_OUTOFMEMORY;
 
 	// create all modules
-	for (i = 0; i < ARRAY_LENGTH(modules); i++)
-		library->add(modules[i]);
+	for (auto &module : modules)
+		library->add(module);
 
 	// remove irrelevant modules
-	for (i = 0; i < ARRAY_LENGTH(irrelevant_modules); i++)
-	{
-		library->unlink(irrelevant_modules[i]);
-	}
+	for (auto &module : irrelevant_modules)
+		library->unlink(module);
 
 	// if we are omitting untested, go through and block out the functionality in question
 	if (omit_untested)

--- a/src/tools/imgtool/modules/bml3.cpp
+++ b/src/tools/imgtool/modules/bml3.cpp
@@ -604,8 +604,8 @@ eof:
 
 		get_dirent_fname(fname, &rsent);
 
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fname);
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
+		snprintf(ent.filename, std::size(ent.filename), "%s", fname);
+		snprintf(ent.attr, std::size(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
 	}
 	return IMGTOOLERR_SUCCESS;
 }

--- a/src/tools/imgtool/modules/concept.cpp
+++ b/src/tools/imgtool/modules/concept.cpp
@@ -357,8 +357,8 @@ static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgt
 		int len = iter->image->dev_dir.file_dir[iter->index].filename[0];
 		const char *type;
 
-		if (len > ARRAY_LENGTH(ent.filename))
-			len = ARRAY_LENGTH(ent.filename);
+		if (len > std::size(ent.filename))
+			len = std::size(ent.filename);
 		memcpy(ent.filename, iter->image->dev_dir.file_dir[iter->index].filename + 1, len);
 		ent.filename[len] = 0;
 
@@ -382,7 +382,7 @@ static imgtoolerr_t concept_image_nextenum(imgtool::directory &enumeration, imgt
 			type = "???";
 			break;
 		}
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%s", type);
+		snprintf(ent.attr, std::size(ent.attr), "%s", type);
 
 		/* len in physrecs */
 		ent.filesize = get_UINT16xE(iter->image->dev_dir.vol_hdr.disk_flipped, iter->image->dev_dir.file_dir[iter->index].next_block)

--- a/src/tools/imgtool/modules/dgndos.cpp
+++ b/src/tools/imgtool/modules/dgndos.cpp
@@ -539,8 +539,8 @@ static imgtoolerr_t dgndos_diskimage_nextenum(imgtool::directory &enumeration, i
 		err = dgndos_count_dirents(entire_track20, dgnent, &dir_ent_count);
 		if (err) return err;
 
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fname.c_str());
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%c (%03d)",
+		snprintf(ent.filename, std::size(ent.filename), "%s", fname.c_str());
+		snprintf(ent.attr, std::size(ent.attr), "%c (%03d)",
 			(char) (dgnent.flag_byte & DGNDOS_PROTECT_BIT ? 'P' : '.'),
 			dir_ent_count);
 	}

--- a/src/tools/imgtool/modules/fat.cpp
+++ b/src/tools/imgtool/modules/fat.cpp
@@ -1326,11 +1326,11 @@ static imgtoolerr_t fat_read_dirent(imgtool::partition &partition, fat_file *fil
 				lfn_checksum = entry[13];
 			}
 			lfn_lastentry = entry[0] & 0x3F;
-			prepend_lfn_bytes(lfn_buf, ARRAY_LENGTH(lfn_buf),
+			prepend_lfn_bytes(lfn_buf, std::size(lfn_buf),
 				&lfn_len, entry, 28, 2);
-			prepend_lfn_bytes(lfn_buf, ARRAY_LENGTH(lfn_buf),
+			prepend_lfn_bytes(lfn_buf, std::size(lfn_buf),
 				&lfn_len, entry, 14, 6);
-			prepend_lfn_bytes(lfn_buf, ARRAY_LENGTH(lfn_buf),
+			prepend_lfn_bytes(lfn_buf, std::size(lfn_buf),
 				&lfn_len, entry,  1, 5);
 		}
 		else if (freeent && (freeent->position == ~0))
@@ -1372,8 +1372,8 @@ static imgtoolerr_t fat_read_dirent(imgtool::partition &partition, fat_file *fil
 			j = 0;
 			do
 			{
-				i += uchar_from_utf16(&ch, &lfn_buf[i], ARRAY_LENGTH(lfn_buf) - i);
-				j += utf8_from_uchar(&ent.long_filename[j], ARRAY_LENGTH(ent.long_filename) - j, ch);
+				i += uchar_from_utf16(&ch, &lfn_buf[i], std::size(lfn_buf) - i);
+				j += utf8_from_uchar(&ent.long_filename[j], std::size(ent.long_filename) - j, ch);
 			}
 			while(ch != 0);
 		}
@@ -1834,7 +1834,7 @@ static imgtoolerr_t fat_partition_nextenum(imgtool::directory &enumeration, imgt
 		return err;
 
 	/* copy stuff from the FAT dirent to the Imgtool dirent */
-	snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fatent.long_filename[0]
+	snprintf(ent.filename, std::size(ent.filename), "%s", fatent.long_filename[0]
 		? fatent.long_filename : fatent.short_filename);
 	ent.filesize = fatent.filesize;
 	ent.directory = fatent.directory;

--- a/src/tools/imgtool/modules/mac.cpp
+++ b/src/tools/imgtool/modules/mac.cpp
@@ -5308,11 +5308,11 @@ static void mac_image_info(imgtool::image &img, std::ostream &stream)
 	switch (image->format)
 	{
 	case L2I_MFS:
-		mac_to_c_strncpy(buffer, ARRAY_LENGTH(buffer), image->u.mfs.volname);
+		mac_to_c_strncpy(buffer, std::size(buffer), image->u.mfs.volname);
 		break;
 
 	case L2I_HFS:
-		mac_to_c_strncpy(buffer, ARRAY_LENGTH(buffer), image->u.hfs.volname);
+		mac_to_c_strncpy(buffer, std::size(buffer), image->u.hfs.volname);
 		break;
 	}
 
@@ -5397,7 +5397,7 @@ static imgtoolerr_t mfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 	}
 
 	/* copy info */
-	mac_to_c_strncpy(ent.filename, ARRAY_LENGTH(ent.filename), cur_dir_entry->name);
+	mac_to_c_strncpy(ent.filename, std::size(ent.filename), cur_dir_entry->name);
 	ent.filesize = get_UINT32BE(cur_dir_entry->dataPhysicalSize)
 						+ get_UINT32BE(cur_dir_entry->rsrcPhysicalSize);
 
@@ -5489,7 +5489,7 @@ static imgtoolerr_t hfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 	}
 
 	/* initialize file path buffer */
-	cur_name_head = ARRAY_LENGTH(ent.filename);
+	cur_name_head = std::size(ent.filename);
 	if (cur_name_head > 0)
 	{
 		cur_name_head--;
@@ -5497,8 +5497,8 @@ static imgtoolerr_t hfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 	}
 
 	/* insert folder/file name in buffer */
-	mac_to_c_strncpy(ent.filename, ARRAY_LENGTH(ent.filename), catrec_key->cName);
-//  concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename) - 1, buf);
+	mac_to_c_strncpy(ent.filename, std::size(ent.filename), catrec_key->cName);
+//  concat_fname(ent.filename, &cur_name_head, std::size(ent.filename) - 1, buf);
 
 #if 0
 	/* extract parent directory ID */
@@ -5513,10 +5513,10 @@ static imgtoolerr_t hfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 		if (err)
 		{
 			/* error */
-			concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename) - 1, ":");
-			concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename) - 1, "???");
+			concat_fname(ent.filename, &cur_name_head, std::size(ent.filename) - 1, ":");
+			concat_fname(ent.filename, &cur_name_head, std::size(ent.filename) - 1, "???");
 
-			memmove(ent.filename, ent.filename+cur_name_head, ARRAY_LENGTH(ent.filename) - cur_name_head);
+			memmove(ent.filename, ent.filename+cur_name_head, std::size(ent.filename) - cur_name_head);
 			ent.corrupt = 1;
 			return err;
 		}
@@ -5526,10 +5526,10 @@ static imgtoolerr_t hfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 		if (dataRecType != hcrt_FolderThread)
 		{
 			/* error */
-			concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename)-1, ":");
-			concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename)-1, "???");
+			concat_fname(ent.filename, &cur_name_head, std::size(ent.filename)-1, ":");
+			concat_fname(ent.filename, &cur_name_head, std::size(ent.filename)-1, "???");
 
-			memmove(ent.filename, ent.filename+cur_name_head, ARRAY_LENGTH(ent.filename)-cur_name_head);
+			memmove(ent.filename, ent.filename+cur_name_head, std::size(ent.filename)-cur_name_head);
 			ent.corrupt = 1;
 			return IMGTOOLERR_CORRUPTIMAGE;
 		}
@@ -5537,13 +5537,13 @@ static imgtoolerr_t hfs_image_nextenum(mac_iterator *iter, imgtool_dirent &ent)
 		/* got folder thread record: insert the folder name at the start of
 		file path, then iterate */
 		mac_to_c_strncpy(buf, sizeof(buf), catrec_data->thread.nodeName);
-		concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename) - 1, ":");
-		concat_fname(ent.filename, &cur_name_head, ARRAY_LENGTH(ent.filename) - 1, buf);
+		concat_fname(ent.filename, &cur_name_head, std::size(ent.filename) - 1, ":");
+		concat_fname(ent.filename, &cur_name_head, std::size(ent.filename) - 1, buf);
 
 		/* extract parent directory ID */
 		parID = get_UINT32BE(catrec_data->thread.parID);
 	}
-	memmove(ent.filename, ent.filename+cur_name_head, ARRAY_LENGTH(ent.filename) -cur_name_head);
+	memmove(ent.filename, ent.filename+cur_name_head, std::size(ent.filename) -cur_name_head);
 #endif
 	return IMGTOOLERR_SUCCESS;
 }
@@ -6185,8 +6185,8 @@ static imgtoolerr_t mac_image_geticoninfo(imgtool::partition &partition, const c
 	const void *fref;
 	uint32_t resource_length;
 
-	assert((ARRAY_LENGTH(attrs) - 1)
-		== ARRAY_LENGTH(attr_values));
+	assert((std::size(attrs) - 1)
+		== std::size(attr_values));
 
 	/* first retrieve type and creator code */
 	err = mac_image_getattrs(partition, path, attrs, attr_values);

--- a/src/tools/imgtool/modules/os9.cpp
+++ b/src/tools/imgtool/modules/os9.cpp
@@ -275,7 +275,7 @@ static imgtoolerr_t os9_decode_file_header(imgtool::image &image,
 
 	/* read all sector map entries */
 	max_entries = (disk_info->sector_size - 16) / 5;
-	max_entries = (std::min<std::size_t>)(max_entries, ARRAY_LENGTH(info->sector_map) - 1);
+	max_entries = (std::min<std::size_t>)(max_entries, std::size(info->sector_map) - 1);
 	for (i = 0; i < max_entries; i++)
 	{
 		lsn = pick_integer_be(header, 16 + (i * 5) + 0, 3);
@@ -393,7 +393,7 @@ static imgtoolerr_t os9_set_file_size(imgtool::image &image,
 		/* first find out the size of our sector map */
 		sector_map_length = 0;
 		lsn = 0;
-		while((lsn < current_lsn_count) && (sector_map_length < ARRAY_LENGTH(file_info->sector_map)))
+		while((lsn < current_lsn_count) && (sector_map_length < std::size(file_info->sector_map)))
 		{
 			if (file_info->sector_map[sector_map_length].count == 0)
 				return os9_corrupt_file_error(file_info);
@@ -434,7 +434,7 @@ static imgtoolerr_t os9_set_file_size(imgtool::image &image,
 			{
 				file_info->sector_map[sector_map_length - 1].count++;
 			}
-			else if (sector_map_length >= ARRAY_LENGTH(file_info->sector_map))
+			else if (sector_map_length >= std::size(file_info->sector_map))
 			{
 				return IMGTOOLERR_NOSPACE;
 			}
@@ -461,7 +461,7 @@ static imgtoolerr_t os9_set_file_size(imgtool::image &image,
 	/* do we have to write the sector map? */
 	if (sector_map_length >= 0)
 	{
-		for (i = 0; i < (std::min<std::size_t>)(sector_map_length + 1, ARRAY_LENGTH(file_info->sector_map)); i++)
+		for (i = 0; i < (std::min<std::size_t>)(sector_map_length + 1, std::size(file_info->sector_map)); i++)
 		{
 			place_integer_be(header, 16 + (i * 5) + 0, 3, file_info->sector_map[i].lsn);
 			place_integer_be(header, 16 + (i * 5) + 3, 2, file_info->sector_map[i].count);
@@ -952,8 +952,8 @@ static imgtoolerr_t os9_diskimage_nextenum(imgtool::directory &enumeration, imgt
 		return err;
 
 	/* fill out imgtool_dirent structure */
-	snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", filename);
-	snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%c%c%c%c%c%c%c%c",
+	snprintf(ent.filename, std::size(ent.filename), "%s", filename);
+	snprintf(ent.attr, std::size(ent.attr), "%c%c%c%c%c%c%c%c",
 		file_info.directory      ? 'd' : '-',
 		file_info.non_sharable   ? 's' : '-',
 		file_info.public_execute ? 'x' : '-',
@@ -1143,7 +1143,7 @@ static imgtoolerr_t os9_diskimage_delete(imgtool::partition &partition, const ch
 		if (err)
 			return err;
 
-		for (i = 0; (i < ARRAY_LENGTH(file_info.sector_map)) && file_info.sector_map[i].count; i++)
+		for (i = 0; (i < std::size(file_info.sector_map)) && file_info.sector_map[i].count; i++)
 		{
 			lsn = file_info.sector_map[i].lsn;
 			for (j = 0;  j < file_info.sector_map[i].count; j++)

--- a/src/tools/imgtool/modules/pc_hard.cpp
+++ b/src/tools/imgtool/modules/pc_hard.cpp
@@ -193,7 +193,6 @@ done:
 static imgtoolerr_t pc_chd_read_partition_header(imgtool::image &image)
 {
 	imgtoolerr_t err;
-	int i;
 	const uint8_t *partition_info;
 	pc_chd_image_info *info;
 	uint8_t buffer[FAT_SECLEN];
@@ -209,7 +208,7 @@ static imgtoolerr_t pc_chd_read_partition_header(imgtool::image &image)
 	if ((buffer[510] != 0x55) || (buffer[511] != 0xAA))
 		return IMGTOOLERR_CORRUPTIMAGE;
 
-	for (i = 0; i < ARRAY_LENGTH(info->partitions); i++)
+	for (int i = 0; i < std::size(info->partitions); i++)
 	{
 		partition_info = &buffer[446 + i * 16];
 

--- a/src/tools/imgtool/modules/prodos.cpp
+++ b/src/tools/imgtool/modules/prodos.cpp
@@ -1183,7 +1183,7 @@ static imgtoolerr_t prodos_lookup_path(imgtool::image &image, const char *path,
 			ent->key_pointer[0] = new_file_block;
 			ent->file_type = 0x3F3F3F3F;
 			ent->file_creator = 0x3F3F3F3F;
-			strncpy(ent->filename, old_path, ARRAY_LENGTH(ent->filename));
+			strncpy(ent->filename, old_path, std::size(ent->filename));
 
 			/* and place it */
 			err = prodos_put_dirent(image, direnum, ent);

--- a/src/tools/imgtool/modules/rsdos.cpp
+++ b/src/tools/imgtool/modules/rsdos.cpp
@@ -340,8 +340,8 @@ eof:
 
 		std::string fname = get_dirent_fname(rsent);
 
-		snprintf(ent.filename, ARRAY_LENGTH(ent.filename), "%s", fname.c_str());
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
+		snprintf(ent.filename, std::size(ent.filename), "%s", fname.c_str());
+		snprintf(ent.attr, std::size(ent.attr), "%d %c", (int) rsent.ftype, (char) (rsent.asciiflag + 'B'));
 	}
 	return IMGTOOLERR_SUCCESS;
 }

--- a/src/tools/imgtool/modules/thomson.cpp
+++ b/src/tools/imgtool/modules/thomson.cpp
@@ -1740,7 +1740,7 @@ static imgtoolerr_t thom_basic_write_file(imgtool::partition &partition,
 			if ((c == '\r') || (c == '\n'))
 				break;
 
-			if (pos <= ARRAY_LENGTH(buf) - 1)
+			if (pos <= std::size(buf) - 1)
 			{
 				buf[pos++] = c;
 			}

--- a/src/tools/imgtool/modules/ti99.cpp
+++ b/src/tools/imgtool/modules/ti99.cpp
@@ -1837,7 +1837,7 @@ static int dsk_read_catalog(struct ti99_lvl2_imgref *l2_img, int aphysrec, ti99_
 			|| ((dest->files[i].fdr_ptr && dest->files[i+1].fdr_ptr) && (memcmp(dest->files[i].name, dest->files[i+1].name, 10) >= 0)))
 		{
 			/* if the catalog is not sorted, we repair it */
-			qsort(dest->files, ARRAY_LENGTH(dest->files), sizeof(dest->files[0]),
+			qsort(dest->files, std::size(dest->files), sizeof(dest->files[0]),
 					cat_file_compare_qsort);
 			break;
 		}
@@ -4275,10 +4275,10 @@ static imgtoolerr_t dsk_image_nextenum(imgtool::directory &enumeration, imgtool_
 	{
 		if (iter->listing_subdirs)
 		{
-			fname_to_str(ent.filename, iter->image->dsk.catalogs[0].subdirs[iter->index[iter->level]].name, ARRAY_LENGTH(ent.filename));
+			fname_to_str(ent.filename, iter->image->dsk.catalogs[0].subdirs[iter->index[iter->level]].name, std::size(ent.filename));
 
 			/* set type of DIR */
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "DIR");
+			snprintf(ent.attr, std::size(ent.attr), "DIR");
 
 			/* len in physrecs */
 			/* @BN@ return length in bytes */
@@ -4299,7 +4299,7 @@ static imgtoolerr_t dsk_image_nextenum(imgtool::directory &enumeration, imgtool_
 			if (reply)
 				return IMGTOOLERR_READERROR;
 #if 0
-			fname_to_str(ent.filename, fdr.name, ARRAY_LENGTH(ent.filename));
+			fname_to_str(ent.filename, fdr.name, std::size(ent.filename));
 #else
 			{
 				char buf[11];
@@ -4307,19 +4307,19 @@ static imgtoolerr_t dsk_image_nextenum(imgtool::directory &enumeration, imgtool_
 				ent.filename[0] = '\0';
 				if (iter->level)
 				{
-					fname_to_str(ent.filename, iter->image->dsk.catalogs[0].subdirs[iter->index[0]].name, ARRAY_LENGTH(ent.filename));
-					strncat(ent.filename, ".", ARRAY_LENGTH(ent.filename) - 1);
+					fname_to_str(ent.filename, iter->image->dsk.catalogs[0].subdirs[iter->index[0]].name, std::size(ent.filename));
+					strncat(ent.filename, ".", std::size(ent.filename) - 1);
 				}
 				fname_to_str(buf, fdr.name, 11);
-				strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
+				strncat(ent.filename, buf, std::size(ent.filename) - 1);
 			}
 #endif
 			/* parse flags */
 			if (fdr.flags & fdr99_f_program)
-				snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "PGM%s",
+				snprintf(ent.attr, std::size(ent.attr), "PGM%s",
 							(fdr.flags & fdr99_f_wp) ? " R/O" : "");
 			else
-				snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%c/%c %d%s",
+				snprintf(ent.attr, std::size(ent.attr), "%c/%c %d%s",
 							(fdr.flags & fdr99_f_int) ? 'I' : 'D',
 							(fdr.flags & fdr99_f_var) ? 'V' : 'F',
 							fdr.reclen,
@@ -4399,7 +4399,7 @@ static imgtoolerr_t win_image_nextenum(imgtool::directory &enumeration, imgtool_
 		if (iter->listing_subdirs)
 		{
 #if 0
-			fname_to_str(ent.filename, iter->catalog[iter->level].subdirs[iter->index[iter->level]].name, ARRAY_LENGTH(ent.filename));
+			fname_to_str(ent.filename, iter->catalog[iter->level].subdirs[iter->index[iter->level]].name, std::size(ent.filename));
 #else
 			{
 				char buf[11];
@@ -4408,16 +4408,16 @@ static imgtoolerr_t win_image_nextenum(imgtool::directory &enumeration, imgtool_
 				for (i=0; i<iter->level; i++)
 				{
 					fname_to_str(buf, iter->catalog[i].subdirs[iter->index[i]].name, 11);
-					strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
-					strncat(ent.filename, ".", ARRAY_LENGTH(ent.filename) - 1);
+					strncat(ent.filename, buf, std::size(ent.filename) - 1);
+					strncat(ent.filename, ".", std::size(ent.filename) - 1);
 				}
 				fname_to_str(buf, iter->catalog[iter->level].subdirs[iter->index[iter->level]].name, 11);
-				strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
+				strncat(ent.filename, buf, std::size(ent.filename) - 1);
 			}
 #endif
 
 			/* set type of DIR */
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "DIR");
+			snprintf(ent.attr, std::size(ent.attr), "DIR");
 
 			/* len in physrecs */
 			/* @BN@ return length in bytes */
@@ -4442,7 +4442,7 @@ static imgtoolerr_t win_image_nextenum(imgtool::directory &enumeration, imgtool_
 			if (reply)
 				return IMGTOOLERR_READERROR;
 #if 0
-			fname_to_str(ent.filename, iter->catalog[iter->level].files[iter->index[iter->level]].name, ARRAY_LENGTH(ent.filename));
+			fname_to_str(ent.filename, iter->catalog[iter->level].files[iter->index[iter->level]].name, std::size(ent.filename));
 #else
 			{
 				char buf[11];
@@ -4451,19 +4451,19 @@ static imgtoolerr_t win_image_nextenum(imgtool::directory &enumeration, imgtool_
 				for (i=0; i<iter->level; i++)
 				{
 					fname_to_str(buf, iter->catalog[i].subdirs[iter->index[i]].name, 11);
-					strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
-					strncat(ent.filename, ".", ARRAY_LENGTH(ent.filename) - 1);
+					strncat(ent.filename, buf, std::size(ent.filename) - 1);
+					strncat(ent.filename, ".", std::size(ent.filename) - 1);
 				}
 				fname_to_str(buf, iter->catalog[iter->level].files[iter->index[iter->level]].name, 11);
-				strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
+				strncat(ent.filename, buf, std::size(ent.filename) - 1);
 			}
 #endif
 			/* parse flags */
 			if (fdr.flags & fdr99_f_program)
-				snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "PGM%s",
+				snprintf(ent.attr, std::size(ent.attr), "PGM%s",
 							(fdr.flags & fdr99_f_wp) ? " R/O" : "");
 			else
-				snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%c/%c %d%s",
+				snprintf(ent.attr, std::size(ent.attr), "%c/%c %d%s",
 							(fdr.flags & fdr99_f_int) ? 'I' : 'D',
 							(fdr.flags & fdr99_f_var) ? 'V' : 'F',
 							fdr.reclen,

--- a/src/tools/imgtool/modules/ti990hd.cpp
+++ b/src/tools/imgtool/modules/ti990hd.cpp
@@ -1250,7 +1250,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 	else
 	{
 #if 0
-		fname_to_str(ent.filename, iter->xdr[iter->level].fdr.fnm, ARRAY_LENGTH(ent.filename));
+		fname_to_str(ent.filename, iter->xdr[iter->level].fdr.fnm, std::size(ent.filename));
 #else
 		{
 			int i;
@@ -1260,11 +1260,11 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 			for (i=0; i<iter->level; i++)
 			{
 				fname_to_str(buf, iter->xdr[i].fdr.fnm, 9);
-				strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
-				strncat(ent.filename, ".", ARRAY_LENGTH(ent.filename) - 1);
+				strncat(ent.filename, buf, std::size(ent.filename) - 1);
+				strncat(ent.filename, ".", std::size(ent.filename) - 1);
 			}
 			fname_to_str(buf, iter->xdr[iter->level].fdr.fnm, 9);
-			strncat(ent.filename, buf, ARRAY_LENGTH(ent.filename) - 1);
+			strncat(ent.filename, buf, std::size(ent.filename) - 1);
 		}
 #endif
 
@@ -1272,7 +1272,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 		flag = get_UINT16BE(iter->xdr[iter->level].fdr.flg);
 		if (flag & fdr_flg_cdr)
 		{
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "CHANNEL");
+			snprintf(ent.attr, std::size(ent.attr), "CHANNEL");
 
 			ent.filesize = 0;
 		}
@@ -1290,7 +1290,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 
 			fname_to_str(buf, target_fdr.fnm, 9);
 
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "ALIAS OF %s", buf);
+			snprintf(ent.attr, std::size(ent.attr), "ALIAS OF %s", buf);
 
 			ent.filesize = 0;
 		}
@@ -1340,7 +1340,7 @@ static imgtoolerr_t ti990_image_nextenum(imgtool::directory &enumeration, imgtoo
 				}
 				break;
 			}
-			snprintf(ent.attr, ARRAY_LENGTH(ent.attr),
+			snprintf(ent.attr, std::size(ent.attr),
 						"%s %c %s%s%s%s%s", fmt, (flag & fdr_flg_all) ? 'N' : 'C', type,
 							(flag & fdr_flg_blb) ? "" : " BLK",
 							(flag & fdr_flg_tmp) ? " TMP" : "",

--- a/src/tools/imgtool/modules/vzdos.cpp
+++ b/src/tools/imgtool/modules/vzdos.cpp
@@ -453,7 +453,7 @@ static imgtoolerr_t vzdos_diskimage_nextenum(imgtool::directory &enumeration, im
 		default:   type = "Unknown";
 		}
 
-		snprintf(ent.attr, ARRAY_LENGTH(ent.attr), "%s", type);
+		snprintf(ent.attr, std::size(ent.attr), "%s", type);
 
 		iter->index++;
 	}

--- a/src/tools/jedutil.cpp
+++ b/src/tools/jedutil.cpp
@@ -135,6 +135,7 @@
 
 ***************************************************************************/
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -145,7 +146,6 @@
 
 #include "corestr.h"
 #include "jedparse.h"
-#include "osdcomm.h"
 #include "plaparse.h"
 
 
@@ -2131,93 +2131,93 @@ static pin_fuse_columns _82s100_pls100_pinfusecolumns[] = {
 
 static pal_data paldata[] = {
 	{"PAL10L8", 320,
-		pal10l8pinfuserows, ARRAY_LENGTH(pal10l8pinfuserows),
-		pal10l8pinfusecolumns, ARRAY_LENGTH(pal10l8pinfusecolumns),
+		pal10l8pinfuserows, std::size(pal10l8pinfuserows),
+		pal10l8pinfusecolumns, std::size(pal10l8pinfusecolumns),
 		print_pal10l8_product_terms,
 		config_pal10l8_pins,
 		nullptr,
 		nullptr},
 	{"PAL10H8", 320,
-		pal10h8pinfuserows, ARRAY_LENGTH(pal10h8pinfuserows),
-		pal10h8pinfusecolumns, ARRAY_LENGTH(pal10h8pinfusecolumns),
+		pal10h8pinfuserows, std::size(pal10h8pinfuserows),
+		pal10h8pinfusecolumns, std::size(pal10h8pinfusecolumns),
 		print_pal10h8_product_terms,
 		config_pal10h8_pins,
 		nullptr,
 		nullptr},
 	{"PAL12H6", 384,
-		pal12h6pinfuserows, ARRAY_LENGTH(pal12h6pinfuserows),
-		pal12h6pinfusecolumns, ARRAY_LENGTH(pal12h6pinfusecolumns),
+		pal12h6pinfuserows, std::size(pal12h6pinfuserows),
+		pal12h6pinfusecolumns, std::size(pal12h6pinfusecolumns),
 		print_pal12h6_product_terms,
 		config_pal12h6_pins,
 		nullptr,
 		nullptr},
 	{"PAL14H4", 448,
-		pal14h4pinfuserows, ARRAY_LENGTH(pal14h4pinfuserows),
-		pal14h4pinfusecolumns, ARRAY_LENGTH(pal14h4pinfusecolumns),
+		pal14h4pinfuserows, std::size(pal14h4pinfuserows),
+		pal14h4pinfusecolumns, std::size(pal14h4pinfusecolumns),
 		print_pal14h4_product_terms,
 		config_pal14h4_pins,
 		nullptr,
 		nullptr},
 	{"PAL16H2", 512,
-		pal16h2pinfuserows, ARRAY_LENGTH(pal16h2pinfuserows),
-		pal16h2pinfusecolumns, ARRAY_LENGTH(pal16h2pinfusecolumns),
+		pal16h2pinfuserows, std::size(pal16h2pinfuserows),
+		pal16h2pinfusecolumns, std::size(pal16h2pinfusecolumns),
 		print_pal16h2_product_terms,
 		config_pal16h2_pins,
 		nullptr,
 		nullptr},
 	{"PAL16C1", 512,
-		pal16c1pinfuserows, ARRAY_LENGTH(pal16c1pinfuserows),
-		pal16c1pinfusecolumns, ARRAY_LENGTH(pal16c1pinfusecolumns),
+		pal16c1pinfuserows, std::size(pal16c1pinfuserows),
+		pal16c1pinfusecolumns, std::size(pal16c1pinfusecolumns),
 		print_pal16c1_product_terms,
 		config_pal16c1_pins,
 		nullptr,
 		nullptr},
 	{"PAL12L6", 384,
-		pal12l6pinfuserows, ARRAY_LENGTH(pal12l6pinfuserows),
-		pal12l6pinfusecolumns, ARRAY_LENGTH(pal12l6pinfusecolumns),
+		pal12l6pinfuserows, std::size(pal12l6pinfuserows),
+		pal12l6pinfusecolumns, std::size(pal12l6pinfusecolumns),
 		print_pal12l6_product_terms,
 		config_pal12l6_pins,
 		nullptr,
 		nullptr},
 	{"PAL14L4", 448,
-		pal14l4pinfuserows, ARRAY_LENGTH(pal14l4pinfuserows),
-		pal14l4pinfusecolumns, ARRAY_LENGTH(pal14l4pinfusecolumns),
+		pal14l4pinfuserows, std::size(pal14l4pinfuserows),
+		pal14l4pinfusecolumns, std::size(pal14l4pinfusecolumns),
 		print_pal14l4_product_terms,
 		config_pal14l4_pins,
 		nullptr,
 		nullptr},
 	{"PAL16L2", 512,
-		pal16l2pinfuserows, ARRAY_LENGTH(pal16l2pinfuserows),
-		pal16l2pinfusecolumns, ARRAY_LENGTH(pal16l2pinfusecolumns),
+		pal16l2pinfuserows, std::size(pal16l2pinfuserows),
+		pal16l2pinfusecolumns, std::size(pal16l2pinfusecolumns),
 		print_pal16l2_product_terms,
 		config_pal16l2_pins,
 		nullptr,
 		nullptr},
 	/*{"15S8", 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL},*/
 	{"PAL16L8", 2048,
-		pal16l8pinfuserows, ARRAY_LENGTH(pal16l8pinfuserows),
-		pal16l8pinfusecolumns, ARRAY_LENGTH(pal16l8pinfusecolumns),
+		pal16l8pinfuserows, std::size(pal16l8pinfuserows),
+		pal16l8pinfusecolumns, std::size(pal16l8pinfusecolumns),
 		print_pal16l8_product_terms,
 		config_pal16l8_pins,
 		nullptr,
 		nullptr},
 	{"PAL16R4", 2048,
-		pal16r4pinfuserows, ARRAY_LENGTH(pal16r4pinfuserows),
-		pal16r4pinfusecolumns, ARRAY_LENGTH(pal16r4pinfusecolumns),
+		pal16r4pinfuserows, std::size(pal16r4pinfuserows),
+		pal16r4pinfusecolumns, std::size(pal16r4pinfusecolumns),
 		print_pal16r4_product_terms,
 		config_pal16r4_pins,
 		nullptr,
 		nullptr},
 	{"PAL16R6", 2048,
-		pal16r6pinfuserows, ARRAY_LENGTH(pal16r6pinfuserows),
-		pal16r6pinfusecolumns, ARRAY_LENGTH(pal16r6pinfusecolumns),
+		pal16r6pinfuserows, std::size(pal16r6pinfuserows),
+		pal16r6pinfusecolumns, std::size(pal16r6pinfusecolumns),
 		print_pal16r6_product_terms,
 		config_pal16r6_pins,
 		nullptr,
 		nullptr},
 	{"PAL16R8", 2048,
-		pal16r8pinfuserows, ARRAY_LENGTH(pal16r8pinfuserows),
-		pal16r8pinfusecolumns, ARRAY_LENGTH(pal16r8pinfusecolumns),
+		pal16r8pinfuserows, std::size(pal16r8pinfuserows),
+		pal16r8pinfusecolumns, std::size(pal16r8pinfusecolumns),
 		print_pal16r8_product_terms,
 		config_pal16r8_pins,
 		nullptr,
@@ -2225,416 +2225,416 @@ static pal_data paldata[] = {
 	/*{"PAL16RA8", 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL},
 	{"PAL16V8R", 0, NULL, 0, NULL, 0, NULL, NULL, NULL, NULL},*/ // PAL16V8 same fusemap as GAL16V8?
 	{"PALCE16V8", 2194,
-		gal16v8pinfuserows, ARRAY_LENGTH(gal16v8pinfuserows),
-		gal16v8pinfusecolumns, ARRAY_LENGTH(gal16v8pinfusecolumns),
+		gal16v8pinfuserows, std::size(gal16v8pinfuserows),
+		gal16v8pinfusecolumns, std::size(gal16v8pinfusecolumns),
 		print_gal16v8_product_terms,
 		config_gal16v8_pins,
 		nullptr,
 		nullptr},
 	{"GAL16V8", 2194,
-		gal16v8pinfuserows, ARRAY_LENGTH(gal16v8pinfuserows),
-		gal16v8pinfusecolumns, ARRAY_LENGTH(gal16v8pinfusecolumns),
+		gal16v8pinfuserows, std::size(gal16v8pinfuserows),
+		gal16v8pinfusecolumns, std::size(gal16v8pinfusecolumns),
 		print_gal16v8_product_terms,
 		config_gal16v8_pins,
 		is_gal16v8_product_term_enabled,
 		nullptr},
 	{"ATF16V8", 2194,
-		gal16v8pinfuserows, ARRAY_LENGTH(gal16v8pinfuserows),
-		gal16v8pinfusecolumns, ARRAY_LENGTH(gal16v8pinfusecolumns),
+		gal16v8pinfuserows, std::size(gal16v8pinfuserows),
+		gal16v8pinfusecolumns, std::size(gal16v8pinfusecolumns),
 		print_gal16v8_product_terms,
 		config_gal16v8_pins,
 		is_gal16v8_product_term_enabled,
 		nullptr},
 	{"18CV8", 2696,
-		peel18cv8pinfuserows, ARRAY_LENGTH(peel18cv8pinfuserows),
-		peel18cv8pinfusecolumns, ARRAY_LENGTH(peel18cv8pinfusecolumns),
+		peel18cv8pinfuserows, std::size(peel18cv8pinfuserows),
+		peel18cv8pinfusecolumns, std::size(peel18cv8pinfusecolumns),
 		print_peel18cv8_product_terms,
 		config_peel18cv8_pins,
 		nullptr,
 		get_peel18cv8_pin_fuse_state},
 	{"AMPAL18P8", 2600,
-		ampal18p8pinfuserows, ARRAY_LENGTH(ampal18p8pinfuserows),
-		ampal18p8pinfusecolumns, ARRAY_LENGTH(ampal18p8pinfusecolumns),
+		ampal18p8pinfuserows, std::size(ampal18p8pinfuserows),
+		ampal18p8pinfusecolumns, std::size(ampal18p8pinfusecolumns),
 		print_ampal18p8_product_terms,
 		config_ampal18p8_pins,
 		nullptr,
 		nullptr},
 	{"GAL18V10", 3540,
-		gal18v10pinfuserows, ARRAY_LENGTH(gal18v10pinfuserows),
-		gal18v10pinfusecolumns, ARRAY_LENGTH(gal18v10pinfusecolumns),
+		gal18v10pinfuserows, std::size(gal18v10pinfuserows),
+		gal18v10pinfusecolumns, std::size(gal18v10pinfusecolumns),
 		print_gal18v10_product_terms,
 		config_gal18v10_pins,
 		nullptr,
 		nullptr},
 	{"PAL20L8", 2560,
-		pal20l8pinfuserows, ARRAY_LENGTH(pal20l8pinfuserows),
-		pal20l8pinfusecolumns, ARRAY_LENGTH(pal20l8pinfusecolumns),
+		pal20l8pinfuserows, std::size(pal20l8pinfuserows),
+		pal20l8pinfusecolumns, std::size(pal20l8pinfusecolumns),
 		print_pal20l8_product_terms,
 		config_pal20l8_pins,
 		nullptr,
 		nullptr},
 	{"PAL20L10", 1600,
-		pal20l10pinfuserows, ARRAY_LENGTH(pal20l10pinfuserows),
-		pal20l10pinfusecolumns, ARRAY_LENGTH(pal20l10pinfusecolumns),
+		pal20l10pinfuserows, std::size(pal20l10pinfuserows),
+		pal20l10pinfusecolumns, std::size(pal20l10pinfusecolumns),
 		print_pal20l10_product_terms,
 		config_pal20l10_pins,
 		nullptr,
 		nullptr},
 	{"PAL20R4", 2560,
-		pal20r4pinfuserows, ARRAY_LENGTH(pal20r4pinfuserows),
-		pal20r4pinfusecolumns, ARRAY_LENGTH(pal20r4pinfusecolumns),
+		pal20r4pinfuserows, std::size(pal20r4pinfuserows),
+		pal20r4pinfusecolumns, std::size(pal20r4pinfusecolumns),
 		print_pal20r4_product_terms,
 		config_pal20r4_pins,
 		nullptr,
 		nullptr},
 	{"PAL20R6", 2560,
-		pal20r6pinfuserows, ARRAY_LENGTH(pal20r6pinfuserows),
-		pal20r6pinfusecolumns, ARRAY_LENGTH(pal20r6pinfusecolumns),
+		pal20r6pinfuserows, std::size(pal20r6pinfuserows),
+		pal20r6pinfusecolumns, std::size(pal20r6pinfusecolumns),
 		print_pal20r6_product_terms,
 		config_pal20r6_pins,
 		nullptr,
 		nullptr},
 	{"PAL20R8", 2560,
-		pal20r8pinfuserows, ARRAY_LENGTH(pal20r8pinfuserows),
-		pal20r8pinfusecolumns, ARRAY_LENGTH(pal20r8pinfusecolumns),
+		pal20r8pinfuserows, std::size(pal20r8pinfuserows),
+		pal20r8pinfusecolumns, std::size(pal20r8pinfusecolumns),
 		print_pal20r8_product_terms,
 		config_pal20r8_pins,
 		nullptr,
 		nullptr},
 	{"PAL20RA10", 3210,
-		pal20ra10pinfuserows, ARRAY_LENGTH(pal20ra10pinfuserows),
-		pal20ra10pinfusecolumns, ARRAY_LENGTH(pal20ra10pinfusecolumns),
+		pal20ra10pinfuserows, std::size(pal20ra10pinfuserows),
+		pal20ra10pinfusecolumns, std::size(pal20ra10pinfusecolumns),
 		print_pal20ra10_product_terms,
 		config_pal20ra10_pins,
 		nullptr,
 		nullptr },
 	{"PAL20X4", 1600,
-		pal20x4pinfuserows, ARRAY_LENGTH(pal20x4pinfuserows),
-		pal20x4pinfusecolumns, ARRAY_LENGTH(pal20x4pinfusecolumns),
+		pal20x4pinfuserows, std::size(pal20x4pinfuserows),
+		pal20x4pinfusecolumns, std::size(pal20x4pinfusecolumns),
 		print_pal20x4_product_terms,
 		config_pal20x4_pins,
 		nullptr,
 		nullptr},
 	{"PAL20X8", 1600,
-		pal20x8pinfuserows, ARRAY_LENGTH(pal20x8pinfuserows),
-		pal20x8pinfusecolumns, ARRAY_LENGTH(pal20x8pinfusecolumns),
+		pal20x8pinfuserows, std::size(pal20x8pinfuserows),
+		pal20x8pinfusecolumns, std::size(pal20x8pinfusecolumns),
 		print_pal20x8_product_terms,
 		config_pal20x8_pins,
 		nullptr,
 		nullptr},
 	{"PAL20X10", 1600,
-		pal20x10pinfuserows, ARRAY_LENGTH(pal20x10pinfuserows),
-		pal20x10pinfusecolumns, ARRAY_LENGTH(pal20x10pinfusecolumns),
+		pal20x10pinfuserows, std::size(pal20x10pinfuserows),
+		pal20x10pinfusecolumns, std::size(pal20x10pinfusecolumns),
 		print_pal20x10_product_terms,
 		config_pal20x10_pins,
 		nullptr,
 		nullptr},
 	{"GAL20V8", 2706,
-		gal20v8pinfuserows, ARRAY_LENGTH(gal20v8pinfuserows),
-		gal20v8pinfusecolumns, ARRAY_LENGTH(gal20v8pinfusecolumns),
+		gal20v8pinfuserows, std::size(gal20v8pinfuserows),
+		gal20v8pinfusecolumns, std::size(gal20v8pinfusecolumns),
 		print_gal20v8_product_terms,
 		config_gal20v8_pins,
 		is_gal20v8_product_term_enabled,
 		nullptr},
 	{"PALCE20V8", 2706,
-		gal20v8pinfuserows, ARRAY_LENGTH(gal20v8pinfuserows),
-		gal20v8pinfusecolumns, ARRAY_LENGTH(gal20v8pinfusecolumns),
+		gal20v8pinfuserows, std::size(gal20v8pinfuserows),
+		gal20v8pinfusecolumns, std::size(gal20v8pinfusecolumns),
 		print_gal20v8_product_terms,
 		config_gal20v8_pins,
 		is_gal20v8_product_term_enabled,
 		nullptr},
 	{"ATF20V10", 2706,
-		gal20v8pinfuserows, ARRAY_LENGTH(gal20v8pinfuserows),
-		gal20v8pinfusecolumns, ARRAY_LENGTH(gal20v8pinfusecolumns),
+		gal20v8pinfuserows, std::size(gal20v8pinfuserows),
+		gal20v8pinfusecolumns, std::size(gal20v8pinfusecolumns),
 		print_gal20v8_product_terms,
 		config_gal20v8_pins,
 		is_gal20v8_product_term_enabled,
 		nullptr},
 	{"PAL22V10", 5828,
-		palce22v10_pal22v10pinfuserows, ARRAY_LENGTH(palce22v10_pal22v10pinfuserows),
-		palce22v10_pal22v10pinfusecolumns, ARRAY_LENGTH(palce22v10_pal22v10pinfusecolumns),
+		palce22v10_pal22v10pinfuserows, std::size(palce22v10_pal22v10pinfuserows),
+		palce22v10_pal22v10pinfusecolumns, std::size(palce22v10_pal22v10pinfusecolumns),
 		print_palce22v10_pal22v10_product_terms,
 		config_palce22v10_pal22v10_pins,
 		nullptr,
 		nullptr},
 	{"PALCE22V10", 5828,
-		palce22v10_pal22v10pinfuserows, ARRAY_LENGTH(palce22v10_pal22v10pinfuserows),
-		palce22v10_pal22v10pinfusecolumns, ARRAY_LENGTH(palce22v10_pal22v10pinfusecolumns),
+		palce22v10_pal22v10pinfuserows, std::size(palce22v10_pal22v10pinfuserows),
+		palce22v10_pal22v10pinfusecolumns, std::size(palce22v10_pal22v10pinfusecolumns),
 		print_palce22v10_pal22v10_product_terms,
 		config_palce22v10_pal22v10_pins,
 		nullptr,
 		nullptr},
 	{"ATF22V10", 5828,
-		palce22v10_pal22v10pinfuserows, ARRAY_LENGTH(palce22v10_pal22v10pinfuserows),
-		palce22v10_pal22v10pinfusecolumns, ARRAY_LENGTH(palce22v10_pal22v10pinfusecolumns),
+		palce22v10_pal22v10pinfuserows, std::size(palce22v10_pal22v10pinfuserows),
+		palce22v10_pal22v10pinfusecolumns, std::size(palce22v10_pal22v10pinfusecolumns),
 		print_palce22v10_pal22v10_product_terms,
 		config_palce22v10_pal22v10_pins,
 		nullptr,
 		nullptr},
 	{"GAL22V10", 5892,
-		gal22v10pinfuserows, ARRAY_LENGTH(gal22v10pinfuserows),
-		gal22v10pinfusecolumns, ARRAY_LENGTH(gal22v10pinfusecolumns),
+		gal22v10pinfuserows, std::size(gal22v10pinfuserows),
+		gal22v10pinfusecolumns, std::size(gal22v10pinfusecolumns),
 		print_gal22v10_product_terms,
 		config_gal22v10_pins,
 		nullptr,
 		nullptr},
 	{"ATF22V10", 5892,
-		gal22v10pinfuserows, ARRAY_LENGTH(gal22v10pinfuserows),
-		gal22v10pinfusecolumns, ARRAY_LENGTH(gal22v10pinfusecolumns),
+		gal22v10pinfuserows, std::size(gal22v10pinfuserows),
+		gal22v10pinfusecolumns, std::size(gal22v10pinfusecolumns),
 		print_gal22v10_product_terms,
 		config_gal22v10_pins,
 		nullptr,
 		nullptr},
 	{"ATF22V10", 5893,
-		atf22v10powerdownmodepinfuserows, ARRAY_LENGTH(atf22v10powerdownmodepinfuserows),
-		atf22v10powerdownmodepinfusecolumns, ARRAY_LENGTH(atf22v10powerdownmodepinfusecolumns),
+		atf22v10powerdownmodepinfuserows, std::size(atf22v10powerdownmodepinfuserows),
+		atf22v10powerdownmodepinfusecolumns, std::size(atf22v10powerdownmodepinfusecolumns),
 		print_atf22v10_power_down_mode_product_terms,
 		config_atf22v10_power_down_mode_pins,
 		nullptr,
 		nullptr},
 	{"82S153", 1842,
-		_82s153_pls153pinfuserows, ARRAY_LENGTH(_82s153_pls153pinfuserows),
-		_82s153_pls153pinfusecolumns, ARRAY_LENGTH(_82s153_pls153pinfusecolumns),
+		_82s153_pls153pinfuserows, std::size(_82s153_pls153pinfuserows),
+		_82s153_pls153pinfusecolumns, std::size(_82s153_pls153pinfusecolumns),
 		print_82s153_pls153_product_terms,
 		config_82s153_pls153_pins,
 		nullptr,
 		nullptr},
 	{"PLS153", 1842,
-		_82s153_pls153pinfuserows, ARRAY_LENGTH(_82s153_pls153pinfuserows),
-		_82s153_pls153pinfusecolumns, ARRAY_LENGTH(_82s153_pls153pinfusecolumns),
+		_82s153_pls153pinfuserows, std::size(_82s153_pls153pinfuserows),
+		_82s153_pls153pinfusecolumns, std::size(_82s153_pls153pinfusecolumns),
 		print_82s153_pls153_product_terms,
 		config_82s153_pls153_pins,
 		nullptr,
 		nullptr},
 	{"CK2605", 1106,
-		ck2605pinfuserows, ARRAY_LENGTH(ck2605pinfuserows),
-		ck2605pinfusecolumns, ARRAY_LENGTH(ck2605pinfusecolumns),
+		ck2605pinfuserows, std::size(ck2605pinfuserows),
+		ck2605pinfusecolumns, std::size(ck2605pinfusecolumns),
 		print_ck2605_product_terms,
 		config_ck2605_pins,
 		nullptr,
 		nullptr},
 #if defined(ricoh_pals)
 	{"EPL10P8", 664,
-		epl10p8pinfuserows, ARRAY_LENGTH(epl10p8pinfuserows),
-		epl10p8pinfusecolumns, ARRAY_LENGTH(epl10p8pinfusecolumns),
+		epl10p8pinfuserows, std::size(epl10p8pinfuserows),
+		epl10p8pinfusecolumns, std::size(epl10p8pinfusecolumns),
 		print_epl10p8_product_terms,
 		config_epl10p8_pins,
 		nullptr,
 		nullptr},
 	{"EPL12P6", 786,
-		epl12p6pinfuserows, ARRAY_LENGTH(epl12p6pinfuserows),
-		epl12p6pinfusecolumns, ARRAY_LENGTH(epl12p6pinfusecolumns),
+		epl12p6pinfuserows, std::size(epl12p6pinfuserows),
+		epl12p6pinfusecolumns, std::size(epl12p6pinfusecolumns),
 		print_epl12p6_product_terms,
 		config_epl12p6_pins,
 		nullptr,
 		nullptr},
 	{"EPL14P4", 908,
-		epl14p4pinfuserows, ARRAY_LENGTH(epl14p4pinfuserows),
-		epl14p4pinfusecolumns, ARRAY_LENGTH(epl14p4pinfusecolumns),
+		epl14p4pinfuserows, std::size(epl14p4pinfuserows),
+		epl14p4pinfusecolumns, std::size(epl14p4pinfusecolumns),
 		print_epl14p4_product_terms,
 		config_epl14p4_pins,
 		nullptr,
 		nullptr},
 	{"EPL16P2", 1030,
-		epl16p2pinfuserows, ARRAY_LENGTH(epl16p2pinfuserows),
-		epl16p2pinfusecolumns, ARRAY_LENGTH(epl16p2pinfusecolumns),
+		epl16p2pinfuserows, std::size(epl16p2pinfuserows),
+		epl16p2pinfusecolumns, std::size(epl16p2pinfusecolumns),
 		print_epl16p2_product_terms,
 		config_epl16p2_pins,
 		nullptr,
 		nullptr},
 	{"EPL16P8", 2072,
-		epl16p8pinfuserows, ARRAY_LENGTH(epl16p8pinfuserows),
-		epl16p8pinfusecolumns, ARRAY_LENGTH(epl16p8pinfusecolumns),
+		epl16p8pinfuserows, std::size(epl16p8pinfuserows),
+		epl16p8pinfusecolumns, std::size(epl16p8pinfusecolumns),
 		print_epl16p8_product_terms,
 		config_epl16p8_pins,
 		nullptr,
 		nullptr},
 	{"EPL16RP8", 2072,
-		epl16rp8pinfuserows, ARRAY_LENGTH(epl16rp8pinfuserows),
-		epl16rp8pinfusecolumns, ARRAY_LENGTH(epl16rp8pinfusecolumns),
+		epl16rp8pinfuserows, std::size(epl16rp8pinfuserows),
+		epl16rp8pinfusecolumns, std::size(epl16rp8pinfusecolumns),
 		print_epl16rp8_product_terms,
 		config_epl16rp8_pins,
 		nullptr,
 		nullptr},
 	{"EPL16RP6", 2072,
-		epl16rp6pinfuserows, ARRAY_LENGTH(epl16rp6pinfuserows),
-		epl16rp6pinfusecolumns, ARRAY_LENGTH(epl16rp6pinfusecolumns),
+		epl16rp6pinfuserows, std::size(epl16rp6pinfuserows),
+		epl16rp6pinfusecolumns, std::size(epl16rp6pinfusecolumns),
 		print_epl16rp6_product_terms,
 		config_epl16rp6_pins,
 		nullptr,
 		nullptr},
 	{"EPL16RP4", 2072,
-		epl16rp4pinfuserows, ARRAY_LENGTH(epl16rp4pinfuserows),
-		epl16rp4pinfusecolumns, ARRAY_LENGTH(epl16rp4pinfusecolumns),
+		epl16rp4pinfuserows, std::size(epl16rp4pinfuserows),
+		epl16rp4pinfusecolumns, std::size(epl16rp4pinfusecolumns),
 		print_epl16rp4_product_terms,
 		config_epl16rp4_pins,
 		nullptr,
 		nullptr},
 #endif
 	{"PAL10P8", 328,
-		pal10p8pinfuserows, ARRAY_LENGTH(pal10p8pinfuserows),
-		pal10p8pinfusecolumns, ARRAY_LENGTH(pal10p8pinfusecolumns),
+		pal10p8pinfuserows, std::size(pal10p8pinfuserows),
+		pal10p8pinfusecolumns, std::size(pal10p8pinfusecolumns),
 		print_pal10p8_product_terms,
 		config_pal10p8_pins,
 		nullptr,
 		nullptr},
 	{"PAL12P6", 390,
-		pal12p6pinfuserows, ARRAY_LENGTH(pal12p6pinfuserows),
-		pal12p6pinfusecolumns, ARRAY_LENGTH(pal12p6pinfusecolumns),
+		pal12p6pinfuserows, std::size(pal12p6pinfuserows),
+		pal12p6pinfusecolumns, std::size(pal12p6pinfusecolumns),
 		print_pal12p6_product_terms,
 		config_pal12p6_pins,
 		nullptr,
 		nullptr},
 	{"PAL14P4", 452,
-		pal14p4pinfuserows, ARRAY_LENGTH(pal14p4pinfuserows),
-		pal14p4pinfusecolumns, ARRAY_LENGTH(pal14p4pinfusecolumns),
+		pal14p4pinfuserows, std::size(pal14p4pinfuserows),
+		pal14p4pinfusecolumns, std::size(pal14p4pinfusecolumns),
 		print_pal14p4_product_terms,
 		config_pal14p4_pins,
 		nullptr,
 		nullptr},
 	{"PAL16P2", 514,
-		pal16p2pinfuserows, ARRAY_LENGTH(pal16p2pinfuserows),
-		pal16p2pinfusecolumns, ARRAY_LENGTH(pal16p2pinfusecolumns),
+		pal16p2pinfuserows, std::size(pal16p2pinfuserows),
+		pal16p2pinfusecolumns, std::size(pal16p2pinfusecolumns),
 		print_pal16p2_product_terms,
 		config_pal16p2_pins,
 		nullptr,
 		nullptr},
 	{"PAL16P8", 2056,
-		pal16p8pinfuserows, ARRAY_LENGTH(pal16p8pinfuserows),
-		pal16p8pinfusecolumns, ARRAY_LENGTH(pal16p8pinfusecolumns),
+		pal16p8pinfuserows, std::size(pal16p8pinfuserows),
+		pal16p8pinfusecolumns, std::size(pal16p8pinfusecolumns),
 		print_pal16p8_product_terms,
 		config_pal16p8_pins,
 		nullptr,
 		nullptr},
 	{"PAL16RP4", 2056,
-		pal16rp4pinfuserows, ARRAY_LENGTH(pal16rp4pinfuserows),
-		pal16rp4pinfusecolumns, ARRAY_LENGTH(pal16rp4pinfusecolumns),
+		pal16rp4pinfuserows, std::size(pal16rp4pinfuserows),
+		pal16rp4pinfusecolumns, std::size(pal16rp4pinfusecolumns),
 		print_pal16rp4_product_terms,
 		config_pal16rp4_pins,
 		nullptr,
 		nullptr},
 	{"PAL16RP6", 2056,
-		pal16rp6pinfuserows, ARRAY_LENGTH(pal16rp6pinfuserows),
-		pal16rp6pinfusecolumns, ARRAY_LENGTH(pal16rp6pinfusecolumns),
+		pal16rp6pinfuserows, std::size(pal16rp6pinfuserows),
+		pal16rp6pinfusecolumns, std::size(pal16rp6pinfusecolumns),
 		print_pal16rp6_product_terms,
 		config_pal16rp6_pins,
 		nullptr,
 		nullptr},
 	{"PAL16RP8", 2056,
-		pal16rp8pinfuserows, ARRAY_LENGTH(pal16rp8pinfuserows),
-		pal16rp8pinfusecolumns, ARRAY_LENGTH(pal16rp8pinfusecolumns),
+		pal16rp8pinfuserows, std::size(pal16rp8pinfuserows),
+		pal16rp8pinfusecolumns, std::size(pal16rp8pinfusecolumns),
 		print_pal16rp8_product_terms,
 		config_pal16rp8_pins,
 		nullptr,
 		nullptr},
 	{"PAL6L16", 192,
-		pal6l16pinfuserows, ARRAY_LENGTH(pal6l16pinfuserows),
-		pal6l16pinfusecolumns, ARRAY_LENGTH(pal6l16pinfusecolumns),
+		pal6l16pinfuserows, std::size(pal6l16pinfuserows),
+		pal6l16pinfusecolumns, std::size(pal6l16pinfusecolumns),
 		print_pal6l16_product_terms,
 		config_pal6l16_pins,
 		nullptr,
 		nullptr},
 	{"PAL8L14", 224,
-		pal8l14pinfuserows, ARRAY_LENGTH(pal8l14pinfuserows),
-		pal8l14pinfusecolumns, ARRAY_LENGTH(pal8l14pinfusecolumns),
+		pal8l14pinfuserows, std::size(pal8l14pinfuserows),
+		pal8l14pinfusecolumns, std::size(pal8l14pinfusecolumns),
 		print_pal8l14_product_terms,
 		config_pal8l14_pins,
 		nullptr,
 		nullptr},
 	{"PAL12H10", 480,
-		pal12h10pinfuserows, ARRAY_LENGTH(pal12h10pinfuserows),
-		pal12h10pinfusecolumns, ARRAY_LENGTH(pal12h10pinfusecolumns),
+		pal12h10pinfuserows, std::size(pal12h10pinfuserows),
+		pal12h10pinfusecolumns, std::size(pal12h10pinfusecolumns),
 		print_pal12h10_product_terms,
 		config_pal12h10_pins,
 		nullptr,
 		nullptr},
 	{"PAL12L10", 480,
-		pal12l10pinfuserows, ARRAY_LENGTH(pal12l10pinfuserows),
-		pal12l10pinfusecolumns, ARRAY_LENGTH(pal12l10pinfusecolumns),
+		pal12l10pinfuserows, std::size(pal12l10pinfuserows),
+		pal12l10pinfusecolumns, std::size(pal12l10pinfusecolumns),
 		print_pal12l10_product_terms,
 		config_pal12l10_pins,
 		nullptr,
 		nullptr},
 	{"PAL14H8", 560,
-		pal14h8pinfuserows, ARRAY_LENGTH(pal14h8pinfuserows),
-		pal14h8pinfusecolumns, ARRAY_LENGTH(pal14h8pinfusecolumns),
+		pal14h8pinfuserows, std::size(pal14h8pinfuserows),
+		pal14h8pinfusecolumns, std::size(pal14h8pinfusecolumns),
 		print_pal14h8_product_terms,
 		config_pal14h8_pins,
 		nullptr,
 		nullptr},
 	{"PAL14L8", 560,
-		pal14l8pinfuserows, ARRAY_LENGTH(pal14l8pinfuserows),
-		pal14l8pinfusecolumns, ARRAY_LENGTH(pal14l8pinfusecolumns),
+		pal14l8pinfuserows, std::size(pal14l8pinfuserows),
+		pal14l8pinfusecolumns, std::size(pal14l8pinfusecolumns),
 		print_pal14l8_product_terms,
 		config_pal14l8_pins,
 		nullptr,
 		nullptr},
 	{"PAL16H6", 640,
-		pal16h6pinfuserows, ARRAY_LENGTH(pal16h6pinfuserows),
-		pal16h6pinfusecolumns, ARRAY_LENGTH(pal16h6pinfusecolumns),
+		pal16h6pinfuserows, std::size(pal16h6pinfuserows),
+		pal16h6pinfusecolumns, std::size(pal16h6pinfusecolumns),
 		print_pal16h6_product_terms,
 		config_pal16h6_pins,
 		nullptr,
 		nullptr},
 	{"PAL16L6", 640,
-		pal16l6pinfuserows, ARRAY_LENGTH(pal16l6pinfuserows),
-		pal16l6pinfusecolumns, ARRAY_LENGTH(pal16l6pinfusecolumns),
+		pal16l6pinfuserows, std::size(pal16l6pinfuserows),
+		pal16l6pinfusecolumns, std::size(pal16l6pinfusecolumns),
 		print_pal16l6_product_terms,
 		config_pal16l6_pins,
 		nullptr,
 		nullptr},
 	{"PAL18H4", 720,
-		pal18h4pinfuserows, ARRAY_LENGTH(pal18h4pinfuserows),
-		pal18h4pinfusecolumns, ARRAY_LENGTH(pal18h4pinfusecolumns),
+		pal18h4pinfuserows, std::size(pal18h4pinfuserows),
+		pal18h4pinfusecolumns, std::size(pal18h4pinfusecolumns),
 		print_pal18h4_product_terms,
 		config_pal18h4_pins,
 		nullptr,
 		nullptr},
 	{"PAL18L4", 720,
-		pal18l4pinfuserows, ARRAY_LENGTH(pal18l4pinfuserows),
-		pal18l4pinfusecolumns, ARRAY_LENGTH(pal18l4pinfusecolumns),
+		pal18l4pinfuserows, std::size(pal18l4pinfuserows),
+		pal18l4pinfusecolumns, std::size(pal18l4pinfusecolumns),
 		print_pal18l4_product_terms,
 		config_pal18l4_pins,
 		nullptr,
 		nullptr},
 	{"PAL20C1", 640,
-		pal20c1pinfuserows, ARRAY_LENGTH(pal20c1pinfuserows),
-		pal20c1pinfusecolumns, ARRAY_LENGTH(pal20c1pinfusecolumns),
+		pal20c1pinfuserows, std::size(pal20c1pinfuserows),
+		pal20c1pinfusecolumns, std::size(pal20c1pinfusecolumns),
 		print_pal20c1_product_terms,
 		config_pal20c1_pins,
 		nullptr,
 		nullptr},
 	{"PAL20L2", 640,
-		pal20l2pinfuserows, ARRAY_LENGTH(pal20l2pinfuserows),
-		pal20l2pinfusecolumns, ARRAY_LENGTH(pal20l2pinfusecolumns),
+		pal20l2pinfuserows, std::size(pal20l2pinfuserows),
+		pal20l2pinfusecolumns, std::size(pal20l2pinfusecolumns),
 		print_pal20l2_product_terms,
 		config_pal20l2_pins,
 		nullptr,
 		nullptr},
 	{"82S100", 1928,
-		_82s100_pls100_pinfuserows, ARRAY_LENGTH(_82s100_pls100_pinfuserows),
-		_82s100_pls100_pinfusecolumns, ARRAY_LENGTH(_82s100_pls100_pinfusecolumns),
+		_82s100_pls100_pinfuserows, std::size(_82s100_pls100_pinfuserows),
+		_82s100_pls100_pinfusecolumns, std::size(_82s100_pls100_pinfusecolumns),
 		print_82s100_pls100_product_terms,
 		config_82s100_pls100_pins,
 		nullptr,
 		nullptr},
 	{"PLS100", 1928,
-		_82s100_pls100_pinfuserows, ARRAY_LENGTH(_82s100_pls100_pinfuserows),
-		_82s100_pls100_pinfusecolumns, ARRAY_LENGTH(_82s100_pls100_pinfusecolumns),
+		_82s100_pls100_pinfuserows, std::size(_82s100_pls100_pinfuserows),
+		_82s100_pls100_pinfusecolumns, std::size(_82s100_pls100_pinfusecolumns),
 		print_82s100_pls100_product_terms,
 		config_82s100_pls100_pins,
 		nullptr,
 		nullptr},
 	{"82S101", 1928,
-		_82s100_pls100_pinfuserows, ARRAY_LENGTH(_82s100_pls100_pinfuserows),
-		_82s100_pls100_pinfusecolumns, ARRAY_LENGTH(_82s100_pls100_pinfusecolumns),
+		_82s100_pls100_pinfuserows, std::size(_82s100_pls100_pinfuserows),
+		_82s100_pls100_pinfusecolumns, std::size(_82s100_pls100_pinfusecolumns),
 		print_82s100_pls100_product_terms,
 		config_82s100_pls100_pins,
 		nullptr,
 		nullptr},
 	{"PLS101", 1928,
-		_82s100_pls100_pinfuserows, ARRAY_LENGTH(_82s100_pls100_pinfuserows),
-		_82s100_pls100_pinfusecolumns, ARRAY_LENGTH(_82s100_pls100_pinfusecolumns),
+		_82s100_pls100_pinfuserows, std::size(_82s100_pls100_pinfuserows),
+		_82s100_pls100_pinfusecolumns, std::size(_82s100_pls100_pinfusecolumns),
 		print_82s100_pls100_product_terms,
 		config_82s100_pls100_pins,
 		nullptr,
@@ -2693,7 +2693,7 @@ static void find_pal_data(const char *name, pal_data_vector& pal_data_vector)
 {
 	int index;
 
-	for (index = 0; index < ARRAY_LENGTH(paldata); ++index)
+	for (index = 0; index < std::size(paldata); ++index)
 	{
 		if (!core_stricmp(name, paldata[index].name))
 		{
@@ -4217,7 +4217,7 @@ static void print_epl10p8_product_terms(const pal_data* pal, const jed_data* jed
 
 	printf("Equations:\n\n");
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		flags = outputpins[index].flags;
 
@@ -4767,8 +4767,8 @@ static void config_pal10l8_pins(const pal_data* pal, const jed_data* jed)
 		{18, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{19, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4791,8 +4791,8 @@ static void config_pal10h8_pins(const pal_data* pal, const jed_data* jed)
 		{18, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{19, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4813,8 +4813,8 @@ static void config_pal12l6_pins(const pal_data* pal, const jed_data* jed)
 		{17, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{18, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4835,8 +4835,8 @@ static void config_pal12h6_pins(const pal_data* pal, const jed_data* jed)
 		{17, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{18, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4855,8 +4855,8 @@ static void config_pal14l4_pins(const pal_data* pal, const jed_data* jed)
 		{16, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{17, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4875,8 +4875,8 @@ static void config_pal14h4_pins(const pal_data* pal, const jed_data* jed)
 		{16, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{17, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4893,8 +4893,8 @@ static void config_pal16l2_pins(const pal_data* pal, const jed_data* jed)
 		{15, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{16, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4911,8 +4911,8 @@ static void config_pal16h2_pins(const pal_data* pal, const jed_data* jed)
 		{15, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{16, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4929,8 +4929,8 @@ static void config_pal16c1_pins(const pal_data* pal, const jed_data* jed)
 		{15, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{16, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -4959,7 +4959,7 @@ static void config_pal16l8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -4995,7 +4995,7 @@ static void config_pal16r4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -5019,7 +5019,7 @@ static void config_pal16r4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5047,7 +5047,7 @@ static void config_pal16r6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -5063,7 +5063,7 @@ static void config_pal16r6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5087,8 +5087,8 @@ static void config_pal16r8_pins(const pal_data* pal, const jed_data* jed)
 		{18, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED},
 		{19, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -5198,7 +5198,7 @@ static void config_gal16v8_pins(const pal_data* pal, const jed_data* jed)
 	static uint16_t input_pins_registered[] = {2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 14, 15, 16, 17, 18, 19};
 	static uint16_t input_pins_combinatorialcomplex[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 14, 15, 16, 17, 18};
 	uint16_t input_pins_combinatorialsimple[18];
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, input_pin_count, output_pin_count;
 
 	output_pin_count = 0;
@@ -5214,12 +5214,12 @@ static void config_gal16v8_pins(const pal_data* pal, const jed_data* jed)
 		{
 			/* Complex Mode */
 
-			set_input_pins(input_pins_combinatorialcomplex, ARRAY_LENGTH(input_pins_combinatorialcomplex));
+			set_input_pins(input_pins_combinatorialcomplex, std::size(input_pins_combinatorialcomplex));
 
 			memcpy(gal16v8pinfuserows, pinfuserows_combinatorialcomplex, sizeof(pinfuserows_combinatorialcomplex));
 			memcpy(gal16v8pinfusecolumns, pinfusecolumns_combinatorialcomplex, sizeof(pinfusecolumns_combinatorialcomplex));
 
-			for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+			for (index = 0; index < std::size(macrocells); ++index)
 			{
 				if (is_gal16v8_product_term_enabled(pal, jed, pal->pinfuserows[index].fuserowoutputenable) &&
 					does_output_enable_fuse_row_allow_output(pal, jed, pal->pinfuserows[index].fuserowoutputenable))
@@ -5270,7 +5270,7 @@ static void config_gal16v8_pins(const pal_data* pal, const jed_data* jed)
 			memcpy(gal16v8pinfuserows, pinfuserows_combinatorialsimple, sizeof(pinfuserows_combinatorialsimple));
 			memcpy(gal16v8pinfusecolumns, pinfusecolumns_combinatorialsimple, sizeof(pinfusecolumns_combinatorialsimple));
 
-			for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+			for (index = 0; index < std::size(macrocells); ++index)
 			{
 				if (jed_get_fuse(jed, macrocells[index].ac1_fuse))
 				{
@@ -5325,11 +5325,11 @@ static void config_gal16v8_pins(const pal_data* pal, const jed_data* jed)
 	{
 		/* Registered */
 
-		set_input_pins(input_pins_registered, ARRAY_LENGTH(input_pins_registered));
+		set_input_pins(input_pins_registered, std::size(input_pins_registered));
 
 		memcpy(gal16v8pinfusecolumns, pinfusecolumns_registered, sizeof(pinfusecolumns_registered));
 
-		for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+		for (index = 0; index < std::size(macrocells); ++index)
 		{
 			if (jed_get_fuse(jed, macrocells[index].ac1_fuse))
 			{
@@ -5414,14 +5414,14 @@ static void config_peel18cv8_pins(const pal_data* pal, const jed_data* jed)
 		{18, 2668, 2669, 2670, 2671},
 		{19, 2664, 2665, 2666, 2667}};
 	static uint16_t input_pins[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, output_pin_count;
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 
 	output_pin_count = 0;
 
-	for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+	for (index = 0; index < std::size(macrocells); ++index)
 	{
 		if (jed_get_fuse(jed, macrocells[index].feedback1_fuse) &&
 			!jed_get_fuse(jed, macrocells[index].feedback2_fuse))
@@ -5536,7 +5536,7 @@ static void config_ampal18p8_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index, output_pin_count;
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 
 	output_pin_count = 0;
 
@@ -5592,12 +5592,12 @@ static void config_gal18v10_pins(const pal_data* pal, const jed_data* jed)
 		{18, 3458, 3459},
 		{19, 3456, 3457}};
 	static uint16_t input_pins[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, output_pin_count;
 
 	output_pin_count = 0;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		if (jed_get_fuse(jed, macrocells[index].s1_fuse))
 		{
@@ -5640,7 +5640,7 @@ static void config_gal18v10_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5680,7 +5680,7 @@ static void config_pal20l8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5720,7 +5720,7 @@ static void config_pal20l10_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5756,7 +5756,7 @@ static void config_pal20r4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -5780,7 +5780,7 @@ static void config_pal20r4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5808,7 +5808,7 @@ static void config_pal20r6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -5824,7 +5824,7 @@ static void config_pal20r6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -5848,8 +5848,8 @@ static void config_pal20r8_pins(const pal_data* pal, const jed_data* jed)
 		{21, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED},
 		{22, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -5874,8 +5874,8 @@ static void config_pal20ra10_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -5900,8 +5900,8 @@ static void config_pal20x4_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_OUTPUT},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_OUTPUT}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 /*-------------------------------------------------
@@ -5924,8 +5924,8 @@ static void config_pal20x8_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_OUTPUT}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -5950,8 +5950,8 @@ static void config_pal20x10_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6073,7 +6073,7 @@ static void config_gal20v8_pins(const pal_data* pal, const jed_data* jed)
 	static uint16_t input_pins_registered[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
 	static uint16_t input_pins_combinatorialcomplex[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 16, 17, 18, 19, 20, 21, 23};
 	uint16_t input_pins_combinatorialsimple[22];
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, input_pin_count, output_pin_count;
 
 	output_pin_count = 0;
@@ -6089,12 +6089,12 @@ static void config_gal20v8_pins(const pal_data* pal, const jed_data* jed)
 		{
 			/* Complex Mode */
 
-			set_input_pins(input_pins_combinatorialcomplex, ARRAY_LENGTH(input_pins_combinatorialcomplex));
+			set_input_pins(input_pins_combinatorialcomplex, std::size(input_pins_combinatorialcomplex));
 
 			memcpy(gal20v8pinfuserows, pinfuserows_combinatorialcomplex, sizeof(pinfuserows_combinatorialcomplex));
 			memcpy(gal20v8pinfusecolumns, pinfusecolumns_combinatorialcomplex, sizeof(pinfusecolumns_combinatorialcomplex));
 
-			for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+			for (index = 0; index < std::size(macrocells); ++index)
 			{
 				if (is_gal20v8_product_term_enabled(pal, jed, pal->pinfuserows[index].fuserowoutputenable) &&
 					does_output_enable_fuse_row_allow_output(pal, jed, pal->pinfuserows[index].fuserowoutputenable))
@@ -6148,7 +6148,7 @@ static void config_gal20v8_pins(const pal_data* pal, const jed_data* jed)
 			memcpy(gal20v8pinfuserows, pinfuserows_combinatorialsimple, sizeof(pinfuserows_combinatorialsimple));
 			memcpy(gal20v8pinfusecolumns, pinfusecolumns_combinatorialsimple, sizeof(pinfusecolumns_combinatorialsimple));
 
-			for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+			for (index = 0; index < std::size(macrocells); ++index)
 			{
 				if (jed_get_fuse(jed, macrocells[index].ac1_fuse))
 				{
@@ -6206,11 +6206,11 @@ static void config_gal20v8_pins(const pal_data* pal, const jed_data* jed)
 	{
 		/* Registered */
 
-		set_input_pins(input_pins_registered, ARRAY_LENGTH(input_pins_registered));
+		set_input_pins(input_pins_registered, std::size(input_pins_registered));
 
 		memcpy(gal20v8pinfusecolumns, pinfusecolumns_registered, sizeof(pinfusecolumns_registered));
 
-		for (index = 0; index < ARRAY_LENGTH(macrocells); ++index)
+		for (index = 0; index < std::size(macrocells); ++index)
 		{
 			if (jed_get_fuse(jed, macrocells[index].ac1_fuse))
 			{
@@ -6295,12 +6295,12 @@ static void config_palce22v10_pal22v10_pins(const pal_data* pal, const jed_data*
 		{22, 5810, 5811},
 		{23, 5808, 5809}};
 	static uint16_t input_pins[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, output_pin_count;
 
 	output_pin_count = 0;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		if (jed_get_fuse(jed, macrocells[index].s1_fuse))
 		{
@@ -6343,7 +6343,7 @@ static void config_palce22v10_pal22v10_pins(const pal_data* pal, const jed_data*
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -6376,12 +6376,12 @@ static void config_gal22v10_pins(const pal_data* pal, const jed_data* jed)
 		{22, 5810, 5811},
 		{23, 5808, 5809}};
 	static uint16_t input_pins[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, output_pin_count;
 
 	output_pin_count = 0;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		if (jed_get_fuse(jed, macrocells[index].s1_fuse))
 		{
@@ -6424,7 +6424,7 @@ static void config_gal22v10_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -6457,7 +6457,7 @@ static void config_atf22v10_power_down_mode_pins(const pal_data* pal, const jed_
 		{22, 5810, 5811},
 		{23, 5808, 5809}};
 	static uint16_t input_pins[] = {1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
-	pin_output_config output_pins[ARRAY_LENGTH(macrocells)];
+	pin_output_config output_pins[std::size(macrocells)];
 	uint16_t index, output_pin_count;
 
 	output_pin_count = 0;
@@ -6467,7 +6467,7 @@ static void config_atf22v10_power_down_mode_pins(const pal_data* pal, const jed_
 		fprintf(stderr, "Warning: Power down fuse not blown!\n");
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		if (jed_get_fuse(jed, macrocells[index].s1_fuse))
 		{
@@ -6510,7 +6510,7 @@ static void config_atf22v10_power_down_mode_pins(const pal_data* pal, const jed_
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -6549,7 +6549,7 @@ static void config_82s153_pls153_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -6588,7 +6588,7 @@ static void config_ck2605_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -6622,7 +6622,7 @@ static void config_epl10p8_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -6637,8 +6637,8 @@ static void config_epl10p8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6670,7 +6670,7 @@ static void config_epl12p6_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -6685,8 +6685,8 @@ static void config_epl12p6_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6716,7 +6716,7 @@ static void config_epl14p4_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -6731,8 +6731,8 @@ static void config_epl14p4_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6760,7 +6760,7 @@ static void config_epl16p2_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -6775,8 +6775,8 @@ static void config_epl16p2_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6810,7 +6810,7 @@ static void config_epl16p8_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -6825,8 +6825,8 @@ static void config_epl16p8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6860,7 +6860,7 @@ static void config_epl16rp8_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 		output_pins[index].flags = OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -6875,8 +6875,8 @@ static void config_epl16rp8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6910,7 +6910,7 @@ static void config_epl16rp6_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 
@@ -6935,8 +6935,8 @@ static void config_epl16rp6_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -6970,7 +6970,7 @@ static void config_epl16rp4_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(memory_cells); ++index)
+	for (index = 0; index < std::size(memory_cells); ++index)
 	{
 		output_pins[index].pin = memory_cells[index].pin;
 
@@ -6994,8 +6994,8 @@ static void config_epl16rp4_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 #endif
 
@@ -7012,7 +7012,7 @@ static void config_pal10p8_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[8];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		output_pins[index].pin = index + 12;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -7027,8 +7027,8 @@ static void config_pal10p8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7044,7 +7044,7 @@ static void config_pal12p6_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[6];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		output_pins[index].pin = index + 13;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -7059,8 +7059,8 @@ static void config_pal12p6_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7076,7 +7076,7 @@ static void config_pal14p4_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[4];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		output_pins[index].pin = index + 14;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -7091,8 +7091,8 @@ static void config_pal14p4_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7108,7 +7108,7 @@ static void config_pal16p2_pins(const pal_data* pal, const jed_data* jed)
 	pin_output_config output_pins[2];
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		output_pins[index].pin = index + 15;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -7123,8 +7123,8 @@ static void config_pal16p2_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7162,7 +7162,7 @@ static void config_pal16p8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -7216,7 +7216,7 @@ static void config_pal16rp4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -7267,7 +7267,7 @@ static void config_pal16rp4_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -7304,7 +7304,7 @@ static void config_pal16rp6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(registered_pins); ++index)
+	for (index = 0; index < std::size(registered_pins); ++index)
 	{
 		output_pins[output_pin_count].pin = registered_pins[index];
 		output_pins[output_pin_count].flags = OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED;
@@ -7338,7 +7338,7 @@ static void config_pal16rp6_pins(const pal_data* pal, const jed_data* jed)
 		++output_pin_count;
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
+	set_input_pins(input_pins, std::size(input_pins));
 	set_output_pins(output_pins, output_pin_count);
 }
 
@@ -7363,7 +7363,7 @@ static void config_pal16rp8_pins(const pal_data* pal, const jed_data* jed)
 		{19, OUTPUT_REGISTERED | OUTPUT_FEEDBACK_REGISTERED}};
 	uint16_t index;
 
-	for (index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (index = 0; index < std::size(output_pins); ++index)
 	{
 		if (!jed_get_fuse(jed, 2055 - index))
 		{
@@ -7375,8 +7375,8 @@ static void config_pal16rp8_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7407,8 +7407,8 @@ static void config_pal6l16_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7437,8 +7437,8 @@ static void config_pal8l14_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7463,8 +7463,8 @@ static void config_pal12h10_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{23, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7489,8 +7489,8 @@ static void config_pal12l10_pins(const pal_data* pal, const jed_data* jed)
 		{22, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{23, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7513,8 +7513,8 @@ static void config_pal14h8_pins(const pal_data* pal, const jed_data* jed)
 		{21, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{22, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7537,8 +7537,8 @@ static void config_pal14l8_pins(const pal_data* pal, const jed_data* jed)
 		{21, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{22, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7559,8 +7559,8 @@ static void config_pal16h6_pins(const pal_data* pal, const jed_data* jed)
 		{20, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{21, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7581,8 +7581,8 @@ static void config_pal16l6_pins(const pal_data* pal, const jed_data* jed)
 		{20, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{21, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7601,8 +7601,8 @@ static void config_pal18h4_pins(const pal_data* pal, const jed_data* jed)
 		{19, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{20, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7621,8 +7621,8 @@ static void config_pal18l4_pins(const pal_data* pal, const jed_data* jed)
 		{19, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{20, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7639,8 +7639,8 @@ static void config_pal20c1_pins(const pal_data* pal, const jed_data* jed)
 		{18, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{19, OUTPUT_ACTIVEHIGH | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7657,8 +7657,8 @@ static void config_pal20l2_pins(const pal_data* pal, const jed_data* jed)
 		{18, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE},
 		{19, OUTPUT_ACTIVELOW | OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE}};
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -7673,7 +7673,7 @@ static void config_82s100_pls100_pins(const pal_data* pal, const jed_data* jed)
 	static uint16_t input_pins[] = {9, 8, 7, 6, 5, 4, 3, 2, 27, 26, 25, 24, 23, 22, 21, 20};
 	pin_output_config output_pins[8];
 
-	for (uint16_t index = 0; index < ARRAY_LENGTH(output_pins); ++index)
+	for (uint16_t index = 0; index < std::size(output_pins); ++index)
 	{
 		output_pins[index].pin = pal->pinfuserows[index].pin;
 		output_pins[index].flags = OUTPUT_COMBINATORIAL | OUTPUT_FEEDBACK_NONE;
@@ -7688,8 +7688,8 @@ static void config_82s100_pls100_pins(const pal_data* pal, const jed_data* jed)
 		}
 	}
 
-	set_input_pins(input_pins, ARRAY_LENGTH(input_pins));
-	set_output_pins(output_pins, ARRAY_LENGTH(output_pins));
+	set_input_pins(input_pins, std::size(input_pins));
+	set_output_pins(output_pins, std::size(output_pins));
 }
 
 
@@ -8195,7 +8195,7 @@ static int command_viewlist(int argc, char *argv[])
 		return print_usage();
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(paldata); ++index)
+	for (index = 0; index < std::size(paldata); ++index)
 	{
 		nameset.insert(paldata[index].name);
 	}
@@ -8265,7 +8265,7 @@ static int command_listcompatible(int argc, char *argv[])
 		}
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(paldata); ++index)
+	for (index = 0; index < std::size(paldata); ++index)
 	{
 		if (paldata[index].numfuses == jed.numfuses)
 		{
@@ -8298,7 +8298,7 @@ int main(int argc, char *argv[])
 		return print_usage();
 	}
 
-	for (index = 0; index < ARRAY_LENGTH(command_entries); ++index)
+	for (index = 0; index < std::size(command_entries); ++index)
 	{
 		if (!strcmp(argv[1], command_entries[index].command))
 			return command_entries[index].command_func(argc - 2, &argv[2]);

--- a/src/tools/regrep.cpp
+++ b/src/tools/regrep.cpp
@@ -698,7 +698,7 @@ static void output_report(std::string &dirname, std::string &tempheader, std::st
 	}
 
 	/* iterate over buckets and output them */
-	for (bucknum = 0; bucknum < ARRAY_LENGTH(bucket_output_order); bucknum++)
+	for (bucknum = 0; bucknum < std::size(bucket_output_order); bucknum++)
 	{
 		int curbucket = bucket_output_order[bucknum];
 

--- a/src/tools/srcclean.cpp
+++ b/src/tools/srcclean.cpp
@@ -51,7 +51,6 @@
 
 #include "corefile.h"
 #include "corestr.h"
-#include "osdcomm.h"
 #include "strformat.h"
 
 #include <algorithm>
@@ -597,7 +596,7 @@ void cleaner_base::output_utf8(char32_t ch)
 
 void cleaner_base::commit_character(char32_t ch)
 {
-	assert(ARRAY_LENGTH(m_buffer) > m_position);
+	assert(std::size(m_buffer) > m_position);
 	assert(1U <= m_code_length);
 	assert(6U >= m_code_length);
 
@@ -697,7 +696,7 @@ void cleaner_base::commit_character(char32_t ch)
 
 void cleaner_base::process_if_full()
 {
-	if (ARRAY_LENGTH(m_buffer) == m_position)
+	if (std::size(m_buffer) == m_position)
 	{
 		process_characters(m_buffer, m_buffer + m_position);
 		m_position = 0U;

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -1180,14 +1180,14 @@ usage:
 	printf("Supported architectures:");
 	const int colwidth = 1 + std::strlen(std::max_element(std::begin(dasm_table), std::end(dasm_table), [](const dasm_table_entry &a, const dasm_table_entry &b) { return std::strlen(a.name) < std::strlen(b.name); })->name);
 	const int columns = std::max(1, 80 / colwidth);
-	const int numrows = (ARRAY_LENGTH(dasm_table) + columns - 1) / columns;
+	const int numrows = (std::size(dasm_table) + columns - 1) / columns;
 	for(unsigned curarch = 0; curarch < numrows * columns; curarch++) {
 		const int row = curarch / columns;
 		const int col = curarch % columns;
 		const int index = col * numrows + row;
 		if(col == 0)
 			printf("\n  ");
-		printf("%-*s", colwidth, (index < ARRAY_LENGTH(dasm_table)) ? dasm_table[index].name : "");
+		printf("%-*s", colwidth, (index < std::size(dasm_table)) ? dasm_table[index].name : "");
 	}
 	printf("\n");
 	return 1;


### PR DESCRIPTION
* osdcomm.h: Move definition of EQUIVALENT_ARRAY to coretmpl.h

* sharc.cpp, gt64xxx.cpp, ym2413.cpp, gb_lcd.cpp, snes_ppu.cpp: Use STRUCT_MEMBER for save state registration

* gio/newport.cpp, megadrive/svp.cpp, nes_ctrl/bcbattle.cpp, arm7.cpp, tms9995.cpp, pckeybrd.cpp, sa1110.cpp, sa1111.cpp, jangou_blitter.cpp, vic4567.cpp: Use std::fill(_n) instead of memset

* emucore.h: Remove obsolete typedef

Note: I'm opening this pull request to see how the CI builds deal with the changes, which affect OSD stuff which has caused some unpleasant surprises with past refactorings. I don't have total confidence that all compilers support the standard equally well.