### PR TITLE
gamegear - Updated description

### DIFF
--- a/hash/gamegear.xml
+++ b/hash/gamegear.xml
@@ -8717,7 +8717,7 @@ a certain item) -->
 	</software>
 
 	<software name="suprjedi">
-		<description>Super Return of the Jedi (Euro, USA)</description>
+		<description>Super Star Wars: Return of the Jedi (Euro, USA)</description>
 		<year>1995</year>
 		<publisher>Black Pearl</publisher>
 		<info name="serial" value="T-100088, T-100088-50"/>


### PR DESCRIPTION
Rename: [suprjedi] Super Return of the Jedi (Euro, USA) -> Super Star Wars: Return of the Jedi (Euro, USA)
(information source: https://segaretro.org/Super_Star_Wars:_Return_of_the_Jedi)