### PR TITLE
coco3: fix video glitch in Skiing

### DIFF
--- a/src/mame/includes/coco3.h
+++ b/src/mame/includes/coco3.h
@@ -50,11 +50,17 @@ public:
 	void coco3_mem(address_map &map);
 
 protected:
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
 	virtual void update_cart_base(uint8_t *cart_base) override;
 
 	// miscellaneous
 	virtual void update_keyboard_input(uint8_t value) override;
 	virtual void cart_w(bool line) override;
+
+	uint8_t m_pia1b_control_register;
 
 private:
 	required_device<gime_device> m_gime;

--- a/src/mame/machine/coco3.cpp
+++ b/src/mame/machine/coco3.cpp
@@ -47,6 +47,34 @@
 #include "includes/coco3.h"
 
 //-------------------------------------------------
+//  device_start
+//-------------------------------------------------
+
+void coco3_state::device_start()
+{
+	// call parent device_start
+	coco_state::device_start();
+
+	// save state support
+	save_item(NAME(m_pia1b_control_register));
+
+}
+
+//-------------------------------------------------
+//  device_reset
+//-------------------------------------------------
+
+void coco3_state::device_reset()
+{
+	/* call parent device_start */
+	coco_state::device_reset();
+
+	/* reset state */
+	m_pia1b_control_register = 0;
+
+}
+
+//-------------------------------------------------
 //  ff20_write
 //-------------------------------------------------
 
@@ -54,7 +82,11 @@ void coco3_state::ff20_write(offs_t offset, uint8_t data)
 {
 	coco_state::ff20_write(offset, data);
 
-	if (offset == 0x02)
+	if (offset == 0x03)
+		m_pia1b_control_register = data;
+
+	/* only pass ff22 to gime if the data register is addressed */
+	if (offset == 0x02 && ((m_pia1b_control_register & 0x04) == 0x04))
 		m_gime->ff22_write(data);
 }
 


### PR DESCRIPTION
It is documented that the GIME monitors $FF22 to determine the proper legacy video mode. But it also monitors $FF23 to be sure $FF22 is the data register and not the data direction register. This fixes MAME testers: https://mametesters.org/view.php?id=7512