### PR TITLE
-i2cmem: Added Xicor X24C01 support. [Ryan Holtz]

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -2555,7 +2555,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 			<feature name="ic3" value="PC74HC125P"/>
 			<feature name="ic4" value="PC74HC74P"/>
 			<feature name="ic5" value="AT24C01,X24C01P"/>
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="mpr-14860-t.ic1" size="524288" crc="4fef37c8" sha1="eb4aca22f8b5837a0a0b10491c46714948b09844"/>
 			</dataarea>
@@ -3390,7 +3390,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<feature name="pcb" value="171-6584A"/>
 			<feature name="ic1" value="MPR-16211-SM"/>
 			<feature name="ic2" value="74HC32N"/>
@@ -3409,7 +3409,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<year>1994</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<feature name="pcb" value="171-6584A"/>
 			<feature name="ic1" value="MPR-15754 W41"/>
 			<feature name="ic2" value="PC74HC32P"/>
@@ -4964,7 +4964,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<year>1994</year>
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<feature name="pcb" value="171-6584A"/>
 			<feature name="ic1" value="MPR-17776-F"/>
 			<feature name="ic2" value="HD74HC32P"/>
@@ -7622,7 +7622,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<feature name="pcb" value="171-6111A"/>
 			<feature name="ic1" value="MPR-14676 W30"/>
 			<feature name="ic2" value="PC74HC32P"/>
@@ -9183,7 +9183,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<year>1992</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<feature name="pcb" value="171-6111A"/>
 			<feature name="ic1" value="MPR-14556-H"/>
 			<feature name="ic2" value="HD74HC32P"/>
@@ -16513,7 +16513,7 @@ but dumps still have to be confirmed.
 		<info name="release" value="19940527"/>
 		<info name="alt_title" value="グレイテスト ヘビーウェイツ"/>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="greatest heavyweights (jpn).bin" size="2097152" crc="7ef8b162" sha1="1d5fe812df75e0dc1ff379c563058e078b839a09"/>
 			</dataarea>
@@ -16786,7 +16786,7 @@ but dumps still have to be confirmed.
 		<info name="release" value="19920710"/>
 		<info name="alt_title" value="炎の闘球児 ドッジ弾平"/>
 		<part name="cart" interface="megadriv_cart">
-			<feature name="slot" value="rom_eeprom"/>
+			<feature name="slot" value="rom_eeprom_mode1"/>
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="mpr-14856.bin" size="524288" crc="630f07c6" sha1="ebdf20fd8aaeb3c7ec97302089b3330265118cf0"/>
 			</dataarea>

--- a/src/devices/bus/megadrive/eeprom.cpp
+++ b/src/devices/bus/megadrive/eeprom.cpp
@@ -3,35 +3,36 @@
 /***********************************************************************************************************
 
 
- MegaDrive / Genesis cart+EEPROM emulation
+ MegaDrive / Genesis cart + I2C EEPROM emulation
 
 
- TODO: proper EEPROM emulation, still not worked on (just hooked up the I2C device)
+ TODO: EEPROM hookup verification in most games.
 
 
- i2c games mapping table:
+ I2C games mapping table:
 
- game name                         |   SDA_IN   |  SDA_OUT   |     SCL    |  SIZE_MASK     | PAGE_MASK |
- ----------------------------------|------------|------------|------------|----------------|-----------|
- NBA Jam                           | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x00ff (24C02) |   0x03    | xx
- NBA Jam TE                        | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    | xx
- NBA Jam TE (32x)                  | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    |
- NFL Quarterback Club              | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    | xx
- NFL Quarterback Club 96           | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x07ff (24C16) |   0x07    | xx
- College Slam                      | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x1fff (24C64) |   0x07    | xx
- Frank Thomas Big Hurt Baseball    | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x1fff (24C64) |   0x07    | xx
- NHLPA Hockey 93                   | 0x200001-7 | 0x200001-7 | 0x200001-6 | 0x007f (24C01) |   0x03    | xx
- Rings of Power                    | 0x200001-7 | 0x200001-7 | 0x200001-6 | 0x007f (24C01) |   0x03    | xx
- Evander Holyfield's Boxing        | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    | xx
- Greatest Heavyweights of the Ring | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    | xx
- Wonder Boy V                      | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    | xx
- Sports Talk Baseball              | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    | xx
- Megaman - the Wily Wars           | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    | xx **
- Micro Machines 2                  | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x03ff (24C08) |   0x0f    |
- Micro Machines Military           | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x03ff (24C08) |   0x0f    |
- Micro Machines 96                 | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x07ff (24C16) |   0x0f    |
- Brian Lara Cricket 96             | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x1fff (24C64) |   0x??*   |
- ----------------------------------|------------|------------|------------|----------------|-----------|
+ Game mame                         |   SDA_IN   |  SDA_OUT   |     SCL    |  SIZE_MASK     | PAGE_MASK | WORKS |
+ ----------------------------------|------------|------------|------------|----------------|-----------|-------|
+ NBA Jam                           | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x00ff (24C02) |   0x03    |       | xx
+ NBA Jam TE                        | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    |       | xx
+ NBA Jam TE (32x)                  | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    |       |
+ NFL Quarterback Club              | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x00ff (24C02) |   0x03    |       | xx
+ NFL Quarterback Club 96           | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x07ff (24C16) |   0x07    |       | xx
+ College Slam                      | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x1fff (24C64) |   0x07    |       | xx
+ Frank Thomas Big Hurt Baseball    | 0x200001-0 | 0x200001-0 | 0x200000-0 | 0x1fff (24C64) |   0x07    |       | xx
+ NHLPA Hockey 93                   | 0x200001-7 | 0x200001-7 | 0x200001-6 | 0x007f (24C01) |   0x03    |       | xx
+ Rings of Power                    | 0x200001-7 | 0x200001-7 | 0x200001-6 | 0x007f (24C01) |   0x03    |       | xx
+ Honoo no Toukyuuji - Dodge Danpei | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Unk. | xx
+ Evander Holyfield's Boxing        | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Unk. | xx
+ Greatest Heavyweights of the Ring | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Unk. | xx
+ Wonder Boy V                      | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Yes  | xx
+ Sports Talk Baseball              | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Unk. | xx
+ Megaman - The Wily Wars           | 0x200001-0 | 0x200001-0 | 0x200001-1 | 0x007f (24C01) |   0x03    |  Yes  | xx **
+ Micro Machines 2                  | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x03ff (24C08) |   0x0f    |       |
+ Micro Machines Military           | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x03ff (24C08) |   0x0f    |       |
+ Micro Machines 96                 | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x07ff (24C16) |   0x0f    |       |
+ Brian Lara Cricket 96             | 0x380001-7 | 0x300000-0*| 0x300000-1*| 0x1fff (24C64) |   0x??*   |       |
+ ----------------------------------|------------|------------|------------|----------------|-----------|-------|
 
  * Notes: check these
  ** original Rockman Mega World (J) set uses normal backup RAM
@@ -58,6 +59,7 @@ DEFINE_DEVICE_TYPE(MD_EEPROM_NFLQB,    md_eeprom_nflqb_device,    "md_eeprom_nfl
 DEFINE_DEVICE_TYPE(MD_EEPROM_CSLAM,    md_eeprom_cslam_device,    "md_eeprom_cslam",    "MD College Slam")
 DEFINE_DEVICE_TYPE(MD_EEPROM_NHLPA,    md_eeprom_nhlpa_device,    "md_eeprom_nhlpa",    "MD NHLPA 93")
 DEFINE_DEVICE_TYPE(MD_EEPROM_BLARA,    md_eeprom_blara_device,    "md_eeprom_blara",    "MD Brian Lara")
+DEFINE_DEVICE_TYPE(MD_EEPROM_MODE1,    md_eeprom_mode1_device,    "md_eeprom_mode1",    "MD Serial EEPROM Mode 1")
 
 
 md_std_eeprom_device::md_std_eeprom_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
@@ -102,6 +104,11 @@ md_eeprom_blara_device::md_eeprom_blara_device(const machine_config &mconfig, co
 {
 }
 
+md_eeprom_mode1_device::md_eeprom_mode1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: md_std_eeprom_device(mconfig, MD_EEPROM_MODE1, tag, owner, clock)
+{
+}
+
 
 //-------------------------------------------------
 //  device_add_mconfig - add device configuration
@@ -142,6 +149,11 @@ void md_eeprom_blara_device::device_add_mconfig(machine_config &config)
 	I2C_24C64(config, m_i2cmem);
 }
 
+void md_eeprom_mode1_device::device_add_mconfig(machine_config &config)
+{
+	I2C_X24C01(config, m_i2cmem);
+}
+
 void md_std_eeprom_device::device_start()
 {
 	save_item(NAME(m_i2c_mem));
@@ -166,7 +178,8 @@ uint16_t md_std_eeprom_device::read(offs_t offset)
 {
 	if (offset == 0x200000/2)
 	{
-		return m_i2cmem->read_sda();
+		const uint8_t data = m_i2cmem->read_sda();
+		return ((uint16_t)data << 8) | data;
 	}
 	if (offset < 0x400000/2)
 		return m_rom[MD_ADDR(offset)];

--- a/src/devices/bus/megadrive/eeprom.h
+++ b/src/devices/bus/megadrive/eeprom.h
@@ -140,6 +140,19 @@ protected:
 	virtual void write(offs_t offset, uint16_t data, uint16_t mem_mask = ~0) override;
 };
 
+// ======================> md_eeprom_mode1_device
+
+class md_eeprom_mode1_device : public md_std_eeprom_device
+{
+public:
+	// construction/destruction
+	md_eeprom_mode1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+};
+
 
 // device type definition
 DECLARE_DEVICE_TYPE(MD_STD_EEPROM,      md_std_eeprom_device)
@@ -149,6 +162,7 @@ DECLARE_DEVICE_TYPE(MD_EEPROM_CSLAM,    md_eeprom_cslam_device)
 DECLARE_DEVICE_TYPE(MD_EEPROM_NFLQB,    md_eeprom_nflqb_device)
 DECLARE_DEVICE_TYPE(MD_EEPROM_NHLPA,    md_eeprom_nhlpa_device)
 DECLARE_DEVICE_TYPE(MD_EEPROM_BLARA,    md_eeprom_blara_device)
+DECLARE_DEVICE_TYPE(MD_EEPROM_MODE1,    md_eeprom_mode1_device)
 
 
 

--- a/src/devices/bus/megadrive/md_carts.cpp
+++ b/src/devices/bus/megadrive/md_carts.cpp
@@ -32,7 +32,7 @@ void md_cart(device_slot_interface &device)
 	device.option_add_internal("rom_sf001",  MD_ROM_BEGGARP);
 	device.option_add_internal("rom_sf002",  MD_ROM_WUKONG);
 	device.option_add_internal("rom_sf004",  MD_ROM_STARODYS);
-// EEPROM handling (not supported fully yet)
+// EEPROM handling (most not supported fully yet)
 	device.option_add_internal("rom_eeprom",  MD_STD_EEPROM);
 	device.option_add_internal("rom_nbajam",  MD_EEPROM_NBAJAM);
 	device.option_add_internal("rom_nbajamte",  MD_EEPROM_NBAJAMTE);
@@ -40,6 +40,7 @@ void md_cart(device_slot_interface &device)
 	device.option_add_internal("rom_cslam",  MD_EEPROM_CSLAM);
 	device.option_add_internal("rom_nhlpa",  MD_EEPROM_NHLPA);
 	device.option_add_internal("rom_blara",  MD_EEPROM_BLARA);
+	device.option_add_internal("rom_eeprom_mode1",  MD_EEPROM_MODE1);
 // J-Cart controller (Sampras Tennis)
 	device.option_add_internal("rom_jcart",  MD_JCART);
 // J-Cart controller + EEPROM handling (not supported fully yet)

--- a/src/devices/machine/i2cmem.h
+++ b/src/devices/machine/i2cmem.h
@@ -60,6 +60,9 @@ protected:
 	virtual void nvram_read( emu_file &file ) override;
 	virtual void nvram_write( emu_file &file ) override;
 
+	// configuration helpers
+	void set_devsel_address_low(bool devsel_address_low) { m_devsel_address_low = devsel_address_low; }
+
 	// internal helpers
 	int address_mask();
 	int select_device();
@@ -90,6 +93,7 @@ protected:
 	std::vector<uint8_t> m_page;
 	int m_page_offset;
 	int m_page_written_size;
+	bool m_devsel_address_low;
 };
 
 #define DECLARE_I2C_DEVICE(name) \
@@ -99,6 +103,7 @@ protected:
 		i2c_##name##_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0); \
 	};
 
+DECLARE_I2C_DEVICE(x24c01);
 DECLARE_I2C_DEVICE(24c01);
 DECLARE_I2C_DEVICE(pcf8570);
 DECLARE_I2C_DEVICE(pcd8572);
@@ -113,17 +118,18 @@ DECLARE_I2C_DEVICE(24c64);
 DECLARE_I2C_DEVICE(24c512);
 
 // device type definition
-DECLARE_DEVICE_TYPE(I2C_24C01,  i2c_24c01_device)
+DECLARE_DEVICE_TYPE(I2C_X24C01,  i2c_x24c01_device)
+DECLARE_DEVICE_TYPE(I2C_24C01,   i2c_24c01_device)
 DECLARE_DEVICE_TYPE(I2C_PCF8570, i2c_pcf8570_device)
 DECLARE_DEVICE_TYPE(I2C_PCD8572, i2c_pcd8572_device)
 DECLARE_DEVICE_TYPE(I2C_PCF8582, i2c_pcf8582_device)
-DECLARE_DEVICE_TYPE(I2C_24C02,  i2c_24c02_device)
+DECLARE_DEVICE_TYPE(I2C_24C02,   i2c_24c02_device)
 DECLARE_DEVICE_TYPE(I2C_M24C02,  i2c_m24c02_device)
-DECLARE_DEVICE_TYPE(I2C_24C04,  i2c_24c04_device)
-DECLARE_DEVICE_TYPE(I2C_X2404P, i2c_x2404p_device)
-DECLARE_DEVICE_TYPE(I2C_24C08,  i2c_24c08_device)
-DECLARE_DEVICE_TYPE(I2C_24C16,  i2c_24c16_device)
-DECLARE_DEVICE_TYPE(I2C_24C64,  i2c_24c64_device)
-DECLARE_DEVICE_TYPE(I2C_24C512, i2c_24c512_device)
+DECLARE_DEVICE_TYPE(I2C_24C04,   i2c_24c04_device)
+DECLARE_DEVICE_TYPE(I2C_X2404P,  i2c_x2404p_device)
+DECLARE_DEVICE_TYPE(I2C_24C08,   i2c_24c08_device)
+DECLARE_DEVICE_TYPE(I2C_24C16,   i2c_24c16_device)
+DECLARE_DEVICE_TYPE(I2C_24C64,   i2c_24c64_device)
+DECLARE_DEVICE_TYPE(I2C_24C512,  i2c_24c512_device)
 
 #endif // MAME_MACHINE_I2CMEM_H


### PR DESCRIPTION
Note, not for inclusion in merge: It would be appreciated if someone could take the time to verify that Dodge Danpei, Evander Holyfield's Boxing, Greatest Heavyweights of the Ring, and Sports Talk Baseball are fixed, and update the table in eeprom.cpp accordingly. I cannot stand sports games, and the gameplay is opaque enough that it's not immediately obvious at what point a given game can be saved.