### PR TITLE
es5503: Register E0 bits 0 and 6 are always high

### DIFF
--- a/src/devices/sound/es5503.cpp
+++ b/src/devices/sound/es5503.cpp
@@ -352,7 +352,7 @@ u8 es5503_device::read(offs_t offset)
 					}
 				}
 
-				return retval;
+				return retval | 0x41;
 
 			case 0xe1:  // oscillator enable
 				return oscsenabled<<1;


### PR DESCRIPTION
(This is in preparation for the Ensoniq Mirage driver I will be committing soon)
In the documentation I found on the ES 5503, these bits are always returned hi. This needs to be corrected to make the ISR in the Mirage work correctly.
I don't know if this negatively affects the Apple ][gs. I'll be happy to do some testing, but I would need help getting setup. 