### PR TITLE
nes.xml: more dumps added, more dumps confirmed

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -1031,7 +1031,8 @@ license:CC0
 		<info name="alt_title" value="アフターバーナー ~ After Burner (Box)"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sunsoft4" />
-			<feature name="pcb" value="SUNSOFT-6A" />
+			<feature name="pcb" value="SUNSOFT-4" />
+			<feature name="pcb_model" value="SUNSOFT-6A" />
 			<dataarea name="prg" size="131072">
 				<rom name="mpr-12363" size="131072" crc="88f202f0" sha1="709e2744cf4f7ce43c41ed57ec858128e008f305" offset="00000" />
 			</dataarea>
@@ -26692,6 +26693,7 @@ license:CC0
 		<description>The New Zealand Story (Euro)</description>
 		<year>1991</year>
 		<publisher>Ocean</publisher>
+		<info name="serial" value="NES-38-ESP"/>
 		<info name="serial" value="NES-38-FRA"/>
 		<info name="release" value="19911227"/>
 		<part name="cart" interface="nes_cart">
@@ -27294,7 +27296,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="nobubufu">
+	<software name="nobubufua" cloneof="nobubufu">
 		<description>Nobunaga no Yabou - Bushou Fuuunroku (Jpn)</description>
 		<year>1991</year>
 		<publisher>Koei</publisher>
@@ -28245,7 +28247,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="pachikn3">
+	<software name="pachikn3a" cloneof="pachikn3">
 		<description>Pachio-kun 3 (Jpn)</description>
 		<year>1990</year>
 		<publisher>Coconuts Japan</publisher>
@@ -30203,6 +30205,25 @@ license:CC0
 		</part>
 	</software>
 
+	<software name="rcproam">
+		<description>R.C. Pro-Am (Euro, Rev. A)</description>
+		<year>1988</year>
+		<publisher>Nintendo</publisher>
+		<info name="serial" value="NES-PM-ESP"/>
+		<info name="release" value="19880415"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="sxrom" />
+			<feature name="pcb" value="NES-SEROM" />
+			<feature name="mmc1_type" value="MMC1B2" />
+			<dataarea name="prg" size="32768">
+				<rom name="pal-pm-1 prg" size="32768" crc="2dbddd11" sha1="b619ecf43277af93b5a6c0d62fe6d956cb5a7548" offset="00000" />
+			</dataarea>
+			<dataarea name="chr" size="32768">
+				<rom name="pal-pm-0 chr" size="32768" crc="aa938ec3" sha1="92e111e08c413cfe2a7173362bf6aba745cd96e8" offset="00000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="rcproam2u" cloneof="rcproam2">
 		<description>R.C. Pro-Am II (USA)</description>
 		<year>1992</year>
@@ -30395,6 +30416,25 @@ license:CC0
 			<feature name="mmc1_type" value="MMC1A" />
 			<dataarea name="prg" size="262144">
 				<rom name="nes-re-0 prg" size="262144" crc="928361d4" sha1="dade19bf4163790c4e3615778e574449266c7661" offset="00000" />
+			</dataarea>
+			<dataarea name="chr" size="131072">
+				<rom name="nes-re-0 chr" size="131072" crc="3374191d" sha1="f5dc0ba5bad714281d453b7010983178fb87e36e" offset="00000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="racketat">
+		<description>Racket Attack (Euro)</description>
+		<year>1994</year>
+		<publisher>Jaleco</publisher>
+		<info name="serial" value="NES-RE-ESP"/>
+		<info name="release" value="19940324"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="sxrom" />
+			<feature name="pcb" value="NES-SLROM" />
+			<feature name="mmc1_type" value="MMC1B3" />
+			<dataarea name="prg" size="262144">
+				<rom name="pal-re-0 prg" size="262144" crc="e3f40f20" sha1="81f0f4b2dd106efb134fcb1325ff0afd227fe63b" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="131072">
 				<rom name="nes-re-0 chr" size="131072" crc="3374191d" sha1="f5dc0ba5bad714281d453b7010983178fb87e36e" offset="00000" />
@@ -31034,6 +31074,7 @@ license:CC0
 		<year>1990</year>
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NES-VE-NOE"/>
+		<info name="serial" value="NES-VE-ESP"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
@@ -32343,8 +32384,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="sdsango">
-		<description>SD Sangoku Bushou Retsuden (Jpn)</description>
+	<software name="sdsengo">
+		<description>SD Sengoku Bushou Retsuden (Jpn)</description>
 		<year>1990</year>
 		<publisher>Banpresto</publisher>
 		<info name="serial" value="BAP-X6"/>
@@ -38493,7 +38534,7 @@ license:CC0
 	</software>
 
 	<software name="tecmosbwp" cloneof="tecmosbw">
-		<description>Tecmo Super Bowl (USA, Prototype)</description>
+		<description>Tecmo Super Bowl (USA, prototype)</description>
 		<year>1991</year>
 		<publisher>Tecmo</publisher>
 		<part name="cart" interface="nes_cart">
@@ -38513,12 +38554,12 @@ license:CC0
 			<feature name="u10" value="74HC139AP" />
 			<feature name="batt?" value="BATTERY" />
 			<dataarea name="prg" size="262144">
-			<!-- The PRG split ROMs have to be confirmed -->
-				<rom name="8-27 0 5-20.u1" size="131072" crc="06074289" sha1="7c5b4a7f51eb79458cbe7cb7e77aae4df6eac4f3" offset="0x00000" status="baddump" />    <!-- Actual label: 8/27 0 5:20 -->
-				<rom name="8-27 1 5-20.u2" size="131072" crc="937992d7" sha1="e335b4c2dc3fc21effaa8a12d47677090c8b30c4" offset="0x20000" status="baddump" />    <!-- Actual label: 8/27 1 5:20 -->
+			<!-- Combined CRC matches bootgod yet u1 does not. Error on their end or here? -->
+				<rom name="8-27 0 5-20.u1" size="131072" crc="06074289" sha1="7c5b4a7f51eb79458cbe7cb7e77aae4df6eac4f3" offset="0x00000" status="baddump" /> <!-- Actual label: 8/27 0 5:20 -->
+				<rom name="8-27 1 5-20.u2" size="131072" crc="937992d7" sha1="e335b4c2dc3fc21effaa8a12d47677090c8b30c4" offset="0x20000" /> <!-- Actual label: 8/27 1 5:20 -->
 			</dataarea>
 			<dataarea name="chr" size="131072">
-				<rom name="t.s.b. chr 8-27.u5" size="131072" crc="e5f74c77" sha1="3657693f08c66d2db84bcf62fdd4c439603778f5" offset="00000" />   <!-- Actual label: T.S.B. CHR 8/27 -->
+				<rom name="t.s.b. chr 8-17.u5" size="131072" crc="e5f74c77" sha1="3657693f08c66d2db84bcf62fdd4c439603778f5" offset="00000" /> <!-- Actual label: T.S.B. CHR 8/17 -->
 			</dataarea>
 			<!-- 8k WRAM on cartridge, battery backed up -->
 			<dataarea name="bwram" size="8192">
@@ -41379,6 +41420,23 @@ license:CC0
 			</dataarea>
 			<dataarea name="chr" size="131072">
 				<rom name="0.chr" size="131072" crc="07731c55" sha1="46a40978751326126ee66fbaac618fc29a161cb7" offset="00000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="uwc">
+		<description>UWC (USA, prototype)</description>
+		<year>1989</year>
+		<publisher>Seta</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="uxrom" />
+			<feature name="pcb" value="NES-UNEPROM" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="131072">
+				<rom name="uwc prg" size="131072" crc="55568f0d" sha1="9c993afcd1950d4574784a1dffa0d6edd3e4e773" offset="00000" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
 			</dataarea>
 		</part>
 	</software>
@@ -44497,6 +44555,23 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 		</part>
 	</software>
 
+	<software name="advisln3p" cloneof="advisln3">
+		<description>Adventure Island 3 (Euro, prototype)</description>
+		<year>1992</year>
+		<publisher>Hudson Soft</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="txrom" />
+			<feature name="pcb" value="NES-TLROM" />
+			<feature name="mmc3_type" value="MMC3C" />
+			<dataarea name="prg" size="131072">
+				<rom name="ai3 prg" size="131072" crc="e20190de" sha1="1ea7d4ffa438d4cc186955d2cd51a01b0cdab948" offset="00000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="131072">
+				<rom name="ai3 chr" size="131072" crc="b107d9b0" sha1="0819aeaaf339dbf0b3d3238f5e896fd5ea05e3a4" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="magickdmup" cloneof="magickdm">
 		<description>Disney's Adventures In The Magic Kingdom (USA, Prototype)</description>
 		<year>1992</year>
@@ -46446,6 +46521,28 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
+	<software name="ffantp" cloneof="ffant">
+		<description>Final Fantasy (USA, prototype)</description>
+		<year>1987</year>
+		<publisher>Nintendo</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="sxrom" />
+			<feature name="pcb" value="NES-SNWEPROM" />
+			<feature name="mmc1_type" value="MMC1A" />
+			<dataarea name="prg" size="262144">
+				<rom name="0.ic1" size="131072" crc="efd7cd61" sha1="2481c2533b0e59cab61aff1ef57ebb87ac3e2bb9" offset="0x00000" status="baddump" />
+				<rom name="0.ic2" size="131072" crc="3206a013" sha1="cafc2b61a5184dd930dbac16ec87b882070d24d6" offset="0x20000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="flintj" cloneof="flint">
 		<description>The Flintstones - The Rescue of Dino &amp; Hoppy (Jpn)</description>
 		<year>1992</year>
@@ -47834,7 +47931,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 			<dataarea name="chr" size="8192">
-				<rom name="mahjong (japan.chr" size="8192" crc="e1e96e97" sha1="1dd83c4f5971bde5d2ee33d1232312b1213184b2" offset="00000" status="baddump" />
+				<rom name="mahjong (japan).chr" size="8192" crc="e1e96e97" sha1="1dd83c4f5971bde5d2ee33d1232312b1213184b2" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -48634,6 +48731,32 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
+	<software name="nobubufu">
+		<description>Nobunaga no Yabou - Bushou Fuuunroku (Jpn, Rev. A)</description>
+		<year>1991</year>
+		<publisher>Koei</publisher>
+		<info name="serial" value="KOE-IZ"/>
+		<info name="release" value="19911221"/>
+		<info name="alt_title" value="信長の野望 武将風雲録"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="exrom" />
+			<feature name="pcb" value="HVC-EWROM" />
+			<dataarea name="prg" size="524288">
+				<rom name="koe-iz-1 prg" size="524288" crc="02123025" sha1="dc830651fa796d824e91cc4f7f0da1cca05ff2b0" offset="00000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="262144">
+				<rom name="koe-iz-0 chr" size="262144" crc="5bca457a" sha1="9577bd125828bb76aa70eb91b6d2cb0ca06ade7f" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 32k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="32768">
+				<rom value="0x00" size="32768" offset="0" loadflag="fill" />
+			</dataarea>
+			<!-- 1k Internal RAM in the MMC5 chip (ExRAM) -->
+			<dataarea name="mapper_ram" size="1024">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="nobuseng" cloneof="nobuamb2">
 		<description>Nobunaga no Yabou - Sengoku Gunyuuden (Jpn, rev. A)</description>
 		<year>1990</year>
@@ -48782,6 +48905,30 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<dataarea name="prg" size="32768">
 				<rom name="pac-man (europe).prg" size="16384" crc="6fa1193b" sha1="8fef2bdce0c0be2ece67b26587aa22097ba3c9cf" offset="00000" status="baddump" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pachikn3">
+		<description>Pachio-kun 3 (Jpn, Rev. A)</description>
+		<year>1990</year>
+		<publisher>Coconuts Japan</publisher>
+		<info name="serial" value="CDS-P3"/>
+		<info name="release" value="19901026"/>
+		<info name="alt_title" value="パチ夫くん3 帰ってきたパチ夫くん"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="txrom" />
+			<feature name="pcb" value="HVC-TKROM" />
+			<feature name="mmc3_type" value="MMC3B" />
+			<dataarea name="prg" size="262144">
+				<rom name="pachio-kun 3 (japan) (rev a).prg" size="262144" crc="0dc38898" sha1="f0506561aed8b9a0561cd69f2fa7e095996e7ab2" offset="00000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="131072">
+				<rom name="pachio-kun 3 (japan) (rev a).chr" size="131072" crc="4d63ddae" sha1="9f5182985046e172ebbe3d12d8979fe1398c95fb" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -48998,22 +49145,6 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="rcproam">
-		<description>R.C. Pro-Am (Euro, Rev. A)</description>
-		<year>1988</year>
-		<publisher>Nintendo</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="sxrom" />
-			<feature name="pcb" value="NES-SLROM" />
-			<dataarea name="chr" size="32768">
-				<rom name="r.c. pro-am (europe) (rev a).chr" size="32768" crc="aa938ec3" sha1="92e111e08c413cfe2a7173362bf6aba745cd96e8" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="32768">
-				<rom name="r.c. pro-am (europe) (rev a).prg" size="32768" crc="2dbddd11" sha1="b619ecf43277af93b5a6c0d62fe6d956cb5a7548" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
 <!-- from GoodNES, has CHR -->
 	<software name="racermt2a1" cloneof="racermt2" supported="no">
 		<description>Racermate Challenge 2 (USA, v6.02.002, w/CHR)</description>
@@ -49027,22 +49158,6 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			</dataarea>
 			<dataarea name="prg" size="65536">
 				<rom name="racermate challenger ii v6.02.002 (u).prg" size="65536" crc="3e59e951" sha1="b66382b1ee59a531cd15318aea5d4b965975e13a" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="racketat">
-		<description>Racket Attack (Euro)</description>
-		<year>1988</year>
-		<publisher>Jaleco</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="sxrom" />
-			<feature name="pcb" value="NES-SLROM" />
-			<dataarea name="prg" size="262144">
-				<rom name="racket attack (europe).prg" size="262144" crc="e3f40f20" sha1="81f0f4b2dd106efb134fcb1325ff0afd227fe63b" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="chr" size="131072">
-				<rom name="nes-re-0 chr" size="131072" crc="3374191d" sha1="f5dc0ba5bad714281d453b7010983178fb87e36e" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -49219,7 +49334,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="rockman4" cloneof="megaman4">
-		<description>Rockman 4 - Aratanaru Yabou!! (Jpn) (Rev. A)</description>
+		<description>Rockman 4 - Aratanaru Yabou!! (Jpn, Rev. A)</description>
 		<year>1991</year>
 		<publisher>Capcom</publisher>
 		<info name="serial" value="CAP-4V"/>
@@ -50426,7 +50541,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 	</software>
 
 	<software name="tigerhel">
-		<description>Tiger-Heli (Euro) (Rev. A)</description>
+		<description>Tiger-Heli (Euro, Rev. A)</description>
 		<year>1990</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NES-TI-EEC"/>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Adventure Island 3 (Euro, prototype) [Hidden Palace]
Final Fantasy (USA, prototype) [Hidden Palace, Stephan Reese]
Nobunaga no Yabou - Bushou Fuuunroku (Jpn, Rev. A) [No-Intro]
Pachio-kun 3 (Jpn, Rev. A) [No-Intro]
UWC (USA, prototype) [Hidden Palace, Stephan Reese]

nes.xml:
* UWC info confirmed against PCB photos
* other four additions need info from PCB and/or confirmation of split ROM dumps
* also verified racketat, rcproam against bootgod's DB + minor corrections