### PR TITLE
megadriv.xml: more protos, even more blast processing

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -22845,11 +22845,11 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
-<!-- Move Putty with second controller -->
 	<software name="puttsqup1" cloneof="puttsqup">
 		<description>Putty Squad (early prototype)</description>
 		<year>1992</year>
 		<publisher>System 3 / Ocean</publisher>
+		<info name="usage" value="Move Putty with second controller"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="0x100000">
 				<rom name="putty squad (early prototype).bin" size="0x100000" crc="4974ae73" sha1="68be5cc2aae704777bbe47fb4a0e8ffe9afca9d3"/>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -50,7 +50,6 @@ Known undumped protos
   * Payne Stewart Golf
   * Jack Nicklaus 95
   * Jack Nicklaus Power Challenge
-  * Danny Sullivan's Indy Heat
   * Star Trek Starfleet Academy
   * Teenage Mutant Hero Turtles - The Hyperstone Heist (Euro)
   * Spot Goes to Hollywood (Euro)
@@ -330,9 +329,10 @@ Info on Sega chip labels (from Sunbeam / Digital Corruption)
 		<publisher>Black Pearl</publisher>
 		<info name="alt_title" value="アキラ"/>
 		<part name="cart" interface="megadriv_cart">
+			<feature name="pcb" value="SGEP2A AW REV. A"/>
 			<feature name="u1" value="M27C4001-12F1"/>
 			<feature name="u2" value="M27C4001-12F1"/>
-			<feature name="u3" value="74HC139N"/>
+			<feature name="u3" value="SN74HC139N"/>
 			<feature name="u4" value="M27C4001-12F1"/>
 			<feature name="u5" value="M27C4001-12F1"/>
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
@@ -10415,6 +10415,23 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
+	<software name="aladdinup1" cloneof="aladdin">
+		<description>Disney's Aladdin (prototype 19930627)</description>
+		<year>1993</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="pcb" value="171-6108A"/>
+			<feature name="ic9" value="KM62256ALP-10L"/>
+			<feature name="ic13" value="PC74HC139P"/>
+			<feature name="ic17" value="PC74HC74P"/>
+			<feature name="ic18" value="PC74HC125P"/>
+			<feature name="ic19" value="PC74HC32P"/>
+			<dataarea name="rom" width="16" endianness="big" size="4194304">
+				<rom name="aladdin (prototype 19930627).bin" size="4194304" crc="78110310" sha1="b84b231c53dffba7f48561b79562faa3f4ed2ac5"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="aladdinup" cloneof="aladdin">
 		<description>Disney's Aladdin (USA, Prototype)</description>
 		<year>1993</year>
@@ -10965,6 +10982,17 @@ but dumps still have to be confirmed.
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="australian rugby league (euro).bin" size="2097152" crc="ac5bc26a" sha1="b54754180f22d52fc56bab3aeb7a1edd64c13fef"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="austrarlp" cloneof="austrarl">
+		<description>Australian Rugby League (prototype)</description>
+		<year>1994</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="australian rugby league (prototype).bin" size="2097152" crc="51117c67" sha1="bb84be50eb4d31dbe601058bf9ea1adaaec1a1b1"/>
 			</dataarea>
 		</part>
 	</software>
@@ -11827,6 +11855,20 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
+<!-- Found in a development cart with an Alien Storm label -->
+	<software name="biohazrbp1" cloneof="biohazrb">
+		<description>Bio Hazard Battle (prototype)</description>
+		<year>1991?</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="pcb" value="171-5694-01"/>
+			<feature name="ic5" value="PC74HC139P"/>
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="bio hazard battle (prototype).bin" size="1048576" crc="4f19a73d" sha1="66439a7a4b8cb3f195a5830b62ceb03c68392ac2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="biohazrbp" cloneof="biohazrb">
 		<description>Bio Hazard Battle (USA, Prototype)</description>
 		<year>1992</year>
@@ -12362,6 +12404,17 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
+	<software name="captlangp" cloneof="havoc">
+		<description>Captain Lang (prototype)</description>
+		<year>1993</year>
+		<publisher>Data East</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="captain lang (early prototype).bin" size="1048576" crc="89418d48" sha1="47307d1a7ea1e813547c94700885595c6e8d156a"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="captplanu" cloneof="captplan">
 		<description>Captain Planet and the Planeteers (USA)</description>
 		<year>1993</year>
@@ -12430,6 +12483,17 @@ but dumps still have to be confirmed.
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
 				<rom name="chakan - the forever man (oct 6, 1992 build).bin" size="1048576" crc="77b7e85f" sha1="c4fd030560c627908a75acef2de5b908cb9255d6" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="champwcsp" cloneof="champwcs">
+		<description>Champions World Class Soccer (prototype)</description>
+		<year>1994</year>
+		<publisher>Flying Edge</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="champions world class soccer (prototype 19940318).bin" size="1048576" crc="7b3eb69d" sha1="d99c4bc35f3380338f6b69daa527cbd8e0d7b257"/>
 			</dataarea>
 		</part>
 	</software>
@@ -12766,6 +12830,18 @@ but dumps still have to be confirmed.
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="college football usa 96 (usa).bin" size="2097152" crc="b9075385" sha1="3079bdc5f2d29dcf3798f899a3098736cdc2cd88"/>
+			</dataarea>
+		</part>
+	</software>
+
+<!-- Nearly identical to final build save for a few bytes -->
+	<software name="colleg96p" cloneof="colleg96">
+		<description>College Football USA 96 (prototype 19950621)</description>
+		<year>1995</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="college football usa 96 (prototype 19950621).bin" size="2097152" crc="e70bd01d" sha1="5438ba1baa3400c73905e25fdfe9d504c3604d5a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -13769,6 +13845,18 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
+<!-- This is likely a dump from one of 50 reproduction cartridges, sold on AtariAge, based on an original prototype -->
+	<software name="indyheat">
+		<description>Danny Sullivan's Indy Heat (prototype) (pirate)</description>
+		<year>1992</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="danny sullivan's indy heat (prototype).bin" size="2097152" crc="0e356a3c" sha1="6e76ff6a74374cd9170a902c250a1674ef69fd56"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="darkcstl">
 		<description>Dark Castle (Euro, USA)</description>
 		<year>1991</year>
@@ -14372,13 +14460,24 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
-	<software name="drrobotnup" cloneof="drrobotn">
-		<description>Dr. Robotnik's Mean Bean Machine (USA, Prototype)</description>
+	<software name="drrobotnup1" cloneof="drrobotn">
+		<description>Dr. Robotnik's Mean Bean Machine (USA, prototype)</description>
 		<year>1993</year>
 		<publisher>Sega</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
 				<rom name="dr. robotnik's mean bean machine (usa) (beta).bin" size="1048576" crc="4d0e5273" sha1="312f9a283bebc5d612a63afd2cf67eb923f4f074"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="drrobotnup" cloneof="drrobotn">
+		<description>Dr. Robotnik's Mean Bean Machine (USA, prototype b)</description>
+		<year>1993</year>
+		<publisher>Sega</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="dr. robotnik's mean bean machine (prototype b).bin" size="1048576" crc="c631bfff" sha1="9d65fd99d8306b09d0cb7ce728647d223294208c"/>
 			</dataarea>
 		</part>
 	</software>
@@ -14527,6 +14626,17 @@ but dumps still have to be confirmed.
 				<rom name="duke nukem 3d (bra).bin" size="4194304" crc="6bd2accb" sha1="a4663f2b96787a92db604a92491fa27e2b5ced9e"/>
 			</dataarea>
 			<dataarea name="sram" size="65536">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dune2p" cloneof="dune2">
+		<description>Dune - The Battle for Arrakis (Euro, prototype 19940111)</description>
+		<year>1993</year>
+		<publisher>Virgin Interactive</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="dune ii - the battle for arrakis (prototype 19940111).bin" size="1048576" crc="781cb285" sha1="d02cf6e07071cf3d47e867182bf42d67b9e30a3e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15955,6 +16065,18 @@ but dumps still have to be confirmed.
 		</part>
 	</software>
 
+<!-- A Sega Channel version was released, but this is apparently an earlier prototype without sound -->
+	<software name="flintop">
+		<description>The Flintstones (Ocean prototype)</description>
+		<year>1995</year>
+		<publisher>Ocean</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+			<rom name="the flintstones (ocean) (prototype).bin" size="1048576" crc="9281ff45" sha1="23c1ad486457ee73b504133014970aea316634f6"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="foreman">
 		<description>Foreman for Real (World)</description>
 		<year>1995</year>
@@ -16515,6 +16637,17 @@ but dumps still have to be confirmed.
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="granada (usa, jpn).bin" size="524288" crc="7f45719b" sha1="6830d6ca1d7e2b220eb4431b42d33382e16e2791"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="granadap" cloneof="granada">
+		<description>Granada (Jpn, USA, v1.1 prototype)</description>
+		<year>1990</year>
+		<publisher>Renovation ~ Wolf Team</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="524288">
+				<rom name="granada (rev01 prototype).bin" size="524288" crc="129a37dd" sha1="ae23265cdc4907bae676101d3086929425ef641a"/>
 			</dataarea>
 		</part>
 	</software>
@@ -20318,6 +20451,20 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
+	<software name="nbajamp" cloneof="nbajam">
+		<description>NBA Jam (Apr 1993 prototype)</description>
+		<year>1993</year>
+		<publisher>Arena</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="slot" value="rom_nbajam_alt"/>
+			<feature name="pcb" value="SGEP2A AW REV. A"/>
+			<feature name="u3" value="74HC139AP"/>
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="nba jam april 1993.bin" size="2097152" crc="e35f7eee" sha1="1aad8b146ec1eb2a9823878fbfddc02efe3f6ad9"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="nbajamtef" cloneof="nbajamte">
 		<description>NBA Jam Tournament Edition (World, 2002 Fix Release)</description>
 		<year>2002?</year>
@@ -21044,6 +21191,19 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 			<feature name="u6" value="X24C01P"/>
 			<dataarea name="rom" width="16" endianness="big" size="524288">
 				<rom name="nhlpa93 h9306 (alt).u1" size="524288" crc="cbbf4262" sha1="8efc1cacb079ea223966dda065c16c49e584cac2"/>
+			</dataarea>
+		</part>
+	</software>
+
+<!-- This is mostly identical to v1.1 and yet the internal header claims it is earlier than the above alt -->
+	<software name="nhlpa93b" cloneof="nhlpa93">
+		<description>NHLPA Hockey 93 (Euro, USA, v1.1 alt)</description>
+		<year>1992</year>
+		<publisher>Electronic Arts</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="slot" value="rom_nhlpa"/>
+			<dataarea name="rom" width="16" endianness="big" size="524288">
+				<rom name="nhlpa hockey 93 (alternate build).bin" size="524288" crc="93e509ea" sha1="af5dbf3e70417753164ceeb76be63f51e492626f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -22606,6 +22766,27 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
+	<software name="psychop" cloneof="psycho">
+		<description>Psycho Pinball (prototype)</description>
+		<year>1994</year>
+		<publisher>Codemasters</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+			<!-- This is the order they appear on PCB. Release by drx had ODD0/1 names swapped. -->
+				<rom name="EVN0.bin" size="524288" crc="495ca575" sha1="08a60b9bb4b09aa646edb28d787058754ee899ef" offset="0x000001" loadflag="load16_byte"/>
+				<rom name="EVN1.bin" size="524288" crc="c025faf7" sha1="b97b1edbfd94661bdfd32d27c21c65f8ff662a39" offset="0x100001" loadflag="load16_byte"/> <!-- EVN1 silkscreen not on PCB -->
+				<rom name="ODD1.bin" size="524288" crc="5e4f5343" sha1="45694929f8b854d60b5daaf128227af0d233f731" offset="0x100000" loadflag="load16_byte"/>
+				<rom name="ODD0.bin" size="524288" crc="aa1dedde" sha1="c9e230e064b1c3a760c449c745ea483d97c00de1" offset="0x000000" loadflag="load16_byte"/>
+			</dataarea>
+		</part>
+<!-- LABEL(S)
+
+    PSYCHO PINBALL
+    Mega Drive - Full game
+    17
+-->
+	</software>
+
 	<software name="puggsyp" cloneof="puggsy">
 		<description>Puggsy (Prototype)</description>
 		<year>1993</year>
@@ -22653,7 +22834,6 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
-
 	<software name="puttsqup">
 		<description>Putty Squad (prototype)</description>
 		<year>1992</year>
@@ -22665,6 +22845,17 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
+<!-- Move Putty with second controller -->
+	<software name="puttsqup1" cloneof="puttsqup">
+		<description>Putty Squad (early prototype)</description>
+		<year>1992</year>
+		<publisher>System 3 / Ocean</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="0x100000">
+				<rom name="putty squad (early prototype).bin" size="0x100000" crc="4974ae73" sha1="68be5cc2aae704777bbe47fb4a0e8ffe9afca9d3"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="putter">
 		<description>Putter Golf (Jpn, SegaNet)</description>
@@ -22929,6 +23120,17 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
 				<rom name="radical rex (euro).bin" size="1048576" crc="d02d3282" sha1="c8dc73b7cabf43813f9cf09370a4437af4f1573f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="radrexp" cloneof="radrex">
+		<description>Radical Rex (Euro, prototype)</description>
+		<year>1994</year>
+		<publisher>Activision</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="radical rex (prototype).bin" size="1048576" crc="bf2912e3" sha1="da7400580b757d531f86e62b3f211798d8663237"/>
 			</dataarea>
 		</part>
 	</software>
@@ -24339,13 +24541,28 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
-	<software name="ship">
-		<description>Ship (Prototype)</description>
+<!-- This was a demo program distributed with the GEMS 2.5 devkit. This version was compiled from source code. -->
+	<software name="ship1" cloneof="ship">
+		<description>Ship (prototype)</description>
 		<year>199?</year>
 		<publisher>Technopop</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="131072">
 				<rom name="ship (prototype).bin" size="131072" crc="4cdc9f16" sha1="95bab798ecd769567300e1dddfbed3aeee206e87"/>
+			</dataarea>
+		</part>
+	</software>
+
+<!-- This is from an original developer's cart that had a Sega VISITOR sticker slapped on the front as a joke by programmer Randel Reiss -->
+	<software name="ship">
+		<description>Ship (visitor prototype)</description>
+		<year>199?</year>
+		<publisher>Technopop</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="pcb" value="171-5694-01"/>
+			<feature name="ic5" value="PC74HC139P"/>
+			<dataarea name="rom" width="16" endianness="big" size="262144">
+				<rom name="ship (visitor prototype).bin" size="262144" crc="852b5511" sha1="167c163e10135b6d0fcd63b1d1b6981d30db9af0"/>
 			</dataarea>
 		</part>
 	</software>
@@ -25549,6 +25766,17 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
+	<software name="spiroup" cloneof="spirou">
+		<description>Spirou (Euro, prototype)</description>
+		<year>1996</year>
+		<publisher>Infogrames</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="spirou (prototype).bin" size="1048576" crc="51bc6c35" sha1="1b03b04a1d3ae75b51e487dced305c6a729b4fa6"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="splatth2">
 		<description>Splatterhouse 2 (Euro)</description>
 		<year>1992</year>
@@ -26161,6 +26389,18 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="street fighter ii' turbo (pirate).bin" size="2097152" crc="a85491ae" sha1="23e1e1b587a7d2d1a82599d82d01c9931ca7b4cf"/>
+			</dataarea>
+		</part>
+	</software>
+
+<!-- This mostly differs from final build only in the internal header... -->
+	<software name="sracerp" cloneof="sracer">
+		<description>Street Racer (Euro, prototype 19950321)</description>
+		<year>1995</year>
+		<publisher>Ubi Soft</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="1048576">
+				<rom name="street racer (prototype 19950321).bin" size="1048576" crc="a439a96e" sha1="674e3c5185923a98bd8e9ae9bc0409d0c6503432"/>
 			</dataarea>
 		</part>
 	</software>
@@ -27720,6 +27960,17 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="tintin au tibet (euro).bin" size="2097152" crc="4243caf3" sha1="54fb11f601be37418b5bba3e0762d8b87068177a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="tintinp" cloneof="tintin">
+		<description>Tintin au Tibet (Euro, prototype)</description>
+		<year>1995</year>
+		<publisher>Infogrames</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="tintin in tibet (prototype).bin" size="2097152" crc="5d4e0ea1" sha1="28a63f4e7c063c127b00dc7c8c3f1439eed437ba"/>
 			</dataarea>
 		</part>
 	</software>
@@ -30961,6 +31212,23 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="262144">
 				<rom name="flux (euro).bin" size="262144" crc="2a1da08c" sha1="6357f38db012278bc889c77c5780a82d535760fd"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- To be used in conjuction with a MegaCD -->
+	<software name="fluxp" cloneof="flux">
+		<description>Flux (Euro, prototype 19950425)</description>
+		<year>1995</year>
+		<publisher>&lt;unknown&gt;</publisher>
+		<part name="cart" interface="megadriv_cart">
+			<feature name="pcb" value="171-5694-01"/>
+			<feature name="ic1" value="M27C1000-12XF1"/>
+			<feature name="ic2" value="M27C1000-12XF1"/>
+			<feature name="ic5" value="74HC139AP"/>
+			<dataarea name="rom" width="16" endianness="big" size="262144">
+				<rom name="ic1.bin" size="131072" crc="ae6f6975" sha1="24364fcf4373af48e833fdb82ec5beda05d95a50" offset="0x000001" loadflag="load16_byte"/>
+				<rom name="ic2.bin" size="131072" crc="4dd9f61e" sha1="1d833920ce871dfdfbc8442efcc9a931138fb683" offset="0x000000" loadflag="load16_byte"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -24562,6 +24562,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 			<feature name="pcb" value="171-5694-01"/>
 			<feature name="ic5" value="PC74HC139P"/>
 			<dataarea name="rom" width="16" endianness="big" size="262144">
+			<!-- The known dump is a 512KB overdump. PCB clearly has two 128KB 27C100s. This cuts off the second half (all 0xFF). -->
 				<rom name="ship (visitor prototype).bin" size="262144" crc="852b5511" sha1="167c163e10135b6d0fcd63b1d1b6981d30db9af0"/>
 			</dataarea>
 		</part>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Bio Hazard Battle (prototype) [Modern Vintage Gamer]
Ship (visitor prototype) [Modern Vintage Gamer]
Disney's Aladdin (prototype 19930627) [Hidden Palace]
Australian Rugby League (prototype) [Hidden Palace]
Captain Lang (prototype) [Hidden Palace]
Champions World Class Soccer (prototype) [Hidden Palace]
College Football USA 96 (prototype 19950621) [Hidden Palace]
Danny Sullivan's Indy Heat (prototype) (pirate) [Hidden Palace]
Dr. Robotnik's Mean Bean Machine (USA, prototype b) [Hidden Palace]
Dune - The Battle for Arrakis (Euro, prototype 19940111) [Hidden Palace]
The Flintstones (Ocean prototype) [Hidden Palace]
Granada (Jpn, USA, v1.1 prototype) [Hidden Palace]
NBA Jam (Apr 1993 prototype) [Hidden Palace]
NHLPA Hockey 93 (Euro, USA, v1.1 alt) [Hidden Palace]
Psycho Pinball (prototype) [Hidden Palace]
Putty Squad (early prototype) [Hidden Palace]
Radical Rex (Euro, prototype) [Hidden Palace]
Spirou (Euro, prototype) [Hidden Palace]
Street Racer (Euro, prototype 19950321) [Hidden Palace]
Tintin au Tibet (Euro, prototype) [Hidden Palace]
Flux (Euro, prototype 19950425) [Hidden Palace]