### PR TITLE
asuka.cpp: Added new clone earthjkrb: "U.N. Defense Force: Earth Joker (US / Japan, set 3)"

### DIFF
--- a/src/mame/drivers/asuka.cpp
+++ b/src/mame/drivers/asuka.cpp
@@ -1681,6 +1681,33 @@ ROM_START( earthjkra )
 	ROM_LOAD( "b68-05.ic43", 0x00000, 0x104, CRC(d6524ccc) SHA1(f3b56253692aebb63278d47832fc27b8b212b59c) )
 ROM_END
 
+ROM_START( earthjkrb ) /* Taito PCB: K1100726A / J1100169B */
+	ROM_REGION( 0x100000, "maincpu", 0 )     /* 1024k for 68000 code */
+	/* Very close to earthjkra set. Labels are numbered in the same way as earthjkrp, but 3 and 4 ones are swapped (Maybe a typo in earthjkrp ?). In this case 4 is placed at ic24 position and 3 is placed at ic8 position */
+	ROM_LOAD16_BYTE( "4.ic23", 0x00000, 0x20000, CRC(250f09f8) SHA1(124f65a499414b4ec06cf6c370850cdc962dd2ee) ) /* 4.ic23 vs ejok_ic23 99.967957% similar (42 changed bytes) */
+	ROM_LOAD16_BYTE( "3.ic8",  0x00001, 0x20000, CRC(88fc1c5d) SHA1(83d4177603c5671ece906810f01284a477388bf7) ) /* 3.ic8  vs ejok_ic8  99.967957% similar (42 changed bytes) */
+	/* 0x40000 - 0x7ffff is intentionally empty */
+	ROM_LOAD16_WORD( "ic30e.ic30", 0x80000, 0x80000, CRC(49d1f77f) SHA1(f6c9b2fc88b77cc9baa5be48da5c3eb72310e471) ) /* Fix ROM */
+
+	ROM_REGION( 0x80000, "tc0100scn", 0 )
+	ROM_LOAD16_WORD_SWAP( "ej_chr-0.ic3", 0x00000, 0x80000, CRC(ac675297) SHA1(2a34e1eae3a4be84dbf709053f5e8a781b1073fc) )    /* SCR tiles (8 x 8) - mask ROM */
+
+	ROM_REGION( 0xa0000, "pc090oj", 0 )
+	ROM_LOAD16_WORD_SWAP( "ej_obj-0.ic6", 0x00000, 0x80000, CRC(5f21ac47) SHA1(45c94ffb53ee9b822b0676f6fb151fed4ce6d967) ) /* Sprites (16 x 16) - mask ROM */
+	ROM_LOAD16_BYTE     ( "1.ic5",        0x80001, 0x10000, CRC(cb4891db) SHA1(af1112608cdd897ef6028ef617f5ca69d7964861) )
+	ROM_LOAD16_BYTE     ( "0.ic4",        0x80000, 0x10000, CRC(b612086f) SHA1(625748fcb698ec57b7b3ce46019cf85de99aaaa1) )
+
+	ROM_REGION( 0x10000, "audiocpu", 0 )    /* sound cpu */
+	ROM_LOAD( "2.ic27", 0x00000, 0x10000, CRC(42ba2566) SHA1(c437388684b565c7504d6bad6accd73aa000faca) ) /* banked */
+
+	ROM_REGION( 0x10000, "msm", ROMREGION_ERASEFF )   /* ADPCM samples */
+	/* Empty socket on U.N. Defense Force: Earth Joker - but sound chips present */
+
+	ROM_REGION( 0x144, "pals", 0 )
+	ROM_LOAD( "b68-04.ic32", 0x00000, 0x144, CRC(9be618d1) SHA1(61ee33c3db448a05ff8f455e77fe17d51106baec) )
+	ROM_LOAD( "b68-05.ic43", 0x00000, 0x104, CRC(d6524ccc) SHA1(f3b56253692aebb63278d47832fc27b8b212b59c) )
+ROM_END
+
 // Known to exist (not dumped) a Japanese version with ROMs 3 & 4 also stamped "A" same as above or different version??
 // Also known to exist (not dumped) a US version of Earth Joker, title screen shows "DISTRIBUTED BY ROMSTAR, INC."  ROMs were numbered
 // from 0 through 4 and the fix ROM at IC30 is labeled 1 even though IC5 is also labled as 1 similar to the below set:
@@ -1767,8 +1794,9 @@ GAME( 1989, cadashs,   cadash,   cadash,   cadash,   asuka_state, init_cadash,  
 
 GAME( 1992, galmedes,  0,        asuka,    galmedes, asuka_state, empty_init,    ROT270, "Visco",                     "Galmedes (Japan)", MACHINE_SUPPORTS_SAVE )
 
-GAME( 1993, earthjkr,  0,        asuka,    earthjkr, asuka_state, init_earthjkr, ROT270, "Visco",                     "U.N. Defense Force: Earth Joker (US / Japan, set 1)", MACHINE_SUPPORTS_SAVE ) // sets 1 + 2 have ROMSTAR (US?) license and no region disclaimer if you change the dipswitch
+GAME( 1993, earthjkr,  0,        asuka,    earthjkr, asuka_state, init_earthjkr, ROT270, "Visco",                     "U.N. Defense Force: Earth Joker (US / Japan, set 1)", MACHINE_SUPPORTS_SAVE ) // sets 1 + 2 + 3 have ROMSTAR (US?) license and no region disclaimer if you change the dipswitch
 GAME( 1993, earthjkra, earthjkr, asuka,    earthjkr, asuka_state, empty_init,    ROT270, "Visco",                     "U.N. Defense Force: Earth Joker (US / Japan, set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1993, earthjkrb, earthjkr, asuka,    earthjkr, asuka_state, empty_init,    ROT270, "Visco",                     "U.N. Defense Force: Earth Joker (US / Japan, set 3)", MACHINE_SUPPORTS_SAVE )
 GAME( 1993, earthjkrp, earthjkr, asuka,    earthjkrp,asuka_state, empty_init,    ROT270, "Visco",                     "U.N. Defense Force: Earth Joker (Japan, prototype?)", MACHINE_SUPPORTS_SAVE )
 
 GAME( 1994, eto,       0,        eto,      eto,      asuka_state, empty_init,    ROT0,   "Visco",                     "Kokontouzai Eto Monogatari (Japan)", MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -2472,6 +2472,7 @@ cadashu                         // C21 (c) 1989 Taito America Corporation
 cadashu1                        // C21 (c) 1989 Taito America Corporation
 earthjkr                        // (c) 1993 Visco (Japan)
 earthjkra                       //
+earthjkrb                       //
 earthjkrp                       //
 eto                             // (c) 1994 Visco (Japan)
 galmedes                        // (c) 1992 Visco (Japan)


### PR DESCRIPTION
Added new clone earthjkrb to asuka.cpp
Dump credits to: JammaFever, Nebula, Recreativos Piscis, Spain

* Found in Taito PCB: K1100726A / J1100169B
* It only differs from parent set in 2 program roms: `4.ic23` and `3.ic8`. They are very close to the earthjkra set ones and only differs in 42 bytes in each rom.
* Eprom labels are numbered in the same way as earthjkrp set, but 3 and 4 ones are swapped (Maybe a typo in earthjkrp ?)
* Same ROMSTAR license and no region disclaimer when dipswitch is changed, like earthjkr and earthjkra sets.
* It seems a newer version than earthjkra set, including additional changes to those added in earthjkra in comparison to earthjkr set, as earthjkra and earthjkrb share the same changes from earthjkr.
* Actual PCB picture: https://i.imgur.com/DYgniZc.jpg
* Comparison between earthjkrb and earthjkra:
  * `4.ic23` vs. `ejok_ic23`: https://i.imgur.com/NpBidEY.png
  * `3.ic8`  vs. `ejok_ic8`: https://i.imgur.com/rnenDhW.png
* Comparison between earthjkrb and earthjkr:
  * `4.ic23` vs. `ej_3b.ic23`: https://i.imgur.com/Co8hmCe.png
  * `3.ic8`  vs. `ej_3a.ic8`: https://i.imgur.com/EcnvW3Q.png