### PR TITLE
apple2gs: don't segfault when floppy drive disabled

### DIFF
--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -1824,8 +1824,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(apple2gs_state::apple2_interrupt)
 			m_motoroff_time--;
 			if (m_motoroff_time == 0)
 			{
-				m_floppy[2]->get_device()->tfsel_w(0);
-				m_floppy[3]->get_device()->tfsel_w(0);
+				if (m_floppy[2]->get_device()) m_floppy[2]->get_device()->tfsel_w(0);
+				if (m_floppy[3]->get_device()) m_floppy[3]->get_device()->tfsel_w(0);
 			}
 		}
 


### PR DESCRIPTION
eg, `mame apple2gs -fdc:3 ""`