### PR TITLE
galaxian.cpp: Started splitting up the state class

### DIFF
--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -10961,7 +10961,8 @@ ROM_START( tenspot )
 	ROM_LOAD( "u1.u1",    0x0000, 0x100, CRC(f18006f7) SHA1(f9a3541cd7f2b75816227d8befc03d2e33eeebac) )
 
 
-	/* temporary - replace game_x with the game number you want to test. */
+	// temporary - replace game_x with the game number you want to test.
+	ROM_REGION( 0x4000, "maincpu", ROMREGION_ERASEFF )
 	ROM_REGION( 0x2000, "gfx1", ROMREGION_ERASEFF )
 	ROM_REGION( 0x2000, "gfx2", ROMREGION_ERASEFF )
 	ROM_REGION( 0x0020, "proms", ROMREGION_ERASEFF )

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -701,6 +701,7 @@ TODO:
 
 #include "emu.h"
 #include "includes/galaxian.h"
+
 #include "audio/cclimber.h"
 #include "audio/galaxian.h"
 
@@ -713,6 +714,7 @@ TODO:
 #include "speaker.h"
 
 #include "audio/nl_konami.h"
+
 
 /*************************************
  *
@@ -1208,9 +1210,9 @@ void galaxian_state::turtles_ppi8255_1_w(offs_t offset, uint8_t data){ m_ppi8255
  *
  *************************************/
 
-uint8_t galaxian_state::scorpion_ay8910_r(offs_t offset)
+uint8_t zac_scorpion_state::ay8910_r(offs_t offset)
 {
-	/* the decoding here is very simplistic, and you can address both simultaneously */
+	// the decoding here is very simplistic, and you can address both simultaneously
 	uint8_t result = 0xff;
 	if (offset & 0x08) result &= m_ay8910[2]->data_r();
 	if (offset & 0x20) result &= m_ay8910[1]->data_r();
@@ -1219,9 +1221,9 @@ uint8_t galaxian_state::scorpion_ay8910_r(offs_t offset)
 }
 
 
-void galaxian_state::scorpion_ay8910_w(offs_t offset, uint8_t data)
+void zac_scorpion_state::ay8910_w(offs_t offset, uint8_t data)
 {
-	/* the decoding here is very simplistic, and you can address all six simultaneously */
+	// the decoding here is very simplistic, and you can address all six simultaneously
 	if (offset & 0x04) m_ay8910[2]->address_w(data);
 	if (offset & 0x08) m_ay8910[2]->data_w(data);
 	if (offset & 0x10) m_ay8910[1]->address_w(data);
@@ -1231,41 +1233,39 @@ void galaxian_state::scorpion_ay8910_w(offs_t offset, uint8_t data)
 }
 
 
-uint8_t galaxian_state::scorpion_protection_r()
+uint8_t zac_scorpion_state::protection_r()
 {
-	uint16_t paritybits;
+	// compute parity of the current (bitmask & $CE29)
 	uint8_t parity = 0;
-
-	/* compute parity of the current (bitmask & $CE29) */
-	for (paritybits = m_protection_state & 0xce29; paritybits != 0; paritybits >>= 1)
+	for (uint16_t paritybits = m_protection_state & 0xce29; paritybits != 0; paritybits >>= 1)
 		if (paritybits & 1)
 			parity++;
 
-	/* only the low bit matters for protection, but bit 2 is also checked */
+	// only the low bit matters for protection, but bit 2 is also checked
 	return parity;
 }
 
 
-void galaxian_state::scorpion_protection_w(uint8_t data)
+void zac_scorpion_state::protection_w(uint8_t data)
 {
-	/* bit 5 low is a reset */
+	// bit 5 low is a reset
 	if (!(data & 0x20))
 		m_protection_state = 0x0000;
 
-	/* bit 4 low is a clock */
+	// bit 4 low is a clock
 	if (!(data & 0x10))
 	{
-		/* each clock shifts left one bit and ORs in the inverse of the parity */
-		m_protection_state = (m_protection_state << 1) | (~scorpion_protection_r() & 1);
+		// each clock shifts left one bit and ORs in the inverse of the parity
+		m_protection_state = (m_protection_state << 1) | (~protection_r() & 1);
 	}
 }
 
-uint8_t galaxian_state::scorpion_digitalker_intr_r()
+uint8_t zac_scorpion_state::digitalker_intr_r()
 {
 	return m_digitalker->digitalker_0_intr_r();
 }
 
-void galaxian_state::scorpion_digitalker_control_w(uint8_t data)
+void zac_scorpion_state::digitalker_control_w(uint8_t data)
 {
 	m_digitalker->digitalker_0_cs_w(data & 1 ? ASSERT_LINE : CLEAR_LINE);
 	m_digitalker->digitalker_0_cms_w(data & 2 ? ASSERT_LINE : CLEAR_LINE);
@@ -1278,19 +1278,35 @@ void galaxian_state::scorpion_digitalker_control_w(uint8_t data)
  *
  *************************************/
 
+void gmgalax_state::machine_start()
+{
+	bagmanmc_state::machine_start();
+
+	m_stars_enabled = 0;
+	std::fill(std::begin(m_gfxbank), std::end(m_gfxbank), 0);
+
+	save_item(NAME(m_selected_game));
+
+	m_rombank->configure_entries(0, 2, memregion("maincpu")->base(), 0x4000);
+
+	// callback when the game select is toggled
+	game_changed(*m_gamesel->fields().first(), 0, 0, 0);
+}
+
+
 INPUT_CHANGED_MEMBER(gmgalax_state::game_changed)
 {
-	/* new value is the selected game */
+	// new value is the selected game
 	m_selected_game = newval;
 
-	/* select the bank and graphics bank based on it */
-	m_bank1->set_entry(m_selected_game);
+	// select the bank and graphics bank based on it
+	m_rombank->set_entry(m_selected_game);
 	galaxian_gfxbank_w(0, m_selected_game);
 
-	/* reset the stars */
+	// reset the stars
 	galaxian_stars_enable_w(0);
 
-	/* reset the CPU */
+	// reset the CPU
 	m_maincpu->pulse_input_line(INPUT_LINE_RESET, attotime::zero);
 }
 
@@ -1309,34 +1325,51 @@ CUSTOM_INPUT_MEMBER(gmgalax_state::port_r)
  *
  *************************************/
 
-void galaxian_state::zigzag_bankswap_w(uint8_t data)
+void zigzagb_state::machine_start()
 {
-	/* Zig Zag can swap ROMs 2 and 3 as a form of copy protection */
-	m_bank1->set_entry(data & 1);
-	membank("bank2")->set_entry(~data & 1);
+	galaxian_state::machine_start();
+
+	m_ay8910_latch = 0;
+
+	save_item(NAME(m_ay8910_latch));
+
+	// make ROMs 2 & 3 swappable
+	m_rombanks[0]->configure_entries(0, 2, memregion("maincpu")->base() + 0x2000, 0x1000);
+	m_rombanks[1]->configure_entries(0, 2, memregion("maincpu")->base() + 0x2000, 0x1000);
+
+	// set initial ROM mapping
+	bankswap_w(0);
 }
 
 
-void galaxian_state::zigzag_ay8910_w(offs_t offset, uint8_t data)
+void zigzagb_state::bankswap_w(uint8_t data)
+{
+	// Zig Zag can swap ROMs 2 and 3 as a form of copy protection
+	m_rombanks[0]->set_entry(data & 1);
+	m_rombanks[1]->set_entry(~data & 1);
+}
+
+
+void zigzagb_state::ay8910_w(offs_t offset, uint8_t data)
 {
 	switch (offset & 0x300)
 	{
-		case 0x000:
-			/* control lines */
-			/* bit 0 = WRITE */
-			/* bit 1 = C/D */
-			if ((offset & 1) != 0)
-				m_ay8910[0]->data_address_w(offset >> 1, m_zigzag_ay8910_latch);
-			break;
+	case 0x000:
+		// control lines
+		// bit 0 = WRITE
+		// bit 1 = C/D
+		if (BIT(offset, 0))
+			m_ay8910[0]->data_address_w(BIT(offset, 1), m_ay8910_latch);
+		break;
 
-		case 0x100:
-			/* data latch */
-			m_zigzag_ay8910_latch = offset & 0xff;
-			break;
+	case 0x100:
+		// data latch
+		m_ay8910_latch = offset & 0xff;
+		break;
 
-		case 0x200:
-			/* unknown */
-			break;
+	case 0x200:
+		// unknown
+		break;
 	}
 }
 
@@ -1362,14 +1395,26 @@ READ_LINE_MEMBER(galaxian_state::azurian_port_r)
  *
  *************************************/
 
-READ_LINE_MEMBER(galaxian_state::kingball_muxbit_r)
+void kingball_state::machine_start()
 {
-	/* multiplex the service mode switch with a speech DIP switch */
-	return (ioport("FAKE")->read() >> m_kingball_speech_dip) & 1;
+	galaxian_state::machine_start();
+
+	m_speech_dip = 0;
+	m_sound = 0;
+
+	save_item(NAME(m_speech_dip));
+	save_item(NAME(m_sound));
 }
 
 
-READ_LINE_MEMBER(galaxian_state::kingball_noise_r)
+READ_LINE_MEMBER(kingball_state::muxbit_r)
+{
+	// multiplex the service mode switch with a speech DIP switch
+	return BIT(m_mux_port->read(), m_speech_dip);
+}
+
+
+READ_LINE_MEMBER(kingball_state::noise_r)
 {
 	/* bit 5 is the NOISE line from the sound circuit.  The code just verifies
 	   that it's working, doesn't actually use return value, so we can just use
@@ -1378,26 +1423,26 @@ READ_LINE_MEMBER(galaxian_state::kingball_noise_r)
 }
 
 
-void galaxian_state::kingball_speech_dip_w(uint8_t data)
+void kingball_state::speech_dip_w(uint8_t data)
 {
-	m_kingball_speech_dip = data;
+	m_speech_dip = data;
 }
 
 
-void galaxian_state::kingball_sound1_w(uint8_t data)
+void kingball_state::sound1_w(uint8_t data)
 {
-	m_kingball_sound = (m_kingball_sound & ~0x01) | data;
+	m_sound = (m_sound & ~0x01) | data;
 }
 
 
-void galaxian_state::kingball_sound2_w(uint8_t data)
+void kingball_state::sound2_w(uint8_t data)
 {
-	m_kingball_sound = (m_kingball_sound & ~0x02) | (data << 1);
-	m_soundlatch->write(m_kingball_sound | 0xf0);
+	m_sound = (m_sound & ~0x02) | (data << 1);
+	m_soundlatch->write(m_sound | 0xf0);
 }
 
 
-void galaxian_state::kingball_dac_w(uint8_t data)
+void kingball_state::dac_w(uint8_t data)
 {
 	m_dac->write(data >> 4);
 }
@@ -1410,31 +1455,42 @@ void galaxian_state::kingball_dac_w(uint8_t data)
  *
  *************************************/
 
-void galaxian_state::mshuttle_ay8910_cs_w(uint8_t data)
+void mshuttle_state::machine_start()
 {
-	m_mshuttle_ay8910_cs = data & 1;
+	galaxian_state::machine_start();
+
+	m_ay8910_cs = 0;
+
+	save_item(NAME(m_ay8910_cs));
 }
 
 
-void galaxian_state::mshuttle_ay8910_control_w(uint8_t data)
+void mshuttle_state::ay8910_cs_w(uint8_t data)
 {
-	if (!m_mshuttle_ay8910_cs)
+	m_ay8910_cs = data & 1;
+}
+
+
+void mshuttle_state::ay8910_control_w(uint8_t data)
+{
+	if (!m_ay8910_cs)
 		m_ay8910_cclimber->address_w(data);
 }
 
 
-void galaxian_state::mshuttle_ay8910_data_w(uint8_t data)
+void mshuttle_state::ay8910_data_w(uint8_t data)
 {
-	if (!m_mshuttle_ay8910_cs)
+	if (!m_ay8910_cs)
 		m_ay8910_cclimber->data_w(data);
 }
 
 
-uint8_t galaxian_state::mshuttle_ay8910_data_r()
+uint8_t mshuttle_state::ay8910_data_r()
 {
-	if (!m_mshuttle_ay8910_cs)
+	if (!m_ay8910_cs)
 		return m_ay8910_cclimber->data_r();
-	return 0xff;
+	else
+		return 0xff;
 }
 
 
@@ -1633,7 +1689,7 @@ void galaxian_state::galaxian_map(address_map &map)
 	galaxian_map_discrete(map);
 }
 
-void galaxian_state::pisces_map(address_map &map)
+void pisces_state::pisces_map(address_map &map)
 {
 	galaxian_map(map);
 	map(0x6002, 0x6002).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_gfxbank_w)); // coin lockout replaced by graphics bank
@@ -1722,7 +1778,7 @@ void galaxian_state::thepitm_map(address_map &map)
 	map(0xb004, 0xb004).mirror(0x7f8).nopw(); // disable the stars
 }
 
-void galaxian_state::porter_map(address_map &map)
+void pisces_state::porter_map(address_map &map)
 {
 	mooncrst_map(map);
 	map(0x0000, 0x4fff).rom().region("maincpu", 0); // extend ROM
@@ -1730,7 +1786,7 @@ void galaxian_state::porter_map(address_map &map)
 	map(0xa002, 0xa002).mirror(0x7f8).w(FUNC(galaxian_state::galaxian_gfxbank_w)); // coin lockout replaced by graphics bank
 }
 
-void galaxian_state::skybase_map(address_map &map)
+void pisces_state::skybase_map(address_map &map)
 {
 	mooncrst_map(map);
 	map(0x0000, 0x5fff).rom().region("maincpu", 0); // extend ROM
@@ -1816,22 +1872,22 @@ void galaxian_state::ckongmc_map(address_map &map)
 	map(0xb800, 0xb800).r("watchdog", FUNC(watchdog_timer_device::reset_r));
 }
 
-void galaxian_state::bagmanmc_map(address_map &map)
+void bagmanmc_state::bagmanmc_map(address_map &map)
 {
 	ckongg_map_base(map);
 	mooncrst_map_discrete(map);
 	map(0xa000, 0xa000).portr("IN0");
-	map(0xa003, 0xa003).w(FUNC(galaxian_state::coin_count_0_w));
+	map(0xa003, 0xa003).w(FUNC(bagmanmc_state::coin_count_0_w));
 	map(0xa800, 0xa800).portr("IN1");
 	map(0xb000, 0xb000).portr("IN2").nopw();
-	map(0xb001, 0xb001).w(FUNC(galaxian_state::irq_enable_w));
-	map(0xb002, 0xb002).w(FUNC(galaxian_state::galaxian_gfxbank_w));
-	map(0xb006, 0xb006).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0xb007, 0xb007).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0xb001, 0xb001).w(FUNC(bagmanmc_state::irq_enable_w));
+	map(0xb002, 0xb002).w(FUNC(bagmanmc_state::galaxian_gfxbank_w));
+	map(0xb006, 0xb006).w(FUNC(bagmanmc_state::galaxian_flip_screen_x_w));
+	map(0xb007, 0xb007).w(FUNC(bagmanmc_state::galaxian_flip_screen_y_w));
 	map(0xb800, 0xb800).r("watchdog", FUNC(watchdog_timer_device::reset_r));
 }
 
-void galaxian_state::bagmanmc_io_map(address_map &map)
+void bagmanmc_state::bagmanmc_io_map(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x08, 0x09).nopw(); // remnant of AY-3-8910 port-based input
@@ -1861,27 +1917,34 @@ void galaxian_state::fantastc_map(address_map &map)
 //  map(0xfff8, 0xffff).nopw(); // timefgtr, sound related?
 }
 
-void galaxian_state::zigzag_map(address_map &map)
+void zigzagb_state::zigzag_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0x1fff).rom();
-	map(0x2000, 0x2fff).bankr("bank1");
-	map(0x3000, 0x3fff).bankr("bank2");
+	map(0x2000, 0x2fff).bankr(m_rombanks[0]);
+	map(0x3000, 0x3fff).bankr(m_rombanks[1]);
 	map(0x4000, 0x47ff).ram(); // needs a full 2K of RAM
-	map(0x4800, 0x4fff).w(FUNC(galaxian_state::zigzag_ay8910_w));
-	map(0x5000, 0x53ff).mirror(0x0400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x5800, 0x58ff).mirror(0x0700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
+	map(0x4800, 0x4fff).w(FUNC(zigzagb_state::ay8910_w));
+	map(0x5000, 0x53ff).mirror(0x0400).ram().w(FUNC(zigzagb_state::galaxian_videoram_w)).share("videoram");
+	map(0x5800, 0x58ff).mirror(0x0700).ram().w(FUNC(zigzagb_state::galaxian_objram_w)).share("spriteram");
 	map(0x6000, 0x6000).mirror(0x07ff).portr("IN0");
-	map(0x6000, 0x6001).mirror(0x07f8).w(FUNC(galaxian_state::start_lamp_w));
-	map(0x6003, 0x6003).mirror(0x07f8).w(FUNC(galaxian_state::coin_count_0_w));
+	map(0x6000, 0x6001).mirror(0x07f8).w(FUNC(zigzagb_state::start_lamp_w));
+	map(0x6003, 0x6003).mirror(0x07f8).w(FUNC(zigzagb_state::coin_count_0_w));
 	map(0x6800, 0x6800).mirror(0x07ff).portr("IN1");
 	map(0x7000, 0x7000).mirror(0x07ff).portr("IN2");
-	map(0x7001, 0x7001).mirror(0x07f8).w(FUNC(galaxian_state::irq_enable_w));
-	map(0x7002, 0x7002).mirror(0x07f8).w(FUNC(galaxian_state::zigzag_bankswap_w));
-	map(0x7004, 0x7004).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_stars_enable_w));
-	map(0x7006, 0x7006).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0x7007, 0x7007).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0x7001, 0x7001).mirror(0x07f8).w(FUNC(zigzagb_state::irq_enable_w));
+	map(0x7002, 0x7002).mirror(0x07f8).w(FUNC(zigzagb_state::bankswap_w));
+	map(0x7004, 0x7004).mirror(0x07f8).w(FUNC(zigzagb_state::galaxian_stars_enable_w));
+	map(0x7006, 0x7006).mirror(0x07f8).w(FUNC(zigzagb_state::galaxian_flip_screen_x_w));
+	map(0x7007, 0x7007).mirror(0x07f8).w(FUNC(zigzagb_state::galaxian_flip_screen_y_w));
 	map(0x7800, 0x7800).mirror(0x07ff).r("watchdog", FUNC(watchdog_timer_device::reset_r));
+}
+
+void gmgalax_state::gmgalax_map(address_map &map)
+{
+	galaxian_map(map);
+
+	map(0x0000, 0x3fff).bankr(m_rombank); // ROM is banked
 }
 
 // not derived from schematics
@@ -1930,13 +1993,13 @@ void namenayo_state::namenayo_map(address_map &map)
 	map(0x0000, 0x3fff).rom();
 	map(0x4000, 0x4fff).ram();
 	map(0x5000, 0x6fff).rom();
-	map(0xc800, 0xc8ff).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
-	map(0xd000, 0xd3ff).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
+	map(0xc800, 0xc8ff).ram().w(FUNC(namenayo_state::galaxian_objram_w)).share("spriteram");
+	map(0xd000, 0xd3ff).ram().w(FUNC(namenayo_state::galaxian_videoram_w)).share("videoram");
 	map(0xd800, 0xd800).w(FUNC(namenayo_state::namenayo_unk_d800_w)); // some kind of split position for bg colour maybe?
 	map(0xe000, 0xe01f).ram().w(FUNC(namenayo_state::namenayo_extattr_w)).share("extattrram");
-	map(0xe801, 0xe801).w(FUNC(galaxian_state::irq_enable_w));
-	map(0xe806, 0xe806).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0xe807, 0xe807).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0xe801, 0xe801).w(FUNC(namenayo_state::irq_enable_w));
+	map(0xe806, 0xe806).mirror(0x07f8).w(FUNC(namenayo_state::galaxian_flip_screen_x_w));
+	map(0xe807, 0xe807).mirror(0x07f8).w(FUNC(namenayo_state::galaxian_flip_screen_y_w));
 	map(0xf900, 0xf903).rw("ppi8255_0", FUNC(i8255_device::read), FUNC(i8255_device::write));
 	map(0xfa00, 0xfa03).rw("ppi8255_1", FUNC(i8255_device::read), FUNC(i8255_device::write));
 	map(0xf000, 0xf000).r("watchdog", FUNC(watchdog_timer_device::reset_r));
@@ -2054,7 +2117,7 @@ void galaxian_state::mimonscr_map(address_map &map)
 
 
 
-void galaxian_state::scorpion_map(address_map &map)
+void zac_scorpion_state::scorpion_map(address_map &map)
 {
 	theend_map(map);
 	map(0x5800, 0x67ff).rom().region("maincpu", 0x5800); // extra ROM
@@ -2377,20 +2440,20 @@ void galaxian_state::frogf_map(address_map &map)
 }
 
 
-/* mooncrst */
-void galaxian_state::mshuttle_map(address_map &map)
+// mshuttle
+void mshuttle_state::mshuttle_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x0000, 0x7fff).rom();
 	map(0x8000, 0x83ff).ram();
-	map(0x9000, 0x93ff).mirror(0x0400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x9800, 0x98ff).mirror(0x0700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
+	map(0x9000, 0x93ff).mirror(0x0400).ram().w(FUNC(mshuttle_state::galaxian_videoram_w)).share("videoram");
+	map(0x9800, 0x98ff).mirror(0x0700).ram().w(FUNC(mshuttle_state::galaxian_objram_w)).share("spriteram");
 	map(0xa000, 0xa000).portr("IN0");
-	map(0xa000, 0xa000).w(FUNC(galaxian_state::irq_enable_w));
-	map(0xa001, 0xa001).w(FUNC(galaxian_state::galaxian_stars_enable_w));
-	map(0xa002, 0xa002).w(FUNC(galaxian_state::galaxian_flip_screen_xy_w));
+	map(0xa000, 0xa000).w(FUNC(mshuttle_state::irq_enable_w));
+	map(0xa001, 0xa001).w(FUNC(mshuttle_state::galaxian_stars_enable_w));
+	map(0xa002, 0xa002).w(FUNC(mshuttle_state::galaxian_flip_screen_xy_w));
 	map(0xa004, 0xa004).w("cclimber_audio", FUNC(cclimber_audio_device::sample_trigger_w));
-	map(0xa007, 0xa007).w(FUNC(galaxian_state::mshuttle_ay8910_cs_w));
+	map(0xa007, 0xa007).w(FUNC(mshuttle_state::ay8910_cs_w));
 	map(0xa800, 0xa800).portr("IN1");
 	map(0xa800, 0xa800).w("cclimber_audio", FUNC(cclimber_audio_device::sample_rate_w));
 	map(0xb000, 0xb000).portr("IN2");
@@ -2398,64 +2461,66 @@ void galaxian_state::mshuttle_map(address_map &map)
 	map(0xb800, 0xb800).r("watchdog", FUNC(watchdog_timer_device::reset_r));
 }
 
-void galaxian_state::mshuttle_decrypted_opcodes_map(address_map &map)
+void mshuttle_state::mshuttle_decrypted_opcodes_map(address_map &map)
 {
 	map(0x0000, 0x7fff).rom().share("decrypted_opcodes");
 }
 
-void galaxian_state::mshuttle_portmap(address_map &map)
+void mshuttle_state::mshuttle_portmap(address_map &map)
 {
 	map.unmap_value_high();
 	map.global_mask(0x0f);
-	map(0x08, 0x08).w(FUNC(galaxian_state::mshuttle_ay8910_control_w));
-	map(0x09, 0x09).w(FUNC(galaxian_state::mshuttle_ay8910_data_w));
-	map(0x0c, 0x0c).r(FUNC(galaxian_state::mshuttle_ay8910_data_r));
+	map(0x08, 0x08).w(FUNC(mshuttle_state::ay8910_control_w));
+	map(0x09, 0x09).w(FUNC(mshuttle_state::ay8910_data_w));
+	map(0x0c, 0x0c).r(FUNC(mshuttle_state::ay8910_data_r));
 }
 
-void galaxian_state::fourplay_map(address_map &map)
+
+// fourplay
+void fourplay_state::fourplay_map(address_map &map)
 {
-	map(0x0000,0x3fff).bankr("bank1");
+	map(0x0000,0x3fff).bankr(m_rombank);
 	map(0x4000,0x47ff).ram();
-	map(0x5000,0x53ff).mirror(0x0400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x5800,0x58ff).mirror(0x0700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
+	map(0x5000,0x53ff).mirror(0x0400).ram().w(FUNC(fourplay_state::galaxian_videoram_w)).share("videoram");
+	map(0x5800,0x58ff).mirror(0x0700).ram().w(FUNC(fourplay_state::galaxian_objram_w)).share("spriteram");
 	map(0x6000,0x6000).portr("IN0");
 	map(0x6800,0x6800).portr("IN1");
 	map(0x7000,0x7000).portr("IN2");
 	map(0x7800,0x7fff).r("watchdog",FUNC(watchdog_timer_device::reset_r));
-	map(0x6000,0x6001).w(FUNC(galaxian_state::start_lamp_w));
-	map(0x6002,0x6002).nopw();  // .w(FUNC(galaxian_state::coin_lock_w));
-	map(0x6003,0x6003).w(FUNC(galaxian_state::coin_count_0_w));
+	map(0x6000,0x6001).w(FUNC(fourplay_state::start_lamp_w));
+	map(0x6002,0x6002).nopw();  // .w(FUNC(fourplay_state::coin_lock_w));
+	map(0x6003,0x6003).w(FUNC(fourplay_state::coin_count_0_w));
 	map(0x6004,0x6007).w("cust",FUNC(galaxian_sound_device::lfo_freq_w));
 	map(0x6800,0x6807).w("cust",FUNC(galaxian_sound_device::sound_w));
-	map(0x7001,0x7001).w(FUNC(galaxian_state::irq_enable_w));
-	map(0x7002,0x7003).w(FUNC(galaxian_state::fourplay_rombank_w));
-	map(0x7004,0x7004).w(FUNC(galaxian_state::galaxian_stars_enable_w));
+	map(0x7001,0x7001).w(FUNC(fourplay_state::irq_enable_w));
+	map(0x7002,0x7003).w(FUNC(fourplay_state::fourplay_rombank_w));
+	map(0x7004,0x7004).w(FUNC(fourplay_state::galaxian_stars_enable_w));
 	map(0x7005,0x7005).nopw();  /* bit 3 of rombank select - always 0 */
-	map(0x7006,0x7006).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0x7007,0x7007).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0x7006,0x7006).w(FUNC(fourplay_state::galaxian_flip_screen_x_w));
+	map(0x7007,0x7007).w(FUNC(fourplay_state::galaxian_flip_screen_y_w));
 	map(0x7008,0x7008).nopw();  /* bit 4 of rombank select - always 0 */
 	map(0x7800,0x7800).w("cust",FUNC(galaxian_sound_device::pitch_w));
 }
 
-void galaxian_state::videight_map(address_map &map)
+void videight_state::videight_map(address_map &map)
 {
-	map(0x0000,0x3fff).bankr("bank1");
+	map(0x0000,0x3fff).bankr(m_rombank);
 	map(0x4000,0x47ff).ram();
-	map(0x5000,0x53ff).mirror(0x400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x5800,0x58ff).mirror(0x700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
+	map(0x5000,0x53ff).mirror(0x400).ram().w(FUNC(videight_state::galaxian_videoram_w)).share("videoram");
+	map(0x5800,0x58ff).mirror(0x700).ram().w(FUNC(videight_state::galaxian_objram_w)).share("spriteram");
 	map(0x6000,0x6000).portr("IN0");
 	map(0x6800,0x6800).portr("IN1");
 	map(0x7000,0x7000).portr("IN2");
 	map(0x7800,0x7fff).r("watchdog",FUNC(watchdog_timer_device::reset_r));
-	map(0x6000,0x6002).w(FUNC(galaxian_state::videight_gfxbank_w));
-	map(0x6003,0x6003).w(FUNC(galaxian_state::coin_count_0_w));
+	map(0x6000,0x6002).w(FUNC(videight_state::videight_gfxbank_w));
+	map(0x6003,0x6003).w(FUNC(videight_state::coin_count_0_w));
 	map(0x6004,0x6007).w("cust",FUNC(galaxian_sound_device::lfo_freq_w));
 	map(0x6800,0x6807).w("cust",FUNC(galaxian_sound_device::sound_w));
 	map(0x6808,0x68ff).nopw();
-	map(0x7001,0x7001).w(FUNC(galaxian_state::irq_enable_w));
-	map(0x7002,0x7005).w(FUNC(galaxian_state::videight_rombank_w));
-	map(0x7006,0x7006).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0x7007,0x7007).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0x7001,0x7001).w(FUNC(videight_state::irq_enable_w));
+	map(0x7002,0x7005).w(FUNC(videight_state::videight_rombank_w));
+	map(0x7006,0x7006).w(FUNC(videight_state::galaxian_flip_screen_x_w));
+	map(0x7007,0x7007).w(FUNC(videight_state::galaxian_flip_screen_y_w));
 	map(0x7008,0x7008).nopw();  /* bit 4 of rombank select - always 0 */
 	map(0x7800,0x7800).w("cust",FUNC(galaxian_sound_device::pitch_w));
 }
@@ -2649,22 +2714,32 @@ void galaxian_state::takeoff_sound_portmap(address_map &map)
 
 // Scorpion with 3 x AY-8910A and Digitalker
 
-void galaxian_state::scorpion_sound_map(address_map &map)
+void zac_scorpion_state::scorpion_sound_map(address_map &map)
 {
 	konami_sound_map(map);
-	map(0x3000, 0x3000).r(FUNC(galaxian_state::scorpion_digitalker_intr_r));
+	map(0x3000, 0x3000).r(FUNC(zac_scorpion_state::digitalker_intr_r));
 }
 
-void galaxian_state::scorpion_sound_portmap(address_map &map)
+void zac_scorpion_state::scorpion_sound_portmap(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0xff).rw(FUNC(galaxian_state::scorpion_ay8910_r), FUNC(galaxian_state::scorpion_ay8910_w));
+	map(0x00, 0xff).rw(FUNC(zac_scorpion_state::ay8910_r), FUNC(zac_scorpion_state::ay8910_w));
 }
 
 
 // King and Balloon with DAC
 
-void galaxian_state::kingball_sound_map(address_map &map)
+void kingball_state::kingball_map(address_map &map)
+{
+	mooncrst_map(map);
+	map(0xb000, 0xb000).mirror(0x07f8).w(FUNC(kingball_state::sound1_w));
+	map(0xb001, 0xb001).mirror(0x07f8).w(FUNC(kingball_state::irq_enable_w));
+	map(0xb002, 0xb002).mirror(0x07f8).w(FUNC(kingball_state::sound2_w));
+	map(0xb003, 0xb003).mirror(0x07f8).w(FUNC(kingball_state::speech_dip_w));
+	map(0xb004, 0xb004).mirror(0x07f8).unmapw(); // disable the stars
+}
+
+void kingball_state::kingball_sound_map(address_map &map)
 {
 	map.unmap_value_high();
 	map.global_mask(0x3fff);
@@ -2672,11 +2747,11 @@ void galaxian_state::kingball_sound_map(address_map &map)
 	map(0x0000, 0x1fff).rom();
 }
 
-void galaxian_state::kingball_sound_portmap(address_map &map)
+void kingball_state::kingball_sound_portmap(address_map &map)
 {
 	map.unmap_value_high();
 	map.global_mask(0xff);
-	map(0x00, 0x00).mirror(0xff).r(m_soundlatch, FUNC(generic_latch_8_device::read)).w(FUNC(galaxian_state::kingball_dac_w));
+	map(0x00, 0x00).mirror(0xff).r(m_soundlatch, FUNC(generic_latch_8_device::read)).w(FUNC(kingball_state::dac_w));
 }
 
 
@@ -4708,14 +4783,14 @@ static INPUT_PORTS_START( kingball )
 	PORT_INCLUDE(galaxian)
 
 	PORT_MODIFY("IN0")
-	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(galaxian_state, kingball_muxbit_r)
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(kingball_state, muxbit_r)
 	/* Relating to above port:Hack? - possibly multiplexed via writes to $b003 */
 	//PORT_DIPNAME( 0x40, 0x40, "Speech" )
 	//PORT_DIPSETTING(    0x00, DEF_STR( Off ) )
 	//PORT_DIPSETTING(    0x40, DEF_STR( On ) )
 
 	PORT_MODIFY("IN1")
-	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(galaxian_state, kingball_noise_r)   /* NOISE line */
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_READ_LINE_MEMBER(kingball_state, noise_r)   /* NOISE line */
 	PORT_DIPNAME( 0xc0, 0x40, DEF_STR( Coinage ) )
 	PORT_DIPSETTING(    0xc0, DEF_STR( 2C_1C ) )
 	PORT_DIPSETTING(    0x40, DEF_STR( 1C_1C ) )
@@ -6980,13 +7055,17 @@ void galaxian_state::sidam_bootleg_base(machine_config &config)
 {
 	galaxian_base(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
 	m_maincpu->set_clock(12_MHz_XTAL / 2 / 2);
 
-	/* video hardware */
+	// video hardware
 	m_gfxdecode->set_info(gfx_sidam);
 
+	// adjust for 12 MHz pixel clock
 	m_screen->set_raw(12_MHz_XTAL, SIDAM_HTOTAL, SIDAM_HBEND, SIDAM_HBSTART, GALAXIAN_VTOTAL, GALAXIAN_VBEND, GALAXIAN_VBSTART);
+	set_x_scale(SIDAM_XSCALE);
+	set_h0_start(SIDAM_H0START);
+
 }
 
 
@@ -7129,10 +7208,10 @@ void galaxian_state::galaxian(machine_config &config)
 	GALAXIAN_SOUND(config, "cust", 0);
 }
 
-void galaxian_state::pisces(machine_config &config)
+void pisces_state::pisces(machine_config &config)
 {
 	galaxian(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::pisces_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &pisces_state::pisces_map);
 }
 
 void galaxian_state::victoryc(machine_config &config)
@@ -7164,7 +7243,7 @@ void galaxian_state::pacmanbl(machine_config &config)
 {
 	galaxian(config);
 
-	/* separate tile/sprite ROMs */
+	// separate tile/sprite ROMs
 	m_gfxdecode->set_info(gfx_pacmanbl);
 }
 
@@ -7181,17 +7260,28 @@ void galaxian_state::tenspot(machine_config &config)
 	m_gfxdecode->set_info(gfx_tenspot);
 }
 
-void galaxian_state::zigzag(machine_config &config)
+void galaxian_state::devilfsg(machine_config &config)
+{
+	pacmanbl(config);
+
+	// IRQ line is INT, not NMI
+	set_irq_line(0);
+}
+
+void zigzagb_state::zigzag(machine_config &config)
 {
 	galaxian_base(config);
 
-	/* separate tile/sprite ROMs */
+	// separate tile/sprite ROMs
 	m_gfxdecode->set_info(gfx_pacmanbl);
 
-	/* basic machine hardware */
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::zigzag_map);
+	// two sprite generators
+	set_num_spritegens(2);
 
-	/* sound hardware */
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &zigzagb_state::zigzag_map);
+
+	// sound hardware
 	AY8910(config, m_ay8910[0], GALAXIAN_PIXEL_CLOCK/3/2).add_route(ALL_OUTPUTS, "speaker", 0.5); /* matches PCB video - unconfirmed */
 }
 
@@ -7199,6 +7289,8 @@ void galaxian_state::zigzag(machine_config &config)
 void gmgalax_state::gmgalax(machine_config &config)
 {
 	galaxian(config);
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &gmgalax_state::gmgalax_map);
 
 	/* banked video hardware */
 	m_gfxdecode->set_info(gfx_gmgalax);
@@ -7244,16 +7336,16 @@ void galaxian_state::thepitm(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::thepitm_map);
 }
 
-void galaxian_state::porter(machine_config &config)
+void pisces_state::porter(machine_config &config)
 {
 	mooncrst(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::porter_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &pisces_state::porter_map);
 }
 
-void galaxian_state::skybase(machine_config &config)
+void pisces_state::skybase(machine_config &config)
 {
 	mooncrst(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::skybase_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &pisces_state::skybase_map);
 }
 
 void galaxian_state::kong(machine_config &config)
@@ -7296,11 +7388,15 @@ void galaxian_state::ckongmc(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::ckongmc_map);
 }
 
-void galaxian_state::bagmanmc(machine_config &config)
+void bagmanmc_state::bagmanmc(machine_config &config)
 {
 	mooncrst(config);
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::bagmanmc_map);
-	m_maincpu->set_addrmap(AS_IO, &galaxian_state::bagmanmc_io_map);
+
+	m_maincpu->set_addrmap(AS_PROGRAM, &bagmanmc_state::bagmanmc_map);
+	m_maincpu->set_addrmap(AS_IO, &bagmanmc_state::bagmanmc_io_map);
+
+	// IRQ line is INT, not NMI
+	set_irq_line(0);
 }
 
 
@@ -7310,6 +7406,12 @@ void galaxian_state::fantastc(machine_config &config)
 
 	// alternate memory map
 	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::fantastc_map);
+
+	// bullets moved from $60 to $c0
+	set_bullets_base(0xc0);
+
+	// two sprite generators
+	set_num_spritegens(2);
 
 	// sound hardware
 	AY8910(config, m_ay8910[0], GALAXIAN_PIXEL_CLOCK/3/2).add_route(ALL_OUTPUTS, "speaker", 0.25); // 3.072MHz
@@ -7397,32 +7499,37 @@ void galaxian_state::checkmaj(machine_config &config)
 }
 
 
-void galaxian_state::mshuttle(machine_config &config)
+void mshuttle_state::mshuttle(machine_config &config)
 {
 	galaxian_base(config);
 
 	// basic machine hardware
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::mshuttle_map);
-	m_maincpu->set_addrmap(AS_OPCODES, &galaxian_state::mshuttle_decrypted_opcodes_map);
-	m_maincpu->set_addrmap(AS_IO, &galaxian_state::mshuttle_portmap);
+	m_maincpu->set_addrmap(AS_PROGRAM, &mshuttle_state::mshuttle_map);
+	m_maincpu->set_addrmap(AS_OPCODES, &mshuttle_state::mshuttle_decrypted_opcodes_map);
+	m_maincpu->set_addrmap(AS_IO, &mshuttle_state::mshuttle_portmap);
+
+	// IRQ line is INT, not NMI
+	set_irq_line(0);
 
 	// sound hardware
 	CCLIMBER_AUDIO(config, "cclimber_audio", 0);
 }
 
 
-void galaxian_state::kingball(machine_config &config)
+void kingball_state::kingball(machine_config &config)
 {
 	mooncrst(config);
 
-	/* basic machine hardware */
+	// basic machine hardware
+	m_maincpu->set_addrmap(AS_PROGRAM, &kingball_state::kingball_map);
+
 	Z80(config, m_audiocpu, 5000000/2);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &galaxian_state::kingball_sound_map);
-	m_audiocpu->set_addrmap(AS_IO, &galaxian_state::kingball_sound_portmap);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &kingball_state::kingball_sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &kingball_state::kingball_sound_portmap);
 
 	GENERIC_LATCH_8(config, m_soundlatch);
 
-	/* sound hardware */
+	// sound hardware
 	DAC_4BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 0.53); // unknown DAC
 }
 
@@ -7529,11 +7636,13 @@ void namenayo_state::namenayo(machine_config &config)
 	konami_base(config);
 	konami_sound_2x_ay8910(config);
 
+	// video hardware
 	m_maincpu->set_addrmap(AS_PROGRAM, &namenayo_state::namenayo_map);
 	m_palette->set_entries(64);
 
-	/* video hardware */
 	m_gfxdecode->set_info(gfx_namenayo);
+
+	set_left_sprite_clip(0);
 }
 
 // TODO: should be derived from theend, re-sort machine configs later
@@ -7641,23 +7750,23 @@ void galaxian_state::amigo2(machine_config &config) // marked "AMI", but similar
 	AY8910(config, m_ay8910[1], 12_MHz_XTAL / 2 / 2 / 2).add_route(ALL_OUTPUTS, "speaker", 0.25); /* matches PCB, needs verification */
 }
 
-void galaxian_state::scorpion(machine_config &config)
+void zac_scorpion_state::scorpion(machine_config &config)
 {
 	scramble_base(config);
 
 	// alternate memory map
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::scorpion_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &zac_scorpion_state::scorpion_map);
 
-	m_audiocpu->set_addrmap(AS_PROGRAM, &galaxian_state::scorpion_sound_map);
-	m_audiocpu->set_addrmap(AS_IO, &galaxian_state::scorpion_sound_portmap);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &zac_scorpion_state::scorpion_sound_map);
+	m_audiocpu->set_addrmap(AS_IO, &zac_scorpion_state::scorpion_sound_portmap);
 
-	m_ppi8255[1]->in_pc_callback().set(FUNC(galaxian_state::scorpion_protection_r));
-	m_ppi8255[1]->out_pc_callback().set(FUNC(galaxian_state::scorpion_protection_w));
+	m_ppi8255[1]->in_pc_callback().set(FUNC(zac_scorpion_state::protection_r));
+	m_ppi8255[1]->out_pc_callback().set(FUNC(zac_scorpion_state::protection_w));
 
-	/* extra AY8910 with I/O ports */
+	// extra AY8910 with I/O ports
 	AY8910(config, m_ay8910[2], KONAMI_SOUND_CLOCK/8);
 	m_ay8910[2]->port_a_write_callback().set(m_digitalker, FUNC(digitalker_device::digitalker_data_w));
-	m_ay8910[2]->port_b_write_callback().set(FUNC(galaxian_state::scorpion_digitalker_control_w));
+	m_ay8910[2]->port_b_write_callback().set(FUNC(zac_scorpion_state::digitalker_control_w));
 	m_ay8910[2]->add_route(ALL_OUTPUTS, "speaker", 0.25);
 
 	DIGITALKER(config, m_digitalker, 4_MHz_XTAL).add_route(ALL_OUTPUTS, "speaker", 0.16);
@@ -7860,24 +7969,24 @@ void galaxian_state::moonwar(machine_config &config)
 	m_palette->set_init(FUNC(galaxian_state::moonwar_palette)); // bullets are less yellow
 }
 
-void galaxian_state::fourplay(machine_config &config)
+void fourplay_state::fourplay(machine_config &config)
 {
 	galaxian(config);
 
 	// basic machine hardware
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::fourplay_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &fourplay_state::fourplay_map);
 
-	/* video hardware */
+	// video hardware
 	m_gfxdecode->set_info(gfx_gmgalax);
 	m_palette->set_entries(64);
 }
 
-void galaxian_state::videight(machine_config &config)
+void videight_state::videight(machine_config &config)
 {
 	galaxian(config);
 
 	// basic machine hardware
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::videight_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &videight_state::videight_map);
 
 	/* video hardware */
 	m_gfxdecode->set_info(gfx_videight);
@@ -8118,22 +8227,16 @@ void galaxian_state::decode_victoryc()
  *
  *************************************/
 
-void galaxian_state::common_init(galaxian_draw_bullet_func draw_bullet,galaxian_draw_background_func draw_background,
-	galaxian_extend_tile_info_func extend_tile_info,galaxian_extend_sprite_info_func extend_sprite_info)
+void galaxian_state::common_init(
+		draw_bullet_func draw_bullet,
+		draw_background_func draw_background,
+		extend_tile_info_func extend_tile_info,
+		extend_sprite_info_func extend_sprite_info)
 {
-	m_x_scale = GALAXIAN_XSCALE;
-	m_h0_start = GALAXIAN_H0START;
-	m_irq_enabled = 0;
-	m_irq_line = INPUT_LINE_NMI;
-	m_numspritegens = 1;
-	m_bullets_base = 0x60;
-	m_sprites_base = 0x40;
-	m_frogger_adjust = false;
-	m_sfx_tilemap = false;
-	m_draw_bullet_ptr = (draw_bullet != nullptr) ? draw_bullet : &galaxian_state::galaxian_draw_bullet;
-	m_draw_background_ptr = (draw_background != nullptr) ? draw_background : &galaxian_state::galaxian_draw_background;
-	m_extend_tile_info_ptr = extend_tile_info;
-	m_extend_sprite_info_ptr = extend_sprite_info;
+	m_draw_bullet_ptr = draw_bullet_delegate(draw_bullet ? draw_bullet : &galaxian_state::galaxian_draw_bullet, this);
+	m_draw_background_ptr = draw_background_delegate(draw_background ? draw_background : &galaxian_state::galaxian_draw_background, this);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(extend_tile_info ? extend_tile_info : &galaxian_state::empty_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(extend_sprite_info ? extend_sprite_info : &galaxian_state::empty_extend_sprite_info, this);
 }
 
 
@@ -8232,28 +8335,19 @@ void galaxian_state::init_azurian()
 
 void gmgalax_state::init_gmgalax()
 {
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-
-	m_stars_enabled = 0;
-	std::fill(std::begin(m_gfxbank), std::end(m_gfxbank), 0);
-
-	/* video extensions */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, &gmgalax_state::gmgalax_extend_tile_info, &gmgalax_state::gmgalax_extend_sprite_info);
-
-	/* ROM is banked */
-	space.install_read_bank(0x0000, 0x3fff, m_bank1);
-	m_bank1->configure_entries(0, 2, memregion("maincpu")->base() + 0x10000, 0x4000);
-
-	/* callback when the game select is toggled */
-	game_changed(*machine().ioport().ports().begin()->second->fields().first(), 0, 0, 0);
-	save_item(NAME(m_selected_game));
+	// video extensions
+	common_init(nullptr, nullptr, nullptr, nullptr);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&gmgalax_state::bagmanmc_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&gmgalax_state::bagmanmc_extend_sprite_info, this);
 }
 
 
-void galaxian_state::init_pisces()
+void pisces_state::init_pisces()
 {
 	/* video extensions */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, &galaxian_state::pisces_extend_tile_info, &galaxian_state::pisces_extend_sprite_info);
+	common_init(nullptr, nullptr, nullptr, nullptr);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&pisces_state::pisces_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&pisces_state::pisces_extend_sprite_info, this);
 }
 
 
@@ -8278,30 +8372,33 @@ void galaxian_state::init_victoryc()
 }
 
 
-void galaxian_state::init_fourplay()
+void fourplay_state::init_fourplay()
 {
-	m_bank1->configure_entries(0, 4, memregion("maincpu")->base() + 0x10000, 0x4000);
-	m_bank1->set_entry(0);
+	m_rombank->configure_entries(0, 4, memregion("maincpu")->base(), 0x4000);
+	m_rombank->set_entry(0);
 
 	/* video extensions */
-	common_init(NULL, NULL, &galaxian_state::pisces_extend_tile_info, &galaxian_state::pisces_extend_sprite_info);
+	common_init(nullptr, nullptr, nullptr, nullptr);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&fourplay_state::pisces_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&fourplay_state::pisces_extend_sprite_info, this);
 }
 
-void galaxian_state::init_videight()
+void videight_state::init_videight()
 {
-	m_bank1->configure_entries(0, 8, memregion("maincpu")->base() + 0x10000, 0x4000);
-	m_bank1->set_entry(0);
+	m_rombank->configure_entries(0, 8, memregion("maincpu")->base(), 0x4000);
+	m_rombank->set_entry(0);
 
 	/* video extensions */
-	common_init(NULL, NULL, &galaxian_state::videight_extend_tile_info, &galaxian_state::videight_extend_sprite_info);
+	common_init(nullptr, nullptr, nullptr, nullptr);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&videight_state::videight_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&videight_state::videight_extend_sprite_info, this);
 }
 
 void guttangt_state::init_guttangt()
 {
 	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, nullptr, &galaxian_state::guttangt_extend_sprite_info);
 
-	m_rombank->configure_entry( 0, memregion("maincpu")->base() + 0x2000);
-	m_rombank->configure_entry( 1, memregion("maincpu")->base() + 0x4000);
+	m_rombank->configure_entries(0, 2, memregion("maincpu")->base() + 0x2000, 0x2000);
 	m_rombank->set_entry(0);
 }
 
@@ -8440,42 +8537,20 @@ void galaxian_state::init_tenspot()
 }
 
 
-
-void galaxian_state::init_devilfsg()
+void bagmanmc_state::init_bagmanmc()
 {
 	/* video extensions */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, nullptr, nullptr);
-
-	/* IRQ line is INT, not NMI */
-	m_irq_line = 0;
+	common_init(nullptr, nullptr, nullptr, nullptr);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&bagmanmc_state::bagmanmc_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&bagmanmc_state::bagmanmc_extend_sprite_info, this);
 }
 
 
-void galaxian_state::init_bagmanmc()
+void zigzagb_state::init_zigzag()
 {
-	/* video extensions */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, &galaxian_state::gmgalax_extend_tile_info, &galaxian_state::gmgalax_extend_sprite_info);
-
-	/* IRQ line is INT, not NMI */
-	m_irq_line = 0;
-}
-
-
-void galaxian_state::init_zigzag()
-{
-	/* video extensions */
+	// video extensions
 	common_init(nullptr, &galaxian_state::galaxian_draw_background, nullptr, nullptr);
-	m_draw_bullet_ptr = nullptr;
-
-	/* two sprite generators */
-	m_numspritegens = 2;
-
-	/* make ROMs 2 & 3 swappable */
-	m_bank1->configure_entries(0, 2, memregion("maincpu")->base() + 0x2000, 0x1000);
-	membank("bank2")->configure_entries(0, 2, memregion("maincpu")->base() + 0x2000, 0x1000);
-
-	/* handler for doing the swaps */
-	zigzag_bankswap_w(0);
+	m_draw_bullet_ptr = draw_bullet_delegate();
 }
 
 
@@ -8565,33 +8640,31 @@ void galaxian_state::init_kong()
 }
 
 
-void galaxian_state::mshuttle_decode(const uint8_t convtable[8][16])
+void mshuttle_state::mshuttle_decode(const uint8_t convtable[8][16])
 {
-	uint8_t *rom = memregion("maincpu")->base();
+	const uint8_t *const rom = memregion("maincpu")->base();
 
-	for (int A = 0x0000;A < 0x8000;A++)
+	for (int addr = 0x0000; addr < 0x8000; addr++)
 	{
-		int i,j;
-		uint8_t src = rom[A];
+		const uint8_t src = rom[addr];
 
-		/* pick the translation table from bit 0 of the address */
-		/* and from bits 1 7 of the source data */
-		i = (A & 1) | (src & 0x02) | ((src & 0x80) >> 5);
+		// pick the translation table from bit 0 of the address and from bits 1 7 of the source data
+		const int i = (addr & 1) | (src & 0x02) | ((src & 0x80) >> 5);
 
-		/* pick the offset in the table from bits 0 2 4 6 of the source data */
-		j = (src & 0x01) | ((src & 0x04) >> 1) | ((src & 0x10) >> 2) | ((src & 0x40) >> 3);
+		// pick the offset in the table from bits 0 2 4 6 of the source data
+		const int j = (src & 0x01) | ((src & 0x04) >> 1) | ((src & 0x10) >> 2) | ((src & 0x40) >> 3);
 
-		/* decode the opcodes */
-		m_decrypted_opcodes[A] = (src & 0xaa) | convtable[i][j];
+		// decode the opcodes
+		m_decrypted_opcodes[addr] = (src & 0xaa) | convtable[i][j];
 	}
 }
 
 
-void galaxian_state::init_mshuttle()
+void mshuttle_state::init_mshuttle()
 {
 	static const uint8_t convtable[8][16] =
 	{
-		/* 0xff marks spots which are unused and therefore unknown */
+		// 0xff marks spots which are unused and therefore unknown
 		{ 0x40,0x41,0x44,0x15,0x05,0x51,0x54,0x55,0x50,0x00,0x01,0x04,0xff,0x10,0x11,0x14 },
 		{ 0x45,0x51,0x55,0x44,0x40,0x11,0x05,0x41,0x10,0x14,0x54,0x50,0x15,0x04,0x00,0x01 },
 		{ 0x11,0x14,0x10,0x00,0x44,0x05,0xff,0x04,0x45,0x15,0x55,0x50,0xff,0x01,0x54,0x51 },
@@ -8602,18 +8675,15 @@ void galaxian_state::init_mshuttle()
 		{ 0x05,0x04,0x51,0x01,0xff,0xff,0x55,0xff,0x00,0x50,0x15,0x14,0x44,0x41,0x40,0x54 },
 	};
 
-	/* video extensions */
+	// video extensions
 	common_init(&galaxian_state::mshuttle_draw_bullet, &galaxian_state::galaxian_draw_background, &galaxian_state::mshuttle_extend_tile_info, &galaxian_state::mshuttle_extend_sprite_info);
 
-	/* IRQ line is INT, not NMI */
-	m_irq_line = 0;
-
-	/* decrypt the code */
+	// decrypt the code
 	mshuttle_decode(convtable);
 }
 
 
-void galaxian_state::init_mshuttlj()
+void mshuttle_state::init_mshuttlj()
 {
 	static const uint8_t convtable[8][16] =
 	{
@@ -8627,13 +8697,10 @@ void galaxian_state::init_mshuttlj()
 		{ 0x55,0x50,0x15,0x10,0x01,0x04,0x41,0x44,0x45,0x40,0x05,0x00,0x11,0x14,0x51,0x54 },
 	};
 
-	/* video extensions */
+	// video extensions
 	common_init(&galaxian_state::mshuttle_draw_bullet, &galaxian_state::galaxian_draw_background, &galaxian_state::mshuttle_extend_tile_info, &galaxian_state::mshuttle_extend_sprite_info);
 
-	/* IRQ line is INT, not NMI */
-	m_irq_line = 0;
-
-	/* decrypt the code */
+	// decrypt the code
 	mshuttle_decode(convtable);
 }
 
@@ -8642,12 +8709,6 @@ void galaxian_state::init_fantastc()
 {
 	/* video extensions */
 	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, nullptr, &galaxian_state::upper_extend_sprite_info);
-
-	/* two sprite generators */
-	m_numspritegens = 2;
-
-	/* bullets moved from $60 to $c0 */
-	m_bullets_base = 0xc0;
 
 	/* decode code */
 	static const uint16_t lut_am_unscramble[32] = {
@@ -8673,35 +8734,10 @@ void galaxian_state::init_fantastc()
 
 void galaxian_state::init_timefgtr()
 {
-	/* two sprite generators */
-	m_numspritegens = 2;
-
-	/* bullets moved from $60 to $c0 */
-	m_bullets_base = 0xc0;
-
 	/* video extensions */
 	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, nullptr, &galaxian_state::upper_extend_sprite_info);
 }
 
-
-void galaxian_state::init_kingball()
-{
-	address_space &space = m_maincpu->space(AS_PROGRAM);
-
-	/* video extensions */
-	common_init(&galaxian_state::galaxian_draw_bullet, &galaxian_state::galaxian_draw_background, nullptr, nullptr);
-
-	/* disable the stars */
-	space.unmap_write(0xb004, 0xb004, 0x7f8);
-
-	space.install_write_handler(0xb000, 0xb000, 0, 0x7f8, 0, write8smo_delegate(*this, FUNC(galaxian_state::kingball_sound1_w)));
-	space.install_write_handler(0xb001, 0xb001, 0, 0x7f8, 0, write8smo_delegate(*this, FUNC(galaxian_state::irq_enable_w)));
-	space.install_write_handler(0xb002, 0xb002, 0, 0x7f8, 0, write8smo_delegate(*this, FUNC(galaxian_state::kingball_sound2_w)));
-	space.install_write_handler(0xb003, 0xb003, 0, 0x7f8, 0, write8smo_delegate(*this, FUNC(galaxian_state::kingball_speech_dip_w)));
-
-	save_item(NAME(m_kingball_speech_dip));
-	save_item(NAME(m_kingball_sound));
-}
 
 /*************************************
  *
@@ -8767,25 +8803,10 @@ void galaxian_state::init_atlantis()
 }
 
 
-void galaxian_state::init_sidam()
-{
-	/* adjust for 12 MHz pixel clock */
-	m_x_scale = SIDAM_XSCALE;
-	m_h0_start = SIDAM_H0START;
-}
-
 void galaxian_state::init_explorer()
 {
 	/* video extensions */
 	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::null_draw_background, nullptr, nullptr); // no 555 timer; there might be no stars at all
-	init_sidam();
-}
-
-void galaxian_state::init_amigo2()
-{
-	/* video extensions */
-	init_turtles();
-	init_sidam();
 }
 
 
@@ -8889,7 +8910,7 @@ void galaxian_state::init_amidar()
 #endif
 
 
-void galaxian_state::init_scorpion()
+void zac_scorpion_state::init_scorpion()
 {
 	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::scramble_draw_background, &galaxian_state::batman2_extend_tile_info, &galaxian_state::upper_extend_sprite_info);
 
@@ -9038,7 +9059,10 @@ void galaxian_state::init_mimonkey()
 void namenayo_state::init_namenayo()
 {
 	/* video extensions */
-	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::namenayo_draw_background, &namenayo_state::namenayo_extend_tile_info, &namenayo_state::namenayo_extend_sprite_info);
+	common_init(&galaxian_state::scramble_draw_bullet, nullptr, nullptr, nullptr);
+	m_draw_background_ptr = draw_background_delegate(&namenayo_state::namenayo_draw_background, this);
+	m_extend_tile_info_ptr = extend_tile_info_delegate(&namenayo_state::namenayo_extend_tile_info, this);
+	m_extend_sprite_info_ptr = extend_sprite_info_delegate(&namenayo_state::namenayo_extend_sprite_info, this);
 }
 
 /*************************************
@@ -10452,14 +10476,14 @@ ROM_END
 
 
 ROM_START( gmgalax )
-	ROM_REGION( 0x18000, "maincpu", 0 ) /* 64k for code + 32k for banked code */
-	ROM_LOAD( "pcb1_pm1.bin", 0x10000, 0x1000, CRC(19338c70) SHA1(cc2665b7d534d324627d12025ee099ff415d4214) )
-	ROM_LOAD( "pcb1_pm2.bin", 0x11000, 0x1000, CRC(18db074d) SHA1(a70ed18f632e947493e648e6fc057dfb7a2a3322) )
-	ROM_LOAD( "pcb1_pm3.bin", 0x12000, 0x1000, CRC(abb98b1d) SHA1(bb0109d353359bb192a3e6856a857c2f842838cb) )
-	ROM_LOAD( "pcb1_pm4.bin", 0x13000, 0x1000, CRC(2403c78e) SHA1(52d8c8a4efcf47871485080ab217098a019e6579) )
-	ROM_LOAD( "pcb1_gx1.bin", 0x14000, 0x1000, CRC(2faa9f53) SHA1(1e7010d407601c5da1adc68bc9f4742c79d57286) )
-	ROM_LOAD( "pcb1_gx2.bin", 0x15000, 0x1000, CRC(121c5f16) SHA1(cb1806fa984870133fd883969838dca85f992515) )
-	ROM_LOAD( "pcb1_gx3.bin", 0x16000, 0x1000, CRC(02d81a21) SHA1(39209cfb7cf142a65e157544d93803ea542a8efb) )
+	ROM_REGION( 0x8000, "maincpu", 0 ) // 32k banked code
+	ROM_LOAD( "pcb1_pm1.bin", 0x0000, 0x1000, CRC(19338c70) SHA1(cc2665b7d534d324627d12025ee099ff415d4214) )
+	ROM_LOAD( "pcb1_pm2.bin", 0x1000, 0x1000, CRC(18db074d) SHA1(a70ed18f632e947493e648e6fc057dfb7a2a3322) )
+	ROM_LOAD( "pcb1_pm3.bin", 0x2000, 0x1000, CRC(abb98b1d) SHA1(bb0109d353359bb192a3e6856a857c2f842838cb) )
+	ROM_LOAD( "pcb1_pm4.bin", 0x3000, 0x1000, CRC(2403c78e) SHA1(52d8c8a4efcf47871485080ab217098a019e6579) )
+	ROM_LOAD( "pcb1_gx1.bin", 0x4000, 0x1000, CRC(2faa9f53) SHA1(1e7010d407601c5da1adc68bc9f4742c79d57286) )
+	ROM_LOAD( "pcb1_gx2.bin", 0x5000, 0x1000, CRC(121c5f16) SHA1(cb1806fa984870133fd883969838dca85f992515) )
+	ROM_LOAD( "pcb1_gx3.bin", 0x6000, 0x1000, CRC(02d81a21) SHA1(39209cfb7cf142a65e157544d93803ea542a8efb) )
 
 	ROM_REGION( 0x4000, "gfx1", 0 )
 	ROM_LOAD( "pcb2gfx1.bin", 0x0000, 0x0800, CRC(7021bbc0) SHA1(52d2983d74e722fccb31eb02ca56255850c4f41c) )
@@ -10926,8 +10950,8 @@ ROM_START( tenspot )
 
 
 ROM_START( fourplay )
-	ROM_REGION( 0x20000, "maincpu", 0 )
-	ROM_LOAD( "fourplay.bin", 0x10000, 0x10000, CRC(b42b2c2c) SHA1(f3b6f136b39e7a6adadecb9acf906fcfe649f398) )
+	ROM_REGION( 0x10000, "maincpu", 0 )
+	ROM_LOAD( "fourplay.bin", 0x00000, 0x10000, CRC(b42b2c2c) SHA1(f3b6f136b39e7a6adadecb9acf906fcfe649f398) )
 
 	ROM_REGION( 0x2000, "gfx1", 0 )
 	ROM_LOAD( "graph1.bin",   0x0000, 0x1000, CRC(359c0c1f) SHA1(9e39baae4ab5763db236d0a49a6665d2e69cba11) )
@@ -10938,8 +10962,8 @@ ROM_START( fourplay )
 ROM_END
 
 ROM_START( videight )
-	ROM_REGION( 0x30000, "maincpu", 0 )
-	ROM_LOAD( "videight.bin", 0x10000, 0x20000, CRC(0601db09) SHA1(0c9cd1afb0034946261219bf42b2f9b1ed5bdb17) )
+	ROM_REGION( 0x20000, "maincpu", 0 )
+	ROM_LOAD( "videight.bin", 0x00000, 0x20000, CRC(0601db09) SHA1(0c9cd1afb0034946261219bf42b2f9b1ed5bdb17) )
 
 	ROM_REGION( 0x10000, "gfx1", 0 )
 	ROM_LOAD( "v8g1.bin",     0x0000, 0x8000, CRC(af771e33) SHA1(cdc960c5f548e19da4eabdaf8b789ca8ffb6a29f) )
@@ -14959,23 +14983,23 @@ GAME( 1979, kamakazi3,   galaxian, galaxian,   superg,     galaxian_state, init_
 GAME( 1982, azurian,     0,        galaxian,   azurian,    galaxian_state, init_azurian,    ROT90,  "Rait Electronics Ltd", "Azurian Attack", MACHINE_SUPPORTS_SAVE )
 
 // Extra characters controlled via bank at $6002
-GAME( 19??, pisces,      0,        pisces,     pisces,     galaxian_state, init_pisces,     ROT90,  "Subelectro",                 "Pisces",                                           MACHINE_SUPPORTS_SAVE )
-GAME( 19??, piscesb,     pisces,   pisces,     piscesb,    galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Pisces (bootleg)",                                 MACHINE_SUPPORTS_SAVE )
-GAME( 19??, omni,        pisces,   pisces,     piscesb,    galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Omni",                                             MACHINE_SUPPORTS_SAVE )
-GAME( 1980, uniwars,     0,        pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "Irem",                       "UniWar S",                                         MACHINE_SUPPORTS_SAVE )
-GAME( 1980, uniwarsa,    uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "bootleg (Karateco)",         "UniWar S (bootleg)",                               MACHINE_SUPPORTS_SAVE )
-GAME( 1980, mltiwars,    uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "bootleg (Gayton Games)",     "Multi Wars (bootleg of UniWar S)",                 MACHINE_SUPPORTS_SAVE )
-GAME( 1980, gteikoku,    uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "Irem",                       "Gingateikoku no Gyakushu",                         MACHINE_SUPPORTS_SAVE )
-GAME( 1980, gteikokub,   uniwars,  pisces,     gteikokub,  galaxian_state, init_pisces,     ROT270, "bootleg",                    "Gingateikoku no Gyakushu (bootleg set 1)",         MACHINE_SUPPORTS_SAVE )
-GAME( 1980, gteikokub2,  uniwars,  pisces,     gteikokub2, galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Gingateikoku no Gyakushu (bootleg set 2)",         MACHINE_SUPPORTS_SAVE )
-GAME( 1980, gteikokub3,  uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "bootleg (Honly)",            "Gingateikoku no Gyakushu (bootleg set 3)",         MACHINE_SUPPORTS_SAVE )
-GAME( 1980, spacbatt,    uniwars,  pisces,     spacbatt,   galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Space Battle (bootleg set 1)",                     MACHINE_SUPPORTS_SAVE )
-GAME( 1980, spacbat2,    uniwars,  pisces,     spacbatt,   galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Space Battle (bootleg set 2)",                     MACHINE_SUPPORTS_SAVE )
-GAME( 1980, spacempr,    uniwars,  pisces,     spacbatt,   galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Space Empire (bootleg)",                           MACHINE_SUPPORTS_SAVE )
-GAME( 1980, skyraidr,    uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "bootleg",                    "Sky Raider (Uniwars bootleg)",                     MACHINE_SUPPORTS_SAVE )
-GAME( 1980, galemp,      uniwars,  pisces,     superg,     galaxian_state, init_pisces,     ROT90,  "bootleg (Taito do Brasil)",  "Galaxy Empire (bootleg?)",                         MACHINE_SUPPORTS_SAVE ) // Clearly a hack, but was it licensed?
-GAME( 1980, asideral,    uniwars,  pisces,     asideral,   galaxian_state, init_pisces,     ROT90,  "bootleg (Electrogame S.A.)", "Ataque Sideral (Spanish bootleg of UniWar S)",     MACHINE_SUPPORTS_SAVE )
-GAME( 1980, pajaroes,    uniwars,  pisces,     asideral,   galaxian_state, init_pisces,     ROT90,  "bootleg (PSV S.A.)",         "Pajaro del Espacio (Spanish bootleg of UniWar S)", MACHINE_SUPPORTS_SAVE ) // Very similar to 'asideral'
+GAME( 19??, pisces,      0,        pisces,     pisces,     pisces_state,   init_pisces,     ROT90,  "Subelectro",                 "Pisces",                                           MACHINE_SUPPORTS_SAVE )
+GAME( 19??, piscesb,     pisces,   pisces,     piscesb,    pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Pisces (bootleg)",                                 MACHINE_SUPPORTS_SAVE )
+GAME( 19??, omni,        pisces,   pisces,     piscesb,    pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Omni",                                             MACHINE_SUPPORTS_SAVE )
+GAME( 1980, uniwars,     0,        pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "Irem",                       "UniWar S",                                         MACHINE_SUPPORTS_SAVE )
+GAME( 1980, uniwarsa,    uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "bootleg (Karateco)",         "UniWar S (bootleg)",                               MACHINE_SUPPORTS_SAVE )
+GAME( 1980, mltiwars,    uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "bootleg (Gayton Games)",     "Multi Wars (bootleg of UniWar S)",                 MACHINE_SUPPORTS_SAVE )
+GAME( 1980, gteikoku,    uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "Irem",                       "Gingateikoku no Gyakushu",                         MACHINE_SUPPORTS_SAVE )
+GAME( 1980, gteikokub,   uniwars,  pisces,     gteikokub,  pisces_state,   init_pisces,     ROT270, "bootleg",                    "Gingateikoku no Gyakushu (bootleg set 1)",         MACHINE_SUPPORTS_SAVE )
+GAME( 1980, gteikokub2,  uniwars,  pisces,     gteikokub2, pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Gingateikoku no Gyakushu (bootleg set 2)",         MACHINE_SUPPORTS_SAVE )
+GAME( 1980, gteikokub3,  uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "bootleg (Honly)",            "Gingateikoku no Gyakushu (bootleg set 3)",         MACHINE_SUPPORTS_SAVE )
+GAME( 1980, spacbatt,    uniwars,  pisces,     spacbatt,   pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Space Battle (bootleg set 1)",                     MACHINE_SUPPORTS_SAVE )
+GAME( 1980, spacbat2,    uniwars,  pisces,     spacbatt,   pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Space Battle (bootleg set 2)",                     MACHINE_SUPPORTS_SAVE )
+GAME( 1980, spacempr,    uniwars,  pisces,     spacbatt,   pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Space Empire (bootleg)",                           MACHINE_SUPPORTS_SAVE )
+GAME( 1980, skyraidr,    uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "bootleg",                    "Sky Raider (Uniwars bootleg)",                     MACHINE_SUPPORTS_SAVE )
+GAME( 1980, galemp,      uniwars,  pisces,     superg,     pisces_state,   init_pisces,     ROT90,  "bootleg (Taito do Brasil)",  "Galaxy Empire (bootleg?)",                         MACHINE_SUPPORTS_SAVE ) // Clearly a hack, but was it licensed?
+GAME( 1980, asideral,    uniwars,  pisces,     asideral,   pisces_state,   init_pisces,     ROT90,  "bootleg (Electrogame S.A.)", "Ataque Sideral (Spanish bootleg of UniWar S)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1980, pajaroes,    uniwars,  pisces,     asideral,   pisces_state,   init_pisces,     ROT90,  "bootleg (PSV S.A.)",         "Pajaro del Espacio (Spanish bootleg of UniWar S)", MACHINE_SUPPORTS_SAVE ) // Very similar to 'asideral'
 
 // Artic Multi-System games - separate tile/sprite ROMs
 GAME( 1980, streakng,    0,        pacmanbl,   streakng,   galaxian_state, init_galaxian,   ROT90,  "Shoei",                        "Streaking (set 1)",                                          MACHINE_IMPERFECT_COLORS | MACHINE_SUPPORTS_SAVE )
@@ -14986,26 +15010,26 @@ GAME( 1981, pacmanblb,   puckman,  pacmanbl,   pacmanblb,  galaxian_state, init_
 GAME( 1981, pacmanblc,   puckman,  pacmanbl,   pacmanbl,   galaxian_state, init_pacmanbl,   ROT270, "bootleg (Calfesa)",            "Pac-Man (Calfesa, Spanish bootleg on Galaxian hardware)",    MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )  // same PROM as Moon Cresta, gives very strange colors and sprites get cut
 GAME( 1981, pacmanblv,   puckman,  pacmanbl,   pacmanbl,   galaxian_state, init_pacmanbl,   ROT270, "bootleg (Video Dens)",         "Pac-Man (Video Dens, Spanish bootleg on Galaxian hardware)", MACHINE_SUPPORTS_SAVE )
 GAME( 1981, ghostmun,    puckman,  pacmanbl,   streakng,   galaxian_state, init_ghostmun,   ROT90,  "bootleg (Leisure and Allied)", "Ghost Muncher",                                              MACHINE_SUPPORTS_SAVE )
-GAME( 1981, phoenxp2,    phoenix,  pisces,     phoenxp2,   galaxian_state, init_batman2,    ROT270, "bootleg",                      "Phoenix Part 2",                                             MACHINE_SUPPORTS_SAVE )
-GAME( 1981, batman2,     phoenix,  pisces,     batman2,    galaxian_state, init_batman2,    ROT270, "bootleg",                      "Batman Part 2",                                              MACHINE_SUPPORTS_SAVE ) // Similar to pisces, but with different video banking characteristics
-GAME( 1983, ladybugg,    ladybug,  pisces,     ladybugg,   galaxian_state, init_batman2,    ROT270, "bootleg",                      "Lady Bug (bootleg on Galaxian hardware)",                    MACHINE_SUPPORTS_SAVE )
+GAME( 1981, phoenxp2,    phoenix,  pisces,     phoenxp2,   pisces_state,   init_batman2,    ROT270, "bootleg",                      "Phoenix Part 2",                                             MACHINE_SUPPORTS_SAVE )
+GAME( 1981, batman2,     phoenix,  pisces,     batman2,    pisces_state,   init_batman2,    ROT270, "bootleg",                      "Batman Part 2",                                              MACHINE_SUPPORTS_SAVE ) // Similar to pisces, but with different video banking characteristics
+GAME( 1983, ladybugg,    ladybug,  pisces,     ladybugg,   pisces_state,   init_batman2,    ROT270, "bootleg",                      "Lady Bug (bootleg on Galaxian hardware)",                    MACHINE_SUPPORTS_SAVE )
 GAME( 1981, atlantisb,   atlantis, galaxian,   atlantib,   galaxian_state, init_galaxian,   ROT270, "bootleg",                      "Battle of Atlantis (bootleg)",                               MACHINE_SUPPORTS_SAVE ) // I don't know if this should have a starfield...
 GAME( 1982, tenspot,     0,        tenspot,    tenspot,    galaxian_state, init_tenspot,    ROT270, "Thomas Automatics",            "Ten Spot",                                                   MACHINE_NOT_WORKING ) // Work out how menu works
 
 // Separate tile/sprite ROMs, plus INT instead of NMI
-GAME( 1984, devilfsg,    devilfsh, pacmanbl,   devilfsg,   galaxian_state, init_devilfsg,   ROT270, "Vision / Artic", "Devil Fish (Galaxian hardware, bootleg?)", MACHINE_SUPPORTS_SAVE )
+GAME( 1984, devilfsg,    devilfsh, devilfsg,   devilfsg,   galaxian_state, init_galaxian,   ROT270, "Vision / Artic", "Devil Fish (Galaxian hardware, bootleg?)", MACHINE_SUPPORTS_SAVE )
 
 // Sound hardware replaced with AY8910
 // We're missing the original set by Taito do Brasil, we only have the bootlegs
-GAME( 1982, zigzagb,     0,        zigzag,     zigzag,     galaxian_state, init_zigzag,     ROT90,  "bootleg (LAX)", "Zig Zag (Dig Dug conversion on Galaxian hardware, bootleg set 1)", MACHINE_SUPPORTS_SAVE ) // rewrite of Dig Dug (!) not a clone
-GAME( 1982, zigzagb2,    zigzagb,  zigzag,     zigzag,     galaxian_state, init_zigzag,     ROT90,  "bootleg (LAX)", "Zig Zag (Dig Dug conversion on Galaxian hardware, bootleg set 2)", MACHINE_SUPPORTS_SAVE )
+GAME( 1982, zigzagb,     0,        zigzag,     zigzag,     zigzagb_state,  init_zigzag,     ROT90,  "bootleg (LAX)", "Zig Zag (Dig Dug conversion on Galaxian hardware, bootleg set 1)", MACHINE_SUPPORTS_SAVE ) // rewrite of Dig Dug (!) not a clone
+GAME( 1982, zigzagb2,    zigzagb,  zigzag,     zigzag,     zigzagb_state,  init_zigzag,     ROT90,  "bootleg (LAX)", "Zig Zag (Dig Dug conversion on Galaxian hardware, bootleg set 2)", MACHINE_SUPPORTS_SAVE )
 
 // multi-game select via external switch
 GAME( 1981, gmgalax,     0,        gmgalax,    gmgalax,    gmgalax_state,  init_gmgalax,    ROT90,  "bootleg", "Ghostmuncher Galaxian (bootleg)", MACHINE_SUPPORTS_SAVE )
 
 // Multigames
-GAME( 2002, fourplay,    0,        fourplay,   galaxian,   galaxian_state, init_fourplay,   ROT90, "Macro", "Four Play",   MACHINE_SUPPORTS_SAVE )
-GAME( 2001, videight,    0,        videight,   warofbug,   galaxian_state, init_videight,   ROT90, "Macro", "Video Eight", MACHINE_SUPPORTS_SAVE )
+GAME( 2002, fourplay,    0,        fourplay,   galaxian,   fourplay_state, init_fourplay,   ROT90, "Macro", "Four Play",   MACHINE_SUPPORTS_SAVE )
+GAME( 2001, videight,    0,        videight,   warofbug,   videight_state, init_videight,   ROT90, "Macro", "Video Eight", MACHINE_SUPPORTS_SAVE )
 
 
 /*************************************
@@ -15070,13 +15094,13 @@ GAME( 1981, ckongmc2,    ckong,    ckongmc,    ckongmc2,   galaxian_state, init_
 GAME( 1981, ckonggx,     ckong,    ckongg,     ckonggx,    galaxian_state, init_ckonggx,    ROT90,  "bootleg",       "Crazy Kong (bootleg on Galaxian hardware, encrypted, set 1)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 GAME( 1982, ckongcv,     ckong,    ckongg,     ckonggx,    galaxian_state, init_ckonggx,    ROT90,  "bootleg",       "Crazy Kong (bootleg on Galaxian hardware, encrypted, set 2)", MACHINE_NOT_WORKING )
 GAME( 1982, ckongis,     ckong,    ckongg,     ckonggx,    galaxian_state, init_ckonggx,    ROT90,  "bootleg",       "Crazy Kong (bootleg on Galaxian hardware, encrypted, set 3)", MACHINE_NOT_WORKING )
-GAME( 1982, bagmanmc,    bagman,   bagmanmc,   bagmanmc,   galaxian_state, init_bagmanmc,   ROT90,  "bootleg",       "Bagman (bootleg on Moon Cresta hardware, set 1)",             MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
-GAME( 1984, bagmanm2,    bagman,   bagmanmc,   bagmanmc,   galaxian_state, init_bagmanmc,   ROT90,  "bootleg (GIB)", "Bagman (bootleg on Moon Cresta hardware, set 2)",             MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1982, bagmanmc,    bagman,   bagmanmc,   bagmanmc,   bagmanmc_state, init_bagmanmc,   ROT90,  "bootleg",       "Bagman (bootleg on Moon Cresta hardware, set 1)",             MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1984, bagmanm2,    bagman,   bagmanmc,   bagmanmc,   bagmanmc_state, init_bagmanmc,   ROT90,  "bootleg (GIB)", "Bagman (bootleg on Moon Cresta hardware, set 2)",             MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 
 // Other games on basic mooncrst hardware
-GAME( 1982, porter,      dockman,  porter,     porter,     galaxian_state, init_pisces,     ROT90,  "bootleg",                  "Port Man (bootleg on Moon Cresta hardware)",                      MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL )
-GAME( 1982, portera,     dockman,  porter,     porter,     galaxian_state, init_pisces,     ROT90,  "bootleg",                  "El Estivador (Spanish bootleg of Port Man on Galaxian hardware)", MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL )
-GAME( 1982, skybase,     0,        skybase,    skybase,    galaxian_state, init_pisces,     ROT90,  "Omori Electric Co., Ltd.", "Sky Base",                                                        MACHINE_SUPPORTS_SAVE )
+GAME( 1982, porter,      dockman,  porter,     porter,     pisces_state,   init_pisces,     ROT90,  "bootleg",                  "Port Man (bootleg on Moon Cresta hardware)",                      MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL )
+GAME( 1982, portera,     dockman,  porter,     porter,     pisces_state,   init_pisces,     ROT90,  "bootleg",                  "El Estivador (Spanish bootleg of Port Man on Galaxian hardware)", MACHINE_IMPERFECT_COLORS | MACHINE_NO_COCKTAIL )
+GAME( 1982, skybase,     0,        skybase,    skybase,    pisces_state,   init_pisces,     ROT90,  "Omori Electric Co., Ltd.", "Sky Base",                                                        MACHINE_SUPPORTS_SAVE )
 GAME( 198?, kong,        0,        kong,       kong,       galaxian_state, init_kong,       ROT90,  "Taito do Brasil",          "Kong (Donkey Kong conversion on Galaxian hardware)",              MACHINE_SUPPORTS_SAVE | MACHINE_WRONG_COLORS ) // rewrite of Donkey Kong (!) not a clone
 
 // Larger romspace, 2*AY8910, based on Super Star Crest board?
@@ -15099,15 +15123,15 @@ GAME( 1983, dingo,       0,        checkmaj,   dingo,      galaxian_state, init_
 GAME( 1983, dingoe,      dingo,    checkman,   dingo,      galaxian_state, init_dingoe,     ROT90,  "Ashby Computers and Graphics Ltd.",                  "Dingo (encrypted)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
 
 // Crazy Climber sound plus AY8910 instead of galaxian sound, plus INT instead of NMI
-GAME( 1981, mshuttle,    0,        mshuttle,   mshuttle,   galaxian_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US? set 1)",     MACHINE_SUPPORTS_SAVE )
-GAME( 1981, mshuttle2,   mshuttle, mshuttle,   mshuttle,   galaxian_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US? set 2)",     MACHINE_SUPPORTS_SAVE )
-GAME( 1981, mshuttlea,   mshuttle, mshuttle,   mshuttle,   galaxian_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US, version A)", MACHINE_SUPPORTS_SAVE )
-GAME( 1981, mshuttlej,   mshuttle, mshuttle,   mshuttle,   galaxian_state, init_mshuttlj,   ROT0,   "Nichibutsu", "Moon Shuttle (Japan set 1)",   MACHINE_SUPPORTS_SAVE )
-GAME( 1981, mshuttlej2,  mshuttle, mshuttle,   mshuttle,   galaxian_state, init_mshuttlj,   ROT0,   "Nichibutsu", "Moon Shuttle (Japan set 2)",   MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mshuttle,    0,        mshuttle,   mshuttle,   mshuttle_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US? set 1)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mshuttle2,   mshuttle, mshuttle,   mshuttle,   mshuttle_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US? set 2)",     MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mshuttlea,   mshuttle, mshuttle,   mshuttle,   mshuttle_state, init_mshuttle,   ROT0,   "Nichibutsu", "Moon Shuttle (US, version A)", MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mshuttlej,   mshuttle, mshuttle,   mshuttle,   mshuttle_state, init_mshuttlj,   ROT0,   "Nichibutsu", "Moon Shuttle (Japan set 1)",   MACHINE_SUPPORTS_SAVE )
+GAME( 1981, mshuttlej2,  mshuttle, mshuttle,   mshuttle,   mshuttle_state, init_mshuttlj,   ROT0,   "Nichibutsu", "Moon Shuttle (Japan set 2)",   MACHINE_SUPPORTS_SAVE )
 
 // 2nd CPU driving DAC for sound
-GAME( 1980, kingball,    0,        kingball,   kingball,   galaxian_state, init_kingball,   ROT90,  "Namco", "King & Balloon (US)",    MACHINE_SUPPORTS_SAVE )
-GAME( 1980, kingballj,   kingball, kingball,   kingball,   galaxian_state, init_kingball,   ROT90,  "Namco", "King & Balloon (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1980, kingball,    0,        kingball,   kingball,   kingball_state, init_galaxian,   ROT90,  "Namco", "King & Balloon (US)",    MACHINE_SUPPORTS_SAVE )
+GAME( 1980, kingballj,   kingball, kingball,   kingball,   kingball_state, init_galaxian,   ROT90,  "Namco", "King & Balloon (Japan)", MACHINE_SUPPORTS_SAVE )
 
 
 
@@ -15146,7 +15170,7 @@ GAME( 1982, amidaru,     amidar,   turtles,    amidaru,    galaxian_state, init_
 GAME( 1982, amidaro,     amidar,   turtles,    amidaro,    galaxian_state, init_turtles,    ROT90,  "Konami (Olympia license)",           "Amidar (Olympia)",                                                       MACHINE_SUPPORTS_SAVE )
 GAME( 1982, amidarb,     amidar,   turtles,    amidaru,    galaxian_state, init_turtles,    ROT90,  "bootleg",                            "Amidar (bootleg)",                                                       MACHINE_SUPPORTS_SAVE ) // Similar to Amigo bootleg
 GAME( 1982, amigo,       amidar,   turtles,    amidaru,    galaxian_state, init_turtles,    ROT90,  "bootleg",                            "Amigo (bootleg of Amidar, set 1)",                                       MACHINE_SUPPORTS_SAVE )
-GAME( 1982, amigo2,      amidar,   amigo2,     amidaru,    galaxian_state, init_amigo2,     ROT90,  "bootleg",                            "Amigo (bootleg of Amidar, set 2)",                                       MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND ) // sound timer might be different?
+GAME( 1982, amigo2,      amidar,   amigo2,     amidaru,    galaxian_state, init_turtles,    ROT90,  "bootleg",                            "Amigo (bootleg of Amidar, set 2)",                                       MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_SOUND ) // sound timer might be different?
 GAME( 1982, amidars,     amidar,   scramble,   amidars,    galaxian_state, init_scramble,   ROT90,  "Konami",                             "Amidar (Scramble hardware)",                                             MACHINE_SUPPORTS_SAVE )
 GAME( 1982, mandinga,    amidar,   scramble,   amidars,    galaxian_state, init_mandinga,   ROT90,  "bootleg (Artemi)",                   "Mandinga (Artemi bootleg of Amidar)",                                    MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE ) // color PROM needs bitswap<8> on addressing, reference: http://www.youtube.com/watch?v=6uGK4AZxV2U
 GAME( 1982, mandingaeg,  amidar,   scramble,   amidars,    galaxian_state, init_mandingaeg, ROT90,  "bootleg (Electrogame S.A.)",         "Mandinga (Electrogame S.A. bootleg of Amidar)",                          MACHINE_WRONG_COLORS | MACHINE_SUPPORTS_SAVE )
@@ -15192,11 +15216,11 @@ GAME( 1981, ckongs,      ckong,    ckongs,     ckongs,     galaxian_state, init_
 GAME( 1981, jungsub,    jungler,   jungsub,    jungsub,    galaxian_state, init_jungsub,    ROT90,  "bootleg (Subelectro)", "Jungler (Subelectro, bootleg on Scramble hardware)", MACHINE_NOT_WORKING | MACHINE_IMPERFECT_GRAPHICS | MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE ) // mostly works, bad GFX ROM causes lots of glitches
 
 // Scorpion hardware; based on Scramble but with a 3rd AY-8910 and a speech chip
-GAME( 1982, scorpion,    0,        scorpion,   scorpion,   galaxian_state, init_scorpion,   ROT90,  "Zaccaria",           "Scorpion (set 1)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
-GAME( 1982, scorpiona,   scorpion, scorpion,   scorpion,   galaxian_state, init_scorpion,   ROT90,  "Zaccaria",           "Scorpion (set 2)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
-GAME( 1982, scorpionb,   scorpion, scorpion,   scorpion,   galaxian_state, init_scorpion,   ROT90,  "Zaccaria",           "Scorpion (set 3)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
-GAME( 19??, scorpionmc,  scorpion, scorpnmc,   scorpnmc,   galaxian_state, init_batman2,    ROT90,  "bootleg? (Dorneer)", "Scorpion (Moon Cresta hardware)",                       MACHINE_SUPPORTS_SAVE )
-GAME( 19??, aracnis,     scorpion, scorpnmc,   aracnis,    galaxian_state, init_batman2,    ROT90,  "bootleg",            "Aracnis (bootleg of Scorpion on Moon Cresta hardware)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1982, scorpion,    0,        scorpion,   scorpion,   zac_scorpion_state, init_scorpion, ROT90,  "Zaccaria",           "Scorpion (set 1)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
+GAME( 1982, scorpiona,   scorpion, scorpion,   scorpion,   zac_scorpion_state, init_scorpion, ROT90,  "Zaccaria",           "Scorpion (set 2)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
+GAME( 1982, scorpionb,   scorpion, scorpion,   scorpion,   zac_scorpion_state, init_scorpion, ROT90,  "Zaccaria",           "Scorpion (set 3)",                                      MACHINE_IMPERFECT_SOUND | MACHINE_SUPPORTS_SAVE)
+GAME( 19??, scorpionmc,  scorpion, scorpnmc,   scorpnmc,   galaxian_state,     init_batman2,  ROT90,  "bootleg? (Dorneer)", "Scorpion (Moon Cresta hardware)",                       MACHINE_SUPPORTS_SAVE )
+GAME( 19??, aracnis,     scorpion, scorpnmc,   aracnis,    galaxian_state,     init_batman2,  ROT90,  "bootleg",            "Aracnis (bootleg of Scorpion on Moon Cresta hardware)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
 // SF-X hardware; based on Scramble with extra Z80 and 8255 driving a DAC-based sample player
 GAME( 1983, sfx,         0,        sfx,        sfx,        galaxian_state, init_sfx,        ORIENTATION_FLIP_X, "Taiyo System (Nichibutsu license)",     "SF-X",         MACHINE_SUPPORTS_SAVE )

--- a/src/mame/drivers/galaxian.cpp
+++ b/src/mame/drivers/galaxian.cpp
@@ -1014,30 +1014,40 @@ uint8_t galaxian_state::explorer_sound_latch_r()
  *
  *************************************/
 
-uint8_t galaxian_state::sfx_sample_io_r(offs_t offset)
+void taiyo_sfx_state::machine_start()
 {
-	/* the decoding here is very simplistic, and you can address both simultaneously */
+	galaxian_state::machine_start();
+
+	m_sample_control = 0;
+
+	save_item(NAME(m_sample_control));
+}
+
+
+uint8_t taiyo_sfx_state::sample_io_r(offs_t offset)
+{
+	// the decoding here is very simplistic, and you can address both simultaneously
 	uint8_t result = 0xff;
 	if (offset & 0x04) result &= m_ppi8255[2]->read(offset & 3);
 	return result;
 }
 
 
-void galaxian_state::sfx_sample_io_w(offs_t offset, uint8_t data)
+void taiyo_sfx_state::sample_io_w(offs_t offset, uint8_t data)
 {
-	/* the decoding here is very simplistic, and you can address both simultaneously */
+	// the decoding here is very simplistic, and you can address both simultaneously
 	if (offset & 0x04) m_ppi8255[2]->write(offset & 3, data);
 	if (offset & 0x10) m_dac->write(data);
 }
 
 
-void galaxian_state::sfx_sample_control_w(uint8_t data)
+void taiyo_sfx_state::sample_control_w(uint8_t data)
 {
-	uint8_t old = m_sfx_sample_control;
-	m_sfx_sample_control = data;
+	uint8_t old = m_sample_control;
+	m_sample_control = data;
 
-	/* the inverse of bit 0 clocks the flip flop to signal an INT */
-	/* it is automatically cleared on the acknowledge */
+	// the inverse of bit 0 clocks the flip flop to signal an INT
+	// it is automatically cleared on the acknowledge
 	if ((old & 0x01) && !(data & 0x01))
 		m_audio2->set_input_line(0, HOLD_LINE);
 }
@@ -1059,13 +1069,13 @@ void galaxian_state::sfx_sample_control_w(uint8_t data)
     The data(code) in the extra RAM is later jumped/called to in many parts of the game.
 */
 
-uint8_t galaxian_state::monsterz_protection_r()
+uint8_t taiyo_sfx_state::monsterz_protection_r()
 {
 	return m_protection_result;
 }
 
 
-void galaxian_state::monsterz_set_latch()
+void taiyo_sfx_state::monsterz_set_latch()
 {
 	// read from a rom (which one?? "a-3e.k3" from audiocpu ($2700-$2fff) looks very suspicious)
 	uint8_t *rom = memregion("audiocpu")->base();
@@ -1076,7 +1086,7 @@ void galaxian_state::monsterz_set_latch()
 }
 
 
-void galaxian_state::monsterz_porta_1_w(uint8_t data)
+void taiyo_sfx_state::monsterz_porta_1_w(uint8_t data)
 {
 	// d7 high: set latch + advance address high bits (and reset low bits?)
 	if (data & 0x80)
@@ -1086,7 +1096,7 @@ void galaxian_state::monsterz_porta_1_w(uint8_t data)
 	}
 }
 
-void galaxian_state::monsterz_portb_1_w(uint8_t data)
+void taiyo_sfx_state::monsterz_portb_1_w(uint8_t data)
 {
 	// d3 high: set latch + advance address low bits
 	if (data & 0x08)
@@ -1096,7 +1106,7 @@ void galaxian_state::monsterz_portb_1_w(uint8_t data)
 	}
 }
 
-void galaxian_state::monsterz_portc_1_w(uint8_t data)
+void taiyo_sfx_state::monsterz_portc_1_w(uint8_t data)
 {
 }
 
@@ -2361,46 +2371,45 @@ void galaxian_state::turpins_map(address_map &map)
 
 
 
-/* this is the same as theend, except for separate RGB background controls
-   and some extra ROM space at $7000 and $C000 */
-void galaxian_state::sfx_map(address_map &map)
+// this is the same as theend, except for separate RGB background controls and some extra ROM space at $7000 and $C000
+void taiyo_sfx_state::sfx_map(address_map &map)
 {
 	map(0x0000, 0x3fff).rom();
 	map(0x4000, 0x47ff).ram();
-	map(0x4800, 0x4bff).mirror(0x0400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x5000, 0x50ff).mirror(0x0700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
-	map(0x6800, 0x6800).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_red_w));
-	map(0x6801, 0x6801).mirror(0x07f8).w(FUNC(galaxian_state::irq_enable_w));
-	map(0x6802, 0x6802).mirror(0x07f8).w(FUNC(galaxian_state::coin_count_0_w));
-	map(0x6803, 0x6803).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_blue_w));
-	map(0x6804, 0x6804).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_stars_enable_w));
-	map(0x6805, 0x6805).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_green_w));
-	map(0x6806, 0x6806).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0x6807, 0x6807).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
+	map(0x4800, 0x4bff).mirror(0x0400).ram().w(FUNC(taiyo_sfx_state::galaxian_videoram_w)).share("videoram");
+	map(0x5000, 0x50ff).mirror(0x0700).ram().w(FUNC(taiyo_sfx_state::galaxian_objram_w)).share("spriteram");
+	map(0x6800, 0x6800).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_red_w));
+	map(0x6801, 0x6801).mirror(0x07f8).w(FUNC(taiyo_sfx_state::irq_enable_w));
+	map(0x6802, 0x6802).mirror(0x07f8).w(FUNC(taiyo_sfx_state::coin_count_0_w));
+	map(0x6803, 0x6803).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_blue_w));
+	map(0x6804, 0x6804).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_stars_enable_w));
+	map(0x6805, 0x6805).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_green_w));
+	map(0x6806, 0x6806).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_flip_screen_x_w));
+	map(0x6807, 0x6807).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_flip_screen_y_w));
 	map(0x7000, 0x7fff).rom();
-	map(0x8000, 0xbfff).rw(FUNC(galaxian_state::theend_ppi8255_r), FUNC(galaxian_state::theend_ppi8255_w));
+	map(0x8000, 0xbfff).rw(FUNC(taiyo_sfx_state::theend_ppi8255_r), FUNC(taiyo_sfx_state::theend_ppi8255_w));
 	map(0xc000, 0xefff).rom();
 }
 
 
-void galaxian_state::monsterz_map(address_map &map)
+void taiyo_sfx_state::monsterz_map(address_map &map)
 {
 	map(0x0000, 0x37ff).rom();
 	map(0x3800, 0x3fff).ram(); // extra RAM used by protection
 	map(0x4000, 0x47ff).ram();
-	map(0x4800, 0x4bff).mirror(0x0400).ram().w(FUNC(galaxian_state::galaxian_videoram_w)).share("videoram");
-	map(0x5000, 0x50ff).mirror(0x0700).ram().w(FUNC(galaxian_state::galaxian_objram_w)).share("spriteram");
-	map(0x6800, 0x6800).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_red_w));
-	map(0x6801, 0x6801).mirror(0x07f8).w(FUNC(galaxian_state::irq_enable_w));
-	map(0x6802, 0x6802).mirror(0x07f8).w(FUNC(galaxian_state::coin_count_0_w));
-	map(0x6803, 0x6803).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_blue_w));
-	map(0x6804, 0x6804).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_stars_enable_w));
-	map(0x6805, 0x6805).mirror(0x07f8).w(FUNC(galaxian_state::scramble_background_green_w));
-	map(0x6806, 0x6806).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_x_w));
-	map(0x6807, 0x6807).mirror(0x07f8).w(FUNC(galaxian_state::galaxian_flip_screen_y_w));
-	map(0x8000, 0xbfff).rw(FUNC(galaxian_state::theend_ppi8255_r), FUNC(galaxian_state::theend_ppi8255_w));
+	map(0x4800, 0x4bff).mirror(0x0400).ram().w(FUNC(taiyo_sfx_state::galaxian_videoram_w)).share("videoram");
+	map(0x5000, 0x50ff).mirror(0x0700).ram().w(FUNC(taiyo_sfx_state::galaxian_objram_w)).share("spriteram");
+	map(0x6800, 0x6800).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_red_w));
+	map(0x6801, 0x6801).mirror(0x07f8).w(FUNC(taiyo_sfx_state::irq_enable_w));
+	map(0x6802, 0x6802).mirror(0x07f8).w(FUNC(taiyo_sfx_state::coin_count_0_w));
+	map(0x6803, 0x6803).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_blue_w));
+	map(0x6804, 0x6804).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_stars_enable_w));
+	map(0x6805, 0x6805).mirror(0x07f8).w(FUNC(taiyo_sfx_state::scramble_background_green_w));
+	map(0x6806, 0x6806).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_flip_screen_x_w));
+	map(0x6807, 0x6807).mirror(0x07f8).w(FUNC(taiyo_sfx_state::galaxian_flip_screen_y_w));
+	map(0x8000, 0xbfff).rw(FUNC(taiyo_sfx_state::theend_ppi8255_r), FUNC(taiyo_sfx_state::theend_ppi8255_w));
 	map(0xc000, 0xd7ff).rom();
-	map(0xd800, 0xd800).r(FUNC(galaxian_state::monsterz_protection_r));
+	map(0xd800, 0xd800).r(FUNC(taiyo_sfx_state::monsterz_protection_r));
 }
 
 
@@ -2691,7 +2700,7 @@ void galaxian_state::konami_sound_portmap(address_map &map)
 	map(0x00, 0xff).rw(FUNC(galaxian_state::konami_ay8910_r), FUNC(galaxian_state::konami_ay8910_w));
 }
 
-void galaxian_state::monsterz_sound_map(address_map &map)
+void taiyo_sfx_state::monsterz_sound_map(address_map &map)
 {
 	konami_sound_map(map);
 	map(0x0000, 0x3fff).rom().region("audiocpu", 0); // sound board has space for extra ROM
@@ -2792,16 +2801,16 @@ void kingball_state::kingball_sound_portmap(address_map &map)
 
 // SF-X sample player
 
-void galaxian_state::sfx_sample_map(address_map &map)
+void taiyo_sfx_state::sfx_sample_map(address_map &map)
 {
 	map(0x0000, 0x5fff).rom();
 	map(0x8000, 0x83ff).mirror(0x6c00).ram();
 }
 
-void galaxian_state::sfx_sample_portmap(address_map &map)
+void taiyo_sfx_state::sfx_sample_portmap(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0xff).rw(FUNC(galaxian_state::sfx_sample_io_r), FUNC(galaxian_state::sfx_sample_io_w));
+	map(0x00, 0xff).rw(FUNC(taiyo_sfx_state::sample_io_r), FUNC(taiyo_sfx_state::sample_io_w));
 }
 
 void galaxian_state::turpins_sound_map(address_map &map)
@@ -7816,19 +7825,19 @@ void galaxian_state::ckongs(machine_config &config)
 }
 
 
-void galaxian_state::sfx(machine_config &config)
+void taiyo_sfx_state::sfx(machine_config &config)
 {
 	scramble_base(config);
 
 	config.device_remove("watchdog");
 
 	// alternate memory map
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::sfx_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &taiyo_sfx_state::sfx_map);
 
 	/* 3rd CPU for the sample player */
 	Z80(config, m_audio2, KONAMI_SOUND_CLOCK/8);
-	m_audio2->set_addrmap(AS_PROGRAM, &galaxian_state::sfx_sample_map);
-	m_audio2->set_addrmap(AS_IO, &galaxian_state::sfx_sample_portmap);
+	m_audio2->set_addrmap(AS_PROGRAM, &taiyo_sfx_state::sfx_sample_map);
+	m_audio2->set_addrmap(AS_IO, &taiyo_sfx_state::sfx_sample_portmap);
 
 	I8255A(config, m_ppi8255[2]);
 	m_ppi8255[2]->in_pa_callback().set("soundlatch2", FUNC(generic_latch_8_device::read));
@@ -7837,24 +7846,24 @@ void galaxian_state::sfx(machine_config &config)
 
 	/* port on 2nd 8910 is used for communication */
 	m_ay8910[1]->port_a_write_callback().set("soundlatch2", FUNC(generic_latch_8_device::write));
-	m_ay8910[1]->port_b_write_callback().set(FUNC(galaxian_state::sfx_sample_control_w));
+	m_ay8910[1]->port_b_write_callback().set(FUNC(taiyo_sfx_state::sample_control_w));
 
 	/* DAC for the sample player */
 	DAC_8BIT_R2R(config, m_dac, 0).add_route(ALL_OUTPUTS, "speaker", 1.0); // 16-pin IC (not identified by schematics)
 }
 
 
-void galaxian_state::monsterz(machine_config &config)
+void taiyo_sfx_state::monsterz(machine_config &config)
 {
 	sfx(config);
 
 	// alternate memory map
-	m_maincpu->set_addrmap(AS_PROGRAM, &galaxian_state::monsterz_map);
-	m_audiocpu->set_addrmap(AS_PROGRAM, &galaxian_state::monsterz_sound_map);
+	m_maincpu->set_addrmap(AS_PROGRAM, &taiyo_sfx_state::monsterz_map);
+	m_audiocpu->set_addrmap(AS_PROGRAM, &taiyo_sfx_state::monsterz_sound_map);
 
-	m_ppi8255[1]->out_pa_callback().set(FUNC(galaxian_state::monsterz_porta_1_w));
-	m_ppi8255[1]->out_pb_callback().set(FUNC(galaxian_state::monsterz_portb_1_w));
-	m_ppi8255[1]->out_pc_callback().set(FUNC(galaxian_state::monsterz_portc_1_w));
+	m_ppi8255[1]->out_pa_callback().set(FUNC(taiyo_sfx_state::monsterz_porta_1_w));
+	m_ppi8255[1]->out_pb_callback().set(FUNC(taiyo_sfx_state::monsterz_portb_1_w));
+	m_ppi8255[1]->out_pc_callback().set(FUNC(taiyo_sfx_state::monsterz_portc_1_w));
 
 	// there are likely other differences too, but those can wait until after protection is sorted out
 }
@@ -8800,10 +8809,11 @@ void galaxian_state::init_mandinga()
 	space.unmap_read(0x7000, 0x7000, 0x7ff);
 }
 
-void galaxian_state::init_sfx()
+void taiyo_sfx_state::init_sfx()
 {
-	/* basic configuration */
-	common_init(&galaxian_state::scramble_draw_bullet, &galaxian_state::sfx_draw_background, &galaxian_state::upper_extend_tile_info, nullptr);
+	// basic configuration
+	common_init(&galaxian_state::scramble_draw_bullet, nullptr, &galaxian_state::upper_extend_tile_info, nullptr);
+	m_draw_background_ptr = draw_background_delegate(&taiyo_sfx_state::sfx_draw_background, this);
 	m_sfx_tilemap = true;
 }
 
@@ -15232,9 +15242,9 @@ GAME( 19??, scorpionmc,  scorpion, scorpnmc,   scorpnmc,   galaxian_state,     i
 GAME( 19??, aracnis,     scorpion, scorpnmc,   aracnis,    galaxian_state,     init_batman2,  ROT90,  "bootleg",            "Aracnis (bootleg of Scorpion on Moon Cresta hardware)", MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS )
 
 // SF-X hardware; based on Scramble with extra Z80 and 8255 driving a DAC-based sample player
-GAME( 1983, sfx,         0,        sfx,        sfx,        galaxian_state, init_sfx,        ORIENTATION_FLIP_X, "Taiyo System (Nichibutsu license)",     "SF-X",         MACHINE_SUPPORTS_SAVE )
-GAME( 1983, skelagon,    sfx,      sfx,        sfx,        galaxian_state, init_sfx,        ORIENTATION_FLIP_X, "Taiyo System (Nichibutsu USA license)", "Skelagon",     MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE)
-GAME( 1982, monsterz,    0,        monsterz,   sfx,        galaxian_state, init_sfx,        ORIENTATION_FLIP_X, "Taiyo System",                          "Monster Zero", MACHINE_UNEMULATED_PROTECTION | MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING )
+GAME( 1983, sfx,         0,        sfx,        sfx,        taiyo_sfx_state, init_sfx,  ORIENTATION_FLIP_X, "Taiyo System (Nichibutsu license)",     "SF-X",         MACHINE_SUPPORTS_SAVE )
+GAME( 1983, skelagon,    sfx,      sfx,        sfx,        taiyo_sfx_state, init_sfx,  ORIENTATION_FLIP_X, "Taiyo System (Nichibutsu USA license)", "Skelagon",     MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE)
+GAME( 1982, monsterz,    0,        monsterz,   sfx,        taiyo_sfx_state, init_sfx,  ORIENTATION_FLIP_X, "Taiyo System",                          "Monster Zero", MACHINE_UNEMULATED_PROTECTION | MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING )
 
 
 /*

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -80,7 +80,6 @@ public:
 		, m_filter_ctl(*this, "konami:ctl%u", 0)
 		, m_ckong_coinage(*this, "COINAGE")
 		, m_fake_select(*this, "FAKE_SELECT")
-		, m_tenspot_game_dsw(*this, {"IN2_GAME0", "IN2_GAME1", "IN2_GAME2", "IN2_GAME3", "IN2_GAME4", "IN2_GAME5", "IN2_GAME6", "IN2_GAME7", "IN2_GAME8", "IN2_GAME9"})
 		, m_spriteram(*this, "spriteram")
 		, m_videoram(*this, "videoram")
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
@@ -110,7 +109,6 @@ public:
 	void scramble_background_blue_w(uint8_t data);
 	void galaxian_gfxbank_w(offs_t offset, uint8_t data);
 	template <int N> DECLARE_READ_LINE_MEMBER(azurian_port_r);
-	DECLARE_CUSTOM_INPUT_MEMBER(moonwar_dial_r);
 	void irq_enable_w(uint8_t data);
 	void start_lamp_w(offs_t offset, uint8_t data);
 	void coin_lock_w(uint8_t data);
@@ -146,13 +144,9 @@ public:
 	uint8_t dingo_3000_r();
 	uint8_t dingo_3035_r();
 	uint8_t dingoe_3001_r();
-	void tenspot_unk_6000_w(uint8_t data);
-	void tenspot_unk_8000_w(uint8_t data);
-	void tenspot_unk_e000_w(uint8_t data);
 	uint8_t froggeram_ppi8255_r(offs_t offset);
 	void froggeram_ppi8255_w(offs_t offset, uint8_t data);
 	void artic_gfxbank_w(uint8_t data);
-	uint8_t tenspot_dsw_read();
 	void konami_sound_control_w(uint8_t data);
 	uint8_t konami_sound_timer_r();
 	void konami_portc_0_w(uint8_t data);
@@ -164,7 +158,6 @@ public:
 	void monsterz_portb_1_w(uint8_t data);
 	void monsterz_portc_1_w(uint8_t data);
 	uint8_t frogger_sound_timer_r();
-	void moonwar_port_select_w(uint8_t data);
 	void init_galaxian();
 	void init_nolock();
 	void init_azurian();
@@ -176,7 +169,6 @@ public:
 	void init_mooncrgx();
 	void init_moonqsr();
 	void init_pacmanbl();
-	void init_tenspot();
 	void init_jumpbug();
 	void init_checkman();
 	void init_checkmaj();
@@ -206,7 +198,6 @@ public:
 	void init_anteateruk();
 	void init_superbon();
 	void init_calipso();
-	void init_moonwar();
 	void init_ghostmun();
 	void init_froggrs();
 	void init_warofbugg();
@@ -217,12 +208,9 @@ public:
 
 	TILE_GET_INFO_MEMBER(bg_get_tile_info);
 	void galaxian_palette(palette_device &palette);
-	void moonwar_palette(palette_device &palette);
 	void eagle_palette(palette_device &palette);
-	void tenspot_set_game_bank(int bank, int from_game);
 	uint32_t screen_update_galaxian(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(vblank_interrupt_w);
-	DECLARE_INPUT_CHANGED_MEMBER(tenspot_fake);
 	TIMER_DEVICE_CALLBACK_MEMBER(checkmaj_irq0_gen);
 	TIMER_DEVICE_CALLBACK_MEMBER(scramble_stars_blink_timer);
 	TIMER_DEVICE_CALLBACK_MEMBER(timefgtr_scanline);
@@ -302,7 +290,6 @@ public:
 	void quaak(machine_config &config);
 	void galaxian(machine_config &config);
 	void highroll(machine_config &config);
-	void tenspot(machine_config &config);
 	void devilfsg(machine_config &config);
 	void froggers(machine_config &config);
 	void froggervd(machine_config &config);
@@ -310,7 +297,6 @@ public:
 	void monsterz(machine_config &config);
 	void anteaterg(machine_config &config);
 	void anteater(machine_config &config);
-	void moonwar(machine_config &config);
 	void turpins(machine_config &config);
 	void explorer(machine_config &config);
 	void scramble(machine_config &config);
@@ -405,7 +391,6 @@ protected:
 	void spactrai_map(address_map &map);
 	void takeoff_sound_map(address_map &map);
 	void takeoff_sound_portmap(address_map &map);
-	void tenspot_select_map(address_map &map);
 	void theend_map(address_map &map);
 	void thepitm_map(address_map &map);
 	void turpins_map(address_map &map);
@@ -436,7 +421,6 @@ protected:
 	optional_device_array<netlist_mame_logic_input_device, 12> m_filter_ctl;
 	optional_ioport m_ckong_coinage;
 	optional_ioport m_fake_select;
-	optional_ioport_array<10> m_tenspot_game_dsw;
 
 	required_shared_ptr<uint8_t> m_spriteram;
 	required_shared_ptr<uint8_t> m_videoram;
@@ -446,16 +430,12 @@ protected:
 	int m_bullets_base = 0x60;
 	int m_sprites_base = 0x40;
 	int m_numspritegens = 1;
-	int m_counter_74ls161[2];
-	int m_direction[2];
 	uint16_t m_protection_state;
 	uint8_t m_protection_result;
 	uint8_t m_konami_sound_control;
 	uint8_t m_sfx_sample_control;
-	uint8_t m_moonwar_port_select;
 	uint8_t m_irq_enabled;
 	int m_irq_line = INPUT_LINE_NMI;
-	int m_tenspot_current_game;
 	uint8_t m_frogger_adjust = false;
 	uint8_t m_x_scale = GALAXIAN_XSCALE;
 	uint8_t m_h0_start = GALAXIAN_H0START;
@@ -674,6 +654,43 @@ private:
 };
 
 
+class tenspot_state : public galaxian_state
+{
+public:
+	tenspot_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_game_dsw(*this, "IN2_GAME%u", 0U)
+		, m_mainbank(*this, "mainbank")
+	{
+	}
+
+	DECLARE_INPUT_CHANGED_MEMBER(tenspot_fake);
+
+	void tenspot(machine_config &config);
+
+	void init_tenspot();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	void unk_6000_w(uint8_t data);
+	void unk_8000_w(uint8_t data);
+	void unk_e000_w(uint8_t data);
+	uint8_t dsw_read();
+
+	void set_game_bank(int bank, bool invalidate_gfx);
+
+	void tenspot_map(address_map &map);
+	void tenspot_select_map(address_map &map);
+
+	required_ioport_array<10> m_game_dsw;
+	required_memory_bank m_mainbank;
+
+	uint8_t m_current_game;
+};
+
+
 class zigzagb_state : public galaxian_state
 {
 public:
@@ -767,6 +784,34 @@ private:
 	void scorpion_sound_portmap(address_map &map);
 
 	required_device<digitalker_device> m_digitalker;
+};
+
+
+class moonwar_state : public galaxian_state
+{
+public:
+	moonwar_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_dials(*this, "P%u_DIAL", 1U)
+	{
+	}
+
+	DECLARE_CUSTOM_INPUT_MEMBER(dial_r);
+
+	void moonwar(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	void port_select_w(uint8_t data);
+	void moonwar_palette(palette_device &palette);
+
+	required_ioport_array<2> m_dials;
+
+	uint8_t m_port_select;
+	uint8_t m_direction[2];
+	uint8_t m_counter_74ls161[2];
 };
 
 #endif // MAME_INCLUDES_GALAXIAN_H

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -12,14 +12,17 @@
 
 #include "machine/gen_latch.h"
 #include "machine/i8255.h"
+#include "machine/netlist.h"
 #include "machine/timer.h"
+
 #include "sound/ay8910.h"
 #include "sound/dac.h"
 #include "sound/digitalk.h"
-#include "machine/netlist.h"
+
 #include "emupal.h"
 #include "screen.h"
 #include "tilemap.h"
+
 
 namespace {
 
@@ -68,7 +71,6 @@ public:
 		, m_dac(*this, "dac")
 		, m_ay8910(*this, "8910.%u", 0)
 		, m_ay8910_cclimber(*this, "cclimber_audio:aysnd")
-		, m_digitalker(*this, "digitalker")
 		, m_ppi8255(*this, "ppi8255_%u", 0)
 		, m_gfxdecode(*this, "gfxdecode")
 		, m_screen(*this, "screen")
@@ -81,18 +83,20 @@ public:
 		, m_tenspot_game_dsw(*this, {"IN2_GAME0", "IN2_GAME1", "IN2_GAME2", "IN2_GAME3", "IN2_GAME4", "IN2_GAME5", "IN2_GAME6", "IN2_GAME7", "IN2_GAME8", "IN2_GAME9"})
 		, m_spriteram(*this, "spriteram")
 		, m_videoram(*this, "videoram")
-		, m_exattrram(*this, "extattrram")
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
 		, m_lamps(*this, "lamp%u", 0U)
-		, m_bank1(*this, "bank1")
-		, m_leftspriteclip(16)
 	{ }
 
 	/* video extension callbacks */
-	typedef void (galaxian_state::*galaxian_extend_tile_info_func)(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
-	typedef void (galaxian_state::*galaxian_extend_sprite_info_func)(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	typedef void (galaxian_state::*galaxian_draw_bullet_func)(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
-	typedef void (galaxian_state::*galaxian_draw_background_func)(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	typedef void (galaxian_state::*extend_tile_info_func)(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	typedef void (galaxian_state::*extend_sprite_info_func)(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
+	typedef void (galaxian_state::*draw_bullet_func)(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
+	typedef void (galaxian_state::*draw_background_func)(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	typedef delegate<void (uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)> extend_tile_info_delegate;
+	typedef delegate<void (const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)> extend_sprite_info_delegate;
+	typedef delegate<void (bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y)> draw_bullet_delegate;
+	typedef delegate<void (bitmap_rgb32 &bitmap, const rectangle &cliprect)> draw_background_delegate;
 
 	void galaxian_videoram_w(offs_t offset, uint8_t data);
 	void galaxian_objram_w(offs_t offset, uint8_t data);
@@ -106,8 +110,6 @@ public:
 	void scramble_background_blue_w(uint8_t data);
 	void galaxian_gfxbank_w(offs_t offset, uint8_t data);
 	template <int N> DECLARE_READ_LINE_MEMBER(azurian_port_r);
-	DECLARE_READ_LINE_MEMBER(kingball_muxbit_r);
-	DECLARE_READ_LINE_MEMBER(kingball_noise_r);
 	DECLARE_CUSTOM_INPUT_MEMBER(moonwar_dial_r);
 	void irq_enable_w(uint8_t data);
 	void start_lamp_w(offs_t offset, uint8_t data);
@@ -138,18 +140,6 @@ public:
 	uint8_t turtles_ppi8255_1_r(offs_t offset);
 	void turtles_ppi8255_0_w(offs_t offset, uint8_t data);
 	void turtles_ppi8255_1_w(offs_t offset, uint8_t data);
-	uint8_t scorpion_ay8910_r(offs_t offset);
-	void scorpion_ay8910_w(offs_t offset, uint8_t data);
-	uint8_t scorpion_digitalker_intr_r();
-	void zigzag_bankswap_w(uint8_t data);
-	void zigzag_ay8910_w(offs_t offset, uint8_t data);
-	void kingball_speech_dip_w(uint8_t data);
-	void kingball_sound1_w(uint8_t data);
-	void kingball_sound2_w(uint8_t data);
-	void mshuttle_ay8910_cs_w(uint8_t data);
-	void mshuttle_ay8910_control_w(uint8_t data);
-	void mshuttle_ay8910_data_w(uint8_t data);
-	uint8_t mshuttle_ay8910_data_r();
 	uint8_t jumpbug_protection_r(offs_t offset);
 	void checkman_sound_command_w(uint8_t data);
 	uint8_t checkmaj_protection_r();
@@ -174,17 +164,10 @@ public:
 	void monsterz_portb_1_w(uint8_t data);
 	void monsterz_portc_1_w(uint8_t data);
 	uint8_t frogger_sound_timer_r();
-	uint8_t scorpion_protection_r();
-	void scorpion_protection_w(uint8_t data);
-	void scorpion_digitalker_control_w(uint8_t data);
-	void kingball_dac_w(uint8_t data);
 	void moonwar_port_select_w(uint8_t data);
-	void init_fourplay();
-	void init_videight();
 	void init_galaxian();
 	void init_nolock();
 	void init_azurian();
-	void init_pisces();
 	void init_batman2();
 	void init_highroll();
 	void init_frogg();
@@ -194,25 +177,17 @@ public:
 	void init_moonqsr();
 	void init_pacmanbl();
 	void init_tenspot();
-	void init_devilfsg();
-	void init_bagmanmc();
-	void init_zigzag();
 	void init_jumpbug();
 	void init_checkman();
 	void init_checkmaj();
 	void init_dingo();
 	void init_dingoe();
 	void init_kong();
-	void init_mshuttle();
-	void init_mshuttlj();
 	void init_fantastc();
 	void init_timefgtr();
-	void init_kingball();
 	void init_theend();
 	void init_scramble();
-	void init_sidam();
 	void init_explorer();
-	void init_amigo2();
 	void init_mandinga();
 	void init_mandingaeg();
 	void init_sfx();
@@ -225,7 +200,6 @@ public:
 	void init_froggers();
 	void init_quaak();
 	void init_turtles();
-	void init_scorpion();
 	void init_ckongs();
 	void init_ckonggx();
 	void init_anteater();
@@ -268,20 +242,17 @@ public:
 	void turtles_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void frogger_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void namenayo_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	inline void galaxian_draw_pixel(bitmap_rgb32 &bitmap, const rectangle &cliprect, int y, int x, rgb_t color);
 	void galaxian_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void mshuttle_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void scramble_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
 	void theend_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
+	void empty_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	void empty_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void upper_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void upper_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void frogger_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void frogger_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	void gmgalax_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
-	void gmgalax_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	void pisces_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
-	void pisces_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void batman2_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void mooncrst_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void mooncrst_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
@@ -294,8 +265,6 @@ public:
 	void jumpbug_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void mimonkey_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void mimonkey_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	void namenayo_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
-	void namenayo_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void guttangt_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void monsterz_set_latch();
 	void decode_mooncrst(int length, uint8_t *dest);
@@ -308,9 +277,11 @@ public:
 	void decode_losttomb_gfx();
 	void decode_superbon();
 	void decode_victoryc();
-	void mshuttle_decode(const uint8_t convtable[8][16]);
-	void common_init(galaxian_draw_bullet_func draw_bullet,galaxian_draw_background_func draw_background,
-					 galaxian_extend_tile_info_func extend_tile_info,galaxian_extend_sprite_info_func extend_sprite_info);
+	void common_init(
+			draw_bullet_func draw_bullet,
+			draw_background_func draw_background,
+			extend_tile_info_func extend_tile_info,
+			extend_sprite_info_func extend_sprite_info);
 	void galaxian_base(machine_config &config);
 	void sidam_bootleg_base(machine_config &config);
 	void konami_base(machine_config &config);
@@ -330,15 +301,13 @@ public:
 	void pacmanbl(machine_config &config);
 	void quaak(machine_config &config);
 	void galaxian(machine_config &config);
-	void pisces(machine_config &config);
 	void highroll(machine_config &config);
 	void tenspot(machine_config &config);
+	void devilfsg(machine_config &config);
 	void froggers(machine_config &config);
 	void froggervd(machine_config &config);
-	void mshuttle(machine_config &config);
 	void anteateruk(machine_config &config);
 	void monsterz(machine_config &config);
-	void kingball(machine_config &config);
 	void anteaterg(machine_config &config);
 	void anteater(machine_config &config);
 	void moonwar(machine_config &config);
@@ -353,27 +322,20 @@ public:
 	void sfx(machine_config &config);
 	void mooncrst(machine_config &config);
 	void eagle(machine_config &config);
-	void scorpion(machine_config &config);
 	void ckongs(machine_config &config);
 	void frogf(machine_config &config);
 	void amigo2(machine_config &config);
-	void zigzag(machine_config &config);
 	void checkman(machine_config &config);
 	void jungsub(machine_config &config);
 	void victoryc(machine_config &config);
 	void frogg(machine_config &config);
 	void mandingarf(machine_config &config);
 	void thepitm(machine_config &config);
-	void porter(machine_config &config);
-	void skybase(machine_config &config);
 	void kong(machine_config &config);
 	void bongo(machine_config &config);
 	void scorpnmc(machine_config &config);
 	void ckongg(machine_config &config);
 	void ckongmc(machine_config &config);
-	void bagmanmc(machine_config &config);
-	void fourplay(machine_config &config);
-	void videight(machine_config &config);
 	void astroamb(machine_config &config);
 	void mimonkey(machine_config &config);
 	void mimonscr(machine_config &config);
@@ -382,13 +344,19 @@ public:
 	template <int Mask> DECLARE_READ_LINE_MEMBER(ckongs_coinage_r);
 
 protected:
+	// machine configuration helpers
+	void set_irq_line(int line) { m_irq_line = line; }
+	void set_bullets_base(int base) { m_bullets_base = base; }
+	void set_num_spritegens(int num) { m_numspritegens = num; }
+	void set_x_scale(uint8_t scale) { m_x_scale = scale; }
+	void set_h0_start(uint8_t start) { m_h0_start = start; }
+	void set_left_sprite_clip(uint8_t clip) { m_leftspriteclip = clip; }
+
 	void amigo2_map(address_map &map);
 	void anteaterg_map(address_map &map);
 	void anteatergg_map(address_map &map);
 	void anteateruk_map(address_map &map);
 	void astroamb_map(address_map &map);
-	void bagmanmc_map(address_map &map);
-	void bagmanmc_io_map(address_map &map);
 	void bongo_map(address_map &map);
 	void bongo_io_map(address_map &map);
 	void checkmaj_sound_map(address_map &map);
@@ -415,8 +383,6 @@ protected:
 	void jumpbug_map(address_map &map);
 	void jungsub_map(address_map &map);
 	void jungsub_io_map(address_map &map);
-	void kingball_sound_map(address_map &map);
-	void kingball_sound_portmap(address_map &map);
 	void konami_sound_map(address_map &map);
 	void konami_sound_portmap(address_map &map);
 	void kong_map(address_map &map);
@@ -429,22 +395,13 @@ protected:
 	void mooncrst_map_base(address_map &map);
 	void mooncrst_map_discrete(address_map &map);
 	void moonqsr_decrypted_opcodes_map(address_map &map);
-	void mshuttle_decrypted_opcodes_map(address_map &map);
-	void mshuttle_map(address_map &map);
-	void mshuttle_portmap(address_map &map);
 	void ozon1_map(address_map &map);
 	void ozon1_io_map(address_map &map);
-	void pisces_map(address_map &map);
-	void porter_map(address_map &map);
 	void scobra_map(address_map &map);
-	void scorpion_map(address_map &map);
-	void scorpion_sound_map(address_map &map);
-	void scorpion_sound_portmap(address_map &map);
 	void scorpnmc_map(address_map &map);
 	void sfx_map(address_map &map);
 	void sfx_sample_map(address_map &map);
 	void sfx_sample_portmap(address_map &map);
-	void skybase_map(address_map &map);
 	void spactrai_map(address_map &map);
 	void takeoff_sound_map(address_map &map);
 	void takeoff_sound_portmap(address_map &map);
@@ -455,9 +412,13 @@ protected:
 	void turpins_sound_map(address_map &map);
 	void turtles_map(address_map &map);
 	void victoryc_map(address_map &map);
-	void zigzag_map(address_map &map);
 
-	virtual void machine_start() override { m_lamps.resolve(); }
+	virtual void machine_start() override
+	{
+		m_lamps.resolve();
+
+		m_irq_enabled = 0;
+	}
 	virtual void video_start() override;
 
 	required_device<cpu_device> m_maincpu;
@@ -466,7 +427,6 @@ protected:
 	optional_device<dac_byte_interface> m_dac;
 	optional_device_array<ay8910_device, 3> m_ay8910;
 	optional_device<ay8910_device> m_ay8910_cclimber;
-	optional_device<digitalker_device> m_digitalker;
 	optional_device_array<i8255_device, 3> m_ppi8255;
 	required_device<gfxdecode_device> m_gfxdecode;
 	required_device<screen_device> m_screen;
@@ -480,38 +440,31 @@ protected:
 
 	required_shared_ptr<uint8_t> m_spriteram;
 	required_shared_ptr<uint8_t> m_videoram;
-	optional_shared_ptr<uint8_t> m_exattrram; // belongs in namenayo_state but the callbacks are problematic as things are set up
 	optional_shared_ptr<uint8_t> m_decrypted_opcodes;
 	output_finder<2> m_lamps;
 
-	memory_bank_creator m_bank1;
-
-	int m_bullets_base;
-	int m_sprites_base;
-	int m_numspritegens;
+	int m_bullets_base = 0x60;
+	int m_sprites_base = 0x40;
+	int m_numspritegens = 1;
 	int m_counter_74ls161[2];
 	int m_direction[2];
-	uint8_t m_zigzag_ay8910_latch;
-	uint8_t m_kingball_speech_dip;
-	uint8_t m_kingball_sound;
-	uint8_t m_mshuttle_ay8910_cs;
 	uint16_t m_protection_state;
 	uint8_t m_protection_result;
 	uint8_t m_konami_sound_control;
 	uint8_t m_sfx_sample_control;
 	uint8_t m_moonwar_port_select;
 	uint8_t m_irq_enabled;
-	int m_irq_line;
+	int m_irq_line = INPUT_LINE_NMI;
 	int m_tenspot_current_game;
-	uint8_t m_frogger_adjust;
-	uint8_t m_x_scale;
-	uint8_t m_h0_start;
-	uint8_t m_sfx_tilemap;
+	uint8_t m_frogger_adjust = false;
+	uint8_t m_x_scale = GALAXIAN_XSCALE;
+	uint8_t m_h0_start = GALAXIAN_H0START;
+	uint8_t m_sfx_tilemap = false;
 
-	galaxian_extend_tile_info_func m_extend_tile_info_ptr;
-	galaxian_extend_sprite_info_func m_extend_sprite_info_ptr;
-	galaxian_draw_bullet_func m_draw_bullet_ptr;
-	galaxian_draw_background_func m_draw_background_ptr;
+	extend_tile_info_delegate m_extend_tile_info_ptr;
+	extend_sprite_info_delegate m_extend_sprite_info_ptr;
+	draw_bullet_delegate m_draw_bullet_ptr;
+	draw_background_delegate m_draw_background_ptr;
 
 	tilemap_t *m_bg_tilemap;
 	uint8_t m_flipscreen_x;
@@ -528,24 +481,40 @@ protected:
 	uint8_t m_stars_blink_state;
 	rgb_t m_bullet_color[8];
 	uint8_t m_gfxbank[5];
-	uint8_t m_leftspriteclip;
-
-	void fourplay_rombank_w(offs_t offset, uint8_t data);
-	void videight_rombank_w(offs_t offset, uint8_t data);
-	void videight_gfxbank_w(offs_t offset, uint8_t data);
-	void videight_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
-	void videight_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	void fourplay_map(address_map &map);
-	void videight_map(address_map &map);
+	uint8_t m_leftspriteclip = 16;
 };
 
-class gmgalax_state : public galaxian_state
+
+class bagmanmc_state : public galaxian_state
+{
+public:
+	bagmanmc_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+	{
+	}
+
+	void bagmanmc(machine_config &config);
+	void init_bagmanmc();
+
+protected:
+	void bagmanmc_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	void bagmanmc_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
+
+private:
+	void bagmanmc_map(address_map &map);
+	void bagmanmc_io_map(address_map &map);
+};
+
+
+class gmgalax_state : public bagmanmc_state
 {
 public:
 	gmgalax_state(const machine_config &mconfig, device_type type, const char *tag)
-		: galaxian_state(mconfig, type, tag)
+		: bagmanmc_state(mconfig, type, tag)
 		, m_glin(*this, "GLIN%u", 0U)
 		, m_gmin(*this, "GMIN%u", 0U)
+		, m_gamesel(*this, "GAMESEL")
+		, m_rombank(*this, "rombank")
 	{ }
 
 	void gmgalax(machine_config &config);
@@ -555,29 +524,203 @@ public:
 
 	void init_gmgalax();
 
+protected:
+	virtual void machine_start() override;
+
 private:
-	uint8_t m_selected_game;
+	void gmgalax_map(address_map &map);
+
 	required_ioport_array<3> m_glin;
 	required_ioport_array<3> m_gmin;
+	required_ioport m_gamesel;
+	required_memory_bank m_rombank;
+
+	uint8_t m_selected_game;
 };
+
+
+class pisces_state : public galaxian_state
+{
+public:
+	pisces_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+	{
+	}
+
+	void pisces(machine_config &config);
+	void porter(machine_config &config);
+	void skybase(machine_config &config);
+
+	void init_pisces();
+
+protected:
+	void pisces_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	void pisces_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
+
+private:
+	void pisces_map(address_map &map);
+	void skybase_map(address_map &map);
+	void porter_map(address_map &map);
+};
+
+
+class fourplay_state : public pisces_state
+{
+public:
+	fourplay_state(const machine_config &mconfig, device_type type, const char *tag)
+		: pisces_state(mconfig, type, tag)
+		, m_rombank(*this, "rombank")
+	{
+	}
+
+	void fourplay(machine_config &config);
+	void init_fourplay();
+
+private:
+	void fourplay_rombank_w(offs_t offset, uint8_t data);
+	void fourplay_map(address_map &map);
+
+	required_memory_bank m_rombank;
+};
+
+
+class mshuttle_state : public galaxian_state
+{
+public:
+	mshuttle_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+	{
+	}
+
+	void mshuttle(machine_config &config);
+
+	void init_mshuttle();
+	void init_mshuttlj();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	void ay8910_cs_w(uint8_t data);
+	void ay8910_control_w(uint8_t data);
+	void ay8910_data_w(uint8_t data);
+	uint8_t ay8910_data_r();
+
+	void mshuttle_map(address_map &map);
+	void mshuttle_decrypted_opcodes_map(address_map &map);
+	void mshuttle_portmap(address_map &map);
+
+	void mshuttle_decode(const uint8_t convtable[8][16]);
+
+	uint8_t m_ay8910_cs;
+};
+
+
+class kingball_state : public galaxian_state
+{
+public:
+	kingball_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_mux_port(*this, "FAKE")
+	{
+	}
+
+	DECLARE_READ_LINE_MEMBER(muxbit_r);
+	DECLARE_READ_LINE_MEMBER(noise_r);
+
+	void kingball(machine_config &config);
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	void speech_dip_w(uint8_t data);
+	void sound1_w(uint8_t data);
+	void sound2_w(uint8_t data);
+	void dac_w(uint8_t data);
+
+	void kingball_map(address_map &map);
+	void kingball_sound_map(address_map &map);
+	void kingball_sound_portmap(address_map &map);
+
+	required_ioport m_mux_port;
+
+	uint8_t m_speech_dip;
+	uint8_t m_sound;
+};
+
 
 class namenayo_state : public galaxian_state
 {
 public:
 	namenayo_state(const machine_config &mconfig, device_type type, const char *tag)
 		: galaxian_state(mconfig, type, tag)
+		, m_exattrram(*this, "extattrram")
 	{
-		m_leftspriteclip = 0;
 	}
 
 	void namenayo(machine_config &config);
 	void init_namenayo();
 
 private:
+	void namenayo_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+	void namenayo_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	void namenayo_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void namenayo_map(address_map &map);
 	void namenayo_extattr_w(offs_t offset, uint8_t data);
 	void namenayo_unk_d800_w(uint8_t data);
+
+	required_shared_ptr<uint8_t> m_exattrram;
 };
+
+
+class zigzagb_state : public galaxian_state
+{
+public:
+	zigzagb_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_rombanks(*this, "bank%u", 1U)
+	{
+	}
+
+	void zigzag(machine_config &config);
+	void init_zigzag();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	void bankswap_w(uint8_t data);
+	void ay8910_w(offs_t offset, uint8_t data);
+	void zigzag_map(address_map &map);
+
+	required_memory_bank_array<2> m_rombanks;
+	uint8_t m_ay8910_latch;
+};
+
+
+class videight_state : public galaxian_state
+{
+public:
+	videight_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_rombank(*this, "rombank")
+	{
+	}
+
+	void videight(machine_config &config);
+	void init_videight();
+
+private:
+	void videight_rombank_w(offs_t offset, uint8_t data);
+	void videight_gfxbank_w(offs_t offset, uint8_t data);
+	void videight_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
+	void videight_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
+	void videight_map(address_map &map);
+
+	required_memory_bank m_rombank;
+};
+
 
 class guttangt_state : public galaxian_state
 {
@@ -598,5 +741,32 @@ private:
 	required_memory_bank m_rombank;
 };
 
+
+class zac_scorpion_state : public galaxian_state
+{
+public:
+	zac_scorpion_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_digitalker(*this, "digitalker")
+	{
+	}
+
+	void scorpion(machine_config &config);
+	void init_scorpion();
+
+private:
+	uint8_t ay8910_r(offs_t offset);
+	void ay8910_w(offs_t offset, uint8_t data);
+	uint8_t digitalker_intr_r();
+	void digitalker_control_w(uint8_t data);
+	uint8_t protection_r();
+	void protection_w(uint8_t data);
+
+	void scorpion_map(address_map &map);
+	void scorpion_sound_map(address_map &map);
+	void scorpion_sound_portmap(address_map &map);
+
+	required_device<digitalker_device> m_digitalker;
+};
 
 #endif // MAME_INCLUDES_GALAXIAN_H

--- a/src/mame/includes/galaxian.h
+++ b/src/mame/includes/galaxian.h
@@ -67,8 +67,6 @@ public:
 		: driver_device(mconfig, type, tag)
 		, m_maincpu(*this, "maincpu")
 		, m_audiocpu(*this, "audiocpu")
-		, m_audio2(*this, "audio2")
-		, m_dac(*this, "dac")
 		, m_ay8910(*this, "8910.%u", 0)
 		, m_ay8910_cclimber(*this, "cclimber_audio:aysnd")
 		, m_ppi8255(*this, "ppi8255_%u", 0)
@@ -79,7 +77,6 @@ public:
 		, m_netlist(*this, "konami")
 		, m_filter_ctl(*this, "konami:ctl%u", 0)
 		, m_ckong_coinage(*this, "COINAGE")
-		, m_fake_select(*this, "FAKE_SELECT")
 		, m_spriteram(*this, "spriteram")
 		, m_videoram(*this, "videoram")
 		, m_decrypted_opcodes(*this, "decrypted_opcodes")
@@ -123,9 +120,6 @@ public:
 	uint8_t theend_protection_r();
 	template <int N> DECLARE_READ_LINE_MEMBER(theend_protection_alt_r);
 	void explorer_sound_control_w(uint8_t data);
-	uint8_t sfx_sample_io_r(offs_t offset);
-	void sfx_sample_io_w(offs_t offset, uint8_t data);
-	uint8_t monsterz_protection_r();
 	uint8_t frogger_ppi8255_r(offs_t offset);
 	void frogger_ppi8255_w(offs_t offset, uint8_t data);
 	uint8_t frogger_ay8910_r(offs_t offset);
@@ -153,10 +147,6 @@ public:
 	void konami_portc_1_w(uint8_t data);
 	void theend_coin_counter_w(uint8_t data);
 	uint8_t explorer_sound_latch_r();
-	void sfx_sample_control_w(uint8_t data);
-	void monsterz_porta_1_w(uint8_t data);
-	void monsterz_portb_1_w(uint8_t data);
-	void monsterz_portc_1_w(uint8_t data);
 	uint8_t frogger_sound_timer_r();
 	void init_galaxian();
 	void init_nolock();
@@ -182,7 +172,6 @@ public:
 	void init_explorer();
 	void init_mandinga();
 	void init_mandingaeg();
-	void init_sfx();
 	void init_atlantis();
 	void init_scobra();
 	void init_scobrae();
@@ -228,7 +217,6 @@ public:
 	void anteater_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void jumpbug_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void turtles_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
-	void sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	void frogger_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	inline void galaxian_draw_pixel(bitmap_rgb32 &bitmap, const rectangle &cliprect, int y, int x, rgb_t color);
 	void galaxian_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &cliprect, int offs, int x, int y);
@@ -254,7 +242,6 @@ public:
 	void mimonkey_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y);
 	void mimonkey_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
 	void guttangt_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color);
-	void monsterz_set_latch();
 	void decode_mooncrst(int length, uint8_t *dest);
 	void decode_checkman();
 	void decode_dingoe();
@@ -294,7 +281,6 @@ public:
 	void froggers(machine_config &config);
 	void froggervd(machine_config &config);
 	void anteateruk(machine_config &config);
-	void monsterz(machine_config &config);
 	void anteaterg(machine_config &config);
 	void anteater(machine_config &config);
 	void turpins(machine_config &config);
@@ -305,7 +291,6 @@ public:
 	void froggeram(machine_config &config);
 	void spactrai(machine_config &config);
 	void takeoff(machine_config &config);
-	void sfx(machine_config &config);
 	void mooncrst(machine_config &config);
 	void eagle(machine_config &config);
 	void ckongs(machine_config &config);
@@ -375,8 +360,6 @@ protected:
 	void mandingarf_map(address_map &map);
 	void mimonkey_map(address_map &map);
 	void mimonscr_map(address_map &map);
-	void monsterz_map(address_map &map);
-	void monsterz_sound_map(address_map &map);
 	void mooncrst_map(address_map &map);
 	void mooncrst_map_base(address_map &map);
 	void mooncrst_map_discrete(address_map &map);
@@ -385,9 +368,6 @@ protected:
 	void ozon1_io_map(address_map &map);
 	void scobra_map(address_map &map);
 	void scorpnmc_map(address_map &map);
-	void sfx_map(address_map &map);
-	void sfx_sample_map(address_map &map);
-	void sfx_sample_portmap(address_map &map);
 	void spactrai_map(address_map &map);
 	void takeoff_sound_map(address_map &map);
 	void takeoff_sound_portmap(address_map &map);
@@ -408,8 +388,6 @@ protected:
 
 	required_device<cpu_device> m_maincpu;
 	optional_device<cpu_device> m_audiocpu;
-	optional_device<cpu_device> m_audio2;
-	optional_device<dac_byte_interface> m_dac;
 	optional_device_array<ay8910_device, 3> m_ay8910;
 	optional_device<ay8910_device> m_ay8910_cclimber;
 	optional_device_array<i8255_device, 3> m_ppi8255;
@@ -420,7 +398,6 @@ protected:
 	optional_device<netlist_mame_sound_device> m_netlist;
 	optional_device_array<netlist_mame_logic_input_device, 12> m_filter_ctl;
 	optional_ioport m_ckong_coinage;
-	optional_ioport m_fake_select;
 
 	required_shared_ptr<uint8_t> m_spriteram;
 	required_shared_ptr<uint8_t> m_videoram;
@@ -433,7 +410,6 @@ protected:
 	uint16_t m_protection_state;
 	uint8_t m_protection_result;
 	uint8_t m_konami_sound_control;
-	uint8_t m_sfx_sample_control;
 	uint8_t m_irq_enabled;
 	int m_irq_line = INPUT_LINE_NMI;
 	uint8_t m_frogger_adjust = false;
@@ -601,6 +577,7 @@ class kingball_state : public galaxian_state
 public:
 	kingball_state(const machine_config &mconfig, device_type type, const char *tag)
 		: galaxian_state(mconfig, type, tag)
+		, m_dac(*this, "dac")
 		, m_mux_port(*this, "FAKE")
 	{
 	}
@@ -623,6 +600,7 @@ private:
 	void kingball_sound_map(address_map &map);
 	void kingball_sound_portmap(address_map &map);
 
+	required_device<dac_byte_interface> m_dac;
 	required_ioport m_mux_port;
 
 	uint8_t m_speech_dip;
@@ -784,6 +762,50 @@ private:
 	void scorpion_sound_portmap(address_map &map);
 
 	required_device<digitalker_device> m_digitalker;
+};
+
+
+class taiyo_sfx_state : public galaxian_state
+{
+public:
+	taiyo_sfx_state(const machine_config &mconfig, device_type type, const char *tag)
+		: galaxian_state(mconfig, type, tag)
+		, m_audio2(*this, "audio2")
+		, m_dac(*this, "dac")
+	{
+	}
+
+	void sfx(machine_config &config);
+	void monsterz(machine_config &config);
+
+	void init_sfx();
+
+protected:
+	virtual void machine_start() override;
+
+private:
+	uint8_t sample_io_r(offs_t offset);
+	void sample_io_w(offs_t offset, uint8_t data);
+	void sample_control_w(uint8_t data);
+
+	uint8_t monsterz_protection_r();
+	void monsterz_porta_1_w(uint8_t data);
+	void monsterz_portb_1_w(uint8_t data);
+	void monsterz_portc_1_w(uint8_t data);
+	void monsterz_set_latch();
+
+	void sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect);
+
+	void sfx_map(address_map &map);
+	void sfx_sample_map(address_map &map);
+	void sfx_sample_portmap(address_map &map);
+	void monsterz_map(address_map &map);
+	void monsterz_sound_map(address_map &map);
+
+	required_device<cpu_device> m_audio2;
+	required_device<dac_byte_interface> m_dac;
+
+	uint8_t m_sample_control;
 };
 
 

--- a/src/mame/video/galaxian.cpp
+++ b/src/mame/video/galaxian.cpp
@@ -358,7 +358,7 @@ void galaxian_state::galaxian_palette(palette_device &palette)
 	m_bullet_color[7] = rgb_t(0xff,0xff,0x00);
 }
 
-void galaxian_state::moonwar_palette(palette_device &palette)
+void moonwar_state::moonwar_palette(palette_device &palette)
 {
 	galaxian_palette(palette);
 

--- a/src/mame/video/galaxian.cpp
+++ b/src/mame/video/galaxian.cpp
@@ -448,7 +448,7 @@ void galaxian_state::state_save_register()
 uint32_t galaxian_state::screen_update_galaxian(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	/* draw the background layer (including stars) */
-	(this->*m_draw_background_ptr)(bitmap, cliprect);
+	m_draw_background_ptr(bitmap, cliprect);
 
 	/* draw the tilemap characters over top */
 	m_bg_tilemap->draw(screen, bitmap, cliprect, 0, 0);
@@ -458,7 +458,7 @@ uint32_t galaxian_state::screen_update_galaxian(screen_device &screen, bitmap_rg
 		sprites_draw(bitmap, cliprect, &m_spriteram[m_sprites_base + i * 0x20]);
 
 	/* if we have bullets to draw, render them following */
-	if (m_draw_bullet_ptr != nullptr)
+	if (!m_draw_bullet_ptr.isnull())
 		bullets_draw(bitmap, cliprect, &m_spriteram[m_bullets_base]);
 
 	return 0;
@@ -482,8 +482,7 @@ TILE_GET_INFO_MEMBER(galaxian_state::bg_get_tile_info)
 	uint8_t attrib = m_spriteram[x*2+1];
 	uint8_t color = attrib & 7;
 
-	if (m_extend_tile_info_ptr != nullptr)
-		(this->*m_extend_tile_info_ptr)(&code, &color, attrib, x, y);
+	m_extend_tile_info_ptr(&code, &color, attrib, x, y);
 
 	tileinfo.set(0, code, color, 0);
 }
@@ -573,8 +572,7 @@ void galaxian_state::sprites_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 		uint8_t sx = base[3] + hoffset;
 
 		/* extend the sprite information */
-		if (m_extend_sprite_info_ptr != nullptr)
-			(this->*m_extend_sprite_info_ptr)(base, &sx, &sy, &flipx, &flipy, &code, &color);
+		m_extend_sprite_info_ptr(base, &sx, &sy, &flipx, &flipy, &code, &color);
 
 		/* apply flipscreen in X direction */
 		if (m_flipscreen_x)
@@ -609,25 +607,22 @@ void galaxian_state::sprites_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 void galaxian_state::bullets_draw(bitmap_rgb32 &bitmap, const rectangle &cliprect, const uint8_t *base)
 {
-	int y;
-
 	/* iterate over scanlines */
-	for (y = cliprect.min_y; y <= cliprect.max_y; y++)
+	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
 	{
 		uint8_t shell = 0xff, missile = 0xff;
 		uint8_t effy;
-		int which;
 
 		/* the first 3 entries match Y-1 */
 		effy = m_flipscreen_y ? ((y - 1) ^ 255) : (y - 1);
-		for (which = 0; which < 3; which++)
-			if ((uint8_t)(base[which*4+1] + effy) == 0xff)
+		for (int which = 0; which < 3; which++)
+			if (uint8_t(base[which*4+1] + effy) == 0xff)
 				shell = which;
 
 		/* remaining entries match Y */
 		effy = m_flipscreen_y ? (y ^ 255) : y;
-		for (which = 3; which < 8; which++)
-			if ((uint8_t)(base[which*4+1] + effy) == 0xff)
+		for (int which = 3; which < 8; which++)
+			if (uint8_t(base[which*4+1] + effy) == 0xff)
 			{
 				if (which != 7)
 					shell = which;
@@ -637,9 +632,9 @@ void galaxian_state::bullets_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 
 		/* draw the shell */
 		if (shell != 0xff)
-			(this->*m_draw_bullet_ptr)(bitmap, cliprect, shell, 255 - base[shell*4+3], y);
+			m_draw_bullet_ptr(bitmap, cliprect, shell, 255 - base[shell*4+3], y);
 		if (missile != 0xff)
-			(this->*m_draw_bullet_ptr)(bitmap, cliprect, missile, 255 - base[missile*4+3], y);
+			m_draw_bullet_ptr(bitmap, cliprect, missile, 255 - base[missile*4+3], y);
 	}
 }
 
@@ -1244,6 +1239,14 @@ void galaxian_state::theend_draw_bullet(bitmap_rgb32 &bitmap, const rectangle &c
  *************************************/
 
 /*** generic ***/
+void galaxian_state::empty_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
+{
+}
+
+void galaxian_state::empty_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
+{
+}
+
 void galaxian_state::upper_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
 {
 	/* tiles are in the upper half of a larger ROM */
@@ -1269,14 +1272,14 @@ void galaxian_state::frogger_extend_sprite_info(const uint8_t *base, uint8_t *sx
 }
 
 
-/*** Ghostmuncher Galaxian ***/
-void galaxian_state::gmgalax_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
+/*** Bagman on Moon Cresta hardware, Ghostmuncher Galaxian ***/
+void bagmanmc_state::bagmanmc_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
 {
 	*code |= m_gfxbank[0] << 9;
-//  *color |= m_gfxbank[0] << 3;
+	//*color |= m_gfxbank[0] << 3;
 }
 
-void galaxian_state::gmgalax_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
+void bagmanmc_state::bagmanmc_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
 {
 	*code |= (m_gfxbank[0] << 7) | 0x40;
 	*color |= m_gfxbank[0] << 3;
@@ -1284,12 +1287,12 @@ void galaxian_state::gmgalax_extend_sprite_info(const uint8_t *base, uint8_t *sx
 
 
 /*** Pisces ***/
-void galaxian_state::pisces_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
+void pisces_state::pisces_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
 {
 	*code |= m_gfxbank[0] << 8;
 }
 
-void galaxian_state::pisces_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
+void pisces_state::pisces_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
 {
 	*code |= m_gfxbank[0] << 6;
 }
@@ -1384,17 +1387,15 @@ void galaxian_state::jumpbug_extend_sprite_info(const uint8_t *base, uint8_t *sx
 	}
 }
 
-void galaxian_state::namenayo_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y) // should be in namenayo_state
+void namenayo_state::namenayo_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
 {
-	// main game display
-	if ((attrib & 0x01) == 0x00)
+	if ((attrib & 0x01) == 0x00) // main game display
 	{
 		int attr = m_exattrram[y & 0x1f];
 		*code += ((attr & 0x38) >> 3) * 0x100;
 		*color = attr & 0x07;
 	}
-	// status bar
-	else
+	else // status bar
 	{
 		// course map
 		if ((attrib & 0xfe) == 0x20)
@@ -1402,7 +1403,7 @@ void galaxian_state::namenayo_extend_tile_info(uint16_t *code, uint8_t *color, u
 	}
 }
 
-void galaxian_state::namenayo_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
+void namenayo_state::namenayo_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
 {
 	if (base[2] & 0x08)
 		*code += 0x40;
@@ -1418,7 +1419,7 @@ void namenayo_state::namenayo_unk_d800_w(uint8_t data)
 }
 
 
-void galaxian_state::namenayo_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
+void namenayo_state::namenayo_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
 	bitmap.fill(rgb_t::black(), cliprect);
 
@@ -1455,14 +1456,14 @@ void galaxian_state::guttangt_extend_sprite_info(const uint8_t *base, uint8_t *s
  *
  *************************************/
 
-/* gfxbank[4] is used as a cpu bank number, and gfxbank[0] for graphics banking */
-void galaxian_state::fourplay_rombank_w(offs_t offset, uint8_t data)
+// gfxbank[4] is used as a cpu bank number, and gfxbank[0] for graphics banking
+void fourplay_state::fourplay_rombank_w(offs_t offset, uint8_t data)
 {
 	m_gfxbank[4] = (m_gfxbank[4] & (2 - offset)) | (data << offset);
 
 	m_gfxbank[0] = (m_gfxbank[4] == 3); // 1 = true, 0 = false
 
-	membank("bank1")->set_entry( m_gfxbank[4] );
+	m_rombank->set_entry(m_gfxbank[4]);
 }
 
 
@@ -1473,13 +1474,13 @@ void galaxian_state::fourplay_rombank_w(offs_t offset, uint8_t data)
  *
  *************************************/
 
-void galaxian_state::videight_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
+void videight_state::videight_extend_tile_info(uint16_t *code, uint8_t *color, uint8_t attrib, uint8_t x, uint8_t y)
 {
 	*code |= (m_gfxbank[0] << 8);
 	*color |= (m_gfxbank[4] << 3);
 }
 
-void galaxian_state::videight_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
+void videight_state::videight_extend_sprite_info(const uint8_t *base, uint8_t *sx, uint8_t *sy, uint8_t *flipx, uint8_t *flipy, uint16_t *code, uint8_t *color)
 {
 	*code |= (m_gfxbank[0] << 6);
 	*color |= (m_gfxbank[4] << 3);
@@ -1487,24 +1488,24 @@ void galaxian_state::videight_extend_sprite_info(const uint8_t *base, uint8_t *s
 
 
 /* This handles the main bankswitching for code and one-bank gfx games */
-void galaxian_state::videight_rombank_w(offs_t offset, uint8_t data)
+void videight_state::videight_rombank_w(offs_t offset, uint8_t data)
 {
-	uint8_t gfxbanks[] = { 0, 10, 2, 8, 1, 9, 4, 11 };
+	static constexpr uint8_t gfxbanks[] = { 0, 10, 2, 8, 1, 9, 4, 11 };
 	if (offset == 2)
-		galaxian_stars_enable_w( data );
+		galaxian_stars_enable_w(data);
 	else
 	{
 		m_gfxbank[4] = (m_gfxbank[4] & (6 - offset)) | (data << ((offset + 1) >> 1));
 		galaxian_gfxbank_w (0, gfxbanks[m_gfxbank[4]]);
-		membank("bank1")->set_entry( m_gfxbank[4] );
+		m_rombank->set_entry(m_gfxbank[4]);
 	}
 }
 
 /* This handles those games with multiple gfx banks */
-void galaxian_state::videight_gfxbank_w(offs_t offset, uint8_t data)
+void videight_state::videight_gfxbank_w(offs_t offset, uint8_t data)
 {
 	/* Moon Cresta (mooncrgx) */
-	if (( data < 2 ) && (m_gfxbank[4] == 3))
+	if ((data < 2) && (m_gfxbank[4] == 3))
 	{
 		uint8_t gfxbanks[] = { 8, 12, 8, 14, 8, 13, 8, 15 };
 		if (!offset) m_gfxbank[3] = (m_gfxbank[3] & 6) | data;
@@ -1514,12 +1515,12 @@ void galaxian_state::videight_gfxbank_w(offs_t offset, uint8_t data)
 	}
 
 	/* Uniwar S */
-	if (( data < 2 ) && (m_gfxbank[4] == 2) && (offset == 2))
-		galaxian_gfxbank_w( 0, data+2 );
+	if ((data < 2) && (m_gfxbank[4] == 2) && (offset == 2))
+		galaxian_gfxbank_w(0, data + 2);
 
 	/* Pisces (piscesb) */
-	if (( data < 2 ) && (m_gfxbank[4] == 6) && (offset == 2))
-		galaxian_gfxbank_w( 0, data+4 );
+	if ((data < 2) && (m_gfxbank[4] == 6) && (offset == 2))
+		galaxian_gfxbank_w(0, data + 4);
 }
 
 void namenayo_state::namenayo_extattr_w(offs_t offset, uint8_t data)

--- a/src/mame/video/galaxian.cpp
+++ b/src/mame/video/galaxian.cpp
@@ -589,11 +589,10 @@ void galaxian_state::sprites_draw(bitmap_rgb32 &bitmap, const rectangle &cliprec
 		}
 
 		/* draw */
-
-				m_gfxdecode->gfx(1)->transpen(bitmap,clip,
-				code, color,
-				flipx, flipy,
-				m_h0_start + m_x_scale * sx, sy, 0);
+		m_gfxdecode->gfx(1)->transpen(bitmap,clip,
+		code, color,
+		flipx, flipy,
+		m_h0_start + m_x_scale * sx, sy, 0);
 	}
 }
 
@@ -1067,9 +1066,9 @@ void galaxian_state::turtles_draw_background(bitmap_rgb32 &bitmap, const rectang
 }
 
 
-void galaxian_state::sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
+void taiyo_sfx_state::sfx_draw_background(bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	/* current schematics are unreadable, assuming like Turtles */
+	// current schematics are unreadable, assuming like Turtles
 	bitmap.fill(rgb_t(m_background_red * 0x55, m_background_green * 0x47, m_background_blue * 0x55), cliprect);
 	scramble_draw_stars(bitmap, cliprect, 256);
 }
@@ -1507,7 +1506,7 @@ void videight_state::videight_gfxbank_w(offs_t offset, uint8_t data)
 	/* Moon Cresta (mooncrgx) */
 	if ((data < 2) && (m_gfxbank[4] == 3))
 	{
-		uint8_t gfxbanks[] = { 8, 12, 8, 14, 8, 13, 8, 15 };
+		static constexpr uint8_t gfxbanks[] = { 8, 12, 8, 14, 8, 13, 8, 15 };
 		if (!offset) m_gfxbank[3] = (m_gfxbank[3] & 6) | data;
 		if (offset == 1) m_gfxbank[3] = (m_gfxbank[3] & 5) | (data << 1);
 		if (offset == 2) m_gfxbank[3] = (m_gfxbank[3] & 3) | (data << 2);


### PR DESCRIPTION
This is a starting-point for splitting up the “everything-bucket” state class in the “new” Galaxian driver.  It’s mostly the help @DavidHaywood with the impasse mentioned in #8164.

This is really just a starting point, and there’s a lot of work to do:
* There’s obviously still a huge amount of game-specific stuff in the state class
* I’m not sure whether `bagmanmc_state` and `pisces_state` are the right points to split things at – I wouldn’t be offended if that stuff got pushed back down into `galaxian_state`
* There’s a bunch of stuff in driver init functions that should go in machine configuration and machine start functions
* Eventually the tile extension callbacks and draw callbacks should be turned into device delegates and set from machine configuration