### PR TITLE
wd177x: test track count is under drive limit

### DIFF
--- a/src/lib/formats/wd177x_dsk.cpp
+++ b/src/lib/formats/wd177x_dsk.cpp
@@ -204,6 +204,18 @@ bool wd177x_format::load(io_generic *io, uint32_t form_factor, const std::vector
 		return false;
 
 	const format &f = formats[type];
+	int max_tracks, max_heads;
+	image->get_maximal_geometry(max_tracks, max_heads);
+
+	if(f.track_count > max_tracks) {
+		osd_printf_error("wd177x_format: Number of tracks in image file too high for floppy drive (%d > %d)\n", f.track_count, max_tracks);
+		return false;
+	}
+
+	if(f.head_count > max_heads) {
+		osd_printf_error("wd177x_format: Number of sides in image file too high for floppy drive (%d > %d)\n", f.track_count, max_heads);
+		return false;
+	}
 
 	for(int track=0; track < f.track_count; track++)
 		for(int head=0; head < f.head_count; head++) {


### PR DESCRIPTION
Error gracefully if the image format has too many tracks for floppy drive.

I changed the default drive in the CoCo from 80 tracks to 40. If you try to load an 80 track disk with a 40 track drive, MAME would segfault because there was no room for the extra tracks.