### PR TITLE
qx10: Enable drive B motor when doing a write motor on register

### DIFF
--- a/src/mame/drivers/qx10.cpp
+++ b/src/mame/drivers/qx10.cpp
@@ -386,6 +386,7 @@ void qx10_state::fdd_motor_w(uint8_t data)
 	m_fdcmotor = 1;
 
 	m_floppy[0]->get_device()->mon_w(false);
+	m_floppy[1]->get_device()->mon_w(false);
 	// motor off controlled by clock
 }
 


### PR DESCRIPTION
The second floppy drive was always reporting not ready due to its motor not being enabled on the write to io address 0x30