### PR TITLE
mac_hdflop.xml: attach the list and start adding stuff

### DIFF
--- a/hash/mac_hdflop.xml
+++ b/hash/mac_hdflop.xml
@@ -2889,19 +2889,19 @@ license:CC0
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk01.img" size="1474560" crc="04489288" sha1="5d03758fbbfb7761f2545979b9b658c21e493714" />
+				<rom name="macwrite_pro_15v3_disk01.img" size="1474560" crc="04489288" sha1="5d03758fbbfb7761f2545979b9b658c21e493714" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk02.img" size="1474560" crc="1529122b" sha1="7b42da1380233489406f4b30dc2c57af3392e777" />
+				<rom name="macwrite_pro_15v3_disk02.img" size="1474560" crc="1529122b" sha1="7b42da1380233489406f4b30dc2c57af3392e777" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk03.img" size="1474560" crc="9693ecfd" sha1="eaf35fe598f0319d7da035ded83c8d4b2eafd0c4" />
+				<rom name="macwrite_pro_15v3_disk03.img" size="1474560" crc="9693ecfd" sha1="eaf35fe598f0319d7da035ded83c8d4b2eafd0c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2913,13 +2913,13 @@ license:CC0
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk01.img" size="1474560" crc="c7b3a7a3" sha1="3f822f72bf15e301c4590db6090753a698301b3d" />
+				<rom name="macwrite_pro_15v1_disk01.img" size="1474560" crc="c7b3a7a3" sha1="3f822f72bf15e301c4590db6090753a698301b3d" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1474560">
-				<rom name="disk02.img" size="1474560" crc="3faeb185" sha1="bc9bc42e1835cfbf7390e3dd5a95083e888c704e" />
+				<rom name="macwrite_pro_15v1_disk02.img" size="1474560" crc="3faeb185" sha1="bc9bc42e1835cfbf7390e3dd5a95083e888c704e" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/mac_hdflop.xml
+++ b/hash/mac_hdflop.xml
@@ -2018,6 +2018,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- These images are probably extracted from the installation CD -->
 	<software name="sys712lcq" supported="no">
 		<description>System Software 7.1.2 (LC 580/Quadra 630, US English)</description>
 		<year>1994</year>
@@ -2638,8 +2639,8 @@ license:CC0
 	</software>
 
 	<!-- S/N: Z93350-001A -->
-	<software name="clarisw">
-		<description>ClarisWorks (Swedish)</description>
+	<software name="clarisw20sv">
+		<description>ClarisWorks 2.0 (Swedish)</description>
 		<year>1993</year>
 		<publisher>Claris</publisher>
 		<info name="version" value="2.0" />
@@ -2881,24 +2882,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="macwp15v1">
-		<description>MacWrite Pro 1.5v1</description>
-		<year>1993</year>
-		<publisher>Claris</publisher>
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 1" />
-			<dataarea name="flop" size="1474560">
-				<rom name="disk01.img" size="1474560" crc="c7b3a7a3" sha1="3f822f72bf15e301c4590db6090753a698301b3d" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Disk 2" />
-			<dataarea name="flop" size="1474560">
-				<rom name="disk02.img" size="1474560" crc="3faeb185" sha1="bc9bc42e1835cfbf7390e3dd5a95083e888c704e" />
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="macwp15v3">
 		<description>MacWrite Pro 1.5v3</description>
 		<year>1994</year>
@@ -2919,6 +2902,24 @@ license:CC0
 			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1474560">
 				<rom name="disk03.img" size="1474560" crc="9693ecfd" sha1="eaf35fe598f0319d7da035ded83c8d4b2eafd0c4" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="macwp15v1" cloneof="macwp15v3">
+		<description>MacWrite Pro 1.5v1</description>
+		<year>1993</year>
+		<publisher>Claris</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="c7b3a7a3" sha1="3f822f72bf15e301c4590db6090753a698301b3d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="3faeb185" sha1="bc9bc42e1835cfbf7390e3dd5a95083e888c704e" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/mac_hdflop.xml
+++ b/hash/mac_hdflop.xml
@@ -5,8 +5,2640 @@ license:CC0
 -->
 <softwarelist name="mac_hdflop" description="Macintosh High Density Disk images">
 
+<!-- Operating system disks -->
+
+	<software name="htalk71">
+		<description>HangulTalk 7.1</description>
+		<year>1993</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="ba32b4b9" sha1="f879da787acd6e0b69c01bf54ee44b5f0b11b6db" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="aedb3021" sha1="a3f23008a11d2ae049ee3cc24ac47d0fcf2e0202" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="78f8dcb4" sha1="3d3b1cf8b975caee27695e74a32bdfb1fde1929e" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="468dca9f" sha1="01f805449759a9770d46efead1cdca4e87cf9ad3" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts 1.img" size="1474560" crc="afe1e696" sha1="b3418831c590a9ad6c9e407660349cf6755d6712" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts 2.img" size="1474560" crc="b66a008c" sha1="66e124a37db4a2e2ba4f2f12b2603d8f5ad8fc5e" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="2d80558f" sha1="49bf776a4e3de23ea765354abfac10b5335bec7e" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="AppleGothic 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleGothic 1.img" size="1474560" crc="de2119cc" sha1="2b638dc672bb0ebed93268c830cd663b7ae4ad81" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="AppleGothic 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleGothic 2.img" size="1474560" crc="88e9dcff" sha1="568556bb2248f5e9ecd19cf950d9859dc7e542b6" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="AppleGothic 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleGothic 3.img" size="1474560" crc="24f0767e" sha1="918b3408bdd7fd94eb7bff90af9f5ed057fc0fd0" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="AppleMyungjo 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleMyungjo 1.img" size="1474560" crc="10064505" sha1="045abcd16b47ecaf9b8eea047a6aa19a2390f1ad" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="AppleMyungjo 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleMyungjo 2.img" size="1474560" crc="f73e3a27" sha1="3a12f72d7f88fb8973419f928532ff65cef58295" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="AppleMyungjo 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleMyungjo 3.img" size="1474560" crc="f69b2674" sha1="488d87a48b2e75b9ddf4a835f65f49ddda66e576" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="AppleMyungjo 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleMyungjo 4.img" size="1474560" crc="ef2bcedb" sha1="6d2fa2ceaae7b3857567fad0303d0d395d5aa57a" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="6302f466" sha1="4937e6528c1fdb7cc723c12c23f521554fdd1cb0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ktalk75">
+		<description>KanjiTalk 7.5</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install1.img" size="1474560" crc="8763e6b6" sha1="cef15a57afbbcb2c398f8d8dd514e7910b1bf767" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install2.img" size="1474560" crc="e52148e9" sha1="38a2c32649a19cee573baf851fd585c4ea16bcdd" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install3.img" size="1474560" crc="c9cbeaa3" sha1="3b8fbe8704406d2a6f9ed73d1601c0873c204b50" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install4.img" size="1474560" crc="48cfff2c" sha1="c9344d3d48466426fb8567b3b944f54117d3a5cc" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install5.img" size="1474560" crc="a8bebe42" sha1="5b50a9d2840524ee2c1283a95d3f891e59a40668" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install6.img" size="1474560" crc="eaec31bd" sha1="b4e693708a4b0022534fe0a1e3bb46d67070ca57" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install7.img" size="1474560" crc="875c1cff" sha1="33724e276bb0b3694d8afc35bfa9e5a6b7f97876" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="インストール 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="install8.img" size="1474560" crc="7bd300d1" sha1="e75d29f8752ebcb140f78c0689da4d1d241d8e23" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts1.img" size="1474560" crc="b4235d63" sha1="18b7c729c714a44c136ce3261535c402f6044eb4" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts2.img" size="1474560" crc="612cab63" sha1="2ba21bedb2e42b22e2ac65a5bea2157335f31614" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts3.img" size="1474560" crc="a473d615" sha1="d07f24e245e630a9117a6426c8821e9ea1c26b71" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts4.img" size="1474560" crc="640db216" sha1="154e0c8a95ff864123a9b5513c0617453496abc9" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts5.img" size="1474560" crc="6fb915fd" sha1="1b637cecef947d1442e6ac3dbcab661c2ec0cfbd" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts6.img" size="1474560" crc="ebb88eb3" sha1="7a1fc53032fd8abb841bafa009f67e5aa210710f" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts7.img" size="1474560" crc="b8606eac" sha1="c6049e08ba3bb3562adc6a0fa29d2b58490e420b" />
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts8.img" size="1474560" crc="a417bd6b" sha1="3bb55edbd816b6cd18b0647880938f368d841250" />
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts9.img" size="1474560" crc="5010a279" sha1="2e0895b0ca3c0bd361dc92d2bd9d65c3b42948b9" />
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts10.img" size="1474560" crc="c4fb51d5" sha1="58444b6a6496a7bf5ec3f9b1564492c79cb63e5d" />
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="フォント 11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="fonts11.img" size="1474560" crc="78989333" sha1="46cfac96306ec40af4b828d0ecd3b658d91131c8" />
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<feature name="part_id" value="ディスクツール" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disktools.img" size="1474560" crc="7044805c" sha1="0b9df8a48dad944d81176b6662fb6bf9a76dda96" />
+			</dataarea>
+		</part>
+		<part name="flop21" interface="floppy_3_5">
+			<feature name="part_id" value="HyperCard Lite" />
+			<dataarea name="flop" size="1474560">
+				<rom name="hypercard_lite.img" size="1474560" crc="722ec6fd" sha1="ab3f5a0d3287c412e3dd30e1e017e6518708e2ce" />
+			</dataarea>
+		</part>
+		<part name="flop22" interface="floppy_3_5">
+			<feature name="part_id" value="HyperCard Lite 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="hypercard_lite_2.img" size="1474560" crc="ac469289" sha1="a02aafbe6d0f80b6aa23a5bcbbd94df982895e78" />
+			</dataarea>
+		</part>
+		<part name="flop23" interface="floppy_3_5">
+			<feature name="part_id" value="PowerTalk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="powertalk.img" size="1474560" crc="e0b22c95" sha1="b8215a6a734cc1d9bd1d43ea79d3aa642b475c5c" />
+			</dataarea>
+		</part>
+		<part name="flop24" interface="floppy_3_5">
+			<feature name="part_id" value="PowerTalk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="powertalk2.img" size="1474560" crc="499a12da" sha1="5d4d4b5f8eaf79a2a3b7da4a0e8d8dc661726ccf" />
+			</dataarea>
+		</part>
+		<part name="flop25" interface="floppy_3_5">
+			<feature name="part_id" value="QuickDraw GX インストール" />
+			<dataarea name="flop" size="1474560">
+				<rom name="quickdraw_gx_install.img" size="1474560" crc="6ab7442d" sha1="48f89f41ef159a195e97021d1f6a0b5b4ff2368e" />
+			</dataarea>
+		</part>
+		<part name="flop26" interface="floppy_3_5">
+			<feature name="part_id" value="QuickDraw GX 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="quickdraw_gx_1.img" size="1474560" crc="a4239ec9" sha1="742525d2bc7fca925818337e7e91da12a3688c08" />
+			</dataarea>
+		</part>
+		<part name="flop27" interface="floppy_3_5">
+			<feature name="part_id" value="QuickDraw GX 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="quickdraw_gx_2.img" size="1474560" crc="77055b88" sha1="2c771ab722e530d000cd885e70e3c048481d12d7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="macos76es">
+		<description>Mac OS 7.6 (Spanish)</description>
+		<year>1997</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="499462cd" sha1="9da1a1c4debdb658b3e2330680c7ab759055888b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="31534063" sha1="47054f51dbae8aa22aa25fb96043c69c1608ca2f" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="58909c31" sha1="4e95beb7584765eec8eba19f5525a2afb154355e" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="110867f4" sha1="15d5d1d3501aaeaf7a7290d304d7e5552d677392" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="0367a11f" sha1="820f3f0bc1c4e24047d9be0609eddce5866a53c1" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="dca17dc4" sha1="07e7dbce742441c49aeb458a3ac6a134bc6c02ea" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="ba600e48" sha1="1884712df034cbbe0dc744fffb9da275a609a176" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk08.img" size="1474560" crc="d64e6a2a" sha1="19bd2a4f2608bd83deca53c1a4442bf4028d2bba" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk09.img" size="1474560" crc="d09225bb" sha1="719687a5ffe054d88e96b351c8953015fa192825" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk10.img" size="1474560" crc="cffb5553" sha1="fdaa9c17c8335aea61ffd935ba0aa6848277e827" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk11.img" size="1474560" crc="345cfb41" sha1="8e6256299290d6ff43ecbe58c878e64b44e0e1c6" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 12" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk12.img" size="1474560" crc="551a3433" sha1="62262043228ea5a02c1b7d3f723ef7e95d9e8ea3" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 13" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk13.img" size="1474560" crc="545e472d" sha1="2b8fb261f8f89aeef8848bde996247ba4f6f9d2d" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 14" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk14.img" size="1474560" crc="1847813d" sha1="f7429d5c3aa956ddc787197eb6267a9dee267e99" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 15" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk15.img" size="1474560" crc="5496df44" sha1="62a595f78feb6a82b096f1384b39b0ffb4196f17" />
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 16" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk16.img" size="1474560" crc="49df524f" sha1="af040a3cc0b018f24e148c78e9074ecb285646f8" />
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 17" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk17.img" size="1474560" crc="406c1981" sha1="5ccec3bb64fd1881947086c8c06a00e4f666a321" />
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 18" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk18.img" size="1474560" crc="805fe03e" sha1="39853c41516b11ef143cadf0c278ae318621b66d" />
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 19" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk19.img" size="1474560" crc="5e2b9863" sha1="3be5f6f4e271d35caefd0bb1d7e044c7761611bb" />
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<feature name="part_id" value="Utilidades del Instalador" />
+			<dataarea name="flop" size="1474560">
+				<rom name="util.img" size="1474560" crc="4c0d76a9" sha1="afd36d3acb29066c9c192ebc3893a3972142161f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Requires at least a 68040 or PowerPC CPU -->
+	<software name="macos80" supported="no">
+		<description>Mac OS 8.0 (US English)</description>
+		<year>1997</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="cd261720" sha1="ad634189af3002220d1c0ccd90171788b7fce67b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="461f3fab" sha1="d36248fdae8b131d4a6f885ccd70eb01bd6a65f6" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Install 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="0a8e1c62" sha1="7049524983a4d345618586f4e9e728fb62f1b9e4" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Install 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="8c28390f" sha1="d05f0edd82b62f1a4cc087b916782f3a83cf453a" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Install 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="e5e17456" sha1="04ae4626bd8271d9ab749665cf1d1c587729f953" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Install 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="a2d7cafe" sha1="d5252b5858cadc5c906bea6dfadfe19549953124" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Install 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="4f3530e5" sha1="d05ca6dbb8751bbfb580e208ba7ae7f9fba981a0" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Install 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk08.img" size="1474560" crc="17db3abd" sha1="c770e403a277531f2cbd292e5a225a1811b7519b" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Install 9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk09.img" size="1474560" crc="0636dade" sha1="df684eed6aac94357a84be6ac598245364257253" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Install 10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk10.img" size="1474560" crc="5fe9a36b" sha1="42203bae44098b75d3122496707a1646f8f2e6f7" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Install 11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk11.img" size="1474560" crc="3711299a" sha1="f19bf8474c3d4359963788d7e461e271378c4e74" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Install 12" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk12.img" size="1474560" crc="c479c2f2" sha1="4bb359a4744609d14a38f0522d8ce765de99a0c3" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="Install 13" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk13.img" size="1474560" crc="4390c455" sha1="25005fe28fb8e3c3521e53ec1d62e4efc560e7c9" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="Install 14" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk14.img" size="1474560" crc="5581022f" sha1="21c4e61b3be2fb9ea8df98348a03cba8b697990e" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="Install 15" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk15.img" size="1474560" crc="56b3e0c2" sha1="c161e2ba70a2d1728340707befcd8baa14ed6dfd" />
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="Install 16" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk16.img" size="1474560" crc="202b85c5" sha1="c51ddbf59ed0280d1ed6eb8b953cc409377b6b04" />
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="Install 17" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk17.img" size="1474560" crc="40b75f2d" sha1="9f85da2c5a8c5f10ab15cd4a66899ec86e5af071" />
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="Install 18" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk18.img" size="1474560" crc="61a43a48" sha1="9885ec5a24ee1ac6510a8cc9146e83ba905d80ce" />
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="Install 19" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk19.img" size="1474560" crc="1920c00a" sha1="5e45c4e044406efd47403edffc08d483239c2e2f" />
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<feature name="part_id" value="Install 20" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk20.img" size="1474560" crc="3b80685f" sha1="4925ad93ad058e1f4da23c0dc91c8543104efddd" />
+			</dataarea>
+		</part>
+		<part name="flop21" interface="floppy_3_5">
+			<feature name="part_id" value="Install 21" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk21.img" size="1474560" crc="0166bea0" sha1="ddb9cdfbe17747d3627cf9289ba8576d78cb4aaf" />
+			</dataarea>
+		</part>
+		<part name="flop22" interface="floppy_3_5">
+			<feature name="part_id" value="Install 22" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk22.img" size="1474560" crc="4b3d0028" sha1="807bdf6668b009b447a01076b7d811544039abc3" />
+			</dataarea>
+		</part>
+		<part name="flop23" interface="floppy_3_5">
+			<feature name="part_id" value="Install 23" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk23.img" size="1474560" crc="7cb19230" sha1="43646e6dbd9b44091d3e8215ea41e6a7d5b7a80f" />
+			</dataarea>
+		</part>
+		<part name="flop24" interface="floppy_3_5">
+			<feature name="part_id" value="Install 24" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk24.img" size="1474560" crc="51bfcb2b" sha1="29034e044ea1fe0e08ae298af27b982e2664d64e" />
+			</dataarea>
+		</part>
+		<part name="flop25" interface="floppy_3_5">
+			<feature name="part_id" value="Install 25" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk25.img" size="1474560" crc="5ebd8d53" sha1="b61dc1b3700c87f4aeb89871ff0d8428fc9fbcc3" />
+			</dataarea>
+		</part>
+		<part name="flop26" interface="floppy_3_5">
+			<feature name="part_id" value="Install 26" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk26.img" size="1474560" crc="941bee77" sha1="81eaccb3d15c4d5c7d946dbc8683448815907323" />
+			</dataarea>
+		</part>
+		<part name="flop27" interface="floppy_3_5">
+			<feature name="part_id" value="Install 27" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk27.img" size="1474560" crc="1d1a997f" sha1="a1e40fd9f45384826c91ee11eb14d6271f561a06" />
+			</dataarea>
+		</part>
+		<part name="flop28" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="tools1.img" size="1474560" crc="5386767c" sha1="0a2e97e9339ae10517feeb7f17d657b87926d191" />
+			</dataarea>
+		</part>
+		<part name="flop29" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="tool2.img" size="1474560" crc="dbe32599" sha1="08c25057183eeff319b43990abe3c055ca15fe4e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys607">
+		<description>System Software 6.0.7 (US English)</description>
+		<year>1990</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Startup" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Startup.img" size="1474560" crc="d775b2f8" sha1="aa46cffee666ae88d3d1d7ad7bd38a9f895d2168" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="System Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Additions.img" size="1474560" crc="03ad60c5" sha1="93aa0cd79726c4b47cb8e6d171aa36eaf3d7a380" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys607pl">
+		<description>System Software 6.0.7 (Polish)</description>
+		<year>1990</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System startowy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Startup.img" size="1474560" crc="78ca93fb" sha1="7f11533e2e4d3a98632efe911032692177405595" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Dodatki systemowe" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="5c053a21" sha1="80eb9e2d6a66a59fc4062c31598a6246e3977135" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Narzędzia drukowania" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing Tools.img" size="1474560" crc="d67f623f" sha1="44b900851a8b57276139b7775d8b2ab480c2de0d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys607es">
+		<description>System Software 6.0.7 (Spanish)</description>
+		<year>1990</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Sistema" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="eb5a5a55" sha1="161a926f56a43aa87573245e4f51a8193df52f3a" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Adiciones Sistema" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="e060faa4" sha1="2830b38f0d003cb2ad8662fca0a65345e3b86fa7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys608">
+		<description>System Software 6.0.8 (US English)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Startup" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Startup.img" size="1474560" crc="072e70d0" sha1="0a434f4f10e639798de5ec2f2e6158896d35369c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="System Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Additions.img" size="1474560" crc="a2131b7c" sha1="5a6542a6fe7859c9f60807831117e83526537fae" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys608int">
+		<description>System Software 6.0.8 (International English)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Startup" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Z-690-5830-B (Startup).img" size="1474560" crc="497edc40" sha1="e09c4660176ce430a862c215e56cdb464e5820c9" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="System Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Z-690-5831-B (Additions).img" size="1474560" crc="f9550fd1" sha1="2c0bbbdd232385b4a0fc556d812adaf4b54c5315" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys608l">
+		<description>System Software 6.0.8L (US English)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Startup" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Startup.img" size="1474560" crc="52de5a12" sha1="5c2aacbd6556d8965ac2d59e4b14fe8198565064" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+		<feature name="part_id" value="System Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Additions.img" size="1474560" crc="e6a1cdc7" sha1="b8447e06e4dee8740e48b93eba9bfdde4c94f0ea" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys70">
+		<description>System Software 7.0 (US English)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="45bd390f" sha1="48b0217e48aa9092dafcbc093e1f107c398c696c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="402a7287" sha1="0e651cb021b87578a9f35980926238e6352d8224" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="77a7efc5" sha1="50cb80322c7fc13399dbcb4270b4692ebca028aa" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="6d5260f8" sha1="8291b6f2a6fa8682fec8ed09a1289fe7d11981d8" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="02a0a20d" sha1="408ad04578edb7e485614bdc9d74ab6bc47dbf3b" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+		<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="461c1408" sha1="0e7f8b491b08f7d0037fd9bf9d56c7b7299ee27b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys701">
+		<description>System Software 7.0.1 (US English)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="f0d0b58a" sha1="783928b63f329dbf1a3cda97680a377f4330fc70" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="43d8208d" sha1="4590fe1615c362cc6317a65b88475f1779b1f57e" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="e6f037aa" sha1="7b6d19525b974e1f088ccf4a8f03b07c94deec9e" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="c2176833" sha1="3ade5ab74e474d4c066c6d547408dd3f2823df97" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="74f3cc4d" sha1="cf2538659854a601260e5c78970a736927607760" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="9c98ef38" sha1="346952bfdb86214d6da491651d4df7ac3a93f314" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys701el">
+		<description>System Software 7.0.1 (Greek)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Εγκατάσταση 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="ee167e0f" sha1="21a26c2059c8d87019477b839cbaedd9eeac5479" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Εγκατάσταση 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="dbd93ab7" sha1="a40c2cde9e791dc73c7c5f065903ac3a7f154538" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Γραμματοσειρές" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="6fbb14e7" sha1="d855f6d1cc3051f8915d31992e2c4b7665043aa1" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Εκτυπωτες" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="7fc991fa" sha1="40bfb598845e2d1e931fed99308ecfc313d9694d" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Διάφορα" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="7692c8b2" sha1="666aef220923619271ffced9fe55f38801588ebe" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Εργαλεία Δίσκων" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="a10e5720" sha1="ecfde78348eda1bbe486db44a577045afd3fdf68" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys701it">
+		<description>System Software 7.0.1 (Italian)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installazione 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Installation 1.img" size="1474560" crc="43b662bd" sha1="ae4852a5ced0213c7eb81acc707a9121586381cd" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installazione 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Installation 2.img" size="1474560" crc="888f3425" sha1="e91b58c13bbc0f037d3c68f9fda666d0c9a41b06" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Caratteri" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="f8b62568" sha1="afb2a3aa317ac66a3e2bdc6cdaaa9211ab69a8a1" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Risorse di Stampa" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="2bb308f0" sha1="7e28836a699e6f7ad755cee6eaf1832728b4a22f" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Risorse 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="ce51fa2d" sha1="08fac837a1b7a1ea60e29f5fa27da2c60ae9a170" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilities" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utilities.img" size="1474560" crc="281efbd8" sha1="c33e38fe1233019ef465fd713fa668a3b264f1c7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys701pl">
+		<description>System Software 7.0.1 (Polish)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Instalacja 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="cb62d00c" sha1="b5fe3311dec216d1341fd119c1c8e733205f50bb" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Instalacja 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="2389b0ba" sha1="bf50247160282c39a1cc4c64a00eef3242ae7fe1" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Czcionki" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="13f5e527" sha1="5a9908070e28f5b0e65cac856b415edd62be6e99" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Drukowanie" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printers.img" size="1474560" crc="5e691eec" sha1="75044a3de1e94bc3926c59320070384c189388eb" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Okruchy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="a17c5058" sha1="bf9a3ba1aaaa4ab7ae10e3589e334560f0928091" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Narzędzia Dyskowe" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="6b347c57" sha1="6add1995657d188448f40c29972cbb92a77e1a37" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys701pt">
+		<description>System Software 7.0.1 (Portuguese)</description>
+		<year>1991</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Instalação 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="f3b07410" sha1="461fb18cc227a809e158344540cdc7e742dadf50" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Instalação 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="0e1c4257" sha1="fa1affba732b885cb9e632a4babab98a790d23be" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Tipos" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="7c26c885" sha1="7e34b83fd382b8c0f61aa80e66005f6667542b55" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Impressoras" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="c03f177a" sha1="187ce15fb6b8547b2f01a1c0e456d63709c09c47" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Recursos" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="441fd18f" sha1="557b51c132b330467d7283f8bb4880f59af08cc3" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilitários" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="198912fc" sha1="24e08363a3d2c3d9c6246c89893bb5585a23b9f5" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Optimizador para Sistema 7" />
+			<dataarea name="flop" size="819200">
+				<rom name="Optimizer.img" size="819200" crc="e278a7a5" sha1="394d525cbe4699ec4eaee664226c8ed3705edc8a" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys7011el">
+		<description>System Software 7.0.1.1 (Greek)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Εγκατάσταση 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="4108bc03" sha1="6ee6e886e7e8e5c17a1ab2b4bedb8a3a06b65d95" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Εγκατάσταση 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="3924c674" sha1="519c3cc7cd2bdaba54cb21fc49c1c0a453020ae1" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Γραμματοσειρές" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="e4584bbd" sha1="96821defa4f354f2bb2d01ed6ec421583df76b7b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Εκτυπωτες" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="ae606d9c" sha1="c7d29f1d480d48c469d0282dc5da8fd8f40ead96" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Διάφορα" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="4d2fbe30" sha1="98ef4ca797e745a46e9cbb19536db7c08acd2845" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Εργαλεία Δίσκων" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="b0bfa884" sha1="7f36e965d05292fc397d8e4c627c048302d8ebfa" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys704sv">
+		<description>System Software 7.0.4 (Swedish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Installation 1 (S690-0237-A).img" size="1474560" crc="e80d99a4" sha1="361d8a5a884fb02bf8577bc384c58518a4945ed1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Installation 2 (S690-0238-A).img" size="1474560" crc="415908e6" sha1="53d13b604c669d10a971813bc8e0e1f3f46b4e42" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Typsnitt" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts (S690-0243-A).img" size="1474560" crc="65b5a362" sha1="b28e138131c12815876ec1569fda7e37292b8660" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Skrivardrivrutiner" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing (S690-0242-A).img" size="1474560" crc="79d8135d" sha1="d081f34fa8f4cd615ce7170aa79f8e19fd397d07" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Tillbehör" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tillbehor (S690-0244-A).img" size="1474560" crc="f8be7ca5" sha1="6118354edf5fd232764e9e86d3c3aad3780f446b" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Startskivas först (LC III)" />
+			<dataarea name="flop" size="1474560">
+				<rom name="LCIII-Install Me First (S690-0347-A).img" size="1474560" crc="51b746ce" sha1="c62e8b95d6e4477ec8ec01d35c7b1be94439825a" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="QuickTime" />
+			<dataarea name="flop" size="1474560">
+				<rom name="QuickTime (S690-0325-A).img" size="1474560" crc="3ced73a6" sha1="03e7a3510e1ef74ddd3af4dc793384e072896fdb" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Verktyg" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools (S690-0348-A).img" size="1474560" crc="66e59f47" sha1="d49b8d34fcf008688e3cf69a45197ee392a43948" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Välkommen" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Macintosh Basics (S690-6055-A).img" size="1474560" crc="e49038f7" sha1="ae0ac6d46e4c8bb9213ee55570561b7d27ef7a4e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71">
+		<description>System Software 7.1 (US English)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="893c700f" sha1="c700224afeda6794a9c4fc12314677fad7ee82f3" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="1b11422b" sha1="2077f368b6046d2df9a535c1080cd63010e82a95" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="fdf567db" sha1="a1bcc7994750d2dceeb02b68554a7e6f03c10809" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="f41e1976" sha1="d2e445980568260f1c431457251e40bbb807766d" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="4a9a7cb8" sha1="34f9ec9fc9b7cc28fe145f836bca99e85b654c41" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="0acbc910" sha1="541fb18a648df79f82348859a6139d94fa35bb66" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71b7">
+		<description>System Software 7.1b7 (beta, US English)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="5aa7c894" sha1="9b8a17d5a686c7d09c8a6766b414748396400132" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="eb97ba50" sha1="1b86f3e05d6f8f5313b055ba2b06ce2741f43e6e" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="5c8a1210" sha1="4496053d38a88cf73deabf53ca00fc617b1774da" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="f2632a94" sha1="3d60585b18b94d3d8e3f06e11f2e47a4356b4a22" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="987b2c49" sha1="fe6cd8e17037e5d903329642a01ba33a4956f5f3" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="d69337c1" sha1="4504095e62525cdbdcd63e35b6dc979d7fd1a927" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="QuickTime Extension" />
+			<dataarea name="flop" size="819200">
+				<rom name="QuickTime Extension.img" size="819200" crc="9f0adb0f" sha1="cabd7cd65986e609d415be9a1904e342977a3cfb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71da">
+		<description>System Software 7.1 (Danish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installering, 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="bd0714b9" sha1="56a63ddd0dd41946da6ff304d02cfc91614a7bd1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installering, 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="6b3baca4" sha1="3367114922a7597215bfd36211ba2a501a40c63b" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Hjælpefunktioner, 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="062c08e5" sha1="b6c042cdf56a30fd6c5ad2ef284cd88027911930" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Hjælpefunktioner, 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="05d7f2e5" sha1="b5df07868aff63a08b11119b52964d454e689573" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Printerarkiver" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="e587d4c1" sha1="7d305ede046cf822d03126797d225ec09a277659" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Skrifter" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="2c5250d1" sha1="9f9bfbc81aee24962f9748dc708766f5f543cd24" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71nl">
+		<description>System Software 7.1 (Dutch)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installatie 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="5f4c0121" sha1="819d1a9b35630fb83bcba7130211d7594e2c9041" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installatie 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="d34d8748" sha1="572988062b0cf5ae7836104309519dff318395fd" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Schijfbeheer" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="ec538518" sha1="8ff51ad4fec0e1a263c0f95b9e51300bd46880f8" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Diversen" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="fe59025e" sha1="4ec55c190982bd96209a9beec7249ddc7357c97c" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Lettertypen" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="36f59057" sha1="59b3baecfbf7ebf7d16b0121e562a697b6ee5ec8" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Printers" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="b313371f" sha1="418822cebcf6c86aa48b20dda993ac98cae90911" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71fi">
+		<description>System Software 7.1 (Finnish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Asennus 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="a37fd350" sha1="dcef51ae3a5f7cb66a3872fafb8b1d7cd650b0c0" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Asennus 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="e71b97f2" sha1="09e47c1bea2afd23f5097d18eddc3ae53cb16a40" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Kirjasimet" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="58e1467c" sha1="09a2d873393822a3b0f1a01226c155370001e82a" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Kirjoittimet" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="92785995" sha1="e880fc69aa80277521674583a8fad5c79d54d62f" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Apuohjelmat" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="3dbcfc1e" sha1="cec2caecceacb2ef0e3deaf7bdfc15421a6a9e3c" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Levytyökalut" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Tools.img" size="1474560" crc="4dbf5307" sha1="e44a8f377b37f4e61624c19edc70c638ed9b3879" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71fr">
+		<description>System Software 7.1 (French)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="c1e5d5ff" sha1="fa0eabf1cc08ec3c016e6d11e65e4ee8d1efc7e6" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="48b501d2" sha1="346834eacbf343d03bb9247beaa4b0fc52d108ab" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Polices" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="44fba020" sha1="b66db4aeae951e4fb76cad657163143968866d75" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Imprimantes" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printers.img" size="1474560" crc="d5cd8f20" sha1="8a38c0862daf18a64d4d373d8f1ae50afe20801d" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Utilitaires 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utils 1.img" size="1474560" crc="ece8e916" sha1="b982900f04a77e09a05b0c6bc822b3c1f68bb346" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilitaires 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utils 2.img" size="1474560" crc="ce8059a5" sha1="df3c6003aa057eb2e432f85b52afd939333ec269" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71frc">
+		<description>System Software 7.1 (Canadian French)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="f0e896bf" sha1="e330d687a9a66e166fb1d30cb2ea53b73ae229ab" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="0be65da6" sha1="fa55eed3567f1b94798f8cfd342681bebecce581" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Polices" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="93c33566" sha1="fb0699043a0e0beae2cc63dcbf033bb44049c850" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Imprimantes" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printers.img" size="1474560" crc="d46ef314" sha1="8e9c38c3cf9d399b0eb69643a0e13e7891c2b54c" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Utilitaires 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utils 1.img" size="1474560" crc="1da5168e" sha1="c04e69b700b8c4575df390db98c70112cbe858f1" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilitaires 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utils 2.img" size="1474560" crc="52729229" sha1="3c265e607b2d9a84dd0f212f4dc0d8e15aed310c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71de">
+		<description>System Software 7.1 (German)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install1.img" size="1474560" crc="717e9ecf" sha1="5335f67478f7602c2f3f787cf268a6a445945068" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installation 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install2.img" size="1474560" crc="09af41b9" sha1="be98af77537c8694fd16fbe0251ebbf935c2426a" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Zeichensätze" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="f00db37c" sha1="b036954a3b248c1a8c0f69ef56e7dbff1f3258cf" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Druckerdiskette" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="011a1e3a" sha1="b7f182dea6907ec8981b487afca97ddd295df6d4" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Hilfsprogramme" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="804e1eab" sha1="d43d05933470dccb44504dd9f87c8f66e46c439e" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Dienstprogramme" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="2f1ce28d" sha1="18e5f87a4bbabc3a3f214362b26de4fa07b82fc1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71it">
+		<description>System Software 7.1 (Italian)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installazione 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="9b8d95d1" sha1="62ab22f62c1e61d14c6a9e6a32f0bdeb7c884bd2" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installazione 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="8043b09f" sha1="08e7902736bcdea024b9e92bc448af8155fcd5f4" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Caratteri" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="8d964137" sha1="b5c7b882eebcaf31f6fa55bdbfb1b14a5a0c704d" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Risorse di Stampa" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="61b0ce0c" sha1="01e63317c10134f6a5acd641b0b65479715faf34" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Risorse 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="f56eae54" sha1="848d33158ef0a901636c8872b2bd305ce5491608" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilities" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="aac7c168" sha1="51384680769c4d231989f896808f978cac9c41c3" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71no">
+		<description>System Software 7.1 (Norwegian)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installering 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="f6d6c0bf" sha1="577615d0821fc688ecacf6d1e96ddfbd71b0286c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Installering 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="b22d9b30" sha1="293bd74065ba284655bd8a0523a301ae2320f325" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fonter" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="a4a848a8" sha1="a7f68a2f801105a0342aa199bc4062ad054d94a0" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Skriververktøy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="b05e9498" sha1="fac3319dc7971e8462bb3e97869010f1fabfa18a" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Verktøydiskett 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits 1.img" size="1474560" crc="345619bb" sha1="92189df07d4a63fc35ad2f98ffca479d69ed8aed" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Verktøydiskett 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits 2.img" size="1474560" crc="6e7c88a0" sha1="b3d4d4c7a0438bbca838ef6e2e16e929e88fe64f" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Installer først" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="a0d2eed8" sha1="5eee9bffa8692683bcb05e082eadaa584eb51ba1" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71pl">
+		<description>System Software 7.1 (Polish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Instalacja" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="5d0f4b28" sha1="11d71d856e98eb2c809df6613650e76c298facb5" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Instalacja 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="6f528974" sha1="6d88337aafa3bf63fb53bc038742e56f318a9460" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Czcionki" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonrts.img" size="1474560" crc="6688ffe8" sha1="9b5d572e26321d8ca3ae2005c82796a17138e0dc" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Drukowanie" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="961226cb" sha1="f4532a7ca8b38156cd76c5f33728459ff2cec98e" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Okruchy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="4c33fa51" sha1="6b3dbc8e3823380f1d2c503c20de1e951c3fca8d" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Narzędzia Dyskowe" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="95cb70f6" sha1="fee0b9003354389f086bb7d4fcbfcfc15d9f4697" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71ru">
+		<description>System Software 7.1 (Russian)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Установка 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="36238f19" sha1="cf82255cc3c327b5395f7f11a9f562577abae299" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Установка 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="d8163382" sha1="9b6aa78c6fceda555a34df21d2e0085b242881ee" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Шрифты 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts 1.img" size="1474560" crc="3077855c" sha1="892bc3b013af0d1166199c252d8ceb7ca1e5239b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Шрифты 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts 2.img" size="1474560" crc="a039daf8" sha1="13d2c86a38c061bf12d54260e4a69bac4db14b76" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Принтеры" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="e09f5414" sha1="317e4234063014a6bbed6c76ed5711e4f9b5793b" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Утилиты" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="9b217572" sha1="c01cb77443570ce16afde4c111b776755799d879" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Дисковые утилиты" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="d9c2ab7f" sha1="018b59a1ddea49785a8523f1c1b510ca009674c0" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71es">
+		<description>System Software 7.1 (Spanish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="637ccdb2" sha1="26a6f74b368156a678f795e32f144f40b756e42e" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Instalación 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="4efcedbe" sha1="cabb57621c545ce68353069122c4791f409061f5" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Tipos" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="7c4094d8" sha1="ad195188d71bf6415731e9c6396e8b9a19fb309a" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Impresoras" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="9cea26f2" sha1="9d68adfde026e792a05de33caff78871526c57e0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Utilidades 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="1a29c66c" sha1="2c08549bfb5c08e82adbb499327a97141d2f4f9d" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilidades 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="bbc3bb63" sha1="fcc3c7cc5d6e03761da0185743f18ecd5da73d68" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71th">
+		<description>System Software 7.1 (Thai)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="81397e19" sha1="534e07777ab308cf865ac47d5271a038e3d63243" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="90f8248c" sha1="2fa9767f086afb68c95938a61d0a97a36a084c19" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="a10ead7b" sha1="46b79ea3a706953fde7eecddb8cc115f5469987b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="1ca9e9d5" sha1="897b36333c7950a78cb7ca7ffd05b5ce18abacb1" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="b9d6cb91" sha1="e5291e0cd4ef31a77f88e2bb48fe26917ec638b9" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="473750a6" sha1="620ff988bc09f949fb74e61aa9e738ce9397181f" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="2a81a4bb" sha1="332a80590e629ac4bb541ec5b0493e7b9285462c" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71tr">
+		<description>System Software 7.1 (Turkish)</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Yükle 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="05c7f250" sha1="cd89c8a2de6f989b3c344ce81a084892a31b0ade" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Yükle 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="82377a0a" sha1="82e507abf4c54facc42e1d0305920f2bdbb30ba2" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Fontlar" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="90749250" sha1="ac15627fd37d399ccd4c6ae75f3b08daef9525db" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Baskı Araçları" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="06f54a69" sha1="8c11df9b0d57d40aad6af2ce90029b99e1df5469" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Ekler" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="937bcad4" sha1="2f392e33cc8fd649492cec06aa69d0cf8ab4cb11" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Araçları" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Tools.img" size="1474560" crc="862fcc25" sha1="e1b55f0fa643b6f231d1d768459dcfea89efcafe" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys71zhs">
+		<description>System Software 7.1 (Simplified Chinese)</description>
+		<year>1993</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="安装一" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 1.img" size="1474560" crc="34e1ecf1" sha1="9a78d55419deb6f0bb65ec025fe06c11eeb5805f" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="安装二" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="b509470e" sha1="9e1ddce64b7bae031df0d6e50bcdd2e82679dd5b" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="系统磁盘一" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="d925fca3" sha1="278d66e1395adecc5039e823ac7cd177d936562c" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="系统磁盘二" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="04d7e8d3" sha1="73423b6747ab5ae59d575a3e7b9ee2feb283e69d" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="字体磁盘" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="6adee5c4" sha1="3f2955d9d5fd2bc789cc3a32ae12ffffd4da3b80" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 1.img" size="1474560" crc="51f10cdb" sha1="a8178a3ad99ff6a6d75a13866fc37f79b3a2079c" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 2.img" size="1474560" crc="7bd03533" sha1="85f52614c0c8a53aea482d9e585cf3db5d741561" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 3.img" size="1474560" crc="f100aa89" sha1="4a6f36c88317713ac576446376d6f3657d534081" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 4.img" size="1474560" crc="ec255d91" sha1="017e6857afce42964a81397de948fb1f07e7528d" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 5.img" size="1474560" crc="fda1ff46" sha1="5addc273045c811d62435c23bf53adca423648d3" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 6.img" size="1474560" crc="ad061a07" sha1="a4e18718bbec53d47cd4438b4aceb5e192ba6b4e" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 7.img" size="1474560" crc="55932801" sha1="aff5c5d2be437f25de20255426faca89d94981d7" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 8.img" size="1474560" crc="3da9eb4b" sha1="a6006022eb2cd9094875f01e2d1509f335fa7720" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 9.img" size="1474560" crc="a26d84cb" sha1="237c7bfa2bceda9173069af262a9cbb2f6107b4d" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 10.img" size="1474560" crc="1dcf7aa7" sha1="9df052adba5e06bd4a9519d09479a0c71e969f34" />
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 11.img" size="1474560" crc="18ec7e16" sha1="402d6d6ecee9adf5e3e42e900c5da35de38a7641" />
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘12" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 12.img" size="1474560" crc="b4892f5a" sha1="551830fc9e344b198a218eebd954021158985d4b" />
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘13" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 13.img" size="1474560" crc="c1c423f1" sha1="64099b9948e79b47be0310e9576f40229f51bf13" />
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘14" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 14.img" size="1474560" crc="642eb22d" sha1="23ee5b1880cdadd812a0659846c37f58848994ef" />
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘15" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 15.img" size="1474560" crc="1cea17a9" sha1="0d3b0fa60dee54b3b135db99f53de7b91dd0cb76" />
+			</dataarea>
+		</part>
+		<part name="flop21" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘16" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 16.img" size="1474560" crc="a2be5d6a" sha1="69c6bf51caf6c9c9ad92159947ddfee0dd194a11" />
+			</dataarea>
+		</part>
+		<part name="flop22" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘17" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 17.img" size="1474560" crc="7d281ba4" sha1="0b4f187518f30aed3238127073fddc8dbd2cda8e" />
+			</dataarea>
+		</part>
+		<part name="flop23" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘18" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 18.img" size="1474560" crc="d9c81633" sha1="c02535ec3b403f6c2b76822b03885a965dc82c93" />
+			</dataarea>
+		</part>
+		<part name="flop24" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘19" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 19.img" size="1474560" crc="b5c85f8f" sha1="c2dca6f0a6b1963c1f734a13dab002340854a6de" />
+			</dataarea>
+		</part>
+		<part name="flop25" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘20" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 20.img" size="1474560" crc="9cca1a25" sha1="f8bc536bb9818b3d40403417fb0e45c50a1430e7" />
+			</dataarea>
+		</part>
+		<part name="flop26" interface="floppy_3_5">
+			<feature name="part_id" value="中文字盘21" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Chinese Fonts 21.img" size="1474560" crc="19ab8f81" sha1="a25c6c1f5dccec639123c49e9cd8873ac3975e07" />
+			</dataarea>
+		</part>
+		<part name="flop27" interface="floppy_3_5">
+			<feature name="part_id" value="请先安装" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="867571ff" sha1="fe674a4b084e42e18be2082a8282b3c97958a74b" />
+			</dataarea>
+		</part>
+		<part name="flop28" interface="floppy_3_5">
+			<feature name="part_id" value="工具磁盘一" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools 1.img" size="1474560" crc="56d482c0" sha1="266c45e5583170f2fca3b5023bffc20a8c48c853" />
+			</dataarea>
+		</part>
+		<part name="flop29" interface="floppy_3_5">
+			<feature name="part_id" value="工具磁盘二" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools 2.img" size="1474560" crc="31d931f0" sha1="0699c9b3bb2898f9f23579b3cb08a3f2bf428449" />
+			</dataarea>
+		</part>
+		<part name="flop30" interface="floppy_3_5">
+			<feature name="part_id" value="特殊工具磁盘一" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Disk Tools 1.img" size="1474560" crc="d3949208" sha1="1297b3e8b0940fb5c89c627c369945612e7dbf72" />
+			</dataarea>
+		</part>
+		<part name="flop31" interface="floppy_3_5">
+			<feature name="part_id" value="特殊工具磁盘二" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Disk Tools 2.img" size="1474560" crc="8041389f" sha1="3030235c51e8c55b93b6b23d39d7b5596cdb81dc" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys711">
+		<description>System Software 7.1.1 (US English)</description>
+		<year>1993</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="097d5762" sha1="c328dfe17478fd765208db328a2b61dad05c3a83" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 2.img" size="1474560" crc="80326cf4" sha1="d8d6abfd5b4a00258c59a7a944ffee6aca846ca4" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Install 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 3.img" size="1474560" crc="400574b3" sha1="6d19da238c68462e55818fd68d2947080ac2c575" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Tidbits" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Tidbits.img" size="1474560" crc="8b74a1bd" sha1="ce1bc5f0b5281b0bf62ac6666054cb566eb4eb85" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Printing" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="e211f37c" sha1="e17b43814173132bead138f740549fc7cd051c3f" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="498cca4e" sha1="df73ae16c7bd5a6b493a481f57d0839546f48fef" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="PowerTalk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="PowerTalk.img" size="1474560" crc="bd60f5eb" sha1="339b08c9b33ec8a1ceb45b0b117d22817f047fa9" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="PowerTalk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="PowerTalk 2.img" size="1474560" crc="df5e11b8" sha1="eff9fb985e3c8afeb99cc83d5fc8562eca435fd3" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="QuickTime" />
+			<dataarea name="flop" size="1474560">
+				<rom name="QuickTime.img" size="1474560" crc="87d834dc" sha1="ad04cd8325b3b2da1caddc2635162736418a188e" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="AppleScript Setup" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AppleScript Setup.img" size="1474560" crc="2a049c49" sha1="8f9d9946e005bc1abe37636156827b6af74571fb" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Before You Install" />
+			<dataarea name="flop" size="819200">
+				<rom name="Before You Install.img" size="819200" crc="f6d55a1c" sha1="81906cd5519f02a1ae4d9c074bd432a2f869edfc" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="23adcd0f" sha1="5f81b98c6adb47c05d5e16fc5f8c84c5a2dfcb34" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys711pb150" supported="no">
+		<description>System Software 7.1.1 (PowerBook 150, US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="977805c8" sha1="5171b008ec41954d3e0204ce2e4522f4d60defa2" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="3ed3c068" sha1="48aa1362943a775f00e54e9ee05a773f563e6406" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Goodies" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="1f6c79e0" sha1="f2e8ab8b0fc337bebd44eb242237db1a060a0edf" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing &amp; Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing And Fonts.img" size="1474560" crc="7758c49a" sha1="1456129ffddf67aebd100812e89f16088ba80d15" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="b7d59e65" sha1="eb6a41f97c762d423a3c0b77e11a340bfaeff5df" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Utilities" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Utilities.img" size="1474560" crc="3cadd68a" sha1="1ecef7d3a19cf44dc8942faeb70c2653aee3ee2b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys712lcq" supported="no">
+		<description>System Software 7.1.2 (LC 580/Quadra 630, US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="20401dee" sha1="7d9a909f8d7022c42166d48ed40a77917692e7d6" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="24d63656" sha1="fa77a895152bdf3049fbd7a020d3a0c8b6758dd6" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Goodies" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="1f6c79e0" sha1="f2e8ab8b0fc337bebd44eb242237db1a060a0edf" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing &amp; Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing and Fonts.img" size="1474560" crc="7758c49a" sha1="1456129ffddf67aebd100812e89f16088ba80d15" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="0dac31ce" sha1="7767056ca0d053d4049520af29aa373fb8e32668" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys712pm" supported="no">
+		<description>System Software 7.1.2 (Power Macintosh, US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="c565d14d" sha1="15b8251041faa9ae41055c3a912f02ec31a2ea0b" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="38440c0b" sha1="50ce41d3efef3f280437cedcd62c6f95b7ecd502" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Goodies" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="1f6c79e0" sha1="f2e8ab8b0fc337bebd44eb242237db1a060a0edf" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing &amp; Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing and Fonts.img" size="1474560" crc="7758c49a" sha1="1456129ffddf67aebd100812e89f16088ba80d15" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="65dacd2b" sha1="45bd87843bb84e12a7e2a20ac03f42e8a3687689" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys712pmde" supported="no">
+		<description>System Software 7.1.2 (Power Macintosh, German)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Spezial Installation" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Me First.img" size="1474560" crc="0e0d29c6" sha1="3dd1103ecbf4990c5d9ee61bc2616a4d86b49a91" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Dienstprogramme" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="cc4112be" sha1="75929eb121b4ab3cdb78e5ba871711f90ba16e70" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Systemzusätze 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="a705d58a" sha1="8c7bc833a11cbf79b4f0163c1bf09a2f510a054b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Drucker und Zeichensätze" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing and Fonts.img" size="1474560" crc="4b7ac5aa" sha1="197f892aa357770e73b9d28af2ebe82979cad4b2" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Systemzusätze 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="861eeb69" sha1="93cae4e6de62d7eaa761d1e74a30b39166657e04" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys712qd" supported="no">
+		<description>System Software 7.1.2 (Quadra, US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Me First" />
+			<dataarea name="flop" size="1474560">
+				<rom name="InstallMeFirst.img" size="1474560" crc="403419f2" sha1="65316e24d8f9da0cfe48a6a7cb2487be93413624" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools.img" size="1474560" crc="24d63656" sha1="fa77a895152bdf3049fbd7a020d3a0c8b6758dd6" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Goodies" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="1f6c79e0" sha1="f2e8ab8b0fc337bebd44eb242237db1a060a0edf" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Printing &amp; Fonts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing and Fonts.img" size="1474560" crc="7758c49a" sha1="1456129ffddf67aebd100812e89f16088ba80d15" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Additions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="0dac31ce" sha1="7767056ca0d053d4049520af29aa373fb8e32668" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys712pmcz" supported="no">
+		<description>System Software 7.1.2 (Power Macintosh, Czech)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Začátek instalace" />
+			<dataarea name="flop" size="1474560">
+				<rom name="IMF.img" size="1474560" crc="c59a3e5f" sha1="5e35c9bbea3f8c59c6c568bc089c310e4336891f" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Tiskové nástroje" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Printing.img" size="1474560" crc="655d04fe" sha1="8bd384ca97672f8b9fa358d5aff56e786e8a4894" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Písma" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Fonts.img" size="1474560" crc="5b06ca82" sha1="1debfc2a09cdde24214bfcd715f6267865953ca2" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Přídavky" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Goodies.img" size="1474560" crc="3adf57f1" sha1="0fd5ab83bec908d50d8f56be8c56404a4d8f23c3" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Instalace 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Additions.img" size="1474560" crc="8da5b1d5" sha1="3ee6d3e17a660efebdac7d25feec7b816f0b017b" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Různé" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Extras.img" size="1474560" crc="0e6bc130" sha1="a937409bf2f0f2c66b814cb3655cc52022eb7e40" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Různé 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Extras2.img" size="1474560" crc="7a491fd5" sha1="507b7407c8eff5c97c9170674a64d32745a3b5b9" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Macintosh - základy" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Demo.img" size="1474560" crc="fc6b6e91" sha1="8780b05f8ae9870ece510718b5e1bc461a341012" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Macintosh - základy 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Demo 2.img" size="1474560" crc="bc8db19b" sha1="4d255eca79ca74254f410f50110eb6970ddd5681" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Diskové nástroje" />
+			<dataarea name="flop" size="1474560">
+				<rom name="DT.img" size="1474560" crc="ab6664e3" sha1="64d35eaf2b74e1a51f5316464700a7da6dd84363" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys75">
+		<description>System Software 7.5 (US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_1of7.img" size="1474560" crc="a04871d0" sha1="76bbc187b8a22e2b97b2593b295086eb3a6e4838" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_2of7.img" size="1474560" crc="7dcd891b" sha1="1a3853bb6aaa150a64883977010a5bbf35460f2f" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_3of7.img" size="1474560" crc="0ddc83c4" sha1="bd241a75b4a5146fe60cb9e9ad90f03e3c91c611" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_4of7.img" size="1474560" crc="9d0cfdd1" sha1="50d4c2db926fce8d11d7bd94fefbc1c33b7416dd" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_5of7.img" size="1474560" crc="6d8fcd57" sha1="20bb100637978be5639f560664b5f6086e4ebe07" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_6of7.img" size="1474560" crc="dd5f62e3" sha1="c29bc0a058190117e0620a1e799570e785ee81c9" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_7of7.img" size="1474560" crc="b0052393" sha1="8d6439c12ecb7a874955445b06dda6794824b87c" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools" />
+			<dataarea name="flop" size="1474560">
+				<rom name="SSW750_DiskTools.img" size="1474560" crc="9da10b17" sha1="97ab64faf924e291427e3ca24b1584c89e9171a7" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys753r2">
+		<description>System Software 7.5.3 Revision 2 (US English)</description>
+		<year>1996</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 01.img" size="1474560" crc="b8804441" sha1="8045fb3d37af92aa4b9f63dffdb97601b27458ec" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 02.img" size="1474560" crc="7fe4b1d2" sha1="1e69b93c30a918e1f92255a48393dffac4604a46" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 03.img" size="1474560" crc="cb0ba302" sha1="99bee1f2c8bc0ae6939f85606bc6f38240e6ebbc" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 04.img" size="1474560" crc="9c0a4b39" sha1="c1f5692c529beaa8c27994d83c7df5f4183bf0bd" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 05.img" size="1474560" crc="4f058f1e" sha1="f09117feb2b691a4bfa9f6fe033b2549b5db844e" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 06.img" size="1474560" crc="0819bbdc" sha1="1fae08f8a9dc455b1fbe50e9221fbada34c9ed1f" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 07.img" size="1474560" crc="22ec780e" sha1="8d72ac794e01167d4a65e46cf8dfb8dc7fe2c409" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 08.img" size="1474560" crc="aa8bf32c" sha1="698c63d9ca051df70b24158174fb27e2df76752f" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 09.img" size="1474560" crc="71ad3d64" sha1="f7992339d7eb76d4328c2600ae44f381853613fd" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 10.img" size="1474560" crc="692b1bb9" sha1="357358f25be4e05dd6314ac909906e54783da163" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 11.img" size="1474560" crc="7e92b721" sha1="f6026d8b77d3144ee512c0a4f6a47d7fb63643c4" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 12" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 12.img" size="1474560" crc="3a5a7927" sha1="142591225c5cd54f03fab01a176d81d02c8e1a4b" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 13" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 13.img" size="1474560" crc="ea6c7e05" sha1="15c23a724ad8fa25b6cc3683660856a4dc6091f9" />
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 14" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 14.img" size="1474560" crc="c71d5955" sha1="40b459ab645ac8d906ab60c1faa4cedb68320273" />
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 15" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 15.img" size="1474560" crc="efff8077" sha1="4db6800959f3aff0ea7eefaec2cdbacd162c22b8" />
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 16" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install 16.img" size="1474560" crc="810b1dbf" sha1="fc9181b8a96f3309e38d20e46a90d20805b3fcb3" />
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="Before You Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Before You Install.img" size="1474560" crc="47371648" sha1="954da125236703c31bea3de5eeff84e5b329dfce" />
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools 1.img" size="1474560" crc="24ca9e4a" sha1="70574cac9acf6c2114ebe2aef720a91202eef8fd" />
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="Disk Tools 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk Tools 2.img" size="1474560" crc="b34406a4" sha1="647dad932d496f1bc55b83319f0492da171feb29" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sys755up">
+		<description>System Software 7.5.5 Update (US English)</description>
+		<year>1996</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System 7.5.5 Update - 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="DISK01.IMG" size="1474560" crc="6922bf52" sha1="b91dd6395d3a673ad22362656b30127720bf20ef" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="System 7.5.5 Update - 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="DISK02.IMG" size="1474560" crc="0bb12cba" sha1="386bc7e08e534de88ffdf16650361392c1a1f4a1" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="System 7.5.5 Update - 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="DISK03.IMG" size="1474560" crc="41c7aafc" sha1="016d27e050a66b00f0f51b9f68da83692e5c056d" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sysup201">
+		<description>System Update 2.0.1 (US English)</description>
+		<year>1993</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="System Update 2.0.1.img" size="1474560" crc="c920a8ff" sha1="9d7b7c531743a010e7871c6b33612269376f3141" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sysup30">
+		<description>System Update 3.0 (US English)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Update 3.0 Disk 1.img" size="1474560" crc="2d98e5a2" sha1="8d3f3026c6a33fe83a258a8de1c0f3df198237d5" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="System Update 3.0 Disk 2.img" size="1474560" crc="cb04049f" sha1="134e9b449f771cf9fabcf97c658028c54783830f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sysup30fr">
+		<description>System Update 3.0 (French)</description>
+		<year>1994</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disque 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="61395223" sha1="986e2550ec652002aa82fe65eeadf5e651d7f4f1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disque 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="539db76f" sha1="ce16012d1c8b42eacfbd2193a5f04cac8927a51d" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- Application disks -->
+
+	<!-- MAME crashes on startup with "Fatal error: fpgen_rm_reg: unimplemented opmode 0A at 01E33D00" -->
+	<software name="acadr12" supported="no">
+		<description>AutoCAD Release 12c3</description>
+		<year>1994</year>
+		<publisher>Autodesk</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install.img" size="1474560" crc="0ab8b9d1" sha1="86cd9a1cf8a87e990348584d36e5bd759d98f18c" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="AutoCAD 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AutoCAD 1.img" size="1474560" crc="31d17ea9" sha1="37cd2bd45ec4088f6cbcb3363e57af8551f45203" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="AutoCAD 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AutoCAD 2.img" size="1474560" crc="9690c84e" sha1="8c1b5d58bb10f98d370ef81efd510e3e398abbb3" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="AutoCAD 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AutoCAD 3.img" size="1474560" crc="cd6dc2ad" sha1="097c5a35119277f0f0597715accdf0d714ae045f" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="AutoCAD 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AutoCAD 4.img" size="1474560" crc="d5fcbd6d" sha1="b46e9a3b5b6806f64b05de75feb6a17cff51605e" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<!-- The AME disk isn't recognized by the main installer. It can be installed separately. -->
+			<feature name="part_id" value="AME" />
+			<dataarea name="flop" size="1474560">
+				<rom name="AME.img" size="1474560" crc="4c3576ad" sha1="7d2f361a601d7a7bc5f27cc4c00e835932702a5a" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Extensions" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Extensions.img" size="1474560" crc="7f55ef0e" sha1="a8da09452963d610da799549c105db8c18789d3b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="atease101">
+		<description>At Ease 1.0.1</description>
+		<year>1992</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="At Ease Installer.img" size="1474560" crc="c3d62438" sha1="7b8288be4d9917d276c06d0407056ade5f706f0b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="atease30">
+		<description>At Ease 3.0</description>
+		<year>1995</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1474560">
+				<rom name="At Ease 3.0 Install.img" size="1474560" crc="e1bea2c7" sha1="e938504135484f51f745c0827420101aeef1c12f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ateasew30">
+		<description>At Ease for Workgroups 3.0</description>
+		<year>1995</year>
+		<publisher>Apple</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="At Ease WG Install 1.img" size="1474560" crc="c298f781" sha1="7770ebfc1590446a5f586f0b4de5ba0ce6ea2fde" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="At Ease WG Install 2.img" size="1474560" crc="155e7479" sha1="65ec4ec09d061160fba2db5cee2ae7543e9d4fea" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="civ">
+		<description>Sid Meier's Civilization</description>
+		<year>1992</year>
+		<publisher>MicroProse</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk1.img" size="1474560" crc="51e78a07" sha1="bd38b4e1b4f057b4221f0eecf701fda9252b2c8d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk2.img" size="1474560" crc="e68d61d7" sha1="04660d264db37f29cef2535c6e80fab721c895b0" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk3.img" size="1474560" crc="57b49a19" sha1="b718d9deb36652108938121e7eab514496fe3eaa" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk4.img" size="1474560" crc="f0684c1a" sha1="f775747910baa887a2e53a6c2a97c3de90e2d135" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="clarisd10v3">
+		<description>ClarisDraw 1.0v3</description>
+		<year>1993</year>
+		<publisher>Claris</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk01.img" size="1474560" crc="7e12bb1c" sha1="a8a84383b1d5db0e1a8793bb238de5a2779e81c1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk02.img" size="1474560" crc="473e95af" sha1="6cd471d4425d96cb9923d4b43bed400e0e3fc5a1" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk03.img" size="1474560" crc="3b1f90dd" sha1="43803d3e21222d8b4e1a895c3ae204faa724dfb7" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk04.img" size="1474560" crc="7c37142f" sha1="0afdb39d99e9d8f82b03c889192f27f1773af65b" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk05.img" size="1474560" crc="8dafa209" sha1="5340297877b50076c6a7bd81d66b55960fefa3cb" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk06.img" size="1474560" crc="a83aed12" sha1="c1991ee1f6712ea0b6372dd423e71a82c89f509e" />
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- S/N: Z93350-001A -->
-	<software name="clarisw" supported="no">
+	<software name="clarisw">
 		<description>ClarisWorks (Swedish)</description>
 		<year>1993</year>
 		<publisher>Claris</publisher>
@@ -38,13 +2670,91 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="gayblade" supported="no">
+	<software name="dim20">
+		<description>Adobe Dimensions 2.0</description>
+		<year>1994</year>
+		<publisher>Adobe</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="abb3a974" sha1="faa5ce0932a623ea7ed5f65f12558e6527fe7e85" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="5f095f2a" sha1="f88fa0a2b285fc436a5b67f47dfedef36e40abb8" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="5ae6d4ec" sha1="92b1a4a48ee829ec24f861ce1c76aa041223b0be" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="f5255a93" sha1="5d33684db86afd3804b9c5b9984f847873ee8391" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="gayblade">
 		<description>GayBlade</description>
 		<year>1992</year>
 		<publisher>RJBest</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1474560">
 				<rom name="gayblade disk.img" size="1474560" crc="4723aa7b" sha1="998664937a591a0cde8aee7219dcbdb2dc1ba482"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="illust55">
+		<description>Adobe Illustrator 5.5</description>
+		<year>1994</year>
+		<publisher>Adobe</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Installer - Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk1.img" size="1474560" crc="53163c94" sha1="a0b3051feadcfd2ec05b20a53881027527c81313" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk2.img" size="1474560" crc="2b7c4ea0" sha1="6fda27a5dac69985820c4376fd57c8b6951f3531" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk3.img" size="1474560" crc="71117759" sha1="0a36abca7f536f5ba58c62e860c552d6dba8681e" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk4.img" size="1474560" crc="449838f0" sha1="2550836eea10737eca2d3d2b2bb2cb75d9cd1907" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk5.img" size="1474560" crc="c88f64f9" sha1="1123ce764a702314e55934d98f1c42e5b6139b9a" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk6.img" size="1474560" crc="0d2bc039" sha1="6195d2d14d55200c8901432b816d9b8abaf1fc69" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk7.img" size="1474560" crc="5cef7d72" sha1="8ae99a093641a86a60b7f62c6d3956a21f896640" />
 			</dataarea>
 		</part>
 	</software>
@@ -124,6 +2834,518 @@ license:CC0
 			<feature name="part_id" value="Disk 11/11" />
 			<dataarea name="flop" size="4225984">
 				<rom name="lost in time parts 1 and 2 disk 11.mfm" size="4225984" crc="00626ee8" sha1="87b70f342762eb88a3e625e43914aadae8660217" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Seems to miscalculate the space needed for instalation in anything other than a 68000 CPU -->
+	<software name="mactools30a" supported="partial">
+		<description>Central Point MacTools 3.0a</description>
+		<year>1993</year>
+		<publisher>Central Point Software</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk #1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="MacTools Disk 1.img" size="1474560" crc="d1add1a5" sha1="a25d3fd52a1321a9a8ed8216369ea60bb527e4ac" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk #2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="MacTools Disk 2.img" size="1474560" crc="454432b1" sha1="255c33034e64af6b1d4414bdb1b2b4bcb433f6d9" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk #3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="MacTools Disk 3.img" size="1474560" crc="ccd3b60c" sha1="8f732b7bcf93870e543391ed8a98f85c21930fd4" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Disk #4" />
+			<dataarea name="flop" size="819200">
+				<rom name="MacTools Disk 4.img" size="819200" crc="19a6266d" sha1="c8b45e9ef549841261628a8aa9c779ded0a10141" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Optimizer Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Optimizer Disk.img" size="1474560" crc="97db31b7" sha1="e3acd588b03b5356babae472949952081dcd7bb1" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Emergency Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Emergency Disk.img" size="1474560" crc="ebf6c551" sha1="3ef9200e4df3ff8dfe7ee9e7e05843f9c1021197" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="macwp15v1">
+		<description>MacWrite Pro 1.5v1</description>
+		<year>1993</year>
+		<publisher>Claris</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="c7b3a7a3" sha1="3f822f72bf15e301c4590db6090753a698301b3d" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="3faeb185" sha1="bc9bc42e1835cfbf7390e3dd5a95083e888c704e" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="macwp15v3">
+		<description>MacWrite Pro 1.5v3</description>
+		<year>1994</year>
+		<publisher>Claris</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="04489288" sha1="5d03758fbbfb7761f2545979b9b658c21e493714" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="1529122b" sha1="7b42da1380233489406f4b30dc2c57af3392e777" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="9693ecfd" sha1="eaf35fe598f0319d7da035ded83c8d4b2eafd0c4" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmaker50">
+		<description>Aldus PageMaker 5.0 (English)</description>
+		<year>1993</year>
+		<publisher>Aldus</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="9e571d78" sha1="5c72fbbfb81637a9a8d78525acf5ee1c3a639811" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="7231d43b" sha1="e065efa8f85619ba1bb3cd934b41ee9debb30f62" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="d321c2e9" sha1="1afa2161a9fc58c3cf1a7a840b0d6b653511e93f" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="5293c308" sha1="dcb705a36fcc6381f4e9b110d5273e5300828cda" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="5b9975fa" sha1="324ad9f94da9be80db0d0334f4461b1d498bc2af" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="0633e1a2" sha1="89f6a279c3a10975eeb6aed4959cc1ece042271a" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="01112e18" sha1="bb3b48165f24e787f26f38255103bde821aded62" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Filter/Driver Pack Plus" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Update.img" size="1474560" crc="4ccb166e" sha1="703d8e093532c769e6557654014d266b2f74bae2" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmaker50da">
+		<description>Aldus PageMaker 5.0 (Danish)</description>
+		<year>1993</year>
+		<publisher>Aldus</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="1" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="d3b8acd6" sha1="5d696dbc63ecae46ff6dc7a4d700aeda80efc83b"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="2" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="559f8242" sha1="5e01956272e94aaf87700f76f7aa3d296bc5b3e2"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="3" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="bc7f4f2b" sha1="5e42fa9d46a4bc0184af6a904b5fa0c736a8dc23"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="4" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="1cfcd877" sha1="a7014f2a1caf1620bf3ac90f747bc959a6d3325a"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="5" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="4c49b14a" sha1="4578d9cd660637a2d30df4804a5c0bac727693d9"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="6" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="aad16dff" sha1="08782658e8329915ea56c979a662a686bbff1a45"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="7" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="d6841162" sha1="62eca71b8a612fed4efcf74bc8e6eb6b4c846c19"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="8" />
+			<dataarea name="rom" size="1474560">
+				<rom name="disk08.img" size="1474560" crc="6a42b9f9" sha1="f09c3fe14a4093bee2e1d64d22d53b55394c6abe"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmaker50de">
+		<description>Aldus PageMaker 5.0 (German)</description>
+		<year>1993</year>
+		<publisher>Aldus</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="13a2eb9a" sha1="57c6ec46c3a3708895ee3e7fea63da7e48eecd08" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="be33175e" sha1="a1366c7f6379ac5905f3d2de169d54819d6ba52f" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="863639ab" sha1="20edf0eb78fd89496ac437316cc88a1ab58873e6" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk04.img" size="1474560" crc="9fd925c3" sha1="f70cb9ce0484a5ae247743f4105062ae7f6fc1f7" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk05.img" size="1474560" crc="d2e6f62c" sha1="3b0ddf1961daede5acaee9199feb49ed1787e3f5" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk06.img" size="1474560" crc="763323d9" sha1="f03e4bf827500a5e3f81b256def24b29ead7665f" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk07.img" size="1474560" crc="f1585a37" sha1="7a1631fe8cf7ebadb616fd736a54f47dbfb0b6bb" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk08.img" size="1474560" crc="db3c38e6" sha1="72533f9e2b28350c1e6e92ecc96e3dc38538f163" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="pmaker50sv">
+		<description>Aldus PageMaker 5.0 (Swedish)</description>
+		<year>1993</year>
+		<publisher>Aldus</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk01.img" size="1474560" crc="32778c17" sha1="7157acd292fc7391c5c0039a7c1f90de8c0bdf0a" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk02.img" size="1474560" crc="83d3273a" sha1="5e0113740d235d6b26e326efc1804707fc9fa1f7" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk03.img" size="1474560" crc="ae59d9ae" sha1="4ce5515ab650ac62f338ddb9683eb7c403631c01" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk04.img" size="1474560" crc="5af3839c" sha1="57e8740a4036dbd1323358735663ceadd768346c" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk05.img" size="1474560" crc="ddd2697e" sha1="95f7b1034324403e127865f12514308fe9ef4ad2" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk06.img" size="1474560" crc="81ebe4a8" sha1="386875d33e6e8f36d65d398d990c964b243e53aa" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk07.img" size="1474560" crc="285ff02f" sha1="9a7db99eb10374bd2e44747a79fab0b2e679a17f" offset="0"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Disk08.img" size="1474560" crc="8cc3fdf2" sha1="d48e7550bdfb2a1a4a0b7d9b1d2b80905d71ede4" offset="0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ppoint40">
+		<description>Microsoft PowerPoint 4.0</description>
+		<year>1994</year>
+		<publisher>Microsoft</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 1.img" size="1474560" crc="f7ce6f88" sha1="ccf1dbeae1a21c10c271261236b1e5b6eeae9cc1" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 2.img" size="1474560" crc="2a172d57" sha1="897c689530865ac2a12be094e8f974f6d576633c" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 3.img" size="1474560" crc="d695b7b4" sha1="35fdbd13da42f518733c691917eb5d05cbef02cb" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 4.img" size="1474560" crc="a3360db3" sha1="d5d3b054514187588b96ffb8a249aa9d0a0541f7" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 5.img" size="1474560" crc="5864cb2c" sha1="8185a2b8ce3687625cf18dbd5e01bac8a3a9ac1d" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 6" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 6.img" size="1474560" crc="ebdb7e69" sha1="5064ac7f0e0e20b5575b3ebfb7e455d7a1318287" />
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 7" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 7.img" size="1474560" crc="bd60ad7a" sha1="b333713eb0d5c01630bebedff3b9b700b92f0122" />
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 8" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 8.img" size="1474560" crc="9f6aed39" sha1="9286957803e662a296b2e269dde13e447340f4cc" />
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 9" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 9.img" size="1474560" crc="f4a50486" sha1="eafb21ede215c148b9278b9bab43b3f2b7ff1cc6" />
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 10" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 10.img" size="1474560" crc="791df125" sha1="65d65ad021ae74ec6e9f09912bf90609c80c9b78" />
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 11" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 11.img" size="1474560" crc="5161f0f5" sha1="05aafbe8a3f606479f72a37242deaebface31941" />
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Install Disk 12" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Install Disk 12.img" size="1474560" crc="2bed9fb6" sha1="2e003e10ab33de68c3303753b29af91aef082c69" />
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="Viewer Disk" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Viewer Disk.img" size="1474560" crc="27ba6536" sha1="a51a14a60ebec0d5360cc208e99eb46d0d61953b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!--
+	    These disks were bundled as part of a single package that also contained:
+	    WordPerfect 3.0
+	    Random House Webster's Electronic Dictionary & Thesaurus, College Edition
+	    Links Pro Golf
+	-->
+	<software name="stessntl">
+		<description>Macintosh Student Essentials</description>
+		<year>1994</year>
+		<publisher>WordPerfect</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Bitstream Fonts 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Bitstream Fonts 1.img" size="1474560" crc="5056d7ef" sha1="e2bde5c3d20d21e290c0f9908cd4fae9e19f5866" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Bitstream Fonts 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Bitstream Fonts 2.img" size="1474560" crc="2c0c60f6" sha1="7a8e05203bded64159f5f4f461f7dd56440b611d" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Bitstream Fonts 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Bitstream Fonts 3.img" size="1474560" crc="31da3665" sha1="0495274059d230abce2c4ea798618e40c7c86e9b" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Document Experts" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Document Experts.img" size="1474560" crc="88357546" sha1="a31a11366f3303728b2174e0fbdf710db1c028c0" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Language Modules 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Language Modules 1.img" size="1474560" crc="0cd5461e" sha1="784710b3450737657451c02a5f975ebbedd92571" />
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Language Modules 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="Language Modules 2.img" size="1474560" crc="8cc915fc" sha1="946a65e2455556a21da57d16cacf82964b86a0ff" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="symcpp60">
+		<description>Symantec C++ for Macintosh 6.0</description>
+		<year>1993</year>
+		<publisher>Symantec</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="d8e06b7f" sha1="c12225fdccd68b467db7fcb073cc12f55e41c051" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="21de706d" sha1="6e673fc9c28b28afd6cf26798528e8e681d9c687" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk03.img" size="1474560" crc="7f3f7d08" sha1="575be5504268e4b8db6cabfb7277c977197043fb" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Requires a PowerPC CPU -->
+	<software name="vellum269" supported="no">
+		<description>Vellum 3D 2.6.9</description>
+		<year>1994</year>
+		<publisher>Ashlar</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk01.img" size="1474560" crc="676b090c" sha1="409c8d3397b6e226b5515308ace43b267ff58cbb" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Disk 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="disk02.img" size="1474560" crc="d1f15563" sha1="f334ac6a09d3bfdd800d1ad319939d4bd13a88b5" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="wp30a">
+		<description>WordPerfect 3.0a</description>
+		<year>1994</year>
+		<publisher>WordPerfect</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="WordPerfect 1" />
+			<dataarea name="flop" size="1474560">
+				<rom name="WordPerfect 1.img" size="1474560" crc="6dbb7880" sha1="b0cffbaa9705cd4c59b92e090340c1167c4be9d5" />
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="WordPerfect 2" />
+			<dataarea name="flop" size="1474560">
+				<rom name="WordPerfect 2.img" size="1474560" crc="a87bbefc" sha1="2d3c92bf9d6ecbe8c7a9cfb5cbb6cd79ffa76921" />
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="WordPerfect 3" />
+			<dataarea name="flop" size="1474560">
+				<rom name="WordPerfect 3.img" size="1474560" crc="484cfe15" sha1="867570cea587d18f517bf11bca8adc7b04596eaa" />
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="WordPerfect 4" />
+			<dataarea name="flop" size="1474560">
+				<rom name="WordPerfect 4.img" size="1474560" crc="cd85a4c6" sha1="21aa48c0682d4fbb829f891215763cfb25b3e162" />
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="WordPerfect 5" />
+			<dataarea name="flop" size="1474560">
+				<rom name="WordPerfect 5.img" size="1474560" crc="edad9018" sha1="c3058bff39e6436cce392abe6ca682263cb82311" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/mame/drivers/mac.cpp
+++ b/src/mame/drivers/mac.cpp
@@ -627,6 +627,8 @@ void mac_state::add_base_devices(machine_config &config, bool rtc, int woz_versi
 	{
 		applefdintf_device::add_35_hd(config, m_floppy[0]);
 		applefdintf_device::add_35_nc(config, m_floppy[1]);
+
+		SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 	}
 
 	SCC8530(config, m_scc, C7M);
@@ -807,6 +809,8 @@ void mac_state::maciihd(machine_config &config)
 
 	applefdintf_device::add_35_hd(config, m_floppy[0]);
 	applefdintf_device::add_35_hd(config, m_floppy[1]);
+
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 }
 
 void mac_state::maciifx(machine_config &config)
@@ -970,6 +974,8 @@ void mac_state::maciix(machine_config &config, bool nubus_bank1, bool nubus_bank
 
 	applefdintf_device::add_35_hd(config, m_floppy[0]);
 	applefdintf_device::add_35_hd(config, m_floppy[1]);
+
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 
 	m_ram->set_default_size("2M");
 	m_ram->set_extra_options("8M,32M,64M,96M,128M");

--- a/src/mame/drivers/mac128.cpp
+++ b/src/mame/drivers/mac128.cpp
@@ -1295,6 +1295,8 @@ void mac128_state::macsefd(machine_config &config)
 
 	applefdintf_device::add_35_hd(config, m_floppy[0]);
 	applefdintf_device::add_35_hd(config, m_floppy[1]);
+
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 }
 
 void mac128_state::macclasc(machine_config &config)

--- a/src/mame/drivers/macprtb.cpp
+++ b/src/mame/drivers/macprtb.cpp
@@ -589,6 +589,7 @@ void macportable_state::macprtb(machine_config &config)
 	m_ram->set_extra_options("1M,3M,5M,7M,9M");
 
 	SOFTWARE_LIST(config, "flop35_list").set_original("mac_flop");
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 	SOFTWARE_LIST(config, "hdd_list").set_original("mac_hdd");
 }
 

--- a/src/mame/drivers/macpwrbk030.cpp
+++ b/src/mame/drivers/macpwrbk030.cpp
@@ -974,6 +974,7 @@ void macpb030_state::macpb140(machine_config &config)
 	m_ram->set_extra_options("4M,6M,8M");
 
 	SOFTWARE_LIST(config, "flop35_list").set_original("mac_flop");
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 	SOFTWARE_LIST(config, "hdd_list").set_original("mac_hdd");
 }
 

--- a/src/mame/drivers/macquadra700.cpp
+++ b/src/mame/drivers/macquadra700.cpp
@@ -1030,6 +1030,7 @@ void macquadra_state::macqd700(machine_config &config)
 	m_ram->set_extra_options("8M,16M,32M,64M,68M,72M,80M,96M,128M");
 
 	SOFTWARE_LIST(config, "flop35_list").set_original("mac_flop");
+	SOFTWARE_LIST(config, "flop35hd_list").set_original("mac_hdflop");
 }
 
 ROM_START( macqd700 )


### PR DESCRIPTION
This change attaches the orphan mac_hdflop.xml software list to (hopefully) all the Macintosh machines with HD floppy drives, and adds about 70 new software items to it.

The Mac is a bit out of my comfort zone, but rockleevk sent me some previously undumped KanjiTalk images a few months ago, and now that the Mac drivers fully support HD disks and all the obvious bugs have been ironed out, I thought this was a good time to add them along with some other things I got from WinWorld. I actually have about 60 more more waiting to be added, but as this is an almost-new list I wanted to submit my work so far and see if everything checks out.

A couple of notes about the naming...

- I have tried to reproduce disk labels as part_ids as closely as possible. In some cases this involves languages that are completely unknown to me, so I might have made some mistakes there. At the very least I know that the English, Spanish and Japanese labels shoud be 100% correct. 

- Application names can be a bit inconsistent, so I have tried to go with what the installer or README files call them (including the company name if it's there, like "Microsoft PowerPoint" or "Adobe Illustrator").

- About the name of the operating system, I think Apple only started calling it "Mac OS" officially with version 7.6, so I have followed that convention. Also, the Korean and Japanese versions have their own regional names (HangulTalk and KanjiTalk, respectively), so I follow those too.

And as a side note, I know mac_flop.xml needs a lot of love too. I may start working on that when I finish sorting out the HD stuff.