### PR TITLE
coco3: improve timer value

### DIFF
--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -134,6 +134,8 @@ gime_device::gime_device(const machine_config &mconfig, device_type type, const 
 	, m_cart_device(*this, finder_base::DUMMY_TAG)
 	, m_rom(nullptr)
 	, m_rom_region(*this, finder_base::DUMMY_TAG)
+	, m_short_timer_source(attotime::from_hz(clock) * 3648)
+	, m_long_timer_source(attotime::from_hz(clock) * 16)
 {
 }
 
@@ -479,11 +481,14 @@ void gime_device::reset_timer(void)
 
 		if (timer_type() == GIME_TIMER_63USEC)
 		{
-			m_gime_clock_timer->adjust(attotime::from_usec(63.695) * m_timer_value);
+			// master clock divided by 8, divided by 228, divided by 2
+			m_gime_clock_timer->adjust(m_short_timer_source * m_timer_value);
+
 		}
 		else
 		{
-			m_gime_clock_timer->adjust(attotime::from_nsec(279.365) * m_timer_value);
+			// master clock divided by 8, divided by 2
+			m_gime_clock_timer->adjust(m_long_timer_source * m_timer_value);
 		}
 	}
 	else

--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -134,8 +134,6 @@ gime_device::gime_device(const machine_config &mconfig, device_type type, const 
 	, m_cart_device(*this, finder_base::DUMMY_TAG)
 	, m_rom(nullptr)
 	, m_rom_region(*this, finder_base::DUMMY_TAG)
-	, m_short_timer_source(attotime::from_hz(clock) * 3648)
-	, m_long_timer_source(attotime::from_hz(clock) * 16)
 {
 }
 
@@ -482,13 +480,12 @@ void gime_device::reset_timer(void)
 		if (timer_type() == GIME_TIMER_63USEC)
 		{
 			// master clock divided by 8, divided by 228, divided by 2
-			m_gime_clock_timer->adjust(m_short_timer_source * m_timer_value);
-
+			m_gime_clock_timer->adjust(attotime::from_hz(clock()) * 3648 * m_timer_value);
 		}
 		else
 		{
 			// master clock divided by 8, divided by 2
-			m_gime_clock_timer->adjust(m_long_timer_source * m_timer_value);
+			m_gime_clock_timer->adjust(attotime::from_hz(clock()) * 16 * m_timer_value);
 		}
 	}
 	else

--- a/src/mame/video/gime.h
+++ b/src/mame/video/gime.h
@@ -227,6 +227,8 @@ protected:
 	const char *timer_type_string(void);
 	void reset_timer(void);
 	void timer_elapsed(void);
+	const attotime m_short_timer_source;
+	const attotime m_long_timer_source;
 
 	// video
 	bool update_screen(bitmap_rgb32 &bitmap, const rectangle &cliprect, const pixel_t *palette);

--- a/src/mame/video/gime.h
+++ b/src/mame/video/gime.h
@@ -227,8 +227,6 @@ protected:
 	const char *timer_type_string(void);
 	void reset_timer(void);
 	void timer_elapsed(void);
-	const attotime m_short_timer_source;
-	const attotime m_long_timer_source;
 
 	// video
 	bool update_screen(bitmap_rgb32 &bitmap, const rectangle &cliprect, const pixel_t *palette);


### PR DESCRIPTION
1. Calculate based on clock divisors.
2. Fix PAL timings.
3. Stopping passing a floating point value to a function that expects an integer.