### PR TITLE
stfight.cpp: Remove YM2203 frequency hack, and set prescaler at machine_start

### DIFF
--- a/src/mame/drivers/stfight.cpp
+++ b/src/mame/drivers/stfight.cpp
@@ -483,14 +483,13 @@ void stfight_state::stfight_base(machine_config &config)
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();
 
-	// YM2203_PITCH_HACK - These should be clocked at 1.5Mhz (see TODO list)
-	ym2203_device &ym1(YM2203(config, "ym1", 12_MHz_XTAL / 8 * 3));
+	ym2203_device &ym1(YM2203(config, m_ym1, 12_MHz_XTAL / 8));
 	ym1.add_route(0, "mono", 0.15);
 	ym1.add_route(1, "mono", 0.15);
 	ym1.add_route(2, "mono", 0.15);
 	ym1.add_route(3, "mono", 0.10);
 
-	ym2203_device &ym2(YM2203(config, "ym2", 12_MHz_XTAL / 8 * 3));
+	ym2203_device &ym2(YM2203(config, m_ym2, 12_MHz_XTAL / 8));
 	ym2.add_route(0, "mono", 0.15);
 	ym2.add_route(1, "mono", 0.15);
 	ym2.add_route(2, "mono", 0.15);

--- a/src/mame/drivers/stfight.cpp
+++ b/src/mame/drivers/stfight.cpp
@@ -245,11 +245,10 @@ conventional RAM. See the memory map for sprite data format.
 TODO:
 - handle transparency in text layer properly (how?)
 - second bank of sf02 is this used? (probably NOT)
-- stfight/empcity YM2203s should be clocked at 1.5MHz but this results in
-  the sound and music being 1/3 of the pitch they should be. The game never
-  writes the YM2203s' divider registers yet other games (e.g. Lock-On)
-  suggest the default values are correct.
-  cshootert however, sounds too high-pitched at 1.5MHz*3.
+- empcity/stfight never writes the YM2203s' divider registers but it expects
+  0x2f, there's a workaround for it in machine_start
+- empcity/stfight has an NMI handler, but it's not hooked up in MAME, missing
+  comms somewhere?
 - Each version of empcity/stfight has a different protection code stored in the
   MCU (at $1D2) so each 68705 will need to be dumped.
   We currently use hacked versions of the empcityu MCU for each different set.

--- a/src/mame/includes/stfight.h
+++ b/src/mame/includes/stfight.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "cpu/m6805/m68705.h"
+#include "sound/ym2203.h"
 #include "sound/msm5205.h"
 #include "video/stfight_dev.h"
 #include "video/airraid_dev.h"
@@ -20,6 +21,8 @@ public:
 		, m_audiocpu(*this, "audiocpu")
 		, m_mcu(*this, "mcu")
 		, m_msm(*this, "msm")
+		, m_ym1(*this, "ym1")
+		, m_ym2(*this, "ym2")
 		, m_main_bank(*this, "mainbank")
 		, m_samples(*this, "adpcm")
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
@@ -87,6 +90,9 @@ private:
 	required_device<cpu_device>      m_audiocpu;
 	required_device<m68705p5_device> m_mcu;
 	required_device<msm5205_device>  m_msm;
+
+	required_device<ym2203_device>   m_ym1;
+	required_device<ym2203_device>   m_ym2;
 
 	required_memory_bank             m_main_bank;
 

--- a/src/mame/machine/stfight.cpp
+++ b/src/mame/machine/stfight.cpp
@@ -80,6 +80,10 @@ void stfight_state::machine_start()
 
 	m_int1_timer = timer_alloc(TIMER_STFIGHT_INTERRUPT_1);
 
+	// Set clock prescaler FM:1/2 PSG:1/1
+	m_ym1->write(0, 0x2f); 
+	m_ym2->write(0, 0x2f);
+
 	save_item(NAME(m_coin_state));
 
 	save_item(NAME(m_fm_data));


### PR DESCRIPTION
[testers-03911](https://mametesters.org/view.php?id=3911):   stfight,  empcity: Music pitch is too low

Empire City: 1931 implements a hack that 3x YM2203 clock frequency in order to solve the all sounds too low pitch. But FM (BGM) be correct, but SSG (timer countdown, clear bonus count) is still low pitch.
Frequency hack can't seem to get the correct pitch.
This PR removes frequency hack and sets YM2203 clock prescaler at machine_start in order to get right pitch.
This PR may be a hack-like approach, but I proposed the fix in this because this can remove hack that result in wrong pitch.