### PR TITLE
Eliminate remaining uses of auto_alloc and friends

### DIFF
--- a/src/devices/cpu/alto2/a2disp.h
+++ b/src/devices/cpu/alto2/a2disp.h
@@ -238,7 +238,7 @@ struct {
  *  O3 (010) = MBEMPTY'
  * </PRE>
  */
-uint8_t* m_disp_a38;
+std::unique_ptr<uint8_t[]> m_disp_a38;
 
 //! output bits of PROM A38
 enum {
@@ -273,7 +273,7 @@ enum {
  * which happens to be very close to every 7th CPU microcycle.
  * </PRE>
  */
-uint8_t* m_disp_a63;
+std::unique_ptr<uint8_t[]> m_disp_a63;
 
 enum {
 	disp_a63_HBLANK     = (1 << 0),         //!< PROM a63 B0 is latched as HBLANK signal
@@ -293,7 +293,7 @@ enum {
  * Address lines are driven by H[1] to H[128] of the horz. line counters.
  * The PROM is enabled whenever H[256] and H[512] are both 0.
  */
-uint8_t* m_disp_a66;
+std::unique_ptr<uint8_t[]> m_disp_a66;
 
 enum {
 	disp_a66_VSYNC_ODD      = (1 << 0),     //!< Q1 (001) is VSYNC for the odd field (with H1024=1)

--- a/src/devices/cpu/alto2/a2ether.h
+++ b/src/devices/cpu/alto2/a2ether.h
@@ -37,9 +37,9 @@ enum {
 												//!< f2 (1111): undefined
 };
 
-uint8_t* m_ether_a41;                             //!< BPROM; P3601-1; 256x4; enet.a41 "PE1"
-uint8_t* m_ether_a42;                             //!< BPROM; P3601-1; 256x4; enet.a42 "PE2"
-uint8_t* m_ether_a49;                             //!< BPROM; P3601-1; 265x4 enet.a49 "AFIFO"
+std::unique_ptr<uint8_t[]> m_ether_a41;                             //!< BPROM; P3601-1; 256x4; enet.a41 "PE1"
+std::unique_ptr<uint8_t[]> m_ether_a42;                             //!< BPROM; P3601-1; 256x4; enet.a42 "PE2"
+std::unique_ptr<uint8_t[]> m_ether_a49;                             //!< BPROM; P3601-1; 265x4 enet.a49 "AFIFO"
 enum {
 	ether_a49_BE    = (1 << 0),                 //!< buffer empty
 	ether_a49_BNE   = (1 << 1),                 //!< buffer next empty

--- a/src/devices/cpu/alto2/a2mouse.h
+++ b/src/devices/cpu/alto2/a2mouse.h
@@ -51,7 +51,7 @@
  * sequence: 10 -> 70 -> e0 -> 80
  * </PRE>
  */
-uint8_t* m_madr_a32;
+std::unique_ptr<uint8_t[]> m_madr_a32;
 
 //! mouse context
 struct {

--- a/src/devices/cpu/alto2/a2roms.h
+++ b/src/devices/cpu/alto2/a2roms.h
@@ -38,5 +38,5 @@ typedef struct {
 #define DMAP_DEFAULT        {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}
 #define DMAP_REVERSE_0_3    {3,2,1,0,}
 
-extern uint8_t* prom_load(running_machine& machine, const prom_load_t* prom, const uint8_t* src, int pages = 1, int segments = 1);
+extern std::unique_ptr<uint8_t[]> prom_load(running_machine& machine, const prom_load_t* prom, const uint8_t* src, int pages = 1, int segments = 1);
 #endif // MAME_CPU_ALTO2_A2ROMS_H

--- a/src/devices/cpu/alto2/alto2cpu.cpp
+++ b/src/devices/cpu/alto2/alto2cpu.cpp
@@ -1009,7 +1009,7 @@ void alto2_cpu_device::state_string_export(const device_state_entry &entry, std:
 uint32_t alto2_cpu_device::crom_cram_r(offs_t offset)
 {
 	if (offset < m_ucode_ram_base)
-		return *reinterpret_cast<uint32_t *>(m_ucode_crom + offset * 4);
+		return *reinterpret_cast<uint32_t *>(m_ucode_crom.get() + offset * 4);
 	return *reinterpret_cast<uint32_t *>(m_ucode_cram.get() + (offset - m_ucode_ram_base) * 4);
 }
 
@@ -1024,12 +1024,12 @@ void alto2_cpu_device::crom_cram_w(offs_t offset, uint32_t data)
 //! read constants PROM
 uint16_t alto2_cpu_device::const_r(offs_t offset)
 {
-	return *reinterpret_cast<uint16_t *>(m_const_data + offset * 2);
+	return *reinterpret_cast<uint16_t *>(m_const_data.get() + offset * 2);
 }
 
 //! direct read access to the microcode CROM or CRAM
 #define RD_UCODE(addr) (addr < m_ucode_ram_base ? \
-	*reinterpret_cast<uint32_t *>(m_ucode_crom + addr * 4) : \
+	*reinterpret_cast<uint32_t *>(m_ucode_crom.get() + addr * 4) : \
 	*reinterpret_cast<uint32_t *>(m_ucode_cram.get() + (addr - m_ucode_ram_base) * 4))
 
 //-------------------------------------------------

--- a/src/devices/cpu/alto2/alto2cpu.h
+++ b/src/devices/cpu/alto2/alto2cpu.h
@@ -251,9 +251,9 @@ private:
 	uint32_t m_ucode_size;                    //!< Size of both, CROM and CRAM together
 	uint32_t m_sreg_banks;                    //!< Number of S register banks; derived from m_cram_config
 
-	uint8_t* m_ucode_crom;
+	std::unique_ptr<uint8_t[]> m_ucode_crom;
 	std::unique_ptr<uint8_t[]> m_ucode_cram;
-	uint8_t* m_const_data;
+	std::unique_ptr<uint8_t[]> m_const_data;
 
 	void ucode_map(address_map &map);
 	void const_map(address_map &map);
@@ -655,7 +655,7 @@ private:
 	 * access it. Also both, address and data lines, are inverted.
 	 * </PRE>
 	 */
-	uint8_t* m_ctl2k_u3;
+	std::unique_ptr<uint8_t[]> m_ctl2k_u3;
 
 	/**
 	 * @brief 2KCTL PROM u38; 82S23; 32x8 bit
@@ -704,7 +704,7 @@ private:
 	 *  B7     9      NEXT[06]'
 	 * </PRE>
 	 */
-	uint8_t* m_ctl2k_u38;
+	std::unique_ptr<uint8_t[]> m_ctl2k_u38;
 
 	//! output lines of the 2KCTL U38 PROM
 	enum {
@@ -776,22 +776,22 @@ private:
 	 * depending on the current NEXT[01]' level.
 	 * </PRE>
 	 */
-	uint8_t* m_ctl2k_u76;
+	std::unique_ptr<uint8_t[]> m_ctl2k_u76;
 
 	/**
 	 * @brief 3k CRAM PROM a37
 	 */
-	uint8_t* m_cram3k_a37;
+	std::unique_ptr<uint8_t[]> m_cram3k_a37;
 
 	/**
 	 * @brief memory addressing PROM a64
 	 */
-	uint8_t* m_madr_a64;
+	std::unique_ptr<uint8_t[]> m_madr_a64;
 
 	/**
 	 * @brief memory addressing PROM a65
 	 */
-	uint8_t* m_madr_a65;
+	std::unique_ptr<uint8_t[]> m_madr_a65;
 
 	/**
 	 * @brief unused PROM a90
@@ -806,7 +806,7 @@ private:
 	 *
 	 * I haven't found yet where KP3-KP5 are used
 	 */
-	uint8_t* m_madr_a90;
+	std::unique_ptr<uint8_t[]> m_madr_a90;
 
 	/**
 	 * @brief unused PROM a91
@@ -833,12 +833,12 @@ private:
 	 * KE(6)    KB(^L)  KB(RTN) KB(")   KB(/)   KB(S3)  KB(<-)    KB(])  KB(\)
 	 * KE(7)    KB(S1)  KB(DEL) KB(S2)  KB(LF)  KB(S4)  KB(S5)   KB(BW) KB(BS)
 	 */
-	uint8_t* m_madr_a91;
+	std::unique_ptr<uint8_t[]> m_madr_a91;
 
 	/**
 	 * @brief ALU function to 74181 operation lookup PROM
 	 */
-	uint8_t* m_alu_a10;
+	std::unique_ptr<uint8_t[]> m_alu_a10;
 
 	//! output lines of the ALU a10 PROM
 	enum {

--- a/src/devices/machine/smartmed.h
+++ b/src/devices/machine/smartmed.h
@@ -156,7 +156,8 @@ protected:
 						// 0 means no card loaded
 	int m_log2_pages_per_block; // log2 of number of pages per erase block (usually 4 or 5)
 
-	uint8_t* m_data_ptr;  // FEEPROM data area
+	uint8_t *m_feeprom_data;  // FEEPROM data area
+	std::unique_ptr<uint8_t[]> m_feeprom_data_alloc;
 	std::unique_ptr<uint8_t[]> m_data_uid_ptr;
 
 	sm_mode_t m_mode;               // current operation mode

--- a/src/devices/video/polylgcy.h
+++ b/src/devices/video/polylgcy.h
@@ -58,6 +58,16 @@ static constexpr uint8_t POLYLGCY_FLAG_ALLOW_QUADS         = 0x08;
 
 /* opaque reference to the poly manager */
 struct legacy_poly_manager;
+class legacy_poly_manager_owner
+{
+public:
+    legacy_poly_manager_owner();
+    ~legacy_poly_manager_owner();
+
+    operator legacy_poly_manager *() { return m_poly; }
+
+    legacy_poly_manager *m_poly;
+};
 
 
 /* input vertex data */
@@ -99,7 +109,7 @@ typedef void (*poly_draw_scanline_func)(void *dest, int32_t scanline, const poly
 /* ----- initialization/teardown ----- */
 
 /* allocate a new poly manager that can render triangles */
-legacy_poly_manager *poly_alloc(running_machine &machine, int max_polys, size_t extra_data_size, uint8_t flags);
+void poly_alloc(legacy_poly_manager_owner &owner, running_machine &machine, int max_polys, size_t extra_data_size, uint8_t flags);
 
 /* free a poly manager */
 void poly_free(legacy_poly_manager *poly);

--- a/src/devices/video/tms34061.cpp
+++ b/src/devices/video/tms34061.cpp
@@ -64,14 +64,14 @@ void tms34061_device::device_start()
 	m_vrammask = m_vramsize - 1;
 
 	/* allocate memory for VRAM */
-	m_vram = auto_alloc_array_clear(machine(), u8, m_vramsize + 256 * 2);
+	m_vram_alloc = std::make_unique<u8[]>(m_vramsize + 256 * 2);
 
 	/* allocate memory for latch RAM */
-	m_latchram = auto_alloc_array_clear(machine(), u8, m_vramsize + 256 * 2);
+	m_latchram_alloc = std::make_unique<u8[]>(m_vramsize + 256 * 2);
 
 	/* add some buffer space for VRAM and latch RAM */
-	m_vram += 256;
-	m_latchram += 256;
+	m_vram = &m_vram_alloc[256];
+	m_latchram = &m_latchram_alloc[256];
 
 	/* point the shift register to the base of VRAM for now */
 	m_shiftreg = m_vram;

--- a/src/devices/video/tms34061.h
+++ b/src/devices/video/tms34061.h
@@ -99,6 +99,8 @@ private:
 	u8               m_latchdata;
 	u8 *             m_shiftreg;
 	emu_timer *      m_timer;
+	std::unique_ptr<u8[]> m_vram_alloc;
+	std::unique_ptr<u8[]> m_latchram_alloc;
 
 	void update_interrupts();
 	TIMER_CALLBACK_MEMBER( interrupt );

--- a/src/devices/video/voodoo.cpp
+++ b/src/devices/video/voodoo.cpp
@@ -5652,7 +5652,7 @@ void voodoo_device::device_start()
 	m_pciint.resolve();
 
 	/* create a multiprocessor work queue */
-	poly = poly_alloc(machine(), 64, sizeof(poly_extra_data), 0);
+	poly_alloc(poly, machine(), 64, sizeof(poly_extra_data), 0);
 	thread_stats = std::make_unique<stats_block[]>(WORK_MAX_THREADS);
 
 	/* create a table of precomputed 1/n and log2(n) values */
@@ -6477,7 +6477,6 @@ voodoo_device::voodoo_device(const machine_config &mconfig, device_type type, co
 	, regaccess(nullptr)
 	, regnames(nullptr)
 	, alt_regmap(0)
-	, poly(nullptr)
 	, thread_stats(nullptr)
 	, last_status_pc(0)
 	, last_status_value(0)

--- a/src/devices/video/voodoo.h
+++ b/src/devices/video/voodoo.h
@@ -1337,7 +1337,7 @@ public:
 	tmu_shared_state    tmushare;               // TMU shared state
 	banshee_info        banshee;                // Banshee state
 
-	legacy_poly_manager * poly;                 // polygon manager
+	legacy_poly_manager_owner poly;              // polygon manager
 	std::unique_ptr<stats_block[]> thread_stats; // per-thread statistics
 
 	voodoo_stats        stats;                  // internal statistics

--- a/src/emu/machine.h
+++ b/src/emu/machine.h
@@ -62,18 +62,6 @@ constexpr int DEBUG_FLAG_OSD_ENABLED    = 0x00001000;       // The OSD debugger 
 
 
 //**************************************************************************
-//  MACROS
-//**************************************************************************
-
-// global allocation helpers
-#define auto_alloc(m, t)                pool_alloc(static_cast<running_machine &>(m).respool(), t)
-#define auto_alloc_clear(m, t)          pool_alloc_clear(static_cast<running_machine &>(m).respool(), t)
-#define auto_alloc_array(m, t, c)       pool_alloc_array(static_cast<running_machine &>(m).respool(), t, c)
-#define auto_alloc_array_clear(m, t, c) pool_alloc_array_clear(static_cast<running_machine &>(m).respool(), t, c)
-#define auto_free(m, v)                 pool_free(static_cast<running_machine &>(m).respool(), v)
-
-
-//**************************************************************************
 //  TYPE DEFINITIONS
 //**************************************************************************
 
@@ -125,9 +113,6 @@ class running_machine
 
 	typedef std::function<void (const char*)> logerror_callback;
 
-	// must be at top of member variables
-	resource_pool           m_respool;              // pool of resources for this machine
-
 public:
 	// construction/destruction
 	running_machine(const machine_config &config, machine_manager &manager);
@@ -139,7 +124,6 @@ public:
 	const game_driver &system() const { return m_system; }
 	osd_interface &osd() const;
 	machine_manager &manager() const { return m_manager; }
-	[[deprecated("use smart pointers to manage object lifecycles")]] resource_pool &respool() { return m_respool; }
 	device_scheduler &scheduler() { return m_scheduler; }
 	save_manager &save() { return m_save; }
 	memory_manager &memory() { return m_memory; }

--- a/src/mame/audio/acan.h
+++ b/src/mame/audio/acan.h
@@ -61,6 +61,7 @@ private:
 	uint16_t m_dma_channels;
 	acan_channel m_channels[16];
 	uint8_t m_regs[256];
+	std::unique_ptr<int32_t[]> m_mix;
 };
 
 DECLARE_DEVICE_TYPE(ACANSND, acan_sound_device)

--- a/src/mame/audio/exidy440.cpp
+++ b/src/mame/audio/exidy440.cpp
@@ -21,7 +21,6 @@
 
 
 /* internal caching */
-#define MAX_CACHE_ENTRIES       1024                /* maximum separate samples we expect to ever see */
 #define SAMPLE_BUFFER_LENGTH    1024                /* size of temporary decode buffer on the stack */
 
 /* FIR digital filter parameters */
@@ -74,9 +73,6 @@ exidy440_sound_device::exidy440_sound_device(const machine_config &mconfig, cons
 		m_samples(*this, "samples"),
 		m_sound_command(0),
 		m_sound_command_ack(0),
-		m_sound_cache(nullptr),
-		m_sound_cache_end(nullptr),
-		m_sound_cache_max(nullptr),
 		m_m6844_priority(0x00),
 		m_m6844_interrupt(0x00),
 		m_m6844_chain(0x00),
@@ -116,7 +112,7 @@ void exidy440_sound_device::device_add_mconfig(machine_config &config)
 
 void exidy440_sound_device::device_start()
 {
-	int i, length;
+	int i;
 
 	/* reset the system */
 	m_sound_command = 0;
@@ -145,14 +141,6 @@ void exidy440_sound_device::device_start()
 
 	/* get stream channels */
 	m_stream = stream_alloc(0, 2, clock());
-
-	/* allocate the sample cache */
-	length = m_samples.bytes() * 16 + MAX_CACHE_ENTRIES * sizeof(sound_cache_entry);
-	m_sound_cache = (sound_cache_entry *)auto_alloc_array_clear(machine(), uint8_t, length);
-
-	/* determine the hard end of the cache and reset */
-	m_sound_cache_max = (sound_cache_entry *)((uint8_t *)m_sound_cache + length);
-	reset_sound_cache();
 
 	/* allocate the mixer buffer */
 	m_mixer_buffer_left.resize(clock()/50);
@@ -545,46 +533,26 @@ void exidy440_sound_device::m6844_w(offs_t offset, uint8_t data)
  *
  *************************************/
 
-void exidy440_sound_device::reset_sound_cache()
-{
-	m_sound_cache_end = m_sound_cache;
-}
-
-
 int16_t *exidy440_sound_device::add_to_sound_cache(uint8_t *input, int address, int length, int bits, int frequency)
 {
-	sound_cache_entry *current = m_sound_cache_end;
-
-	/* compute where the end will be once we add this entry */
-	m_sound_cache_end = (sound_cache_entry *)((uint8_t *)current + sizeof(sound_cache_entry) + length * 16);
-
-	/* if this will overflow the cache, reset and re-add */
-	if (m_sound_cache_end > m_sound_cache_max)
-	{
-		reset_sound_cache();
-		return add_to_sound_cache(input, address, length, bits, frequency);
-	}
-
 	/* fill in this entry */
-	current->next = m_sound_cache_end;
-	current->address = address;
-	current->length = length;
-	current->bits = bits;
-	current->frequency = frequency;
+	auto &current = m_sound_cache.emplace_back();
+	current.address = address;
+	current.length = length;
+	current.bits = bits;
+	current.frequency = frequency;
 
 	/* decode the data into the cache */
-	decode_and_filter_cvsd(input, length, bits, frequency, current->data);
-	return current->data;
+	decode_and_filter_cvsd(input, length, bits, frequency, current.data);
+	return &current.data[0];
 }
 
 
 int16_t *exidy440_sound_device::find_or_add_to_sound_cache(int address, int length, int bits, int frequency)
 {
-	sound_cache_entry *current;
-
-	for (current = m_sound_cache; current < m_sound_cache_end; current = current->next)
-		if (current->address == address && current->length == length && current->bits == bits && current->frequency == frequency)
-			return current->data;
+	for (auto &current : m_sound_cache)
+		if (current.address == address && current.length == length && current.bits == bits && current.frequency == frequency)
+			return &current.data[0];
 
 	return add_to_sound_cache(&m_samples[address], address, length, bits, frequency);
 }
@@ -698,7 +666,7 @@ void exidy440_sound_device::fir_filter(int32_t *input, int16_t *output, int coun
  *
  *************************************/
 
-void exidy440_sound_device::decode_and_filter_cvsd(uint8_t *input, int bytes, int maskbits, int frequency, int16_t *output)
+void exidy440_sound_device::decode_and_filter_cvsd(uint8_t *input, int bytes, int maskbits, int frequency, std::vector<int16_t> &output)
 {
 	int32_t buffer[SAMPLE_BUFFER_LENGTH + FIR_HISTORY_LENGTH];
 	int total_samples = bytes * 8;
@@ -725,6 +693,7 @@ void exidy440_sound_device::decode_and_filter_cvsd(uint8_t *input, int bytes, in
 	integrator = 0.0;
 
 	/* loop over chunks */
+	output.resize(total_samples);
 	for (chunk_start = 0; chunk_start < total_samples; chunk_start += SAMPLE_BUFFER_LENGTH)
 	{
 		int32_t *bufptr = &buffer[FIR_HISTORY_LENGTH];
@@ -809,7 +778,7 @@ void exidy440_sound_device::decode_and_filter_cvsd(uint8_t *input, int bytes, in
 		int16_t *data;
 
 		chunk_start = (total_samples > 512) ? total_samples - 512 : 0;
-		data = output + chunk_start;
+		data = &output[chunk_start];
 		for ( ; chunk_start < total_samples; chunk_start++)
 		{
 			*data = (*data * ((total_samples - chunk_start) >> 9));

--- a/src/mame/audio/exidy440.h
+++ b/src/mame/audio/exidy440.h
@@ -58,12 +58,11 @@ private:
 	/* sound_cache_entry structure contains info on each decoded sample */
 	struct sound_cache_entry
 	{
-		struct sound_cache_entry *next;
 		int address;
 		int length;
 		int bits;
 		int frequency;
-		int16_t data[1];
+		std::vector<int16_t> data;
 	};
 
 	required_device<cpu_device> m_audiocpu;
@@ -78,9 +77,7 @@ private:
 	uint8_t m_sound_volume[0x10];
 	std::vector<int32_t> m_mixer_buffer_left;
 	std::vector<int32_t> m_mixer_buffer_right;
-	sound_cache_entry *m_sound_cache;
-	sound_cache_entry *m_sound_cache_end;
-	sound_cache_entry *m_sound_cache_max;
+	std::list<sound_cache_entry> m_sound_cache;
 
 	/* 6844 description */
 	m6844_channel_data m_m6844_channel[4];
@@ -103,11 +100,10 @@ private:
 	void play_cvsd(int ch);
 	void stop_cvsd(int ch);
 
-	void reset_sound_cache();
 	int16_t *add_to_sound_cache(uint8_t *input, int address, int length, int bits, int frequency);
 	int16_t *find_or_add_to_sound_cache(int address, int length, int bits, int frequency);
 
-	void decode_and_filter_cvsd(uint8_t *data, int bytes, int maskbits, int frequency, int16_t *dest);
+	void decode_and_filter_cvsd(uint8_t *data, int bytes, int maskbits, int frequency, std::vector<int16_t> &output);
 	void fir_filter(int32_t *input, int16_t *output, int count);
 
 	void add_and_scale_samples(int ch, int32_t *dest, int samples, int volume);

--- a/src/mame/drivers/aquarium.cpp
+++ b/src/mame/drivers/aquarium.cpp
@@ -326,7 +326,7 @@ ROM_START( aquariumj )
 	ROM_LOAD( "excellent_4.7d",  0x000000, 0x80000, CRC(9a4af531) SHA1(bb201b7a6c9fd5924a0d79090257efffd8d4aba1) )
 ROM_END
 
-void aquarium_state::expand_gfx(int low, int hi)
+std::unique_ptr<u8[]> aquarium_state::expand_gfx(int low, int hi)
 {
 	/* The BG tiles are 5bpp, this rearranges the data from
 	   the roms containing the 1bpp data so we can decode it
@@ -335,10 +335,10 @@ void aquarium_state::expand_gfx(int low, int hi)
 	gfx_element *gfx_h = m_gfxdecode->gfx(hi);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gfx_l->elements() * gfx_l->width() * gfx_l->height());
+	auto decoded = std::make_unique<u8[]>(gfx_l->elements() * gfx_l->width() * gfx_l->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = decoded.get();
 	for (int c = 0; c < gfx_l->elements(); c++)
 	{
 		const u8 *c0base = gfx_l->get_data(c);
@@ -360,15 +360,16 @@ void aquarium_state::expand_gfx(int low, int hi)
 		}
 	}
 
-	gfx_l->set_raw_layout(srcdata, gfx_l->width(), gfx_l->height(), gfx_l->elements(), 8 * gfx_l->width(), 8 * gfx_l->width() * gfx_l->height());
+	gfx_l->set_raw_layout(decoded.get(), gfx_l->width(), gfx_l->height(), gfx_l->elements(), 8 * gfx_l->width(), 8 * gfx_l->width() * gfx_l->height());
 	gfx_l->set_granularity(32);
 	m_gfxdecode->set_gfx(hi, nullptr);
+	return decoded;
 }
 
 void aquarium_state::init_aquarium()
 {
-	expand_gfx(1, 4);
-	expand_gfx(2, 3);
+	m_decoded_gfx[0] = expand_gfx(1, 4);
+	m_decoded_gfx[1] = expand_gfx(2, 3);
 
 	u8 *Z80 = memregion("audiocpu")->base();
 

--- a/src/mame/drivers/cps3.cpp
+++ b/src/mame/drivers/cps3.cpp
@@ -887,7 +887,8 @@ void cps3_state::init_crypt(u32 key1, u32 key2, int altEncryption)
 	}
 	else
 	{
-		m_user4 = auto_alloc_array(machine(), u8, USER4REGION_LENGTH);
+		m_user4_allocated = std::make_unique<u8[]>(USER4REGION_LENGTH);
+		m_user4 = m_user4_allocated.get();
 	}
 
 	if (m_user5_region)
@@ -896,7 +897,8 @@ void cps3_state::init_crypt(u32 key1, u32 key2, int altEncryption)
 	}
 	else
 	{
-		m_user5 = auto_alloc_array(machine(), u8, USER5REGION_LENGTH);
+		m_user5_allocated = std::make_unique<u8[]>(USER5REGION_LENGTH);
+		m_user5 = m_user5_allocated.get();
 	}
 
 	m_cps3sound->set_base((s8*)m_user5);

--- a/src/mame/drivers/freekick.cpp
+++ b/src/mame/drivers/freekick.cpp
@@ -1599,10 +1599,10 @@ void freekick_state::init_gigasb()
 
 void freekick_state::init_pbillrds()
 {
-	uint8_t *decrypted_opcodes = auto_alloc_array(machine(), uint8_t, 0x10000);
-	downcast<mc8123_device &>(*m_maincpu).decode(memregion("maincpu")->base(), decrypted_opcodes, 0x10000);
-	membank("bank0d")->set_base(decrypted_opcodes);
-	m_bank1d->configure_entries(0, 2, decrypted_opcodes + 0x8000, 0x4000);
+	m_decrypted_opcodes = std::make_unique<uint8_t[]>(0x10000);
+	downcast<mc8123_device &>(*m_maincpu).decode(memregion("maincpu")->base(), m_decrypted_opcodes.get(), 0x10000);
+	membank("bank0d")->set_base(m_decrypted_opcodes.get());
+	m_bank1d->configure_entries(0, 2, &m_decrypted_opcodes[0x8000], 0x4000);
 }
 
 
@@ -1615,10 +1615,10 @@ void freekick_state::init_pbillrdbl()
 
 void freekick_state::init_gigas()
 {
-	uint8_t *decrypted_opcodes = auto_alloc_array(machine(), uint8_t, 0xc000);
-	downcast<mc8123_device &>(*m_maincpu).decode(memregion("maincpu")->base(), decrypted_opcodes, 0xc000);
-	membank("bank0d")->set_base(decrypted_opcodes);
-	m_bank1d->set_base(decrypted_opcodes + 0x8000);
+	m_decrypted_opcodes = std::make_unique<uint8_t[]>(0xc000);
+	downcast<mc8123_device &>(*m_maincpu).decode(memregion("maincpu")->base(), m_decrypted_opcodes.get(), 0xc000);
+	membank("bank0d")->set_base(m_decrypted_opcodes.get());
+	m_bank1d->set_base(&m_decrypted_opcodes[0x8000]);
 }
 
 

--- a/src/mame/drivers/mitchell.cpp
+++ b/src/mame/drivers/mitchell.cpp
@@ -2616,11 +2616,11 @@ void mitchell_state::configure_banks(void (*decode)(uint8_t *src, uint8_t *dst, 
 {
 	uint8_t *src = memregion("maincpu")->base();
 	int size = memregion("maincpu")->bytes();
-	uint8_t *dst = auto_alloc_array(machine(), uint8_t, size);
-	decode(src, dst, size);
+	m_decoded = std::make_unique<uint8_t[]>(size);
+	decode(src, m_decoded.get(), size);
 	m_bank1->configure_entries(0, 16, src + 0x10000, 0x4000);
-	m_bank0d->set_base(dst);
-	m_bank1d->configure_entries(0, 16, dst + 0x10000, 0x4000);
+	m_bank0d->set_base(m_decoded.get());
+	m_bank1d->configure_entries(0, 16, &m_decoded[0x10000], 0x4000);
 }
 
 

--- a/src/mame/drivers/ninjakd2.cpp
+++ b/src/mame/drivers/ninjakd2.cpp
@@ -183,15 +183,13 @@ SAMPLES_START_CB_MEMBER(ninjakd2_state::ninjakd2_init_samples)
 
 	const uint8_t* const rom = m_pcm_region->base();
 	const int length = m_pcm_region->bytes();
-	int16_t* sampledata = auto_alloc_array(machine(), int16_t, length);
+	m_sampledata = std::make_unique<int16_t[]>(length);
 
 	// convert unsigned 8-bit PCM to signed 16-bit
 	for (int i = 0; i < length; ++i)
 	{
-		sampledata[i] = rom[i] << 7;
+		m_sampledata[i] = rom[i] << 7;
 	}
-
-	m_sampledata = sampledata;
 }
 
 void ninjakd2_state::ninjakd2_pcm_play_w(uint8_t data)

--- a/src/mame/drivers/pc6001.cpp
+++ b/src/mame/drivers/pc6001.cpp
@@ -186,7 +186,7 @@ void pc6001_state::system_latch_w(uint8_t data)
 {
 	static const uint16_t startaddr[] = {0xC000, 0xE000, 0x8000, 0xA000 };
 
-	m_video_ram =  &m_ram[startaddr[(data >> 1) & 0x03] - 0x8000];
+	m_video_base =  &m_ram[startaddr[(data >> 1) & 0x03] - 0x8000];
 
 	cassette_latch_control((data & 8) == 8);
 	m_sys_latch = data;
@@ -622,7 +622,7 @@ void pc6001mk2_state::mk2_vram_bank_w(uint8_t data)
 
 //  popmessage("%02x",data);
 
-//  m_video_ram = work_ram + startaddr[(data >> 1) & 0x03];
+//  m_video_base = work_ram + startaddr[(data >> 1) & 0x03];
 }
 
 void pc6001mk2_state::mk2_col_bank_w(uint8_t data)
@@ -1341,7 +1341,7 @@ void pc6001_state::machine_start()
 
 inline void pc6001_state::set_videoram_bank(uint32_t offs)
 {
-	m_video_ram = m_region_maincpu->base() + offs;
+	m_video_base = m_region_maincpu->base() + offs;
 }
 
 void pc6001_state::machine_reset()

--- a/src/mame/drivers/pc88va.cpp
+++ b/src/mame/drivers/pc88va.cpp
@@ -32,9 +32,9 @@
 
 void pc88va_state::video_start()
 {
-	m_kanjiram = auto_alloc_array(machine(), uint8_t, 0x4000);
-	m_gfxdecode->gfx(2)->set_source(m_kanjiram);
-	m_gfxdecode->gfx(3)->set_source(m_kanjiram);
+	m_kanjiram = std::make_unique<uint8_t[]>(0x4000);
+	m_gfxdecode->gfx(2)->set_source(m_kanjiram.get());
+	m_gfxdecode->gfx(3)->set_source(m_kanjiram.get());
 }
 
 void pc88va_state::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect)

--- a/src/mame/drivers/qix.cpp
+++ b/src/mame/drivers/qix.cpp
@@ -1416,30 +1416,30 @@ void qix_state::init_kram3()
 
 	//patch = memregion("user1")->base();
 	uint8_t *rom = memregion("maincpu")->base();
-	uint8_t *decrypted = auto_alloc_array(machine(), uint8_t, 0x6000);
+	m_decrypted = std::make_unique<uint8_t[]>(0x6000);
 
-	memcpy(decrypted,&rom[0xa000],0x6000);
+	memcpy(m_decrypted.get(),&rom[0xa000],0x6000);
 	for (int i = 0xa000; i < 0x10000; ++i)
 	{
-		decrypted[i-0xa000] = kram3_decrypt(i, rom[i]);
+		m_decrypted[i-0xa000] = kram3_decrypt(i, rom[i]);
 	}
 
 	m_bank0->configure_entry(0, memregion("maincpu")->base() + 0xa000);
-	m_bank0->configure_entry(1, decrypted);
+	m_bank0->configure_entry(1, m_decrypted.get());
 	m_bank0->set_entry(0);
 
 	//patch = memregion("user2")->base();
 	rom = memregion("videocpu")->base();
-	decrypted = auto_alloc_array(machine(), uint8_t, 0x6000);
+	m_decrypted2 = std::make_unique<uint8_t[]>(0x6000);
 
-	memcpy(decrypted,&rom[0xa000],0x6000);
+	memcpy(m_decrypted2.get(),&rom[0xa000],0x6000);
 	for (int i = 0xa000; i < 0x10000; ++i)
 	{
-		decrypted[i-0xa000] = kram3_decrypt(i, rom[i]);
+		m_decrypted2[i-0xa000] = kram3_decrypt(i, rom[i]);
 	}
 
 	m_bank1->configure_entry(0, memregion("videocpu")->base() + 0xa000);
-	m_bank1->configure_entry(1, decrypted);
+	m_bank1->configure_entry(1, m_decrypted2.get());
 	m_bank1->set_entry(0);
 }
 

--- a/src/mame/drivers/segae.cpp
+++ b/src/mame/drivers/segae.cpp
@@ -374,6 +374,7 @@ private:
 	optional_memory_bank m_bank1d;
 	optional_ioport_array<2> m_analog_ports;
 	output_finder<> m_lamp;
+	std::unique_ptr<uint8_t[]> m_banked_decrypted_opcodes;
 
 	// Analog input related
 	uint8_t m_port_select;
@@ -971,11 +972,11 @@ void systeme_state::systemeb(machine_config &config)
 
 void systeme_state::init_opaopa()
 {
-	uint8_t *banked_decrypted_opcodes = auto_alloc_array(machine(), uint8_t, m_maincpu_region->bytes());
-	downcast<mc8123_device &>(*m_maincpu).decode(m_maincpu_region->base(), banked_decrypted_opcodes, m_maincpu_region->bytes());
+	m_banked_decrypted_opcodes = std::make_unique<uint8_t[]>(m_maincpu_region->bytes());
+	downcast<mc8123_device &>(*m_maincpu).decode(m_maincpu_region->base(), m_banked_decrypted_opcodes.get(), m_maincpu_region->bytes());
 
-	m_bank0d->set_base(banked_decrypted_opcodes);
-	m_bank1d->configure_entries(0, 16, banked_decrypted_opcodes + 0x10000, 0x4000);
+	m_bank0d->set_base(m_banked_decrypted_opcodes.get());
+	m_bank1d->configure_entries(0, 16, &m_banked_decrypted_opcodes[0x10000], 0x4000);
 }
 
 

--- a/src/mame/drivers/slapshot.cpp
+++ b/src/mame/drivers/slapshot.cpp
@@ -687,10 +687,10 @@ void slapshot_state::driver_init()
 	gfx_element *gx1 = m_gfxdecode->gfx(1);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gx0->elements() * gx0->width() * gx0->height());
+	m_decoded_gfx = std::make_unique<u8[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = m_decoded_gfx.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const u8 *c0base = gx0->get_data(c);
@@ -712,7 +712,7 @@ void slapshot_state::driver_init()
 		}
 	}
 
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_decoded_gfx.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_colors(4096 / 64);
 	gx0->set_granularity(64);
 	m_gfxdecode->set_gfx(1, nullptr);

--- a/src/mame/drivers/taito_f2.cpp
+++ b/src/mame/drivers/taito_f2.cpp
@@ -5387,10 +5387,10 @@ void taitof2_state::init_finalb()
 	gfx_element *gx1 = m_gfxdecode->gfx(1);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gx0->elements() * gx0->width() * gx0->height());
+	m_decoded_gfx = std::make_unique<u8[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = m_decoded_gfx.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const u8 *c0base = gx0->get_data(c);
@@ -5412,7 +5412,7 @@ void taitof2_state::init_finalb()
 		}
 	}
 
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_decoded_gfx.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_colors(4096 / 64);
 	gx0->set_granularity(64);
 	m_gfxdecode->set_gfx(1, nullptr);

--- a/src/mame/drivers/taito_f3.cpp
+++ b/src/mame/drivers/taito_f3.cpp
@@ -4314,7 +4314,7 @@ void taito_f3_state::tile_decode()
 
 	*/
 
-	u8 *srcdata, *dest;
+	u8 *dest;
 	// all but bubsymphb (bootleg board with different sprite gfx layout), 2mindril (no sprite gfx roms)
 	if (m_gfxdecode->gfx(5) != nullptr)
 	{
@@ -4322,10 +4322,10 @@ void taito_f3_state::tile_decode()
 		gfx_element *spr_gfx_hi = m_gfxdecode->gfx(5);
 
 		// allocate memory for the assembled data
-		srcdata = auto_alloc_array(machine(), u8, spr_gfx->elements() * spr_gfx->width() * spr_gfx->height());
+		m_decoded_gfx5 = std::make_unique<u8[]>(spr_gfx->elements() * spr_gfx->width() * spr_gfx->height());
 
 		// loop over elements
-		dest = srcdata;
+		dest = m_decoded_gfx5.get();
 		for (int c = 0; c < spr_gfx->elements(); c++)
 		{
 			const u8 *c1base = spr_gfx->get_data(c);
@@ -4346,7 +4346,7 @@ void taito_f3_state::tile_decode()
 			}
 		}
 
-		spr_gfx->set_raw_layout(srcdata, spr_gfx->width(), spr_gfx->height(), spr_gfx->elements(), 8 * spr_gfx->width(), 8 * spr_gfx->width() * spr_gfx->height());
+		spr_gfx->set_raw_layout(m_decoded_gfx5.get(), spr_gfx->width(), spr_gfx->height(), spr_gfx->elements(), 8 * spr_gfx->width(), 8 * spr_gfx->width() * spr_gfx->height());
 		m_gfxdecode->set_gfx(5, nullptr);
 	}
 
@@ -4356,10 +4356,10 @@ void taito_f3_state::tile_decode()
 		gfx_element *pf_gfx_hi = m_gfxdecode->gfx(4);
 
 		// allocate memory for the assembled data
-		srcdata = auto_alloc_array(machine(), u8, pf_gfx->elements() * pf_gfx->width() * pf_gfx->height());
+		m_decoded_gfx4 = std::make_unique<u8[]>(pf_gfx->elements() * pf_gfx->width() * pf_gfx->height());
 
 		// loop over elements
-		dest = srcdata;
+		dest = m_decoded_gfx4.get();
 		for (int c = 0; c < pf_gfx->elements(); c++)
 		{
 			const u8 *c0base = pf_gfx->get_data(c);
@@ -4379,7 +4379,7 @@ void taito_f3_state::tile_decode()
 			}
 		}
 
-		pf_gfx->set_raw_layout(srcdata, pf_gfx->width(), pf_gfx->height(), pf_gfx->elements(), 8 * pf_gfx->width(), 8 * pf_gfx->width() * pf_gfx->height());
+		pf_gfx->set_raw_layout(m_decoded_gfx4.get(), pf_gfx->width(), pf_gfx->height(), pf_gfx->elements(), 8 * pf_gfx->width(), 8 * pf_gfx->width() * pf_gfx->height());
 		m_gfxdecode->set_gfx(4, nullptr);
 	}
 }

--- a/src/mame/etc/fddebug.cpp
+++ b/src/mame/etc/fddebug.cpp
@@ -222,7 +222,7 @@ static uint8_t *              ignorepc;
 static uint8_t                ignore_all;
 
 /* array of information about each opcode */
-static optable_entry *      optable;
+static std::unique_ptr<optable_entry[]> optable;
 
 /* buffer for undoing operations */
 static uint8_t *              undobuff;
@@ -2087,7 +2087,7 @@ static void build_optable(running_machine &machine)
 	int opnum, inum;
 
 	/* allocate and initialize the opcode table */
-	optable = auto_alloc_array(machine, optable_entry, 65536);
+	optable = std::make_unique<optable_entry[]>(65536);
 	for (opnum = 0; opnum < 65536; opnum++)
 	{
 		optable[opnum].flags = OF_INVALID;

--- a/src/mame/includes/aquarium.h
+++ b/src/mame/includes/aquarium.h
@@ -53,6 +53,7 @@ private:
 	tilemap_t  *m_txt_tilemap;
 	tilemap_t  *m_mid_tilemap;
 	tilemap_t  *m_bak_tilemap;
+	std::unique_ptr<u8[]> m_decoded_gfx[2];
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;
@@ -70,7 +71,7 @@ private:
 	u8 oki_r();
 	void oki_w(u8 data);
 
-	void expand_gfx(int low, int hi);
+	std::unique_ptr<u8[]> expand_gfx(int low, int hi);
 	void txt_videoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void mid_videoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void bak_videoram_w(offs_t offset, u16 data, u16 mem_mask = ~0);

--- a/src/mame/includes/cps3.h
+++ b/src/mame/includes/cps3.h
@@ -118,6 +118,7 @@ private:
 	bitmap_rgb32 m_renderbuffer_bitmap;
 	rectangle m_renderbuffer_clip;
 	u8* m_user4;
+	std::unique_ptr<u8[]> m_user4_allocated;
 	u32 m_key1;
 	u32 m_key2;
 	int m_altEncryption;
@@ -138,6 +139,7 @@ private:
 	u16 m_lastb;
 	u16 m_lastb2;
 	u8* m_user5;
+	std::unique_ptr<u8[]> m_user5_allocated;
 
 	u8 ssram_r(offs_t offset);
 	void ssram_w(offs_t offset, u8 data);

--- a/src/mame/includes/freekick.h
+++ b/src/mame/includes/freekick.h
@@ -50,6 +50,7 @@ private:
 	int        m_spinner;
 	int        m_nmi_en;
 	int        m_ff_data;
+	std::unique_ptr<uint8_t[]> m_decrypted_opcodes;
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_x_w);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_y_w);
 	DECLARE_WRITE_LINE_MEMBER(flipscreen_w);

--- a/src/mame/includes/hp48.h
+++ b/src/mame/includes/hp48.h
@@ -174,6 +174,8 @@ private:
 	emu_timer *m_1st_timer;
 	emu_timer *m_2nd_timer;
 	emu_timer *m_kbd_timer;
+	std::unique_ptr<uint8_t[]> m_allocated_ram;
+	std::unique_ptr<uint8_t[]> m_allocated_rom;
 };
 
 

--- a/src/mame/includes/jedi.h
+++ b/src/mame/includes/jedi.h
@@ -46,7 +46,7 @@ public:
 		m_sacklatch(*this, "sacklatch"),
 		m_tms(*this, "tms"),
 		m_novram(*this, "novram12%c", 'b'),
-#ifdef DEBUG_GFXDECODE
+#if DEBUG_GFXDECODE
 		m_gfxdecode(*this, "gfxdecode"),
 #endif
 		m_palette(*this, "palette"),
@@ -115,8 +115,9 @@ private:
 	required_device<generic_latch_8_device> m_sacklatch;
 	required_device<tms5220_device> m_tms;
 	required_device_array<x2212_device, 2> m_novram;
-#ifdef DEBUG_GFXDECODE
+#if DEBUG_GFXDECODE
 	required_device<gfxdecode_device> m_gfxdecode;
+	std::unique_ptr<u8[]> m_gfxdata;
 #endif
 	required_device<palette_device> m_palette;
 	required_device<screen_device> m_screen;

--- a/src/mame/includes/konamigx.h
+++ b/src/mame/includes/konamigx.h
@@ -119,6 +119,8 @@ public:
 	K055673_CB_MEMBER(salmndr2_sprite_callback);
 	K055673_CB_MEMBER(le2_sprite_callback);
 
+	struct GX_OBJ { int order, offs, code, color; };
+
 	void common_init();
 	uint32_t k_6bpp_rom_long_r(offs_t offset, uint32_t mem_mask = ~0);
 	void konamigx_mixer     (screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect,tilemap_t *sub1, int sub1flags,tilemap_t *sub2, int sub2flags,int mixerflags, bitmap_ind16 *extra_bitmap, int rushingheroes_hack);
@@ -126,7 +128,7 @@ public:
 						tilemap_t *sub1, int sub1flags,
 						tilemap_t *sub2, int sub2flags,
 						int mixerflags, bitmap_ind16 *extra_bitmap, int rushingheroes_hack,
-						struct GX_OBJ *objpool,
+						GX_OBJ *objpool,
 						int *objbuf,
 						int nobj
 						);
@@ -240,6 +242,7 @@ protected:
 	uint16_t m_prot_data[0x20];
 
 	uint16_t *m_gx_spriteram;
+	std::unique_ptr<uint16_t[]> m_gx_spriteram_alloc;
 
 	// mirrored K054338 settings
 	int *m_K054338_shdRGB;
@@ -290,6 +293,8 @@ protected:
 	std::unique_ptr<bitmap_ind16> m_gxtype1_roz_dstbitmap;
 	std::unique_ptr<bitmap_ind16> m_gxtype1_roz_dstbitmap2;
 	rectangle m_gxtype1_roz_dstbitmapclip;
+
+	std::unique_ptr<GX_OBJ[]> m_gx_objpool;
 
 	u8 m_type3_psac2_bank;
 	u8 m_type3_spriteram_bank;

--- a/src/mame/includes/mitchell.h
+++ b/src/mame/includes/mitchell.h
@@ -105,6 +105,7 @@ private:
 	int        m_dial_selected;
 	int        m_dir[2];
 	int        m_keymatrix;
+	std::unique_ptr<uint8_t[]> m_decoded;
 
 	uint8_t m_irq_source;
 	uint8_t pang_port5_r();

--- a/src/mame/includes/n64.h
+++ b/src/mame/includes/n64.h
@@ -8,6 +8,7 @@
 #include "cpu/rsp/rsp.h"
 #include "cpu/mips/mips3.h"
 #include "sound/dmadac.h"
+#include "video/n64.h"
 
 /*----------- driver state -----------*/
 
@@ -38,7 +39,7 @@ public:
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank_n64);
 
 	// Getters
-	n64_rdp* rdp() { return m_rdp; }
+	n64_rdp* rdp() { return m_rdp.get(); }
 	uint32_t* rdram() { return m_rdram; }
 	uint32_t* sram() { return m_sram; }
 	uint32_t* rsp_imem() { return m_rsp_imem; }
@@ -56,7 +57,7 @@ protected:
 	required_device<n64_periphs> m_rcp_periphs;
 
 	/* video-related */
-	n64_rdp *m_rdp;
+	std::unique_ptr<n64_rdp> m_rdp;
 };
 
 /*----------- devices -----------*/

--- a/src/mame/includes/namcos22.h
+++ b/src/mame/includes/namcos22.h
@@ -152,6 +152,7 @@ private:
 
 	struct namcos22_scenenode m_scenenode_root;
 	struct namcos22_scenenode *m_scenenode_cur;
+	std::list<namcos22_scenenode> m_scenenode_alloc;
 
 	float m_clipx;
 	float m_clipy;
@@ -451,7 +452,7 @@ protected:
 	u16 m_keycus_rng;
 	int m_gametype;
 	int m_cz_adjust;
-	namcos22_renderer *m_poly;
+	std::unique_ptr<namcos22_renderer> m_poly;
 	u16 m_dspram_bank;
 	u16 m_dspram16_latch;
 	bool m_slave_simulation_active;

--- a/src/mame/includes/ninjakd2.h
+++ b/src/mame/includes/ninjakd2.h
@@ -95,7 +95,7 @@ private:
 
 	required_memory_bank m_mainbank;
 
-	const int16_t* m_sampledata;
+	std::unique_ptr<int16_t[]> m_sampledata;
 	int m_next_sprite_overdraw_enabled;
 	uint8_t m_rom_bank_mask;
 

--- a/src/mame/includes/pc6001.h
+++ b/src/mame/includes/pc6001.h
@@ -117,7 +117,8 @@ protected:
 	void pc6001_screen_draw(bitmap_ind16 &bitmap,const rectangle &cliprect, int has_mc6847);
 
 	emu_timer *m_timer_irq_timer;
-	uint8_t *m_video_ram;
+	uint8_t *m_video_base;
+	std::unique_ptr<uint8_t[]> m_video_ram;
 	uint8_t m_irq_vector;
 	uint8_t m_cas_switch;
 	uint8_t m_sys_latch;

--- a/src/mame/includes/pc88va.h
+++ b/src/mame/includes/pc88va.h
@@ -101,7 +101,7 @@ private:
 	required_device<address_map_bank_device> m_sysbank;
 	required_shared_ptr<uint16_t> m_tvram;
 	required_shared_ptr<uint16_t> m_gvram;
-	uint8_t *m_kanjiram;
+	std::unique_ptr<uint8_t[]> m_kanjiram;
 	uint16_t m_bank_reg;
 	uint16_t m_screen_ctrl_reg;
 	uint8_t m_timer3_io_reg;

--- a/src/mame/includes/qix.h
+++ b/src/mame/includes/qix.h
@@ -101,6 +101,8 @@ protected:
 	optional_memory_bank m_bank0;
 	optional_memory_bank m_bank1;
 	required_device<screen_device> m_screen;
+	std::unique_ptr<uint8_t[]> m_decrypted;
+	std::unique_ptr<uint8_t[]> m_decrypted2;
 
 	pen_t m_pens[0x400];
 	void qix_data_firq_w(uint8_t data);

--- a/src/mame/includes/slapshot.h
+++ b/src/mame/includes/slapshot.h
@@ -93,6 +93,7 @@ private:
 #endif
 
 	emu_timer *m_int6_timer;
+	std::unique_ptr<u8[]> m_decoded_gfx;
 
 	// generic
 	u16 service_input_r(offs_t offset);

--- a/src/mame/includes/taito_f2.h
+++ b/src/mame/includes/taito_f2.h
@@ -159,6 +159,7 @@ protected:
 	int           m_nibble;
 	s32           m_driveout_sound_latch;
 	emu_timer     *m_int6_timer;
+	std::unique_ptr<u8[]> m_decoded_gfx;
 
 	/* devices */
 	required_device<cpu_device> m_maincpu;

--- a/src/mame/includes/taito_f3.h
+++ b/src/mame/includes/taito_f3.h
@@ -167,6 +167,8 @@ protected:
 
 	emu_timer *m_interrupt3_timer;
 	u32 m_coin_word[2];
+	std::unique_ptr<u8[]> m_decoded_gfx4;
+	std::unique_ptr<u8[]> m_decoded_gfx5;
 
 	struct tempsprite
 	{

--- a/src/mame/includes/tatsumi.h
+++ b/src/mame/includes/tatsumi.h
@@ -254,6 +254,7 @@ private:
 	uint16_t m_road_color_bank, m_prev_road_bank;
 	uint16_t m_layer_page_size[4];
 	bool m_layer1_can_be_road;
+	std::unique_ptr<uint8_t[]> m_decoded_gfx;
 
 	void tile_expand();
 	void draw_bg(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect, tilemap_t *src, const uint16_t* scrollx, const uint16_t* scrolly, const uint16_t layer_page_size, bool is_road, int hi_priority);

--- a/src/mame/includes/wecleman.h
+++ b/src/mame/includes/wecleman.h
@@ -77,14 +77,10 @@ protected:
 	tilemap_t *m_bg_tilemap;
 	tilemap_t *m_fg_tilemap;
 	tilemap_t *m_txt_tilemap;
-	int *m_spr_idx_list;
-	int *m_spr_pri_list;
-	int *m_t32x32pm;
 	int m_gameid;
 	int m_spr_offsx;
 	int m_spr_offsy;
 	int m_spr_count;
-	uint16_t *m_rgb_half;
 	int m_cloud_blend;
 	int m_cloud_ds;
 	int m_cloud_visible;
@@ -135,6 +131,7 @@ protected:
 	void wecleman_sound_map(address_map &map);
 	void wecleman_sub_map(address_map &map);
 
+	static constexpr int NUM_SPRITES = 256;
 	struct sprite_t
 	{
 		sprite_t() { }
@@ -155,8 +152,10 @@ protected:
 	template<class BitmapClass> void do_blit_zoom32(BitmapClass &bitmap, const rectangle &cliprect, const sprite_t &sprite);
 	template<class BitmapClass> void sprite_draw(BitmapClass &bitmap, const rectangle &cliprect);
 
-	std::unique_ptr<sprite_t []> m_sprite_list;
-	sprite_t **m_spr_ptr_list;
+	sprite_t *m_spr_ptr_list[NUM_SPRITES];
+	int m_spr_idx_list[NUM_SPRITES];
+	int m_spr_pri_list[NUM_SPRITES];
+	sprite_t m_sprite_list[NUM_SPRITES];
 };
 
 class hotchase_state : public wecleman_state

--- a/src/mame/machine/atarigen.cpp
+++ b/src/mame/machine/atarigen.cpp
@@ -89,10 +89,10 @@ void atarigen_state::blend_gfx(int gfx0, int gfx1, int mask0, int mask1)
 	gfx_element *gx1 = m_gfxdecode->gfx(gfx1);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gx0->elements() * gx0->width() * gx0->height());
+	m_blended_data = std::make_unique<u8[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = m_blended_data.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const u8 *c0base = gx0->get_data(c);
@@ -113,7 +113,7 @@ void atarigen_state::blend_gfx(int gfx0, int gfx1, int mask0, int mask1)
 
 //  int newdepth = gx0->depth() * gx1->depth();
 	int granularity = gx0->granularity();
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_blended_data.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_granularity(granularity);
 
 	// free the second graphics element

--- a/src/mame/machine/atarigen.h
+++ b/src/mame/machine/atarigen.h
@@ -47,6 +47,8 @@ protected:
 
 	optional_device<gfxdecode_device> m_gfxdecode;
 	optional_device<screen_device> m_screen;
+
+	std::unique_ptr<u8[]> m_blended_data;
 };
 
 

--- a/src/mame/video/jedi.cpp
+++ b/src/mame/video/jedi.cpp
@@ -30,15 +30,15 @@
 
 void jedi_state::video_start()
 {
-#ifdef DEBUG_GFXDECODE
+#if DEBUG_GFXDECODE
 	/* the sprite pixel determines pen address bits A4-A7 */
 	gfx_element *gx0 = m_gfxdecode->gfx(2);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gx0->elements() * gx0->width() * gx0->height());
+	m_gfxdata = std::make_unique<u8[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = m_gfxdata.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const u8 *c0base = gx0->get_data(c);
@@ -57,7 +57,7 @@ void jedi_state::video_start()
 		}
 	}
 
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_gfxdata.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_granularity(1);
 #endif
 
@@ -350,7 +350,7 @@ u32 jedi_state::screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const
  *
  *************************************/
 
-#ifdef DEBUG_GFXDECODE
+#if DEBUG_GFXDECODE
 static const gfx_layout text_layout =
 {
 	8, 8,
@@ -393,7 +393,7 @@ GFXDECODE_END
 
 void jedi_state::jedi_video(machine_config &config)
 {
-#ifdef DEBUG_GFXDECODE
+#if DEBUG_GFXDECODE
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_jedi);
 #endif
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);

--- a/src/mame/video/k001005.cpp
+++ b/src/mame/video/k001005.cpp
@@ -1205,7 +1205,7 @@ void k001005_device::device_start()
 
 	m_fifo = std::make_unique<uint32_t[]>(0x800);
 
-	m_renderer = auto_alloc(machine(), k001005_renderer(*this, screen(), m_k001006));
+	m_renderer = std::make_unique<k001005_renderer>(*this, screen(), m_k001006);
 
 	save_pointer(NAME(m_ram[0]), 0x140000);
 	save_pointer(NAME(m_ram[1]), 0x140000);

--- a/src/mame/video/k001005.h
+++ b/src/mame/video/k001005.h
@@ -140,7 +140,7 @@ private:
 	uint32_t m_reg_far_z;
 
 
-	k001005_renderer *m_renderer;
+	std::unique_ptr<k001005_renderer> m_renderer;
 };
 
 DECLARE_DEVICE_TYPE(K001005, k001005_device)

--- a/src/mame/video/k053246_k053247_k055673.cpp
+++ b/src/mame/video/k053246_k053247_k055673.cpp
@@ -978,7 +978,8 @@ void k055673_device::device_start()
 			size4 = (m_gfxrom.length()/(1024*1024))/5;
 			size4 *= 4*1024*1024;
 			/* set the # of tiles based on the 4bpp section */
-			alt_k055673_rom = auto_alloc_array(machine(), u16, size4 * 5 / 2);
+			m_combined_gfx = std::make_unique<u16[]>(size4 * 5 / 2);
+			alt_k055673_rom = m_combined_gfx.get();
 			d = (u8 *)alt_k055673_rom;
 			// now combine the graphics together to form 5bpp
 			s1 = (u8 *)&m_gfxrom[0]; // 4bpp area

--- a/src/mame/video/k053246_k053247_k055673.h
+++ b/src/mame/video/k053246_k053247_k055673.h
@@ -462,7 +462,7 @@ protected:
 	virtual void device_start() override;
 //  virtual void device_reset();
 private:
-
+	std::unique_ptr<u16[]> m_combined_gfx;
 };
 
 DECLARE_DEVICE_TYPE(K055673, k055673_device)

--- a/src/mame/video/n64.cpp
+++ b/src/mame/video/n64.cpp
@@ -25,7 +25,7 @@ TODO:
 *******************************************************************************/
 
 #include "emu.h"
-#include "video/n64.h"
+#include "includes/n64.h"
 #include "video/rdpblend.h"
 #include "video/rdptpipe.h"
 
@@ -91,14 +91,14 @@ int32_t n64_rdp::get_alpha_cvg(int32_t comb_alpha, rdp_span_aux* userdata, const
 
 void n64_state::video_start()
 {
-	m_rdp = auto_alloc(machine(), n64_rdp(*this, m_rdram, m_rsp_dmem));
+	m_rdp = std::make_unique<n64_rdp>(*this, m_rdram, m_rsp_dmem);
 
 	m_rdp->set_machine(machine());
 	m_rdp->init_internal_state();
 	m_rdp->set_n64_periphs(m_rcp_periphs);
 
 	m_rdp->m_blender.set_machine(machine());
-	m_rdp->m_blender.set_processor(m_rdp);
+	m_rdp->m_blender.set_processor(m_rdp.get());
 
 	m_rdp->m_tex_pipe.set_machine(machine());
 

--- a/src/mame/video/n64.h
+++ b/src/mame/video/n64.h
@@ -3,7 +3,6 @@
 #ifndef _VIDEO_N64_H_
 #define _VIDEO_N64_H_
 
-#include "includes/n64.h"
 #include "video/poly.h"
 #include "pin64.h"
 
@@ -129,6 +128,8 @@ class n64_rdp;
 #include "video/rdptpipe.h"
 
 typedef void (*rdp_command_t)(uint64_t w1);
+
+class n64_state;
 
 class n64_rdp : public poly_manager<uint32_t, rdp_poly_state, 8, 32000>
 {

--- a/src/mame/video/namcos22.cpp
+++ b/src/mame/video/namcos22.cpp
@@ -530,7 +530,7 @@ struct namcos22_scenenode *namcos22_renderer::alloc_scenenode(running_machine &m
 	}
 	else
 	{
-		node = auto_alloc(machine, struct namcos22_scenenode);
+		node = &m_scenenode_alloc.emplace_back();
 	}
 	memset(node, 0, sizeof(*node));
 	return node;
@@ -2580,5 +2580,5 @@ void namcos22_state::video_start()
 
 	m_gfxdecode->gfx(0)->set_source((u8 *)m_cgram.target());
 
-	m_poly = auto_alloc(machine(), namcos22_renderer(*this));
+	m_poly = std::make_unique<namcos22_renderer>(*this);
 }

--- a/src/mame/video/tatsumi.cpp
+++ b/src/mame/video/tatsumi.cpp
@@ -1105,13 +1105,13 @@ void cyclwarr_state::tile_expand()
 	*/
 	gfx_element *gx0 = m_gfxdecode->gfx(1);
 	m_mask.resize(gx0->elements() << 3,0);
-	uint8_t *srcdata, *dest;
+	uint8_t *dest;
 
 	// allocate memory for the assembled data
-	srcdata = auto_alloc_array(machine(), uint8_t, gx0->elements() * gx0->width() * gx0->height());
+	m_decoded_gfx = std::make_unique<uint8_t[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	dest = srcdata;
+	dest = m_decoded_gfx.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const uint8_t *c0base = gx0->get_data(c);
@@ -1133,7 +1133,7 @@ void cyclwarr_state::tile_expand()
 		}
 	}
 
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_decoded_gfx.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_granularity(256);
 }
 

--- a/src/mame/video/tc0100scn.cpp
+++ b/src/mame/video/tc0100scn.cpp
@@ -350,10 +350,10 @@ void tc0620scc_device::device_start()
 	gfx_element *gx1 = gfx(1);
 
 	// allocate memory for the assembled data
-	u8 *srcdata = auto_alloc_array(machine(), u8, gx0->elements() * gx0->width() * gx0->height());
+	m_decoded_gfx = std::make_unique<u8[]>(gx0->elements() * gx0->width() * gx0->height());
 
 	// loop over elements
-	u8 *dest = srcdata;
+	u8 *dest = m_decoded_gfx.get();
 	for (int c = 0; c < gx0->elements(); c++)
 	{
 		const u8 *c0base = gx0->get_data(c);
@@ -373,7 +373,7 @@ void tc0620scc_device::device_start()
 		}
 	}
 
-	gx0->set_raw_layout(srcdata, gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
+	gx0->set_raw_layout(m_decoded_gfx.get(), gx0->width(), gx0->height(), gx0->elements(), 8 * gx0->width(), 8 * gx0->width() * gx0->height());
 	gx0->set_granularity(64);
 	tc0100scn_base_device::device_start();
 }

--- a/src/mame/video/tc0100scn.h
+++ b/src/mame/video/tc0100scn.h
@@ -137,6 +137,7 @@ protected:
 private:
 	// decoding info
 	DECLARE_GFXDECODE_MEMBER(gfxinfo_6bpp);
+	std::unique_ptr<u8[]> m_decoded_gfx;
 };
 
 DECLARE_DEVICE_TYPE(TC0100SCN, tc0100scn_device)

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -845,7 +845,7 @@ public:
 	}
 
 private:
-	static keyboard_trans_table* sdlinput_read_keymap(running_machine &machine)
+	keyboard_trans_table* sdlinput_read_keymap(running_machine &machine)
 	{
 		char *keymap_filename;
 		FILE *keymap_file;

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -909,7 +909,7 @@ private:
 					{
 						key_trans_entry &entry = (*m_custom_table)[index];
 						entry.sdl_scancode = sk;
-						entry.ui_name = m_ui_names.emplace_back(kns).c_str();
+						entry.ui_name = const_cast<char *>(m_ui_names.emplace_back(kns).c_str());
 						osd_printf_verbose("Keymap: Mapped <%s> to <%s> with ui-text <%s>\n", sks, mks, kns);
 					}
 					else
@@ -921,7 +921,7 @@ private:
 		fclose(keymap_file);
 		osd_printf_verbose("Keymap: Processed %d lines\n", line);
 
-		return m_custom_table;
+		return m_custom_table.get();
 	}
 
 	std::unique_ptr<keyboard_trans_table> m_custom_table;

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -875,7 +875,7 @@ private:
 			key_trans_entries[i] = default_table[i];
 
 		// Allocate the trans table to be associated with the machine so we don't have to free it
-		keyboard_trans_table *custom_table = auto_alloc(machine, keyboard_trans_table(std::move(key_trans_entries), default_table.size()));
+		m_custom_table = std::make_unique<keyboard_trans_table>(std::move(key_trans_entries), default_table.size());
 
 		while (!feof(keymap_file))
 		{
@@ -907,10 +907,9 @@ private:
 
 					if (sk >= 0 && index >= 0)
 					{
-						key_trans_entry &entry = (*custom_table)[index];
+						key_trans_entry &entry = (*m_custom_table)[index];
 						entry.sdl_scancode = sk;
-						entry.ui_name = auto_alloc_array(machine, char, strlen(kns) + 1);
-						strcpy(entry.ui_name, kns);
+						entry.ui_name = m_ui_names.emplace_back(kns).c_str();
 						osd_printf_verbose("Keymap: Mapped <%s> to <%s> with ui-text <%s>\n", sks, mks, kns);
 					}
 					else
@@ -922,8 +921,11 @@ private:
 		fclose(keymap_file);
 		osd_printf_verbose("Keymap: Processed %d lines\n", line);
 
-		return custom_table;
+		return m_custom_table;
 	}
+
+	std::unique_ptr<keyboard_trans_table> m_custom_table;
+	std::list<std::string> m_ui_names;
 };
 
 //============================================================


### PR DESCRIPTION
This PR removes auto_alloc and related definitions, as well as removing the resource_pool from running_machine. In general the fixes should generally be pretty straightforward. Some notes:

* In a number of cases, memory was allocated and assigned to a pointer, which could later be overridden, so for those cases I generally allocated a separate buffer and assigned the pointer to it at start.
* For a couple of drivers I was familiar with I tried to do a little more extensive cleanup.
* The polylgcy stuff isn't pretty, but will be jettisoned when the new voodoo code is ready.
