### PR TITLE
Fix XML cheats which use multiple spaces.

### DIFF
--- a/plugins/cheat/cheat_xml.lua
+++ b/plugins/cheat/cheat_xml.lua
@@ -264,7 +264,6 @@ function xml.conv_cheat(data)
 		if next(spaces) then
 			data["cheat"][count]["space"] = {}
 			for name, space in pairs(spaces) do
-				data["cheat"][count]["space"] = {}
 				data["cheat"][count]["space"][name] = { type = space["type"], tag = space["tag"] }
 			end
 		end


### PR DESCRIPTION
When turning on they gave message like: "index a nil value (global 'maincpuo')"

I could't build master with my 4G ram and I don't know how to make the compilation lighter, so only tested with 0.230. But pretty straightforward.