### PR TITLE
Arm64 travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       env: SUBTARGET=ci   MAME=mameci64
   allow_failures:
     - arch: ppc64le
+    - arch: s390x
   fast_finish: true
 script:
   - if [ $CC == 'clang' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ addons:
 jobs:
   include:
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
+      virt: vm
       compiler: gcc
       env: SUBTARGET=ci   MAME=mameci
     - os: linux


### PR DESCRIPTION
This PR fixes the arm64 build, but the CI needs to be moved from travis-ci.org to travis-ci.com. I am not sure who and how can do that.
s390x still fails due to insufficient memory and/or disk space. While having two working non-x86_64 arches would be better, having one is still better than not having any at all.