### PR TITLE
ibm5170_hdd: new software list additions

### DIFF
--- a/hash/ibm5170_hdd.xml
+++ b/hash/ibm5170_hdd.xml
@@ -16,7 +16,40 @@ license:CC0
 		<publisher>Digital Research</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="drdos6" sha1="4421e76e30a4f83a73684a879212041aa860a3d9" writeable="yes" />
+				<disk name="drdos6" sha1="4421e76e30a4f83a73684a879212041aa860a3d9" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="freedos10">
+		<description>FreeDOS 1.0</description>
+		<year>2006</year>
+		<publisher>The FreeDOS Project</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="freedos10" sha1="49a47fe1778f335319eb0ed9888b3c80aae569f7" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="freedos13rc4">
+		<description>FreeDOS 1.3 Release Candidate 4</description>
+		<year>2021</year>
+		<publisher>The FreeDOS Project</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="freedos13rc4" sha1="bb81d708746f4e5cfd4207af598cd7691a8e33bf" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="msdos331">
+		<description>MS-DOS (Version 3.31)</description>
+		<year>1987</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="msdos331" sha1="8dcd18e7edbba516efca297181cbf452e7f944d6" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -27,7 +60,7 @@ license:CC0
 		<publisher>Microsoft</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="msdos5" sha1="2c585ce9193b5420bfe4f6fca591226bf69a8664" writeable="yes" />
+				<disk name="msdos5" sha1="2c585ce9193b5420bfe4f6fca591226bf69a8664" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -38,7 +71,18 @@ license:CC0
 		<publisher>Microsoft</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="msdos6" sha1="b90a3e039ba35234124e7cd9a3793b36cad6fa0c" writeable="yes" />
+				<disk name="msdos6" sha1="b90a3e039ba35234124e7cd9a3793b36cad6fa0c" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="msdos62">
+		<description>MS-DOS (Version 6.20)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="msdos62" sha1="a31ce09d250c5cbbb3dd455f428a58dde808f68a" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -71,7 +115,42 @@ license:CC0
 		<publisher>Novell</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="nvldos7" sha1="c3f67f44c015141a09d6aeb104847b9bc90a0fd7" writeable="yes" />
+				<disk name="nvldos7" sha1="c3f67f44c015141a09d6aeb104847b9bc90a0fd7" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pcdos5">
+		<description>IBM DOS (Version 5.00)</description>
+		<year>1991</year>
+		<publisher>IBM</publisher>
+		<info name="version" value="5.00" />
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="pcdos5" sha1="13e5d55c5d8ee2572e4a4b235d67bab85cdc3551" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pcdos502">
+		<description>IBM DOS (Version 5.02)</description>
+		<year>1992</year>
+		<publisher>IBM</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="pcdos502" sha1="cd80077357318245d0aac7090844c3d1179df6e2" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="pcdos61">
+		<description>IBM DOS (Version 6.1)</description>
+		<year>1993</year>
+		<publisher>IBM</publisher>
+		<info name="version" value="6.1" />
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="pcdos61" sha1="87feeccc64414792c16d4b1e5fefc1aa7de8d3c2" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -82,7 +161,7 @@ license:CC0
 		<publisher>IBM</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="pcdos63" sha1="6811617bf057b35ea5879a1cabb1001f5606c0e2" writeable="yes" />
+				<disk name="pcdos63" sha1="6811617bf057b35ea5879a1cabb1001f5606c0e2" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -93,7 +172,29 @@ license:CC0
 		<publisher>IBM</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="pcdos2k" sha1="96addad58a341c5ac005bbec700e7e52e2ae091f" writeable="yes" />
+				<disk name="pcdos2k" sha1="96addad58a341c5ac005bbec700e7e52e2ae091f" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="win21386">
+		<description>Microsoft Windows/386 Version 2.1</description>
+		<year>1988</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="win21386" sha1="c30769289e5aac9e40123941deb3586ab7f588ba" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="wi211386">
+		<description>Microsoft Windows/386 Version 2.11</description>
+		<year>1989</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="wi211386" sha1="6c5dee6d39263238ed429870892d84c5c1fe670e" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -104,7 +205,7 @@ license:CC0
 		<publisher>Microsoft</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="win30" sha1="64c7099b65b6561c8e346d240796bf4c00d381ab" writeable="yes" />
+				<disk name="win30" sha1="64c7099b65b6561c8e346d240796bf4c00d381ab" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>
@@ -115,7 +216,73 @@ license:CC0
 		<publisher>Microsoft</publisher>
 		<part name="hdd" interface="ide_hdd">
 			<diskarea name="harddriv">
-				<disk name="win31" sha1="15a7f0cee36fb8c80b1f378375c70b6dc94d531d" writeable="yes" />
+				<disk name="win31" sha1="15a7f0cee36fb8c80b1f378375c70b6dc94d531d" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="win311">
+		<description>Windows Version 3.11</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="win311" sha1="1bbf5ce3305e1d6d22409ae35d755181ddb36321" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="wfw31">
+		<description>Windows for Workgroups Version 3.1</description>
+		<year>1992</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="wfw31" sha1="6b37720cfb1607c66ebb42ce337fb597fda1f920" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="wfw311">
+		<description>Windows for Workgroups Version 3.11</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="wfw311" sha1="c87f3a1e2e5b848aaa7a75c8cdf0cc2da7c95659" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31w">
+		<description>Windows NT 3.1 Workstation (3.10.511.1)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="winnt31w" sha1="5c1cd3934cfcbd7b22f5f507c23d9b8826678c58" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt351w">
+		<description>Windows NT 3.51 Workstation (3.51.1057.1)</description>
+		<year>1995</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="winnt351w" sha1="b59a2f9254a0023afa37d036638863882906a2e1" writeable="yes"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="win95">
+		<description>Windows 95</description>
+		<year>1995</year>
+		<publisher>Microsoft</publisher>
+		<part name="hdd" interface="ide_hdd">
+			<diskarea name="harddriv">
+				<disk name="win95" sha1="284bfaac43d484d097b832cec48620a0f87dd890" writeable="yes"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
This also includes a handful of formatting fixes for consistency.

New working software list additions:

FreeDOS 1.0
FreeDOS 1.3 Release Candidate 4
MS-DOS (Version 3.31)
MS-DOS (Version 6.20)
IBM DOS (Version 5.00)
IBM DOS (Version 5.02)
IBM DOS (Version 6.1)
Microsoft Windows/386 Version 2.1
Microsoft Windows/386 Version 2.11
Windows Version 3.11
Windows for Workgroups Version 3.1
Windows for Workgroups Version 3.11
Windows NT 3.1 Workstation (3.10.511.1)
Windows NT 3.51 Workstation (3.51.1057.1)
Windows 95