### PR TITLE
Change audio_latency valid range from 1-5 to 0-5

### DIFF
--- a/src/osd/modules/lib/osdobj_common.cpp
+++ b/src/osd/modules/lib/osdobj_common.cpp
@@ -129,7 +129,7 @@ const options_entry osd_options::s_option_entries[] =
 
 	{ nullptr,                                nullptr,          OPTION_HEADER,    "OSD SOUND OPTIONS" },
 	{ OSDOPTION_SOUND,                        OSDOPTVAL_AUTO,   OPTION_STRING,    "sound output method: " },
-	{ OSDOPTION_AUDIO_LATENCY "(1-5)",        "2",              OPTION_INTEGER,   "set audio latency (increase to reduce glitches, decrease for responsiveness)" },
+	{ OSDOPTION_AUDIO_LATENCY "(0-5)",        "2",              OPTION_INTEGER,   "set audio latency (increase to reduce glitches, decrease for responsiveness)" },
 
 #ifndef NO_USE_PORTAUDIO
 	{ nullptr,                                nullptr,          OPTION_HEADER,    "PORTAUDIO OPTIONS" },

--- a/src/osd/modules/sound/direct_sound.cpp
+++ b/src/osd/modules/sound/direct_sound.cpp
@@ -428,7 +428,8 @@ HRESULT sound_direct_sound::dsound_init()
 		stream_format.nAvgBytesPerSec   = stream_format.nSamplesPerSec * stream_format.nBlockAlign;
 
 		// compute the buffer size based on the output sample rate
-		DWORD stream_buffer_size = stream_format.nSamplesPerSec * stream_format.nBlockAlign * m_audio_latency / 10;
+		int audio_latency = std::max(m_audio_latency, 1);
+		DWORD stream_buffer_size = stream_format.nSamplesPerSec * stream_format.nBlockAlign * audio_latency / 10;
 		stream_buffer_size = std::max(DWORD(1024), (stream_buffer_size / 1024) * 1024);
 
 		LOG(("stream_buffer_size = %u\n", (unsigned)stream_buffer_size));

--- a/src/osd/modules/sound/xaudio2_sound.cpp
+++ b/src/osd/modules/sound/xaudio2_sound.cpp
@@ -479,7 +479,8 @@ void sound_xaudio2::create_buffers(const WAVEFORMATEX &format)
 {
 	// Compute the buffer size
 	// buffer size is equal to the bytes we need to hold in memory per X tenths of a second where X is audio_latency
-	float audio_latency_in_seconds = m_audio_latency / 10.0f;
+	int audio_latency = std::max(m_audio_latency, 1);
+	float audio_latency_in_seconds = audio_latency / 10.0f;
 	uint32_t format_bytes_per_second = format.nSamplesPerSec * format.nBlockAlign;
 	uint32_t total_buffer_size = format_bytes_per_second * audio_latency_in_seconds * RESAMPLE_TOLERANCE;
 


### PR DESCRIPTION
Currently with MAME 0.230, if `audio_latency` of 0 is specified then you will get the error `Out-of-range integer value for audio_latency: "0" (must be between 1 and 5, inclusive); reverting to 2` after https://github.com/mamedev/mame/commit/d578fa07444ef8744e9c2c569b49ab1ca0ed11a3 which re-enabled validations.

pasound uses `audio_latency` = 0 to mean "very-low-latency" mode: https://github.com/mamedev/mame/blob/30371b5717b3aa88da7f3d19235821f7eca0d429/src/osd/modules/sound/pa_sound.cpp#L264-L273
CoreAudio and SDL already clamp to 1-5. DirectSound and XAudio2 don't do anything but their calculations would probably break if set to 0 so I've added code to clamp those to 1 as well.