### PR TITLE
laserbat.cpp: Quantise area effect 2/shell to 4-pixel intervals for catnmous.

### DIFF
--- a/src/mame/audio/laserbat.cpp
+++ b/src/mame/audio/laserbat.cpp
@@ -130,7 +130,7 @@ void laserbat_state_base::csound2_w(uint8_t data)
 void laserbat_state::csound2_w(uint8_t data)
 {
 	// there are a bunch of edge-triggered things, so grab changes
-	unsigned const diff = data ^ m_csound2;
+	uint8_t const diff = data ^ m_csound2;
 
 	// SN76477 and distortion control
 	if (data & diff & 0x01)
@@ -317,10 +317,10 @@ void catnmous_state::csound1_w(uint8_t data)
 void catnmous_state::csound2_w(uint8_t data)
 {
 	// the bottom bit is used for sprite banking, of all things
-	m_gfx2 = memregion("gfx2")->base() + ((data & 0x01) ? 0x0800 : 0x0000);
+	m_gfx2_base = uint16_t(BIT(data, 0)) << 11;
 
 	// the top bit is called RESET on the wiring diagram
-	m_audiopcb->reset_w((data & 0x80) ? 1 : 0);
+	m_audiopcb->reset_w(BIT(data, 7));
 
 	m_csound2 = data;
 }

--- a/src/mame/drivers/laserbat.cpp
+++ b/src/mame/drivers/laserbat.cpp
@@ -65,6 +65,11 @@
     * The sprite ROM is twice the size as Laser Battle with the bank
       selected using bit 9 of the 16-bit sound interface (there's a wire
       making this connection visible on the component side of the PCB)
+    * At least some boards have IC13I pins 8, 9, 10 and 11 bent out of
+      the socket, tied together, and pulled high via a 4k7 resistor,
+      which quantises the shell/area effect 2 to four-pixel boundaries
+      (implemented as m_eff2_mask) - would be good to see whether this
+      mod is present on all boards
     * If demo sounds are enabled (using DIP switches), background music
       is played every sixth time through the attract loop
     * Sound board emulation is based on tracing the program and guessing
@@ -412,9 +417,14 @@ INTERRUPT_GEN_MEMBER(laserbat_state_base::laserbat_interrupt)
 	m_maincpu->set_input_line(0, ASSERT_LINE);
 }
 
-void laserbat_state_base::init_laserbat()
+void laserbat_state_base::machine_start()
 {
+	// start rendering scanlines
+	m_screen->register_screen_bitmap(m_bitmap);
 	m_scanline_timer = timer_alloc(TIMER_SCANLINE);
+	m_scanline_timer->adjust(m_screen->time_until_pos(1, 0));
+
+	save_item(NAME(m_gfx2_base));
 
 	save_item(NAME(m_input_mux));
 	save_item(NAME(m_mpx_p_1_2));
@@ -436,10 +446,10 @@ void laserbat_state_base::init_laserbat()
 	save_item(NAME(m_neg1));
 	save_item(NAME(m_neg2));
 
-	save_item(NAME(m_csound1));
-	save_item(NAME(m_csound2));
 	save_item(NAME(m_rhsc));
 	save_item(NAME(m_whsc));
+	save_item(NAME(m_csound1));
+	save_item(NAME(m_csound2));
 }
 
 void laserbat_state::machine_start()
@@ -732,7 +742,7 @@ ROM_START( catnmousa )
 ROM_END
 
 
-GAME( 1981, laserbat,  0,        laserbat, laserbat, laserbat_state, init_laserbat, ROT0,  "Zaccaria", "Laser Battle",                    MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1981, lazarian,  laserbat, laserbat, lazarian, laserbat_state, init_laserbat, ROT0,  "Zaccaria (Bally Midway license)", "Lazarian", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1982, catnmous,  0,        catnmous, catnmous, catnmous_state, init_laserbat, ROT90, "Zaccaria", "Cat and Mouse (type 02 program)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1982, catnmousa, catnmous, catnmous, catnmous, catnmous_state, init_laserbat, ROT90, "Zaccaria", "Cat and Mouse (type 01 program)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, laserbat,  0,        laserbat, laserbat, laserbat_state, empty_init, ROT0,  "Zaccaria", "Laser Battle",                    MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1981, lazarian,  laserbat, laserbat, lazarian, laserbat_state, empty_init, ROT0,  "Zaccaria (Bally Midway license)", "Lazarian", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1982, catnmous,  0,        catnmous, catnmous, catnmous_state, empty_init, ROT90, "Zaccaria", "Cat and Mouse (type 02 program)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1982, catnmousa, catnmous, catnmous, catnmous, catnmous_state, empty_init, ROT90, "Zaccaria", "Cat and Mouse (type 01 program)", MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/video/laserbat.cpp
+++ b/src/mame/video/laserbat.cpp
@@ -157,18 +157,6 @@ void laserbat_state_base::cnt_nav_w(uint8_t data)
 }
 
 
-void laserbat_state_base::video_start()
-{
-	// we render straight from ROM
-	m_gfx1 = memregion("gfx1")->base();
-	m_gfx2 = memregion("gfx2")->base();
-
-	// start rendering scanlines
-	m_screen->register_screen_bitmap(m_bitmap);
-	m_scanline_timer->adjust(m_screen->time_until_pos(1, 0));
-}
-
-
 uint32_t laserbat_state_base::screen_update_laserbat(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
 	bool const flip_y = flip_screen_y(), flip_x = flip_screen_x();
@@ -281,16 +269,14 @@ TIMER_CALLBACK_MEMBER(laserbat_state_base::video_line)
 	for (int x = 0, px = x_offset; max_x >= px; x++)
 	{
 		// calculate area effects
-		// I have no idea where the magical x offset comes from but it's necessary
-		bool const right_half = bool((x + 0) & 0x80);
-		bool const eff1_cmp = right_half ? (uint8_t((x + 0) & 0x7f) < (eff1_val & 0x7f)) : (uint8_t((x + 0) & 0x7f) > (~eff1_val & 0x7f));
-		bool const eff2_cmp = right_half ? (uint8_t((x + 0) & 0x7f) < (eff2_val & 0x7f)) : (uint8_t((x + 0) & 0x7f) > (~eff2_val & 0x7f));
+		bool const right_half = bool(x & 0x80);
+		bool const eff1_cmp = right_half ? (uint8_t(x & 0x7f) < (eff1_val & 0x7f)) : (uint8_t(x & 0x7f) > (~eff1_val & 0x7f));
+		bool const eff2_cmp = right_half ? ((uint8_t(x & 0x7f) | m_eff2_mask) < ((eff2_val & 0x7f) | m_eff2_mask)) : ((uint8_t(x & 0x7f) | m_eff2_mask) > ((~eff2_val & 0x7f) | m_eff2_mask));
 		bool const eff1 = m_abeff1 && (m_neg1 ? !eff1_cmp : eff1_cmp);
 		bool const eff2 = m_abeff2 && (m_neg2 ? !eff2_cmp : eff2_cmp) && m_mpx_eff2_sh;
 
 		// calculate shell point effect
-		// using the same magical offset as the area effects
-		bool const shell = m_abeff2 && (uint8_t((x + 0) & 0xff) == (eff2_val & 0xff)) && !m_mpx_eff2_sh;
+		bool const shell = m_abeff2 && ((uint8_t(x & 0xff) | m_eff2_mask) == ((eff2_val & 0xff) | m_eff2_mask)) && !m_mpx_eff2_sh;
 
 		// set effect bits, and mix in PVI graphics while we're here
 		uint16_t const effect_bits = (shell ? 0x0800 : 0x0000) | (eff1 ? 0x1000 : 0x0000) | (eff2 ? 0x2000 : 0x0000);
@@ -305,7 +291,7 @@ TIMER_CALLBACK_MEMBER(laserbat_state_base::video_line)
 	}
 
 	// render the TTL-generated sprite
-	// more magic offsets here I don't understand the source of
+	// magic offsets here I don't understand the source of
 	if (m_nave)
 	{
 		int const sprite_row = y + y_offset - ((256 - m_wcov) & 0x0ff);
@@ -313,7 +299,7 @@ TIMER_CALLBACK_MEMBER(laserbat_state_base::video_line)
 		{
 			for (unsigned byte = 0, x = x_offset + (3 * ((256 - m_wcoh + 5) & 0x0ff)); 8 > byte; byte++)
 			{
-				uint8_t bits = m_gfx2[((m_shp << 8) & 0x700) | ((sprite_row << 3) & 0x0f8) | (byte & 0x07)];
+				uint8_t bits = m_gfx2[m_gfx2_base | ((m_shp << 8) & 0x700) | ((sprite_row << 3) & 0x0f8) | (byte & 0x07)];
 				for (unsigned pixel = 0; 4 > pixel; pixel++, bits <<= 2)
 				{
 					if (max_x >= x) row[x++] |= (bits >> 6) & 0x03;


### PR DESCRIPTION
According to [this page](http://zzzaccaria.com/zzz/CatnMouseRestoration.htm) and [this photo](http://zzzaccaria.com/zzz/images/Projects/CatnMouseRestoration/DSCN6831.JPG) in particular, there’s a wire mod on at least some Cat'n'Mouse boards to pull up pins 8, 9, 10 and 11 on IC13I.  This would have the effect of quantising area effect 2/shell to 4-pixel intervals.

How plausible does it seem that the boards would have all left the factory with this mod?  They *were* using a wire mod for sprite banking.

(The rest of the change is just tidying up the driver a little.)