### PR TITLE
Use llvm-ar for CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,6 +18,7 @@ jobs:
       env:
         MINGW64: "/mingw64"
         ARCHOPTS: "-fuse-ld=lld"
+        OVERRIDE_AR: "llvm-ar"
         TOOLS: 1
       run: make -j2
     - name: Validate


### PR DESCRIPTION
As an example, here's the improvement for ``liboptional.a``

Standard ar:

```
Tue, 30 Mar 2021 15:52:58 GMT Archiving liboptional.a...
Tue, 30 Mar 2021 15:54:22 GMT Compiling src/mame/mame.cpp...
```
With llvm-ar:

```
Tue, 30 Mar 2021 15:54:15 GMT Archiving liboptional.a...
Tue, 30 Mar 2021 15:54:19 GMT Compiling src/mame/mame.cpp...
```