### PR TITLE
Fix vs2019_clang build

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -490,14 +490,12 @@ language "C++"
 
 flags {
 	"StaticRuntime",
+	"Cpp17",
 }
 
 configuration { "vs20*" }
 	buildoptions {
 		"/bigobj",
-	}
-	buildoptions_cpp {
-		"/std:c++17",
 	}
 	flags {
 		"ExtraWarnings",
@@ -1439,6 +1437,7 @@ if _OPTIONS["vs"]=="clangcl" then
 			"-Wno-unused-local-typedef",
 			"-Wno-unused-private-field",
 			"-Wno-unused-variable",
+			"-Wno-microsoft-cast",
 		}
 end
 


### PR DESCRIPTION
A `vs2019_clang` build is quite a bit faster than `vs2019`, so it has value too. From my observations, the speed of `vs2019_clang` is the same as of a GCC build, while its size is _more than twice_ smaller.