### PR TITLE
cdrom: Return index 1/start of track data instead of index 0/start of pregap data

### DIFF
--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -478,7 +478,7 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, uint32_t lbasector, 
 	// if a CHD, just read
 	if (file->chd != nullptr)
 	{
-		if (!phys) {
+		if (!phys && file->cdtoc.tracks[tracknum].pgdatasize != 0) {
 			// chdman (phys=true) relies on chdframeofs to point to index 0 instead of index 1 for extractcd.
 			// Actually playing CDs requires it to point to index 1 instead of index 0, so adjust the offset when phys=false.
 			chdsector += file->cdtoc.tracks[tracknum].pregap;
@@ -499,7 +499,7 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, uint32_t lbasector, 
 		uint64_t sourcefileoffset = file->track_info.track[tracknum].offset;
 
 		if (file->cdtoc.tracks[tracknum].pgdatasize != 0)
-			sourcefileoffset += file->cdtoc.tracks[tracknum].pregap * bytespersector;
+			chdsector += file->cdtoc.tracks[tracknum].pregap;
 
 		sourcefileoffset += chdsector * bytespersector + startoffs;
 

--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -266,6 +266,7 @@ cdrom_file *cdrom_open(const char *inputfile)
 		file->cdtoc.tracks[i].physframeofs = physofs;
 		file->cdtoc.tracks[i].chdframeofs = 0;
 		file->cdtoc.tracks[i].logframeofs += logofs;
+		file->cdtoc.tracks[i].logframes = file->cdtoc.tracks[i].frames - file->cdtoc.tracks[i].pregap;
 
 		// postgap adds to the track length
 		logofs += file->cdtoc.tracks[i].postgap;
@@ -273,7 +274,7 @@ cdrom_file *cdrom_open(const char *inputfile)
 		physofs += file->cdtoc.tracks[i].frames;
 		logofs  += file->cdtoc.tracks[i].frames;
 
-/*      printf("Track %02d is format %d subtype %d datasize %d subsize %d frames %d extraframes %d pregap %d pgmode %d presize %d postgap %d logofs %d physofs %d chdofs %d\n", i+1,
+/*      printf("Track %02d is format %d subtype %d datasize %d subsize %d frames %d extraframes %d pregap %d pgmode %d presize %d postgap %d logofs %d physofs %d chdofs %d logframes %d\n", i+1,
             file->cdtoc.tracks[i].trktype,
             file->cdtoc.tracks[i].subtype,
             file->cdtoc.tracks[i].datasize,
@@ -286,13 +287,15 @@ cdrom_file *cdrom_open(const char *inputfile)
             file->cdtoc.tracks[i].postgap,
             file->cdtoc.tracks[i].logframeofs,
             file->cdtoc.tracks[i].physframeofs,
-            file->cdtoc.tracks[i].chdframeofs);*/
+            file->cdtoc.tracks[i].chdframeofs,
+            file->cdtoc.tracks[i].logframes);*/
 	}
 
 	/* fill out dummy entries for the last track to help our search */
 	file->cdtoc.tracks[i].physframeofs = physofs;
 	file->cdtoc.tracks[i].logframeofs = logofs;
 	file->cdtoc.tracks[i].chdframeofs = 0;
+	file->cdtoc.tracks[i].logframes = 0;
 
 	return file;
 }
@@ -375,6 +378,7 @@ cdrom_file *cdrom_open(chd_file *chd)
 		file->cdtoc.tracks[i].physframeofs = physofs;
 		file->cdtoc.tracks[i].chdframeofs = chdofs;
 		file->cdtoc.tracks[i].logframeofs += logofs;
+		file->cdtoc.tracks[i].logframes = file->cdtoc.tracks[i].frames - file->cdtoc.tracks[i].pregap;
 
 		// postgap counts against the next track
 		logofs += file->cdtoc.tracks[i].postgap;
@@ -383,8 +387,8 @@ cdrom_file *cdrom_open(chd_file *chd)
 		chdofs  += file->cdtoc.tracks[i].frames;
 		chdofs  += file->cdtoc.tracks[i].extraframes;
 		logofs  += file->cdtoc.tracks[i].frames;
-/*
-      printf("Track %02d is format %d subtype %d datasize %d subsize %d frames %d extraframes %d pregap %d pgmode %d presize %d postgap %d logofs %d physofs %d chdofs %d\n", i+1,
+
+      printf("Track %02d is format %d subtype %d datasize %d subsize %d frames %d extraframes %d pregap %d pgmode %d presize %d postgap %d logofs %d physofs %d chdofs %d logframes %d\n", i+1,
             file->cdtoc.tracks[i].trktype,
             file->cdtoc.tracks[i].subtype,
             file->cdtoc.tracks[i].datasize,
@@ -397,13 +401,15 @@ cdrom_file *cdrom_open(chd_file *chd)
             file->cdtoc.tracks[i].postgap,
             file->cdtoc.tracks[i].logframeofs,
             file->cdtoc.tracks[i].physframeofs,
-            file->cdtoc.tracks[i].chdframeofs);*/
+            file->cdtoc.tracks[i].chdframeofs,
+            file->cdtoc.tracks[i].logframes);
 	}
 
 	/* fill out dummy entries for the last track to help our search */
 	file->cdtoc.tracks[i].physframeofs = physofs;
 	file->cdtoc.tracks[i].logframeofs = logofs;
 	file->cdtoc.tracks[i].chdframeofs = chdofs;
+	file->cdtoc.tracks[i].logframes = 0;
 
 	return file;
 }

--- a/src/lib/util/cdrom.cpp
+++ b/src/lib/util/cdrom.cpp
@@ -185,12 +185,6 @@ static inline uint32_t logical_to_chd_lba(cdrom_file *file, uint32_t loglba, uin
 	{
 		if (loglba < file->cdtoc.tracks[track + 1].logframeofs)
 		{
-			// is this a no-pregap-data track?  compensate for the logical offset pointing to the "wrong" sector.
-			if ((file->cdtoc.tracks[track].pgdatasize == 0) && (loglba > file->cdtoc.tracks[track].pregap))
-			{
-				loglba -= file->cdtoc.tracks[track].pregap;
-			}
-
 			// convert to physical and proceed
 			physlba = file->cdtoc.tracks[track].physframeofs + (loglba - file->cdtoc.tracks[track].logframeofs);
 			chdlba = physlba - file->cdtoc.tracks[track].physframeofs + file->cdtoc.tracks[track].chdframeofs;
@@ -258,15 +252,20 @@ cdrom_file *cdrom_open(const char *inputfile)
 	physofs = logofs = 0;
 	for (i = 0; i < file->cdtoc.numtrks; i++)
 	{
-		file->cdtoc.tracks[i].physframeofs = physofs;
-		file->cdtoc.tracks[i].chdframeofs = 0;
-		file->cdtoc.tracks[i].logframeofs = logofs;
+		file->cdtoc.tracks[i].logframeofs = 0;
 
-		// if the pregap sectors aren't in the track, add them to the track's logical length
 		if (file->cdtoc.tracks[i].pgdatasize == 0)
 		{
 			logofs += file->cdtoc.tracks[i].pregap;
 		}
+		else
+		{
+			file->cdtoc.tracks[i].logframeofs = file->cdtoc.tracks[i].pregap;
+		}
+
+		file->cdtoc.tracks[i].physframeofs = physofs;
+		file->cdtoc.tracks[i].chdframeofs = 0;
+		file->cdtoc.tracks[i].logframeofs += logofs;
 
 		// postgap adds to the track length
 		logofs += file->cdtoc.tracks[i].postgap;
@@ -354,15 +353,28 @@ cdrom_file *cdrom_open(chd_file *chd)
 	physofs = chdofs = logofs = 0;
 	for (i = 0; i < file->cdtoc.numtrks; i++)
 	{
-		file->cdtoc.tracks[i].physframeofs = physofs;
-		file->cdtoc.tracks[i].chdframeofs = chdofs;
-		file->cdtoc.tracks[i].logframeofs = logofs;
+		file->cdtoc.tracks[i].logframeofs = 0;
 
-		// if the pregap sectors aren't in the track, add them to the track's logical length
 		if (file->cdtoc.tracks[i].pgdatasize == 0)
 		{
+			// Anything that isn't cue.
+			// toc (cdrdao): Pregap data seems to be included at the end of previous track.
+			// START/PREGAP is only issued in special cases, for instance alongside ZERO commands.
+			// ZERO and SILENCE commands are supposed to generate additional data that's not included
+			// in the image directly, so the total logofs value must be offset to point to index 1.
 			logofs += file->cdtoc.tracks[i].pregap;
 		}
+		else
+		{
+			// cues: Pregap is the difference between index 0 and index 1 unless PREGAP is specified.
+			// The data is assumed to be in the bin and not generated separately, so the pregap should
+			// only be added to the current track's lba to offset it to index 1.
+			file->cdtoc.tracks[i].logframeofs = file->cdtoc.tracks[i].pregap;
+		}
+
+		file->cdtoc.tracks[i].physframeofs = physofs;
+		file->cdtoc.tracks[i].chdframeofs = chdofs;
+		file->cdtoc.tracks[i].logframeofs += logofs;
 
 		// postgap counts against the next track
 		logofs += file->cdtoc.tracks[i].postgap;
@@ -455,7 +467,7 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, uint32_t lbasector, 
 	// if this is pregap info that isn't actually in the file, just return blank data
 	if (!phys)
 	{
-		if ((file->cdtoc.tracks[tracknum].pgdatasize == 0) && (lbasector < (file->cdtoc.tracks[tracknum].logframeofs + file->cdtoc.tracks[tracknum].pregap)))
+		if ((file->cdtoc.tracks[tracknum].pgdatasize == 0) && (lbasector < file->cdtoc.tracks[tracknum].logframeofs))
 		{
 			//printf("PG missing sector: LBA %d, trklog %d\n", lbasector, file->cdtoc.tracks[tracknum].logframeofs);
 			memset(dest, 0, length);
@@ -466,7 +478,14 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, uint32_t lbasector, 
 	// if a CHD, just read
 	if (file->chd != nullptr)
 	{
+		if (!phys) {
+			// chdman (phys=true) relies on chdframeofs to point to index 0 instead of index 1 for extractcd.
+			// Actually playing CDs requires it to point to index 1 instead of index 0, so adjust the offset when phys=false.
+			chdsector += file->cdtoc.tracks[tracknum].pregap;
+		}
+
 		result = file->chd->read_bytes(uint64_t(chdsector) * uint64_t(CD_FRAME_SIZE) + startoffs, dest, length);
+
 		/* swap CDDA in the case of LE GDROMs */
 		if ((file->cdtoc.flags & CD_FLAG_GDROMLE) && (file->cdtoc.tracks[tracknum].trktype == CD_TRACK_AUDIO))
 			needswap = true;
@@ -476,12 +495,15 @@ chd_error read_partial_sector(cdrom_file *file, void *dest, uint32_t lbasector, 
 		// else read from the appropriate file
 		util::core_file &srcfile = *file->fhandle[tracknum];
 
-		uint64_t sourcefileoffset = file->track_info.track[tracknum].offset;
 		int bytespersector = file->cdtoc.tracks[tracknum].datasize + file->cdtoc.tracks[tracknum].subsize;
+		uint64_t sourcefileoffset = file->track_info.track[tracknum].offset;
+
+		if (file->cdtoc.tracks[tracknum].pgdatasize != 0)
+			sourcefileoffset += file->cdtoc.tracks[tracknum].pregap * bytespersector;
 
 		sourcefileoffset += chdsector * bytespersector + startoffs;
 
-		//  printf("Reading sector %d from track %d at offset %lld\n", chdsector, tracknum, sourcefileoffset);
+		//  printf("Reading sector %d from track %d at offset %lu\n", chdsector, tracknum, sourcefileoffset);
 
 		srcfile.seek(sourcefileoffset, SEEK_SET);
 		srcfile.read(dest, length);

--- a/src/lib/util/cdrom.h
+++ b/src/lib/util/cdrom.h
@@ -88,6 +88,7 @@ struct cdrom_track_info
 	uint32_t logframeofs; /* logical frame of actual track data - offset by pregap size if pregap not physically present */
 	uint32_t physframeofs; /* physical frame of actual track data in CHD data */
 	uint32_t chdframeofs; /* frame number this track starts at on the CHD */
+	uint32_t logframes; /* number of frames from logframeofs until end of track data */
 
 	/* fields used in multi-cue GDI */
 	uint32_t multicuearea;

--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -1837,7 +1837,6 @@ uint8_t towns_state::towns_cdrom_r(offs_t offset)
 									{
 										int track = (m_towns_cd.extra_status/2)-4;
 										addr = cdrom_get_track_start(m_cdrom->get_cdrom_file(),track);
-										addr += cdrom_get_toc(m_cdrom->get_cdrom_file())->tracks[track].pregap;
 										addr = lba_to_msf(addr + 150);
 										towns_cd_set_status(0x17,
 											(addr & 0xff0000) >> 16,(addr & 0x00ff00) >> 8,addr & 0x0000ff);

--- a/src/mame/machine/megacdcd.cpp
+++ b/src/mame/machine/megacdcd.cpp
@@ -455,7 +455,7 @@ void lc89510_temp_device::CDD_Play()
 	SCD_CURLBA = msf_to_lba(msf)-150;
 	if(segacd.cd == nullptr) // no CD is there, bail out
 		return;
-	uint32_t end_msf = segacd.toc->tracks[ cdrom_get_track(segacd.cd, SCD_CURLBA) + 1 ].logframeofs;
+	uint32_t track_length = segacd.toc->tracks[ cdrom_get_track(segacd.cd, SCD_CURLBA) ].logframes;
 	SCD_CURTRK = cdrom_get_track(segacd.cd, SCD_CURLBA)+1;
 	LC8951UpdateHeader();
 	SCD_STATUS = CDD_PLAYINGCDDA;
@@ -464,7 +464,7 @@ void lc89510_temp_device::CDD_Play()
 	printf("%d Track played\n",SCD_CURTRK);
 	CDD_MIN = to_bcd(SCD_CURTRK, false);
 	if(!(CURRENT_TRACK_IS_DATA))
-		m_cdda->start_audio(SCD_CURLBA, end_msf - SCD_CURLBA);
+		m_cdda->start_audio(SCD_CURLBA, SCD_CURLBA + track_length);
 	SET_CDC_READ
 
 

--- a/src/mame/machine/pce_cd.cpp
+++ b/src/mame/machine/pce_cd.cpp
@@ -503,7 +503,7 @@ void pce_cd_device::nec_set_audio_start_position()
 		else
 		{
 			//m_cdda_status = PCE_CD_CDDA_PLAYING;
-			m_end_frame = m_toc->tracks[ cdrom_get_track(m_cd_file, m_current_frame) + 1 ].logframeofs; //get the end of THIS track
+			m_end_frame = m_toc->tracks[ cdrom_get_track(m_cd_file, m_current_frame) ].logframeofs + m_toc->tracks[ cdrom_get_track(m_cd_file, m_current_frame) ].logframes; //get the end of THIS track
 			m_cdda->start_audio(m_current_frame, m_end_frame - m_current_frame);
 			m_end_mark = 0;
 			m_cdda_play_mode = 3;

--- a/src/mame/machine/pce_cd.cpp
+++ b/src/mame/machine/pce_cd.cpp
@@ -700,11 +700,6 @@ void pce_cd_device::nec_get_dir_info()
 			{
 				track = std::max(bcd_2_dec(m_command_buffer[2]), 1U);
 				frame = toc->tracks[track-1].logframeofs;
-				// PCE wants the start sector for data tracks to *not* include the pregap
-				if (toc->tracks[track-1].trktype != CD_TRACK_AUDIO)
-				{
-					frame += toc->tracks[track-1].pregap;
-				}
 				m_data_buffer[3] = (toc->tracks[track-1].trktype == CD_TRACK_AUDIO) ? 0x00 : 0x04;
 			}
 			logerror("track = %d, frame = %d\n", track, frame);

--- a/src/mame/machine/psxcd.cpp
+++ b/src/mame/machine/psxcd.cpp
@@ -1149,7 +1149,8 @@ void psxcd_device::start_play()
 
 	if (mode&mode_autopause)
 	{
-		autopause_sector = cdrom_get_track_start(m_cdrom_handle, track) + cdrom_get_toc(m_cdrom_handle)->tracks[track].frames;
+		auto toc = cdrom_get_toc(m_cdrom_handle);
+		autopause_sector = cdrom_get_track_start(m_cdrom_handle, track) + toc->tracks[track].frames - toc->tracks[track].pregap;
 //      printf("pos=%d auto=%d\n",pos,autopause_sector);
 	}
 

--- a/src/mame/machine/psxcd.cpp
+++ b/src/mame/machine/psxcd.cpp
@@ -1150,7 +1150,7 @@ void psxcd_device::start_play()
 	if (mode&mode_autopause)
 	{
 		auto toc = cdrom_get_toc(m_cdrom_handle);
-		autopause_sector = cdrom_get_track_start(m_cdrom_handle, track) + toc->tracks[track].frames - toc->tracks[track].pregap;
+		autopause_sector = cdrom_get_track_start(m_cdrom_handle, track) + toc->tracks[track].logframes;
 //      printf("pos=%d auto=%d\n",pos,autopause_sector);
 	}
 


### PR DESCRIPTION
Stumbled on a related bug with the way pregap is added to the TOC while trying to fix CDDA audio issues in Firebeat and System 573.

MAME vs Duckstation (both using the same CHD):
![image](https://user-images.githubusercontent.com/63495610/111903023-82847600-8a83-11eb-8c0e-86af3302791b.png)

Results on real PS1:
![image](https://user-images.githubusercontent.com/63495610/111903036-8e703800-8a83-11eb-83ec-cc8e2c7d2f90.png)

Results with this patch applied:
![image](https://user-images.githubusercontent.com/63495610/111903432-a21c9e00-8a85-11eb-8544-07cc69ad96d4.png)

I came up with a simple test program that uses `CdGetToc` and `CdPosToInt` to display the reported MSF and LBA values. Although this change will affect everything that uses cdrom.cpp, I chose the PS1 emulator for testing because I am able to reproduce the bug I'm hunting down using the PS1's CD player functionality in the BIOS.

Testing method for MAME and Duckstation:
1) Load test program cdtester.chd
2) Change disc using file menu from cdtester.chd to a different CHD, in this case a custom CHD named 845jba02.chd
3) Press button which calls `CdGetToc` and `CdPosToInt` on the currently inserted CD and display the results

Same for real PS1 except the CD is switched out for step 2.

845jba02.chd is a CHD made from a CloneCD dump converted to bin/toc. This is what the actual track listing looks like according to the CHD:
```
chdman - MAME Compressed Hunks of Data (CHD) manager 0.229 (unknown)
Input file:   /home/otobear/mame/roms/ddrj/845jba02.chd
File Version: 5
Logical size: 352,727,424 bytes
Hunk Size:    19,584 bytes
Total Hunks:  18,011
Unit Size:    2,448 bytes
Total Units:  144,088
Compression:  cdlz (CD LZMA), cdzl (CD Deflate), cdfl (CD FLAC)
CHD size:     217,136,744 bytes
Ratio:        61.6%
SHA1:         b4dec83e74060f794bff090f6f464cb1d5f51191
Data SHA1:    62d897bb202f16d7ec413845310732b81e1c04b4
Metadata:     Tag='CHT2'  Index=0  Length=93 bytes
              TRACK:1 TYPE:MODE1_RAW SUBTYPE:RW_RAW FRAMES:8661 PREGAP:0 P
Metadata:     Tag='CHT2'  Index=1  Length=91 bytes
              TRACK:2 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:2700 PREGAP:150 PGT
Metadata:     Tag='CHT2'  Index=2  Length=89 bytes
              TRACK:3 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1287 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=3  Length=89 bytes
              TRACK:4 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:4621 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=4  Length=89 bytes
              TRACK:5 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:5661 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=5  Length=89 bytes
              TRACK:6 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:3762 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=6  Length=89 bytes
              TRACK:7 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=7  Length=89 bytes
              TRACK:8 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1802 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=8  Length=89 bytes
              TRACK:9 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTYP
Metadata:     Tag='CHT2'  Index=9  Length=90 bytes
              TRACK:10 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1803 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=10  Length=90 bytes
              TRACK:11 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1805 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=11  Length=90 bytes
              TRACK:12 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=12  Length=90 bytes
              TRACK:13 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=13  Length=90 bytes
              TRACK:14 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1803 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=14  Length=90 bytes
              TRACK:15 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1800 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=15  Length=90 bytes
              TRACK:16 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=16  Length=90 bytes
              TRACK:17 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:1801 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=17  Length=90 bytes
              TRACK:18 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7081 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=18  Length=90 bytes
              TRACK:19 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7351 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=19  Length=90 bytes
              TRACK:20 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7836 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=20  Length=90 bytes
              TRACK:21 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7867 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=21  Length=90 bytes
              TRACK:22 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7075 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=22  Length=90 bytes
              TRACK:23 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7034 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=23  Length=90 bytes
              TRACK:24 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7873 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=24  Length=90 bytes
              TRACK:25 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7860 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=25  Length=90 bytes
              TRACK:26 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:6901 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=26  Length=90 bytes
              TRACK:27 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:6806 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=27  Length=90 bytes
              TRACK:28 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:7754 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=28  Length=90 bytes
              TRACK:29 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:6374 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=29  Length=90 bytes
              TRACK:30 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:3709 PREGAP:0 PGTY
Metadata:     Tag='CHT2'  Index=30  Length=90 bytes
              TRACK:31 TYPE:AUDIO SUBTYPE:RW_RAW FRAMES:5995 PREGAP:0 PGTY
```