### PR TITLE
cdda: Return LBA position as currently playing LBA

### DIFF
--- a/src/devices/sound/cdda.cpp
+++ b/src/devices/sound/cdda.cpp
@@ -114,7 +114,7 @@ void cdda_device::pause_audio(int pause)
 uint32_t cdda_device::get_audio_lba()
 {
 	m_stream->update();
-	return m_audio_lba - (m_audio_samples / (CD_MAX_SECTOR_DATA / 4));
+	return m_audio_lba - ((m_audio_samples + (CD_MAX_SECTOR_DATA / 4) - 1) / (CD_MAX_SECTOR_DATA / 4));
 }
 
 

--- a/src/devices/sound/cdda.cpp
+++ b/src/devices/sound/cdda.cpp
@@ -8,7 +8,7 @@
 #include "emu.h"
 #include "cdda.h"
 
-#define MAX_SECTORS ( 4 )
+#define MAX_SECTORS ( 1 )
 
 
 //-------------------------------------------------

--- a/src/devices/sound/cdda.cpp
+++ b/src/devices/sound/cdda.cpp
@@ -8,7 +8,7 @@
 #include "emu.h"
 #include "cdda.h"
 
-#define MAX_SECTORS ( 1 )
+#define MAX_SECTORS ( 4 )
 
 
 //-------------------------------------------------
@@ -114,7 +114,7 @@ void cdda_device::pause_audio(int pause)
 uint32_t cdda_device::get_audio_lba()
 {
 	m_stream->update();
-	return m_audio_lba;
+	return m_audio_lba - (m_audio_samples / (CD_MAX_SECTOR_DATA / 4));
 }
 
 


### PR DESCRIPTION
Older System 573 Dance Dance Revolution and Guitar Freaks/Drummania games used CDDA audio and relied on the CDDA position for timing and animations. Buffering additional sectors forces the LBA position to also increase an equal amount causing the CDDA position to not be what the game expects. In DDR's case, animations become really choppy. In GFDM's case, the game will just stop playing the song and end the stage early.

Fixes: https://mametesters.org/view.php?id=7856

Not mentioned on mametesters: `drmn`, `drmn2m` and probably other early Guitar Freaks games were also bugged. Instead of playing the song, it would start off playing the song, slow down immediately, and then after a second or two the song would end. This change also fixes those issues.