### PR TITLE
fix pcap builds

### DIFF
--- a/scripts/src/osd/mac_cfg.lua
+++ b/scripts/src/osd/mac_cfg.lua
@@ -7,7 +7,7 @@ forcedincludes {
 --  MAME_DIR .. "src/osd/sdl/sdlprefix.h"
 }
 
-if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]==1 then
+if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]=="1" then
 	defines {
 		"USE_NETWORK",
 	}

--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -7,7 +7,7 @@ forcedincludes {
 	MAME_DIR .. "src/osd/sdl/sdlprefix.h"
 }
 
-if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]==1 then
+if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]=="1" then
 	defines {
 		"USE_NETWORK",
 	}

--- a/scripts/src/osd/windows_cfg.lua
+++ b/scripts/src/osd/windows_cfg.lua
@@ -37,7 +37,7 @@ else
 	}
 end
 
-if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]==1 then
+if _OPTIONS["USE_TAPTUN"]=="1" or _OPTIONS["USE_PCAP"]=="1" then
 	defines {
 		"USE_NETWORK",
 	}


### PR DESCRIPTION
I was not able to build an executable with (pcap) networking enabled on macOS (11.2) until I made this change to mac_cfg.lua. I made the same change to the other scripts in that directory where the same condition is used.

I know nothing about Lua, though, and it's entirely possible some other part of my hours-long pounding on it was what actually made the difference. But I was able to repeat the results in a new branch (which I know doesn't clear out all the build stuff) with just this change, so I guess this was maybe it.