### PR TITLE
HD61830: Fix character blink mode

### DIFF
--- a/src/devices/video/hd61830.cpp
+++ b/src/devices/video/hd61830.cpp
@@ -440,7 +440,7 @@ void hd61830_device::draw_char(bitmap_ind16 &bitmap, const rectangle &cliprect, 
 			{
 				// cursor off, character blink
 				if (!cursor)
-					pixel = m_cursor ? pixel : 0;
+					pixel = m_cursor ? 1 : pixel;
 
 				// cursor blink
 				if (cursor && (cl == m_cp))

--- a/src/mame/drivers/pofo.cpp
+++ b/src/mame/drivers/pofo.cpp
@@ -18,7 +18,6 @@
 
     TODO:
 
-    - cursor is missing
     - where do CDET and NMD1 connect to ??
     - i/o port 8051
     - screen contrast


### PR DESCRIPTION
When Cursor=Off and Blink=On, the controller is in "Character Blink"
mode, according to the data sheet.

This means that the character cell at the the position of the cursor is
turned fully ON at a 50% blink duty cycle. Verified on a device with a
real HD61830 (Atari Portfolio).