### PR TITLE
fmtowns_cd.xml: 14 new dumps, 16 replacements, 4 missing floppies added

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -51,7 +51,6 @@ ByHAND V2.1                                                   Fujitsu           
 ByHAND V3.1                                                   Fujitsu                           1994/3     CD
 California X Party: Joshi Daisei Himitsu Club                 HOP                               1994/9     SET(CD+FD)
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
-Car Marty Exciting CD                                         Fujitsu Ten                       1994/3     CD×2
 Car Marty Exciting CD                                         Fujitsu Ten                       1994/6     CD×2
 Castles 2: Bretagne Touitsu Senki                             Victor Entertainment              1993/10    SET(CD+FD)
 CB Trainer Data Library V1.1 L10                              Fujitsu                           1993/5     CD
@@ -215,7 +214,6 @@ Heisei 6-nendo-ban Keizai Hakusho                             Fujitsu           
 Hello Kitty: Asobi no Omochabako                              Fujitsu Parex                     1995/9     CD
 High C Compiler Multimedia Kaihatsu Kit V3.2                  Fujitsu                           ?          CD
 High School War                                               ISC                               1994/9     CD
-* Hiouden 2                                                   Nihon Telenet                     1994/3     SET(CD+FD)
 HomeSTUDIO V1.1                                               Fujitsu                           1992/12    SET(CD+FD)
 Hot de Art na Barcelona                                       Media Art                         1991/9     CD
 Hyoutan Shima Kouryaku-ki                                     Nihon Dennou Koubou               1994/?     ?
@@ -244,13 +242,12 @@ Hyper Drill Series Shougakkou Shakai 6-nen                    Uchida Youkou     
 Hyper DX                                                      Datt Japan                        1989/10    SET(CD+FD)
 Hyper Ikuji Guide: Babubabu Tenshi                            Dennou Shoukai                    1996/4     CD
 Hyper Koto no Tabi: Kyoto                                     Nanken Koubou                     1993/2     CD
-Hyper Land: Doubutsu no Sekai                                 Datt Japan                        1993/3     CD
+* Hyper Land: Doubutsu no Sekai                               Datt Japan                        1993/3     CD
 Hyper Media NHK Zoku Kiso Eigo: Dai-1-kan                     CSK Research Institute (CRI)      1991/6     SET(CD+FD)
 Hyper Media NHK Zoku Kiso Eigo: Dai-2-kan                     CSK Research Institute (CRI)      1991/7     SET(CD+FD)
 * Hyper Media NHK Zoku Kiso Eigo: Dai-3-kan                   CSK Research Institute (CRI)      1991/9     SET(CD+FD)
-Hyper Note                                                    Datt Japan                        1991/12    SET(CD+FD)
+* Hyper Note                                                  Datt Japan                        1991/12    SET(CD+FD)
 Hyper Photo DB                                                Fujitsu                           1993/9     CD
-* Hyper Planet Shiki Vol. 2: Utsukushii Fuyu no Seiza Hen     Datt Japan                        1993/12    CD
 Hyper Planet Shiki Vol. 3: Uraraka na Haru no Seiza Hen       Datt Japan                        1994/4     CD
 Hyper Planet Shiki Vol. 4: Fukamari Yuku Aki no Seiza Hen     Datt Japan                        1994/11    CD
 Hyper Touhouku Kikou                                          Nanken Koubou                     1991/12    SET(CD+FD)
@@ -291,7 +288,6 @@ Kanjigen CD-ROM                                               Fujitsu           
 Karyuugai                                                     Raison                            1991/1     CD
 Katsuyaku Suru Computer (CD Town)                             Fujitsu Ooita Software Laboratory 1992/12    CD
 Kazadama Vol. 1: Maeda Shinzo no Sekai Ki - Japan             Fujitsu                           1993/9     CD
-Kazadama Vol. 2: Ikeda Masuo Hanga-shuu                       Fujitsu                           1995/4     CD
 Kazu ya Kimi Tashizan / Hikizan Hen                           Media Art                         1995/1     CD
 Kenkyuusha Readers Eiwa CD-ROM                                Fujitsu                           1993/2     CD
 Kerokero Keroppi to Origami no Tabibito                       Fujitsu Parex                     1995/7     CD
@@ -301,8 +297,6 @@ Kitty Town no Nakama-tachi: Tanoshii Seikatsuka               Fujitsu Parex     
 Komaki Naomi                                                  Janis                             1994/2     CD
 Koujien Daisanban CD-ROM                                      Fujitsu                           1989/12    CD
 Koujien Daiyonban CD-ROM                                      Fujitsu                           1993/3     CD
-Kouryuuki                                                     Koei                              1993/10    SET(CD+FD)
-Kusuriyubi no Kyoukasho                                       Active                            1996/4     CD
 Kyouiku & FM Towns Vol. 1                                     Fujitsu                           ?          CD
 Kyouiku & FM Towns Vol. 4                                     Fujitsu                           ?          CD
 Let's go 1-1                                                  DynEd Japan                       1995/7     SET(CD+FD)
@@ -310,21 +304,18 @@ Let's go 1-2                                                  DynEd Japan       
 Let's go 2-1                                                  DynEd Japan                       1995/7     SET(CD+FD)
 Let's go 2-2                                                  DynEd Japan                       1995/7     SET(CD+FD)
 * Lettuce Cooking 2: Tanoshiku Tsukureru Obentou              SS Communications                 1990/8     SET(CD+FD)
-* Lipstick Adventure 3                                        Fairytale                         1993/5     CD
 Little Big Adventure                                          Electronic Arts Victor            1995/12    CD
 LiveAnimation V1.1                                            Fujitsu                           1992/12    CD
 LiveAnimation V2.1                                            Fujitsu                           1994/5     CD
 LiveMorph V1.1                                                Fujitsu                           1994/2     CD
 LiveMovie V1.1                                                Fujitsu                           1992/12    CD
 LiveMovie V2.1                                                Fujitsu                           1994/3     CD
-* Lodoss-tou Senki 2: Goshiki no Maryuu                       MAC                               1994/6     SET(CD+FD)
 M Talk                                                        Fujitsu Office Kiki               1993/6     CD
 Manami no Dokomade Iku no?                                    Wendy Magazine                    1995/5     CD
 Manami: Ai to Koukan no Hibi                                  Fairytale (Red Zone)              1995/10    SET(CD+FD)
 Many Colors 2                                                 Amorphous                         1995/6     CD
 Manyoushuu                                                    Uchida Youkou                     1993/2     CD
 Maruanki Eitango: Chuugaku 1-nensei                           CSK Research Institute (CRI)      1989/12    SET(CD+FD)
-Masuo per Masuo: Ikeda Masuo Hanga-shuu Kazadama Vol. 2       Fujitsu                           1994/7     CD
 Meisou Toshi                                                  Tiara                             1995/12    CD
 Microsoft Windows 95 (Upgrade Package)                        Fujitsu                           1996/6     CD
 Mietarou V2.0                                                 Uchida Youkou                     1992/12    SET(CD+FD)
@@ -404,7 +395,6 @@ Nihongo Nyuumon Dai-2-kan                                     Infortech         
 Nihongo Nyuumon Dai-3-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-4-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-5-kan                                     Infortech                         1991/4     CD
-* Nobunaga no Yabou: Tenshouki                                Koei                              1995/3     SET(CD+FD)
 Nooch: Abakareta Inbou                                        Bombee Bonbon                     1992/11    ?
 Nostalgia 1907                                                Sur de Wave                       1992/5     CD
 Noyama no Kensakuka                                           Fujitsu Social Science Laboratory 1995/3     CD
@@ -416,7 +406,7 @@ Otto Anime-kun                                                Nihon Micom Hanbai
 Palamedes                                                     Ving                              1991/10    CD
 Pasocon de Tanoshimu Yama to Chizu                            Inter Limited Logic               1995/10    CD
 Petit Collage                                                 Pandora Box                       1994/3     CD
-Planet Harmony                                                Datt Japan                        1993/9     SET(CD+FD)
+* Planet Harmony                                              Datt Japan                        1993/9     SET(CD+FD)
 Pocky 1-2 & Ponyon                                            Ponytail Soft                     1994/6     CD
 Powers of Ten                                                 Datt Japan                        1995/10    CD
 Present                                                       Orange House                      1991/6     ?
@@ -425,7 +415,6 @@ Private Slave                                                 Raccoon           
 Psychic Detective Series Vol. 1: Invitation: Kage kara no Shoutaijou (Remake)   Data West                         1993/11    SET(CD+FD)
 Psychic Detective Series Vol. 2: Memories (Remake)            Data West                         1994/4     SET(CD+FD)
 Psychic Detective Series Vol. 3: Aya (Remake)                 Data West                         1994/7     SET(CD+FD)
-Psychic Detective Series Vol. 4: Orgel (Remake)               Data West                         1994/12    SET(CD+FD)
 Psychic Detective Series Vol. 5: Nightmare (Remake)           Data West                         1995/4     SET(CD+FD)
 Pyoko-tan no Niji no Shima: Nanairo no Ninjin wo Sagase       Nanken Koubou                     1994/3     CD
 Q2 ROM Magazine - Soukangou                                   Disinfectant                      1993/5     CD
@@ -444,12 +433,11 @@ Rika Nenpyou CD-ROM                                           Maruzen           
 Robin Hood                                                    DynEd Japan                       1993/12    SET(CD+FD)
 Rockpaedia Vol. 2: 1961-1970                                  Toshiba EMI                       ?          CD
 Round the World in 80 Days                                    DynEd Japan                       1993/12    SET(CD+FD)
-Royal Blood                                                   Koei                              1992/5     SET(CD+FD)
+* Royal Blood                                                 Koei                              1992/5     SET(CD+FD)
 S-DAPS Demo CD [DWDC4922]                                     Data West                         1994/?     CD
 Saishin American Idiom Jiten                                  Sanshusha                         1990/2     CD
 Saishin Igaku Daijiten CD-ROM                                 Fujitsu                           1990/5     CD
 Saishin Igaku Daijiten Standard-ban CD-ROM                    Fujitsu                           1993/2     CD
-* Sangokushi III                                              Koei                              1992/6     SET(CD+FD)
 Sanseido Word Hunter Multi CD-ROM Jiten                       Fujitsu                           1991/10    CD
 School Accessory Illust-hen V1.0                              Fujitsu                           1993/2     CD
 School Navi Nihon no Rekishi CD: Heian, Kamakura              Unitybell                         1995/8     CD
@@ -502,7 +490,6 @@ Stingo Monogatari ST-3: Stingo Umi ni Iku                     Technos Yashima   
 Stingo Monogatari ST-4: Stingo Yuuenchi ni Iku                Technos Yashima                   1995/1     CD
 Stingo Monogatari ST-5: Stingo no Christmas                   Technos Yashima                   1995/1     CD
 Stress                                                        Toshiba EMI                       1989/11    CD
-* Suikoden: Tenmei no Chikai                                  Koei                              1990/2     SET(CD+FD)
 Suisai Graphic Art Software                                   NTT Data Tsuushin                 1993/8     CD
 Sunshine 1-nen                                                Uchida Youkou                     1993/7     CD
 Sunshine 2-nen                                                Uchida Youkou                     1993/7     CD
@@ -515,7 +502,6 @@ Tania                                                         Tips              
 Tankyuu-kun                                                   Fujitsu                           1996/11    CD
 Tanoshii Sansuu Set 1-2-nen                                   Dainippon Tosho                   1994/3     SET(CD+FD)
 Teata -vision- (V1.0-1.3)                                     Nanken Koubou                     1995/6     SET(CD+FD)
-Teitoku no Ketsudan                                           Koei                              1990/4     SET(CD+FD)
 Tender Light Vol. 1                                           Fujitsu                           1994/3     CD
 Tensai Kyuutei Ongaku no Kanade                               Fujitsu                           1992/12    CD
 Tenshi-tachi no Gogo 3: Bangai-hen Hanseiban                  JAST                              1993/3     ?
@@ -1896,19 +1882,23 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="airwar12" supported="no" cloneof="airwar21">
+	<software name="airwar1210" cloneof="airwar21">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
 		<rom name="Fujitsu Air Warrior V1.2 (Japan) (Track 1).bin" size="20815200" crc="f3a20852" sha1="2c09fa527fe06258103728e1fbbd01479b491c92"/>
 		<rom name="Fujitsu Air Warrior V1.2 (Japan) (Track 2).bin" size="22226400" crc="4eba18c7" sha1="bb4246ec0f99b0fca8c1d88f48b252e5fc63e2be"/>
 		<rom name="Fujitsu Air Warrior V1.2 (Japan).cue" size="234" crc="a3cbda9a" sha1="c2cc0bd45a8e2168a2f0ba513da529bc6f05ae54"/>
 		-->
-		<description>Air Warrior V1.2</description>
+		<description>Air Warrior V1.2L10</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="serial" value="HMD-109A"/>
 		<info name="release" value="199311xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="fujitsu_air_warrior_v1.2l10.hdm" size="1261568" crc="f38664a6" sha1="3f3abd3cb145bca79414d32c08a98ae7250d4b6f" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fujitsu air warrior v1.2 (japan)" sha1="cf653365d5ed02479885775d5e470f42d3cdc285" />
@@ -1975,7 +1965,7 @@ User/save disks that can be created from the game itself are not included.
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="alice_no_yakata_2.hdm" size="1261568" crc="1d587e12" sha1="202e99a83a4fd29d3efeb982c806f3670cf7974c" offset="000000" />
+				<rom name="alice_no_yakata_2.hdm" size="1261568" crc="a05edc06" sha1="90da65a58d50fd00891f4166765c90ff973965d6" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -2311,7 +2301,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="エンジェル" />
 		<info name="release" value="199310xx" />
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Save Disk" />
+			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1261568">
 				<rom name="angel (save disk).hdm" size="1261568" crc="8ea3389b" sha1="60792d763d3cac54d19b04673b1f1811cf19b9a8" offset="000000" />
 			</dataarea>
@@ -2390,7 +2380,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Appare CD Vol. 1 - Hiryuu no Maki</description>
 		<year>1994</year>
-		<publisher>ソフトバンク (Softbank)</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="serial" value="HMF-916 / OFMT-001"/>
 		<info name="alt_title" value="天晴CD Vol.1 飛龍の巻" />
 		<info name="release" value="199411xx" />
@@ -2413,7 +2403,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Appare CD Vol. 2 - Houou no Maki</description>
 		<year>1995</year>
-		<publisher>ソフトバンク (Softbank)</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="serial" value="OFMT-002"/>
 		<info name="alt_title" value="天晴CD Vol.2 鳳凰の巻" />
 		<info name="release" value="199408xx" />
@@ -2798,6 +2788,244 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="beatles2">
+		<!--
+		Origin: redump.org
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 01).bin" size="10054800" crc="ea442b7b" sha1="5374f951070b6ddfdba6e70b9889d651470d70c8"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 02).bin" size="15358560" crc="75105df2" sha1="6be3b6fb0a07b721b269ee4cac91a5988d9e715e"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 03).bin" size="2328480" crc="5ec40bd2" sha1="9309bd0cf8a370ef9cedc5cdf3444fcc39b17c1d"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 04).bin" size="2516640" crc="d4763050" sha1="3abaa785e6f57c384283c12719d637314f8ae3fd"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 05).bin" size="2476656" crc="b912c280" sha1="ab375c7b3c5365cd87b50dc5c0b82e87f5c07775"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 06).bin" size="2838864" crc="23f7b685" sha1="71adbdd1b5ed04063ddfe79e870319c8cff67075"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 07).bin" size="2500176" crc="fb446b3f" sha1="56b011ac05fc60fd68960af861a9d15c810a99a3"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 08).bin" size="2716560" crc="d694f8a6" sha1="00dc23523911d11ed8a13d645344856b1307a559"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 09).bin" size="2815344" crc="4dba5b42" sha1="56476978f0e063287e33a159851cb1ae9f1ce3af"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 10).bin" size="2422560" crc="8ed0cfe7" sha1="559e20a52394ea08a114eacac86792738fa9fe17"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 11).bin" size="2464896" crc="dc545415" sha1="a1041e2624f217d37b40b60e1971fb8630ccadce"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 12).bin" size="2775360" crc="3f84fb3f" sha1="dcbccfe95d084ddecce0523321066b6de8a30bac"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 13).bin" size="2744784" crc="56d98a7b" sha1="c1d4c9192f0d4238787aa5e4a575927db1e5a2aa"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 14).bin" size="2217936" crc="156c73db" sha1="08d7d34056d782421e8c2588fb9d21eafe6816f5"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 15).bin" size="2262624" crc="8208a5dd" sha1="2f72c9c70738bc9c8855c746f6dcea7720926993"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 16).bin" size="2775360" crc="ebdf6dc1" sha1="32f2e582c2f276a0755ccf1cbe53e8de588166e1"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 17).bin" size="2558976" crc="0fa4ab34" sha1="60a42d16f6fd333c10dd1bd8112b14ca25437dc3"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 18).bin" size="2297904" crc="aab89233" sha1="77b23b29ce650ecfa61c722b3bfdf45edbea75d8"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 19).bin" size="1975680" crc="d9e6c4c1" sha1="9cd37cae4b82e48b8bfdffef622fdceedb68aced"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 20).bin" size="2622480" crc="013c4628" sha1="c5787ed3d34384f5b560c24a8808c96c6fa47500"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 21).bin" size="2328480" crc="d95e562e" sha1="90150974b702f6e1f386539431e0d48d6101b816"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 22).bin" size="2417856" crc="87e558d7" sha1="7144964791d39c1f4cf7d30833e58ad570fbb71e"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 23).bin" size="3332784" crc="e5a8b472" sha1="14cb5bf2f25087030c006280af74a07b2ccb1cef"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 24).bin" size="2558976" crc="29b9a900" sha1="9f83e32959e21031cb08c01a8a1be304b0e181e5"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 25).bin" size="2885904" crc="56aa1637" sha1="500dafd06f03729a34aeb364dd427166e8df6461"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 26).bin" size="2352000" crc="358ec81c" sha1="2d7c48f669bd3920a426cf755f115bc34807996a"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 27).bin" size="2711856" crc="c5b55806" sha1="1d83471758a22f1da80caab40d9f5d9abb95035c"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 28).bin" size="2239104" crc="8a0490c0" sha1="23bf1292c70b3203b0cfbd26b0a2a1f26a2d6e3e"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 29).bin" size="2187360" crc="19bf28d5" sha1="e355fde4fa6e979aab1df790bcb7ef49720efc6d"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 30).bin" size="2446080" crc="f6aa8cfe" sha1="527d1bd9173c5f21abae4bbd0b29dc2c0e9fbbff"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 31).bin" size="2622480" crc="1b74d38f" sha1="1ecddfbdcd5d2135662385aac070eafe2dc1ec4c"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 32).bin" size="2304960" crc="5245e10e" sha1="1f5385884b8130162294540a916b0c200aafd5db"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 33).bin" size="32511696" crc="613c15d5" sha1="92f3e3ab8ec99bb3165598b87eca0f2f4f8ed2f4"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 34).bin" size="40106304" crc="f9226c21" sha1="50a4d341514c39639cb929e3750aaf566fa105b2"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 35).bin" size="32610480" crc="a8518d9f" sha1="4bd399f9aea6914d214ad176838b089e6ab85ed1"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 36).bin" size="32488176" crc="ad0736ca" sha1="fa9ce3ac069853c5e6784e88d8a9566af28a794f"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 37).bin" size="21215040" crc="4282b155" sha1="9c6d664d5c4498828f93db1e11991dd90373178d"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 38).bin" size="18122160" crc="77c92d0b" sha1="f0fe5d557d9be9e39cd43e6f4133063a8dcb4177"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 39).bin" size="27071520" crc="bc27f318" sha1="8b78cad166ea672487db3b66d8576af1bb7fb8b2"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 40).bin" size="15163344" crc="08c76b53" sha1="27fe938a3730f8ce744200e8fc330e6d8fba3519"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja) (Track 41).bin" size="17000256" crc="07194bb8" sha1="381024a99fcb6fbf31abcf14b24f8822849d2d25"/>
+		<rom name="Remember Beatles No. 2 - Michelle (Japan) (En,Ja).cue" size="5196" crc="001ef104" sha1="2786dc5109566545e12f2e5201bcd18187114e57"/>
+		-->
+		<description>Remember Beatles No. 2 - Michelle</description>
+		<year>1989</year>
+		<publisher>ソフメディア (SofMedia)</publisher>
+		<info name="serial" value="HMA-252"/>
+		<info name="release" value="198912xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="remember beatles no. 2 - michelle (japan) (en,ja)" sha1="63dfdc5407cbe5c6ff126d8cc1f08259a83365f1" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="beatles4">
+		<!--
+		Origin: redump.org
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 01).bin" size="41983200" crc="ec5edcc2" sha1="c01bf45cc553c137c219277077323e7302b103ba"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 02).bin" size="20304816" crc="ca2ebcfc" sha1="72bb93396af001baa383445232cb2488a7a10965"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 03).bin" size="2540160" crc="0e005387" sha1="ef25cb285f0503d8bdfde74ca032641a93a4e962"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 04).bin" size="2944704" crc="b0ac20c9" sha1="15a3c49728864a5faab9b9a0d374795d60a7ca3a"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 05).bin" size="1928640" crc="9eb6a652" sha1="06fc3a89d174f56f245f8e4a098740dfaaec8022"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 06).bin" size="3076416" crc="627285a7" sha1="b573a04d139917c30382062a27d7f53529399ab6"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 07).bin" size="2634240" crc="7505f710" sha1="985d560a99f2f318cd9d7436b4dbc8ac05eb9d6f"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 08).bin" size="2881200" crc="8a69486e" sha1="593e0a5dc380279918b72be61b1f63f56916e4c4"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 09).bin" size="3186960" crc="836bebca" sha1="6fbfe24b4c2eeaf0a4895f52d27d3b4bf4bcc3e7"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 10).bin" size="2544864" crc="aed750df" sha1="906bf17a69e5b70e78ab49bda0606e2a3e839ab5"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 11).bin" size="2888256" crc="f36e1895" sha1="22022b9df27b6d6c8d25223a25a78957dcdaf4dc"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 12).bin" size="3238704" crc="e17edd85" sha1="db946671ef8d042857414c2474db9f0772633ed4"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 13).bin" size="2570736" crc="09b0de71" sha1="960986f427488f8e95bc946075592bbff4f60b1f"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 14).bin" size="2634240" crc="2564c5ee" sha1="d58b465edc544d2ed251d7da42f29bd5ed7f80a4"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 15).bin" size="2810640" crc="b9f62b10" sha1="bd9b8458421a2c30b34149d373170fa4a83e2373"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 16).bin" size="2469600" crc="c0f6de69" sha1="3699de5571f2e192f391fc5476db7f8eb7d107fd"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 17).bin" size="3363360" crc="14484f59" sha1="d9ae8fa9bd069a46d70432381829e2edebe55584"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 18).bin" size="2885904" crc="d1aab8ad" sha1="88110bf2cd47e46ff8200648d578f2cd331bea83"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 19).bin" size="2845920" crc="5583d92c" sha1="abb06090820c4f62e8a9faa10ffde9f4bb66a54c"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 20).bin" size="3304560" crc="4c202eab" sha1="fc8e6a2bcc147add819e5b68de35eec0bc83712c"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 21).bin" size="3022320" crc="b8814119" sha1="07859f1ce85c5c3e50945bd5bb95334294dd4a12"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 22).bin" size="3081120" crc="9c0ea6f0" sha1="d20aed7c377d1e3455e497c1f53bdcd26153e1be"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 23).bin" size="3222240" crc="3286d065" sha1="f835e34638aee767a32a240ab2ae6e6f0b3a7df6"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 24).bin" size="2547216" crc="591f5713" sha1="098260af00ce7129b4a759455fb6dedaf3e2edb9"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 25).bin" size="2662464" crc="91f9ed18" sha1="c2833fa3aa757f0e1e6103277e84b4c5d17e56fe"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 26).bin" size="2716560" crc="30c32ae9" sha1="f27e7d2447ba073ee1b0c2a33bd8355c753ac7fb"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 27).bin" size="3398640" crc="3991c2fe" sha1="a17fa85932659a91e8c7adacd898c26d50f1ea4d"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 28).bin" size="3511536" crc="99d4c851" sha1="61ee09b4e75237157aa00e5c54993917a2a21ae4"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 29).bin" size="2662464" crc="56b590ca" sha1="a18c1b71210235a550bca0ec5fd60f53e71a3784"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 30).bin" size="2410800" crc="e4eec2ae" sha1="a3f441334f6e68f15af31d5621596902c7bc6cde"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 31).bin" size="3005856" crc="afb15540" sha1="c93e0217a99d4b3e9b24aa6ad7397752d8bed892"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 32).bin" size="3398640" crc="9c0703d4" sha1="3c59d41cadc86fca9aef20f8195ffc558326f1c7"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 33).bin" size="3492720" crc="a46c026f" sha1="fa3d3dd6c714adf2ee8dd5da826d4161bdbc9dc3"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 34).bin" size="3556224" crc="890eb113" sha1="75a3c41950733cc8257cb1c33a9472a2f50a9165"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 35).bin" size="27624240" crc="9c5e54e5" sha1="be80ce66bc6ccff1f991e22a053c44943dd76811"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 36).bin" size="42695856" crc="c612a68d" sha1="b8c6f4a187d3f80ca01871ae3ee9af9981fd9f24"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 37).bin" size="39807600" crc="1ad270ff" sha1="7d17e30452005fee4eb8476c1145b6cbe506232f"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 38).bin" size="32034240" crc="7d3a580f" sha1="f09b58a13cad6bfddb94cae9aa4bc098bcd3cca0"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 39).bin" size="21532560" crc="f1c801b3" sha1="d6999c7c1ae9f70f2f2654dcfb484690cd0b5b93"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 40).bin" size="17774064" crc="3599992c" sha1="b98a45856db9af630cba5c532a7ff38b49f3f208"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 41).bin" size="26965680" crc="6479378b" sha1="9694ed48e1e0864ec1848beacde85ec26d2f6ca8"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 42).bin" size="13378176" crc="740125be" sha1="896fcce9a94403409b1ff417eafbe57fd0cf77fd"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 43).bin" size="16828560" crc="d973345a" sha1="212845e6beb72a0a86089d04a56c6381ccf6b4ed"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 44).bin" size="128513280" crc="84d25e22" sha1="69dfa6b141dcd244787df075faa421b8f714d1fa"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 45).bin" size="128506224" crc="dd18631e" sha1="f151358465a0457d670e30c605845bd05ca882a1"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja) (Track 46).bin" size="128155776" crc="5968d3fa" sha1="52f838fc7aedd33817a82d9ec03e504c8ec16f2f"/>
+		<rom name="Remember Beatles No. 4 - Let it Be (Japan) (En,Ja).cue" size="5640" crc="50c71379" sha1="482eadf02d7a4ecf77c559e0aa4d8c625e6e6934"/>
+		-->
+		<description>Remember Beatles No. 4 - Let It Be</description>
+		<year>1990</year>
+		<publisher>ソフメディア (SofMedia)</publisher>
+		<info name="serial" value="HMB-169"/>
+		<info name="release" value="199007xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="remember beatles no. 4 - let it be (japan) (en,ja)" sha1="5319e7628ca012ac5d4ccf6bda736b128faf0fdb" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="beatles5">
+		<!--
+		Origin: redump.org
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 01).bin" size="41637456" crc="a4678857" sha1="1319d1c46313af39f8099419e842298688381dd6"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 02).bin" size="13575744" crc="192fab1f" sha1="a9aa0b18fbb744ce8053296cc742b430c6cdf2f3"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 03).bin" size="2641296" crc="434c7b28" sha1="d03c3ee244a37901bee867bc9147fcdba18dd709"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 04).bin" size="2140320" crc="e46e74e2" sha1="ca0c39ee24e8d2f7c296b2a0639e4a6501c306eb"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 05).bin" size="3069360" crc="a5de4625" sha1="8ff0400b00ad8e616f0841d661798e5761c49403"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 06).bin" size="3709104" crc="fa4dbb5d" sha1="b06786f6038913be60f5ef484a24b52cef82c494"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 07).bin" size="3081120" crc="541978d9" sha1="e0f867f5c5299834f74e64e20a11a934375a7426"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 08).bin" size="2410800" crc="74d1246c" sha1="2794cf11c4089b600857c40c2fefce6182d3c3c8"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 09).bin" size="2834160" crc="092cef54" sha1="5f14d94230d712f2feb988b4d6e197b28f5d3c15"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 10).bin" size="3281040" crc="6e8941c1" sha1="95c1e33aa354e59c684ba219a56814f09713d305"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 11).bin" size="3351600" crc="5e3ffec8" sha1="8bfe5028bfe7c84457cbd8679c1cae177e9e15f0"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 12).bin" size="3539760" crc="7ced6d41" sha1="cee41b8dfa1067d4f647d5e8450ddc037c90da83"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 13).bin" size="4558176" crc="7026db83" sha1="a5665abd10d6fe7ee413ba87ae59364f96c1ed17"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 14).bin" size="2380224" crc="6fb9192c" sha1="9e77c0f8a470f360fde6f861940a728decedec3a"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 15).bin" size="3410400" crc="6e0003da" sha1="b14239261ae9c86c9f132c2f90c6ed3b1ba3cb47"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 16).bin" size="3116400" crc="0edbacae" sha1="756f97f3740868feae9cb4fb9d9bc0d873fcb023"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 17).bin" size="3158736" crc="41f9dfac" sha1="06cae5b53174e86e447590aab03cb0ae07563f75"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 18).bin" size="3469200" crc="e9eb31a6" sha1="d9a938427aa2da57387af5fa1a4e1ff0ab372030"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 19).bin" size="3673824" crc="7a5022e1" sha1="223db490a7e8143d593219d674631698b88c8866"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 20).bin" size="2916480" crc="e7bdd546" sha1="0379b703d6a6d983268771434cc33e45f303524b"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 21).bin" size="2363760" crc="a636ca51" sha1="1b2d33a40033b191e0166d86b75423fce3005254"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 22).bin" size="3445680" crc="577a2803" sha1="ed47f876bf669eded644a1ffea0b277e870623da"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 23).bin" size="3676176" crc="3f5f90a5" sha1="5b561167a5ca7de6d5b3497cc5abb46b87152d0d"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 24).bin" size="3615024" crc="2cc8815b" sha1="2f3331adddd999363b0f58fa1cfb6adc0619f9a7"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 25).bin" size="2646000" crc="8aadf338" sha1="e90ae57d3d5a8b54b1993a36b3883d48c2c6e544"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 26).bin" size="4311216" crc="55eec185" sha1="ebaa15409a6afe597240fc3ca3ed9793290233b7"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 27).bin" size="3203424" crc="30574048" sha1="6d5cbe9bc0e187d11d88cd8a514197cf184d5af1"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 28).bin" size="3123456" crc="8b17aefe" sha1="760f49eb68cd7571821fedfeef289e57a6ce715f"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 29).bin" size="3469200" crc="973ec1b7" sha1="a34469f33c3962508c74af41ec754465502ecb84"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 30).bin" size="3579744" crc="fb57e8c7" sha1="b65d29553d2c8e437564f159f071d3c710899e3c"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 31).bin" size="3022320" crc="0cde42a3" sha1="15528ff4ed7e1cd03cce72f6f9991577a9ab8537"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 32).bin" size="3833760" crc="78b9fbd0" sha1="2b7429fc4caeed90ac867c2a000f76921507611e"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 33).bin" size="3452736" crc="6515e947" sha1="ab6d82940b64dc076b60646c459015a2291a7a98"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 34).bin" size="3403344" crc="740029c4" sha1="3b656fce27f1dae04315c2942dd6ea41d46fd986"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 35).bin" size="38944416" crc="b6095635" sha1="b5b08de0f6341c45d0c328d7da2760792922fbe2"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 36).bin" size="32027184" crc="0672acbc" sha1="2504030586f8c2c94a84cdb9913c69331fdf1acc"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 37).bin" size="21539616" crc="1ae20397" sha1="0c62c4190fa52be2068cd42e70337aadd97d14a0"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 38).bin" size="17769360" crc="2201ee5f" sha1="b6491082881f1f0a595d2e0449270c9d55b2880b"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 39).bin" size="26970384" crc="62604ab8" sha1="e5d1f9f9d6885136bc0a266ca041593ef5673203"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 40).bin" size="13371120" crc="ed008235" sha1="58c36c8a997b472279c88e790ce69fbee96b49fe"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja) (Track 41).bin" size="16828560" crc="ab3ceeb8" sha1="7aa4cfd66ef54fe87099027f97a418b6cf8eb083"/>
+		<rom name="Remember Beatles No. 5 - The Long and Winding Road (Japan) (En,Ja).cue" size="5686" crc="ebdfb54e" sha1="565dc9953d59a742967e5e3a2761c78e09eec00d"/>
+		-->
+		<description>Remember Beatles No. 5 - The Long and Winding Road</description>
+		<year>1990</year>
+		<publisher>ソフメディア (SofMedia)</publisher>
+		<info name="serial" value="HMB-171"/>
+		<info name="release" value="199008xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="remember beatles no. 5 - the long and winding road (japan) (en,ja)" sha1="be48fcdfde7a4548812c3638ea0c4a05aaaa09ac" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="beatles6">
+		<!--
+		Origin: redump.org
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 01).bin" size="41637456" crc="5724e8d8" sha1="2b97cfb875c4842fb232606a145cdc151fc3d32b"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 02).bin" size="13034784" crc="4ec694dc" sha1="3512e3dcc94d56d0348fee0b3ec42451e5c44157"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 03).bin" size="2669520" crc="042e0438" sha1="31ef61876c9b7331c96e3a74a52d196085b8c355"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 04).bin" size="4092480" crc="a85a7e28" sha1="b9a9727e648dc8addca1b0c042ea826903b1baa0"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 05).bin" size="3104640" crc="a0e3332e" sha1="8b179d91916722c8cd3ba798340fd66d144e79e3"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 06).bin" size="3857280" crc="96294b22" sha1="3cbddb9b325e0c3ca75b62aa238926f09f826ca6"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 07).bin" size="2869440" crc="1f7295b9" sha1="721c6033fbdcde63c37617c018aac01d3f02478a"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 08).bin" size="2721264" crc="d72cb9cf" sha1="ca361669d7855e90457d4c3e018462fc0008bd85"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 09).bin" size="3386880" crc="7ad12f91" sha1="e63fd41410ee9481d08cfb1f38bcc56ce7149592"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 10).bin" size="3234000" crc="ec22a893" sha1="32d3e9e7204d5ebc4672ca7a110533d10f9e02c8"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 11).bin" size="3186960" crc="696bab21" sha1="445f55932ec7ae95d458562a0172ec70fe56de8d"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 12).bin" size="2234400" crc="4b4c1962" sha1="032be1745d3dac58a124670793612956633f204a"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 13).bin" size="3029376" crc="dfa26402" sha1="68b65bca275ae4322c408fe68faec31477bfd328"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 14).bin" size="3356304" crc="a4246e0d" sha1="5f973c045021f82497533d90ee0be003cff30a41"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 15).bin" size="2516640" crc="b770f79c" sha1="fab59c96818e56ae12dd8ea3ba2fb0355cd2a837"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 16).bin" size="2888256" crc="f5c8b968" sha1="3a284e4a409479025350d96455e4fcd264eeb635"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 17).bin" size="2497824" crc="f7b09577" sha1="f838336bf89b80351426a7cab0e8212928184a3b"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 18).bin" size="2598960" crc="98564d06" sha1="aec0c12591f446969100901598c31feefb7b97fd"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 19).bin" size="3269280" crc="bbadb973" sha1="57a97a215ff9aed2a7a94fc1adb86c552d64ac9d"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 20).bin" size="2540160" crc="8adc66f6" sha1="cd3601a32dc936a6604fc46a2838dcbb63c90912"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 21).bin" size="3017616" crc="e5d08b65" sha1="ad9da28791b19fbd43639670ac7d2396e76b465c"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 22).bin" size="2309664" crc="643e1c74" sha1="8e609cb6f42605c5063b3a7ca7007b25a87af4db"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 23).bin" size="3328080" crc="f6c9f601" sha1="b585904fa6f04007876f874182915d63dbf2a285"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 24).bin" size="2822400" crc="9ec2b830" sha1="1bb1fb5483f2fea07e152158f5584a998ee5d378"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 25).bin" size="3346896" crc="4a4de7db" sha1="3aa24820676252df8e02c38bd2ee9c0f275bec8c"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 26).bin" size="3262224" crc="346a076e" sha1="a3f7fe145bdccd5cab59e61251f40cce6173dd5f"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 27).bin" size="2417856" crc="2c70e717" sha1="07612227037d6994e1234cc26a41d1943207c5b0"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 28).bin" size="2728320" crc="d824aba3" sha1="b6db815a9aee1de3b5a98c3071744f26e009ba2e"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 29).bin" size="2815344" crc="d07406a2" sha1="5ea32259675402ce2cf97eae9ab8c3481173e6a5"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 30).bin" size="3116400" crc="d3267843" sha1="2f6a3a25377f5364fe7350c8307ba1be5e755c0a"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 31).bin" size="2370816" crc="e9c9d4fa" sha1="29500aaf41c903918a441aef169d5967c1742a8e"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 32).bin" size="3022320" crc="595fe8aa" sha1="b2d7a6e45e5b158ff1b225181fdb4f14710dcbc9"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 33).bin" size="3814944" crc="b06f9884" sha1="bb1f4da64454e68da62e809166f98e1c09a152ba"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 34).bin" size="37862496" crc="6062283a" sha1="1ac1c37148cf8d8d9fd7a40f093678726a0de180"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 35).bin" size="41148240" crc="5b978bdd" sha1="9ee007516f34333df29d453b80fa18b9b1491ae9"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 36).bin" size="34826064" crc="4b2c3186" sha1="977de3691159f6f740da423a83540119b0c2ff6d"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 37).bin" size="32022480" crc="0fa380ac" sha1="41a211f4e2eef8b725efb0b12ffe0a5de144a34b"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 38).bin" size="21539616" crc="58e5a5b4" sha1="3a9a6535d35ac62288fe7fef952e11668aab8fdb"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 39).bin" size="17769360" crc="afb2f152" sha1="1cb30f9245653a72216ee6858284be3a5494ca6e"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 40).bin" size="26970384" crc="34820c65" sha1="2c9a0807c02c029a789f686fa4db2e316db0443d"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 41).bin" size="13371120" crc="51635ca1" sha1="79dde8c6bfc781bedbf5c1991eecc4796a8efe0a"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja) (Track 42).bin" size="16835616" crc="4a96cd65" sha1="c5fcc42894e1b0c394d58134a23abc4e6fb65680"/>
+		<rom name="Remember Beatles No. 6 - Imagine (Japan) (En,Ja).cue" size="5068" crc="402471be" sha1="b7c0ce4b2b311c1aa265ef266305bd74eca2becc"/>
+		-->
+		<description>Remember Beatles No. 6 - Imagine</description>
+		<year>1990</year>
+		<publisher>ソフメディア (SofMedia)</publisher>
+		<info name="serial" value="HMB-172"/>
+		<info name="release" value="199008xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="remember beatles no. 6 - imagine (japan) (en,ja)" sha1="4218209e657230a6da5d87054bf004a1e277844b" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="bfmaria">
 		<!--
 		Origin: redump.org
@@ -2914,6 +3142,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>Beast III</description>
 		<year>1994</year>
 		<publisher>バーディーソフト (Birdy Soft)</publisher>
+		<info name="serial" value="MTC-1028"/>
 		<info name="alt_title" value="ビースト3" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -3203,7 +3432,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Blue - Will to Power</description>
 		<year>1992</year>
-		<publisher>Sofcom</publisher>
+		<publisher>ソフコム (Sofcom)</publisher>
 		<info name="serial" value="HMD-124"/>
 		<info name="release" value="199204xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -4375,30 +4604,29 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!--
-	The collection includes two Dalk images, one marked as "Trurip" and one marked as
-	"freeware". Analysis of the tracks shows that the data track is exactly the same, and
-	audio tracks are the same but shifted forwards by 5980 bytes in the "freeware"
-	image. This difference is probably due to the read offset of the drive used
-	to dump the disk.
-
-	The only difference is in the last track. The image marked as freeware had its
-	data shifted beyond the boundaries of the disc, so it's missing some bytes at the
-	end. Trurip images are always offset-corrected, so we can assume that one is the
-	more "correct" one, and thus the one included in this list.
-	-->
+	<!-- The floppy disks only differ slightly in the contents of the ADISK.DAT and ACG.DAT files -->
 	<software name="dalk">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Dalk.ccd" size="2636" crc="f6c04011" sha1="85c64f64f223ef01ebb6a3b77922ea8960d4b367"/>
-		<rom name="Dalk.cue" size="854" crc="cf539eab" sha1="0ae6c2a4f92f89365e0a9d6e5f7cf2b4a0d0bb7a"/>
-		<rom name="Dalk.img" size="667149504" crc="76f53839" sha1="677ad9b722df5e8a4a4b61bd5322565e7d435b16"/>
-		<rom name="Dalk.sub" size="27230592" crc="dc3ea02b" sha1="8435a0a101de2c7683039e488c0ce48c99bf584d"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Dalk (Japan) (Track 01).bin" size="20815200" crc="b1ed9d10" sha1="cc5e6a1cf2e01273d20a91601062738c2936cae5"/>
+		<rom name="Dalk (Japan) (Track 02).bin" size="54037200" crc="4c20aaed" sha1="f291285ddc0e774fa3ca87ac8b59248f70f78ab3"/>
+		<rom name="Dalk (Japan) (Track 03).bin" size="55389600" crc="83ba4544" sha1="56b6dee1695405f78f5cce824e4d9ea2be36cab5"/>
+		<rom name="Dalk (Japan) (Track 04).bin" size="54876864" crc="d0250f08" sha1="38defbb16a41220204b1694482083ab9175eb269"/>
+		<rom name="Dalk (Japan) (Track 05).bin" size="55737696" crc="34aff21f" sha1="417feb074a98fa5e5d134fe40271b68bb11c1fe8"/>
+		<rom name="Dalk (Japan) (Track 06).bin" size="51866304" crc="ec922af4" sha1="768c382d3c463b3e0b16dc38ddda30beb956c95e"/>
+		<rom name="Dalk (Japan) (Track 07).bin" size="54255936" crc="3c3581c8" sha1="d6d66383e12053c096f535172eb4cab7d9dea8e6"/>
+		<rom name="Dalk (Japan) (Track 08).bin" size="56271600" crc="44b515eb" sha1="21e2e3579d6e5dec4dea9ef8135eb752d219e9d0"/>
+		<rom name="Dalk (Japan) (Track 09).bin" size="54507600" crc="5fe0d9ea" sha1="7397f52d9b649df4d6524f7eb95ac83c72eef00f"/>
+		<rom name="Dalk (Japan) (Track 10).bin" size="54342960" crc="ed67dec0" sha1="c3d65f0fd0dd24478bd9e6b6bbb286e096ee417e"/>
+		<rom name="Dalk (Japan) (Track 11).bin" size="54401760" crc="54b5888e" sha1="a6f6f8a8997b00e0eb1bb49c929eb25fe80154cf"/>
+		<rom name="Dalk (Japan) (Track 12).bin" size="55747104" crc="fbab09c6" sha1="d2fc11518a2f3cc090ee4adb22a2e55f54e6404f"/>
+		<rom name="Dalk (Japan) (Track 13).bin" size="44899680" crc="dea11f0a" sha1="948aa33382d6479e0de09742db62d7f7bd680625"/>
+		<rom name="Dalk (Japan).cue" size="1373" crc="323ce133" sha1="ad78f59ca93ab322e29ae94b718ebb487a82bcf5"/>
 		-->
 		<description>Dalk</description>
 		<year>1993</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
-		<info name="serial" value="HME-128"/>
+		<info name="serial" value="HME-128 / ALS-0003"/>
 		<info name="alt_title" value="ダルク" />
 		<info name="release" value="199304xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -4409,7 +4637,44 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dalk" sha1="6fbf153137807615fc2a62018a1ca2d790ce9728" />
+				<disk name="dalk (japan)" sha1="45fdae45a2f6fb5340167a46a9f8e0f8c0ebd66a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="dalka" cloneof="dalk">
+		<!--
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Dalk (Japan) (Track 01).bin" size="20815200" crc="b1ed9d10" sha1="cc5e6a1cf2e01273d20a91601062738c2936cae5"/>
+		<rom name="Dalk (Japan) (Track 02).bin" size="54037200" crc="4c20aaed" sha1="f291285ddc0e774fa3ca87ac8b59248f70f78ab3"/>
+		<rom name="Dalk (Japan) (Track 03).bin" size="55389600" crc="83ba4544" sha1="56b6dee1695405f78f5cce824e4d9ea2be36cab5"/>
+		<rom name="Dalk (Japan) (Track 04).bin" size="54876864" crc="d0250f08" sha1="38defbb16a41220204b1694482083ab9175eb269"/>
+		<rom name="Dalk (Japan) (Track 05).bin" size="55737696" crc="34aff21f" sha1="417feb074a98fa5e5d134fe40271b68bb11c1fe8"/>
+		<rom name="Dalk (Japan) (Track 06).bin" size="51866304" crc="ec922af4" sha1="768c382d3c463b3e0b16dc38ddda30beb956c95e"/>
+		<rom name="Dalk (Japan) (Track 07).bin" size="54255936" crc="3c3581c8" sha1="d6d66383e12053c096f535172eb4cab7d9dea8e6"/>
+		<rom name="Dalk (Japan) (Track 08).bin" size="56271600" crc="44b515eb" sha1="21e2e3579d6e5dec4dea9ef8135eb752d219e9d0"/>
+		<rom name="Dalk (Japan) (Track 09).bin" size="54507600" crc="5fe0d9ea" sha1="7397f52d9b649df4d6524f7eb95ac83c72eef00f"/>
+		<rom name="Dalk (Japan) (Track 10).bin" size="54342960" crc="ed67dec0" sha1="c3d65f0fd0dd24478bd9e6b6bbb286e096ee417e"/>
+		<rom name="Dalk (Japan) (Track 11).bin" size="54401760" crc="54b5888e" sha1="a6f6f8a8997b00e0eb1bb49c929eb25fe80154cf"/>
+		<rom name="Dalk (Japan) (Track 12).bin" size="55747104" crc="fbab09c6" sha1="d2fc11518a2f3cc090ee4adb22a2e55f54e6404f"/>
+		<rom name="Dalk (Japan) (Track 13).bin" size="44899680" crc="dea11f0a" sha1="948aa33382d6479e0de09742db62d7f7bd680625"/>
+		<rom name="Dalk (Japan).cue" size="1373" crc="323ce133" sha1="ad78f59ca93ab322e29ae94b718ebb487a82bcf5"/>
+		-->
+		<description>Dalk (alt floppy disk)</description>
+		<year>1993</year>
+		<publisher>アリスソフト (AliceSoft)</publisher>
+		<info name="serial" value="HME-128 / ALS-0003"/>
+		<info name="alt_title" value="ダルク" />
+		<info name="release" value="199304xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="dalk.hdm" size="1261568" crc="61bfa42c" sha1="6fa5c82bb8caa68ba8b39a2da825d049f237eb5d" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="dalk (japan)" sha1="45fdae45a2f6fb5340167a46a9f8e0f8c0ebd66a" />
 			</diskarea>
 		</part>
 	</software>
@@ -6344,11 +6609,22 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="eurosens">
 		<!--
-		Origin: Private dump (Reuental)
-		<rom name="opeurope.ccd" size="3437" crc="5377fcce" sha1="58a162c2a5a2ae57a84777fb3dda4d2ef490c4f3"/>
-		<rom name="opeurope.cue" size="857" crc="9548486d" sha1="64e2d2d15320557ab163b6cccda4e533375ef311"/>
-		<rom name="opeurope.img" size="531848352" crc="e3dab297" sha1="44d2a058f16c503c84b0bdeeb06473f295961ee1"/>
-		<rom name="opeurope.sub" size="21708096" crc="ea42c3c3" sha1="8cc44fd0ad60853bbe8430c9fd81592f0989325a"/>
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Europa Sensen (Japan) (Track 01).bin" size="10231200" crc="50123f2c" sha1="742eae4c50cd6666a9300638e73b64c6d639c318"/>
+		<rom name="Europa Sensen (Japan) (Track 02).bin" size="33694752" crc="8eee5b55" sha1="12db0349efc7c4f37484806e3320209eba004546"/>
+		<rom name="Europa Sensen (Japan) (Track 03).bin" size="37044000" crc="58e59796" sha1="f3be2ba69938881c2088c5bea17fe4d7cb6d846f"/>
+		<rom name="Europa Sensen (Japan) (Track 04).bin" size="44805600" crc="0c175bd2" sha1="09ac941ed4e6b83c841f53df71dc870162b001d6"/>
+		<rom name="Europa Sensen (Japan) (Track 05).bin" size="44452800" crc="66433b82" sha1="cb5bffe8e3d6d09ada0c8c366cca3eaf5467008e"/>
+		<rom name="Europa Sensen (Japan) (Track 06).bin" size="46216800" crc="727181d0" sha1="3ede95ea9b9daff8d38de2b31a9652c8bab79c2c"/>
+		<rom name="Europa Sensen (Japan) (Track 07).bin" size="40395600" crc="739e0ed0" sha1="2af573affad833994bef872907b15e85b4963ce3"/>
+		<rom name="Europa Sensen (Japan) (Track 08).bin" size="45864000" crc="a5274b89" sha1="9eb5d0eca8caf43a8ce75d17dd7b0d0ef4a34fdb"/>
+		<rom name="Europa Sensen (Japan) (Track 09).bin" size="29458800" crc="1dd24205" sha1="f4e20d6bb70faa919803b848c5e7bfef6202cd63"/>
+		<rom name="Europa Sensen (Japan) (Track 10).bin" size="44452800" crc="eb7237f5" sha1="ffa369733ada4282e5c0a955ded9811d1f908ffa"/>
+		<rom name="Europa Sensen (Japan) (Track 11).bin" size="39337200" crc="75b3f90c" sha1="91f70211896a1f8ef54157dad2c62c220e2d1a5e"/>
+		<rom name="Europa Sensen (Japan) (Track 12).bin" size="44805600" crc="3b7e637d" sha1="6faeb54a0d73dee86549238bbcaae83e119fceed"/>
+		<rom name="Europa Sensen (Japan) (Track 13).bin" size="34045200" crc="74270078" sha1="f653ecdf61398a631bdb83417c3bfe0e2d8e92f7"/>
+		<rom name="Europa Sensen (Japan) (Track 14).bin" size="37044000" crc="5eaf1ef3" sha1="f71b776a8d3dc84e838738b4bc9487ce6b8292ed"/>
+		<rom name="Europa Sensen (Japan).cue" size="1629" crc="e7706b12" sha1="f0aacb1ee3f4d84e09b7ba696b7d410a3e8c0908"/>
 		-->
 		<description>Europa Sensen</description>
 		<year>1992</year>
@@ -6358,14 +6634,13 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199207xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="User Disk" />
-			<dataarea name="flop" size="1281968">
-				<rom name="opeurope.d88" size="1281968" crc="32174842" sha1="12fd4e6558e0bf7e47a9a27fa5c33db9c3a60cfd" offset="000000" />
+			<dataarea name="flop" size="1261568">
+				<rom name="europa_sensen.hdm" size="1261568" crc="b6355674" sha1="28ed4ad10c4ba16567cbab278b51ca148587be15" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="opeurope" sha1="339dd6e82f81b54bee0cd72cc7e2fb5444e2dea1" />
+				<disk name="europa sensen (japan)" sha1="80f373c8be4389d3b78dc6fbc55292388891fe13" />
 			</diskarea>
 		</part>
 	</software>
@@ -6962,7 +7237,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>FM Towns Hyper CD Demo Futoppara No. 1</description>
 		<year>1989</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="serial" value="HMA-208"/>
 		<info name="alt_title" value="太っ腹 Ｎｏ．１" />
 		<info name="release" value="198907xx" />
@@ -7080,7 +7355,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Free Will: Knight of Argent</description>
 		<year>1992</year>
-		<publisher>Sofcom</publisher>
+		<publisher>ソフコム (Sofcom)</publisher>
 		<info name="serial" value="HMD-185"/>
 		<info name="release" value="199211xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -7764,7 +8039,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1996</year>
 		<publisher>アリスソフト (AliceSoft)</publisher>
 		<info name="serial" value="ALS-0021"/>
-		<info name="alt_title" value="学園KING -日出彦 学校をつくる-" />
+		<info name="alt_title" value="学園KING -日出彦学校をつくる-" />
 		<info name="release" value="199606xx" />
 		<info name="usage" value="Requires HDD installation and 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -7980,7 +8255,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Genocide Square</description>
 		<year>1993</year>
-		<publisher>Zoom</publisher>
+		<publisher>ズーム (Zoom)</publisher>
 		<info name="serial" value="HME-117 / MTC-1040"/>
 		<info name="alt_title" value="ジェノサイド・スクウエア" />
 		<info name="release" value="199304xx" />
@@ -8688,7 +8963,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199504xx" />
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="System Disk" />
+			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="1261568">
 				<rom name="half_moon_ni_kawaru_made.hdm" size="1261568" crc="664957f7" sha1="24dc3bf141e174e52869f29309a0aee1db08ade8" offset="000000" />
 			</dataarea>
@@ -8990,7 +9265,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="hiouden2">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / wiggy2k (floppy)
 		<rom name="Hiouden II (Japan).cue" size="84" crc="497b5f5f" md5="50c108bde5663b3b92ea60b398846d03" sha1="d5d1de91ae78512f7774b317cb42c8c0e6fb4c77"/>
 		<rom name="Hiouden II (Japan).bin" size="31396848" crc="62ee325e" md5="4b3e585d9e28cf65f0b61d15ed3f3490" sha1="eb1980658c818c2964c4974e444cacb7739758af"/>
 		-->
@@ -9001,18 +9276,10 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="緋王伝II" />
 		<info name="release" value="199403xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
-		<!--
-		Note from the dumper:
-
-		When I dumped the system disk it was considerably damaged, with a lot of bad sectors
-		on side 1. Thankfully this doesn't affect the executable files and doesn't prevent the
-		game from running, but there are saved games by the original owner that probably won't work.
-		In any case, the disk needs a redump from a cleaner copy.
-		-->
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System Disk" />
 			<dataarea name="flop" size="1261568">
-				<rom name="hiouden ii (japan) (system disk).hdm" size="1261568" crc="a3430507" sha1="6dadde7fb90329717adce6e98b4b3698cb67a199" offset="000000" status="baddump"/>
+				<rom name="hiouden ii (japan) (system disk).hdm" size="1261568" crc="0e78d3a2" sha1="b610c81e548fe3ed78ba8b79e7766ec7b50f2bd3" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -9297,6 +9564,39 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="hypland" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 01).bin" size="105487200" crc="8fffa18b" sha1="b0ff6c31974dc9e512bf0cf06e594de8089a0ec7"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 02).bin" size="64738800" crc="43d48b65" sha1="a133ee2fbc2670fdcf47b268477222bb3d43fa34"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 03).bin" size="66502800" crc="1d41cac0" sha1="d610585533eaf04eedffbb813974e837e855c91c"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 04).bin" size="5644800" crc="1ebf46bf" sha1="95511f406b6a75c9ba08ffd240d794319dcdb9a7"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 05).bin" size="32104800" crc="843ec986" sha1="9faa3b8c304c599a1b83dbac8a9d6a0b4e35dc15"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 06).bin" size="31928400" crc="937ee660" sha1="0df837ed0b3e978cf82da6c8d943930fe3b173df"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 07).bin" size="31928400" crc="79c4c1d9" sha1="76155c006f46e5c90e2241b787de3d36fea42fbf"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 08).bin" size="31752000" crc="867cb12a" sha1="f88a7d25e844acf0c9d078c1a37198870f3f2d54"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 09).bin" size="5644800" crc="94c176dd" sha1="c7550e83ceb8a01cbf730f620a3ec84ab0e4aeee"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 10).bin" size="5821200" crc="d4132977" sha1="e2a827f04b862fd979f119ed7e5704df08e496d7"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 11).bin" size="5821200" crc="636bd136" sha1="70ddc6d5df058129faee27cc6ca0b09d6f1df32c"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 12).bin" size="5644800" crc="f78965d0" sha1="cf6d7141f469551ac646e158d0b2f80e6e766f37"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 13).bin" size="5821200" crc="12cc11a9" sha1="0e5dc7c0ea795e3c4d05ea32a17e74c577b81a5b"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan) (Track 14).bin" size="5821200" crc="7fda78df" sha1="633eee776c3cd23103b75a2ed5dc0412528dd625"/>
+		<rom name="Hyper Land - Doubutsu no Sekai (Japan).cue" size="1844" crc="2dabd044" sha1="2ab79fd006ef97e3cadbe1376174b5688c325698"/>
+		-->
+		<description>Hyper Land - Doubutsu no Sekai</description>
+		<year>1993</year>
+		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HME-108"/>
+		<info name="alt_title" value="ＨＹＰＥＲ　ＬＡＮＤ -動物の世界-" />
+		<info name="release" value="199303xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper land - doubutsu no sekai (japan)" sha1="d5d4f5cc55bb716a55423aaedbabd70986573088" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Hyper Planet was dumped from two complete copies (CD + floppy). The CD has been verified to be exactly the same between revisions, only the floppy differs. -->
 	<software name="hyplanet">
 		<!--
@@ -9451,28 +9751,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Dumped from a physically damaged disc, it only affects some of the audio tracks (7 and 11) but a redump is needed -->
 	<software name="hyplanets2">
 		<!--
-		Origin: private dump (Maddog)
-		<rom name="Hyper Planet Shiki Vol 2.cue" size="1529" crc="6b0ee345" sha1="2057dcd9739f1cb80d0d84bc7f2310856291dc9e"/>
-		<rom name="Track01.bin" size="20815200" crc="629a63e0" sha1="1f17367785da47a68b7d53c855a6995259d9af17"/>
-		<rom name="Track02.bin" size="47971392" crc="7f41d59d" sha1="ae07f9ac01e974b5df503071031954e8f011c12f"/>
-		<rom name="Track03.bin" size="87200400" crc="e276ca15" sha1="85919ef4e330bb290b621014b801dd3006288976"/>
-		<rom name="Track04.bin" size="72794400" crc="b9771b20" sha1="eac0afde1e7922af99ed779ca115d4c3ce096f53"/>
-		<rom name="Track05.bin" size="84876624" crc="b56453f3" sha1="047d512f8a9dcc3dd413d570ced8d9736b04bb8f"/>
-		<rom name="Track06.bin" size="71331456" crc="9e08a1cd" sha1="f7601f566c41f70f79809d2ff344e40b780734c1"/>
-		<rom name="Track07.bin" size="66279360" crc="71a3a2ff" sha1="878b844d1938350b5c5ff9266939b0bba01fd023"/>
-		<rom name="Track08.bin" size="55272000" crc="12dc9116" sha1="edc9bff5c4e3cb21bee7d934e064c9c94fd49b74"/>
-		<rom name="Track09.bin" size="31293360" crc="21c1d265" sha1="8837ff6ad4db066e304dd134daa63a17a59dea80"/>
-		<rom name="Track10.bin" size="34449744" crc="4cc03069" sha1="c07fc277f0631417d7f8a98ea9306cd8de921020"/>
-		<rom name="Track11.bin" size="56165760" crc="a7bbe6e4" sha1="f5894ee751b89f9fa1831018a1bb3064676f511e"/>
-		<rom name="Track12.bin" size="18140976" crc="650c9b0f" sha1="2b630ff3e86d989da78f687babbcb5b9ce4ac476"/>
-		<rom name="Track13.bin" size="19690944" crc="6240d916" sha1="cd0e982f8fb642e6c79de1f88a21e8b2823d0289"/>
-		<rom name="Track14.bin" size="20445936" crc="0d64bcc9" sha1="c05d52f3f25eb877fe4b0d75b5b652bd8c2b5647"/>
-		<rom name="Track15.bin" size="18686640" crc="fd10137f" sha1="414ca25d1656dd56af56147b5944f97d64d7f92a"/>
-		<rom name="Track16.bin" size="26601120" crc="72073dac" sha1="f94048252b279b42d8b038c1e918b62ca423a2b7"/>
-		<rom name="Track17.bin" size="54825120" crc="0ff85fa0" sha1="a39638049a9d3d49af57610ccec5b2f193f87fe7"/>
+		Origin: redump.org
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 01).bin" size="20815200" crc="629a63e0" sha1="1f17367785da47a68b7d53c855a6995259d9af17"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 02).bin" size="47971392" crc="7f41d59d" sha1="ae07f9ac01e974b5df503071031954e8f011c12f"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 03).bin" size="87200400" crc="e276ca15" sha1="85919ef4e330bb290b621014b801dd3006288976"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 04).bin" size="72794400" crc="b9771b20" sha1="eac0afde1e7922af99ed779ca115d4c3ce096f53"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 05).bin" size="84876624" crc="b56453f3" sha1="047d512f8a9dcc3dd413d570ced8d9736b04bb8f"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 06).bin" size="71331456" crc="9e08a1cd" sha1="f7601f566c41f70f79809d2ff344e40b780734c1"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 07).bin" size="66279360" crc="53d83401" sha1="ebe08f97845e1cf0e6932d29146e517041807750"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 08).bin" size="55272000" crc="12dc9116" sha1="edc9bff5c4e3cb21bee7d934e064c9c94fd49b74"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 09).bin" size="31293360" crc="21c1d265" sha1="8837ff6ad4db066e304dd134daa63a17a59dea80"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 10).bin" size="34449744" crc="4cc03069" sha1="c07fc277f0631417d7f8a98ea9306cd8de921020"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 11).bin" size="56165760" crc="f32746c9" sha1="03c1c17873a8b47d8aa61b81b75f5a8712374e99"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 12).bin" size="18140976" crc="650c9b0f" sha1="2b630ff3e86d989da78f687babbcb5b9ce4ac476"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 13).bin" size="19690944" crc="6240d916" sha1="cd0e982f8fb642e6c79de1f88a21e8b2823d0289"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 14).bin" size="20445936" crc="0d64bcc9" sha1="c05d52f3f25eb877fe4b0d75b5b652bd8c2b5647"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 15).bin" size="18686640" crc="fd10137f" sha1="414ca25d1656dd56af56147b5944f97d64d7f92a"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 16).bin" size="26601120" crc="72073dac" sha1="f94048252b279b42d8b038c1e918b62ca423a2b7"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan) (Track 17).bin" size="54825120" crc="0ff85fa0" sha1="a39638049a9d3d49af57610ccec5b2f193f87fe7"/>
+		<rom name="Hyper Planet Shiki Vol. 2 (Japan).cue" size="2181" crc="300087b0" sha1="4ba0fd13c17cbd77bd16ec8e0a80c8bfe2e506a1"/>
 		-->
 		<description>Hyper Planet Shiki Vol. 2</description>
 		<year>1993</year>
@@ -9483,7 +9782,28 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hyper planet shiki vol 2" sha1="f09dfbb993eefbfed217f91518ff6d0337b65e2d" status="baddump" />
+				<disk name="hyper planet shiki vol. 2 (japan)" sha1="86d8ef51f12b8d811c1f8f6843b5803eb6c1af0f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk -->
+	<software name="hypnote" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Note (Japan) (Track 1).bin" size="52567200" crc="714c1354" sha1="9b3c06bc68e85334830b47aebad2abea578810a6"/>
+		<rom name="Hyper Note (Japan) (Track 2).bin" size="68541984" crc="221a1e77" sha1="f32722e72ad66639e6a6d0915d9dd526b6282d95"/>
+		<rom name="Hyper Note (Japan) (Track 3).bin" size="24185616" crc="add5dddc" sha1="350757204339196703eeabe95f75e4139db4df43"/>
+		<rom name="Hyper Note (Japan).cue" size="318" crc="5bf841e8" sha1="ccdad2acfa8a2e8c41ce31c6d30c717b31753f9c"/>
+		-->
+		<description>Hyper Note</description>
+		<year>1991</year>
+		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HMC-166"/>
+		<info name="release" value="199112xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper note (japan)" sha1="23e86c388f7ef78bcbd63b3fc6abaee5d5d4081f" />
 			</diskarea>
 		</part>
 	</software>
@@ -9809,26 +10129,30 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!--
-	This is named "Go Dojo Yaburi" in the Neo Kobe Collection. That name actually
-	corresponds to a different Go game, also published by Fujitsu.
-	-->
 	<software name="igohonka">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Go Dojo Yaburi.ccd" size="1061" crc="833c729d" sha1="11365f1eae3e7dafdde4f38373af323986a5f4b3"/>
-		<rom name="Go Dojo Yaburi.cue" size="224" crc="fe242e98" sha1="9ff91b652a3f2168a6a670bc646cd95f10f2735d"/>
-		<rom name="Go Dojo Yaburi.img" size="105487200" crc="b9af10b1" sha1="3d0b1a638a3c3fa12fd1c4e76996cc75d618b5e8"/>
-		<rom name="Go Dojo Yaburi.sub" size="4305600" crc="04ee81d0" sha1="06e02a0a1c453188324dd19e801b424175149a4b"/>
+		Origin: redump.org
+		<rom name="Igo Doujou (Japan) (Track 1).bin" size="4410000" crc="f7e4995c" sha1="fc6c6420cfcaf7e78dad2b256cd0e7237d60a559"/>
+		<rom name="Igo Doujou (Japan) (Track 2).bin" size="22061760" crc="ac93538f" sha1="e8d046e6adb5e5f2e0c4b0e55e303e57c5dd4b2d"/>
+		<rom name="Igo Doujou (Japan) (Track 3).bin" size="79015440" crc="5ddf6930" sha1="b14cc6db5b444bb3ed580752feb2b21c7a937a82"/>
+		<rom name="Igo Doujou (Japan).cue" size="318" crc="26b518cd" sha1="a54a622117451057803d3ac9500dc445a0298b2d"/>
 		-->
 		<description>Igo Doujou - Honkakuha Yose Tsumego Shinan</description>
 		<year>1989</year>
 		<publisher>富士通OA (Fujitsu OA)</publisher>
+		<info name="serial" value="FOA-2003"/>
 		<info name="alt_title" value="囲碁道場 本格派寄せ・詰碁指南" />
 		<info name="release" value="198903xx" />
+		<!-- The floppy disk is protected (the last sector of track 0 side 0 has a non-standard ID of 247 and an intentionally bad CRC) -->
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="問題ディスク第2集 / Mondai Disk Dai-2-shuu" />
+			<dataarea name="flop" size="3444632">
+				<rom name="igo_doujou_mondai_disk_dai-2-shuu.mfm" size="3444632" crc="9cfe32cf" sha1="91a66e690b71758708c05b2dca217256d582c466" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="go dojo yaburi" sha1="fa15a75cdaca351704fb4957b019065ec1a3a6ce" />
+				<disk name="igo doujou (japan)" sha1="e02b655f76e26f64c4dc1b3f1abcb566caa0ad4e" />
 			</diskarea>
 		</part>
 	</software>
@@ -10516,7 +10840,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="joshisei">
 		<!--
-		Origin: redump.org / r09
+		Origin: redump.org (CD) / r09 (floppy)
 		<rom name="Joshikou Seifuku Monogatari (Japan).bin" size="13778016" crc="afd0bf24" sha1="b37360c8b030467c5b5ef13e67a38d9d00bcfe19"/>
 		<rom name="Joshikou Seifuku Monogatari (Japan).cue" size="101" crc="767b1881" sha1="36ebfe1adadce7e5c7ec3f856d601e889382d559"/>
 		-->
@@ -10607,6 +10931,40 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="kazadama2">
+		<!--
+		Origin: redump.org
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 01).bin" size="190159200" crc="1e31a047" sha1="4a39f4c931ce8d4737975d1ea037fa11d2d53e18"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 02).bin" size="29106000" crc="c094f039" sha1="a3472ad8fb7c038ac078a27492fed71201eefe1d"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 03).bin" size="25754400" crc="4010f1c4" sha1="3c8994a1cc7fe254de09b9027b9d1f4060f30385"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 04).bin" size="29282400" crc="ff550cdb" sha1="41a6c7b1096158ca2ac6277d873c23e7acc0c48b"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 05).bin" size="28400400" crc="2dd17e69" sha1="0e30731b09e08f2cf2dce7e95aec3cd124ac0bab"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 06).bin" size="39690000" crc="1bbc52cd" sha1="f4d5f28d60c0887f6f8a3deedf01c5defb5e967b"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 07).bin" size="46040400" crc="df2aa95f" sha1="93a3e9ce59962a382633e2c01adcecea7a10c92d"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 08).bin" size="33163200" crc="949d3864" sha1="e6178f929e3bf1beea84da39efe883dd7360ae5f"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 09).bin" size="35632800" crc="034804ae" sha1="6d03ac802e82d1bcedf6cb6722d784c39bf9c418"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 10).bin" size="32457600" crc="48c18106" sha1="ccd20c17220d17107b55ee0113fdfcdb6d13dace"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 11).bin" size="36867600" crc="e1d68530" sha1="3b9582627b530440889553cba25ee2f0274ed1d6"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 12).bin" size="30340800" crc="a481282c" sha1="e677da5c1ecdab5eb5a258f16691d6193b027ffc"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 13).bin" size="66502800" crc="4d6864e2" sha1="e81cec67ac2a08a57414a83d63e290e77add4cb5"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 14).bin" size="66326400" crc="ea7f0f84" sha1="c88e0e91ed5c3e64e5219c895936d43c872b6fc6"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan) (Track 15).bin" size="79909200" crc="8b411d13" sha1="f1517edee973cf7d69aa0a2e8d91420467d47e6a"/>
+		<rom name="Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu (Japan).cue" size="2420" crc="f8a984f9" sha1="e7a34dcfc9a1084d2a08c5601985639ff1f0c11d"/>
+		-->
+		<description>Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu</description>
+		<year>1995</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMG-711 / A288CHE0 / BGV-021"/>
+		<info name="alt_title" value="風珠Ｖｏｌ．２　「Ｍａｓｕｏ　ｐｅｒ　Ｍａｓｕｏ」　池田満寿夫版画集" />
+		<info name="release" value="199504xx" />
+		<info name="usage" value="Requires 6 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="kazadama vol. 2 - masuo per masuo - ikeda masuo hanga-shuu (japan)" sha1="7ab8cacc8f097515f193083a841c59762d72be95" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="knjehon">
 		<!--
 		Origin: redump.org
@@ -10628,6 +10986,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9821 / FM Towns hybrid -->
 	<software name="knjland3">
 		<!--
 		Origin: redump.org
@@ -10751,11 +11110,25 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="kbounty">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="King&apos;s Bounty.ccd" size="3795" crc="b5afc2ab" sha1="11efe9ac63787e040d73a5a9ec0f100fdb57731c"/>
-		<rom name="King&apos;s Bounty.cue" size="709" crc="7575279a" sha1="49f3ceb6cc8f16ee688a217b3202efb1cb219c01"/>
-		<rom name="King&apos;s Bounty.img" size="386494752" crc="cdcf960b" sha1="d31f3214ab0bbb229c9f79ef3f7752d5fcb8cc7e"/>
-		<rom name="King&apos;s Bounty.sub" size="15775296" crc="d291d35c" sha1="66a469ec41ade7ebe882905efbe316c94c790764"/>
+		Origin: redump.org
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 01).bin" size="10231200" crc="a18a80c9" sha1="dd097200f140bc4485c64bd921b1e5440a1044fa"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 02).bin" size="11821152" crc="f8d9d2b7" sha1="29772d5435fb8c7ee2c39863c1b6782b71d1a3ea"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 03).bin" size="1764000" crc="a90e47b2" sha1="36120a216e846d8f44dcf9dca90492b357f63aed"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 04).bin" size="1764000" crc="f1add02d" sha1="2ee63490b938eb805db35807dcc3a27a26ebcd32"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 05).bin" size="22402800" crc="0c9e3ccd" sha1="ab41f47fa981df23e13860c3a24a08fe7b8b72fa"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 06).bin" size="26636400" crc="9de86415" sha1="c95b0534b8a77bdb75baeb3bce0b17d98cec2f4f"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 07).bin" size="28576800" crc="a6b820db" sha1="d17c53d4502b891abf9fdaf3b0138d8a60a88e0d"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 08).bin" size="40572000" crc="70bf52b2" sha1="c78316232099493fc0c03981dc2be35c8c89ac7c"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 09).bin" size="26283600" crc="3bd19c4d" sha1="b57dc053533a525f35607f5169e40cb92bfd37d2"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 10).bin" size="25048800" crc="beb9d7d3" sha1="e20837e01c449da42438701120e25492d0d25f48"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 11).bin" size="19404000" crc="e472bda4" sha1="8fb7409e27d98fd6e18caa411a00212048e0f6c1"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 12).bin" size="21697200" crc="96ccac4c" sha1="3f524033642b481637b5baa7c73409f01c0034b1"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 13).bin" size="2116800" crc="97caf961" sha1="e10b138f3310cb47db8e3a7723f9d2a824a5f2a8"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 14).bin" size="17287200" crc="d0b8690b" sha1="3eef3b68c91886ebb7d0d24529a95c1ce79cbf37"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 15).bin" size="42336000" crc="f999064d" sha1="3c877af726aac6ab5097fe960009b330e74faa3b"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 16).bin" size="53802000" crc="b397a9a7" sha1="67c9a92d8882d793d23fb4daa91be76196c1b006"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan) (Track 17).bin" size="34750800" crc="569020b5" sha1="9d2cc80ef5005aedb537fc15596762ba73b652bb"/>
+		<rom name="King's Bounty - Nusumareta Chitsujo (Japan).cue" size="2351" crc="69d4b5a3" sha1="74f4c66259a04347a12e2162cd0cdd1c7f2a1a65"/>
 		-->
 		<description>King's Bounty - Nusumareta Chitsujo</description>
 		<year>1994</year>
@@ -10766,7 +11139,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="king's bounty" sha1="3bf83f353aee51986e0e73b581feb4a7cc0ad850" />
+				<disk name="king's bounty - nusumareta chitsujo (japan)" sha1="bf99dedb2744e78056c1cbff963e83071baa38ad" />
 			</diskarea>
 		</part>
 	</software>
@@ -10916,6 +11289,67 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="koryuki">
+		<!--
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Kouryuuki (Japan) (Track 01).bin" size="10231200" crc="67cab13d" sha1="0c63fcacb3aac872d307edb17ef0c1377a4fac3e"/>
+		<rom name="Kouryuuki (Japan) (Track 02).bin" size="14841120" crc="3ba16d0b" sha1="34433216abfd9f52455ea5d2a90371382110c290"/>
+		<rom name="Kouryuuki (Japan) (Track 03).bin" size="20203680" crc="3c26bde6" sha1="94e9b65db18627bcdc573a2682da5724b488a666"/>
+		<rom name="Kouryuuki (Japan) (Track 04).bin" size="70383600" crc="19d0f36f" sha1="de64d85f544e028ecb1dd3a5a176a74972e8e47d"/>
+		<rom name="Kouryuuki (Japan) (Track 05).bin" size="16922640" crc="4ad38024" sha1="9fb0e215eab72f96b43dfd7244f93b4948c03b5e"/>
+		<rom name="Kouryuuki (Japan) (Track 06).bin" size="13810944" crc="d80eca09" sha1="c92f32c2b84eb3d3dd8670b6c09b200edec2f3e8"/>
+		<rom name="Kouryuuki (Japan) (Track 07).bin" size="15530256" crc="7de733fb" sha1="1ce734aa329a0698b2ac955dde6f43e2fee5aca3"/>
+		<rom name="Kouryuuki (Japan) (Track 08).bin" size="14057904" crc="aba21579" sha1="0bfae05acb0baed7bbc0e8af60217702efc9c683"/>
+		<rom name="Kouryuuki (Japan) (Track 09).bin" size="52927056" crc="9c0fa14e" sha1="21cf164b8d8ce6ac984d96dec73561e1289d6884"/>
+		<rom name="Kouryuuki (Japan) (Track 10).bin" size="2963520" crc="37658e4c" sha1="60ffb55b2a4bbaa991e8e496b63d6ff295f1ae81"/>
+		<rom name="Kouryuuki (Japan) (Track 11).bin" size="53202240" crc="d5dd4ea0" sha1="da512863fceb705a930efc225dfe78ab2361c757"/>
+		<rom name="Kouryuuki (Japan) (Track 12).bin" size="53900784" crc="1f6ad450" sha1="0729b33ace385cff569ab9bd48e20e5a7449b36c"/>
+		<rom name="Kouryuuki (Japan) (Track 13).bin" size="43947120" crc="fe70e7b4" sha1="3682f4acc55701f07e94ed55091a65608f1d429e"/>
+		<rom name="Kouryuuki (Japan) (Track 14).bin" size="20234256" crc="e5f6ede7" sha1="1d3b17c86d9e7f7bccd4ba438b7ea071b976c036"/>
+		<rom name="Kouryuuki (Japan) (Track 15).bin" size="71035104" crc="d9cbd1da" sha1="e9ecfa90031e96d5a15c3f9910758a97dfe9da16"/>
+		<rom name="Kouryuuki (Japan) (Track 16).bin" size="9031680" crc="017ddeb5" sha1="cc1f25aa8a0cc9bd3528e6ee29ab192c764a972a"/>
+		<rom name="Kouryuuki (Japan).cue" size="1659" crc="e3244b20" sha1="575c26f4ad0281b92b03ed872f7fb31a37f86426"/>
+		-->
+		<description>Kouryuuki</description>
+		<year>1993</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HME-202"/>
+		<info name="alt_title" value="項劉記" />
+		<info name="release" value="199310xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="kouryuuki.hdm" size="1261568" crc="c37a6cb0" sha1="a152158d4d74cf7172f5e53ece8f3ddddf88ce45" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="kouryuuki (japan)" sha1="02c72a8f00f985d6ad6589b305b9c976c7ffb8e8" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Windows / PC-9801 / FM Towns hybrid -->
+	<software name="kusuriyu">
+		<!--
+		Origin: redump.org
+		<rom name="Kusuriyubi no Kyoukasho (Japan).bin" size="23317728" crc="62a4ba1e" sha1="2dc95ea50fb173f50094cb792de23efa8b3719d4"/>
+		<rom name="Kusuriyubi no Kyoukasho (Japan).cue" size="97" crc="a1753f6c" sha1="1630c930750709a35ecc20e0adde6b6748351871"/>
+		-->
+		<description>Kusuriyubi no Kyoukasho</description>
+		<year>1996</year>
+		<publisher>アクティブ (Active)</publisher>
+		<info name="serial" value="WIC-5185"/>
+		<info name="alt_title" value="くすり指の教科書" />
+		<info name="release" value="199604xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="kusuriyubi no kyoukasho (japan)" sha1="3abab66cb04e640a92d745f6d63867e756bb8771" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="kyankyan">
 		<!--
 		Origin: redump.org
@@ -10932,7 +11366,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Kyan Kyan Collection - Daifugouhen</description>
 		<year>1989</year>
-		<publisher>I-Cell</publisher>
+		<publisher>アイセル (I-Cell)</publisher>
 		<info name="serial" value="HMA-236 / YHRS-229"/>
 		<info name="alt_title" value="ＫＹＡＮ　ＫＹＡＮ　ＣＯＬＬＥＣＴＩＯＮ　大富豪編" />
 		<info name="release" value="198912xx" />
@@ -11967,6 +12401,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9821 / FM Towns hybrid -->
 	<software name="lemoncc">
 		<!--
 		Origin: redump.org
@@ -12158,6 +12593,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- PC-9801 / FM Towns hybrid -->
 	<software name="links386">
 		<!--
 		Origin: redump.org
@@ -13596,7 +14032,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Mirrors</description>
 		<year>1992</year>
-		<publisher>Apros</publisher>
+		<publisher>アプロス (Apros)</publisher>
 		<info name="serial" value="HMC-176 / SW-001"/>
 		<info name="alt_title" value="ミラーズ" />
 		<info name="release" value="199206xx" />
@@ -13950,20 +14386,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="moritas2">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Morita Shogi 2.ccd" size="768" crc="682fd8e4" sha1="3026c248c1a86bc04f57788e7c2f2f5eaafe100b"/>
-		<rom name="Morita Shogi 2.cue" size="78" crc="4006a113" sha1="5d83a7529898c2b70c6508ba50f692aab1f571f4"/>
-		<rom name="Morita Shogi 2.img" size="4939200" crc="427533a9" sha1="b871b9aa03a8eb66f02273dad5a193f84bf27bfe"/>
-		<rom name="Morita Shogi 2.sub" size="201600" crc="e120aab9" sha1="6488fb4fff35ea754133d330770a3fad1c5362f8"/>
+		Origin: redump.org
+		<rom name="Morita Shougi II (Japan).bin" size="4939200" crc="22405a0c" sha1="4d4ee55323057d6615811efe9639c98a805e578c"/>
+		<rom name="Morita Shougi II (Japan).cue" size="90" crc="872638d6" sha1="de855cb61aa67aad87a4876aeb14f2ea3c6b9016"/>
 		-->
 		<description>Morita Shougi II</description>
 		<year>1989</year>
 		<publisher>エニックス (Enix)</publisher>
+		<info name="serial" value="EG-228"/>
 		<info name="alt_title" value="森田将棋II" />
 		<info name="release" value="198903xx" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="morita shogi 2" sha1="a5cdde15bd0eabac6c5bfd195a651b18f9b4d869" />
+				<disk name="morita shougi ii (japan)" sha1="1f6d9581306ab86edb449b80f7b67c704a6d299b" />
 			</diskarea>
 		</part>
 	</software>
@@ -14209,21 +14644,32 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="musicmaclt">
 		<!--
-		Origin: P2P
-		<rom name="Image.cdm" size="3347" crc="a049d27c" sha1="74cbee93729fdd87d3eddba95d2f3f3d42b4ea04"/>
-		<rom name="Image.cue" size="627" crc="472c64bb" sha1="3ac1a131481a0fbad19d36b6a2fd86248fdbb543"/>
-		<rom name="Image.img" size="414363600" crc="0d49c9ce" sha1="c97c88ec1ef50a4b6c5993d60a69976dc35979ec"/>
-		<rom name="Image.sub" size="16912800" crc="0050ca58" sha1="5ce4e954f1da8ea4fa0e175a1a8ca018c2f51f18"/>
+		Origin: redump.org
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 01).bin" size="52567200" crc="e8597ac2" sha1="0d837cf4930a558bf2358cb9297c57a3ba6578ed"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 02).bin" size="27518400" crc="70286105" sha1="7327f8b5645a1166569494b9b3ccabc85a24d2fb"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 03).bin" size="21168000" crc="492b5309" sha1="7802c382a73e17bed421d67edd32dacf9c006311"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 04).bin" size="56448000" crc="fff190e9" sha1="c062b0b469d39a1c874beb9a006999cf185d03b3"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 05).bin" size="17640000" crc="c80dfd58" sha1="86aae105487f717871200befe8b3ec2102458d0f"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 06).bin" size="18522000" crc="9aa6bd7e" sha1="773dcbfedfb9fb51a06c7d0ca7135eb5c6978c60"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 07).bin" size="26460000" crc="99c0745c" sha1="e229d7be19220b9a06029b86cc1b90fc25dbd62f"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 08).bin" size="22755600" crc="d571f43b" sha1="4d3f34edd00ab0a79a46a37047992e4c27020583"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 09).bin" size="37573200" crc="8b03fa70" sha1="2a48109fc0b937807f66a975b36471f6ca8f0867"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 10).bin" size="26460000" crc="0e831d63" sha1="0d9685cf5daf0d1c445fb426d549995ef4988a56"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 11).bin" size="34221600" crc="488a30db" sha1="8dafa838ac952cbb220a5e20734bb3d3744d8085"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 12).bin" size="51861600" crc="51942f44" sha1="fad480a2e54c94e329e4870644ef794dfde6cb8a"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 13).bin" size="11995200" crc="b9fb9e7a" sha1="06ff8bd0c38ef4f6a17f6b748cea346c05325790"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A) (Track 14).bin" size="9172800" crc="894aceff" sha1="a749b6f3a6ab054c367e7fb910edd256e95b0876"/>
+		<rom name="Mr. Ed Bogas' Music Machine Lite (Japan) (Rev A).cue" size="1984" crc="fe7e6b05" sha1="d4dc9583179251b132c9c87968b919c74f1f1d35"/>
 		-->
 		<description>Mr. Ed Bogas' Music Machine Lite</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="serial" value="HMD-914"/>
+		<info name="serial" value="HMD-914A / A2760350 / TSC 280"/>
 		<info name="release" value="19931126" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="musicmac" sha1="fd43146d8d7bcdb233b7ca06f164ae52550c5476" />
+				<disk name="mr. ed bogas' music machine lite (japan) (rev a)" sha1="1da4f88bc42ed31e48f903fa5b866c1fe74f10eb" />
 			</diskarea>
 		</part>
 	</software>
@@ -14868,6 +15314,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>NHK Jissen Eikaiwa (HMC-120A)</description>
 		<year>1991</year>
 		<publisher>CRC総合研究所 (CRC Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMC-120A"/>
 		<info name="alt_title" value="ＮＨＫ実践英会話" />
 		<info name="release" value="199108xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -14887,6 +15334,7 @@ User/save disks that can be created from the game itself are not included.
 		<description>NHK Jissen Eikaiwa (HMC-120)</description>
 		<year>1991</year>
 		<publisher>CRC総合研究所 (CRC Sougou Kenkyuusho)</publisher>
+		<info name="serial" value="HMC-120"/>
 		<info name="alt_title" value="ＮＨＫ実践英会話" />
 		<info name="release" value="199108xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
@@ -15318,7 +15766,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Nijiiro Denshoku Musume</description>
 		<year>1994</year>
-		<publisher>ISC</publisher>
+		<publisher>アイエスシー (ISC)</publisher>
 		<info name="serial" value="MTC-1104"/>
 		<info name="alt_title" value="虹色電飾娘" />
 		<info name="release" value="199408xx" />
@@ -15371,11 +15819,24 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="nobubufu">
 		<!--
-		Origin: Private dump (Reuental)
-		<rom name="nobubus.ccd" size="3678" crc="9626485b" sha1="e1d9fd5e695aa965e9e534efa5c00608b89dafa9"/>
-		<rom name="nobubus.cue" size="726" crc="a006f671" sha1="9113dd7894c8168d95490eb46818a59f4e79be8d"/>
-		<rom name="nobubus.img" size="598174752" crc="8987d4a8" sha1="2874039535353d4b87f99f69af90aca07105d4df"/>
-		<rom name="nobubus.sub" size="24415296" crc="88ce164a" sha1="05ef1727a1c6b21497e9a6ebe377c9e05ee2b8fa"/>
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 01).bin" size="10231200" crc="3080e13c" sha1="80bd5384a5621aba1268c079ce1f8df0f3a018f0"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 02).bin" size="26420016" crc="94c68b8c" sha1="7331ef8fef2d1645db417b9a18a0499116f4c256"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 03).bin" size="37086336" crc="e1617066" sha1="7c3759cae4cfc1db1d48fc21cea2410dd81f4820"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 04).bin" size="30601872" crc="4b37eb5c" sha1="d3333a32d406ebc3dd80b44c59880d6203fee87f"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 05).bin" size="11122608" crc="fadf1d13" sha1="d7492ef0500653888a5a081760bb33dd783ec63a"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 06).bin" size="17155488" crc="e65c0c93" sha1="215324989c220a856d4a8ce66974020559261791"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 07).bin" size="12138672" crc="3a39fe6d" sha1="a4f10f4d9ca8b5f8e9de160b85c80db3d2dae2e1"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 08).bin" size="33313728" crc="dc2f3a5e" sha1="05cd50d1e707b91e762a6e163a1766abbf48f612"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 09).bin" size="18352656" crc="d6a7442d" sha1="785fe5435cd41cc366a28fbb1f316cecaff1c8cf"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 10).bin" size="36848784" crc="1f197c7a" sha1="2042de7dc8acdf0b4dda2cd34da3b55ad2ae92ad"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 11).bin" size="15278592" crc="7d2da79f" sha1="de1fb3bb40479ea0a53684db28a7c351d8fc4ab4"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 12).bin" size="31615584" crc="d86cdc87" sha1="cc910e010e00c99412c967ef79dcd6b6ceef1fe2"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 13).bin" size="35103600" crc="6efbd91a" sha1="d4bd80b8c05ef6419efd58773bfe0518ae2380cc"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 14).bin" size="33581856" crc="d55a83b8" sha1="81dd35dd3a81a5fc990c5efd7cac1732dca9ffd7"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 15).bin" size="31069920" crc="99351366" sha1="65a366689d93cc2ea86bea96af6bc7eac7ecf8e3"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan) (Track 16).bin" size="47115264" crc="33e6868e" sha1="d6b7cc72461710de8a7c48fec2548caecc609009"/>
+		<rom name="Nobunaga no Yabou - Bushou Fuuunroku (Japan).cue" size="2137" crc="f79c9a7a" sha1="10783762d4ff77f5ca334afd7e5d76b829a917a7"/>
 		-->
 		<description>Nobunaga no Yabou - Bushou Fuuunroku</description>
 		<year>1991</year>
@@ -15385,14 +15846,13 @@ User/save disks that can be created from the game itself are not included.
 		<info name="release" value="199107xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="User Disk" />
 			<dataarea name="flop" size="1261568">
 				<rom name="nobunaga_no_yabou-bushou_fuuunroku.hdm" size="1261568" crc="91024e24" sha1="28c5f0d822915935b5d3103fd7bd2d47bbf14772" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nobubus" sha1="11da6bfe3635857a25925975576e8351bbb9b2ef" />
+				<disk name="nobunaga no yabou - bushou fuuunroku (japan)" sha1="4b8198c521323f06acdf1801e4636e35449f2eb2" />
 			</diskarea>
 		</part>
 	</software>
@@ -15456,12 +15916,24 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Originally labeled as "mp3 source". It probably needs a redump. -->
 	<software name="nobutens">
 		<!--
-		Origin: Neo Kobe Collection (CD) / wiggy2k (floppy)
-		<rom name="Nobunaga no Yabou - Tenshouki.bin" size="478798992" crc="17ba5021" sha1="936b1f97562762df23cad7d0880bfce31e8e7c73"/>
-		<rom name="Nobunaga no Yabou - Tenshouki.cue" size="628" crc="8652e29d" sha1="3ed6d965bdc9cf9deed37ccbe829d87e525fad68"/>
+		Origin: redump.org (CD) / wiggy2k (floppy)
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 01).bin" size="10231200" crc="0d91bd82" sha1="dc05e3b87c61a43fb586c8c763639c1c1e59eb31"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 02).bin" size="20398896" crc="a9e9bdef" sha1="31ae0be73b87b5922f2e10c3b573a228b2fb0e3d"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 03).bin" size="32434080" crc="188f66c3" sha1="ca84785bba36ee54292048fd0ea401c1f9771909"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 04).bin" size="35691600" crc="45ee17e5" sha1="7e8143e5b662dd841f36b85f4a1b14d425020061"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 05).bin" size="30924096" crc="8ad5d380" sha1="86fb275ff6cb4489a4ae425d4b6e8628d4545cc9"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 06).bin" size="19841472" crc="c368ff48" sha1="160a1fd0e434b0cd98d7ea225a76f3d0f887a13e"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 07).bin" size="51235968" crc="ac12c508" sha1="0d5569971f6a1b04a0c5fc7b11289469aa320dcb"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 08).bin" size="40995360" crc="996ec173" sha1="bc387016aa29e09f4ae5bf5ca72d6c5f63ee27af"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 09).bin" size="21843024" crc="c60bd43e" sha1="8245a797524691a21fa8d4c43497a6eaaaae450a"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 10).bin" size="40078080" crc="0db78b38" sha1="b576f175cbb42ad49eda64214ff16dfd235e2167"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 11).bin" size="26372976" crc="630aa042" sha1="de2b8dbbe43b4911abd38ebc3b6af7b9dc2dde2a"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 12).bin" size="20133120" crc="2d5b11d1" sha1="68fb5966b54c0d494cccfbc4473e495d5c979206"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 13).bin" size="56847840" crc="2cb2a190" sha1="075e43003d79cb72d3724cf6f4a38dc9d8b62794"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan) (Track 14).bin" size="72324000" crc="7596944a" sha1="58e282a5df6cd19dfa01c95998eaf36f2a3bebf3"/>
+		<rom name="Nobunaga no Yabou - Tenshouki (Japan).cue" size="1830" crc="106eb696" sha1="84963d716e4149a4841b8956385f3b9147686346"/>
 		-->
 		<description>Nobunaga no Yabou - Tenshouki</description>
 		<year>1995</year>
@@ -15477,7 +15949,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nobunaga no yabou - tenshouki" sha1="fe1ca3991c5a1399cd720ae177644ca314b5d004" status="baddump" />
+				<disk name="nobunaga no yabou - tenshouki (japan)" sha1="99d6e4ce4a01717804c35ab4d0307f2a014a5430" />
 			</diskarea>
 		</part>
 	</software>
@@ -15690,7 +16162,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Okiraku TownsGEAR</description>
 		<year>1994</year>
-		<publisher>Softbank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="お気楽 TownsGEAR" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -16041,7 +16513,7 @@ User/save disks that can be created from the game itself are not included.
 		<year>1991</year>
 		<publisher>リバーヒルソフト (Riverhill Soft)</publisher>
 		<info name="serial" value="HMC-114"/>
-		<info name="alt_title" value="藤堂龍之介 探偵日記 黄金の羅針盤 翔洋丸桑港航路殺人事件" />
+		<info name="alt_title" value="藤堂龍之介探偵日記 黄金の羅針盤 翔洋丸桑港航路殺人事件" />
 		<info name="release" value="199104xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
@@ -16303,6 +16775,40 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Missing a floppy disk -->
+	<software name="pharmony" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Planet Harmony (Japan) (Track 01).bin" size="20815200" crc="12eaea21" sha1="e5ebb6cb876091a69f59d1c9b421b27b53725104"/>
+		<rom name="Planet Harmony (Japan) (Track 02).bin" size="47592720" crc="6ad17a13" sha1="247ce92ea2f3d4efd2573f8a3100fd99195bba04"/>
+		<rom name="Planet Harmony (Japan) (Track 03).bin" size="9109296" crc="f04642a8" sha1="e0308ef3d3be0c30ad11e3814375a76c4455b195"/>
+		<rom name="Planet Harmony (Japan) (Track 04).bin" size="116906160" crc="f525c139" sha1="ec3f32ddc538d3fda3b6532bdbc33406a423af63"/>
+		<rom name="Planet Harmony (Japan) (Track 05).bin" size="43982400" crc="4989d6bb" sha1="6985e10b8d2c9ae0982d9408d867d3a69526c893"/>
+		<rom name="Planet Harmony (Japan) (Track 06).bin" size="52877664" crc="4c35b9bd" sha1="6b3aa3d64fbcc40408a3c113694ed86da1c9dcb1"/>
+		<rom name="Planet Harmony (Japan) (Track 07).bin" size="42507696" crc="ff7aff75" sha1="210cbf2d59f8e5af7c0b9f195948af0df30d2823"/>
+		<rom name="Planet Harmony (Japan) (Track 08).bin" size="44939664" crc="f89b25c5" sha1="4864eca2543a9f79879306de6dbc6f1d5b89122c"/>
+		<rom name="Planet Harmony (Japan) (Track 09).bin" size="42959280" crc="dcb8fec9" sha1="4e529e06b460f2f3a28793193f7835a818483d3d"/>
+		<rom name="Planet Harmony (Japan) (Track 10).bin" size="44942016" crc="f4260c75" sha1="9d43f12a4963413cda83281bd6dea86e756505df"/>
+		<rom name="Planet Harmony (Japan) (Track 11).bin" size="53994864" crc="b327539e" sha1="9d7a1d8e09fbc3b414880118bd11fc9edc7c7cfa"/>
+		<rom name="Planet Harmony (Japan) (Track 12).bin" size="47134080" crc="983d07b9" sha1="17b9adcc1c20c9f9dcfe2d958037213bef8c5b38"/>
+		<rom name="Planet Harmony (Japan) (Track 13).bin" size="45671136" crc="0f6bc464" sha1="e295f2aad3e49e1b522f84564d2412140a303385"/>
+		<rom name="Planet Harmony (Japan) (Track 14).bin" size="43305024" crc="ff417d0b" sha1="9d1732335ba82b3ffedfe1f810d28525d50a328b"/>
+		<rom name="Planet Harmony (Japan) (Track 15).bin" size="42895776" crc="84325ed7" sha1="5263c3c4a6887630d7e37563a07c44f3efc57e3c"/>
+		<rom name="Planet Harmony (Japan) (Track 16).bin" size="33984048" crc="61362ec7" sha1="de98ee5ba50b52966d267cb6802eb4e78a81e241"/>
+		<rom name="Planet Harmony (Japan).cue" size="1854" crc="3a42c473" sha1="514c60a833bc1214dd373b7cd7c9121173d100ad"/>
+		-->
+		<description>Planet Harmony</description>
+		<year>1993</year>
+		<publisher>ダットジャパン (Datt Japan)</publisher>
+		<info name="serial" value="HME-105"/>
+		<info name="release" value="199309xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="planet harmony (japan)" sha1="b866b435ccc6456f075dbc723b4673522a9c483e" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="phobos">
 		<!--
 		Origin: redump.org
@@ -16325,7 +16831,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="pleasure">
 		<!--
-		Origin: redump.org / r09
+		Origin: redump.org
 		<rom name="Yuka Watanabe &amp; Tomo Kawai - Pleasure (Japan) (Track 1).bin" size="105487200" crc="3ac09566" sha1="fbab998bbfe2adc0dbcd607501b7cbd9c2865b04"/>
 		<rom name="Yuka Watanabe &amp; Tomo Kawai - Pleasure (Japan) (Track 2).bin" size="39690000" crc="9d6157d5" sha1="88140367f5b917f21a46d1ec5eb6ee24f07ce76c"/>
 		<rom name="Yuka Watanabe &amp; Tomo Kawai - Pleasure (Japan) (Track 3).bin" size="37396800" crc="6e2e590f" sha1="20e0a580b02344f91ec9748f6f3a2f3905dc9f22"/>
@@ -16545,7 +17051,6 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- The floppy disks are probably not part of the original distribution. Needs to be investigated further. -->
 	<software name="pmonger">
 		<!--
 		Origin: redump.org
@@ -16757,7 +17262,7 @@ User/save disks that can be created from the game itself are not included.
 		-->
 		<description>Provvidenza - Legenda la Spada di Alfa</description>
 		<year>1991</year>
-		<publisher>Sofcom</publisher>
+		<publisher>ソフコム (Sofcom)</publisher>
 		<info name="serial" value="HMC-147"/>
 		<info name="alt_title" value="プロビデンツァ Legenda la Spada di Alfa" />
 		<info name="release" value="199109xx" />
@@ -16918,6 +17423,38 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="psychic detective series vol. 4 - orgel (japan)" sha1="a689904da30a902e20c3fed837c6cc56a7f118fe" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- DOS/V / PC-9821 / FM Towns hybrid. Each version requires a different floppy disk, but the CD is shared between them. -->
+	<software name="psydet4r">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 1).bin" size="107361744" crc="76efc65e" sha1="20caaa48aa247a8c46bd7efbe8902e83194771d5"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 2).bin" size="6599712" crc="163ccb38" sha1="cbf30d28a9509f9a4613133a2098b420cc20bb88"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 3).bin" size="51791040" crc="a2fc69e8" sha1="4662b38ae6ae66ef79809afe90828197dc63d777"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 4).bin" size="31634400" crc="57f4519d" sha1="4b3ce86bf1a943db6b66143521da0887a521b561"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 5).bin" size="22383984" crc="80fc3fc0" sha1="fb866ed8de91f1304e0236ca768d5bf05f2d67e8"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 6).bin" size="26547024" crc="f26e504b" sha1="5bc1a0dc632af0035a2bf2f62e3853e1cd705823"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake) (Track 7).bin" size="28567392" crc="289076d2" sha1="cc07a9e6befdcbfdaee1cb28b8a922819e0c89f9"/>
+		<rom name="Psychic Detective Series Vol. 4 - Orgel (Japan) (Remake).cue" size="1055" crc="05e069cb" sha1="af74b4b4776c824cffad757a4812f298148b2519"/>
+		-->
+		<description>Psychic Detective Series Vol. 4 - Orgel (DCCS remake)</description>
+		<year>1994</year>
+		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWDC4023"/>
+		<info name="alt_title" value="サイキック・ディテクティヴ・シリーズ　Vol.4　オルゴール" />
+		<info name="release" value="199412xx" />
+		<info name="usage" value="Requires 4 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="psychic_detective_series_vol_4_orgel_remake.hdm" size="1261568" crc="bbf0a03e" sha1="4f4f6161b5fa0b8f1c4e6f0874a8c476aaa42e4f" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="psychic detective series vol. 4 - orgel (japan) (remake)" sha1="60b1d1a9085734c7d86d9d88c1590610b179567c" />
 			</diskarea>
 		</part>
 	</software>
@@ -17697,21 +18234,45 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="retzork">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Return to Zork.ccd" size="5568" crc="a0a0112a" sha1="97432f562d9ca57a104e57117a817c729dc774fd"/>
-		<rom name="Return to Zork.cue" size="1070" crc="b5ca3bb8" sha1="7273a4e6377da0c2e4e79df482af3385c601aa77"/>
-		<rom name="Return to Zork.img" size="467337696" crc="523cc4a6" sha1="4f999397c7f1136382ddbe17bbcd48ab39677365"/>
-		<rom name="Return to Zork.sub" size="19075008" crc="c9417b63" sha1="18abc4e8c977edf9f0790bec6f60d90edfad42c1"/>
+		Origin: redump.org
+		<rom name="Return to Zork (Japan) (Track 01).bin" size="192252480" crc="5b2cf08b" sha1="6cd0ea3f2c6a7eccc703ef7a04fac2affd1208ab"/>
+		<rom name="Return to Zork (Japan) (Track 02).bin" size="4184208" crc="6c3a6fcd" sha1="9fd77972433e1d9c17d79711d6cd1b13af7a407d"/>
+		<rom name="Return to Zork (Japan) (Track 03).bin" size="3368064" crc="b12d6adf" sha1="b4dbb006fe48b3f640ff8ed59a0b230e7bcecc66"/>
+		<rom name="Return to Zork (Japan) (Track 04).bin" size="11964624" crc="d64489ce" sha1="3b2062664ebe04c91b6d632bd9dfd555c54ede09"/>
+		<rom name="Return to Zork (Japan) (Track 05).bin" size="7098336" crc="9946ec48" sha1="51c01ec0066a734a2cfa6ba6b6d84bf38e7535fe"/>
+		<rom name="Return to Zork (Japan) (Track 06).bin" size="7124208" crc="61100f29" sha1="3d17e245c48a95b3d27bd90f63ce3695cff4e694"/>
+		<rom name="Return to Zork (Japan) (Track 07).bin" size="12778416" crc="160a551a" sha1="9c1ff842c045aebc1d2a4cc920738986e8285fa4"/>
+		<rom name="Return to Zork (Japan) (Track 08).bin" size="22122912" crc="e980e832" sha1="0b537dd494f66ae607ac516a3c7d5a673554a579"/>
+		<rom name="Return to Zork (Japan) (Track 09).bin" size="14932848" crc="02ecf480" sha1="4e5705ba6569d456a98ab7c4b306daf4a5cdb17b"/>
+		<rom name="Return to Zork (Japan) (Track 10).bin" size="5183808" crc="319705fb" sha1="2c7f9e0e7600e71c38f6b2893a29eaec7aed6773"/>
+		<rom name="Return to Zork (Japan) (Track 11).bin" size="5181456" crc="4d86a05e" sha1="e0c8baab3722ed76f2087147888bc20ba4fda040"/>
+		<rom name="Return to Zork (Japan) (Track 12).bin" size="6884304" crc="4a37c048" sha1="475862b4f116290609e42983ea0730b145329b04"/>
+		<rom name="Return to Zork (Japan) (Track 13).bin" size="8215536" crc="0e851ba7" sha1="80d71446b3917907efb2e828fb6ae929f2289d19"/>
+		<rom name="Return to Zork (Japan) (Track 14).bin" size="6764352" crc="20eca4a9" sha1="8b311fd5d49445039b9a3ac0de98d75c5aeb2eb9"/>
+		<rom name="Return to Zork (Japan) (Track 15).bin" size="5310816" crc="06a35812" sha1="e1d2c0f930dc97fff4fc8bf145c2edb1fc60b4cf"/>
+		<rom name="Return to Zork (Japan) (Track 16).bin" size="13274688" crc="361f90c3" sha1="96d8e869b4da42795010f153d46b148b1af2ac42"/>
+		<rom name="Return to Zork (Japan) (Track 17).bin" size="10341744" crc="287846fb" sha1="6002e5c6231b0e91b09571bd605862711a634d51"/>
+		<rom name="Return to Zork (Japan) (Track 18).bin" size="11466000" crc="69ce64d5" sha1="1aebc721cc018dd8bf98aeb999b0eddb66066707"/>
+		<rom name="Return to Zork (Japan) (Track 19).bin" size="4163040" crc="73239a23" sha1="a9a9706645b5a59473cd09f67b4359491a871616"/>
+		<rom name="Return to Zork (Japan) (Track 20).bin" size="11200224" crc="bde8b9d3" sha1="7cad209cbb9363c10ccf9cd04a3da1af013d807f"/>
+		<rom name="Return to Zork (Japan) (Track 21).bin" size="7366464" crc="25404596" sha1="0afc9a6a904c5b444ad91da21689edd8f78caa9b"/>
+		<rom name="Return to Zork (Japan) (Track 22).bin" size="9304512" crc="1a48063e" sha1="b7b719fc2e219a2e7ad65a0e7b865bfac5fc7ccc"/>
+		<rom name="Return to Zork (Japan) (Track 23).bin" size="20116656" crc="49cd56cb" sha1="dd7f0a287990ae1f7a5a13dd1949c3908d5bfb9d"/>
+		<rom name="Return to Zork (Japan) (Track 24).bin" size="16108848" crc="ec65b63e" sha1="7111d37dfedaa42fb70f2da575e5f91c895b2837"/>
+		<rom name="Return to Zork (Japan) (Track 25).bin" size="14641200" crc="c0cde5f3" sha1="c3c30770c58ed34f5430ea912b11cd4b4de286ef"/>
+		<rom name="Return to Zork (Japan) (Track 26).bin" size="35987952" crc="db5709d8" sha1="d59b25159c9b8e3980a4688c6eb9793ebabfc45c"/>
+		<rom name="Return to Zork (Japan).cue" size="2495" crc="5129c12e" sha1="72b37ff00c64aedeb16ba2510edcfa8d01b71fb9"/>
 		-->
 		<description>Return to Zork</description>
 		<year>1994</year>
 		<publisher>データウエスト (Data West)</publisher>
+		<info name="serial" value="DWHB4028"/>
 		<info name="alt_title" value="リターントゥゾーク" />
 		<info name="release" value="199410xx" />
 		<info name="usage" value="Requires HDD installation and 6 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="return to zork" sha1="ec6c343f5016d60df7650b636298945372471550" />
+				<disk name="return to zork (japan)" sha1="b46f9759b983c50b53cbc66106cd58283566f327" />
 			</diskarea>
 		</part>
 	</software>
@@ -17788,6 +18349,41 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="rocket ranger" sha1="faee63cd159d68240360149887702560dedff780" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="royalbld">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Royal Blood (Japan) (Track 01).bin" size="10231200" crc="3d2d0e93" sha1="39402454553c2b39c3f9de56863dacd6a2fc301d"/>
+		<rom name="Royal Blood (Japan) (Track 02).bin" size="53886672" crc="fdfddccf" sha1="0149575f3d3af6f2575227cea6ca803ccf2e09fa"/>
+		<rom name="Royal Blood (Japan) (Track 03).bin" size="46134480" crc="4c5d83fe" sha1="51c2dbf041ea6a43bc3e7c4fe65409805c87907d"/>
+		<rom name="Royal Blood (Japan) (Track 04).bin" size="52807104" crc="9a88337b" sha1="23e93f9faf4f31e0583bcd518c0fc4910585f5c7"/>
+		<rom name="Royal Blood (Japan) (Track 05).bin" size="41731536" crc="952508af" sha1="a2b7430912a83102653eee96fcc3a09d40c4afbe"/>
+		<rom name="Royal Blood (Japan) (Track 06).bin" size="31817856" crc="f6a9263a" sha1="0d2babee6fc6312fc7a9e2400520c475e85a02ee"/>
+		<rom name="Royal Blood (Japan) (Track 07).bin" size="35073024" crc="51fcd3db" sha1="c488c7dad85892834f5663cc9c30ea0c95b2ed9a"/>
+		<rom name="Royal Blood (Japan) (Track 08).bin" size="71931216" crc="95f9b42f" sha1="8601cbb167cfd95cf88d384654b7d4439632155d"/>
+		<rom name="Royal Blood (Japan) (Track 09).bin" size="42053760" crc="cd2a83cc" sha1="8ec2bdcfd65538a2a72f36cbeae81bb95c4bdfb3"/>
+		<rom name="Royal Blood (Japan) (Track 10).bin" size="53872560" crc="b92822f6" sha1="0749eeb6e553580ee6764761d3ac9232bbad2662"/>
+		<rom name="Royal Blood (Japan) (Track 11).bin" size="30133824" crc="b8fa54d2" sha1="9a982006cb365d755c0e66a845f4ab7681a73835"/>
+		<rom name="Royal Blood (Japan).cue" size="1236" crc="080b85e5" sha1="60e3fa5e6e642546a9645efb1e04bf84f1728e97"/>
+		-->
+		<description>Royal Blood</description>
+		<year>1992</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMD-131"/>
+		<info name="alt_title" value="ロイヤル・ブラッド" />
+		<info name="release" value="199205xx" />
+		<!-- The floppy disk was damaged and completely missing side 1 of track 0. It has been manually repaired by filling the missing part with 0xE5 bytes. -->
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="royal_blood.hdm" size="1261568" crc="e1747ba7" sha1="063e69171f5f6131b986b4580c562d68aec3eb6e" offset="000000" status="baddump" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="royal blood (japan)" sha1="d7fc451459999e0b21c1b692646ee43930e2c976" />
 			</diskarea>
 		</part>
 	</software>
@@ -18922,7 +19518,6 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Sotsugyou - Graduation '93 (Japan).cue" size="750" crc="c0dc75ed" sha1="9c87ac086174989f21160cab712719c34c358571"/>
 		-->
 		<description>Sotsugyou '93 - Graduation (newer floppy disk)</description>
-
 		<year>1993</year>
 		<publisher>JHV</publisher>
 		<info name="serial" value="JH-002"/>
@@ -20012,10 +20607,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk, the game doesn't work without it -->
-	<software name="suikoden" supported="no">
+	<software name="suikoden">
 		<!--
-		Origin: P2P
+		Origin: P2P (CD) / cyo.the.vile (floppy)
 		<rom name="SUIKODEN.BIN" size="451226496" crc="ea330a93" sha1="8c56e2b77b58ac136f80cb19e6dffdef4adb0d2c"/>
 		<rom name="SUIKODEN.CUE" size="584" crc="46e415ae" sha1="e1169e4b277d495c1b90cf20b97ba6071186e1d3"/>
 		-->
@@ -20025,6 +20619,11 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="HMB-108"/>
 		<info name="alt_title" value="水滸伝・天命の誓い" />
 		<info name="release" value="199002xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="suikoden_tenmei_no_chikai.hdm" size="1261568" crc="7315aacc" sha1="43aa869d5053f3ee0d242b431827a6ebdde836ba" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="suikoden" sha1="e0276dafedb588a7d2b455f72d94a0c9039fe990" />
@@ -20191,11 +20790,10 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="debut">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Tanjou - Debut.ccd" size="972" crc="b9c249db" sha1="50d96c9509eb76c8de503d152295de03aa29a232"/>
-		<rom name="Tanjou - Debut.cue" size="138" crc="eed9520f" sha1="b0f9dccd2843b62b078925d2ef1fb798e7e4ea93"/>
-		<rom name="Tanjou - Debut.img" size="55401360" crc="e7fa4c3b" sha1="1387e54fad5bd7636afee3d7a0b9ac1c8baecd3f"/>
-		<rom name="Tanjou - Debut.sub" size="2261280" crc="d37b24b0" sha1="9a288b4a6d53e9edf3b4f4b15e3a5c695bf0645b"/>
+		Origin: redump.org (CD) / verified by multiple sources (floppy)
+		<rom name="Tanjou - Debut (Japan) (Track 1).bin" size="33457200" crc="270b3dbc" sha1="0b4ba43a3799c51ebc37d078a42fbe1b4e09a8c3"/>
+		<rom name="Tanjou - Debut (Japan) (Track 2).bin" size="21944160" crc="3e8cdaee" sha1="e01672c8903dcf1c3c4c900112c15e2d0e5ade3e"/>
+		<rom name="Tanjou - Debut (Japan).cue" size="214" crc="0c9191df" sha1="d7b2216a5ae77b00438be324926300fd4892d4ac"/>
 		-->
 		<description>Tanjou - Debut</description>
 		<year>1994</year>
@@ -20212,7 +20810,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tanjou - debut" sha1="cb4d6a5ee1ad68584088a7d38a9e0bcefdd47abf" />
+				<disk name="tanjou - debut (japan)" sha1="b3b28256d5d73d95e9aac90e70f0af3df0cd6fb2" />
 			</diskarea>
 		</part>
 	</software>
@@ -20292,9 +20890,41 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="teiketsu">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Teitoku no Ketsudan (Japan) (Track 1).bin" size="20462400" crc="79d5eb47" sha1="4940a56a24b6061928eb3a03f56a80ec02820996"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 2).bin" size="86817024" crc="fc5eac3a" sha1="16b1e58f13c987be15a95d53cae0ba71c848017f"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 3).bin" size="126325920" crc="2441c283" sha1="6514d3f93f7f633c63a2229dac586a52994d0acd"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 4).bin" size="48815760" crc="b36dcdc9" sha1="1ef2518627624a2ce0a63bfe330fa21a61886512"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 5).bin" size="68497296" crc="7d55d8d5" sha1="69fa3eca7a123109b152ad14e7a85dc665d42eb4"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 6).bin" size="24677184" crc="50fe43db" sha1="55433230177768b7ca80b3e134d95d8e3bdf4dc2"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 7).bin" size="25425120" crc="69dd37aa" sha1="08d65686da614a1af529f38e35e89febda0ba95c"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 8).bin" size="6479760" crc="db851c82" sha1="21580d968a0e91ae5b0934cb85c84dc58b81be86"/>
+		<rom name="Teitoku no Ketsudan (Japan) (Track 9).bin" size="47945520" crc="caebb078" sha1="c9bbedc45ed9299f8831bfa28ab1a78f98e61b70"/>
+		<rom name="Teitoku no Ketsudan (Japan).cue" size="1324" crc="63068410" sha1="2b62b988573ef568fa7c27c2f60e51c4e7eb3ced"/>
+		-->
+		<description>Teitoku no Ketsudan</description>
+		<year>1990</year>
+		<publisher>光栄 (Koei)</publisher>
+		<info name="serial" value="HMB-139 / FWKN 14004"/>
+		<info name="alt_title" value="提督の決断" />
+		<info name="release" value="199004xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="teitoku_no_ketsudan.hdm" size="1261568" crc="c944d154" sha1="84c54646887e644e590328608583509f4f8940f6" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="teitoku no ketsudan (japan)" sha1="92b8975d35fcb42ebee4cc6dcaee554ae397a3d2" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="teikets2">
 		<!--
-		Origin: redump.org / private dump (r09)
+		Origin: redump.org (CD) / r09 (floppy)
 		<rom name="Teitoku no Ketsudan II (Japan) (Track 01).bin" size="20462400" crc="4004e7cc" sha1="f189d5d179d938e15c17a09e37afd722d98f9223"/>
 		<rom name="Teitoku no Ketsudan II (Japan) (Track 02).bin" size="36385440" crc="336d138c" sha1="17c9eb69308b1d04c4365ce7055f396dbd89c306"/>
 		<rom name="Teitoku no Ketsudan II (Japan) (Track 03).bin" size="34367424" crc="f2caee14" sha1="573027cce1f15e98f57fe1e6e227e13e088b84f0"/>
@@ -20757,6 +21387,7 @@ User/save disks that can be created from the game itself are not included.
 	</software>
 
 	<!-- Black screen on boot -->
+	<!-- PC-9801 / FM Towns hybrid -->
 	<software name="toshin2" supported="no">
 		<!--
 		Origin: P2P
@@ -20898,9 +21529,18 @@ User/save disks that can be created from the game itself are not included.
 	<!-- Graphics/sound issues; hangs when starting a fight -->
 	<software name="tqodo" cloneof="tqod" supported="no">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="The Queen Of Duellist.cue" size="479" crc="d249b1cd" sha1="56ff832f3bcdf066f3022fae3b40a7d66deddd72"/>
-		<rom name="The Queen Of Duellist.img" size="542100720" crc="12c515ea" sha1="d8b65e806f02006c3cef3c485c2ecf4f73283bc4"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Queen of Duelist, The (Japan) (Track 01).bin" size="15523200" crc="e54628d2" sha1="4a96e0328f960ad6581a834252a38f8db427b11f"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 02).bin" size="59046960" crc="5d326ab2" sha1="16c948e4c404b3952a6bed3cbf5324436afcbb27"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 03).bin" size="69983760" crc="3cab0ea7" sha1="399a99bac2dee814ccd98924c6111ca2a981e805"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 04).bin" size="66291120" crc="d3bf457e" sha1="0f73db9bddec54667266024df7359b02c44134b1"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 05).bin" size="67765824" crc="75c5c0ff" sha1="d60039c3279f80a66a701cd145dd854e1595ca1b"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 06).bin" size="62052816" crc="a9f9c630" sha1="6bebef4fde5fe9e3ae7a9b23e2a130650ffefa84"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 07).bin" size="65479680" crc="a0375ef4" sha1="f9ea648444ade9643d50cd6b4449276fe8569763"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 08).bin" size="66185280" crc="e0d79a73" sha1="67b181ae30e0b6a884ae834f5cd98b32460773bb"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 09).bin" size="3469200" crc="30a3d3fc" sha1="6f89bce2d34d94b0b245c33500bc806a21b2ac5c"/>
+		<rom name="Queen of Duelist, The (Japan) (Track 10).bin" size="66302880" crc="7a80f2d9" sha1="ada7d838f0a5b0ca6cc5e5f2362f8a7fcb270a94"/>
+		<rom name="Queen of Duelist, The (Japan).cue" size="1222" crc="08122952" sha1="ff9f2dd22dc5c93ee5f590ac959040e62455210f"/>
 		-->
 		<description>The Queen of Duellist (HME-166)</description>
 		<year>1993</year>
@@ -20917,7 +21557,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="the queen of duellist" sha1="311993a47783fdad8e1fdc4ed65d388dbf7f7d2d" />
+				<disk name="queen of duelist, the (japan)" sha1="4501fd5de77e00fca335499e077638594f8de9f7" />
 			</diskarea>
 		</part>
 	</software>
@@ -21889,7 +22529,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="vipergts">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / wiggy2k (floppy)
 		<rom name="Viper GTS (Japan).bin" size="47620944" crc="b6481862" sha1="60503c22b96c89204081ac01bfd57c20d643280d"/>
 		<rom name="Viper GTS (Japan).cue" size="83" crc="4e1892d2" sha1="0f5a6d0b2b4e7a7fb87e6b99641e8567fdbf91d6"/>
 		-->
@@ -21899,6 +22539,13 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="HMG-139"/>
 		<info name="release" value="199511xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
+		<!-- The floppy disk contains an updated executable that fixes an incompatibility with 386-based machines -->
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="起動ディスク / Kidou Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="viper_gts.hdm" size="1261568" crc="b3b89caa" sha1="926b28bafc53edf095d778ec91c12b7a61925c8c" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="viper gts (japan)" sha1="99c7c1db44b7f6c1fcde9bc1321b2ad27efb99ff" />
@@ -22162,19 +22809,19 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="wingcmar">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Wing Commander Armada.mdf" size="17195472" crc="1c7c60bb" sha1="5dfade18828211a040785f884a4a3cae40f379d1"/>
-		<rom name="Wing Commander Armada.mds" size="486" crc="6b7bade4" sha1="4c86335e757ec71ff21e4ce2c6f3943c3007c307"/>
+		Origin: redump.org
+		<rom name="Wing Commander - Armada (Japan).bin" size="17195472" crc="1c7c60bb" sha1="5dfade18828211a040785f884a4a3cae40f379d1"/>
+		<rom name="Wing Commander - Armada (Japan).cue" size="120" crc="8b844fe9" sha1="d57a117612e04abf4f24932654cf67135b9819a9"/>
 		-->
 		<description>Wing Commander Armada</description>
 		<year>1995</year>
 		<publisher>エレクトロニック・アーツ・ビクター (Electronic Arts Victor)</publisher>
 		<info name="alt_title" value="ウイングコマンダーアルマダ" />
 		<info name="release" value="199507xx" />
-		<info name="usage" value="Requires HDD installation and 8 MB of RAM"/>
+		<info name="usage" value="Requires HDD installation and 6 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wing commander armada" sha1="fa9ff6997c774c59bf3a97b710049a22b3348e32" />
+				<disk name="wing commander - armada (japan)" sha1="ebf1e1ef36f639e330f5f1ff880d00e2751ad387" />
 			</diskarea>
 		</part>
 	</software>

--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -424,11 +424,7 @@ Rakuraku Sozai Vol. 1                                         Fujitsu           
 Reijou Monogatari                                             Inter Heart                       1995/4     CD
 Rekishi Shiryoukan                                            Uchida Youkou                     1990/12    CD
 Remember Beatles No.1 Yesterday                               SofMedia                          1989/9     CD
-Remember Beatles No.2 Michelle                                SofMedia                          1989/12    CD
 Remember Beatles No.3 Lady Maddonna                           SofMedia                          1990/6     CD
-Remember Beatles No.4 Let It Be                               SofMedia                          1990/7     CD
-Remember Beatles No.5 The Long and Winding Road               SofMedia                          1990/8     CD
-Remember Beatles No.6 Imagine                                 SofMedia                          1990/8     CD
 Rika Nenpyou CD-ROM                                           Maruzen                           1996/1     CD
 Robin Hood                                                    DynEd Japan                       1993/12    SET(CD+FD)
 Rockpaedia Vol. 2: 1961-1970                                  Toshiba EMI                       ?          CD


### PR DESCRIPTION
- Added the missing floppy images to Igo Doujou, Air Warrior V1.2L10 and Suikoden - Tenmei no Chikai [cyo.the.vile]
- Added the missing floppy image to Viper GTS [wiggy2k]
- Replaced the Alice no Yakata II, Europa Sensen and Hiouden II images with cleaner unmodified copies [wiggy2k]
- Removed outdated comments and changed some serials and disk labels to reflect their actual names

New working software list additions
-----------------------------------
Dalk (alt floppy disk) [redump.org, wiggy2k]
Kazadama Vol. 2 - Masuo per Masuo - Ikeda Masuo Hanga-shuu [redump.org]
Kouryuuki [redump.org, wiggy2k]
Kusuriyubi no Kyoukasho [redump.org]
Psychic Detective Series Vol. 4 - Orgel (DCCS remake) [redump.org, cyo.the.vile]
Remember Beatles No. 2 - Michelle [redump.org]
Remember Beatles No. 4 - Let It Be [redump.org]
Remember Beatles No. 5 - The Long and Winding Road [redump.org]
Remember Beatles No. 6 - Imagine [redump.org]
Royal Blood [redump.org, cyo.the.vile]
Teitoku no Ketsudan [redump.org, cyo.the.vile]

New not working software list additions
---------------------------------------
Hyper Land [redump.org]
Hyper Note [redump.org]
Planet Harmony [redump.org]

Replaced software list items
----------------------------
Dalk [redump.org]
Europa Sensen [redump.org, wiggy2k]
Hyper Planet Shiki Vol. 2 [redump.org]
Igo Doujou - Honkakuha Yose Tsumego Shinan [redump.org, cyo.the.vile]
King's Bounty - Nusumareta Chitsujo [redump.org]
Morita Shougi II [redump.org]
Mr. Ed Bogas' Music Machine Lite [redump.org]
Nobunaga no Yabou - Bushou Fuuunroku [redump.org]
Nobunaga no Yabou - Tenshouki [redump.org]
Return to Zork [redump.org]
Tanjou - Debut [redump.org]
The Queen of Duellist (HME-166) [redump.org]
Wing Commander Armada [redump.org]

Software list items promoted to working
---------------------------------------
Air Warrior V1.2L10 [cyo.the.vile]
Suikoden - Tenmei no Chikai [cyo.the.vile]