### PR TITLE
add m68000 to debuger gdbstub

### DIFF
--- a/src/osd/modules/debugger/debuggdbstub.cpp
+++ b/src/osd/modules/debugger/debuggdbstub.cpp
@@ -251,6 +251,34 @@ static const gdb_register_map gdb_register_map_m68020pmmu =
 };
 
 //-------------------------------------------------------------------------
+static const gdb_register_map gdb_register_map_m68000 =
+{
+	"m68k",
+	"org.gnu.gdb.m68k.core",
+	{
+		{ "D0", "d0", false, TYPE_INT },
+		{ "D1", "d1", false, TYPE_INT },
+		{ "D2", "d2", false, TYPE_INT },
+		{ "D3", "d3", false, TYPE_INT },
+		{ "D4", "d4", false, TYPE_INT },
+		{ "D5", "d5", false, TYPE_INT },
+		{ "D6", "d6", false, TYPE_INT },
+		{ "D7", "d7", false, TYPE_INT },
+		{ "A0", "a0", false, TYPE_INT },
+		{ "A1", "a1", false, TYPE_INT },
+		{ "A2", "a2", false, TYPE_INT },
+		{ "A3", "a3", false, TYPE_INT },
+		{ "A4", "a4", false, TYPE_INT },
+		{ "A5", "a5", false, TYPE_INT },
+		{ "A6", "fp", true,  TYPE_INT },
+		{ "A7", "sp", true,  TYPE_INT }, 
+		{ "SR", "ps", false, TYPE_INT }, // NOTE GDB named it ps, but it's actually sr
+		{ "PC", "pc", true,  TYPE_CODE_POINTER },
+		//NOTE m68-elf-gdb complains about fpcontrol register not present but 68000 doesn't have floating point so...
+	}
+};
+
+//-------------------------------------------------------------------------
 static const gdb_register_map gdb_register_map_z80 =
 {
 	"z80",
@@ -313,6 +341,7 @@ static const std::map<std::string, const gdb_register_map &> gdb_register_maps =
 	{ "r4600",      gdb_register_map_r4600 },
 	{ "ppc601",     gdb_register_map_ppc601 },
 	{ "m68020pmmu", gdb_register_map_m68020pmmu },
+	{ "m68000", 	gdb_register_map_m68000 },
 	{ "z80",        gdb_register_map_z80 },
 	{ "m6502",      gdb_register_map_m6502 },
 	{ "n2a03",      gdb_register_map_m6502 },


### PR DESCRIPTION
Simple edit to [debuggdbstub.cpp](https://github.com/mamedev/mame/compare/master...nabetse00:feat-m68000-gdbstub?expand=1#diff-f41329a6fe0bf2bb7c7cf98de36374f1f1e825a637f765277c3495c420fc2c5a) adding m68000 cpu support.

Tested with prebuilt Windows Toolchain for m68k-elf from [here](https://gnutoolchains.com/m68k-elf/).

It Works with minor issues:
-  mame window cannot be moved util gdb connects and starts the emulation.
-  m68-elf-gdb complains about fpcontrol register not present (megadrive/genesis 68000 has no floating point capabilities)
-  Sometimes gdbstub stops to respond (maybe a problem from my test rom) nevertheless wathchdog option solves this.

Command line used (mame compiled from source with standard build mame build tools for windows):
```
.\mame.exe megadriv -cart .\roms\helloworld.bin -window -resolution  640x480 -debugger gdbstub -debugger_port 6868 -debug -watchdog 10
```

Feel free to contact me for any changes.
I hope i'll be merge since it's a nice addin for megadrive/genesis retro devs, and for m68000 users in general.

