### PR TITLE
fmtowns: fix off-by-1 calculation in CDDA length

### DIFF
--- a/src/mame/drivers/fmtowns.cpp
+++ b/src/mame/drivers/fmtowns.cpp
@@ -1614,7 +1614,7 @@ void towns_state::towns_cdrom_play_cdda(cdrom_image_device* device)
 	lba2 += m_towns_cd.parameter[3] << 8;
 	lba2 += m_towns_cd.parameter[2];
 	m_towns_cd.cdda_current = msf_to_lbafm(lba1);
-	m_towns_cd.cdda_length = msf_to_lbafm(lba2) - m_towns_cd.cdda_current;
+	m_towns_cd.cdda_length = msf_to_lbafm(lba2) - m_towns_cd.cdda_current + 1;
 
 	m_cdda->set_cdrom(device->get_cdrom_file());
 	m_cdda->start_audio(m_towns_cd.cdda_current,m_towns_cd.cdda_length);


### PR DESCRIPTION
The changes in commit 2caa566f22606682ee432c410d40376335e12b02 have exposed an existing miscalculation that is currently causing a few Data West games (psydet3/4, shamhat, maybe others) to hang at the initial logo.

Basically what's happening is: the "play CDDA" CD controller command uses the start point and end point as parameters, but MAME's CDDA device needs the total amount of sectors to play, so the "end LBA - start LBA" calculation makes it stop one sector before it should. This change fixes it by adding 1 to the total.