### PR TITLE
Compile fix for Linux

### DIFF
--- a/src/lib/formats/fsmgr.h
+++ b/src/lib/formats/fsmgr.h
@@ -13,6 +13,7 @@
 
 #include <variant>
 #include <unordered_map>
+#include <functional>
 
 enum class fs_meta_name {
 	creation_date,


### PR DESCRIPTION
This addresses an issue found during compilation on GCC 7.5 and GCC 8 on Linux:

../../../../../src/lib/formats/fsmgr.h:179:7: error: ‘function’ in namespace ‘std’ does not name a template type
  std::function<void (const fs_meta &)> m_validator;
       ^~~~~~~~
../../../../../src/lib/formats/fsmgr.h:179:2: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?