### PR TITLE
m68kfpu.cpp: Implement FMOVEM mode 0b11

### DIFF
--- a/src/devices/cpu/m68000/m68kfpu.cpp
+++ b/src/devices/cpu/m68000/m68kfpu.cpp
@@ -1773,6 +1773,10 @@ void m68000_base_device::fmovem(u16 w2)
 				break;
 			}
 
+			case 3: // Dynamic register list, postincrement or control addressing mode.
+				// FIXME: not really tested, but seems to work
+				reglist = REG_D()[(reglist >> 4) & 7];
+				[[fallthrough]];
 			case 2:     // Static register list, postdecrement or control addressing mode
 			{
 				for (i=0; i < 8; i++)


### PR DESCRIPTION
Since the two bits seem to have symmetry (top bit controls post/pre, bottom bit controls static/dynamic), it's odd this wasn't there before.

I'm not sure if copy and pasting the other case was fine, but it does seem to work. :shrug: 

Should fix issues with Domain/OS and NeXTSTEP emulation. (The crash w/o this can be reproduced by trying to start VUE on a DN3500 running Domain/OS 10.4.)