### PR TITLE
a800.xml: remove spurious Unicode code point

### DIFF
--- a/hash/a800.xml
+++ b/hash/a800.xml
@@ -1365,7 +1365,7 @@ Compiled by K1W1
 		<description>Turbo Blizzard</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1379,7 +1379,7 @@ Compiled by K1W1
 		<year>199?</year>
 		<publisher>Info-Cell</publisher>
 		<info name="developer" value="Pawel Mironczuk" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1393,7 +1393,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>DOMAIN SOFT</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1407,7 +1407,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>DOMAIN SOFT</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1421,7 +1421,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>ROBOsoft</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1435,7 +1435,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>ROBOsoft</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1449,7 +1449,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>JK Soft</publisher>
 		<info name="developer" value="Bartek Selinger" />
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
@@ -1462,7 +1462,7 @@ Compiled by K1W1
 		<description>Cartridge System Turbo 2000</description>
 		<year>1991</year>
 		<publisher>Bartek Selinger</publisher>
-		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
+		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
 		<part name="cart" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">

--- a/hash/pmd85_cass.xml
+++ b/hash/pmd85_cass.xml
@@ -851,7 +851,7 @@ If the Usage shows a filename of xx, it's because it hasn't been possible to ide
  12 - ZOFKA 2  - korytnaèka Žofka v BASICu (staršia verzia) (v2/v2A/v3)
  11 - ZOFKA2T  - korytnaèka Žofka v BASICu s prikazom pre tlac (v2/v2A/v3)
  42 - Zofka 3  - korytnaèka Žofka v strojovom kóde (v2/v2A/v3). Po nahratí sa spúšta JUMP 0003
-                 (pri PMD 85-3 je treba najprv prejs do režimu kompatibility zadanim JUMP FFF0 v monitore).
+                 (pri PMD 85-3 je treba najprv prejsť do režimu kompatibility zadanim JUMP FFF0 v monitore).
  34 - MRAVEC   - jednoduchý logický jazyk Mravec (v2/v2A/v3)
  52 - T.MRAVEC - jednoduchý logický jazyk Toèi-Mravec (v2/v2A/v3)
 -->


### PR DESCRIPTION
There's a U+009D following "2000" in each line. Is this somehow related to Czech character  ť  i.e. U+0165? ť is 9D in certain character sets and the Turbo 2000 originates there. This looks like a copy/paste error. U+009D is an invisible control char OSC, Operating System Command.