### PR TITLE
ROM flags are listed in the XML

### DIFF
--- a/src/frontend/mame/infoxml.cpp
+++ b/src/frontend/mame/infoxml.cpp
@@ -969,6 +969,7 @@ void output_rom(std::ostream &out, driver_enumerator *drivlist, const game_drive
 			{
 				// for non-disk entries, print offset
 				out << util::string_format(" offset=\"%x\"", ROM_GETOFFSET(rom));
+				out << util::string_format(" flags=\"%x\"", ROM_GETFLAGS(rom));
 			}
 			else
 			{


### PR DESCRIPTION
This information was missing and it is useful for backend tools. It produces an output like:

```
<rom name="41em_30.11f" size="131072" crc="4249ec61" sha1="5323cfa6938e6d95db8469f09b2fb5b5c5068bfc" region="maincpu" offset="0" flags="1000"/>
```

where the _**flags**_ attribute is the addition of this PR.