### PR TITLE
fix #7806

### DIFF
--- a/src/emu/save.cpp
+++ b/src/emu/save.cpp
@@ -644,7 +644,7 @@ save_error ram_state::load()
 		return STATERR_ILLEGAL_REGISTRATIONS;
 
 	// get the save manager to load state
-	return m_save.write_stream(m_data);
+	return m_save.read_stream(m_data);
 }
 
 


### PR DESCRIPTION
Rewind wasn't working since https://github.com/mamedev/mame/commit/08ba9b0536178d83b89e2380e8323727055cec29
Looks like a copy-paste error, not limited to debugger.