### PR TITLE
apple2gs: added floppy drive sounds (for new IWM implementation)

### DIFF
--- a/src/devices/machine/applefdintf.h
+++ b/src/devices/machine/applefdintf.h
@@ -60,26 +60,26 @@ public:
 	//   5.25
 	static void floppies_525(device_slot_interface &device);
 	template<typename T> static void add_525_13(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_525, "525", formats_525_13);
+		FLOPPY_CONNECTOR(config, floppy, floppies_525, "525", formats_525_13).enable_sound(true);
 	}
 	template<typename T> static void add_525_13_nc(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_525, nullptr, formats_525_13);
+		FLOPPY_CONNECTOR(config, floppy, floppies_525, nullptr, formats_525_13).enable_sound(true);
 	}
 
 	template<typename T> static void add_525(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_525, "525", formats_525);
+		FLOPPY_CONNECTOR(config, floppy, floppies_525, "525", formats_525).enable_sound(true);
 	}
 	template<typename T> static void add_525_nc(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_525, nullptr, formats_525);
+		FLOPPY_CONNECTOR(config, floppy, floppies_525, nullptr, formats_525).enable_sound(true);
 	}
 
 	//   3.5
 	static void floppies_35(device_slot_interface &device);
 	template<typename T> static void add_35(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_35, "35dd", formats_35);
+		FLOPPY_CONNECTOR(config, floppy, floppies_35, "35dd", formats_35).enable_sound(true);
 	}
 	template<typename T> static void add_35_nc(machine_config &config, T &floppy) {
-		FLOPPY_CONNECTOR(config, floppy, floppies_35, nullptr, formats_35);
+		FLOPPY_CONNECTOR(config, floppy, floppies_35, nullptr, formats_35).enable_sound(true);
 	}
 
 	// Sync the state when something external is going to change, like


### PR DESCRIPTION
**apple2gs** has just switched to the new IWM implementation.  This patch adds floppy drive sounds to it.