### PR TITLE
dragon: fix MT#7305

### DIFF
--- a/src/devices/machine/6821pia.cpp
+++ b/src/devices/machine/6821pia.cpp
@@ -54,8 +54,8 @@ pia6821_device::pia6821_device(const machine_config &mconfig, const char *tag, d
 		m_cb2_handler(*this),
 		m_irqa_handler(*this),
 		m_irqb_handler(*this), m_in_a(0),
-		m_in_ca1(0), m_in_ca2(0), m_out_a(0), m_a_input_overrides_output_mask(0), m_out_ca2(0), m_ddr_a(0),
-		m_ctl_a(0), m_irq_a1(false), m_irq_a2(false),
+		m_in_ca1(0), m_in_ca2(0), m_out_a(0), m_a_input_overrides_output_mask(0), m_a_input_pull_up_mask(0),
+		m_out_ca2(0), m_ddr_a(0), m_ctl_a(0), m_irq_a1(false), m_irq_a2(false),
 		m_irq_a_state(0), m_in_b(0),
 		m_in_cb1(0), m_in_cb2(0), m_out_b(0), m_out_cb2(0), m_last_out_cb2_z(0), m_ddr_b(0),
 		m_ctl_b(0), m_irq_b1(false), m_irq_b2(false),
@@ -131,6 +131,8 @@ void pia6821_device::device_start()
 	save_item(NAME(m_irq_a1));
 	save_item(NAME(m_irq_a2));
 	save_item(NAME(m_irq_a_state));
+	save_item(NAME(m_a_input_overrides_output_mask));
+	save_item(NAME(m_a_input_pull_up_mask));
 	save_item(NAME(m_in_b));
 	save_item(NAME(m_in_cb1));
 	save_item(NAME(m_in_cb2));
@@ -264,7 +266,8 @@ uint8_t pia6821_device::get_in_a_value()
 	// the output register will show the external device value on the driven pins.
 	ret = (~m_ddr_a & port_a_data)  // input pins
 		| (m_ddr_a & m_out_a & ~m_a_input_overrides_output_mask)  // normal output pins
-		| (m_ddr_a & port_a_data & m_a_input_overrides_output_mask);  // overridden output pins
+		| (m_ddr_a & port_a_data & m_a_input_overrides_output_mask)  // overridden output pins
+		| (~m_ddr_a & m_a_input_pull_up_mask ); // pull up indicated input pins
 
 	return ret;
 }

--- a/src/devices/machine/6821pia.h
+++ b/src/devices/machine/6821pia.h
@@ -64,6 +64,7 @@ public:
 	void set_a_input(uint8_t data);
 	uint8_t a_output();
 	void set_port_a_input_overrides_output_mask(uint8_t mask) { m_a_input_overrides_output_mask = mask; }
+	void set_port_a_input_pull_up_mask(uint8_t mask) { m_a_input_pull_up_mask = mask; }
 
 	DECLARE_WRITE_LINE_MEMBER( pa0_w ) { write_porta_line(0, state); }
 	DECLARE_WRITE_LINE_MEMBER( pa1_w ) { write_porta_line(1, state); }
@@ -174,6 +175,7 @@ private:
 	uint8_t m_in_ca2;
 	uint8_t m_out_a;
 	uint8_t m_a_input_overrides_output_mask;
+	uint8_t m_a_input_pull_up_mask;
 	uint8_t m_out_ca2;
 	uint8_t m_ddr_a;
 	uint8_t m_ctl_a;

--- a/src/mame/drivers/coco12.cpp
+++ b/src/mame/drivers/coco12.cpp
@@ -489,6 +489,7 @@ void coco12_state::coco(machine_config &config)
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
 	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
 	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
+	pia1.set_port_a_input_pull_up_mask(0xfc);
 
 	SAM6883(config, m_sam, XTAL(14'318'181), m_maincpu);
 	m_sam->set_addrmap(0, &coco12_state::coco_ram);

--- a/src/mame/drivers/coco3.cpp
+++ b/src/mame/drivers/coco3.cpp
@@ -290,6 +290,7 @@ void coco3_state::coco3(machine_config &config)
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
 	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
 	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
+	pia1.set_port_a_input_pull_up_mask(0xfc);
 
 	// Becker Port device
 	COCO_DWSOCK(config, DWSOCK_TAG, 0);

--- a/src/mame/drivers/dragon.cpp
+++ b/src/mame/drivers/dragon.cpp
@@ -263,6 +263,7 @@ void dragon_state::dragon_base(machine_config &config)
 	pia1.cb2_handler().set(FUNC(coco_state::pia1_cb2_w));
 	pia1.irqa_handler().set(m_firqs, FUNC(input_merger_device::in_w<0>));
 	pia1.irqb_handler().set(m_firqs, FUNC(input_merger_device::in_w<1>));
+	pia1.set_port_a_input_pull_up_mask(0xfc);
 
 	SAM6883(config, m_sam, 14.218_MHz_XTAL, m_maincpu);
 	m_sam->set_addrmap(0, &dragon_state::coco_ram);


### PR DESCRIPTION
1. Add emulation of external pull up resistors on input pins.
2. Fix a save state for m_a_input_overrides_output_mask.

I'm not sure if this is the best way to accomplish this.