### PR TITLE
fmtowns: adjust PCM volume

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -2883,8 +2883,8 @@ void towns_state::towns_base(machine_config &config)
 	rf5c68_device &pcm(RF5C68(config, "pcm", 16000000 / 2));  // actual clock speed unknown
 	pcm.set_end_callback(FUNC(towns_state::towns_pcm_irq));
 	pcm.set_addrmap(0, &towns_state::pcm_mem);
-	pcm.add_route(0, "lspeaker", 3.00);
-	pcm.add_route(1, "rspeaker", 3.00);
+	pcm.add_route(0, "lspeaker", 1.00);
+	pcm.add_route(1, "rspeaker", 1.00);
 
 	CDDA(config, m_cdda);
 	m_cdda->add_route(0, "lspeaker", 1.00);

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -2887,8 +2887,8 @@ void towns_state::towns_base(machine_config &config)
 	pcm.add_route(1, "rspeaker", 1.00);
 
 	CDDA(config, m_cdda);
-	m_cdda->add_route(0, "lspeaker", 1.00);
-	m_cdda->add_route(1, "rspeaker", 1.00);
+	m_cdda->add_route(0, "lspeaker", 0.30);
+	m_cdda->add_route(1, "rspeaker", 0.30);
 	SPEAKER_SOUND(config, m_speaker);
 	m_speaker->add_route(ALL_OUTPUTS, "lspeaker", 0.50);
 	m_speaker->add_route(ALL_OUTPUTS, "rspeaker", 0.50);


### PR DESCRIPTION
The volume of the PCM sound in the FM Towns driver has always been a bit too loud, but after the rewrite of the YM3438 core it has become even more evident, with the PCM sounds completely overpowering the FM instruments in music that uses both at the same time. The output of the RF5C68 was set to 3.00 gain, which is clearly too much, so this change sets it to 1.00, which sounds a lot closer to real hardware.

To demonstrate, here are recordings of the same track (from the game Deep) in:

- current MAME (after the FM rewrite): https://www.r-09.net/mame/deep_old.flac
- current MAME after this change: https://www.r-09.net/mame/deep_new.flac
- real hardware (original FM Towns Model 2): https://www.r-09.net/mame/deep_real.flac

The real thing seems to have some kind of lowpass filter that makes everything a lot "softer", but it should be enough to compare the volume levels.