### PR TITLE
coco: Set proper tri-state value for keyboard PIA port B

### DIFF
--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -473,6 +473,7 @@ void coco12_state::coco(machine_config &config)
 	pia6821_device &pia0(PIA6821(config, PIA0_TAG, 0));
 	pia0.writepa_handler().set(FUNC(coco_state::pia0_pa_w));
 	pia0.writepb_handler().set(FUNC(coco_state::pia0_pb_w));
+	pia0.tspb_handler().set_constant(0xff);
 	pia0.ca2_handler().set(FUNC(coco_state::pia0_ca2_w));
 	pia0.cb2_handler().set(FUNC(coco_state::pia0_cb2_w));
 	pia0.irqa_handler().set(m_irqs, FUNC(input_merger_device::in_w<0>));


### PR DESCRIPTION
This fixes Mame Testers bug #07701.