### PR TITLE
Eliminate reacharound calls to fetch the maincpu in the SNES CX4

### DIFF
--- a/src/mame/drivers/snes.cpp
+++ b/src/mame/drivers/snes.cpp
@@ -200,7 +200,7 @@ void snes_console_state::snes20_hi_w(address_space &space, offs_t offset, uint8_
 	{ m_cartslot->chip_write(offset, data); return; }
 	else if (m_cartslot->get_type() == SNES_CX4
 				&& (offset < 0x400000 && (offset & 0xffff) >= 0x6000 && (offset & 0xffff) < 0x8000))    // hack until we emulate the real CPU
-	{ CX4_write(machine(), (offset & 0xffff) - 0x6000, data); return; }
+	{ CX4_write(space, (offset & 0xffff) - 0x6000, data); return; }
 	else if (m_type == SNES_SUFAMITURBO
 				&& address >= 0x8000 && ((offset >= 0x600000 && offset < 0x640000) || (offset >= 0x700000 && offset < 0x740000)))
 	{ m_cartslot->write_h(offset, data); return; }

--- a/src/mame/machine/cx4fn.hxx
+++ b/src/mame/machine/cx4fn.hxx
@@ -94,7 +94,7 @@ static void CX4_C4TransfWireFrame2(void)
 	cx4.C4WFYVal = (int16_t)(cx4.c4y * cx4.C4WFScale / 0x100);
 }
 
-static void CX4_C4DrawWireFrame(running_machine &machine)
+static void CX4_C4DrawWireFrame(address_space &space)
 {
 	uint32_t line = CX4_readl(0x1f80);
 	uint32_t point1, point2;
@@ -103,7 +103,6 @@ static void CX4_C4DrawWireFrame(running_machine &machine)
 	uint8_t Color;
 	int32_t i;
 
-	address_space &space = machine.device<cpu_device>("maincpu")->space(AS_PROGRAM);
 	for(i = cx4.ram[0x0295]; i > 0; i--, line += 5)
 	{
 		if(space.read_byte(line) == 0xff &&

--- a/src/mame/machine/cx4oam.hxx
+++ b/src/mame/machine/cx4oam.hxx
@@ -11,7 +11,7 @@
 ***************************************************************************/
 
 //Build OAM
-static void CX4_op00_00(running_machine &machine)
+static void CX4_op00_00(address_space &space)
 {
 	int32_t i;
 
@@ -46,7 +46,6 @@ static void CX4_op00_00(running_machine &machine)
 	offset = (cx4.ram[0x626] & 3) * 2;
 	srcptr = 0x220;
 
-	address_space &space = machine.device<cpu_device>("maincpu")->space(AS_PROGRAM);
 	for(i = cx4.ram[0x620]; i > 0 && sprcount > 0; i--, srcptr += 16)
 	{
 		uint32_t spraddr = CX4_readl(srcptr + 7);
@@ -135,7 +134,7 @@ static void CX4_op00_03(void)
 }
 
 //Transform Lines
-static void CX4_op00_05(running_machine &machine)
+static void CX4_op00_05(address_space &space)
 {
 	int32_t i;
 	uint32_t ptr = 0, ptr2 = 0;
@@ -154,16 +153,16 @@ static void CX4_op00_05(running_machine &machine)
 		CX4_C4TransfWireFrame();
 
 		//Displace
-		CX4_writew(machine, ptr + 1, cx4.C4WFXVal + 0x80);
-		CX4_writew(machine, ptr + 5, cx4.C4WFYVal + 0x50);
+		CX4_writew(space, ptr + 1, cx4.C4WFXVal + 0x80);
+		CX4_writew(space, ptr + 5, cx4.C4WFYVal + 0x50);
 	}
 
-	CX4_writew(machine, 0x600,     23);
-	CX4_writew(machine, 0x602,     0x60);
-	CX4_writew(machine, 0x605,     0x40);
-	CX4_writew(machine, 0x600 + 8, 23);
-	CX4_writew(machine, 0x602 + 8, 0x60);
-	CX4_writew(machine, 0x605 + 8, 0x40);
+	CX4_writew(space, 0x600,     23);
+	CX4_writew(space, 0x602,     0x60);
+	CX4_writew(space, 0x605,     0x40);
+	CX4_writew(space, 0x600 + 8, 23);
+	CX4_writew(space, 0x602 + 8, 0x60);
+	CX4_writew(space, 0x605 + 8, 0x40);
 
 	ptr = 0xb02;
 
@@ -174,9 +173,9 @@ static void CX4_op00_05(running_machine &machine)
 		cx4.C4WFX2Val = CX4_readw((CX4_read(ptr + 1) << 4) + 1);
 		cx4.C4WFY2Val = CX4_readw((CX4_read(ptr + 1) << 4) + 5);
 		CX4_C4CalcWireFrame();
-		CX4_writew(machine, ptr2 + 0x600, cx4.C4WFDist ? cx4.C4WFDist : 1);
-		CX4_writew(machine, ptr2 + 0x602, cx4.C4WFXVal);
-		CX4_writew(machine, ptr2 + 0x605, cx4.C4WFYVal);
+		CX4_writew(space, ptr2 + 0x600, cx4.C4WFDist ? cx4.C4WFDist : 1);
+		CX4_writew(space, ptr2 + 0x602, cx4.C4WFXVal);
+		CX4_writew(space, ptr2 + 0x605, cx4.C4WFYVal);
 	}
 }
 
@@ -187,13 +186,13 @@ static void CX4_op00_07(void)
 }
 
 //Draw Wireframe
-static void CX4_op00_08(running_machine &machine)
+static void CX4_op00_08(address_space &space)
 {
-	CX4_C4DrawWireFrame(machine);
+	CX4_C4DrawWireFrame(space);
 }
 
 //Disintegrate
-static void CX4_op00_0b(running_machine &machine)
+static void CX4_op00_0b(address_space &space)
 {
 	uint8_t  width, height;
 	uint32_t startx, starty;
@@ -216,7 +215,7 @@ static void CX4_op00_0b(running_machine &machine)
 
 	for(i = 0; i < (width * height) >> 1; i++)
 	{
-		CX4_write(machine, i, 0);
+		CX4_write(space, i, 0);
 	}
 
 	for(y = starty, i = 0;i < height; i++, y += scaley)
@@ -243,7 +242,7 @@ static void CX4_op00_0b(running_machine &machine)
 }
 
 //Bitplane Wave
-static void CX4_op00_0c(running_machine &machine)
+static void CX4_op00_0c(address_space &space)
 {
 	int i, j;
 	uint32_t destptr = 0;
@@ -270,7 +269,7 @@ static void CX4_op00_0c(running_machine &machine)
 						temp |= mask1 & 0xff00;
 					}
 				}
-				CX4_writew(machine, destptr + CX4_wave_data[i], temp);
+				CX4_writew(space, destptr + CX4_wave_data[i], temp);
 				height++;
 			}
 			waveptr = (waveptr + 1) & 0x7f;
@@ -296,7 +295,7 @@ static void CX4_op00_0c(running_machine &machine)
 						temp |= mask1 & 0xff00;
 					}
 				}
-				CX4_writew(machine, destptr + CX4_wave_data[i], temp);
+				CX4_writew(space, destptr + CX4_wave_data[i], temp);
 				height++;
 			}
 			waveptr = (waveptr + 1) & 0x7f;

--- a/src/mame/machine/cx4ops.hxx
+++ b/src/mame/machine/cx4ops.hxx
@@ -11,40 +11,40 @@
 ***************************************************************************/
 
 //Sprite Functions
-static void CX4_op00(running_machine& machine)
+static void CX4_op00(address_space &space)
 {
 	switch(cx4.reg[0x4d])
 	{
-		case 0x00: CX4_op00_00(machine); break;
+		case 0x00: CX4_op00_00(space); break;
 		case 0x03: CX4_op00_03(); break;
-		case 0x05: CX4_op00_05(machine); break;
+		case 0x05: CX4_op00_05(space); break;
 		case 0x07: CX4_op00_07(); break;
-		case 0x08: CX4_op00_08(machine); break;
-		case 0x0b: CX4_op00_0b(machine); break;
-		case 0x0c: CX4_op00_0c(machine); break;
+		case 0x08: CX4_op00_08(space); break;
+		case 0x0b: CX4_op00_0b(space); break;
+		case 0x0c: CX4_op00_0c(space); break;
 	}
 }
 
 //Draw Wireframe
-static void CX4_op01(running_machine& machine)
+static void CX4_op01(address_space &space)
 {
 	memset(cx4.ram + 0x300, 0, 2304);
-	CX4_C4DrawWireFrame(machine);
+	CX4_C4DrawWireFrame(space);
 }
 
 //Propulsion
-static void CX4_op05(running_machine &machine)
+static void CX4_op05(address_space &space)
 {
 	int32_t temp = 0x10000;
 	if(CX4_readw(0x1f83))
 	{
 		temp = CX4_sar((temp / CX4_readw(0x1f83)) * CX4_readw(0x1f81), 8);
 	}
-	CX4_writew(machine, 0x1f80, temp);
+	CX4_writew(space, 0x1f80, temp);
 }
 
 //Set Vector length
-static void CX4_op0d(running_machine &machine)
+static void CX4_op0d(address_space &space)
 {
 	cx4.C41FXVal    = CX4_readw(0x1f80);
 	cx4.C41FYVal    = CX4_readw(0x1f83);
@@ -53,8 +53,8 @@ static void CX4_op0d(running_machine &machine)
 	cx4.tanval = (double)cx4.C41FDistVal / cx4.tanval;
 	cx4.C41FYVal = (int16_t)(((double)cx4.C41FYVal * cx4.tanval) * 0.99);
 	cx4.C41FXVal = (int16_t)(((double)cx4.C41FXVal * cx4.tanval) * 0.98);
-	CX4_writew(machine, 0x1f89, cx4.C41FXVal);
-	CX4_writew(machine, 0x1f8c, cx4.C41FYVal);
+	CX4_writew(space, 0x1f89, cx4.C41FXVal);
+	CX4_writew(space, 0x1f8c, cx4.C41FYVal);
 }
 
 //Triangle
@@ -110,18 +110,18 @@ static void CX4_op13(void)
 }
 
 //Pythagorean
-static void CX4_op15(running_machine &machine)
+static void CX4_op15(address_space &space)
 {
 	double temp = 0.0;
 	cx4.C41FXVal = CX4_readw(0x1f80);
 	cx4.C41FYVal = CX4_readw(0x1f83);
 	temp = sqrt((double)cx4.C41FXVal * (double)cx4.C41FXVal + (double)cx4.C41FYVal * (double)cx4.C41FYVal);
 	cx4.C41FDist = (int16_t)temp;
-	CX4_writew(machine, 0x1f80, cx4.C41FDist);
+	CX4_writew(space, 0x1f80, cx4.C41FDist);
 }
 
 //Calculate distance
-static void CX4_op1f(running_machine &machine)
+static void CX4_op1f(address_space &space)
 {
 	cx4.C41FXVal = CX4_readw(0x1f80);
 	cx4.C41FYVal = CX4_readw(0x1f83);
@@ -140,7 +140,7 @@ static void CX4_op1f(running_machine &machine)
 		}
 		cx4.C41FAngleRes &= 0x1ff;
 	}
-	CX4_writew(machine, 0x1f86, cx4.C41FAngleRes);
+	CX4_writew(space, 0x1f86, cx4.C41FAngleRes);
 }
 
 //Trapezoid
@@ -210,7 +210,7 @@ static void CX4_op25(void)
 }
 
 //Transform Coords
-static void CX4_op2d(running_machine &machine)
+static void CX4_op2d(address_space &space)
 {
 	cx4.C4WFXVal  = CX4_readw(0x1f81);
 	cx4.C4WFYVal  = CX4_readw(0x1f84);
@@ -220,8 +220,8 @@ static void CX4_op2d(running_machine &machine)
 	cx4.C4WFDist  = CX4_read (0x1f8b);
 	cx4.C4WFScale = CX4_readw(0x1f90);
 	CX4_C4TransfWireFrame2();
-	CX4_writew(machine, 0x1f80, cx4.C4WFXVal);
-	CX4_writew(machine, 0x1f83, cx4.C4WFYVal);
+	CX4_writew(space, 0x1f80, cx4.C4WFXVal);
+	CX4_writew(space, 0x1f83, cx4.C4WFYVal);
 }
 
 //Sum

--- a/src/mame/machine/snescx4.cpp
+++ b/src/mame/machine/snescx4.cpp
@@ -20,8 +20,8 @@ static CX4 cx4;
 static uint16_t CX4_readw(uint16_t addr);
 static uint32_t CX4_readl(uint16_t addr);
 
-static void CX4_writew(running_machine &machine, uint16_t addr, uint16_t data);
-//static void CX4_writel(running_machine &machine, uint16_t addr, uint32_t data);
+static void CX4_writew(address_space &space, uint16_t addr, uint16_t data);
+//static void CX4_writel(address_space &space, uint16_t addr, uint32_t data);
 
 static void CX4_C4DrawLine(int32_t X1, int32_t Y1, int16_t Z1, int32_t X2, int32_t Y2, int16_t Z2, uint8_t Color);
 
@@ -98,7 +98,7 @@ static void CX4_immediate_reg(uint32_t start)
 	CX4_str(0, cx4.r0);
 }
 
-static void CX4_transfer_data(running_machine &machine)
+static void CX4_transfer_data(address_space &space)
 {
 	uint32_t src;
 	uint16_t dest, count;
@@ -108,17 +108,16 @@ static void CX4_transfer_data(running_machine &machine)
 	count = (cx4.reg[0x43]) | (cx4.reg[0x44] << 8);
 	dest  = (cx4.reg[0x45]) | (cx4.reg[0x46] << 8);
 
-	address_space &space = machine.device<cpu_device>("maincpu")->space(AS_PROGRAM);
 	for(i=0;i<count;i++)
 	{
-		CX4_write(machine, dest++, space.read_byte(src++));
+		CX4_write(space, dest++, space.read_byte(src++));
 	}
 }
 
 #include "machine/cx4oam.hxx"
 #include "machine/cx4ops.hxx"
 
-void CX4_write(running_machine &machine, uint32_t addr, uint8_t data)
+void CX4_write(address_space &space, uint32_t addr, uint8_t data)
 {
 	addr &= 0x1fff;
 
@@ -141,7 +140,7 @@ void CX4_write(running_machine &machine, uint32_t addr, uint8_t data)
 	if(addr == 0x1f47)
 	{
 		//memory transfer
-		CX4_transfer_data(machine);
+		CX4_transfer_data(space);
 		return;
 	}
 
@@ -157,17 +156,17 @@ void CX4_write(running_machine &machine, uint32_t addr, uint8_t data)
 
 		switch(data)
 		{
-			case 0x00: CX4_op00(machine); break;
-			case 0x01: CX4_op01(machine); break;
-			case 0x05: CX4_op05(machine); break;
-			case 0x0d: CX4_op0d(machine); break;
+			case 0x00: CX4_op00(space); break;
+			case 0x01: CX4_op01(space); break;
+			case 0x05: CX4_op05(space); break;
+			case 0x0d: CX4_op0d(space); break;
 			case 0x10: CX4_op10(); break;
 			case 0x13: CX4_op13(); break;
-			case 0x15: CX4_op15(machine); break;
-			case 0x1f: CX4_op1f(machine); break;
+			case 0x15: CX4_op15(space); break;
+			case 0x1f: CX4_op1f(space); break;
 			case 0x22: CX4_op22(); break;
 			case 0x25: CX4_op25(); break;
-			case 0x2d: CX4_op2d(machine); break;
+			case 0x2d: CX4_op2d(space); break;
 			case 0x40: CX4_op40(); break;
 			case 0x54: CX4_op54(); break;
 			case 0x5c: CX4_op5c(); break;
@@ -193,24 +192,24 @@ void CX4_write(running_machine &machine, uint32_t addr, uint8_t data)
 }
 
 #ifdef UNUSED_FUNCTION
-void CX4_writeb(running_machine &machine, uint16_t addr, uint8_t data)
+void CX4_writeb(address_space &space, uint16_t addr, uint8_t data)
 {
-	CX4_write(machine, addr,     data);
+	CX4_write(space, addr,     data);
 }
 #endif
 
-static void CX4_writew(running_machine &machine, uint16_t addr, uint16_t data)
+static void CX4_writew(address_space &space, uint16_t addr, uint16_t data)
 {
-	CX4_write(machine, addr + 0, data >> 0);
-	CX4_write(machine, addr + 1, data >> 8);
+	CX4_write(space, addr + 0, data >> 0);
+	CX4_write(space, addr + 1, data >> 8);
 }
 
 #ifdef UNUSED_FUNCTION
-void CX4_writel(running_machine &machine, uint16_t addr, uint32_t data)
+void CX4_writel(address_space &space, uint16_t addr, uint32_t data)
 {
-	CX4_write(machine, addr + 0, data >>  0);
-	CX4_write(machine, addr + 1, data >>  8);
-	CX4_write(machine, addr + 2, data >> 16);
+	CX4_write(space, addr + 0, data >>  0);
+	CX4_write(space, addr + 1, data >>  8);
+	CX4_write(space, addr + 2, data >> 16);
 }
 #endif
 

--- a/src/mame/machine/snescx4.h
+++ b/src/mame/machine/snescx4.h
@@ -26,4 +26,4 @@ struct CX4
 };
 
 uint8_t CX4_read(uint32_t addr);
-void CX4_write(running_machine &machine, uint32_t addr, uint8_t data);
+void CX4_write(address_space &space, uint32_t addr, uint8_t data);


### PR DESCRIPTION
It was already passing the machine around everywhere, for no reason other than to fetch the maincpu. Instead just pass the address_space, which is really all it needs in the end anyway.