### PR TITLE
tweaks to the funkyjet addition, also apply single pixel video offset to match hardware

### DIFF
--- a/src/mame/drivers/funkyjet.cpp
+++ b/src/mame/drivers/funkyjet.cpp
@@ -98,7 +98,6 @@ Notes:
 #include "sound/okim6295.h"
 #include "sound/ym2151.h"
 #include "emupal.h"
-#include "screen.h"
 #include "speaker.h"
 
 /******************************************************************************/
@@ -315,13 +314,13 @@ void funkyjet_state::funkyjet(machine_config &config)
 	m_audiocpu->add_route(ALL_OUTPUTS, "rspeaker", 0);
 
 	/* video hardware */
-	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(58);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(529));
-	screen.set_size(40*8, 32*8);
-	screen.set_visarea(0*8, 40*8-1, 1*8, 31*8-1);
-	screen.set_screen_update(FUNC(funkyjet_state::screen_update));
-	screen.set_palette("palette");
+	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
+	m_screen->set_refresh_hz(58);
+	m_screen->set_vblank_time(ATTOSECONDS_IN_USEC(529));
+	m_screen->set_size(40*8, 32*8);
+	m_screen->set_visarea(0*8, 40*8-1, 1*8, 31*8-1);
+	m_screen->set_screen_update(FUNC(funkyjet_state::screen_update));
+	m_screen->set_palette("palette");
 
 	DECO146PROT(config, m_deco146, 0);
 	m_deco146->port_a_cb().set_ioport("INPUTS");
@@ -380,7 +379,9 @@ ROM_START( funkyjet )
 	ROM_LOAD( "mat00", 0x080000, 0x80000, CRC(fbda0228) SHA1(815d49898d02e699393e370209181f2ca8301949) )
 
 	ROM_REGION( 0x40000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "jk03.15h",    0x00000, 0x20000, CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) )
+	// needs verifying, looks like a bad dump compared to the ROM in funkyjeta2
+	// 0x20 bytes at 0x79e0 are blanked out and 0x20 bytes at 0xa6a0 are replaced with different (bad?) data
+	ROM_LOAD( "jk03.15h",    0x00000, 0x20000, BAD_DUMP CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) )
 ROM_END
 
 ROM_START( funkyjeta )
@@ -399,11 +400,13 @@ ROM_START( funkyjeta )
 	ROM_LOAD( "mat00", 0x080000, 0x80000, CRC(fbda0228) SHA1(815d49898d02e699393e370209181f2ca8301949) )
 
 	ROM_REGION( 0x40000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "jk03.15h",    0x00000, 0x20000, CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) )
+	// see comment in funkyjet set
+	ROM_LOAD( "jk03.15h",    0x00000, 0x20000, BAD_DUMP CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) )
 ROM_END
 
 ROM_START( funkyjeta2 )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* 68000 code */
+	// are these labels correct?
 	ROM_LOAD16_BYTE( "jk00-1.12f", 0x00000, 0x40000, CRC(a18de697) SHA1(063f7f4c31c80b8fd807699e0412abb9271ddc59) ) /* sldh */
 	ROM_LOAD16_BYTE( "jk01-1.13f", 0x00001, 0x40000, CRC(695a27cd) SHA1(79b4e61e7c6bdab439d70993c296443f97339351) ) /* sldh */
 
@@ -437,7 +440,8 @@ ROM_START( funkyjetj )
 	ROM_LOAD( "mat00", 0x080000, 0x80000, CRC(fbda0228) SHA1(815d49898d02e699393e370209181f2ca8301949) )
 
 	ROM_REGION( 0x40000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "jh03.15h",    0x00000, 0x20000, CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) ) /* same as jk03.15h from world set */
+	// see comment in funkyjet set, was this verified as label is different?
+	ROM_LOAD( "jh03.15h",    0x00000, 0x20000, BAD_DUMP CRC(69a0eaf7) SHA1(05038e82ee03106625f05082fe9912e16be181ee) ) /* same as jk03.15h from world set */
 ROM_END
 
 ROM_START( sotsugyo )
@@ -468,6 +472,8 @@ void funkyjet_state::init_funkyjet()
 
 GAME( 1992, funkyjet,  0,        funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World, rev 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, funkyjeta, funkyjet, funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World)", MACHINE_SUPPORTS_SAVE )
-GAME( 1992, funkyjeta2,funkyjet, funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World, alternate demo)", MACHINE_SUPPORTS_SAVE )
+// this set has numerous changes, including a different 'how to play' demo, modified stage layouts, and has you collecting smiley faces rather than fuel cells to charge your super
+GAME( 1992, funkyjeta2,funkyjet, funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World, prototype?)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, funkyjetj, funkyjet, funkyjet, funkyjetj, funkyjet_state, init_funkyjet, ROT0, "Mitchell (Data East Corporation license)", "Funky Jet (Japan, rev 2)", MACHINE_SUPPORTS_SAVE )
+
 GAME( 1995, sotsugyo,  0,        funkyjet, sotsugyo,  funkyjet_state, init_funkyjet, ROT0, "Mitchell (Atlus license)", "Sotsugyo Shousho", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/funkyjet.cpp
+++ b/src/mame/drivers/funkyjet.cpp
@@ -2,6 +2,8 @@
 // copyright-holders:Bryan McPhail
 /***************************************************************************
 
+  All game use a DE-0372-0 PCB (see below for layout)
+  
   Funky Jet                               (c) 1992 Data East / Mitchell Corporation
   Sotsugyo Shousho                        (c) 1995 Mitchell Corporation
 
@@ -243,6 +245,17 @@ static INPUT_PORTS_START( funkyjetj )
 	PORT_DIPSETTING(      0x0000, DEF_STR( On ) )
 INPUT_PORTS_END
 
+static INPUT_PORTS_START( funkyjeta2 )
+	PORT_INCLUDE(funkyjetj)
+
+	PORT_MODIFY("DSW")
+	PORT_DIPNAME( 0xc000, 0xc000, DEF_STR( Lives ) )        PORT_DIPLOCATION("SW2:2,1")
+	PORT_DIPSETTING(      0x0000, "0" )
+	PORT_DIPSETTING(      0x8000, "1" )
+	PORT_DIPSETTING(      0xc000, "2" )
+	PORT_DIPSETTING(      0x4000, "3" )
+INPUT_PORTS_END
+
 static INPUT_PORTS_START( sotsugyo )
 	PORT_INCLUDE(funkyjet)
 
@@ -304,7 +317,7 @@ GFXDECODE_END
 void funkyjet_state::funkyjet(machine_config &config)
 {
 	/* basic machine hardware */
-	M68000(config, m_maincpu, XTAL(28'000'000)/2); /* 28 MHz crystal */
+	M68000(config, m_maincpu, XTAL(28'322'000)/2); /* 28 MHz crystal - 28.322000 on funkyjeta2 PCB at least*/
 	m_maincpu->set_addrmap(AS_PROGRAM, &funkyjet_state::funkyjet_map);
 	m_maincpu->set_vblank_int("screen", FUNC(funkyjet_state::irq6_line_hold));
 
@@ -406,12 +419,11 @@ ROM_END
 
 ROM_START( funkyjeta2 )
 	ROM_REGION( 0x80000, "maincpu", 0 ) /* 68000 code */
-	// are these labels correct?
-	ROM_LOAD16_BYTE( "jk00-1.12f", 0x00000, 0x40000, CRC(a18de697) SHA1(063f7f4c31c80b8fd807699e0412abb9271ddc59) ) /* sldh */
-	ROM_LOAD16_BYTE( "jk01-1.13f", 0x00001, 0x40000, CRC(695a27cd) SHA1(79b4e61e7c6bdab439d70993c296443f97339351) ) /* sldh */
+	ROM_LOAD16_BYTE( "12f", 0x00000, 0x40000, CRC(a18de697) SHA1(063f7f4c31c80b8fd807699e0412abb9271ddc59) ) // labels were blank
+	ROM_LOAD16_BYTE( "13f", 0x00001, 0x40000, CRC(695a27cd) SHA1(79b4e61e7c6bdab439d70993c296443f97339351) )
 
 	ROM_REGION( 0x10000, "audiocpu", 0 )    /* Sound CPU */
-	ROM_LOAD( "jk02.16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) )
+	ROM_LOAD( "16f",    0x00000, 0x10000, CRC(748c0bd8) SHA1(35910e6a4c4f198fb76bde0f5b053e2c66cfa0ff) )
 
 	ROM_REGION( 0x080000, "gfx1", 0 )
 	ROM_LOAD( "mat02", 0x000000, 0x80000, CRC(e4b94c7e) SHA1(7b6ddd0bd388c8d32277fce4b3abb102724bc7d1) ) /* Encrypted chars */
@@ -421,7 +433,7 @@ ROM_START( funkyjeta2 )
 	ROM_LOAD( "mat00", 0x080000, 0x80000, CRC(fbda0228) SHA1(815d49898d02e699393e370209181f2ca8301949) )
 
 	ROM_REGION( 0x40000, "oki", 0 ) /* ADPCM samples */
-	ROM_LOAD( "jk03.15h",    0x00000, 0x20000, CRC(d7c0f0fe) SHA1(7a4a21bbf0da27767de099fba66011732b2c835a) ) /* sldh */
+	ROM_LOAD( "15h",    0x00000, 0x20000, CRC(d7c0f0fe) SHA1(7a4a21bbf0da27767de099fba66011732b2c835a) )
 ROM_END
 
 ROM_START( funkyjetj )
@@ -472,8 +484,9 @@ void funkyjet_state::init_funkyjet()
 
 GAME( 1992, funkyjet,  0,        funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World, rev 1)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, funkyjeta, funkyjet, funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World)", MACHINE_SUPPORTS_SAVE )
-// this set has numerous changes, including a different 'how to play' demo, modified stage layouts, and has you collecting smiley faces rather than fuel cells to charge your super
-GAME( 1992, funkyjeta2,funkyjet, funkyjet, funkyjet,  funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (World, prototype?)", MACHINE_SUPPORTS_SAVE )
+// This set, from a Korean PCB, has numerous changes, including a different 'how to play' demo, modified stage layouts
+// It also has you collecting smiley faces rather than fuel cells to charge your super
+GAME( 1992, funkyjeta2,funkyjet, funkyjet, funkyjeta2,funkyjet_state, init_funkyjet, ROT0, "Mitchell", "Funky Jet (Korea, prototype?)", MACHINE_SUPPORTS_SAVE )
 GAME( 1992, funkyjetj, funkyjet, funkyjet, funkyjetj, funkyjet_state, init_funkyjet, ROT0, "Mitchell (Data East Corporation license)", "Funky Jet (Japan, rev 2)", MACHINE_SUPPORTS_SAVE )
 
 GAME( 1995, sotsugyo,  0,        funkyjet, sotsugyo,  funkyjet_state, init_funkyjet, ROT0, "Mitchell (Atlus license)", "Sotsugyo Shousho", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/includes/funkyjet.h
+++ b/src/mame/includes/funkyjet.h
@@ -6,6 +6,8 @@
 
 *************************************************************************/
 
+#include "screen.h"
+
 #include "cpu/h6280/h6280.h"
 #include "video/decospr.h"
 #include "video/deco16ic.h"
@@ -19,6 +21,7 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_spriteram(*this, "spriteram")
 		, m_pf_rowscroll(*this, "pf%u_rowscroll", 1)
+		, m_screen(*this, "screen")
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
 		, m_deco146(*this, "ioprot")
@@ -36,6 +39,7 @@ private:
 	required_shared_ptr_array<uint16_t, 2> m_pf_rowscroll;
 
 	/* devices */
+	required_device<screen_device> m_screen;
 	required_device<cpu_device> m_maincpu;
 	required_device<h6280_device> m_audiocpu;
 	required_device<deco146_device> m_deco146;

--- a/src/mame/video/funkyjet.cpp
+++ b/src/mame/video/funkyjet.cpp
@@ -13,6 +13,22 @@
 
 uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
 {
+	// Similar to chinatwn and tumblep, see video/supbtime.cpp
+	//
+	// This causes a 2 pixel gap on the left side of the first stage of all worlds in funkyjet
+	// but allows subsequent stages to be centered and avoids corruption on the world select
+	// screen after each world.  It also correctly aligns the graphics in sotsugyo.
+	//
+	// The 2 pixel gap on the first stage of each world has been verified to occur on hardware.
+	// (it can easily be seen by moving your player sprite to the far left)
+	//
+	// it is unclear where this offset comes from, but real hardware videos confirm it is needed
+
+	m_deco_tilegen->set_scrolldx(0, 0, 1, 1);
+	m_deco_tilegen->set_scrolldx(0, 1, 1, 1);
+	m_deco_tilegen->set_scrolldx(1, 0, 1, 1);
+	m_deco_tilegen->set_scrolldx(1, 1, 1, 1);
+
 	uint16_t flip = m_deco_tilegen->pf_control_r(0);
 
 	flip_screen_set(BIT(flip, 7));
@@ -25,3 +41,4 @@ uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	return 0;
 }
+

--- a/src/mame/video/funkyjet.cpp
+++ b/src/mame/video/funkyjet.cpp
@@ -41,4 +41,3 @@ uint32_t funkyjet_state::screen_update(screen_device &screen, bitmap_ind16 &bitm
 	m_sprgen->draw_sprites(bitmap, cliprect, m_spriteram, 0x400);
 	return 0;
 }
-


### PR DESCRIPTION
tweaks to the funkyjet addition, also apply single pixel video offset to match hardware videos and correct bg / sprite alignment.

I've also tagged the sample ROM in the other sets as BAD_DUMP pending verification, it definitely looks suspicious compared to the one in the new set.

I've marked the addition as a 'prototype?' rather than alternate demo, because there are many, many more changes than just the demo.
