### PR TITLE
segas16a/sega16b tweaks

### DIFF
--- a/src/mame/drivers/segas16a.cpp
+++ b/src/mame/drivers/segas16a.cpp
@@ -1995,6 +1995,9 @@ void segas16a_state::system16a(machine_config &config)
 	m_screen->set_visarea(0*8, 40*8-1, 0*8, 28*8-1);
 	m_screen->set_screen_update(FUNC(segas16a_state::screen_update));
 	m_screen->set_palette(m_palette);
+	// see MT1852 (glitch in fantzone after stage intro text vanishes)
+	// this is a hack, but the scroll values must be latched at some point, when is unknown
+	m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
 
 	SEGA_SYS16A_SPRITES(config, m_sprites, 0);
 	SEGAIC16VID(config, m_segaic16vid, 0, "gfxdecode");
@@ -2056,6 +2059,9 @@ void segas16a_state::system16a_i8751(machine_config &config)
 	m_mcu->port_out_cb<1>().set(FUNC(segas16a_state::mcu_control_w));
 
 	m_screen->screen_vblank().set(FUNC(segas16a_state::i8751_main_cpu_vblank_w));
+
+	// prevent glitchy background scroll on quartet stage 18
+	config.set_maximum_quantum(attotime::from_hz(6000));
 }
 
 void segas16a_state::system16a_no7751(machine_config &config)

--- a/src/mame/drivers/segas16b.cpp
+++ b/src/mame/drivers/segas16b.cpp
@@ -3974,6 +3974,8 @@ void segas16b_state::system16b(machine_config &config)
 	m_screen->set_raw(MASTER_CLOCK_25MHz/4, 400, 0, 320, 262, 0, 224);
 	m_screen->set_screen_update(FUNC(segas16b_state::screen_update));
 	m_screen->set_palette(m_palette);
+	// see note in segas16a.cpp, also used here for consistency
+	m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
 
 	SEGA_SYS16B_SPRITES(config, m_sprites, 0);
 	SEGAIC16VID(config, m_segaic16vid, 0, m_gfxdecode);
@@ -4198,6 +4200,8 @@ void segas16b_state::lockonph(machine_config &config)
 	m_screen->set_raw(MASTER_CLOCK_25MHz/4, 400, 0, 320, 262, 0, 224); // wrong, other XTAL seems to be 17Mhz?
 	m_screen->set_screen_update(FUNC(segas16b_state::screen_update));
 	m_screen->set_palette(m_palette);
+	// see note in segas16a.cpp, also used here for consistency
+	m_screen->set_video_attributes(VIDEO_UPDATE_AFTER_VBLANK);
 
 	SEGA_SYS16B_SPRITES(config, m_sprites, 0);
 	SEGAIC16VID(config, m_segaic16vid, 0, m_gfxdecode);


### PR DESCRIPTION
- change when video is updated (for fantzone)
- bump quantum time for 16a cases with MCU (for quartet stage 18)

the Fantasy Zone fix was suggested by PhilB back in 2012 here https://mametesters.org/view.php?id=1852 and after discussion in the shoutbox it seemed the general consensus was to just go with it, rather than trying to complicate things with more complex code using a timer to latch values, which could give the impression that it had been measured, despite not having any evidence for the PCB timing.  I've applied it to segas16b too as the platforms are very similar, and if there's an issue with this to suggest different timing it's more likely to show up with more test cases.

the quantum boost is for quartet, I noticed after fixing the MCU hookup some months ago that certain stages on the protected sets (very noticeable on stage 18) had glitchy background scroll every few seconds, it appears to fix that.