### PR TITLE
Added helpers for 64-bit count leading zeroes/ones.

### DIFF
--- a/scripts/src/osd/windows.lua
+++ b/scripts/src/osd/windows.lua
@@ -233,6 +233,7 @@ project ("ocore_" .. _OPTIONS["osd"])
 		MAME_DIR .. "src/osd/eigccppc.h",
 		MAME_DIR .. "src/osd/eigccx86.h",
 		MAME_DIR .. "src/osd/eivc.h",
+		MAME_DIR .. "src/osd/eivcarm.h",
 		MAME_DIR .. "src/osd/eivcx86.h",
 		MAME_DIR .. "src/osd/eminline.h",
 		MAME_DIR .. "src/osd/osdcomm.h",

--- a/src/devices/bus/generic/slot.h
+++ b/src/devices/bus/generic/slot.h
@@ -30,7 +30,7 @@ public:
 		assert(!(decode_limit & base));
 		for (offs_t remain = length, start = 0U; remain && (decode_limit >= start); )
 		{
-			unsigned const msb(31 - count_leading_zeros(u32(remain)));
+			unsigned const msb(31 - count_leading_zeros_32(u32(remain)));
 			offs_t const chunk(offs_t(1) << msb);
 			offs_t range((chunk - 1) & decode_limit);
 			offs_t mirror(decode_limit & ~decode_mask & ~range);

--- a/src/devices/bus/odyssey2/rom.cpp
+++ b/src/devices/bus/odyssey2/rom.cpp
@@ -28,7 +28,7 @@ void o2_rom_device::device_start()
 
 void o2_rom_device::cart_init()
 {
-	m_cart_mask = (1 << (31 - count_leading_zeros(m_rom_size))) - 1;
+	m_cart_mask = (1 << (31 - count_leading_zeros_32(m_rom_size))) - 1;
 }
 
 

--- a/src/devices/cpu/am29000/am29ops.h
+++ b/src/devices/cpu/am29000/am29ops.h
@@ -1396,7 +1396,7 @@ void am29000_cpu_device::CLZ()
 {
 	uint32_t b = INST_M_BIT ? I8: GET_RB_VAL;
 
-	m_r[RC] = count_leading_zeros(b);
+	m_r[RC] = count_leading_zeros_32(b);
 }
 
 void am29000_cpu_device::SETIP()

--- a/src/devices/cpu/arm7/arm7ops.cpp
+++ b/src/devices/cpu/arm7/arm7ops.cpp
@@ -1697,7 +1697,7 @@ void arm7_cpu_device::arm7ops_0123(uint32_t insn)
 		uint32_t rm = insn&0xf;
 		uint32_t rd = (insn>>12)&0xf;
 
-		SetRegister(rd, count_leading_zeros(GetRegister(rm)));
+		SetRegister(rd, count_leading_zeros_32(GetRegister(rm)));
 
 		R15 += 4;
 	}

--- a/src/devices/cpu/drcbec.cpp
+++ b/src/devices/cpu/drcbec.cpp
@@ -1062,11 +1062,11 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_LZCNT, 4, 0):     // LZCNT   dst,src
-				PARAM0 = count_leading_zeros(PARAM1);
+				PARAM0 = count_leading_zeros_32(PARAM1);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_LZCNT, 4, 1):
-				temp32 = count_leading_zeros(PARAM1);
+				temp32 = count_leading_zeros_32(PARAM1);
 				flags = FLAGS32_NZ(temp32);
 				PARAM0 = temp32;
 				break;
@@ -1675,17 +1675,11 @@ int drcbe_c::execute(code_handle &entry)
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_LZCNT, 8, 0):     // DLZCNT  dst,src
-				if ((uint32_t)(DPARAM1 >> 32) != 0)
-					DPARAM0 = count_leading_zeros(DPARAM1 >> 32);
-				else
-					DPARAM0 = 32 + count_leading_zeros(DPARAM1);
+				DPARAM0 = count_leading_zeros_64(DPARAM1);
 				break;
 
 			case MAKE_OPCODE_SHORT(OP_LZCNT, 8, 1):
-				if ((uint32_t)(DPARAM1 >> 32) != 0)
-					temp64 = count_leading_zeros(DPARAM1 >> 32);
-				else
-					temp64 = 32 + count_leading_zeros(DPARAM1);
+				temp64 = count_leading_zeros_64(DPARAM1);
 				flags = FLAGS64_NZ(temp64);
 				DPARAM0 = temp64;
 				break;

--- a/src/devices/cpu/dspp/dspp.cpp
+++ b/src/devices/cpu/dspp/dspp.cpp
@@ -1588,7 +1588,7 @@ void dspp_device::update_fifo_dma()
 
 	while (mask != 0)
 	{
-		uint32_t channel = 31 - count_leading_zeros(mask);
+		uint32_t channel = 31 - count_leading_zeros_32(mask);
 
 		const fifo_dma & dma = m_fifo_dma[channel];
 

--- a/src/devices/cpu/m88000/m88000.cpp
+++ b/src/devices/cpu/m88000/m88000.cpp
@@ -996,14 +996,14 @@ void mc88100_device::execute(u32 const inst)
 			break;
 		case 0x740: // ff1: find first bit set
 			{
-				unsigned const count = count_leading_zeros(m_r[S2]);
+				unsigned const count = count_leading_zeros_32(m_r[S2]);
 
 				m_r[D] = (count == 32) ? count : 31 - count;
 			}
 			break;
 		case 0x760: // ff0: find first bit clear
 			{
-				unsigned const count = count_leading_ones(m_r[S2]);
+				unsigned const count = count_leading_ones_32(m_r[S2]);
 
 				m_r[D] = (count == 32) ? count : 31 - count;
 			}

--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -1175,7 +1175,7 @@ void r4000_base_device::cpu_exception(u32 exception, u16 const vector)
 			u32 const iphw = CAUSE & SR & CAUSE_IPHW;
 
 			if (iphw)
-				debug()->interrupt_hook(22 - count_leading_zeros((iphw - 1) & ~iphw));
+				debug()->interrupt_hook(22 - count_leading_zeros_32((iphw - 1) & ~iphw));
 		}
 	}
 	else
@@ -1530,7 +1530,7 @@ void r4000_base_device::cp0_tlbwi(u8 const index)
 		entry.pfn[0] = m_cp0[CP0_EntryLo0] & EL_WM;
 		entry.pfn[1] = m_cp0[CP0_EntryLo1] & EL_WM;
 
-		entry.low_bit = 32 - count_leading_zeros((entry.mask >> 1) | 0xfff);
+		entry.low_bit = 32 - count_leading_zeros_32((entry.mask >> 1) | 0xfff);
 
 		LOGMASKED(LOG_TLB, "tlb write index %02d mask 0x%016x vpn2 0x%016x %c asid 0x%02x pfn0 0x%016x %c%c pfn1 0x%016x %c%c (%s)\n",
 			index, entry.mask,

--- a/src/devices/cpu/psx/gte.cpp
+++ b/src/devices/cpu/psx/gte.cpp
@@ -215,7 +215,7 @@ void gte::setcp2dr( uint32_t pc, int reg, uint32_t value )
 		break;
 
 	case 30:
-		LZCR = (value & 0x80000000) == 0 ? count_leading_zeros(value) : count_leading_ones(value);
+		LZCR = (value & 0x80000000) == 0 ? count_leading_zeros_32(value) : count_leading_ones_32(value);
 		break;
 
 	case 31:
@@ -314,7 +314,7 @@ static inline uint32_t gte_divide( uint16_t numerator, uint16_t denominator )
 			0x00
 		};
 
-		int shift = count_leading_zeros( denominator ) - 16;
+		int shift = count_leading_zeros_32( denominator ) - 16;
 
 		int r1 = ( denominator << shift ) & 0x7fff;
 		int r2 = table[ ( ( r1 + 0x40 ) >> 7 ) ] + 0x101;

--- a/src/devices/cpu/romp/romp.cpp
+++ b/src/devices/cpu/romp/romp.cpp
@@ -887,7 +887,7 @@ void romp_device::execute_run()
 				flags_log(m_gpr[R2]);
 				break;
 			case 0xf5: // clz: count leading zeros
-				m_gpr[R2] = count_leading_zeros(u16(m_gpr[R3])) - 16;
+				m_gpr[R2] = count_leading_zeros_32(u16(m_gpr[R3])) - 16;
 				break;
 
 			case 0xf9: // mc03: move character zero from three

--- a/src/devices/cpu/tms32031/32031ops.hxx
+++ b/src/devices/cpu/tms32031/32031ops.hxx
@@ -393,7 +393,7 @@ void tms3203x_device::int2float(tmsreg &srcdst)
 	// positive values; count leading zeros and shift
 	else if ((int32_t)man > 0)
 	{
-		cnt = count_leading_zeros(man);
+		cnt = count_leading_zeros_32(man);
 		man <<= cnt;
 		exp = 31 - cnt;
 	}
@@ -401,7 +401,7 @@ void tms3203x_device::int2float(tmsreg &srcdst)
 	// negative values; count leading ones and shift
 	else
 	{
-		cnt = count_leading_ones(man);
+		cnt = count_leading_ones_32(man);
 		man <<= cnt;
 		exp = 31 - cnt;
 	}
@@ -585,13 +585,13 @@ void tms3203x_device::addf(tmsreg &dst, tmsreg &src1, tmsreg &src2)
 	{
 		if (man > 0)
 		{
-			cnt = count_leading_zeros((uint32_t)man);
+			cnt = count_leading_zeros_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}
 		else
 		{
-			cnt = count_leading_ones((uint32_t)man);
+			cnt = count_leading_ones_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}
@@ -698,13 +698,13 @@ void tms3203x_device::subf(tmsreg &dst, tmsreg &src1, tmsreg &src2)
 	{
 		if (man > 0)
 		{
-			cnt = count_leading_zeros((uint32_t)man);
+			cnt = count_leading_zeros_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}
 		else
 		{
-			cnt = count_leading_ones((uint32_t)man);
+			cnt = count_leading_ones_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}
@@ -847,13 +847,13 @@ void tms3203x_device::norm(tmsreg &dst, tmsreg &src)
 		int cnt;
 		if (man > 0)
 		{
-			cnt = count_leading_zeros((uint32_t)man);
+			cnt = count_leading_zeros_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}
 		else
 		{
-			cnt = count_leading_ones((uint32_t)man);
+			cnt = count_leading_ones_32((uint32_t)man);
 			man <<= cnt;
 			exp -= cnt;
 		}

--- a/src/devices/cpu/tms34010/34010ops.hxx
+++ b/src/devices/cpu/tms34010/34010ops.hxx
@@ -2458,16 +2458,16 @@ void tms340x0_device::setcdp(uint16_t op)
 			// .. only single bit set, pitch is power of two!
 			case 1:
 			{
-				m_convdp = 32 - count_leading_zeros(dptch);
+				m_convdp = 32 - count_leading_zeros_32(dptch);
 				COUNT_CYCLES(4);
 				return;
 			}
 			// .. two bits, we can decompose it to sum of two power of two numbers
 			case 2:
 			{
-				uint8_t first_one = count_leading_zeros(dptch);
+				uint8_t first_one = count_leading_zeros_32(dptch);
 				uint8_t v1 = 32 - first_one;
-				uint8_t v2 = 32 - count_leading_zeros(dptch & ~(1 << (first_one - 1)));
+				uint8_t v2 = 32 - count_leading_zeros_32(dptch & ~(1 << (first_one - 1)));
 
 				m_convdp = v2 | (v1 << 8);
 				COUNT_CYCLES(6);

--- a/src/devices/cpu/uml.cpp
+++ b/src/devices/cpu/uml.cpp
@@ -631,14 +631,9 @@ void uml::instruction::simplify()
 			if (m_param[1].is_immediate())
 			{
 				if (m_size == 4)
-					convert_to_mov_immediate(count_leading_zeros(m_param[1].immediate()));
+					convert_to_mov_immediate(count_leading_zeros_32(m_param[1].immediate()));
 				else if (m_size == 8)
-				{
-					if ((m_param[1].immediate() >> 32) == 0)
-						convert_to_mov_immediate(32 + count_leading_zeros(m_param[1].immediate()));
-					else
-						convert_to_mov_immediate(count_leading_zeros(m_param[1].immediate() >> 32));
-				}
+					convert_to_mov_immediate(count_leading_zeros_64(m_param[1].immediate()));
 			}
 			break;
 

--- a/src/devices/cpu/unsp/unsp_fxxx.cpp
+++ b/src/devices/cpu/unsp/unsp_fxxx.cpp
@@ -396,11 +396,11 @@ void unsp_12_device::execute_fxxx_101_group(uint16_t op)
 
 		if (r4 & 0x8000)
 		{
-			m_core->m_r[REG_R2] = count_leading_ones(0xffff0000 | r4) - 17;
+			m_core->m_r[REG_R2] = count_leading_ones_32(0xffff0000 | r4) - 17;
 		}
 		else
 		{
-			m_core->m_r[REG_R2] = count_leading_zeros(r4) - 17; // -17 because count_leading_zeros works with 32-bit values
+			m_core->m_r[REG_R2] = count_leading_zeros_32(r4) - 17; // -17 because count_leading_zeros_32 works with 32-bit values
 		}
 
 		return;

--- a/src/devices/cpu/z80/kp69.cpp
+++ b/src/devices/cpu/z80/kp69.cpp
@@ -409,14 +409,14 @@ int kp69_base_device::z80daisy_irq_ack()
 	// Restrict to high-priority interrupts if any of those are pending
 	if ((m_irr & m_pgr) != 0)
 	{
-		level = 31 - count_leading_zeros(u32(m_irr & m_pgr));
+		level = 31 - count_leading_zeros_32(u32(m_irr & m_pgr));
 		assert(level >= 0 && level < 16);
 		if ((1 << level) < (m_isr & m_pgr))
 			level = -1;
 	}
 	else if (m_irr != 0 && (m_isr & m_pgr) == 0)
 	{
-		level = 31 - count_leading_zeros(u32(m_irr));
+		level = 31 - count_leading_zeros_32(u32(m_irr));
 		assert(level >= 0 && level < 16);
 		if ((1 << level) < m_isr)
 			level = -1;
@@ -461,7 +461,7 @@ void kp69_base_device::z80daisy_irq_reti()
 	}
 	else if (m_isr != 0)
 	{
-		int level = 31 - count_leading_zeros(u32((m_isr & m_pgr) != 0 ? (m_isr & m_pgr) : m_isr));
+		int level = 31 - count_leading_zeros_32(u32((m_isr & m_pgr) != 0 ? (m_isr & m_pgr) : m_isr));
 		assert(level >= 0 && level < 16);
 
 		m_isr &= ~(1 << level);

--- a/src/devices/machine/atmel_arm_aic.cpp
+++ b/src/devices/machine/atmel_arm_aic.cpp
@@ -53,7 +53,7 @@ uint32_t arm_aic_device::irq_vector_r()
 		int midx = -1;
 		do
 		{
-			uint8_t idx = 31 - count_leading_zeros(mask);
+			uint8_t idx = 31 - count_leading_zeros_32(mask);
 			if ((int)(m_aic_smr[idx] & 7) >= pri)
 			{
 				midx = idx;
@@ -146,7 +146,7 @@ void arm_aic_device::check_irqs()
 		int pri = get_level();
 		do
 		{
-			uint8_t idx = 31 - count_leading_zeros(mask);
+			uint8_t idx = 31 - count_leading_zeros_32(mask);
 			if ((int)(m_aic_smr[idx] & 7) > pri)
 			{
 				m_core_status |= 2;

--- a/src/devices/machine/ns32202.cpp
+++ b/src/devices/machine/ns32202.cpp
@@ -275,7 +275,7 @@ void ns32202_device::interrupt(void *ptr, s32 param)
 					// check equal priority unmasked pending cascade interrupt
 					if ((m_csrc & mask) && (m_ipnd & mask) && !(m_imsk & mask))
 					{
-						LOGMASKED(LOG_STATE, "unmasked pending cascade in-service interrupt %d\n", 31 - count_leading_zeros(mask));
+						LOGMASKED(LOG_STATE, "unmasked pending cascade in-service interrupt %d\n", 31 - count_leading_zeros_32(mask));
 						accept = true;
 					}
 
@@ -285,7 +285,7 @@ void ns32202_device::interrupt(void *ptr, s32 param)
 				// check unmasked pending interrupt
 				if ((m_ipnd & mask) && !(m_imsk & mask))
 				{
-					LOGMASKED(LOG_STATE, "unmasked pending interrupt %d\n", 31 - count_leading_zeros(mask));
+					LOGMASKED(LOG_STATE, "unmasked pending interrupt %d\n", 31 - count_leading_zeros_32(mask));
 					accept = true;
 					break;
 				}
@@ -324,7 +324,7 @@ u8 ns32202_device::interrupt_acknowledge(bool side_effects)
 			mask = (mask << 1) | (mask >> 15);
 		}
 
-		unsigned const number = 31 - count_leading_zeros(mask);
+		unsigned const number = 31 - count_leading_zeros_32(mask);
 		if (side_effects)
 		{
 			LOGMASKED(LOG_STATE, "acknowledge highest priority unmasked interrupt %d\n", number);
@@ -400,7 +400,7 @@ u8 ns32202_device::interrupt_return(bool side_effects)
 			// rotate priority mask
 			mask = (mask << 1) | (mask >> 15);
 		}
-		unsigned const number = 31 - count_leading_zeros(mask);
+		unsigned const number = 31 - count_leading_zeros_32(mask);
 
 		if (side_effects)
 		{

--- a/src/devices/machine/sensorboard.cpp
+++ b/src/devices/machine/sensorboard.cpp
@@ -497,7 +497,7 @@ INPUT_CHANGED_MEMBER(sensorboard_device::sensor)
 
 INPUT_CHANGED_MEMBER(sensorboard_device::ui_spawn)
 {
-	u8 pos = (newval) ? (u8)param : 32 - count_leading_zeros(m_inp_spawn->read());
+	u8 pos = (newval) ? (u8)param : 32 - count_leading_zeros_32(m_inp_spawn->read());
 	if (pos == 0 || pos > m_maxspawn)
 		return;
 

--- a/src/devices/video/vooddefs.ipp
+++ b/src/devices/video/vooddefs.ipp
@@ -135,7 +135,7 @@ static inline int32_t fast_reciplog(int64_t value, int32_t *log2)
 	}
 
 	/* determine how many leading zeros in the value and shift it up high */
-	lz = count_leading_zeros(temp);
+	lz = count_leading_zeros_32(temp);
 	temp <<= lz;
 	exp += lz;
 
@@ -1852,15 +1852,15 @@ do                                                                              
 			wfloat = 0xffff;                                                    \
 		else                                                                    \
 		{                                                                       \
-			int exp = count_leading_zeros(temp);                                \
+			int exp = count_leading_zeros_32(temp);                             \
 			wfloat = ((exp << 12) | ((~temp >> (19 - exp)) & 0xfff)) + 1;       \
 		}                                                                       \
 	}                                                                           \
 																				\
 	/* compute depth value (W or Z) for this pixel */                           \
-	if (FBZMODE_WBUFFER_SELECT(FBZMODE))                                   \
+	if (FBZMODE_WBUFFER_SELECT(FBZMODE))                                        \
 	{                                                                           \
-		if (!FBZMODE_DEPTH_FLOAT_SELECT(FBZMODE))                          \
+		if (!FBZMODE_DEPTH_FLOAT_SELECT(FBZMODE))                               \
 			depthval = wfloat;                                                      \
 		else                                                                        \
 		{                                                                           \
@@ -1873,7 +1873,7 @@ do                                                                              
 					depthval = 0xffff;                                              \
 				else                                                                \
 				{                                                                   \
-					int exp = count_leading_zeros(temp);                            \
+					int exp = count_leading_zeros_32(temp);                         \
 					depthval = ((exp << 12) | ((~temp >> (19 - exp)) & 0xfff)) + 1; \
 				}                                                                   \
 			}                                                                       \
@@ -1884,11 +1884,11 @@ do                                                                              
 		CLAMPED_Z(ITERZ, FBZCOLORPATH, depthval);                               \
 	}                                                                           \
 	/* add the bias */                                                          \
-	biasdepth = depthval;                                                     \
+	biasdepth = depthval;                                                       \
 	if (FBZMODE_ENABLE_DEPTH_BIAS(FBZMODE))                                     \
 	{                                                                           \
-		biasdepth += (int16_t)vd->reg[zaColor].u;                                \
-		CLAMP(biasdepth, 0, 0xffff);                                             \
+		biasdepth += (int16_t)vd->reg[zaColor].u;                               \
+		CLAMP(biasdepth, 0, 0xffff);                                            \
 	}
 
 
@@ -1898,12 +1898,12 @@ do                                                                              
 	/* handle depth buffer testing */                                           \
 	if (FBZMODE_ENABLE_DEPTHBUF(FBZMODE))                                       \
 	{                                                                           \
-		int32_t depthsource;                                                      \
+		int32_t depthsource;                                                    \
 																				\
 		/* the source depth is either the iterated W/Z+bias or a */             \
 		/* constant value */                                                    \
 		if (FBZMODE_DEPTH_SOURCE_COMPARE(FBZMODE) == 0)                         \
-			depthsource = biasdepth;                                             \
+			depthsource = biasdepth;                                            \
 		else                                                                    \
 			depthsource = (uint16_t)vd->reg[zaColor].u;                         \
 																				\

--- a/src/emu/emumem_mview.cpp
+++ b/src/emu/emumem_mview.cpp
@@ -788,7 +788,7 @@ std::pair<handler_entry *, handler_entry *> memory_view::make_handlers(address_s
 		m_space = &space;
 
 		offs_t span = addrstart ^ addrend;
-		u32 awidth = 32 - count_leading_zeros(span);
+		u32 awidth = 32 - count_leading_zeros_32(span);
 
 		h_make(awidth, m_config->data_width(), m_config->addr_shift(), m_config->endianness(), space, *this, m_handler_read, m_handler_write);
 		m_handler_read->ref();

--- a/src/emu/validity.cpp
+++ b/src/emu/validity.cpp
@@ -519,14 +519,14 @@ void validity_checker::validate_inlines()
 	for (int i = 0; i <= 32; i++)
 	{
 		u32 t = i < 32 ? (1 << (31 - i) | testu32a >> i) : 0;
-		u8 resultu8 = count_leading_zeros(t);
+		u8 resultu8 = count_leading_zeros_32(t);
 		if (resultu8 != i)
-			osd_printf_error("Error testing count_leading_zeros %08x=%02x (expected %02x)\n", t, resultu8, i);
+			osd_printf_error("Error testing count_leading_zeros_32 %08x=%02x (expected %02x)\n", t, resultu8, i);
 
 		t ^= 0xffffffff;
-		resultu8 = count_leading_ones(t);
+		resultu8 = count_leading_ones_32(t);
 		if (resultu8 != i)
-			osd_printf_error("Error testing count_leading_ones %08x=%02x (expected %02x)\n", t, resultu8, i);
+			osd_printf_error("Error testing count_leading_ones_32 %08x=%02x (expected %02x)\n", t, resultu8, i);
 	}
 }
 

--- a/src/frontend/mame/ui/confswitch.cpp
+++ b/src/frontend/mame/ui/confswitch.cpp
@@ -62,7 +62,7 @@ inline bool menu_confswitch::switch_group_descriptor::matches(ioport_field const
 
 inline unsigned menu_confswitch::switch_group_descriptor::switch_count() const noexcept
 {
-	return (sizeof(mask) * 8) - count_leading_zeros(mask);
+	return (sizeof(mask) * 8) - count_leading_zeros_32(mask);
 }
 
 

--- a/src/lib/util/msdib.cpp
+++ b/src/lib/util/msdib.cpp
@@ -93,9 +93,9 @@ union bitmap_headers
 
 bool dib_parse_mask(uint32_t mask, unsigned &shift, unsigned &bits)
 {
-	shift = count_leading_zeros(mask);
+	shift = count_leading_zeros_32(mask);
 	mask <<= shift;
-	bits = count_leading_ones(mask);
+	bits = count_leading_ones_32(mask);
 	mask <<= shift;
 	shift = 32 - shift - bits;
 	return !mask;

--- a/src/mame/drivers/aci_ggm.cpp
+++ b/src/mame/drivers/aci_ggm.cpp
@@ -172,7 +172,7 @@ void ggm_state::update_reset(ioport_value state)
 DEVICE_IMAGE_LOAD_MEMBER(ggm_state::load_cart)
 {
 	u32 size = m_cart->common_get_size("rom");
-	m_cart_mask = ((1 << (31 - count_leading_zeros(size))) - 1) & 0xffff;
+	m_cart_mask = ((1 << (31 - count_leading_zeros_32(size))) - 1) & 0xffff;
 
 	m_cart->rom_alloc(size, GENERIC_ROM8_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");

--- a/src/mame/drivers/ave_arb.cpp
+++ b/src/mame/drivers/ave_arb.cpp
@@ -148,7 +148,7 @@ void arb_state::update_reset()
 DEVICE_IMAGE_LOAD_MEMBER(arb_state::cart_load)
 {
 	u32 size = m_cart->common_get_size("rom");
-	m_cart_mask = ((1 << (31 - count_leading_zeros(size))) - 1) & 0x7fff;
+	m_cart_mask = ((1 << (31 - count_leading_zeros_32(size))) - 1) & 0x7fff;
 
 	m_cart->rom_alloc(size, GENERIC_ROM8_WIDTH, ENDIANNESS_LITTLE);
 	m_cart->common_load_rom(m_cart->get_rom_base(), size, "rom");

--- a/src/mame/drivers/fidel_cc1.cpp
+++ b/src/mame/drivers/fidel_cc1.cpp
@@ -143,7 +143,7 @@ u8 cc1_state::ppi_porta_r()
 {
 	// 74148(priority encoder) I0-I7: inputs
 	// d0-d2: 74148 S0-S2, d3: 74148 GS
-	u8 data = count_leading_zeros(m_inputs[0]->read()) - 24;
+	u8 data = count_leading_zeros_32(m_inputs[0]->read()) - 24;
 	if (data == 8) data = 0xf;
 
 	// d5-d7: more inputs (direct)

--- a/src/mame/drivers/hp80.cpp
+++ b/src/mame/drivers/hp80.cpp
@@ -696,7 +696,7 @@ static const uint8_t keyboard_table[ 80 ][ 2 ] = {
 bool hp80_base_state::kb_scan_ioport(ioport_value pressed , unsigned idx_base , uint8_t& row , uint8_t& col)
 {
 	if (pressed) {
-		unsigned bit_no = 31 - count_leading_zeros(pressed);
+		unsigned bit_no = 31 - count_leading_zeros_32(pressed);
 		row = (idx_base + bit_no) / 8;
 		col = (idx_base + bit_no) % 8;
 		return true;

--- a/src/mame/drivers/hp9825.cpp
+++ b/src/mame/drivers/hp9825.cpp
@@ -558,7 +558,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(hp9825_state::kb_scan)
 void hp9825_state::kb_scan_ioport(ioport_value pressed , ioport_port &port , unsigned idx_base , int& max_seq_len , unsigned& max_seq_idx)
 {
 	while (pressed) {
-		unsigned bit_no = 31 - count_leading_zeros(pressed);
+		unsigned bit_no = 31 - count_leading_zeros_32(pressed);
 		ioport_value mask = BIT_MASK<ioport_value>(bit_no);
 		int seq_len = port.field(mask)->seq().length();
 		if (seq_len > max_seq_len) {

--- a/src/mame/drivers/hp9845.cpp
+++ b/src/mame/drivers/hp9845.cpp
@@ -550,7 +550,7 @@ attotime hp9845_base_state::time_to_gv_mem_availability() const
 void hp9845_base_state::kb_scan_ioport(ioport_value pressed , ioport_port &port , unsigned idx_base , int& max_seq_len , unsigned& max_seq_idx)
 {
 	while (pressed) {
-		unsigned bit_no = 31 - count_leading_zeros(pressed);
+		unsigned bit_no = 31 - count_leading_zeros_32(pressed);
 		ioport_value mask = BIT_MASK(bit_no);
 		int seq_len = port.field(mask)->seq().length();
 		if (seq_len > max_seq_len) {

--- a/src/mame/drivers/intellect02.cpp
+++ b/src/mame/drivers/intellect02.cpp
@@ -132,7 +132,7 @@ u8 intel02_state::input_r()
 {
 	// d0-d3: buttons through a maze of logic gates
 	// basically giving each button its own 4-bit scancode
-	u8 data = count_leading_zeros(m_inputs[0]->read()) - 17;
+	u8 data = count_leading_zeros_32(m_inputs[0]->read()) - 17;
 
 	// d4: Vcc, d5-d7: buttons (direct)
 	return data | (~m_inputs[1]->read() << 4 & 0xf0);

--- a/src/mame/drivers/odyssey2.cpp
+++ b/src/mame/drivers/odyssey2.cpp
@@ -401,7 +401,7 @@ u8 odyssey2_state::p2_read()
 	{
 		// P12: 74156 keyboard decoder enable, 74156 inputs from P20-P22
 		// 74148 priority encoder, GS to P24, outputs to P25-P27
-		u8 inp = count_leading_zeros(m_keyboard[m_p2 & 0x07]->read()) - 24;
+		u8 inp = count_leading_zeros_32(m_keyboard[m_p2 & 0x07]->read()) - 24;
 		if (inp < 8)
 			data &= inp << 5 | 0xf;
 	}

--- a/src/mame/drivers/olibochu.cpp
+++ b/src/mame/drivers/olibochu.cpp
@@ -257,7 +257,7 @@ void olibochu_state::sound_command_w(offs_t offset, uint8_t data)
 	else
 		m_cmd = (m_cmd & 0xff00) | uint16_t(data);
 
-	unsigned c = count_leading_zeros(uint32_t(m_cmd)) - 16;
+	unsigned c = count_leading_zeros_32(uint32_t(m_cmd)) - 16;
 	if (c < 16)
 		m_soundlatch->write(c);
 }

--- a/src/mame/drivers/roland_cm32p.cpp
+++ b/src/mame/drivers/roland_cm32p.cpp
@@ -407,7 +407,7 @@ DEVICE_IMAGE_LOAD_MEMBER(cm32p_state::card_load)
 	u8* base = pcmcard->get_rom_base();
 	if (size < 0x080000)
 	{
-		uint32_t mirror = (1 << (31 - count_leading_zeros(size)));
+		uint32_t mirror = (1 << (31 - count_leading_zeros_32(size)));
 		if (mirror < 0x020000)  // due to how address descrambling works, we can currently only do mirroring for 128K pages
 			mirror = 0x020000;
 		for (uint32_t ofs = mirror; ofs < 0x080000; ofs += mirror)

--- a/src/mame/drivers/subhuntr.cpp
+++ b/src/mame/drivers/subhuntr.cpp
@@ -147,7 +147,7 @@ void subhuntr_state::txtram_w(offs_t offset, u8 data)
 
 u8 subhuntr_state::intack_r()
 {
-	unsigned const source = count_leading_zeros(m_intreqs) - 24;
+	unsigned const source = count_leading_zeros_32(m_intreqs) - 24;
 	u8 const vector = ((m_intreq_cnf->read() & 0x01) ? 0x91 : 0x11) | (source << 1);
 	switch (source)
 	{

--- a/src/osd/eigcc.h
+++ b/src/osd/eigcc.h
@@ -55,6 +55,62 @@ inline bool _addu_64x64_co(uint64_t a, uint64_t b, uint64_t &sum)
 ***************************************************************************/
 
 /*-------------------------------------------------
+    count_leading_zeros_32 - return the number of
+    leading zero bits in a 32-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_zeros_32
+inline uint8_t count_leading_zeros_32(uint32_t val)
+{
+	// uses CPU feature if available, otherwise falls back to runtime library call
+	static_assert(sizeof(val) == sizeof(unsigned), "expected 32-bit unsigned int");
+	return uint8_t(unsigned(val ? __builtin_clz(val) : 32));
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_32 - return the number of
+    leading one bits in a 32-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_ones_32
+inline uint8_t count_leading_ones_32(uint32_t val)
+{
+	return count_leading_zeros_32(~val);
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_zeros_64 - return the number of
+    leading zero bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_zeros_64
+inline uint8_t count_leading_zeros_64(uint64_t val)
+{
+	// uses CPU feature if available, otherwise falls back to runtime library call
+	static_assert(sizeof(val) == sizeof(unsigned long long), "expected 64-bit unsigned long long int");
+	return uint8_t(unsigned(val ? __builtin_clzll(val) : 64));
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_64 - return the number of
+    leading one bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_ones_64
+inline uint8_t count_leading_ones_64(uint64_t val)
+{
+	return count_leading_zeros_64(~val);
+}
+#endif
+
+
+/*-------------------------------------------------
     population_count_32 - return the number of
     one bits in a 32-bit value
 -------------------------------------------------*/

--- a/src/osd/eigccarm.h
+++ b/src/osd/eigccarm.h
@@ -239,14 +239,14 @@ _mulu_64x64(uint64_t a, uint64_t b, uint64_t &hi)
 ***************************************************************************/
 
 /*-------------------------------------------------
-    count_leading_zeros - return the number of
+    count_leading_zeros_32 - return the number of
     leading zero bits in a 32-bit value
 -------------------------------------------------*/
 
 #if defined(__aarch64__)
-#define count_leading_zeros _count_leading_zeros
+#define count_leading_zeros_32 _count_leading_zeros_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_zeros(uint32_t value)
+_count_leading_zeros_32(uint32_t value)
 {
 	uint32_t result;
 
@@ -256,20 +256,20 @@ _count_leading_zeros(uint32_t value)
 		: [value]  "r"  (value)
 	);
 
-	return result;
+	return uint8_t(result);
 }
 #endif
 
 
 /*-------------------------------------------------
-    count_leading_ones - return the number of
+    count_leading_ones_32 - return the number of
     leading one bits in a 32-bit value
 -------------------------------------------------*/
 
 #if defined(__aarch64__)
-#define count_leading_ones _count_leading_ones
+#define count_leading_ones_32 _count_leading_ones_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_ones(uint32_t value)
+_count_leading_ones_32(uint32_t value)
 {
 	uint32_t result;
 
@@ -279,7 +279,53 @@ _count_leading_ones(uint32_t value)
 		: [value]  "r"  (~value)
 	);
 
-	return result;
+	return uint8_t(result);
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_zeros_64 - return the number of
+    leading zero bits in a 64-bit value
+-------------------------------------------------*/
+
+#if defined(__aarch64__)
+#define count_leading_zeros_64 _count_leading_zeros_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_zeros_64(uint64_t value)
+{
+	uint64_t result;
+
+	__asm__ (
+		" clz  %[result], %[value] \n"
+		: [result] "=r" (result)
+		: [value]  "r"  (value)
+	);
+
+	return uint8_t(result);
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_64 - return the number of
+    leading one bits in a 64-bit value
+-------------------------------------------------*/
+
+#if defined(__aarch64__)
+#define count_leading_ones_64 _count_leading_ones_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_ones_64(uint64_t value)
+{
+	uint64_t result;
+
+	__asm__ (
+		" clz  %[result], %[value] \n"
+		: [result] "=r" (result)
+		: [value]  "r"  (~value)
+	);
+
+	return uint8_t(result);
 }
 #endif
 

--- a/src/osd/eigccppc.h
+++ b/src/osd/eigccppc.h
@@ -239,13 +239,13 @@ _mulu_64x64(uint64_t a, uint64_t b, uint64_t &hi)
 ***************************************************************************/
 
 /*-------------------------------------------------
-    count_leading_zeros - return the number of
+    count_leading_zeros_32 - return the number of
     leading zero bits in a 32-bit value
 -------------------------------------------------*/
 
-#define count_leading_zeros _count_leading_zeros
+#define count_leading_zeros_32 _count_leading_zeros_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_zeros(uint32_t value)
+_count_leading_zeros_32(uint32_t value)
 {
 	uint32_t result;
 
@@ -255,18 +255,18 @@ _count_leading_zeros(uint32_t value)
 		: [value]  "r"  (value)
 	);
 
-	return result;
+	return uint8_t(result);
 }
 
 
 /*-------------------------------------------------
-    count_leading_ones - return the number of
+    count_leading_ones_32 - return the number of
     leading one bits in a 32-bit value
 -------------------------------------------------*/
 
-#define count_leading_ones _count_leading_ones
+#define count_leading_ones_32 _count_leading_ones_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_ones(uint32_t value)
+_count_leading_ones_32(uint32_t value)
 {
 	uint32_t result;
 
@@ -276,7 +276,53 @@ _count_leading_ones(uint32_t value)
 		: [value]  "r"  (~value)
 	);
 
-	return result;
+	return uint8_t(result);
 }
+
+
+/*-------------------------------------------------
+    count_leading_zeros_64 - return the number of
+    leading zero bits in a 64-bit value
+-------------------------------------------------*/
+
+#if defined(__ppc64__)
+#define count_leading_zeros_64 _count_leading_zeros_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_zeros_64(uint64_t value)
+{
+	uint64_t result;
+
+	__asm__ (
+		" cntlzd  %[result], %[value] \n"
+		: [result] "=r" (result)
+		: [value]  "r"  (value)
+	);
+
+	return uint8_t(result);
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_64 - return the number of
+    leading one bits in a 64-bit value
+-------------------------------------------------*/
+
+#if defined(__ppc64__)
+#define count_leading_ones_64 _count_leading_ones_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_ones_64(uint64_t value)
+{
+	uint64_t result;
+
+	__asm__ (
+		" cntlzd  %[result], %[value] \n"
+		: [result] "=r" (result)
+		: [value]  "r"  (~value)
+	);
+
+	return uint8_t(result);
+}
+#endif
 
 #endif // MAME_OSD_EIGCCPPC_H

--- a/src/osd/eigccx86.h
+++ b/src/osd/eigccx86.h
@@ -433,13 +433,13 @@ _mulu_64x64(uint64_t a, uint64_t b, uint64_t &hi)
 ***************************************************************************/
 
 /*-------------------------------------------------
-    count_leading_zeros - return the number of
+    count_leading_zeros_32 - return the number of
     leading zero bits in a 32-bit value
 -------------------------------------------------*/
 
-#define count_leading_zeros _count_leading_zeros
+#define count_leading_zeros_32 _count_leading_zeros_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_zeros(uint32_t value)
+_count_leading_zeros_32(uint32_t value)
 {
 	uint32_t result;
 	__asm__ (
@@ -450,18 +450,18 @@ _count_leading_zeros(uint32_t value)
 		, [bias]   "rm"  (~uint32_t(0)) // 'bias' can be register or memory
 		: "cc"                          // clobbers condition codes
 	);
-	return 31U - result;
+	return uint8_t(31U - result);
 }
 
 
 /*-------------------------------------------------
-    count_leading_ones - return the number of
+    count_leading_ones_32 - return the number of
     leading one bits in a 32-bit value
 -------------------------------------------------*/
 
-#define count_leading_ones _count_leading_ones
+#define count_leading_ones_32 _count_leading_ones_32
 inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
-_count_leading_ones(uint32_t value)
+_count_leading_ones_32(uint32_t value)
 {
 	uint32_t result;
 	__asm__ (
@@ -472,7 +472,55 @@ _count_leading_ones(uint32_t value)
 		, [bias]   "rm"  (~uint32_t(0)) // 'bias' can be register or memory
 		: "cc"                          // clobbers condition codes
 	);
-	return 31U - result;
+	return uint8_t(31U - result);
 }
+
+
+/*-------------------------------------------------
+    count_leading_zeros_64 - return the number of
+    leading zero bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifdef __x86_64__
+#define count_leading_zeros_64 _count_leading_zeros_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_zeros_64(uint64_t value)
+{
+	uint64_t result;
+	__asm__ (
+		" bsrq    %[value], %[result] ;"
+		" cmovzq  %[bias], %[result]  ;"
+		: [result] "=&r" (result)       // result can be in any register
+		: [value]  "rm"  (value)        // 'value' can be register or memory
+		, [bias]   "rm"  (~uint64_t(0)) // 'bias' can be register or memory
+		: "cc"                          // clobbers condition codes
+	);
+	return uint8_t(63U - result);
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_64 - return the number of
+    leading one bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifdef __x86_64__
+#define count_leading_ones_64 _count_leading_ones_64
+inline uint8_t ATTR_CONST ATTR_FORCE_INLINE
+_count_leading_ones_64(uint64_t value)
+{
+	uint64_t result;
+	__asm__ (
+		" bsrq    %[value], %[result] ;"
+		" cmovzq  %[bias], %[result]  ;"
+		: [result] "=&r" (result)       // result can be in any register
+		: [value]  "rm"  (~value)       // 'value' can be register or memory
+		, [bias]   "rm"  (~uint64_t(0)) // 'bias' can be register or memory
+		: "cc"                          // clobbers condition codes
+	);
+	return uint8_t(63U - result);
+}
+#endif
 
 #endif // MAME_OSD_EIGCCX86_H

--- a/src/osd/eivcarm.h
+++ b/src/osd/eivcarm.h
@@ -1,23 +1,24 @@
 // license:BSD-3-Clause
-// copyright-holders:Aaron Giles
+// copyright-holders:Vas Crabb
 //============================================================
 //
-//  eivc.h
+//  eivcarm.h
 //
-//  Inline implementations for MSVC compiler.
+//  ARM/AArch64 inline implementations for MSVC compiler.
 //
 //============================================================
 
-#ifndef MAME_OSD_EIVC_H
-#define MAME_OSD_EIVC_H
+#ifndef MAME_OSD_EIVCARM_H
+#define MAME_OSD_EIVCARM_H
 
 #pragma once
 
 #include <intrin.h>
-#pragma intrinsic(_BitScanReverse)
-#ifdef PTR64
-#pragma intrinsic(_BitScanReverse64)
-#endif
+
+#pragma intrinsic(_CountLeadingZeros)
+#pragma intrinsic(_CountLeadingZeros64)
+#pragma intrinsic(_CountLeadingOnes)
+#pragma intrinsic(_CountLeadingOnes64)
 
 
 /***************************************************************************
@@ -29,14 +30,11 @@
     leading zero bits in a 32-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_zeros_32
 #define count_leading_zeros_32 _count_leading_zeros_32
 __forceinline uint8_t _count_leading_zeros_32(uint32_t value)
 {
-	unsigned long index;
-	return _BitScanReverse(&index, value) ? (31U - index) : 32U;
+	return uint8_t(_CountLeadingZeros(value));
 }
-#endif
 
 
 /*-------------------------------------------------
@@ -44,14 +42,11 @@ __forceinline uint8_t _count_leading_zeros_32(uint32_t value)
     leading one bits in a 32-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_ones_32
 #define count_leading_ones_32 _count_leading_ones_32
 __forceinline uint8_t _count_leading_ones_32(uint32_t value)
 {
-	unsigned long index;
-	return _BitScanReverse(&index, ~value) ? (31U - index) : 32U;
+	return uint8_t(_CountLeadingOnes(value));
 }
-#endif
 
 
 /*-------------------------------------------------
@@ -59,18 +54,11 @@ __forceinline uint8_t _count_leading_ones_32(uint32_t value)
     leading zero bits in a 64-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_zeros_64
 #define count_leading_zeros_64 _count_leading_zeros_64
 __forceinline uint8_t _count_leading_zeros_64(uint64_t value)
 {
-	unsigned long index;
-#ifdef PTR64
-	return _BitScanReverse64(&index, value) ? (63U - index) : 64U;
-#else
-	return _BitScanReverse(&index, uint32_t(value >> 32)) ? (31U - index) : _BitScanReverse(&index, uint32_t(value)) ? (63U - index) : 64U;
-#endif
+	return uint8_t(_CountLeadingZeros64(value));
 }
-#endif
 
 
 /*-------------------------------------------------
@@ -78,17 +66,10 @@ __forceinline uint8_t _count_leading_zeros_64(uint64_t value)
     leading one bits in a 64-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_ones_64
 #define count_leading_ones_64 _count_leading_ones_64
 __forceinline uint8_t _count_leading_ones_64(uint64_t value)
 {
-	unsigned long index;
-#ifdef PTR64
-	return _BitScanReverse64(&index, ~value) ? (63U - index) : 64U;
-#else
-	return _BitScanReverse(&index, ~uint32_t(value >> 32)) ? (31U - index) : _BitScanReverse(&index, ~uint32_t(value)) ? (63U - index) : 64U;
-#endif
+	return uint8_t(_CountLeadingOnes64(value));
 }
-#endif
 
-#endif // MAME_OSD_EIVC_H
+#endif // MAME_OSD_EIVCARM_H

--- a/src/osd/eminline.h
+++ b/src/osd/eminline.h
@@ -33,8 +33,10 @@
 
 #elif defined(_MSC_VER)
 
-#if (defined(_M_IX86) || defined(_M_X64))
+#if defined(_M_IX86) || defined(_M_X64)
 #include "eivcx86.h"
+#elif defined(_M_ARM) || defined(_M_ARM64)
+#include "eivcarm.h"
 #endif
 
 #include "eivc.h"
@@ -352,12 +354,12 @@ inline bool addu_64x64_co(uint64_t a, uint64_t b, uint64_t &sum)
 ***************************************************************************/
 
 /*-------------------------------------------------
-    count_leading_zeros - return the number of
+    count_leading_zeros_32 - return the number of
     leading zero bits in a 32-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_zeros
-inline uint8_t count_leading_zeros(uint32_t val)
+#ifndef count_leading_zeros_32
+inline uint8_t count_leading_zeros_32(uint32_t val)
 {
 	if (!val) return 32U;
 	uint8_t count;
@@ -368,15 +370,46 @@ inline uint8_t count_leading_zeros(uint32_t val)
 
 
 /*-------------------------------------------------
-    count_leading_ones - return the number of
+    count_leading_ones_32 - return the number of
     leading one bits in a 32-bit value
 -------------------------------------------------*/
 
-#ifndef count_leading_ones
-inline uint8_t count_leading_ones(uint32_t val)
+#ifndef count_leading_ones_32
+inline uint8_t count_leading_ones_32(uint32_t val)
 {
 	uint8_t count;
 	for (count = 0; int32_t(val) < 0; count++) val <<= 1;
+	return count;
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_zeros_64 - return the number of
+    leading zero bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_zeros_64
+inline uint8_t count_leading_zeros_64(uint64_t val)
+{
+	if (!val) return 64U;
+	uint8_t count;
+	for (count = 0; int64_t(val) >= 0; count++) val <<= 1;
+	return count;
+}
+#endif
+
+
+/*-------------------------------------------------
+    count_leading_ones_64 - return the number of
+    leading one bits in a 64-bit value
+-------------------------------------------------*/
+
+#ifndef count_leading_ones_64
+inline uint8_t count_leading_ones_64(uint64_t val)
+{
+	uint8_t count;
+	for (count = 0; int64_t(val) < 0; count++) val <<= 1;
 	return count;
 }
 #endif

--- a/src/tools/unidasm.cpp
+++ b/src/tools/unidasm.cpp
@@ -1345,7 +1345,7 @@ int main(int argc, char *argv[])
 	}
 
 	// Compute the shift amount from pc delta to granularity-sized elements
-	u32 granularity_shift = 31 - count_leading_zeros(disasm->opcode_alignment());
+	u32 granularity_shift = 31 - count_leading_zeros_32(disasm->opcode_alignment());
 
 	// Number of pc steps to disassemble
 	u32 count = pclength;
@@ -1355,7 +1355,7 @@ int main(int argc, char *argv[])
 
 	// pc to string conversion
 	std::function<std::string (offs_t pc)> pc_to_string;
-	int aw = 32 - count_leading_zeros(pc_mask);
+	int aw = 32 - count_leading_zeros_32(pc_mask);
 	bool is_octal = opts.octal; // Parameter?  Per-cpu config?
 	if((flags & util::disasm_interface::PAGED2LEVEL) == util::disasm_interface::PAGED2LEVEL) {
 		int bits1 = disasm->page_address_bits();


### PR DESCRIPTION
Some observations:
* On AArch64, clang is smart enough to realise that `x ? __builtin_clz(x) : 32` is equivalent to a `clz` instruction, while GCC is not (GCC will do a separate test and conditional move).
* On x86, neither clang nor GCC realises that the `bsr` instruction does the test for free, and both produce extra instructions to do the test.
* On ARM/AArch64, MSVC is terrible at generating code for anything using the `_BitScanReverse` intrinsic – it’s far better to use the `CountLeading…` intrinsics (which are not available on x86).
* On x86, MSVC seems to heavily favour conditional branches over conditional moves, while on ARM (really Thumb-2) it uses predicated moves/arithmetic.

I think I’ve covered enough cases.  I realise clang/GCC 32-bit ARM isn’t covered – the `clz` instruction is relatively new and may not be available, so it would be necessary to test for it, which is annoying to do.  I didn’t bother with optimised versions for i686 and 32-bit PowerPC, because I just don’t care enough.