### PR TITLE
Atari Portfolio: Emulation fixes and improvements

### DIFF
--- a/src/devices/bus/pofo/hpc104.cpp
+++ b/src/devices/bus/pofo/hpc104.cpp
@@ -169,7 +169,7 @@ uint8_t pofo_hpc104_device::nrdi_r(offs_t offset, uint8_t data, bool iom, bool b
 		{
 			if (offset >= 0x1f000 && offset < 0x5f000)
 			{
-				data = m_nvram[offset - 0x1f000] = data;
+				data = m_nvram[offset - 0x1f000];
 			}
 		}
 	}

--- a/src/mame/drivers/pofo.cpp
+++ b/src/mame/drivers/pofo.cpp
@@ -613,7 +613,7 @@ uint8_t portfolio_state::mem_r(offs_t offset)
 			break;
 
 		default:
-			if (LOG) logerror("%s %s Invalid bus read %05x\n", machine().time().as_string(), machine().describe_context(), offset & 0x1ffff);
+			logerror("%s %s Invalid bus read %05x\n", machine().time().as_string(), machine().describe_context(), offset & 0x1ffff);
 			break;
 		}
 	}
@@ -665,7 +665,7 @@ void portfolio_state::mem_w(offs_t offset, uint8_t data)
 			break;
 
 		default:
-			if (LOG) logerror("%s %s Invalid bus write %05x\n", machine().time().as_string(), machine().describe_context(), offset & 0x1ffff);
+			logerror("%s %s Invalid bus write %05x\n", machine().time().as_string(), machine().describe_context(), offset & 0x1ffff);
 			break;
 		}
 	}

--- a/src/mame/drivers/pofo.cpp
+++ b/src/mame/drivers/pofo.cpp
@@ -230,9 +230,17 @@ WRITE_LINE_MEMBER( portfolio_state::wake_w )
 
 uint8_t portfolio_state::irq_status_r()
 {
-	return m_ip;
-}
+	uint8_t data = m_ip;
+	/*
+		The BIOS interrupt 11h (Equipment list) reports that the second floppy drive (B:) is
+		installed if the 3rd bit is set (which is also the external interrupt line).
+		It is not clear if the ~NMD1 line is OR or XORed or muxed with the interrupt line,
+		but this way seems to work.
+	*/
+	data |= !m_exp->nmd1_r() << 3;
 
+	return data;
+}
 
 //-------------------------------------------------
 //  irq_mask_w - interrupt enable mask

--- a/src/mame/drivers/pofo.cpp
+++ b/src/mame/drivers/pofo.cpp
@@ -703,6 +703,11 @@ uint8_t portfolio_state::io_r(offs_t offset)
 			break;
 		}
 	}
+	else if (offset == 0x61)
+	{
+		// Magic port to detect the Pofo
+		data = 0x61;
+	}
 
 	data = m_exp->nrdi_r(offset, data, iom, bcom, ncc1);
 


### PR DESCRIPTION
A combination of various fixes:

---

pofo: Fix RAM expander read access

This was writing the uninitialized `data` value into RAM on read
accesses, causing the external RAM checks to fail. Probably a typo, fix.

---

pofo: Magic port 0x61 emulation

This is used by various utility programs (such as `ram_test.com` and
`lcd_test.com`) to identify if the program is running on a Pofo.

Apparently 0x61 is the Pofo developers favorite magic value, since the
Pofo-specific services' interrupt number is also 0x61.

---

pofo: Fix external drive B: detection

(see added comment in code)

---

pofo: Better control register 0x8051 emulation

(see added comment in code)