### PR TITLE
apple2gs: configure scc channel speeds

### DIFF
--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -4925,6 +4925,7 @@ void apple2gs_state::apple2gs(machine_config &config)
 
 	/* serial */
 	SCC85C30(config, m_scc, A2GS_14M/2);
+	m_scc->configure_channels(3'686'400, 3'686'400, 3'686'400, 3'686'400);
 	m_scc->out_int_callback().set(FUNC(apple2gs_state::scc_irq_w));
 	m_scc->out_txda_callback().set("printer", FUNC(rs232_port_device::write_txd));
 	m_scc->out_txdb_callback().set("modem", FUNC(rs232_port_device::write_txd));


### PR DESCRIPTION
The z8530 baud rate generator works a whole lot better when the speed is configured.

[IIgs tech note #30](http://www.1000bit.it/support/manuali/apple/technotes/iigs/tn.iigs.030.html)

> The SCC's Receive/Transmit Clock (/RTxC) inputs for both ports are driven by a single crystal oscillator circuit. This is accomplished by connecting a 3.6864 MHz crystal between the /RTxC and Synchronization (/SYNC) input of port A. Port B's /RTxC pin is connected to port A's /SYNC pin to drive port B's clocks from port A's oscillator circuit. Because of this single circuit, Write Register 11 (WR11) bit 7 must be set to 1 for SCC port A and must be set to 0 for SCC port B. The SCC itself is clocked at 3.58 MHz by the Apple IIgs' Color-Reference clock (CREF) at the SCC's PCLK clock input. The maximum asynchronous transmission rate supported by the SCC is 57,600 bits per second (bps) in X16 clock mode (WR4=01xxxxxx).