### PR TITLE
megadriv - Update info on 11 entries

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -2102,7 +2102,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="doublecl">
 		<description>Double Clutch (Euro)</description>
-		<year>1992</year>
+		<year>1993</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="171-5703"/>
@@ -3707,7 +3707,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="hook">
 		<description>Hook (Euro)</description>
-		<year>1992</year>
+		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="171-5978BA"/>
@@ -4663,7 +4663,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="lostvik">
 		<description>The Lost Vikings (Euro)</description>
-		<year>1993</year>
+		<year>1994</year>
 		<publisher>Interplay</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="171-5978BA"/>
@@ -5338,7 +5338,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 <!-- Both Euro & USA are confirmed -->
 	<software name="nbaallst">
 		<description>NBA All-Star Challenge (Euro, USA)</description>
-		<year>1992</year>
+		<year>1993</year>
 		<publisher>Flying Edge</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="670115 REV 3 [EUR] ~ 670100 REV 8 [USA]"/>
@@ -6479,7 +6479,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="ppersia">
 		<description>Prince of Persia (Euro)</description>
-		<year>1993</year>
+		<year>1994</year>
 		<publisher>Domark</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="pcb" value="171-5978B"/>
@@ -7062,7 +7062,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="sensibie">
 		<description>Sensible Soccer - International Edition (Euro)</description>
-		<year>1993</year>
+		<year>1994</year>
 		<publisher>Sony Imagesoft</publisher>
 		<info name="alt_title" value="International Sensible Soccer - Limited Edition: World Champions (Box)"/>
 		<part name="cart" interface="megadriv_cart">
@@ -7682,7 +7682,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="renstim">
 		<description>Stimpy's Invention Starring Starring Ren Hoëk &amp; Stimpy (Euro)</description>
-		<year>1993</year>
+		<year>1994</year>
 		<publisher>Sega</publisher>
 		<info name="alt_title" value="The Ren &amp; Stimpy Show Presents Stimpy's Invention (Box)"/>
 		<part name="cart" interface="megadriv_cart">
@@ -8036,7 +8036,7 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 
 	<software name="skickoff">
 		<description>Super Kick Off (Euro)</description>
-		<year>1992</year>
+		<year>1993</year>
 		<publisher>U.S. Gold</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="slot" value="rom_sram"/>
@@ -12477,7 +12477,7 @@ but dumps still have to be confirmed.
 
 	<software name="chaoseng">
 		<description>The Chaos Engine (Euro)</description>
-		<year>1992</year>
+		<year>1994</year>
 		<publisher>Microprose</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1572864">
@@ -15486,7 +15486,7 @@ but dumps still have to be confirmed.
 
 	<software name="fantdizz">
 		<description>Fantastic Dizzy (Euro, USA)</description>
-		<year>1991</year>
+		<year>1993</year>
 		<publisher>Codemasters</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
@@ -16795,7 +16795,7 @@ but dumps still have to be confirmed.
 
 	<software name="hooku" cloneof="hook">
 		<description>Hook (USA)</description>
-		<year>1992</year>
+		<year>1993</year>
 		<publisher>Sony Imagesoft</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
@@ -18317,7 +18317,7 @@ but dumps still have to be confirmed.
 
 	<software name="lostviku" cloneof="lostvik">
 		<description>The Lost Vikings (USA)</description>
-		<year>1992</year>
+		<year>1994</year>
 		<publisher>Interplay</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
@@ -18327,7 +18327,7 @@ but dumps still have to be confirmed.
 	</software>
 
 	<software name="lotus2">
-		<description>Lotus II (Euro, USA)</description>
+		<description>Lotus II: RECS (Euro, USA)</description>
 		<year>1993</year>
 		<publisher>Electronic Arts</publisher>
 		<part name="cart" interface="megadriv_cart">
@@ -22463,7 +22463,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 
 	<software name="ppersiau" cloneof="ppersia">
 		<description>Prince of Persia (USA)</description>
-		<year>1993</year>
+		<year>1994</year>
 		<publisher>Tengen</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">


### PR DESCRIPTION
Super Kick Off : 1992 -> 1993 [https://segaretro.org/Super_Kick_Off]
Fantastic Dizzy : 1991 -> 1993 [https://segaretro.org/Fantastic_Dizzy]
Sensible Soccer - International Edition : 1993 -> 1994 [https://segaretro.org/Sensible_Soccer:_International_Edition]
Double Clutch : 1992 -> 1993 [https://segaretro.org/Double_Clutch]
Hook : 1992 -> 1993 [https://segaretro.org/Hook]
Prince of Persia : 1993 -> 1994 [https://segaretro.org/Prince_Of_Persia]
NBA All-Star Challenge : 1992 -> 1993 [https://segaretro.org/NBA_All-Star_Challenge]
Stimpy's Invention : 1993 -> 1994 [https://segaretro.org/The_Ren_%26_Stimpy_Show_Presents_Stimpy%27s_Invention]
The Lost Vikings : 1993 -> 1994 [https://segaretro.org/The_Lost_Vikings]
The Chaos Engine (Euro) : 1992 -> 1994 [https://segaretro.org/The_Chaos_Engine]

Update Description:
Lotus II -> Lotus II: RECS [https://segaretro.org/Lotus_II:_RECS]