### PR TITLE
Allow breaking into main menu before the machine fully starts (i.e. j…

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -355,6 +355,8 @@ int running_machine::run(bool quiet)
 		if (!quiet)
 			sound().start_recording();
 
+		m_hard_reset_pending = false;
+
 		// initialize ui lists
 		// display the startup screens
 		manager().ui_initialize(*this);
@@ -367,8 +369,6 @@ int running_machine::run(bool quiet)
 			handle_saveload();
 
 		export_http_api();
-
-		m_hard_reset_pending = false;
 
 #if defined(__EMSCRIPTEN__)
 		// break out to our async javascript loop and halt

--- a/src/frontend/mame/ui/menu.cpp
+++ b/src/frontend/mame/ui/menu.cpp
@@ -1174,7 +1174,10 @@ void menu::do_handle()
 		// add an item to return - this is a really hacky way of doing this
 		if (!m_parent)
 		{
-			item_append(_("Return to Machine"), 0, nullptr);
+			if (machine().phase() == machine_phase::INIT)
+				item_append(_("Start Machine"), 0, nullptr);
+			else
+				item_append(_("Return to Machine"), 0, nullptr);
 		}
 		else if (m_parent->is_special_main_menu())
 		{


### PR DESCRIPTION
…ust before the initial soft reset) by using the normal "Config Menu" UI input

Note that the minor code shuffling in machine.cpp is necessary to prevent emulation from getting confused if "Select New Game" happens to be selected.