### PR TITLE
bus/coco/fdc: call super device start in subclass

### DIFF
--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -278,6 +278,8 @@ void coco_fdc_device_base::device_start()
 
 	save_item(NAME(m_cache_controler));
 	save_item(NAME(m_cache_pointer));
+
+	coco_family_fdc_device_base::device_start();
 }
 
 

--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -272,14 +272,14 @@ coco_fdc_device_base::coco_fdc_device_base(const machine_config &mconfig, device
 
 void coco_fdc_device_base::device_start()
 {
+	coco_family_fdc_device_base::device_start();
+	
 	install_readwrite_handler(0xFF74, 0xFF76,
 			read8sm_delegate(*this, FUNC(coco_fdc_device_base::ff74_read)),
 			write8sm_delegate(*this, FUNC(coco_fdc_device_base::ff74_write)));
 
 	save_item(NAME(m_cache_controler));
 	save_item(NAME(m_cache_pointer));
-
-	coco_family_fdc_device_base::device_start();
 }
 
 


### PR DESCRIPTION
Add a call to super in bus/coco/fdc: coco_fdc_device_base::device_start()