### PR TITLE
Add option to memory viewer to display addresses in decimal

### DIFF
--- a/src/emu/debug/dvmemory.cpp
+++ b/src/emu/debug/dvmemory.cpp
@@ -111,6 +111,7 @@ debug_view_memory::debug_view_memory(running_machine &machine, debug_view_osd_up
 		m_reverse_view(false),
 		m_ascii_view(true),
 		m_no_translation(false),
+		m_decimal_addr(false),
 		m_edit_enabled(true),
 		m_maxaddr(0),
 		m_bytes_per_row(16),
@@ -591,11 +592,16 @@ void debug_view_memory::recompute()
 		addrchars = string_format("%X", m_maxaddr).size();
 	}
 
-	// generate an 8-byte aligned format for the address
-	if (!m_reverse_view)
-		m_addrformat = string_format("%*s%%0%dX", 8 - addrchars, "", addrchars);
+	if (m_decimal_addr)
+		m_addrformat = m_reverse_view ? "%-10d" : "%10d";
 	else
-		m_addrformat = string_format("%%0%dX%*s", addrchars, 8 - addrchars, "");
+	{
+		// generate an 8-byte aligned format for the address
+		if (!m_reverse_view)
+			m_addrformat = string_format("%*s%%0%dX", 8 - addrchars, "", addrchars);
+		else
+			m_addrformat = string_format("%%0%dX%*s", addrchars, 8 - addrchars, "");
+	}
 
 	// if we are viewing a space with a minimum chunk size, clamp the bytes per chunk
 	// BAD
@@ -621,6 +627,8 @@ void debug_view_memory::recompute()
 
 	// compute the section widths
 	m_section[0].m_width = 1 + 8 + 1;
+	if (m_decimal_addr)
+		m_section[0].m_width += 2;
 	if (m_data_format <= 8)
 		m_section[1].m_width = 1 + 3 * m_bytes_per_row + 1;
 	else {
@@ -1038,6 +1046,20 @@ void debug_view_memory::set_reverse(bool reverse)
 {
 	cursor_pos pos = begin_update_and_get_cursor_pos();
 	m_reverse_view = reverse;
+	m_recompute = m_update_pending = true;
+	end_update_and_set_cursor_pos(pos);
+}
+
+
+//-------------------------------------------------
+//  set_decimal_addr - specify true if the memory
+//  view should display addresses in decimal
+//-------------------------------------------------
+
+void debug_view_memory::set_decimal_addr(bool decimal)
+{
+	cursor_pos pos = begin_update_and_get_cursor_pos();
+	m_decimal_addr = decimal;
 	m_recompute = m_update_pending = true;
 	end_update_and_set_cursor_pos(pos);
 }

--- a/src/emu/debug/dvmemory.h
+++ b/src/emu/debug/dvmemory.h
@@ -63,6 +63,7 @@ public:
 	bool reverse() const { return m_reverse_view; }
 	bool ascii() const { return m_ascii_view; }
 	bool physical() const { return m_no_translation; }
+	bool decimal_addr() const { return m_decimal_addr; }
 	offs_t addressAtCursorPosition(const debug_view_xy& pos) { return get_cursor_pos(pos).m_address; }
 
 	// setters
@@ -72,6 +73,7 @@ public:
 	void set_reverse(bool reverse);
 	void set_ascii(bool reverse);
 	void set_physical(bool physical);
+	void set_decimal_addr(bool decimal);
 
 protected:
 	// view overrides
@@ -115,6 +117,7 @@ private:
 	bool                m_reverse_view;         // reverse-endian view?
 	bool                m_ascii_view;           // display ASCII characters?
 	bool                m_no_translation;       // don't run addresses through the cpu translation hook
+	bool                m_decimal_addr;         // display addresses as decimal numbers
 	bool                m_edit_enabled;         // can modify contents ?
 	offs_t              m_maxaddr;              // (derived) maximum address to display
 	u32                 m_bytes_per_row;        // (derived) number of bytes displayed per line

--- a/src/osd/modules/debugger/qt/memorywindow.cpp
+++ b/src/osd/modules/debugger/qt/memorywindow.cpp
@@ -132,6 +132,12 @@ MemoryWindow::MemoryWindow(running_machine &machine, QWidget *parent) :
 	reverseAct->setShortcut(QKeySequence("Ctrl+R"));
 	connect(reverseAct, &QAction::toggled, this, &MemoryWindow::reverseChanged);
 
+	// Create a decimal addressing radio
+	QAction *decimalAct = new QAction("Decimal Addresses", this);
+	decimalAct->setObjectName("decimal");
+	decimalAct->setCheckable(true);
+	connect(decimalAct, &QAction::toggled, this, &MemoryWindow::decimalChanged);
+
 	// Create increase and decrease bytes-per-line actions
 	QAction *increaseBplAct = new QAction("Increase Bytes Per Line", this);
 	QAction *decreaseBplAct = new QAction("Decrease Bytes Per Line", this);
@@ -147,6 +153,7 @@ MemoryWindow::MemoryWindow(running_machine &machine, QWidget *parent) :
 	optionsMenu->addActions(addressGroup->actions());
 	optionsMenu->addSeparator();
 	optionsMenu->addAction(reverseAct);
+	optionsMenu->addAction(decimalAct);
 	optionsMenu->addSeparator();
 	optionsMenu->addAction(increaseBplAct);
 	optionsMenu->addAction(decreaseBplAct);
@@ -249,6 +256,14 @@ void MemoryWindow::reverseChanged(bool changedTo)
 {
 	debug_view_memory *memView = downcast<debug_view_memory*>(m_memTable->view());
 	memView->set_reverse(changedTo);
+	m_memTable->viewport()->update();
+}
+
+
+void MemoryWindow::decimalChanged(bool changedTo)
+{
+	debug_view_memory *memView = downcast<debug_view_memory*>(m_memTable->view());
+	memView->set_decimal_addr(changedTo);
 	m_memTable->viewport()->update();
 }
 
@@ -394,6 +409,9 @@ void MemoryWindowQtConfig::buildFromQWidget(QWidget *widget)
 	QAction *reverse = window->findChild<QAction *>("reverse");
 	m_reverse = reverse->isChecked();
 
+	QAction *decimal = window->findChild<QAction *>("decimal");
+	m_decimalAddr = decimal->isChecked();
+
 	QActionGroup *addressGroup = window->findChild<QActionGroup*>("addressgroup");
 	if (addressGroup->checkedAction()->text() == "Logical Addresses")
 		m_addressMode = 0;
@@ -429,6 +447,10 @@ void MemoryWindowQtConfig::applyToQWidget(QWidget *widget)
 	if (m_reverse)
 		reverse->trigger();
 
+	QAction *decimal = window->findChild<QAction *>("decimal");
+	if (m_decimalAddr)
+		decimal->trigger();
+
 	QActionGroup *addressGroup = window->findChild<QActionGroup*>("addressgroup");
 	addressGroup->actions()[m_addressMode]->trigger();
 
@@ -442,6 +464,7 @@ void MemoryWindowQtConfig::addToXmlDataNode(util::xml::data_node &node) const
 	WindowQtConfig::addToXmlDataNode(node);
 	node.set_attribute_int("memoryregion", m_memoryRegion);
 	node.set_attribute_int("reverse", m_reverse);
+	node.set_attribute_int("decimaladdr", m_decimalAddr);
 	node.set_attribute_int("addressmode", m_addressMode);
 	node.set_attribute_int("dataformat", m_dataFormat);
 }
@@ -452,6 +475,7 @@ void MemoryWindowQtConfig::recoverFromXmlNode(util::xml::data_node const &node)
 	WindowQtConfig::recoverFromXmlNode(node);
 	m_memoryRegion = node.get_attribute_int("memoryregion", m_memoryRegion);
 	m_reverse = node.get_attribute_int("reverse", m_reverse);
+	m_decimalAddr = node.get_attribute_int("decimaladdr", m_decimalAddr);
 	m_addressMode = node.get_attribute_int("addressmode", m_addressMode);
 	m_dataFormat = node.get_attribute_int("dataformat", m_dataFormat);
 }

--- a/src/osd/modules/debugger/qt/memorywindow.h
+++ b/src/osd/modules/debugger/qt/memorywindow.h
@@ -29,6 +29,7 @@ private slots:
 	void formatChanged(QAction *changedTo);
 	void addressChanged(QAction *changedTo);
 	void reverseChanged(bool changedTo);
+	void decimalChanged(bool changedTo);
 	void increaseBytesPerLine(bool changedTo);
 	void decreaseBytesPerLine(bool checked = false);
 
@@ -78,6 +79,7 @@ public:
 	MemoryWindowQtConfig() :
 		WindowQtConfig(WIN_TYPE_MEMORY),
 		m_reverse(0),
+		m_decimalAddr(0),
 		m_addressMode(0),
 		m_dataFormat(0),
 		m_memoryRegion(0)
@@ -88,6 +90,7 @@ public:
 
 	// Settings
 	int m_reverse;
+	int m_decimalAddr;
 	int m_addressMode;
 	int m_dataFormat;
 	int m_memoryRegion;


### PR DESCRIPTION
The option is currently hooked up only for the QT debugger, but could be added to others easily.