### PR TITLE
Fixed conflicting softlist entries in SGI softlists.

### DIFF
--- a/hash/sgi_mips_hdd.xml
+++ b/hash/sgi_mips_hdd.xml
@@ -18,57 +18,57 @@ license:CC0
 	corresponding sgi_mips sets.
 	-->
 
-	<software name="irix_5_2">
+	<software name="irix_5_2_hdd">
 		<description>IRIX 5.2</description>
 		<year>1994</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="irix_5_2" sha1="e32910287c9f9ca5b4efe6a328a7c71bdbaed235" writeable="yes" />
+				<disk name="irix_5_2_hdd" sha1="e32910287c9f9ca5b4efe6a328a7c71bdbaed235" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
-	<software name="irix_5_3">
+	<software name="irix_5_3_hdd">
 		<description>IRIX 5.3</description>
 		<year>1994</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="irix_5_3" sha1="22de8751b85fd5f5ff002657e0f475cce719ee52" writeable="yes" />
+				<disk name="irix_5_3_hdd" sha1="22de8751b85fd5f5ff002657e0f475cce719ee52" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
-	<software name="irix_6_2">
+	<software name="irix_6_2_hdd">
 		<description>IRIX 6.2</description>
 		<year>1996</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="irix_6_2" sha1="d5ebffe77590551ff18d3107751983b62e059af3" writeable="yes" />
+				<disk name="irix_6_2_hdd" sha1="d5ebffe77590551ff18d3107751983b62e059af3" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
-	<software name="irix_6_5">
+	<software name="irix_6_5_hdd">
 		<description>IRIX 6.5</description>
 		<year>1998</year>
 		<publisher>Silicon Graphics</publisher>
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="irix_6_5" sha1="87ab8431fb9be519d05343f6fc735a1730cff49d" writeable="yes" />
+				<disk name="irix_6_5_hdd" sha1="87ab8431fb9be519d05343f6fc735a1730cff49d" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>
 
-	<software name="irix_6_5_22">
+	<software name="irix_6_5_22_hdd">
 		<description>IRIX 6.5.22</description>
 		<year>2003</year>
 		<publisher>SGI</publisher>
 		<part name="hdd" interface="scsi_hdd">
 			<diskarea name="harddriv">
-				<disk name="irix_6_5_22" sha1="02a015321dc31a08a08ff4751687bc474583190a" writeable="yes" />
+				<disk name="irix_6_5_22_hdd" sha1="02a015321dc31a08a08ff4751687bc474583190a" writeable="yes" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
-sgi_mips_hdd: Added _hdd suffix to entries to prevent conflicts with CD-ROM entries when both are present. [Ryan Holtz]