### PR TITLE
Fix issue where game/ROM cartridges can not be inserted into a multi-pak.

### DIFF
--- a/src/devices/bus/coco/coco_multi.cpp
+++ b/src/devices/bus/coco/coco_multi.cpp
@@ -160,33 +160,27 @@ namespace
     IMPLEMENTATION
 ***************************************************************************/
 
-static void coco_cart_slot1_3(device_slot_interface &device)
-{
-	coco_cart_add_basic_devices(device);
-}
-
-static void coco_cart_slot4(device_slot_interface &device)
+static void coco_cart_slot1_4(device_slot_interface &device)
 {
 	coco_cart_add_basic_devices(device);
 	coco_cart_add_fdcs(device);
 }
 
-
 void coco_multipak_device::device_add_mconfig(machine_config &config)
 {
-	COCOCART_SLOT(config, m_slots[0], DERIVED_CLOCK(1, 1), coco_cart_slot1_3, nullptr);
+	COCOCART_SLOT(config, m_slots[0], DERIVED_CLOCK(1, 1), coco_cart_slot1_4, nullptr);
 	m_slots[0]->cart_callback().set(FUNC(coco_multipak_device::multi_slot1_cart_w));
 	m_slots[0]->nmi_callback().set(FUNC(coco_multipak_device::multi_slot1_nmi_w));
 	m_slots[0]->halt_callback().set(FUNC(coco_multipak_device::multi_slot1_halt_w));
-	COCOCART_SLOT(config, m_slots[1], DERIVED_CLOCK(1, 1), coco_cart_slot1_3, nullptr);
+	COCOCART_SLOT(config, m_slots[1], DERIVED_CLOCK(1, 1), coco_cart_slot1_4, nullptr);
 	m_slots[1]->cart_callback().set(FUNC(coco_multipak_device::multi_slot2_cart_w));
 	m_slots[1]->nmi_callback().set(FUNC(coco_multipak_device::multi_slot2_nmi_w));
 	m_slots[1]->halt_callback().set(FUNC(coco_multipak_device::multi_slot2_halt_w));
-	COCOCART_SLOT(config, m_slots[2], DERIVED_CLOCK(1, 1), coco_cart_slot1_3, nullptr);
+	COCOCART_SLOT(config, m_slots[2], DERIVED_CLOCK(1, 1), coco_cart_slot1_4, nullptr);
 	m_slots[2]->cart_callback().set(FUNC(coco_multipak_device::multi_slot3_cart_w));
 	m_slots[2]->nmi_callback().set(FUNC(coco_multipak_device::multi_slot3_nmi_w));
 	m_slots[2]->halt_callback().set(FUNC(coco_multipak_device::multi_slot3_halt_w));
-	COCOCART_SLOT(config, m_slots[3], DERIVED_CLOCK(1, 1), coco_cart_slot4, "fdcv11");
+	COCOCART_SLOT(config, m_slots[3], DERIVED_CLOCK(1, 1), coco_cart_slot1_4, "fdcv11");
 	m_slots[3]->cart_callback().set(FUNC(coco_multipak_device::multi_slot4_cart_w));
 	m_slots[3]->nmi_callback().set(FUNC(coco_multipak_device::multi_slot4_nmi_w));
 	m_slots[3]->halt_callback().set(FUNC(coco_multipak_device::multi_slot4_halt_w));

--- a/src/devices/bus/coco/cococart.cpp
+++ b/src/devices/bus/coco/cococart.cpp
@@ -694,8 +694,10 @@ void device_cococart_interface::set_line_value(cococart_slot_device::line line, 
 void coco_cart_add_basic_devices(device_slot_interface &device)
 {
 	// basic devices, on both the main slot and the Multi-Pak interface
-	device.option_add_internal("banked_16k", COCO_PAK_BANKED);
-	device.option_add_internal("pak", COCO_PAK);
+//	device.option_add_internal("banked_16k", COCO_PAK_BANKED);
+	device.option_add("banked_16k", COCO_PAK_BANKED);
+//	device.option_add_internal("pak", COCO_PAK);
+	device.option_add("pak", COCO_PAK);
 	device.option_add("ccpsg", COCO_PSG);
 	device.option_add("dcmodem", COCO_DCMODEM);
 	device.option_add("games_master", COCO_PAK_GMC);


### PR DESCRIPTION
Fix issue where with a multi-pak inserted, it is not possible to select a device of "pak" or "banked 16k" for any multi-pak slot. Also allow any cartridge to be inserted into any multi-pak slot.