### PR TITLE
nl_segas16b: fix two capacitor labels

### DIFF
--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -8270,4 +8270,16 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="3dadp">
+		<description>3-D Adaptor</description>
+		<year>1987</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="sms_card">
+			<feature name="slot" value="3dadp" />
+			<dataarea name="rom" size="1">
+				<!-- this card is just an adapter -->
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>

--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -3112,6 +3112,8 @@ if (BUSES["SEGA8"]~=null) then
 		MAME_DIR .. "src/devices/bus/sega8/ccatch.h",
 		MAME_DIR .. "src/devices/bus/sega8/mgear.cpp",
 		MAME_DIR .. "src/devices/bus/sega8/mgear.h",
+		MAME_DIR .. "src/devices/bus/sega8/3dadp.cpp",
+		MAME_DIR .. "src/devices/bus/sega8/3dadp.h",
 	}
 end
 
@@ -3174,6 +3176,28 @@ if (BUSES["SMS_EXP"]~=null) then
 		MAME_DIR .. "src/devices/bus/sms_exp/smsexp.h",
 		MAME_DIR .. "src/devices/bus/sms_exp/gender.cpp",
 		MAME_DIR .. "src/devices/bus/sms_exp/gender.h",
+	}
+end
+
+---------------------------------------------------
+--
+--@src/devices/bus/sms_3d/s3dport.h,BUSES["SMS_3D"] = true
+---------------------------------------------------
+
+if (BUSES["SMS_3D"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/bus/sms_3d/s3dport.cpp",
+		MAME_DIR .. "src/devices/bus/sms_3d/s3dport.h",
+		MAME_DIR .. "src/devices/bus/sms_3d/s3dglass.cpp",
+		MAME_DIR .. "src/devices/bus/sms_3d/s3dglass.h",
+	}
+
+	dependency {
+		{ MAME_DIR .. "src/devices/bus/sms_3d/s3dglass.cpp", GEN_DIR .. "emu/layout/s3dglass.lh" },
+	}
+
+	custombuildtask {
+		layoutbuildtask("emu/layout", "s3dglass"),
 	}
 end
 

--- a/scripts/target/mame/arcade.lua
+++ b/scripts/target/mame/arcade.lua
@@ -819,6 +819,7 @@ BUSES["SG1000_EXP"] = true
 BUSES["SGIKBD"] = true
 BUSES["SMS_CTRL"] = true
 BUSES["SMS_EXP"] = true
+BUSES["SMS_3D"] = true
 --BUSES["SNES"] = true
 --BUSES["SPC1000"] = true
 BUSES["SUNKBD"] = true

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -946,6 +946,7 @@ BUSES["SG1000_EXP"] = true
 BUSES["SGIKBD"] = true
 BUSES["SMS_CTRL"] = true
 BUSES["SMS_EXP"] = true
+BUSES["SMS_3D"] = true
 BUSES["SNES"] = true
 BUSES["SNES_CTRL"] = true
 BUSES["SPC1000"] = true

--- a/src/devices/bus/sega8/3dadp.cpp
+++ b/src/devices/bus/sega8/3dadp.cpp
@@ -1,0 +1,35 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+/***********************************************************************************************************
+
+ Sega 3-D Adaptor emulation
+
+ The 3-D Adaptor allows to plug the Sega 3-D glasses into the card slot of
+ a Mark III or Master System 1 console.
+
+ ***********************************************************************************************************/
+
+
+#include "emu.h"
+#include "3dadp.h"
+
+//-------------------------------------------------
+//  constructors
+//-------------------------------------------------
+
+DEFINE_DEVICE_TYPE(SEGA8_ROM_3D_ADAPTOR, sega8_3d_adaptor_device, "sega8_3d_adaptor", "3-D Adaptor")
+
+sega8_3d_adaptor_device::sega8_3d_adaptor_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: sega8_rom_device(mconfig, SEGA8_ROM_3D_ADAPTOR, tag, owner, clock), m_port_3d(*this, "3dport")
+{
+}
+
+
+void sega8_3d_adaptor_device::device_add_mconfig(machine_config &config)
+{
+	SMS_3D_PORT(config, m_port_3d, sms_3d_port_devices, "3dglass");
+	if (dynamic_cast<sms_card_slot_device *>(m_slot)) {
+		m_port_3d->set_screen_tag(dynamic_cast<sms_card_slot_device *>(m_slot)->m_screen);
+	}
+}
+

--- a/src/devices/bus/sega8/3dadp.cpp
+++ b/src/devices/bus/sega8/3dadp.cpp
@@ -28,8 +28,11 @@ sega8_3d_adaptor_device::sega8_3d_adaptor_device(const machine_config &mconfig, 
 void sega8_3d_adaptor_device::device_add_mconfig(machine_config &config)
 {
 	SMS_3D_PORT(config, m_port_3d, sms_3d_port_devices, "3dglass");
-	if (dynamic_cast<sms_card_slot_device *>(m_slot)) {
-		m_port_3d->set_screen_tag(dynamic_cast<sms_card_slot_device *>(m_slot)->m_screen);
-	}
+}
+
+
+void sega8_3d_adaptor_device::device_resolve_objects()
+{
+	m_port_3d->set_screen_device(*m_screen);
 }
 

--- a/src/devices/bus/sega8/3dadp.h
+++ b/src/devices/bus/sega8/3dadp.h
@@ -1,0 +1,36 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+#ifndef MAME_BUS_SEGA8_3D_ADAPTOR_H
+#define MAME_BUS_SEGA8_3D_ADAPTOR_H
+
+#pragma once
+
+#include "sega8_slot.h"
+#include "rom.h"
+#include "bus/sms_3d/s3dport.h"
+
+
+// ======================> sega8_3d_adaptor_device
+
+class sega8_3d_adaptor_device : public sega8_rom_device
+{
+public:
+	// construction/destruction
+	sega8_3d_adaptor_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	// reading and writing
+	virtual DECLARE_WRITE_LINE_MEMBER(write_sscope) override { m_port_3d->write_sscope(state); }
+
+private:
+	required_device<sms_3d_port_device> m_port_3d;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(SEGA8_ROM_3D_ADAPTOR, sega8_3d_adaptor_device)
+
+#endif // MAME_BUS_SEGA8_3D_ADAPTOR_H

--- a/src/devices/bus/sega8/3dadp.h
+++ b/src/devices/bus/sega8/3dadp.h
@@ -21,8 +21,9 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override;
+	virtual void device_resolve_objects() override;
 
-	// reading and writing
+	// writing
 	virtual DECLARE_WRITE_LINE_MEMBER(write_sscope) override { m_port_3d->write_sscope(state); }
 
 private:

--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -67,8 +67,8 @@ device_sega8_cart_interface::device_sega8_cart_interface(const machine_config &m
 	, m_late_battery_enable(false)
 	, m_lphaser_xoffs(-1)
 	, m_sms_mode(0)
+	, m_screen(nullptr)
 {
-	m_slot = dynamic_cast<sega8_cart_slot_device *>(device.owner());
 }
 
 
@@ -200,6 +200,13 @@ sega8_cart_slot_device::~sega8_cart_slot_device()
 void sega8_cart_slot_device::device_start()
 {
 	m_cart = get_card_device();
+}
+
+void sms_card_slot_device::device_resolve_objects()
+{
+	m_cart = get_card_device();
+	if (m_cart)
+		m_cart->set_screen_device(*m_screen);
 }
 
 //-------------------------------------------------

--- a/src/devices/bus/sega8/sega8_slot.cpp
+++ b/src/devices/bus/sega8/sega8_slot.cpp
@@ -68,6 +68,7 @@ device_sega8_cart_interface::device_sega8_cart_interface(const machine_config &m
 	, m_lphaser_xoffs(-1)
 	, m_sms_mode(0)
 {
+	m_slot = dynamic_cast<sega8_cart_slot_device *>(device.owner());
 }
 
 
@@ -174,7 +175,8 @@ gamegear_cart_slot_device::gamegear_cart_slot_device(const machine_config &mconf
 
 
 sms_card_slot_device::sms_card_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: sega8_card_slot_device(mconfig, SMS_CARD_SLOT, tag, owner, clock)
+	: sega8_card_slot_device(mconfig, SMS_CARD_SLOT, tag, owner, clock),
+	m_screen(*this, finder_base::DUMMY_TAG)
 {
 }
 
@@ -890,6 +892,7 @@ void sega8_cart_slot_device::internal_header_logging(uint8_t *ROM, uint32_t len,
 #include "rom.h"
 #include "ccatch.h"
 #include "mgear.h"
+#include "3dadp.h"
 
 void sg1000_cart(device_slot_interface &device)
 {
@@ -939,6 +942,12 @@ void sms_cart(device_slot_interface &device)
 	device.option_add_internal("hicom",  SEGA8_ROM_HICOM);
 	device.option_add_internal("korean",  SEGA8_ROM_KOREAN);
 	device.option_add_internal("korean_nb",  SEGA8_ROM_KOREAN_NB);
+}
+
+void sms_card(device_slot_interface &device)
+{
+	device.option_add_internal("rom",  SEGA8_ROM_STD);
+	device.option_add_internal("3dadp",  SEGA8_ROM_3D_ADAPTOR);
 }
 
 void gg_cart(device_slot_interface &device)

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "softlist_dev.h"
+#include "screen.h"
 
 
 /***************************************************************************
@@ -63,6 +64,8 @@ public:
 	virtual uint8_t read_io(offs_t offset) { return 0xff; }
 	virtual void write_io(offs_t offset, uint8_t data) { }
 
+	virtual DECLARE_WRITE_LINE_MEMBER(write_sscope) { }
+
 	void rom_alloc(uint32_t size, const char *tag);
 	void ram_alloc(uint32_t size);
 
@@ -101,6 +104,8 @@ protected:
 
 	int m_lphaser_xoffs;
 	int m_sms_mode;
+
+	sega8_cart_slot_device *m_slot;
 };
 
 
@@ -330,7 +335,12 @@ public:
 	sms_card_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	virtual bool must_be_loaded() const noexcept override { return false; }
 	virtual const char *image_interface() const noexcept override { return "sms_card"; }
-	virtual const char *file_extensions() const noexcept override { return "bin"; }
+	virtual const char *file_extensions() const noexcept override { return "bin,sg"; }
+
+	// required for the 3D glasses
+	DECLARE_WRITE_LINE_MEMBER(write_sscope) { if (m_cart) m_cart->write_sscope(state); }
+	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+	required_device<screen_device> m_screen;
 };
 
 // ======================> sg1000_card_slot_device
@@ -373,6 +383,7 @@ DECLARE_DEVICE_TYPE(SG1000_CARD_SLOT,    sg1000_card_slot_device)
 void sg1000_cart(device_slot_interface &device);
 void sg1000mk3_cart(device_slot_interface &device);
 void sms_cart(device_slot_interface &device);
+void sms_card(device_slot_interface &device);
 void gg_cart(device_slot_interface &device);
 
 #endif // MAME_BUS_SEGA8_SLOT_H

--- a/src/devices/bus/sega8/sega8_slot.h
+++ b/src/devices/bus/sega8/sega8_slot.h
@@ -52,6 +52,9 @@ public:
 	// construction/destruction
 	virtual ~device_sega8_cart_interface();
 
+	// configuration
+	virtual void set_screen_device(screen_device &screen) { m_screen = &screen; }
+
 	// reading and writing
 	virtual uint8_t read_cart(offs_t offset) { return 0xff; }
 	virtual void write_cart(offs_t offset, uint8_t data) { }
@@ -105,7 +108,7 @@ protected:
 	int m_lphaser_xoffs;
 	int m_sms_mode;
 
-	sega8_cart_slot_device *m_slot;
+	screen_device *m_screen;
 };
 
 
@@ -337,9 +340,18 @@ public:
 	virtual const char *image_interface() const noexcept override { return "sms_card"; }
 	virtual const char *file_extensions() const noexcept override { return "bin,sg"; }
 
-	// required for the 3D glasses
-	DECLARE_WRITE_LINE_MEMBER(write_sscope) { if (m_cart) m_cart->write_sscope(state); }
+	// configuration
 	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+
+	// writing
+	DECLARE_WRITE_LINE_MEMBER(write_sscope) { if (m_cart) m_cart->write_sscope(state); }
+
+protected:
+	// device-level overrides
+	virtual void device_resolve_objects() override;
+
+private:
+	// required for the 3D glasses
 	required_device<screen_device> m_screen;
 };
 

--- a/src/devices/bus/sms_3d/s3dglass.cpp
+++ b/src/devices/bus/sms_3d/s3dglass.cpp
@@ -1,0 +1,246 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+/**********************************************************************
+
+    The Sega 3-D Glasses / SegaScope 3-D Glasses emulation
+
+
+Release data from the Sega Retro project:
+
+  Year: 1987    Country/region: JP    Model code: ?
+  Year: 1987    Country/region: US    Model code: 3073
+  Year: 1987    Country/region: EU    Model code: MK-3073-50
+  Year: 1989    Country/region: BR    Model code: ? ("Oculos 3D")
+  Year: 1989    Country/region: KR    Model code: ?
+  Year: 19??    Country/region: AR    Model code: ? ("Anteojos 3D")
+
+**********************************************************************/
+
+#include "emu.h"
+#include "s3dglass.h"
+
+#include "s3dglass.lh"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(SMS_3D_GLASSES, sms_3d_glasses_device, "sms_3d_glasses", "Sega 3-D Glasses")
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  sms_3d_glasses_device - constructor
+//-------------------------------------------------
+
+sms_3d_glasses_device::sms_3d_glasses_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, SMS_3D_GLASSES, tag, owner, clock),
+	device_sms_3d_port_interface(mconfig, *this),
+	m_left_lcd(*this, "left_lcd"),
+	m_right_lcd(*this, "right_lcd"),
+	m_port_binocular(*this, "BINOCULAR")
+{
+}
+
+
+//-------------------------------------------------
+//  input_ports - device-specific input ports
+//-------------------------------------------------
+
+static INPUT_PORTS_START( sms_3d_glasses )
+	PORT_START("BINOCULAR")
+	PORT_CONFNAME( 0x03, 0x00, "Binocular Hack" )
+	PORT_CONFSETTING( 0x00, DEF_STR( Off ) )
+	PORT_CONFSETTING( 0x01, "Left Lens" )
+	PORT_CONFSETTING( 0x02, "Right Lens" )
+	PORT_CONFSETTING( 0x03, "Both Lens" )
+INPUT_PORTS_END
+
+ioport_constructor sms_3d_glasses_device::device_input_ports() const
+{
+	return INPUT_PORTS_NAME( sms_3d_glasses );
+}
+
+
+// For consistency, use the same template used by the SMS drivers to workaround a
+// rounding issue in set_raw() that causes the ratio between CPU and pixel clocks
+// to not be exactly 2/3. The SMS VDP emulation controls some counters/flags through
+// screen timing and if the ratio is different the CPU will encounter unexpected
+// state.
+
+template <typename X>
+void sms_3d_glasses_device::screen_sms_ntsc_raw_params(screen_device &screen, X &&pixelclock)
+{
+	screen.set_raw(std::forward<X>(pixelclock),
+		sega315_5124_device::WIDTH,
+		sega315_5124_device::LBORDER_START + sega315_5124_device::LBORDER_WIDTH - 2,
+		sega315_5124_device::LBORDER_START + sega315_5124_device::LBORDER_WIDTH + 256 + 10,
+		sega315_5124_device::HEIGHT_NTSC,
+		sega315_5124_device::TBORDER_START + sega315_5124_device::NTSC_224_TBORDER_HEIGHT,
+		sega315_5124_device::TBORDER_START + sega315_5124_device::NTSC_224_TBORDER_HEIGHT + 224);
+	screen.set_refresh_hz(pixelclock / (sega315_5124_device::WIDTH * sega315_5124_device::HEIGHT_NTSC));
+}
+
+template <typename X>
+void sms_3d_glasses_device::screen_sms_3d_glasses_raw_params(screen_device &screen, sms_3d_port_device *port, X &&pixelclock)
+{
+	screen.set_raw(std::forward<X>(pixelclock),
+		port->m_screen->width(),
+		port->m_screen->visible_area().min_x,
+		port->m_screen->visible_area().max_x + 1,
+		port->m_screen->height(),
+		port->m_screen->visible_area().min_y,
+		port->m_screen->visible_area().max_y + 1);
+	screen.set_refresh_hz(pixelclock / (port->m_screen->width() * port->m_screen->height()));
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void sms_3d_glasses_device::device_start()
+{
+	screen_sms_3d_glasses_raw_params(*m_left_lcd, m_port, ATTOSECONDS_TO_HZ(m_port->m_screen->refresh_attoseconds() / (m_port->m_screen->width() * m_port->m_screen->height())));
+	screen_sms_3d_glasses_raw_params(*m_right_lcd, m_port, ATTOSECONDS_TO_HZ(m_port->m_screen->refresh_attoseconds() / (m_port->m_screen->width() * m_port->m_screen->height())));
+
+	m_port->m_screen->set_video_attributes(VIDEO_ALWAYS_UPDATE);
+	m_port->m_screen->register_screen_bitmap(m_tmpbitmap);
+
+	m_left_lcd->register_screen_bitmap(m_prevleft_bitmap);
+	m_right_lcd->register_screen_bitmap(m_prevright_bitmap);
+
+	save_item(NAME(m_prevleft_bitmap));
+	save_item(NAME(m_prevright_bitmap));
+
+	// Allow screens to have crosshair, useful for the game missil3d
+	machine().crosshair().get_crosshair(0).set_screen(CROSSHAIR_SCREEN_ALL);
+}
+
+
+//-------------------------------------------------
+//  device_reset - device-specific startup
+//-------------------------------------------------
+
+void sms_3d_glasses_device::device_reset()
+{
+	uint8_t binocular_hack = m_port_binocular->read();
+
+	if (binocular_hack & 0x01)
+		m_prevleft_bitmap.fill(rgb_t::black());
+	if (binocular_hack & 0x02)
+		m_prevright_bitmap.fill(rgb_t::black());
+}
+
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void sms_3d_glasses_device::device_add_mconfig(machine_config &config)
+{
+	SCREEN(config, m_left_lcd, SCREEN_TYPE_LCD);
+	m_left_lcd->set_screen_update(FUNC(sms_3d_glasses_device::screen_update_left));
+
+	SCREEN(config, m_right_lcd, SCREEN_TYPE_LCD);
+	m_right_lcd->set_screen_update(FUNC(sms_3d_glasses_device::screen_update_right));
+
+	// initial timings to pass validation and set correct aspect ratio,
+	// they are overridden with main screen parameters in device_start().
+	screen_sms_ntsc_raw_params(*m_left_lcd, XTAL(10'738'635)/2);
+	screen_sms_ntsc_raw_params(*m_right_lcd, XTAL(10'738'635)/2);
+
+	config.set_default_layout(layout_s3dglass);
+}
+
+
+void sms_3d_glasses_device::update_displayed_range()
+{
+	m_left_lcd->update_partial(m_left_lcd->vpos());
+	m_right_lcd->update_partial(m_right_lcd->vpos());
+}
+
+
+void sms_3d_glasses_device::blit_bitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	int min_y = std::max(cliprect.min_y, m_port->m_screen->visible_area().min_y);
+	int max_y = std::min(cliprect.max_y, m_port->m_screen->visible_area().max_y);
+
+	m_port->m_screen->pixels(&m_tmpbitmap.pix(0));
+
+	for (int y = min_y; y <= max_y; y++)
+	{
+		int scr_visible_width = m_port->m_screen->visible_area().max_x - m_port->m_screen->visible_area().min_x + 1;
+		int min_x = std::max(cliprect.min_x, m_port->m_screen->visible_area().min_x);
+		int max_x = std::min(cliprect.max_x, m_port->m_screen->visible_area().max_x);
+
+		uint32_t *const linedst = &bitmap.pix(y);
+		uint32_t const *const line = &m_tmpbitmap.pix(0) + ((y - min_y) * scr_visible_width) - min_x;
+
+		for (int x = min_x; x <= max_x; x++)
+		{
+			linedst[x] = line[x];
+		}
+	}
+}
+
+
+uint32_t sms_3d_glasses_device::screen_update_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	if (m_port->m_sscope_state)
+	{
+		// state 0 = left screen OFF, right screen ON
+
+		blit_bitmap(bitmap, cliprect);
+
+		// HACK: fake 3D->2D handling (if enabled, it repeats each frame twice on the selected lens)
+		// save a copy of current bitmap for the binocular hack
+		if (BIT(m_port_binocular->read(), 0))
+			copybitmap(m_prevleft_bitmap, bitmap, 0, 0, 0, 0, cliprect);
+	}
+	else
+	{
+		// HACK: fake 3D->2D handling (if enabled, it repeats each frame twice on the selected lens)
+		// use the copied bitmap for the binocular hack
+		if (BIT(m_port_binocular->read(), 0))
+		{
+			copybitmap(bitmap, m_prevleft_bitmap, 0, 0, 0, 0, cliprect);
+			return 0;
+		}
+		bitmap.fill(rgb_t::black(), cliprect);
+	}
+
+	return 0;
+}
+
+uint32_t sms_3d_glasses_device::screen_update_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
+{
+	if (!m_port->m_sscope_state)
+	{
+		// state 1 = left screen ON, right screen OFF
+
+		blit_bitmap(bitmap, cliprect);
+
+		// HACK: fake 3D->2D handling (if enabled, it repeats each frame twice on the selected lens)
+		// save a copy of current bitmap for the binocular hack
+		if (BIT(m_port_binocular->read(), 1))
+			copybitmap(m_prevright_bitmap, bitmap, 0, 0, 0, 0, cliprect);
+	}
+	else
+	{
+		// HACK: fake 3D->2D handling (if enabled, it repeats each frame twice on the selected lens)
+		// use the copied bitmap for the binocular hack
+		if (BIT(m_port_binocular->read(), 1))
+		{
+			copybitmap(bitmap, m_prevright_bitmap, 0, 0, 0, 0, cliprect);
+			return 0;
+		}
+		bitmap.fill(rgb_t::black(), cliprect);
+	}
+
+	return 0;
+}
+

--- a/src/devices/bus/sms_3d/s3dglass.cpp
+++ b/src/devices/bus/sms_3d/s3dglass.cpp
@@ -192,7 +192,7 @@ uint32_t sms_3d_glasses_device::screen_update_left(screen_device &screen, bitmap
 {
 	if (m_port->m_sscope_state)
 	{
-		// state 0 = left screen OFF, right screen ON
+		// state 1 = left screen ON, right screen OFF
 
 		blit_bitmap(bitmap, cliprect);
 
@@ -220,7 +220,7 @@ uint32_t sms_3d_glasses_device::screen_update_right(screen_device &screen, bitma
 {
 	if (!m_port->m_sscope_state)
 	{
-		// state 1 = left screen ON, right screen OFF
+		// state 0 = left screen OFF, right screen ON
 
 		blit_bitmap(bitmap, cliprect);
 

--- a/src/devices/bus/sms_3d/s3dglass.h
+++ b/src/devices/bus/sms_3d/s3dglass.h
@@ -37,14 +37,15 @@ protected:
 	virtual void device_reset() override;
 	virtual void device_add_mconfig(machine_config &config) override;
 
-	virtual void update_displayed_range() override;
-
 	// optional information overrides
 	ioport_constructor device_input_ports() const override;
 
+	// writing
+	virtual DECLARE_WRITE_LINE_MEMBER(write_sscope) override;
+
 private:
 	template <typename X> static void screen_sms_ntsc_raw_params(screen_device &screen, X &&pixelclock);
-	template <typename X> static void screen_sms_3d_glasses_raw_params(screen_device &screen, sms_3d_port_device *port, X &&pixelclock);
+	template <typename X> static void screen_sms_3d_glasses_raw_params(screen_device &screen, screen_device &main_screen, X &&pixelclock);
 
 	void blit_bitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
@@ -53,6 +54,7 @@ private:
 	required_device<screen_device> m_left_lcd;
 	required_device<screen_device> m_right_lcd;
 
+	int m_sscope_state;
 	bitmap_rgb32 m_tmpbitmap;
 
 	// for 3D glass binocular hack

--- a/src/devices/bus/sms_3d/s3dglass.h
+++ b/src/devices/bus/sms_3d/s3dglass.h
@@ -1,0 +1,69 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+/**********************************************************************
+
+    The Sega 3-D Glasses / SegaScope 3-D Glasses emulation
+
+**********************************************************************/
+
+#ifndef MAME_BUS_SMS_3D_GLASSES_H
+#define MAME_BUS_SMS_3D_GLASSES_H
+
+#pragma once
+
+
+#include "crsshair.h"
+#include "video/315_5124.h"
+#include "s3dport.h"
+
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> sms_3d_glasses_device
+
+class sms_3d_glasses_device : public device_t,
+							public device_sms_3d_port_interface
+{
+public:
+	// construction/destruction
+	sms_3d_glasses_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual void update_displayed_range() override;
+
+	// optional information overrides
+	ioport_constructor device_input_ports() const override;
+
+private:
+	template <typename X> static void screen_sms_ntsc_raw_params(screen_device &screen, X &&pixelclock);
+	template <typename X> static void screen_sms_3d_glasses_raw_params(screen_device &screen, sms_3d_port_device *port, X &&pixelclock);
+
+	void blit_bitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	required_device<screen_device> m_left_lcd;
+	required_device<screen_device> m_right_lcd;
+
+	bitmap_rgb32 m_tmpbitmap;
+
+	// for 3D glass binocular hack
+	required_ioport m_port_binocular;
+	bitmap_rgb32 m_prevleft_bitmap;
+	bitmap_rgb32 m_prevright_bitmap;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(SMS_3D_GLASSES, sms_3d_glasses_device)
+
+
+#endif // MAME_BUS_SMS_3D_GLASSES_H

--- a/src/devices/bus/sms_3d/s3dport.cpp
+++ b/src/devices/bus/sms_3d/s3dport.cpp
@@ -1,0 +1,104 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+/**********************************************************************
+
+    Input Port for the Sega 3-D Glasses / SegaScope 3-D Glasses
+
+**********************************************************************/
+
+#include "emu.h"
+#include "s3dport.h"
+
+// slot devices
+#include "s3dglass.h"
+
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(SMS_3D_PORT, sms_3d_port_device, "sms_3d_port", "Sega 3-D Glasses Port")
+
+
+
+//**************************************************************************
+//  CARD INTERFACE
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_sms_3d_port_interface - constructor
+//-------------------------------------------------
+
+device_sms_3d_port_interface::device_sms_3d_port_interface(const machine_config &mconfig, device_t &device)
+	: device_interface(device, "3dport")
+{
+	m_port = dynamic_cast<sms_3d_port_device *>(device.owner());
+}
+
+
+//-------------------------------------------------
+//  ~device_sms_3d_port_interface - destructor
+//-------------------------------------------------
+
+device_sms_3d_port_interface::~device_sms_3d_port_interface()
+{
+}
+
+
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  sms_3d_port_device - constructor
+//-------------------------------------------------
+
+sms_3d_port_device::sms_3d_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, SMS_3D_PORT, tag, owner, clock),
+	device_slot_interface(mconfig, *this),
+	m_screen(*this, finder_base::DUMMY_TAG),
+	m_device(nullptr)
+{
+}
+
+
+//-------------------------------------------------
+//  sms_3d_port_device - destructor
+//-------------------------------------------------
+
+sms_3d_port_device::~sms_3d_port_device()
+{
+}
+
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void sms_3d_port_device::device_start()
+{
+	save_item(NAME(m_sscope_state));
+	m_device = dynamic_cast<device_sms_3d_port_interface *>(get_card_device());
+}
+
+
+WRITE_LINE_MEMBER(sms_3d_port_device::write_sscope)
+{
+	if (state != m_sscope_state) {
+		m_device->update_displayed_range();
+		m_sscope_state = state;
+	}
+}
+
+
+//-------------------------------------------------
+//  SLOT_INTERFACE( sms_3d_port_devices )
+//-------------------------------------------------
+
+void sms_3d_port_devices(device_slot_interface &device)
+{
+	device.option_add("3dglass", SMS_3D_GLASSES);
+}
+

--- a/src/devices/bus/sms_3d/s3dport.cpp
+++ b/src/devices/bus/sms_3d/s3dport.cpp
@@ -33,7 +33,6 @@ DEFINE_DEVICE_TYPE(SMS_3D_PORT, sms_3d_port_device, "sms_3d_port", "Sega 3-D Gla
 device_sms_3d_port_interface::device_sms_3d_port_interface(const machine_config &mconfig, device_t &device)
 	: device_interface(device, "3dport")
 {
-	m_port = dynamic_cast<sms_3d_port_device *>(device.owner());
 }
 
 
@@ -58,7 +57,7 @@ device_sms_3d_port_interface::~device_sms_3d_port_interface()
 sms_3d_port_device::sms_3d_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, SMS_3D_PORT, tag, owner, clock),
 	device_single_card_slot_interface<device_sms_3d_port_interface>(mconfig, *this),
-	m_screen(*this, finder_base::DUMMY_TAG),
+	m_screen(nullptr),
 	m_device(nullptr)
 {
 }
@@ -79,17 +78,21 @@ sms_3d_port_device::~sms_3d_port_device()
 
 void sms_3d_port_device::device_start()
 {
-	save_item(NAME(m_sscope_state));
+}
+
+
+void sms_3d_port_device::device_resolve_objects()
+{
 	m_device = dynamic_cast<device_sms_3d_port_interface *>(get_card_device());
+	if (m_device)
+		m_device->set_screen_device(*m_screen);
 }
 
 
 WRITE_LINE_MEMBER(sms_3d_port_device::write_sscope)
 {
-	if (state != m_sscope_state) {
-		m_device->update_displayed_range();
-		m_sscope_state = state;
-	}
+	if (m_device)
+		m_device->write_sscope(state);
 }
 
 

--- a/src/devices/bus/sms_3d/s3dport.cpp
+++ b/src/devices/bus/sms_3d/s3dport.cpp
@@ -57,7 +57,7 @@ device_sms_3d_port_interface::~device_sms_3d_port_interface()
 
 sms_3d_port_device::sms_3d_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
 	device_t(mconfig, SMS_3D_PORT, tag, owner, clock),
-	device_slot_interface(mconfig, *this),
+	device_single_card_slot_interface<device_sms_3d_port_interface>(mconfig, *this),
 	m_screen(*this, finder_base::DUMMY_TAG),
 	m_device(nullptr)
 {

--- a/src/devices/bus/sms_3d/s3dport.h
+++ b/src/devices/bus/sms_3d/s3dport.h
@@ -1,0 +1,87 @@
+// license:BSD-3-Clause
+// copyright-holders:Enik Land
+/**********************************************************************
+
+    Input Port for the Sega 3-D Glasses / SegaScope 3-D Glasses
+
+**********************************************************************
+
+
+**********************************************************************/
+
+#ifndef MAME_BUS_SMS_3D_PORT_H
+#define MAME_BUS_SMS_3D_PORT_H
+
+#include "screen.h"
+
+#pragma once
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> sms_3d_port_device
+
+class device_sms_3d_port_interface;
+
+class sms_3d_port_device : public device_t,
+								public device_slot_interface
+{
+public:
+	// construction/destruction
+	template <typename T>
+	sms_3d_port_device(machine_config const &mconfig, char const *tag, device_t *owner, T &&opts, char const *dflt)
+		: sms_3d_port_device(mconfig, tag, owner, 0)
+	{
+		option_reset();
+		opts(*this);
+		set_default_option(dflt);
+		set_fixed(false);
+	}
+
+	sms_3d_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	virtual ~sms_3d_port_device();
+
+	DECLARE_WRITE_LINE_MEMBER(write_sscope);
+
+	int m_sscope_state;
+
+	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
+
+	required_device<screen_device> m_screen;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+	device_sms_3d_port_interface *m_device;
+};
+
+
+// ======================> device_sms_3d_port_interface
+
+// class representing interface-specific live sms_expansion card
+class device_sms_3d_port_interface : public device_interface
+{
+public:
+	// construction/destruction
+	virtual ~device_sms_3d_port_interface();
+
+	virtual void update_displayed_range() {}
+
+protected:
+	device_sms_3d_port_interface(const machine_config &mconfig, device_t &device);
+
+	sms_3d_port_device *m_port;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(SMS_3D_PORT, sms_3d_port_device)
+
+
+void sms_3d_port_devices(device_slot_interface &device);
+
+
+#endif // MAME_BUS_SMS_3D_PORT_H

--- a/src/devices/bus/sms_3d/s3dport.h
+++ b/src/devices/bus/sms_3d/s3dport.h
@@ -39,22 +39,22 @@ public:
 		set_default_option(dflt);
 		set_fixed(false);
 	}
-
 	sms_3d_port_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 	virtual ~sms_3d_port_device();
 
+	// configuration
+	void set_screen_device(screen_device &screen) { m_screen = &screen; }
+
+	// writing
 	DECLARE_WRITE_LINE_MEMBER(write_sscope);
-
-	int m_sscope_state;
-
-	template <typename T> void set_screen_tag(T &&tag) { m_screen.set_tag(std::forward<T>(tag)); }
-
-	required_device<screen_device> m_screen;
 
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_resolve_objects() override;
 
+private:
+	screen_device *m_screen;
 	device_sms_3d_port_interface *m_device;
 };
 
@@ -68,12 +68,16 @@ public:
 	// construction/destruction
 	virtual ~device_sms_3d_port_interface();
 
-	virtual void update_displayed_range() {}
+	// configuration
+	virtual void set_screen_device(screen_device &screen) { m_screen = &screen; }
+
+	// writing
+	virtual DECLARE_WRITE_LINE_MEMBER(write_sscope) {}
 
 protected:
 	device_sms_3d_port_interface(const machine_config &mconfig, device_t &device);
 
-	sms_3d_port_device *m_port;
+	screen_device *m_screen;
 };
 
 

--- a/src/devices/bus/sms_3d/s3dport.h
+++ b/src/devices/bus/sms_3d/s3dport.h
@@ -26,7 +26,7 @@
 class device_sms_3d_port_interface;
 
 class sms_3d_port_device : public device_t,
-								public device_slot_interface
+								public device_single_card_slot_interface<device_sms_3d_port_interface>
 {
 public:
 	// construction/destruction

--- a/src/emu/layout/s3dglass.lay
+++ b/src/emu/layout/s3dglass.lay
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--
+license:CC0
+-->
+<mamelayout version="2">
+	<view name="SegaScope Left LCD Standard (4:3)">
+		<screen tag="left_lcd">
+			<bounds left="0" top="0" right="4" bottom="3" />
+		</screen>
+	</view>
+
+	<view name="SegaScope Right LCD Standard (4:3)">
+		<screen tag="right_lcd">
+			<bounds left="0" top="0" right="4" bottom="3" />
+		</screen>
+	</view>
+
+	<view name="SegaScope Left LCD Aspect (~scr1nativexaspect~:~scr1nativeyaspect~)">
+		<screen tag="left_lcd">
+			<bounds left="0" top="0" right="~scr1width~" bottom="~scr1height~" />
+		</screen>
+	</view>
+
+	<view name="SegaScope Right LCD Pixel Aspect (~scr1nativexaspect~:~scr1nativeyaspect~)">
+		<screen tag="right_lcd">
+			<bounds left="0" top="0" right="~scr1width~" bottom="~scr1height~" />
+		</screen>
+	</view>
+
+	<view name="SegaScope 3-D Glasses">
+		<screen tag="left_lcd">
+			<bounds x="0" y="0" width="4" height="3" />
+		</screen>
+		<screen tag="right_lcd">
+			<bounds x="4.03" y="0" width="4" height="3" />
+		</screen>
+	</view>
+
+	<view name="SegaScope 3-D Glasses (Gapless)">
+		<screen tag="left_lcd">
+			<bounds x="0" y="0" width="4" height="3" />
+		</screen>
+		<screen tag="right_lcd">
+			<bounds x="4" y="0" width="4" height="3" />
+		</screen>
+	</view>
+</mamelayout>

--- a/src/emu/layout/s3dglass.lay
+++ b/src/emu/layout/s3dglass.lay
@@ -44,4 +44,15 @@ license:CC0
 			<bounds x="4" y="0" width="4" height="3" />
 		</screen>
 	</view>
+
+	<view name="SegaScope 3-D Glasses (3DTV H-SBS)">
+		<!-- suitable for 3D TVs with Half-SBS (Side by Side) mode -->
+		<!-- binocular hack must be enabled in the configuration -->
+		<screen tag="left_lcd">
+			<bounds x="2" y="0" width="6" height="9" />
+		</screen>
+		<screen tag="right_lcd">
+			<bounds x="10" y="0" width="6" height="9" />
+		</screen>
+	</view>
 </mamelayout>

--- a/src/mame/audio/nl_segas16b.cpp
+++ b/src/mame/audio/nl_segas16b.cpp
@@ -73,7 +73,7 @@ NETLIST_START(segas16b_audio)
 
 	CAP(C21, CAP_U(2.2))
 	CAP(C22, CAP_U(2.2)) // Needs verification
-	CAP(C27, CAP_P(1500))
+	CAP(C29, CAP_P(1500))
 	CAP(C28, CAP_P(1500))
 
 	// ------------------------------------
@@ -81,14 +81,14 @@ NETLIST_START(segas16b_audio)
 	// ------------------------------------
 
 	NET_C(CH1, RCOM1.1)
-	NET_C(RCOM1.2, C27.1, D20.5)
+	NET_C(RCOM1.2, C29.1, D20.5)
 	NET_C(D20.7, D20.6, C22.1)
 
 	NET_C(CH2, RCOM2.1)
 	NET_C(RCOM2.2, C28.1, D20.10)
 	NET_C(D20.8, D20.9, C21.1)
 
-	NET_C(GND, C27.2, C28.2)
+	NET_C(GND, C29.2, C28.2)
 
 	// OPAMPS, no information on schematics, assume 12V since
 	// TL084 with 5V would be outside specifications
@@ -110,7 +110,7 @@ NETLIST_START(segas16b_audio)
 	CAP(C25, CAP_U(0.0022))
 	CAP(C26, CAP_U(0.022))
 	CAP(C23, CAP_U(0.022))
-	CAP(C29, CAP_U(0.01))
+	CAP(C24, CAP_U(0.01))
 	CAP(C62, CAP_U(2.2))
 
 	NET_C(VP5, R11.1)
@@ -120,10 +120,10 @@ NETLIST_START(segas16b_audio)
 	NET_C(XC20.7, XC20.6, C26.2, R12.1)
 
 	NET_C(R12.2, C23.1, R13.1)
-	NET_C(R13.2, C29.1, XC20.3)
+	NET_C(R13.2, C24.1, XC20.3)
 	NET_C(XC20.1, XC20.2, C23.2, C62.1)
 
-	NET_C(GND, R16.2, C25.2, C29.2)
+	NET_C(GND, R16.2, C25.2, C24.2)
 
 	// ------------------------------------
 	// Mixing and pre amplifier

--- a/src/mame/drivers/sms.cpp
+++ b/src/mame/drivers/sms.cpp
@@ -386,32 +386,15 @@ static INPUT_PORTS_START( sms )
 	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_OTHER ) PORT_NAME(DEF_STR(Pause)) PORT_CODE(KEYCODE_1) PORT_WRITE_LINE_DEVICE_MEMBER("sms_vdp", sega315_5124_device, n_nmi_in_write)
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( sg1000m3 )
-	PORT_INCLUDE( sms )
-
-	PORT_START("SEGASCOPE")
-	PORT_CONFNAME( 0x01, 0x00, "SegaScope (3-D Glasses)" )
-	PORT_CONFSETTING( 0x00, DEF_STR( Off ) )
-	PORT_CONFSETTING( 0x01, DEF_STR( On ) )
-
-	PORT_START("SSCOPE_BINOCULAR")
-	PORT_CONFNAME( 0x03, 0x00, "SegaScope - Binocular Hack" ) PORT_CONDITION("SEGASCOPE", 0x01, EQUALS, 0x01)
-	PORT_CONFSETTING( 0x00, DEF_STR( Off ) )
-	PORT_CONFSETTING( 0x01, "Left Lens" )
-	PORT_CONFSETTING( 0x02, "Right Lens" )
-	PORT_CONFSETTING( 0x03, "Both Lens" )
-	PORT_BIT( 0x03, 0x00, IPT_UNUSED ) PORT_CONDITION("SEGASCOPE", 0x01, EQUALS, 0x00)
-INPUT_PORTS_END
-
 static INPUT_PORTS_START( sms1 )
-	PORT_INCLUDE( sg1000m3 )
+	PORT_INCLUDE( sms )
 
 	PORT_START("RESET")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE2 ) PORT_NAME("Reset Button")
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( smsj )
-	PORT_INCLUDE( sg1000m3 )
+	PORT_INCLUDE( sms )
 
 	PORT_START("RAPID")
 	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_SERVICE2 ) PORT_NAME("Rapid Button")
@@ -607,16 +590,6 @@ void sms1_state::sms1_ntsc(machine_config &config)
 	screen_sms_ntsc_raw_params(*m_main_scr, XTAL(10'738'635)/2);
 	m_main_scr->set_screen_update(FUNC(sms1_state::screen_update_sms));
 
-	SCREEN(config, m_left_lcd, SCREEN_TYPE_LCD);    // This is needed for SegaScope Left LCD
-	screen_sms_ntsc_raw_params(*m_left_lcd, XTAL(10'738'635)/2);
-	m_left_lcd->set_screen_update(FUNC(sms1_state::screen_update_left));
-
-	SCREEN(config, m_right_lcd, SCREEN_TYPE_LCD);   // This is needed for SegaScope Right LCD
-	screen_sms_ntsc_raw_params(*m_right_lcd, XTAL(10'738'635)/2);
-	m_right_lcd->set_screen_update(FUNC(sms1_state::screen_update_right));
-
-	m_main_scr->screen_vblank().set(FUNC(sms1_state::sscope_vblank));
-
 	config.set_default_layout(layout_sms1);
 
 	SEGA315_5124(config, m_vdp, XTAL(10'738'635));
@@ -627,7 +600,7 @@ void sms1_state::sms1_ntsc(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "mono", 1.00);
 
 	// card and expansion slots, not present in Master System II
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
 
 	m_has_bios_full = true;
@@ -651,7 +624,7 @@ void smssdisp_state::sms_sdisp(machine_config &config)
 	for (int i = 1; i < 16; i++)
 		SMS_CART_SLOT(config, m_slots[i], sms_cart, nullptr);
 	for (int i = 0; i < 16; i++)
-		SMS_CARD_SLOT(config, m_cards[i], sms_cart, nullptr);
+		SMS_CARD_SLOT(config, m_cards[i], sms_card, nullptr).set_screen_tag(m_main_scr);
 
 	m_has_bios_full = false;
 	m_has_pwr_led = false;
@@ -698,16 +671,6 @@ void sms1_state::sms1_pal(machine_config &config)
 	screen_sms_pal_raw_params(*m_main_scr, MASTER_CLOCK_PAL/10);
 	m_main_scr->set_screen_update(FUNC(sms1_state::screen_update_sms));
 
-	SCREEN(config, m_left_lcd, SCREEN_TYPE_LCD);    // This is needed for SegaScope Left LCD
-	screen_sms_pal_raw_params(*m_left_lcd, MASTER_CLOCK_PAL/10);
-	m_left_lcd->set_screen_update(FUNC(sms1_state::screen_update_left));
-
-	SCREEN(config, m_right_lcd, SCREEN_TYPE_LCD);   // This is needed for SegaScope Right LCD
-	screen_sms_pal_raw_params(*m_right_lcd, MASTER_CLOCK_PAL/10);
-	m_right_lcd->set_screen_update(FUNC(sms1_state::screen_update_right));
-
-	m_main_scr->screen_vblank().set(FUNC(sms1_state::sscope_vblank));
-
 	config.set_default_layout(layout_sms1);
 
 	SEGA315_5124(config, m_vdp, MASTER_CLOCK_PAL/5);
@@ -718,7 +681,7 @@ void sms1_state::sms1_pal(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "mono", 1.00);
 
 	// card and expansion slots, not present in Master System II
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
 
 	m_has_bios_full = true;
@@ -767,16 +730,6 @@ void sms1_state::sms1_paln(machine_config &config)
 	screen_sms_pal_raw_params(*m_main_scr, MASTER_CLOCK_PALN/2);
 	m_main_scr->set_screen_update(FUNC(sms1_state::screen_update_sms));
 
-	SCREEN(config, m_left_lcd, SCREEN_TYPE_LCD);    // This is needed for SegaScope Left LCD
-	screen_sms_pal_raw_params(*m_left_lcd, MASTER_CLOCK_PALN/2);
-	m_left_lcd->set_screen_update(FUNC(sms1_state::screen_update_left));
-
-	SCREEN(config, m_right_lcd, SCREEN_TYPE_LCD);   // This is needed for SegaScope Right LCD
-	screen_sms_pal_raw_params(*m_right_lcd, MASTER_CLOCK_PALN/2);
-	m_right_lcd->set_screen_update(FUNC(sms1_state::screen_update_right));
-
-	m_main_scr->screen_vblank().set(FUNC(sms1_state::sscope_vblank));
-
 	config.set_default_layout(layout_sms1);
 
 	SEGA315_5124(config, m_vdp, MASTER_CLOCK_PALN);
@@ -787,7 +740,7 @@ void sms1_state::sms1_paln(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "mono", 1.00);
 
 	// card and expansion slots, not present in Tec Toy Master System III
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
 
 	m_has_bios_full = true;
@@ -838,16 +791,6 @@ void sms1_state::sms1_br(machine_config &config)
 	screen_sms_ntsc_raw_params(*m_main_scr, MASTER_CLOCK_PALM/2);
 	m_main_scr->set_screen_update(FUNC(sms1_state::screen_update_sms));
 
-	SCREEN(config, m_left_lcd, SCREEN_TYPE_LCD);    // This is needed for SegaScope Left LCD
-	screen_sms_ntsc_raw_params(*m_left_lcd, MASTER_CLOCK_PALM/2);
-	m_left_lcd->set_screen_update(FUNC(sms1_state::screen_update_left));
-
-	SCREEN(config, m_right_lcd, SCREEN_TYPE_LCD);   // This is needed for SegaScope Right LCD
-	screen_sms_ntsc_raw_params(*m_right_lcd, MASTER_CLOCK_PALM/2);
-	m_right_lcd->set_screen_update(FUNC(sms1_state::screen_update_right));
-
-	m_main_scr->screen_vblank().set(FUNC(sms1_state::sscope_vblank));
-
 	config.set_default_layout(layout_sms1);
 
 	SEGA315_5124(config, m_vdp, MASTER_CLOCK_PALM);
@@ -858,7 +801,7 @@ void sms1_state::sms1_br(machine_config &config)
 	m_vdp->add_route(ALL_OUTPUTS, "mono", 1.00);
 
 	// card and expansion slots, not present in Tec Toy Master System III
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
 
 	m_has_bios_full = true;
@@ -892,8 +835,11 @@ void sms1_state::sms1_kr(machine_config &config)
 	config.device_remove("mycard");
 	config.device_remove("smsexp");
 	SG1000MK3_CART_SLOT(config, "slot", sg1000mk3_cart, nullptr);
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
+
+	SMS_3D_PORT(config, m_port_3d, sms_3d_port_devices, nullptr);
+	m_port_3d->set_screen_tag(m_main_scr);
 
 	SOFTWARE_LIST(config, "cart_list2").set_original("sg1000");
 
@@ -931,7 +877,7 @@ void sms1_state::sg1000m3(machine_config &config)
 	config.device_remove("mycard");
 	config.device_remove("smsexp");
 	SG1000MK3_CART_SLOT(config, "slot", sg1000mk3_cart, nullptr);
-	SMS_CARD_SLOT(config, "mycard", sms_cart, nullptr);
+	SMS_CARD_SLOT(config, "mycard", sms_card, nullptr).set_screen_tag(m_main_scr);
 	SG1000_EXPANSION_SLOT(config, "sgexp", sg1000_expansion_devices, nullptr, false);
 
 	SOFTWARE_LIST(config, "cart_list2").set_original("sg1000");
@@ -1240,7 +1186,7 @@ ROM_END
 ***************************************************************************/
 
 /*    YEAR  NAME      PARENT    COMPAT  MACHINE    INPUT     CLASS           INIT           COMPANY    FULLNAME                              FLAGS */
-CONS( 1985, sg1000m3, sms,      0,      sg1000m3,  sg1000m3, sms1_state,     empty_init,    "Sega",    "Mark III",                           MACHINE_SUPPORTS_SAVE )
+CONS( 1985, sg1000m3, sms,      0,      sg1000m3,  sms,      sms1_state,     empty_init,    "Sega",    "Mark III",                           MACHINE_SUPPORTS_SAVE )
 CONS( 1986, sms1,     sms,      0,      sms1_ntsc, sms1,     sms1_state,     empty_init,    "Sega",    "Master System I",                    MACHINE_SUPPORTS_SAVE )
 CONS( 1986, sms1pal,  sms,      0,      sms1_pal,  sms1,     sms1_state,     empty_init,    "Sega",    "Master System I (PAL)" ,             MACHINE_SUPPORTS_SAVE )
 CONS( 1986, smssdisp, sms,      0,      sms_sdisp, smssdisp, smssdisp_state, empty_init,    "Sega",    "Master System Store Display Unit",   MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/sms.cpp
+++ b/src/mame/drivers/sms.cpp
@@ -839,7 +839,7 @@ void sms1_state::sms1_kr(machine_config &config)
 	SMS_EXPANSION_SLOT(config, "smsexp", sms_expansion_devices, nullptr);
 
 	SMS_3D_PORT(config, m_port_3d, sms_3d_port_devices, nullptr);
-	m_port_3d->set_screen_tag(m_main_scr);
+	m_port_3d->set_screen_device(*m_main_scr);
 
 	SOFTWARE_LIST(config, "cart_list2").set_original("sg1000");
 

--- a/src/mame/includes/sms.h
+++ b/src/mame/includes/sms.h
@@ -26,6 +26,7 @@
 #include "bus/sg1000_exp/sg1000exp.h"
 #include "bus/sms_ctrl/smsctrl.h"
 #include "bus/sms_exp/smsexp.h"
+#include "bus/sms_3d/s3dport.h"
 #include "sound/ym2413.h"
 #include "video/315_5124.h"
 
@@ -197,7 +198,7 @@ protected:
 	// slot devices
 	sega8_cart_slot_device *m_cartslot;
 	optional_device<sega8_cart_slot_device> m_slot;
-	optional_device<sega8_card_slot_device> m_cardslot;
+	optional_device<sms_card_slot_device> m_cardslot;
 	optional_device<sms_expansion_slot_device> m_smsexpslot;
 	optional_device<sg1000_expansion_slot_device> m_sgexpslot;
 };
@@ -207,10 +208,7 @@ class sms1_state : public sms_state
 public:
 	sms1_state(const machine_config &mconfig, device_type type, const char *tag) :
 		sms_state(mconfig, type, tag),
-		m_left_lcd(*this, "left_lcd"),
-		m_right_lcd(*this, "right_lcd"),
-		m_port_scope(*this, "SEGASCOPE"),
-		m_port_scope_binocular(*this, "SSCOPE_BINOCULAR")
+		m_port_3d(*this, "3dport")
 	{ }
 
 	void sms1_paln(machine_config &config);
@@ -221,31 +219,13 @@ public:
 	void smsj(machine_config &config);
 	void sg1000m3(machine_config &config);
 
-protected:
-	virtual void video_start() override;
-	virtual void video_reset() override;
-
 private:
 	uint8_t sscope_r(offs_t offset);
 	void sscope_w(offs_t offset, uint8_t data);
 
-	DECLARE_WRITE_LINE_MEMBER(sscope_vblank);
-	uint32_t screen_update_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	uint32_t screen_update_right(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
-
 	void sms1_mem(address_map &map);
 
-	// for 3D glass binocular hack
-	required_device<screen_device> m_left_lcd;
-	required_device<screen_device> m_right_lcd;
-	required_ioport m_port_scope;
-	required_ioport m_port_scope_binocular;
-	bitmap_rgb32 m_prevleft_bitmap;
-	bitmap_rgb32 m_prevright_bitmap;
-
-	// Data needed for SegaScope (3D glasses)
-	uint8_t m_sscope_state;
-	uint8_t m_frame_sscope_state;
+	optional_device<sms_3d_port_device> m_port_3d;
 };
 
 class smssdisp_state : public sms1_state

--- a/src/mame/layout/sms1.lay
+++ b/src/mame/layout/sms1.lay
@@ -13,14 +13,16 @@ license:CC0
 		</screen>
 	</view>
 
-	<view name="SegaScope Left LCD Standard (4:3)">
-		<screen index="1">
-			<bounds left="0" top="0" right="4" bottom="3" />
-		</screen>
-	</view>
+	<view name="Main Screen (2x3D) Standard (4:3)">
+		<!-- workaround for MAME selecting a 5-screen view by default -->
+		<!-- screens for one 3d glasses device -->
+		<screen index="1"><bounds left="0" top="0" right="4" bottom="3" /><color alpha="0" /></screen>
+		<screen index="2"><bounds left="0" top="0" right="4" bottom="3" /><color alpha="0" /></screen>
+		<!-- screens for an extra 3d glasses (e.g.: when using adapter + SMSJ built-in port) -->
+		<screen index="3"><bounds left="0" top="0" right="4" bottom="3" /><color alpha="0" /></screen>
+		<screen index="4"><bounds left="0" top="0" right="4" bottom="3" /><color alpha="0" /></screen>
 
-	<view name="SegaScope Right LCD Standard (4:3)">
-		<screen index="2">
+		<screen index="0">
 			<bounds left="0" top="0" right="4" bottom="3" />
 		</screen>
 	</view>
@@ -31,39 +33,9 @@ license:CC0
 		</screen>
 	</view>
 
-	<view name="SegaScope Left LCD Aspect (~scr1nativexaspect~:~scr1nativeyaspect~)">
-		<screen index="1">
-			<bounds left="0" top="0" right="~scr1width~" bottom="~scr1height~" />
-		</screen>
-	</view>
-
-	<view name="SegaScope Right LCD Pixel Aspect (~scr1nativexaspect~:~scr1nativeyaspect~)">
-		<screen index="2">
-			<bounds left="0" top="0" right="~scr1width~" bottom="~scr1height~" />
-		</screen>
-	</view>
-
 	<view name="Main Screen">
 		<screen index="0">
 			<bounds x="0" y="0" width="4" height="3" />
-		</screen>
-	</view>
-
-	<view name="SegaScope 3-D Glasses">
-		<screen index="1">
-			<bounds x="0" y="0" width="4" height="3" />
-		</screen>
-		<screen index="2">
-			<bounds x="4.03" y="0" width="4" height="3" />
-		</screen>
-	</view>
-
-	<view name="SegaScope 3-D Glasses (Gapless)">
-		<screen index="1">
-			<bounds x="0" y="0" width="4" height="3" />
-		</screen>
-		<screen index="2">
-			<bounds x="4" y="0" width="4" height="3" />
 		</screen>
 	</view>
 </mamelayout>

--- a/src/mame/machine/sms.cpp
+++ b/src/mame/machine/sms.cpp
@@ -559,17 +559,7 @@ uint8_t gamegear_state::gg_input_port_00_r()
 
 uint8_t sms1_state::sscope_r(offs_t offset)
 {
-	int sscope = m_port_scope->read();
-
-	// On SMSJ, address $fffb also controls the built-in 3-D port, that works
-	// in parallel with the 3-D adapter that is inserted into the card slot.
-
-	if ( sscope )
-	{
-		// Scope is attached
-		return m_sscope_state;
-	}
-
+	// SegaScope is write-only and writes are mirrored in RAM, from where the values read come from.
 	return read_ram(0x3ff8 + offset);
 }
 
@@ -579,6 +569,9 @@ void sms1_state::sscope_w(offs_t offset, uint8_t data)
 	write_ram(0x3ff8 + offset, data);
 
 	int sscope = m_port_scope->read();
+
+	// On SMSJ, address $fffb also controls the built-in 3-D port, that works
+	// in parallel with the 3-D adapter that is inserted into the card slot.
 
 	if ( sscope )
 	{


### PR DESCRIPTION
While comparing the segas16b netlist implementation with the schematics I noticed two capacitor labels that are incorrect.

Reference: https://www.jammarcade.net/files/Schematics/Arcade/system16b_schematics.pdf (page 6)
PCB pictures: http://reassembler.blogspot.com/2016/01/shinobi-system-16b-fix-log.html
Close-up: http://3.bp.blogspot.com/-iC5WA88RInM/Vpv1ZczijQI/AAAAAAAABq0/y289juQ5Vro/s1600/shinobi14.jpg