### PR TITLE
wd177x: fix segfault based on track count

### DIFF
--- a/src/lib/formats/wd177x_dsk.cpp
+++ b/src/lib/formats/wd177x_dsk.cpp
@@ -212,11 +212,6 @@ bool wd177x_format::load(io_generic *io, uint32_t form_factor, const std::vector
 		return false;
 	}
 
-	if(f.head_count > max_heads) {
-		osd_printf_error("wd177x_format: Number of sides in image file too high for floppy drive (%d > %d)\n", f.track_count, max_heads);
-		return false;
-	}
-
 	for(int track=0; track < f.track_count; track++)
 		for(int head=0; head < f.head_count; head++) {
 			uint8_t sectdata[40*512];
@@ -433,6 +428,15 @@ void wd177x_format::check_compatibility(floppy_image *image, std::vector<int> &c
 	int *ok_cands = &candidates[0];
 	for(unsigned int i=0; i < candidates.size(); i++) {
 		const format &f = formats[candidates[i]];
+
+		int max_tracks, max_heads;
+		image->get_maximal_geometry(max_tracks, max_heads);
+
+		// Fail if floppy drive can't handle track count
+		if(f.track_count > max_tracks) {
+			goto fail;
+		}
+
 		for(int track=0; track < f.track_count; track++) {
 			for(int head=0; head < f.head_count; head++) {
 				const format &tf = get_track_format(f, head, track);


### PR DESCRIPTION
1. Remove test for head count. @cuavas was right about loading a double sided disk in a single sided drive. It doesn't segfault.
2. Add track test in check_compatibility(). generate_bitstream_from_track() will segfault if disk drive doesn't have enough tracks.