### PR TITLE
Fix c6280 volume envelope shape

### DIFF
--- a/src/devices/sound/c6280.cpp
+++ b/src/devices/sound/c6280.cpp
@@ -68,8 +68,8 @@ void c6280_device::sound_stream_update(sound_stream &stream, std::vector<read_st
 			int vlr = (0xf - rmal) + (0xf - al) + (0xf - ral);
 			if (vlr > 0xf) vlr = 0xf;
 
-			vll = m_volume_table[(vll << 1) | (chan->control & 1)];
-			vlr = m_volume_table[(vlr << 1) | (chan->control & 1)];
+			vll = m_volume_table[(vll << 1) | !(chan->control & 1)];
+			vlr = m_volume_table[(vlr << 1) | !(chan->control & 1)];
 
 			/* Check channel mode */
 			if ((ch >= 4) && (chan->noise_control & 0x80))

--- a/src/devices/sound/c6280.cpp
+++ b/src/devices/sound/c6280.cpp
@@ -68,8 +68,8 @@ void c6280_device::sound_stream_update(sound_stream &stream, std::vector<read_st
 			int vlr = (0xf - rmal) + (0xf - al) + (0xf - ral);
 			if (vlr > 0xf) vlr = 0xf;
 
-			vll = m_volume_table[(vll << 1) | !(chan->control & 1)];
-			vlr = m_volume_table[(vlr << 1) | !(chan->control & 1)];
+			vll = m_volume_table[(vll << 1) | (~chan->control & 1)];
+			vlr = m_volume_table[(vlr << 1) | (~chan->control & 1)];
 
 			/* Check channel mode */
 			if ((ch >= 4) && (chan->noise_control & 0x80))


### PR DESCRIPTION
This fixes the envelopes having a weird tremolo like effect not present on the hardware.

You can see what this PR fixes by looking at this examples:
https://deflemask.com/c6280_comparison.png
https://deflemask.com/c6280_before.wav
https://deflemask.com/c6280_after.wav

I used this .vgm to render the examples, feel free to double check:
https://deflemask.com/c6280_example.vgm