### PR TITLE
cyclemb.cpp: Remove MACHINE_IMPERFECT_SOUND flags

### DIFF
--- a/src/mame/drivers/cyclemb.cpp
+++ b/src/mame/drivers/cyclemb.cpp
@@ -10,10 +10,9 @@ appears to be in the exact middle between the gsword / josvolly HW and the ppkin
 driver by Angelo Salese
 
 TODO:
-- separate driver into 2 classes
-- reduce tagmap lookups
-- sound (controlled by three i8741);
-- coinage (controlled by i8741, like Gladiator / Ougon no Shiro);
+- separate driver into 2 classes;
+- reduce tagmap lookups;
+- low-level emulation of inputs/soundlatch (controlled by several i8741, like Gladiator / Ougon no Shiro);
 - color prom resistor network is guessed, cyclemb yellows are more reddish on pcb video and photos;
 
 BTANB verified on pcb: cyclemb standing cones are reddish-yellow/black instead of red/white

--- a/src/mame/drivers/cyclemb.cpp
+++ b/src/mame/drivers/cyclemb.cpp
@@ -1160,5 +1160,5 @@ void cyclemb_state::init_skydest()
 
 
 //    year  name      parent  machine   input    class          init          rot   company              fullname                 flags
-GAME( 1984, cyclemb,  0,      cyclemb,  cyclemb, cyclemb_state, init_cyclemb, ROT0, "Taito Corporation", "Cycle Maabou (Japan)",  MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
-GAME( 1985, skydest,  0,      skydest,  skydest, cyclemb_state, init_skydest, ROT0, "Taito Corporation", "Sky Destroyer (Japan)", MACHINE_NO_COCKTAIL | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE )
+GAME( 1984, cyclemb,  0,      cyclemb,  cyclemb, cyclemb_state, init_cyclemb, ROT0, "Taito Corporation", "Cycle Maabou (Japan)",  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1985, skydest,  0,      skydest,  skydest, cyclemb_state, init_skydest, ROT0, "Taito Corporation", "Sky Destroyer (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
I think Cycle Maaboh sounds was corrected on pull request for #7979.
And, Sky Destroyer does not seem to have any sound imperfections compared to PCB.
So I want to remove MACHINE_IMPERFECT_SOUND flags from the driver.
(If you think I should not remove the flag, please review it)