### PR TITLE
coco3: rework PR#8078

### DIFF
--- a/src/mame/includes/coco3.h
+++ b/src/mame/includes/coco3.h
@@ -50,10 +50,6 @@ public:
 	void coco3_mem(address_map &map);
 
 protected:
-	// device-level overrides
-	virtual void device_start() override;
-	virtual void device_reset() override;
-
 	virtual void update_cart_base(uint8_t *cart_base) override;
 
 	// miscellaneous

--- a/src/mame/machine/coco3.cpp
+++ b/src/mame/machine/coco3.cpp
@@ -47,34 +47,6 @@
 #include "includes/coco3.h"
 
 //-------------------------------------------------
-//  device_start
-//-------------------------------------------------
-
-void coco3_state::device_start()
-{
-	// call parent device_start
-	coco_state::device_start();
-
-	// save state support
-	save_item(NAME(m_pia1b_control_register));
-
-}
-
-//-------------------------------------------------
-//  device_reset
-//-------------------------------------------------
-
-void coco3_state::device_reset()
-{
-	/* call parent device_start */
-	coco_state::device_reset();
-
-	/* reset state */
-	m_pia1b_control_register = 0;
-
-}
-
-//-------------------------------------------------
 //  ff20_write
 //-------------------------------------------------
 
@@ -82,12 +54,8 @@ void coco3_state::ff20_write(offs_t offset, uint8_t data)
 {
 	coco_state::ff20_write(offset, data);
 
-	if (offset == 0x03)
-		m_pia1b_control_register = data;
-
-	/* only pass ff22 to gime if the data register is addressed */
-	if (offset == 0x02 && ((m_pia1b_control_register & 0x04) == 0x04))
-		m_gime->ff22_write(data);
+	/* The GIME monitors writes to the PIA to simulate a VDG */
+	m_gime->pia_write(offset, data);
 }
 
 

--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -184,6 +184,7 @@ void gime_device::device_start(void)
 	save_item(NAME(m_mmu));
 	save_item(NAME(m_sam_state));
 	save_item(NAME(m_ff22_value));
+	save_item(NAME(m_ff23_value));
 	save_item(NAME(m_interrupt_value));
 	save_item(NAME(m_irq));
 	save_item(NAME(m_firq));
@@ -302,6 +303,7 @@ void gime_device::device_reset(void)
 	m_displayed_rgb = false;
 
 	m_ff22_value = 0;
+	m_ff23_value = 0;
 
 	update_memory();
 	reset_timer();
@@ -607,6 +609,22 @@ void gime_device::update_memory(int bank)
 uint8_t *gime_device::memory_pointer(uint32_t address)
 {
 	return &m_ram->pointer()[address % m_ram->size()];
+}
+
+
+
+//-------------------------------------------------
+//  pia_write - observe writes to pia 1
+//-------------------------------------------------
+
+void gime_device::pia_write(offs_t offset, uint8_t data)
+{
+	if (offset == 0x03)
+		m_ff23_value = data;
+
+	/* only cache writes to $FF22 if the data register is addressed */
+	if (offset == 0x02 && ((m_ff23_value & 0x04) == 0x04))
+		m_ff22_value = data;
 }
 
 

--- a/src/mame/video/gime.h
+++ b/src/mame/video/gime.h
@@ -40,7 +40,7 @@ public:
 	bool spare_chip_select_enabled(void) { return m_gime_registers[0] & 0x04 ? true : false; }
 
 	// the GIME seems to intercept writes to $FF22 (not precisely sure how)
-	void ff22_write(uint8_t data) { m_ff22_value = data; }
+	void pia_write(offs_t offset, uint8_t data);
 
 	// updates the cart ROM
 	void update_cart_rom(void);
@@ -141,6 +141,7 @@ protected:
 	uint8_t                     m_gime_registers[16];
 	uint8_t                     m_mmu[16];
 	uint8_t                     m_ff22_value;
+	uint8_t                     m_ff23_value;
 	uint8_t                     m_interrupt_value;
 	uint8_t                     m_irq;
 	uint8_t                     m_firq;


### PR DESCRIPTION
Move the PIA monitor logic into video/gime.cpp to better match the real hardware.