### PR TITLE
Add a couple error messages to emu.thread.

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -959,8 +959,16 @@ void lua_engine::initialize()
 							if (tmp != nullptr)
 								ctx.result = tmp;
 							else
-								exit(0);
+								osd_printf_error("[LUA ERROR] in thread: return value must be string\n");
 						}
+						else {
+							sol::error err = ret;
+							osd_printf_error("[LUA ERROR] in thread: %s\n", err.what());
+						}
+					}
+					else {
+						sol::error err = res;
+						osd_printf_error("[LUA ERROR] when loading script for thread: %s\n", err.what());
 					}
 					ctx.busy = false;
 				});


### PR DESCRIPTION
Also changes exit(0) when the script of the thread returns non-string
to an error message instead. exit stops the whole process not just the
thread.