### PR TITLE
fmtowns_flop_*.xml: 11 new dumps, verifications

### DIFF
--- a/hash/fmtowns_flop_cracked.xml
+++ b/hash/fmtowns_flop_cracked.xml
@@ -5,6 +5,33 @@ license:CC0
 -->
 <softwarelist name="fmtowns_flop_cracked" description="Fujitsu FM Towns cracked floppy disk images">
 
+	<!-- Some graphics issues -->
+	<software name="asuka120" supported="partial">
+		<description>Asuka 120% Burning Fest. (cracked)</description>
+		<year>1994</year>
+		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="あすか 120% BURNING Fest." />
+		<info name="release" value="199403xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="asuka 120 burning fest. (disk a).hdm" size="1261568" crc="46a5074d" sha1="8efb863ea0878f9236082f7d7935f494c4522899"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="asuka 120 burning fest. (disk b).hdm" size="1261568" crc="2a448e8f" sha1="3b57fd0a2fecec56a3362884de0770ec4538f5eb"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="1261568">
+				<rom name="asuka 120 burning fest. (disk c).hdm" size="1261568" crc="ac9a582e" sha1="726b05d573e0776006cee6aa8c71009b1e66b5cc"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Cracked by cyo.the.vile -->
 	<software name="cameltry">
 		<description>Cameltry (cracked)</description>
@@ -59,8 +86,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- All the files in these images match the original disks, except for an additional CONTENTS.GBX file. It's unclear if they are actually cracked or not. -->
 	<software name="supdaisn">
-		<description>Super Daisenryaku (cracked)</description>
+		<description>Super Daisenryaku (cracked?)</description>
 		<year>1990</year>
 		<publisher>システムソフト (SystemSoft)</publisher>
 		<info name="alt_title" value="スーパー大戦略" />

--- a/hash/fmtowns_flop_misc.xml
+++ b/hash/fmtowns_flop_misc.xml
@@ -80,9 +80,27 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="msdos31">
-		<description>Nihongo MS-DOS V3.1 L24</description>
+	<software name="msdos31l36p">
+		<description>Nihongo MS-DOS V3.1 L36+</description>
 		<year>1992</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_3.1_l36_plus_disk1.hdm" size="1261568" crc="5ed67c44" sha1="c45b5838cba0e363baf198a3f150174e5ecee831"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Utility" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_3.1_l36_plus_disk2.hdm" size="1261568" crc="f0c5bbce" sha1="65b068ddebe05fd02cb8e732c1287ac50e0a5f65"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos31l24" cloneof="msdos31l36p">
+		<description>Nihongo MS-DOS V3.1 L24</description>
+		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="System" />
@@ -94,6 +112,36 @@ license:CC0
 			<feature name="part_id" value="Utility" />
 			<dataarea name="flop" size="1261568">
 				<rom name="[os] ms-dos 3.1 l24 (disk 2 - utility).hdm" size="1261568" crc="c6f4c86c" sha1="86e64a6744e2c7d1d5d4e3159ebd1885c691b33b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msdos50l22ap2">
+		<description>Nihongo MS-DOS V5.0 L22 A+2</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1 (FM Towns Kidou Disk)" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_5.0_l22_disk1.hdm" size="1261568" crc="26305845" sha1="c39576f6cfdfb0e00486700d1f8226a7d8297dce"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2 (FM R-280/80/70/60/50 Kidou Disk)" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_5.0_l22_disk2.hdm" size="1261568" crc="94f86910" sha1="fd4c265525588dd2a7542558b9730a20375e06b2"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3 (FM R-70Σ/50Λ Kidou Disk)" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_5.0_l22_disk3.hdm" size="1261568" crc="48b65d69" sha1="ec63ff2b8c34c8c2cada44bb1bfea2e2d728d18d"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ms-dos_5.0_l22_disk4.hdm" size="1261568" crc="2d10eae7" sha1="9fe61eca11cf05e6f788627d2d0187062663e2dc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -181,33 +229,6 @@ license:CC0
 			<feature name="part_id" value="Disk C" />
 			<dataarea name="flop" size="1261568">
 				<rom name="abunai tengu densetsu (disk c).hdm" size="1261568" crc="4271f241" sha1="a6cf43f58681d06151ec8acbbd02fd98df44ed7b"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<!-- Some graphics issues -->
-	<software name="asuka120" supported="partial">
-		<description>Asuka 120% Burning Fest.</description>
-		<year>1994</year>
-		<publisher>ファミリーソフト (Family Soft)</publisher>
-		<info name="alt_title" value="あすか 120% BURNING Fest." />
-		<info name="release" value="199403xx" />
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk A" />
-			<dataarea name="flop" size="1261568">
-				<rom name="asuka 120 burning fest. (disk a).hdm" size="1261568" crc="46a5074d" sha1="8efb863ea0878f9236082f7d7935f494c4522899"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk B" />
-			<dataarea name="flop" size="1261568">
-				<rom name="asuka 120 burning fest. (disk b).hdm" size="1261568" crc="2a448e8f" sha1="3b57fd0a2fecec56a3362884de0770ec4538f5eb"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk C" />
-			<dataarea name="flop" size="1261568">
-				<rom name="asuka 120 burning fest. (disk c).hdm" size="1261568" crc="ac9a582e" sha1="726b05d573e0776006cee6aa8c71009b1e66b5cc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -815,44 +836,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="kawaichi">
-		<description>Kawarazaki-ke no Ichizoku</description>
-		<year>1993</year>
-		<publisher>シルキーズ (Silky's)</publisher>
-		<info name="alt_title" value="河原崎家の一族" />
-		<info name="release" value="199312xx" />
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk A" />
-			<dataarea name="flop" size="1261568">
-				<rom name="kawarazaki-ke no ichizoku (disk a).hdm" size="1261568" crc="8e5377bb" sha1="1b977a5dbc3bae53f995cce516be29eef231267d"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk B" />
-			<dataarea name="flop" size="1261568">
-				<rom name="kawarazaki-ke no ichizoku (disk b).hdm" size="1261568" crc="28cc3fe4" sha1="402e71d702b3af458110e602c3109e82bc26afb0"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk C" />
-			<dataarea name="flop" size="1261568">
-				<rom name="kawarazaki-ke no ichizoku (disk c).hdm" size="1261568" crc="e7647e74" sha1="49053fc637a6d704fc766c3428741fafc6e06e5a"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="Disk D" />
-			<dataarea name="flop" size="1261568">
-				<rom name="kawarazaki-ke no ichizoku (disk d).hdm" size="1261568" crc="12a2bc4b" sha1="57eec756df31ea4e4a2aaf822a7a7200004fcd4a"/>
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_3_5">
-			<feature name="part_id" value="Disk E" />
-			<dataarea name="flop" size="1261568">
-				<rom name="kawarazaki-ke no ichizoku (disk e).hdm" size="1261568" crc="7999334a" sha1="c4e1abf0be91e679867709319fb876f6c6789aa4"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="illcity">
 		<!--
 		Origin: Tokugawa Corporate Forums (yukin)
@@ -1067,50 +1050,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="reiraa" cloneof="reira">
-		<description>Reira (Alt Disk 1)</description>
-		<year>1994</year>
-		<publisher>シルキーズ (Silky's)</publisher>
-		<info name="alt_title" value="レイラ" />
-		<info name="release" value="199407xx" />
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk A" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk a) [alt 1].hdm" size="1261568" crc="d82d5732" sha1="ac51e1ee6be9afa79f984a9ddcd5109347d31c35"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk B" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk b).hdm" size="1261568" crc="3d66ddc6" sha1="05d1d20dd5c535dfe653e6afd23e0e256c3639ec"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk C" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk c).hdm" size="1261568" crc="03fa528c" sha1="635043a3490b03ee0ef06d901e774ae46f14963c"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="Disk D" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk d).hdm" size="1261568" crc="d26f5aef" sha1="9d59989831b58ed6098b517b29f45514932c8580"/>
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_3_5">
-			<feature name="part_id" value="Disk E" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk e).hdm" size="1261568" crc="9008a977" sha1="32cf426ce9f15489c92dd1effc58da5380ea6f16"/>
-			</dataarea>
-		</part>
-		<part name="flop6" interface="floppy_3_5">
-			<feature name="part_id" value="Disk F" />
-			<dataarea name="flop" size="1261568">
-				<rom name="reira (disk f).hdm" size="1261568" crc="fa05a62c" sha1="1990124f647a164b18380b1686094ef29ee100e2"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="shogisei">
 		<description>Shougi Seiten</description>
 		<year>1992</year>
@@ -1202,44 +1141,6 @@ license:CC0
 			<feature name="part_id" value="Tonoo no Mori Disk B" />
 			<dataarea name="flop" size="1261568">
 				<rom name="super d.p.s. (disk 6 - toono no mori b).hdm" size="1261568" crc="78ae11c6" sha1="8410d7c8932eb94178d821d93afd6ce3f03b0c00"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="ushinawa">
-		<description>Ushinawareta Rakuen</description>
-		<year>1995</year>
-		<publisher>シルキーズ (Silky's)</publisher>
-		<info name="alt_title" value="失われた楽園" />
-		<info name="release" value="199504xx" />
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk A" />
-			<dataarea name="flop" size="1261568">
-				<rom name="ushinawareta rakuen (disk a).hdm" size="1261568" crc="43a4ab96" sha1="49848270471a59cbeeb9aaa0fbfee7512f06b448"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk B" />
-			<dataarea name="flop" size="1261568">
-				<rom name="ushinawareta rakuen (disk b).hdm" size="1261568" crc="2cd5aac5" sha1="f42b32087061aa4f0bfa87f712f263744233424c"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Disk C" />
-			<dataarea name="flop" size="1261568">
-				<rom name="ushinawareta rakuen (disk c).hdm" size="1261568" crc="45b0d218" sha1="787c8709d5173d4c63b8acc50b646ec06e64be26"/>
-			</dataarea>
-		</part>
-		<part name="flop4" interface="floppy_3_5">
-			<feature name="part_id" value="Disk D" />
-			<dataarea name="flop" size="1261568">
-				<rom name="ushinawareta rakuen (disk d).hdm" size="1261568" crc="af3eb06d" sha1="a4e9a37f5ae6a61eae587f4cbe0f6c0cf62e185b"/>
-			</dataarea>
-		</part>
-		<part name="flop5" interface="floppy_3_5">
-			<feature name="part_id" value="Disk E" />
-			<dataarea name="flop" size="1261568">
-				<rom name="ushinawareta rakuen (disk e).hdm" size="1261568" crc="1481c370" sha1="95676fc68d7e402fd9e463a5ad9d82490ac544a8"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/fmtowns_flop_orig.xml
+++ b/hash/fmtowns_flop_orig.xml
@@ -30,13 +30,10 @@ ADPCM Kaihatsu Shien Library V1.1                                   Fujitsu     
 ADPCM Kaihatsu Shien Library V2.1                                   Fujitsu                           1992/6     FD
 AgentNet V1.0 (V1.1)                                                CSK Research Institute (CRI)      1990/12    FD
 ASM-386 Tool Kit V2.2                                               Fujitsu                           1995/3     FD
+Bruce Wilcox no AI Igo 3 [FMR]                                      Alfa System                       ?          FD
 Cannon Sight                                                        Nikkonren Kikaku                  1993/?     FD×02
 CB Trainer Jikkou System V1.1                                       Fujitsu                           1993/5     FD
 CD-ROM XA Kyoutsuu Library V1.1                                     Fujitsu                           1991/7     FD
-Champion Course Vol. 1 - Mauna Kea Beach Golf Course                Cybelle                           1995/2     FD×03
-Champion Course Vol. 2 - Firestone Country Club                     Cybelle                           1995/2     FD×02
-Champion Course Vol. 3 - Banff Springs                              Cybelle                           1995/2     FD×03
-Champion Course Vol. 4 - Innisbrook                                 Cybelle                           1995/2     FD×03
 Chuugakkou Ongaku: Ongakushi                                        Musical Plan                      1991/6     FD
 Chuugakkou Subaru-kun Series                                        Uchida Youkou                     1993/4     FD
 Chuugakkou Suugaku New Simulation Zukei-hen 1-nen                   Tokyo Shoseki                     1994/3     FD
@@ -51,6 +48,7 @@ CS-1 Towns                                                          Unitek Japan
 Cyber Animater                                                      Fujitsu                           1992/7     FD
 CyberMotion                                                         Fujitsu                           1993/3     FD
 D.O. Kaizokuban                                                     Brother Kougyou (Takeru)          1993/5     FD×03
+Daifugou Gakuen                                                     Brother Kougyou (Takeru)          ?          FDx??
 Daisenryaku 3 '90 Map Collection Vol. 2                             Pegasus Japan                     1992/7     FD
 Data Townsman                                                       Log                               1991/7     FD
 Dennou Kyoushi (Cyber Teacher)                                      Nikkonren Kikaku                  1993/?     FD
@@ -123,9 +121,8 @@ LPACK                                                               Kansai Denki
 Lucid ASM & Debugger Ver. 1.1                                       Kansai Denki                      1990/4     FD
 Magic Ayako Suzume                                                  Cosmos Computer                   1992/5     FDx03
 Mahjong Clinic Soukangou                                            Mahou (Nihon Home Data)           1991/11    FD×02
-Mahjong Elegance                                                    C-Class                           1994/11    FD×02
 Mahjong Gensoukyouku - Mahjong Fantasia                             Active                            1992/7     FD×04
-Ma-Saiko-Jong                                                       Cosmos Computer                   1992/5     FD×03
+* Mah-Saiko-Jong                                                    Cosmos Computer                   1992/5     FD×03
 Media 4                                                             Fujitsu Social Science Laboratory 1993/4     FD
 Melody Surf: Oto Monogatari                                         TDK                               1994/1     FD
 Micom Drill Chuugaku Suugaku 1-nen~3-nen                            Kyouiku Soft Kenkyuusho           1993/4     FD
@@ -176,6 +173,7 @@ School-Card Alpha Sensei Kit                                        Fujitsu     
 School-Edin Alpha Sensei-you V1.1 L10                               Fujitsu                           1993/5     FD
 Schoolmenu Henshuu-you                                              Fujitsu                           1994/9     FD
 Schoolmenu Jikkou-you                                               Fujitsu                           1994/9     FD
+Setsujuu: Yuganda Kioku                                             JAST                              1995/4     FD×04
 Shin Kakeibo Good Manager                                           Cosmos Computer                   1992/7     FD×02
 Shisetsu Sangokushi                                                 Tensui Software                   1993/9     FD
 Shisetsu Sengoku Jidai                                              Tensui Software                   1994/6     FD
@@ -196,7 +194,6 @@ Super Paso-rika Keisuke                                             Fujitsu Ooit
 Symmetry 17                                                         Jouhou Suuri Kenkyuusho           1992/2     FD
 Tablet Keyboard Driver V1.1                                         Fujitsu                           1993/7     FD
 Tenshi-tachi no Gogo Collection                                     JAST                              1995/3     FD×04
-Tenshi-tachi no Gogo VI: My Fair Teacher                            JAST                              1993/8     FD×03
 TISP V1.1                                                           Fujitsu                           1992/12    FD
 TL-1 Tapeless Recording System                                      Fujitsu Ooita Software Laboratory 1994/3     FD
 Together                                                            JEL                               1989/3     FD
@@ -234,7 +231,7 @@ Towns Drill Shougaku Sansuu 6-nen Gear V1.1L20                      Kyouiku Soft
 Towns Drill Shougaku Sansuu 6-nen Gear V2.1                         Kyouiku Soft Kenkyuusho           1990/2     FD
 Towns Hair Simulator: Hair Maker Towns                              Computer System                   1991/12    FD×10
 Towns Jouhou Kiso Select-F                                          Tokyo Shoseki                     1993/3     FD×03
-*Towns Karaoke V1.1                                                 Fujitsu                           1989/7     FD
+* Towns Karaoke V1.1                                                Fujitsu                           1989/7     FD
 TownsGEAR de Obenkyou Dai-1-kan: Seigo Mondai                       Kyouiku Soft Kenkyuusho           1992/3     FD×02
 TownsGEAR de Obenkyou Dai-2-kan: Sentaku Mondai                     Kyouiku Soft Kenkyuusho           1992/3     FD×02
 TownsGEAR de Obenkyou Dai-3-kan: Suuchi Mondai                      Kyouiku Soft Kenkyuusho           1992/3     FD×02
@@ -245,7 +242,6 @@ VideoCD Saisei Kit V1.1 L10                                         Fujitsu     
 VIP Karaoke                                                         CSK Research Institute (CRI)      1992/4     FD
 WordLook                                                            CSK Research Institute (CRI)      1991/4     FD
 Youjuu Club Custom                                                  D.O.                              1992/3     FD×03
-Yukineko                                                            JAST                              1995/4     FD×04
 Zurukamashi Adult Jisho                                             Nikkonren Kikaku                  1992/2     FD
 Zurukamashi Junior Jisho                                            Nikkonren Kikaku                  1991/5     FD
 Zurukamashi Ver 2.0                                                 Nikkonren Kikaku                  1993/?     FD×02
@@ -309,6 +305,34 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 			<feature name="part_id" value="Disk D" />
 			<dataarea name="flop" size="1261568">
 				<rom name="aishimai_diskd.hdm" size="1261568" crc="48c70c9e" sha1="daeb6f0f1024bf6a715d9d67814e31d2b368bde3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Asks for Disk A on startup. Probably related to the protection. -->
+	<!-- Overlapped sectors and non-standard sector IDs on track 9 side 0 of disk A -->
+	<software name="asuka120" supported="no">
+		<description>Asuka 120% Burning Fest.</description>
+		<year>1994</year>
+		<publisher>ファミリーソフト (Family Soft)</publisher>
+		<info name="alt_title" value="あすか 120% BURNING Fest." />
+		<info name="release" value="199403xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3444655">
+				<rom name="asuka120_disk_a.mfm" size="3444655" crc="22fbc013" sha1="a780007f1b65613d0689cb68f9543c9aeac7c909"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="asuka120_disk_b.hdm" size="1261568" crc="2a448e8f" sha1="3b57fd0a2fecec56a3362884de0770ec4538f5eb"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="1261568">
+				<rom name="asuka120_disk_c.hdm" size="1261568" crc="ac9a582e" sha1="726b05d573e0776006cee6aa8c71009b1e66b5cc"/>
 			</dataarea>
 		</part>
 	</software>
@@ -710,6 +734,146 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<software name="kawaichi">
+		<description>Kawarazaki-ke no Ichizoku</description>
+		<year>1993</year>
+		<publisher>シルキーズ (Silky's)</publisher>
+		<info name="alt_title" value="河原崎家の一族" />
+		<info name="release" value="199312xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="kawarazaki-ke no ichizoku (disk a).hdm" size="1261568" crc="8e5377bb" sha1="1b977a5dbc3bae53f995cce516be29eef231267d"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="kawarazaki-ke no ichizoku (disk b).hdm" size="1261568" crc="28cc3fe4" sha1="402e71d702b3af458110e602c3109e82bc26afb0"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="1261568">
+				<rom name="kawarazaki-ke no ichizoku (disk c).hdm" size="1261568" crc="e7647e74" sha1="49053fc637a6d704fc766c3428741fafc6e06e5a"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk D" />
+			<dataarea name="flop" size="1261568">
+				<rom name="kawarazaki-ke no ichizoku (disk d).hdm" size="1261568" crc="12a2bc4b" sha1="57eec756df31ea4e4a2aaf822a7a7200004fcd4a"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk E" />
+			<dataarea name="flop" size="1261568">
+				<rom name="kawarazaki-ke no ichizoku (disk e).hdm" size="1261568" crc="7999334a" sha1="c4e1abf0be91e679867709319fb876f6c6789aa4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="links386cc1">
+		<description>Golf Links 386 Pro Champion Course Vol. 1 - Mauna Kea Beach Golf Course</description>
+		<year>1995</year>
+		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="ゴルフ・リンクス３８６プロ　チャンピオンコースＶＯＬ．１ マウナケア・ビーチ・ゴルフ・コース" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Add-on course for Golf Links 386 Pro. Boot from the game CD with disk 1 inserted, then run the icon on floppy drive A: to install the course" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_1_disk_1.hdm" size="1261568" crc="1b702c10" sha1="74a6a13592f07630b0f922acc5a125e69e59ba49"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_1_disk_2.hdm" size="1261568" crc="a34e90ce" sha1="cba98efa113ac0d07e94e22bf38eafda8240db38"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_1_disk_3.hdm" size="1261568" crc="85fe3c1f" sha1="6a6c5e7e3607510c4119295f929d6a0fdea861e1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="links386cc2">
+		<description>Golf Links 386 Pro Champion Course Vol. 2 - Firestone Country Club South Course</description>
+		<year>1995</year>
+		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="ゴルフ・リンクス３８６プロ　チャンピオンコースＶＯＬ．２ ファイアストン・カントリー・クラブ・サウス・コース" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Add-on course for Golf Links 386 Pro. Boot from the game CD with disk 1 inserted, then run the icon on floppy drive A: to install the course" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_2_disk_1.hdm" size="1261568" crc="0f3e0e2a" sha1="03c71ce6f96e64a19ecd353d58bf5708011e6be8"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_2_disk_2.hdm" size="1261568" crc="d0a1bbe8" sha1="b727ef45ca5a6b4db1ee79dd6145e46c12e9c263"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="links386cc3">
+		<description>Golf Links 386 Pro Champion Course Vol. 3 - Banff Springs</description>
+		<year>1995</year>
+		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="ゴルフ・リンクス３８６プロ　チャンピオンコースＶＯＬ．３ バンフ・スプリングス" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Add-on course for Golf Links 386 Pro. Boot from the game CD with disk 1 inserted, then run the icon on floppy drive A: to install the course" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_3_disk_1.hdm" size="1261568" crc="23ba9b17" sha1="49f0736f3f4cd75d2cc6bda6fcde5af926e6a911"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_3_disk_2.hdm" size="1261568" crc="43fa8482" sha1="bb2b8116a50f3124021401a977a6a07495cb7b9c"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_3_disk_3.hdm" size="1261568" crc="849a5692" sha1="44d4919fadf15f6196ced2161f16916e04fe8b5a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="links386cc4">
+		<description>Golf Links 386 Pro Champion Course Vol. 4 - Innisbrook Copperhead Course</description>
+		<year>1995</year>
+		<publisher>サイベル (Cybelle)</publisher>
+		<info name="alt_title" value="ゴルフ・リンクス３８６プロ　チャンピオンコースＶＯＬ．４ インニスブルック・コッパーヘッド・コース" />
+		<info name="release" value="199502xx" />
+		<info name="usage" value="Add-on course for Golf Links 386 Pro. Boot from the game CD with disk 1 inserted, then run the icon on floppy drive A: to install the course" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_4_disk_1.hdm" size="1261568" crc="7051b02d" sha1="92c280455ecdf4a7f1bbfd68938f008efeb9b77a"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_4_disk_2.hdm" size="1261568" crc="4a060b79" sha1="7aa38b2e37f6e2efa3367386a63bdf1c8ae64446"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1261568">
+				<rom name="links386_champion_course_4_disk_3.hdm" size="1261568" crc="7055c7bc" sha1="71783444ad069be8042baffdefb55c2e0b5a48aa"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!--
 	Track 15 side 0 of the program disk and track 10 side 0 of the ending disk are protected (overlapped sectors).
 	The game includes a pre-formatted user disk but it can also save to any generic blank disk.
@@ -775,6 +939,27 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 			<feature name="part_id" value="Disk C" />
 			<dataarea name="flop" size="1261568">
 				<rom name="maririndx_diskc.hdm" size="1261568" crc="d4f2fc7d" sha1="2efc64d48f990691420eb51fb284ab585b5cf419"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mjelegan">
+		<description>Mahjong Elegance</description>
+		<year>1994</year>
+		<publisher>C-Class</publisher>
+		<info name="alt_title" value="麻雀エレガンス" />
+		<info name="release" value="199411xx" />
+		<info name="usage" value="Boot TownsOS V2.1L20 or later, then run the icon on floppy drive A:" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="mahjong_elegance_system_disk.hdm" size="1261568" crc="94b1cf70" sha1="16ed9732fabf0c3903fc8cc9885824e8396989d4"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Data Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="mahjong_elegance_data_disk.hdm" size="1261568" crc="90ad2350" sha1="ee96b6fb856600c2c14d3ae9bb26e334370657bb"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1128,6 +1313,27 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<!-- Disk 1 has an additional track with a single 128-byte sector. It's unclear if this is a protection measure or a duplication mark. -->
+	<software name="supdaisn">
+		<description>Super Daisenryaku</description>
+		<year>1990</year>
+		<publisher>システムソフト (SystemSoft)</publisher>
+		<info name="alt_title" value="スーパー大戦略" />
+		<info name="release" value="199003xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Game Disk 1" />
+			<dataarea name="flop" size="3428317">
+				<rom name="super_daisenryaku_disk_1.mfm" size="3428317" crc="2daabb78" sha1="93e8be4f10fe7456a65ac2101b37d3a2bf9ab88d"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Game Disk 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="super_daisenryaku_disk_2.hdm" size="1261568" crc="c7f7f2d3" sha1="394ac85565728e69c30c3cf974d4a3031267f86d"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sweetang">
 		<description>Sweet Angel</description>
 		<year>1992</year>
@@ -1142,6 +1348,33 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		<part name="flop2" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="sweetangel2.hdm" size="1261568" crc="e0f4017c" sha1="447c3e91b01396d249b2aad08001339148df7bf9"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Track 3 side 0 of Disk A is protected (overlapped sectors). -->
+	<software name="tenshi6">
+		<description>Tenshi-tachi no Gogo VI - My Fair Teacher</description>
+		<year>1993</year>
+		<publisher>ジャスト (JAST)</publisher>
+		<info name="alt_title" value="天使たちの午後ＶＩ －Ｍｙ　Ｆａｉｒ　Ｔｅａｃｈｅｒ－" />
+		<info name="release" value="199308xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="3444635">
+				<rom name="tenshi-tachi_no_gogo_vi_disk_a.mfm" size="3444635" crc="f7af9038" sha1="f30bfa2ba530799ff657b11957e1319e53b13c61"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="tenshi-tachi_no_gogo_vi_disk_b.hdm" size="1261568" crc="d5b02db8" sha1="5831cd712db760db63675caf0736f0d64377adae"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="1261568">
+				<rom name="tenshi-tachi_no_gogo_vi_disk_c.hdm" size="1261568" crc="fb775fed" sha1="c4cc8a6244c75035b6c40c4310cb0d497701cc84"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1242,6 +1475,44 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<software name="ushinawa">
+		<description>Ushinawareta Rakuen</description>
+		<year>1995</year>
+		<publisher>シルキーズ (Silky's)</publisher>
+		<info name="alt_title" value="失われた楽園" />
+		<info name="release" value="199504xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ushinawareta rakuen (disk a).hdm" size="1261568" crc="43a4ab96" sha1="49848270471a59cbeeb9aaa0fbfee7512f06b448"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ushinawareta rakuen (disk b).hdm" size="1261568" crc="2cd5aac5" sha1="f42b32087061aa4f0bfa87f712f263744233424c"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk C" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ushinawareta rakuen (disk c).hdm" size="1261568" crc="45b0d218" sha1="787c8709d5173d4c63b8acc50b646ec06e64be26"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk D" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ushinawareta rakuen (disk d).hdm" size="1261568" crc="af3eb06d" sha1="a4e9a37f5ae6a61eae587f4cbe0f6c0cf62e185b"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk E" />
+			<dataarea name="flop" size="1261568">
+				<rom name="ushinawareta rakuen (disk e).hdm" size="1261568" crc="1481c370" sha1="95676fc68d7e402fd9e463a5ad9d82490ac544a8"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="wedderra">
 		<description>Wedding Errantry - Gyakutama Ou</description>
 		<year>1995</year>
@@ -1282,6 +1553,26 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 			<feature name="part_id" value="Disk F" />
 			<dataarea name="flop" size="1261568">
 				<rom name="wedding errantry - gyakutama ou (disk f).hdm" size="1261568" crc="ec99238a" sha1="70eb057a67ffab0072473e37ed3fa39f81492917"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wordwortsp">
+		<description>Words Worth Special Disk</description>
+		<year>1993</year>
+		<publisher>エルフ (Elf)</publisher>
+		<info name="alt_title" value="ワーズ・ワース　スペシャルディスク" />
+		<info name="usage" value="Boot TownsOS V2.1L20 or later, insert the Words Worth CD, then run the icon on floppy drive A:" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk A" />
+			<dataarea name="flop" size="1261568">
+				<rom name="words_worth_specialdisk_a.hdm" size="1261568" crc="85052598" sha1="d9ec7d1048b5de4ca220dfe959f36fde4bfc67b2"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk B" />
+			<dataarea name="flop" size="1261568">
+				<rom name="words_worth_specialdisk_b.hdm" size="1261568" crc="9e5cf67d" sha1="15497d0d60c60644a7933379e76626aad649a1e7"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Moved asuka120 from fmtowns_flop_misc.xml to fmtowns_flop_cracked.xml, since the original disks have been confirmed to be protected
- Moved kawaichi and ushinawa from fmtowns_flop_misc.xml to fmtowns_flop_orig.xml, since they have been verified to match the originals
- Removed the reiraa clone, since it only differs from the parent in the save data
- Additions/corrections to the missing list

New working software list additions (fmtowns_flop_orig.xml)
-----------------------------------------------------------
Golf Links 386 Pro Champion Course Vol. 1 - Mauna Kea Beach Golf Course [al32gabby]
Golf Links 386 Pro Champion Course Vol. 2 - Firestone Country Club South Course [al32gabby]
Golf Links 386 Pro Champion Course Vol. 3 - Banff Springs [al32gabby]
Golf Links 386 Pro Champion Course Vol. 4 - Innisbrook Copperhead Course [al32gabby]
Mahjong Elegance [cyo.the.vile]
Super Daisenryaku [cyo.the.vile]
Tenshi-tachi no Gogo VI - My Fair Teacher [cyo.the.vile]
Words Worth Special Disk [cyo.the.vile]

New not working software list additions (fmtowns_flop_orig.xml)
---------------------------------------------------------------
Asuka 120% Burning Fest. [cyo.the.vile]

New working software list additions (fmtowns_flop_misc.xml)
-----------------------------------------------------------
Nihongo MS-DOS V3.1 L36+ [anonymous]
Nihongo MS-DOS V5.0 L22 A+2 [anonymous]