### PR TITLE
bus/nes: fix Kaiser Metroid, promote games to working

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -51169,7 +51169,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 <!-- ORIGINAL & HACK PIRATE CARTS -->
 
-	<software name="crimebst" supported="no">
+	<software name="crimebst">
 		<description>Crime Busters</description>
 		<year>1989</year>
 		<publisher>Gradiente ~ Bit Corp.</publisher>
@@ -51178,6 +51178,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="bitcorp_dis" />
 			<feature name="pcb" value="BIT-CORP-74*161/138" />
 			<feature name="mirroring" value="vertical" />
+			<feature name="peripheral" value="zapper" />
 			<dataarea name="prg" size="131072">
 				<rom name="0.prg" size="131072" crc="1a8b558e" sha1="e881a8df5352cb21d49a5ab154ba59da2ffc0534" offset="00000" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -66531,10 +66531,11 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="metroidk" supported="partial">
+	<software name="metroidk">
 		<description>Metroid - Jin Ji Zhi Ling (Asia, FDS conversion)</description>
 		<year>19??</year>
 		<publisher>Kaiser</publisher>
+		<info name="alt_title" value="緊急指令"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="ks7037" />
 			<feature name="pcb" value="UNL-KS7037" />

--- a/src/devices/bus/nes/discrete.cpp
+++ b/src/devices/bus/nes/discrete.cpp
@@ -12,9 +12,6 @@
  * PCB with IC 74x377 [mapper 11]
  * PCB with IC 74x161x138 [mapper 38]
 
- TODO:
- - Investigating missing inputs in Crime Busters
-
  ***********************************************************************************************************/
 
 

--- a/src/devices/bus/nes/kaiser.cpp
+++ b/src/devices/bus/nes/kaiser.cpp
@@ -269,7 +269,7 @@ void nes_ks7037_device::pcb_reset()
 	prg8_ef(0x0f);
 	chr8(0, CHRRAM);
 
-	memset(m_reg, 0, sizeof(m_reg));
+	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	m_latch = 0;
 }
 
@@ -674,7 +674,7 @@ void nes_ks7016_device::write_h(offs_t offset, uint8_t data)
  but with WRAM split between 0x6000-0x6fff
  and 0xb000-0xbfff.
 
- iNES:
+ NES 2.0: mapper 307
 
  In MAME: Supported.
 
@@ -696,7 +696,7 @@ uint8_t nes_ks7037_device::read_m(offs_t offset)
 	if (offset < 0x1000)
 		return m_prgram[offset];
 	else
-		return m_prg[0xf000 + (offset & 0x0fff)];
+		return m_prg[0x0f * 0x1000 + (offset & 0x0fff)]; // 4k PRG bank 15 is fixed
 }
 
 void nes_ks7037_device::write_m(offs_t offset, uint8_t data)

--- a/src/devices/bus/nes/kaiser.cpp
+++ b/src/devices/bus/nes/kaiser.cpp
@@ -264,9 +264,9 @@ void nes_ks7037_device::device_start()
 void nes_ks7037_device::pcb_reset()
 {
 	prg8_89(0);
-	prg8_ab(0x1e);
+	prg8_ab(0x0e);
 	prg8_cd(0);
-	prg8_ef(0x1f);
+	prg8_ef(0x0f);
 	chr8(0, CHRRAM);
 
 	memset(m_reg, 0, sizeof(m_reg));
@@ -676,19 +676,17 @@ void nes_ks7016_device::write_h(offs_t offset, uint8_t data)
 
  iNES:
 
- In MESS: Unsupported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
 void nes_ks7037_device::update_prg()
 {
 	prg8_89(m_reg[6]);
-	prg8_ab(0xfe);
 	prg8_cd(m_reg[7]);
-	prg8_ef(0xff);
 	set_nt_page(0, CIRAM, m_reg[2] & 1, 1);
-	set_nt_page(1, CIRAM, m_reg[3] & 1, 1);
-	set_nt_page(2, CIRAM, m_reg[4] & 1, 1);
+	set_nt_page(2, CIRAM, m_reg[3] & 1, 1);
+	set_nt_page(1, CIRAM, m_reg[4] & 1, 1);
 	set_nt_page(3, CIRAM, m_reg[5] & 1, 1);
 }
 
@@ -696,16 +694,16 @@ uint8_t nes_ks7037_device::read_m(offs_t offset)
 {
 //  LOG_MMC(("ks7037 read_m, offset: %04x\n", offset));
 	if (offset < 0x1000)
-		return m_prgram[offset & 0x0fff];
+		return m_prgram[offset];
 	else
-		return m_prg[(0x1e * 0x1000) + (offset & 0x0fff)];
+		return m_prg[0xf000 + (offset & 0x0fff)];
 }
 
 void nes_ks7037_device::write_m(offs_t offset, uint8_t data)
 {
 	LOG_MMC(("ks7037 write_m, offset: %04x, data: %02x\n", offset, data));
 	if (offset < 0x1000)
-		m_prgram[offset & 0x0fff] = data;
+		m_prgram[offset] = data;
 }
 
 uint8_t nes_ks7037_device::read_h(offs_t offset)


### PR DESCRIPTION
- metroidk: corrects fixed bank address that caused game to crash after title screen
- metroidk: corrects the nametable page mis-ordering that then becomes apparent when game is running

Software list items promoted to working
----------------------------------------
Crime Busters
Metroid - Jin Ji Zhi Ling (Asia, FDS conversion)