### PR TITLE
qx10: Add centronics printer port

### DIFF
--- a/src/devices/bus/centronics/ctronics.cpp
+++ b/src/devices/bus/centronics/ctronics.cpp
@@ -32,6 +32,7 @@ centronics_device::centronics_device(const machine_config &mconfig, const char *
 	m_autofd_handler(*this),
 	m_fault_handler(*this),
 	m_init_handler(*this),
+	m_sense_handler(*this),
 	m_select_in_handler(*this),
 	m_dev(nullptr)
 {
@@ -40,6 +41,12 @@ centronics_device::centronics_device(const machine_config &mconfig, const char *
 void centronics_device::device_config_complete()
 {
 	m_dev = dynamic_cast<device_centronics_peripheral_interface *>(get_card_device());
+}
+
+void centronics_device::device_reset()
+{
+	if (m_dev && m_dev->supports_pin35_5v())
+		m_sense_handler(1);
 }
 
 void centronics_device::device_start()
@@ -60,7 +67,10 @@ void centronics_device::device_start()
 	m_autofd_handler.resolve_safe();
 	m_fault_handler.resolve_safe();
 	m_init_handler.resolve_safe();
+	m_sense_handler.resolve_safe();
 	m_select_in_handler.resolve_safe();
+
+	m_sense_handler(0);
 
 	// pull up
 	m_strobe_handler(1);

--- a/src/devices/bus/centronics/ctronics.h
+++ b/src/devices/bus/centronics/ctronics.h
@@ -43,6 +43,7 @@ public:
 	auto autofd_handler() { return m_autofd_handler.bind(); }
 	auto fault_handler() { return m_fault_handler.bind(); }
 	auto init_handler() { return m_init_handler.bind(); }
+	auto sense_handler() { return m_sense_handler.bind(); }
 	auto select_in_handler() { return m_select_in_handler.bind(); }
 
 	template <typename T> void set_data_input_buffer(T &&tag)
@@ -80,6 +81,7 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_config_complete() override;
+	virtual void device_reset() override;
 	virtual void device_start() override;
 
 	devcb_write_line m_strobe_handler;
@@ -98,6 +100,7 @@ protected:
 	devcb_write_line m_autofd_handler;
 	devcb_write_line m_fault_handler;
 	devcb_write_line m_init_handler;
+	devcb_write_line m_sense_handler;
 	devcb_write_line m_select_in_handler;
 
 private:
@@ -150,6 +153,8 @@ protected:
 	virtual DECLARE_WRITE_LINE_MEMBER( input_fault ) { }
 	virtual DECLARE_WRITE_LINE_MEMBER( input_init ) { }
 	virtual DECLARE_WRITE_LINE_MEMBER( input_select_in ) { }
+
+	virtual bool supports_pin35_5v() { return false; }
 
 	centronics_device *m_slot;
 };

--- a/src/devices/bus/centronics/epson_ex800.h
+++ b/src/devices/bus/centronics/epson_ex800.h
@@ -41,6 +41,8 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual ioport_constructor device_input_ports() const override;
 
+	virtual bool supports_pin35_5v() override { return true; }
+
 private:
 	uint8_t porta_r();
 	uint8_t portb_r();

--- a/src/devices/bus/centronics/epson_lx800.h
+++ b/src/devices/bus/centronics/epson_lx800.h
@@ -42,6 +42,8 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual ioport_constructor device_input_ports() const override;
 
+	virtual bool supports_pin35_5v() override { return true; }
+
 private:
 	uint8_t porta_r(offs_t offset);
 	void porta_w(offs_t offset, uint8_t data);

--- a/src/devices/bus/centronics/epson_lx810l.h
+++ b/src/devices/bus/centronics/epson_lx810l.h
@@ -59,6 +59,8 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual ioport_constructor device_input_ports() const override;
 
+	virtual bool supports_pin35_5v() override { return true; }
+
 private:
 	uint8_t porta_r(offs_t offset);
 	void porta_w(offs_t offset, uint8_t data);

--- a/src/devices/bus/centronics/printer.h
+++ b/src/devices/bus/centronics/printer.h
@@ -35,6 +35,7 @@ protected:
 	virtual void device_reset() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
+	virtual bool supports_pin35_5v() override { return true; }
 private:
 	DECLARE_WRITE_LINE_MEMBER( printer_online );
 

--- a/src/mame/drivers/qx10.cpp
+++ b/src/mame/drivers/qx10.cpp
@@ -34,12 +34,14 @@
 
 #include "emu.h"
 
+#include "bus/centronics/ctronics.h"
 #include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
 #include "imagedev/floppy.h"
 #include "machine/am9517a.h"
 #include "machine/i8255.h"
 #include "machine/mc146818.h"
+#include "machine/output_latch.h"
 #include "machine/pic8259.h"
 #include "machine/pit8253.h"
 #include "machine/qx10kbd.h"
@@ -82,6 +84,7 @@ public:
 		m_hgdc(*this, "upd7220"),
 		m_rtc(*this, "rtc"),
 		m_kbd(*this, "kbd"),
+		m_centronics(*this, "centronics"),
 		m_speaker(*this, "speaker"),
 		m_vram_bank(0),
 		m_char_rom(*this, "chargen"),
@@ -124,6 +127,16 @@ private:
 	void vram_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	uint8_t memory_read_byte(offs_t offset);
 	void memory_write_byte(offs_t offset, uint8_t data);
+
+	uint8_t portb_r();
+	void portc_w(uint8_t data);
+
+	void centronics_busy_handler(uint8_t state);
+	void centronics_fault_handler(uint8_t state);
+	void centronics_perror_handler(uint8_t state);
+	void centronics_select_handler(uint8_t state);
+	void centronics_sense_handler(uint8_t state);
+
 	DECLARE_WRITE_LINE_MEMBER(keyboard_clk);
 	DECLARE_WRITE_LINE_MEMBER(keyboard_irq);
 	DECLARE_WRITE_LINE_MEMBER(speaker_freq);
@@ -154,6 +167,7 @@ private:
 	required_device<upd7220_device> m_hgdc;
 	required_device<mc146818_device> m_rtc;
 	required_device<rs232_port_device> m_kbd;
+	required_device<centronics_device> m_centronics;
 	required_device<speaker_sound_device>   m_speaker;
 	uint8_t m_vram_bank;
 	//required_shared_ptr<uint8_t> m_video_ram;
@@ -173,6 +187,14 @@ private:
 	int m_spkr_enable;
 	int m_spkr_freq;
 	int m_pit1_out0;
+
+	/* centronics */
+	int m_centronics_error;
+	int m_centronics_busy;
+	int m_centronics_paper;
+	int m_centronics_select;
+	int m_centronics_sense;
+
 
 	/* memory */
 	int     m_membank;
@@ -449,6 +471,52 @@ uint8_t qx10_state::qx10_30_r()
 			/*m_fdcmotor*/ 0 << 1 |
 			((floppy1 != nullptr) || (floppy2 != nullptr) ? 1 : 0) << 3 |
 			m_membank << 4;
+}
+
+void qx10_state::centronics_busy_handler(uint8_t state)
+{
+	m_centronics_busy = state;
+}
+
+void qx10_state::centronics_perror_handler(uint8_t state)
+{
+	m_centronics_paper = state;
+}
+
+void qx10_state::centronics_fault_handler(uint8_t state)
+{
+	m_centronics_error = state;
+}
+
+void qx10_state::centronics_select_handler(uint8_t state)
+{
+	m_centronics_select = state;
+}
+
+void qx10_state::centronics_sense_handler(uint8_t state)
+{
+	m_centronics_sense = state;
+}
+
+uint8_t qx10_state::portb_r()
+{
+	uint8_t status = 0;
+
+	status |= m_centronics_error  << 3;
+	status |= m_centronics_paper  << 4;
+	status |= m_centronics_busy   << 5;
+	status |= m_centronics_sense  << 6;
+	status |= m_centronics_select << 7;
+
+	return status;
+}
+
+void qx10_state::portc_w(uint8_t data)
+{
+	m_centronics->write_strobe(BIT(data, 0));
+	m_centronics->write_autofd(BIT(data, 4));
+	m_centronics->write_init(!BIT(data, 5));
+	m_pic_s->ir0_w(BIT(data, 3));
 }
 
 /*
@@ -849,6 +917,9 @@ void qx10_state::qx10(machine_config &config)
 	AM9517A(config, m_dma_2, MAIN_CLK/4);
 
 	I8255(config, m_ppi, 0);
+	m_ppi->out_pa_callback().set("prndata", FUNC(output_latch_device::write));
+	m_ppi->in_pb_callback().set(FUNC(qx10_state::portb_r));
+	m_ppi->out_pc_callback().set(FUNC(qx10_state::portc_w));
 
 	UPD7220(config, m_hgdc, 16.67_MHz_XTAL/4/2);
 	m_hgdc->set_addrmap(0, &qx10_state::upd7220_map);
@@ -871,6 +942,16 @@ void qx10_state::qx10(machine_config &config)
 
 	RS232_PORT(config, m_kbd, keyboard, "qx10");
 	m_kbd->rxd_handler().set(m_scc, FUNC(upd7201_device::rxa_w));
+
+	output_latch_device &prndata(OUTPUT_LATCH(config, "prndata"));
+	CENTRONICS(config, m_centronics, centronics_devices, nullptr);
+	m_centronics->set_output_latch(prndata);
+	m_centronics->ack_handler().set(m_ppi, FUNC(i8255_device::pc6_w));
+	m_centronics->busy_handler().set(FUNC(qx10_state::centronics_busy_handler));
+	m_centronics->perror_handler().set(FUNC(qx10_state::centronics_perror_handler));
+	m_centronics->fault_handler().set(FUNC(qx10_state::centronics_fault_handler));
+	m_centronics->select_handler().set(FUNC(qx10_state::centronics_select_handler));
+	m_centronics->sense_handler().set(FUNC(qx10_state::centronics_sense_handler));
 
 	/* sound hardware */
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
Add centronics printer port to qx10 emulation.

The new sense_handler() on the centronics bus is a 5 volt signal generated on pin 35 of the centronics connector and is used to sense if there is a powered up device attached to the port. 