### PR TITLE
Correctly apply -keepaspect with -unevenstretchx/y. Initialize window…

### DIFF
--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1193,37 +1193,58 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 
 			// get target aspect
 			float target_aspect = (float)target_width / (float)target_height * target_pixel_aspect;
-			bool target_is_portrait = (target_aspect < 1.0f);
 
 			// apply automatic axial stretching if required
 			int scale_mode = m_scale_mode;
 			if (m_scale_mode == SCALE_FRACTIONAL_AUTO)
 			{
 				bool is_rotated = (m_manager.machine().system().flags & ORIENTATION_SWAP_XY) ^ (target_orientation & ORIENTATION_SWAP_XY);
-				scale_mode = is_rotated ^ target_is_portrait ? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
+				scale_mode = is_rotated? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
 			}
-
-			// determine the scale mode for each axis
-			bool x_is_integer = !((!target_is_portrait && scale_mode == SCALE_FRACTIONAL_X) || (target_is_portrait && scale_mode == SCALE_FRACTIONAL_Y));
-			bool y_is_integer = !((target_is_portrait && scale_mode == SCALE_FRACTIONAL_X) || (!target_is_portrait && scale_mode == SCALE_FRACTIONAL_Y));
 
 			// first compute scale factors to fit the screen
 			float xscale = (float)target_width / src_width;
 			float yscale = (float)target_height / src_height;
-			float maxxscale = std::max(1.0f, float(m_int_overscan ? render_round_nearest(xscale) : floor(xscale)));
-			float maxyscale = std::max(1.0f, float(m_int_overscan ? render_round_nearest(yscale) : floor(yscale)));
 
-			// now apply desired scale mode and aspect correction
-			if (m_keepaspect && target_aspect > src_aspect) xscale *= src_aspect / target_aspect * (maxyscale / yscale);
-			if (m_keepaspect && target_aspect < src_aspect) yscale *= target_aspect / src_aspect * (maxxscale / xscale);
-			if (x_is_integer) xscale = std::clamp(render_round_nearest(xscale), 1.0f, maxxscale);
-			if (y_is_integer) yscale = std::clamp(render_round_nearest(yscale), 1.0f, maxyscale);
+			// apply aspect correction
+			if (m_keepaspect)
+			{
+				if (target_aspect > src_aspect)
+					xscale *= src_aspect / target_aspect;
+				else
+					yscale *= target_aspect / src_aspect;
+			}
+
+			bool x_fits = render_round_nearest(xscale) * src_width <= target_width;
+			bool y_fits = render_round_nearest(yscale) * src_height <= target_height;
+
+			// compute integer scale factors
+			float integer_x = std::max(1.0f, float(m_int_overscan || x_fits? render_round_nearest(xscale) : floor(xscale)));
+			float integer_y = std::max(1.0f, float(m_int_overscan || y_fits? render_round_nearest(yscale) : floor(yscale)));
+
+			//float integer_x = std::max(1.0f, float(m_int_overscan? render_round_nearest(xscale) : floor(xscale)));
+			//float integer_y = std::max(1.0f, float(m_int_overscan? render_round_nearest(yscale) : floor(yscale)));
 
 			// check if we have user defined scale factors, if so use them instead
-			int user_scale_x = target_is_portrait? m_int_scale_y : m_int_scale_x;
-			int user_scale_y = target_is_portrait? m_int_scale_x : m_int_scale_y;
-			xscale = user_scale_x > 0 ? user_scale_x : xscale;
-			yscale = user_scale_y > 0 ? user_scale_y : yscale;
+			integer_x = m_int_scale_x > 0 ? m_int_scale_x : integer_x;
+			integer_y = m_int_scale_y > 0 ? m_int_scale_y : integer_y;
+
+			// now apply desired scale mode
+			if (scale_mode == SCALE_FRACTIONAL_X)
+			{
+				if (m_keepaspect) xscale *= integer_y / yscale;
+				yscale = integer_y;
+			}
+			else if (scale_mode == SCALE_FRACTIONAL_Y)
+			{
+				if (m_keepaspect) yscale *= integer_x / xscale;
+				xscale = integer_x;
+			}
+			else
+			{
+				xscale = integer_x;
+				yscale = integer_y;
+			}
 
 			// set the final width/height
 			visible_width = render_round_nearest(src_width * xscale);

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1199,7 +1199,7 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 			if (m_scale_mode == SCALE_FRACTIONAL_AUTO)
 			{
 				bool is_rotated = (m_manager.machine().system().flags & ORIENTATION_SWAP_XY) ^ (target_orientation & ORIENTATION_SWAP_XY);
-				scale_mode = is_rotated? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
+				scale_mode = is_rotated ? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
 			}
 
 			// first compute scale factors to fit the screen
@@ -1219,11 +1219,8 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 			bool y_fits = render_round_nearest(yscale) * src_height <= target_height;
 
 			// compute integer scale factors
-			float integer_x = std::max(1.0f, float(m_int_overscan || x_fits? render_round_nearest(xscale) : floor(xscale)));
-			float integer_y = std::max(1.0f, float(m_int_overscan || y_fits? render_round_nearest(yscale) : floor(yscale)));
-
-			//float integer_x = std::max(1.0f, float(m_int_overscan? render_round_nearest(xscale) : floor(xscale)));
-			//float integer_y = std::max(1.0f, float(m_int_overscan? render_round_nearest(yscale) : floor(yscale)));
+			float integer_x = std::max(1.0f, float(m_int_overscan || x_fits ? render_round_nearest(xscale) : floor(xscale)));
+			float integer_y = std::max(1.0f, float(m_int_overscan || y_fits ? render_round_nearest(yscale) : floor(yscale)));
 
 			// check if we have user defined scale factors, if so use them instead
 			integer_x = m_int_scale_x > 0 ? m_int_scale_x : integer_x;

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -904,10 +904,6 @@ osd_rect sdl_window_info::constrain_to_aspect_ratio(const osd_rect &rect, int ad
 	int32_t adjwidth, adjheight;
 	float pixel_aspect;
 
-	// do not constrain aspect ratio for integer scaled views
-	if (target()->scale_mode() != SCALE_FRACTIONAL)
-		return rect;
-
 	// get the pixel aspect ratio for the target monitor
 	pixel_aspect = monitor()->pixel_aspect();
 
@@ -1029,7 +1025,7 @@ osd_dim sdl_window_info::get_min_bounds(int constrain)
 	minheight += wnd_extra_height();
 
 	// if we want it constrained, figure out which one is larger
-	if (constrain && target()->scale_mode() == SCALE_FRACTIONAL)
+	if (constrain)
 	{
 		// first constrain with no height limit
 		osd_rect test1(0,0,minwidth,10000);

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -1099,7 +1099,7 @@ osd_dim sdl_window_info::get_max_bounds(int constrain)
 	maximum = maximum.resize(tempw, temph);
 
 	// constrain to fit
-	if (constrain && target()->scale_mode() == SCALE_FRACTIONAL)
+	if (constrain)
 		maximum = constrain_to_aspect_ratio(maximum, WMSZ_BOTTOMRIGHT);
 
 	// remove extra window stuff

--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -1547,7 +1547,7 @@ osd_dim win_window_info::get_min_bounds(int constrain)
 	minheight += wnd_extra_height();
 
 	// if we want it constrained, figure out which one is larger
-	if (constrain && target()->scale_mode() == SCALE_FRACTIONAL)
+	if (constrain)
 	{
 		// first constrain with no height limit
 		osd_rect test1(0,0,minwidth,10000);
@@ -1607,7 +1607,7 @@ osd_dim win_window_info::get_max_bounds(int constrain)
 	maximum = maximum.resize(tempw, temph);
 
 	// constrain to fit
-	if (constrain && target()->scale_mode() == SCALE_FRACTIONAL)
+	if (constrain)
 		maximum = constrain_to_aspect_ratio(maximum, WMSZ_BOTTOMRIGHT);
 
 	return maximum.dim();

--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -1236,7 +1236,7 @@ LRESULT CALLBACK win_window_info::video_window_proc(HWND wnd, UINT message, WPAR
 	case WM_SIZING:
 		{
 			RECT *rect = (RECT *)lparam;
-			if (window->keepaspect() && !(GetAsyncKeyState(VK_CONTROL) & 0x8000))
+			if (window->keepaspect() && (window->target()->scale_mode() == SCALE_FRACTIONAL) && !(GetAsyncKeyState(VK_CONTROL) & 0x8000))
 			{
 				osd_rect r = window->constrain_to_aspect_ratio(RECT_to_osd_rect(*rect), wparam);
 				rect->top = r.top();
@@ -1420,10 +1420,6 @@ osd_rect win_window_info::constrain_to_aspect_ratio(const osd_rect &rect, int ad
 	// Sometimes this gets called when monitors have already been torn down
 	// In that the case, just return the unmodified rect
 	if (monitor == nullptr)
-		return rect;
-
-	// do not constrain aspect ratio for integer scaled views
-	if (target()->scale_mode() != SCALE_FRACTIONAL)
 		return rect;
 
 	// get the pixel aspect ratio for the target monitor


### PR DESCRIPTION
… at the correct size when -intscalex/y is used.

Fixes [MAME Testers bug 7213](https://mametesters.org/view.php?id=7213)

In MAME there are 2 scaling paths:

- unevenstretch: (i.e. fractional). This applies fractional scaling to both axes, with or without keeping aspect ratio. This is the classical scaling method in MAME and has never been modified. No other modifiers apply.

- nounevenstretch: (i.e. integer). This applies integer scaling to both axes. Optionally, you can turn off integer scaling on one of the 2 axes (not on both o them), by specifying -unevenstretchx (-uesx) or -unevenstretchy (-uesy).  Or, alternatively, -autostretchxy will apply either -unevenstretchx or -unevenstretchy automatically based on the direction of the scanlines of the original game.

The following considerations apply to nounevenstretch:

- Integer factors are calculated as the maximum possible to fit in the window area or fullscreen resolution, without cropping. In order to allow cropping, -intoverscan will be used, so that the closest integer factor is applied even if it means overscan with regards to the window area or fullscreen resolution.

- By using -keepaspect, integer factors on both axes are calculated so they approach the original aspect ratio as much as possible, though this funcionality is limited due to the nature of integer scaling.

- In addition to this, you can use -intscalex (-sx) / -intscaley (-sy) to force custom integer factors to any of the axes, regardless of the window area. These factors lock the size on that axis once set. They also override the fuctionality of keepaspect.

***What this implementation does as compared to the previous one***

- Now, -keepaspect is applied with -unevenstretchx / -unevenstretchy (or -autostretchxy), so that the scaling of the fractional axis is proportional to the size of the integer one.* This works even if forced integer factors are applied to the integer axis.

`mame -window -uesx -ka` will force integer scaling on y, and adjust x fractionally so it meets aspect ratio. As you resize the window, y will jump by integer factors, and x will follow.

`mame -window -uesx -sy 2 -ka` will force integer scaling factor 2 on y, and adjust x fractionally so it meets aspect ratio. Resizing the window won't alter the visible area (it will create black borders around).

- Now, in windowed mode, MAME will start with the correct window size, even when integer factors are forced on command line.

- Now in Windows, you don't need to hold CTRL in order to resize the window by dragging its border.

- Maximizing/minimizing correctly restores the window client area to the integer scaled resolution.

* This change means that with -keepaspect, black borders produced by integer scaling are now propagated to the fractional axis. This is contrary to the behaviour we had before, and means that -nokeepaspect must be used now in certain cases like super resolutions on CRT (e.g. scaling 320x224 over 2560x240 now will need -nokeepaspect to avoid the borders to be propagated as black pillars).
