### PR TITLE
Add 'wpsize' variable to access the data size from a watchpoint

### DIFF
--- a/docs/source/debugger/watchpoint.rst
+++ b/docs/source/debugger/watchpoint.rst
@@ -26,7 +26,7 @@ wpset
 | The optional <condition> parameter lets you specify an expression that will be evaluated each time the watchpoint is hit. If the result of the expression is true (non-zero), the watchpoint will actually halt execution; otherwise, execution will continue with no notification.
 | The optional <action> parameter provides a command that is executed whenever the watchpoint is hit and the <condition> is true. Note that you may need to embed the action within braces { } in order to prevent commas and semicolons from being interpreted as applying to the wpset command itself.
 | Each watchpoint that is set is assigned an index which can be used in other watchpoint commands to reference this watchpoint.
-| In order to help <condition> expressions, two variables are available. For all watchpoints, the variable 'wpaddr' is set to the address that actually triggered the watchpoint. For write watchpoints, the variable 'wpdata' is set to the data that is being written.
+| In order to help <condition> expressions, two variables are available. The variable 'wpaddr' is set to the address that actually triggered the watchpoint, the variable 'wpdata' is set to the data that is being read or written, and the variable 'wpsize' is set to the size of the data in bytes.
 |
 | Examples:
 |

--- a/docs/source/techspecs/luareference.rst
+++ b/docs/source/techspecs/luareference.rst
@@ -2802,11 +2802,11 @@ debug:wpset(space, type, addr, len, [cond], [act])
 
     If specified, the condition must be a debugger expression that will be
     evaluated each time the breakpoint is hit.  Execution will only be stopped
-    if the expression evaluates to a non-zero value.  For all watchpoints, a
-    ``wpaddr`` variable is set to the address that triggered the watchpoint.
-    When a watchpoint is triggered by a write, a ``wpdata`` variable is set to
-    the data being written.  If the condition is not specified, it defaults to
-    always active.
+    if the expression evaluates to a non-zero value.  The variable 'wpaddr' is
+    set to the address that actually triggered the watchpoint, the variable
+    'wpdata' is set to the data that is being read or written, and the variable
+    'wpsize' is set to the size of the data in bytes.  If the condition is not
+    specified, it defaults to always active.
 debug:wpenable([wp])
     Enable the specified watchpoint, or all watchpoints for the device if no
     watchpoint number is specified.  Returns whether the specified number

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -48,6 +48,7 @@ debugger_cpu::debugger_cpu(running_machine &machine)
 	, m_rpindex(1)
 	, m_wpdata(0)
 	, m_wpaddr(0)
+	, m_wpsize(0)
 	, m_last_periodic_update_time(0)
 	, m_comments_loaded(false)
 {
@@ -57,9 +58,10 @@ debugger_cpu::debugger_cpu(running_machine &machine)
 	m_symtable = std::make_unique<symbol_table>(machine);
 	m_symtable->set_memory_modified_func([this]() { set_memory_modified(true); });
 
-	/* add "wpaddr", "wpdata" to the global symbol table */
+	/* add "wpaddr", "wpdata", "wpsize" to the global symbol table */
 	m_symtable->add("wpaddr", symbol_table::READ_ONLY, &m_wpaddr);
 	m_symtable->add("wpdata", symbol_table::READ_ONLY, &m_wpdata);
+	m_symtable->add("wpsize", symbol_table::READ_ONLY, &m_wpsize);
 
 	screen_device_enumerator screen_enumerator = screen_device_enumerator(m_machine.root_device());
 	screen_device_enumerator::iterator iter = screen_enumerator.begin();

--- a/src/emu/debug/debugcpu.h
+++ b/src/emu/debug/debugcpu.h
@@ -399,7 +399,7 @@ public:
 	void set_memory_modified(bool memory_modified) { m_memory_modified = memory_modified; }
 	void set_execution_stopped() { m_execution_state = exec_state::STOPPED; }
 	void set_execution_running() { m_execution_state = exec_state::RUNNING; }
-	void set_wpinfo(offs_t address, u64 data) { m_wpaddr = address; m_wpdata = data; }
+	void set_wpinfo(offs_t address, u64 data, offs_t size) { m_wpaddr = address; m_wpdata = data; m_wpsize = size; }
 
 	// device_debug helpers
 	// [TODO] [RH]: Look into this more later, can possibly merge these two classes
@@ -437,6 +437,7 @@ private:
 
 	u64         m_wpdata;
 	u64         m_wpaddr;
+	u64         m_wpsize;
 	std::unique_ptr<u64[]> m_tempvar;
 
 	osd_ticks_t m_last_periodic_update_time;

--- a/src/emu/debug/points.cpp
+++ b/src/emu/debug/points.cpp
@@ -335,7 +335,7 @@ void debug_watchpoint::triggered(read_or_write type, offs_t address, u64 data, u
 		address += m_space.alignment() - size - address_offset;
 
 	// stash the value that will be written or has just been read
-	debug.cpu().set_wpinfo(address, data);
+	debug.cpu().set_wpinfo(address, data, size * unit_size);
 
 	// protect against recursion
 	debug.cpu().set_within_instruction(true);


### PR DESCRIPTION
This patch adds a variable to the watchpoint engine that exposes the size (in bytes) of the read or write. Among other things, this makes it possible to use a watchpoint script to dump a log of every I/O operation.