### PR TITLE
Jaleco VJ and Stepping Stage, and Taito JC texture unit improvement

### DIFF
--- a/src/mame/drivers/tetrisp2.cpp
+++ b/src/mame/drivers/tetrisp2.cpp
@@ -131,7 +131,7 @@ void tetrisp2_state::rockn2_adpcmbank_w(u16 data)
 
 u16 tetrisp2_state::rockn_soundvolume_r()
 {
-	return 0xff;
+	return 0xffff;
 }
 
 void tetrisp2_state::rockn_soundvolume_w(u16 data)
@@ -519,7 +519,7 @@ void stepstag_state::stepstag_b00000_w(u16 data)
 void  stepstag_state::stepstag_main2pc_w(u16 data)
 {
 	m_stepstag_main2pc = data;
-	popmessage("cmd to pc: 0x%4x\n", data);	// printf
+//	logerror("cmd to pc: 0x%4x\n", data);	// printf	// popmessage
 	stepstag_state::simulate_pc();
 }
 
@@ -614,21 +614,21 @@ void stepstag_state::stepstag_map(address_map &map)
 	map(0x100000, 0x103fff).ram().share("spriteram");									// Object RAM
 	map(0x108000, 0x10ffff).ram();														// Work RAM
 	map(0x200000, 0x23ffff).rw(FUNC(stepstag_state::tetrisp2_priority_r), FUNC(stepstag_state::tetrisp2_priority_w));
-	map(0x300000, 0x31ffff).ram().w(FUNC(stepstag_state::tetrisp2_palette_w)).share("paletteram");		// Palette
-	map(0x400000, 0x403fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_fg_w)).share("vram_fg");			// Foreground
-	map(0x404000, 0x407fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_bg_w)).share("vram_bg");			// Background
+	map(0x300000, 0x31ffff).ram().w(FUNC(stepstag_state::tetrisp2_palette_w)).share("paletteram");
+	map(0x400000, 0x403fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_fg_w)).share("vram_fg");
+	map(0x404000, 0x407fff).ram().w(FUNC(stepstag_state::tetrisp2_vram_bg_w)).share("vram_bg");
 //  map(0x408000, 0x409fff).ram();														// ???
 	map(0x500000, 0x50ffff).ram();														// Line
 	map(0x600000, 0x60ffff).ram().w(FUNC(stepstag_state::tetrisp2_vram_rot_w)).share("vram_rot");		// Rotation
 	map(0x900000, 0x903fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::tetrisp2_nvram_w)).share("nvram"); // NVRAM
 //  map(0x904000, 0x907fff).rw(FUNC(stepstag_state::rockn_nvram_r), FUNC(stepstag_state::tetrisp2_nvram_w);                 // NVRAM (mirror)
-	map(0xa00000, 0xa00001).nopr().w(FUNC(stepstag_state::stepstag_neon_w));					// Neon
-	map(0xa10000, 0xa10001).portr("RHYTHM").w(FUNC(stepstag_state::stepstag_step_leds_w));		// I/O
-	map(0xa20000, 0xa20001).nopr().w(FUNC(stepstag_state::stepstag_button_leds_w));				// I/O
-	map(0xa30000, 0xa30001).portr("VOLUME").w(FUNC(stepstag_state::rockn_soundvolume_w));		// Sound Volume
-	map(0xa42000, 0xa42001).r(FUNC(stepstag_state::stepstag_pc2main_r));				// PC Comm r
+	map(0xa00000, 0xa00001).nopr().w(FUNC(stepstag_state::stepstag_neon_w));
+	map(0xa10000, 0xa10001).portr("RHYTHM").w(FUNC(stepstag_state::stepstag_step_leds_w));
+	map(0xa20000, 0xa20001).nopr().w(FUNC(stepstag_state::stepstag_button_leds_w));		
+	map(0xa30000, 0xa30001).portr("VOLUME").w(FUNC(stepstag_state::rockn_soundvolume_w));
+	map(0xa42000, 0xa42001).r(FUNC(stepstag_state::stepstag_pc2main_r));
 	map(0xa44000, 0xa44001).nopr();														// watchdog
-	map(0xa48000, 0xa48001).w(FUNC(stepstag_state::stepstag_main2pc_w));				// PC Comm w
+	map(0xa48000, 0xa48001).w(FUNC(stepstag_state::stepstag_main2pc_w));
 //  map(0xa4c000, 0xa4c001).nopw();														// PC?
 	map(0xa50000, 0xa50001).r(m_soundlatch, FUNC(generic_latch_16_device::read)).w(FUNC(stepstag_state::stepstag_soundlatch_word_w));
 
@@ -637,15 +637,15 @@ void stepstag_state::stepstag_map(address_map &map)
 
 	map(0xb00000, 0xb00001).w(FUNC(stepstag_state::stepstag_b00000_w));					// init xilinx uploading??
 	map(0xb20000, 0xb20001).w(FUNC(stepstag_state::stepstag_b20000_w));					// 98343 interface board xilinx uploading?
-	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");								// Foreground Scrolling
-	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");								// Background Scrolling
+	map(0xb40000, 0xb4000b).writeonly().share("scroll_fg");
+	map(0xb40010, 0xb4001b).writeonly().share("scroll_bg");
 	map(0xb4003e, 0xb4003f).ram();														// scr_size
-	map(0xb60000, 0xb6002f).writeonly().share("rotregs");								// Rotation Registers
+	map(0xb60000, 0xb6002f).writeonly().share("rotregs");
 	map(0xba0000, 0xba001f).m(m_sysctrl, FUNC(jaleco_ms32_sysctrl_device::amap));
 	map(0xbe0000, 0xbe0001).nopr();														// INT-level1 dummy read
-	map(0xbe0002, 0xbe0003).portr("BUTTONS");											// Inputs
+	map(0xbe0002, 0xbe0003).portr("BUTTONS");
 	map(0xbe0004, 0xbe0005).r(FUNC(stepstag_state::stepstag_coins_r));					// Inputs & protection
-	map(0xbe0008, 0xbe0009).portr("DSW");												// Inputs
+	map(0xbe0008, 0xbe0009).portr("DSW");
 	map(0xbe000a, 0xbe000b).r("watchdog", FUNC(watchdog_timer_device::reset16_r));		// Watchdog
 }
 
@@ -1144,7 +1144,7 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( stepstag )
 	PORT_START("VOLUME")	// $a30000.w
 	PORT_DIPNAME( 0x00ff, 0x0000, "Sound Volume")	// Potentiometer output sampled by 8-bit A/D, then read by main CPU
-	PORT_DIPSETTING(      0x0000, "max")			// TODO, 256 steps
+	PORT_DIPSETTING(      0x0000, "max")			// TODO, use PORT_ADJUSTER()
 	PORT_DIPSETTING(      0x007f, "mid")
 	PORT_DIPSETTING(      0x00ff, "min")
 
@@ -1839,7 +1839,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(stepstag_state::field_cb)
 	// irq 4 is definitely a 30 Hz-ish here as well,
 	// except we have a multi-screen arrangement setup and no way to pinpoint source
 	m_subcpu->set_input_line(4, HOLD_LINE);
-	stepstag_state::simulate_pc();	// any better place to put it into schedule?
+//	stepstag_state::simulate_pc();	// TODO: put it into schedule
 }
 
 void stepstag_state::setup_non_sysctrl_screen(machine_config &config, screen_device *screen, const XTAL xtal)
@@ -1863,114 +1863,85 @@ void stepstag_state::simulate_pc()
 		$072x sample set for music selection
 		$07ff clear music sample region?
 	*/
-	FILE *inFile;
-	unsigned int size, position;	// position2
-	const unsigned int total_ram = 0x1000000;	// full 16MB for each ymz280b
-	if(strcmp(machine().system().name,"vjdash") == 0)
-		position = 0x400000;
-	//	position2 = 0xa00000;	// bass?
-	else
+	/*
+	YMZ RAM address where musin sample files are loaded:
+	For VJ:
+		position = 0x400000;	// treble/midrange?
+		position2 = 0xa00000;	// bass?
+	For Stepping Stage:
 		position = 0x900000;
-
-	if((m_stepstag_main2pc & 0xff0) == 0x700)
-	{
-		inFile = fopen("bgm_l", "rb");
-		if( inFile )
-		{
-			fseek(inFile, 0, SEEK_END);
-			size = ftell(inFile);
-			rewind(inFile);
-			if(size > total_ram - position)
-				size = total_ram - position;
-			fread(m_ymzram + position, 1, size, inFile);
-			fclose(inFile);
-		}
-//		else
-//			printf("BGM file of Left Channel not found!\n");
-
-		inFile = fopen("bgm_r", "rb");
-		if( inFile )
-		{
-			fseek(inFile, 0, SEEK_END);
-			size = ftell(inFile);
-			rewind(inFile);
-			if(size > total_ram - position)
-				size = total_ram - position;
-			fread(m_ymzram1 + position, 1, size, inFile);
-			fclose(inFile);
-		}
-//		else
-//			printf("BGM file of Right Channel not found!\n");
-	}
-	else if((m_stepstag_main2pc & 0x0ff0)==0x720)	//music selection
-	{
-		position += 0x100000;
-
-		inFile=fopen("bgm_sample", "rb");
-		if( inFile )
-		{
-			fseek(inFile, 0, SEEK_END);
-			size = ftell(inFile);
-			rewind(inFile);
-			if(size > total_ram - position)
-				size = total_ram - position;
-			fread(m_ymzram + position, 1, size, inFile);
-			fclose(inFile);
-			memcpy(m_ymzram1 + position, m_ymzram + position, size);
-		}
-	}
-	else if((m_stepstag_main2pc & 0x0fff)==0x714)	//sound effects
-	{
-		position = 0;
-
-		inFile=fopen("sound_effects", "rb");
-		if( inFile )
-		{
-			fseek(inFile, 0, SEEK_END);
-			size = ftell(inFile);
-			rewind(inFile);
-			if(size > total_ram - position)
-				size = total_ram - position;
-			fread(m_ymzram + position, 1, size, inFile);
-			fclose(inFile);
-			memcpy(m_ymzram1 + position, m_ymzram + position, size);
-		}
-	}
-	else if((m_stepstag_main2pc & 0x0fff)==0x715)	//sound effects 2
-	{
-		position = 0x400000;
-
-		inFile=fopen("vjs02.vjs", "rb");
-		if( inFile )
-		{
-			fseek(inFile, 0, SEEK_END);
-			size = ftell(inFile);
-			rewind(inFile);
-			if(size > total_ram - position)
-				size = total_ram - position;
-			fread(m_ymzram + position, 1, size, inFile);
-			fclose(inFile);
-			memcpy(m_ymzram1 + position, m_ymzram + position, size);
-		}
-	}
-	else if((m_stepstag_main2pc & 0x0f00)==0x7ff)
-	{
-	}
-	else if((m_stepstag_main2pc & 0x0f00)==0x700)	 printf(" cmd 0x%x !! unknown !!!\n", m_stepstag_main2pc);
+	*/
 
 	m_stepstag_main2pc = 0;
 }
 
-/*void stepstag_state::simulate_vj_sub()
-{
-}*/
+/*
+VJ and Stepping Stage Hardware consist of three parts: 
+ - a tetrisp2-like board, connected to 2x ymz280b audio ICs. The audio ICs fetch sample data from RAM, not ROM;
+ - a sub 68000 board. It has 3 video output channels, each channel contains a MPEG-1 hardware decoder plus a sprite front layer;
+ - a windows pc, for storing audio samples and FMV files, loading them to audio RAM and MPEG decoder, and controlling the 3 MPEG decoders.
+ 	the vga of the pc is not used.
+
+Diagram of Video System Configuration:
+There're totally four video outputs: 3 on the sub-cpu-board, and 1 on the main-cpu-board
+For stepping stage, however, only three monitors are installed -- the centre one has a video source selector, to choose 
+	between sub-mid source and main-board source.
+
+/------------------\            /------------------\            /------------------\
+|                  |            |                  |            |                  |
+|   Left Screen    |            |    Mid Screen    |            |   Right Screen   |
+|                  |            |                  |            |                  |
+|                  |            |   for stepstag:  |            |                  |
+\------------------/            \--Source Selector-/            \------------------/
+         |                               |    |                          |
+         |                               |    |-<<--From Main BD.        |
+         |                               |   for Service Mode Text Only  |
+         |                               |                               |
+    YUV2RGB Conv.                   YUV2RGB Conv.                   YUV2RGB Conv.
+         |                               |                               |
+ ------------------              ------------------              ------------------
+ | MPEG-1 Decoder |              | MPEG-1 Decoder |              | MPEG-1 Decoder |
+ |   & Overlay    |              |   & Overlay    |              |   & Overlay    |<------Controlled by PC
+ ------------------              ------------------              ------------------
+         |                               |                               |
+         \----------------------\        |        /----------------------/
+                                |        |        |
+                       ------------------------------------
+                       |  3x Video Channels, YUV Format   |
+                       |    352*240p*59.94Hz(or 480i?)    |
+                       |   29.97Hz IRQ for video update   |
+                       |                                  |
+                       |          Sub-CPU Board           |
+                       |                                  |
+                       ------------------------------------
+
+
+                               /------------------\
+                               |       Main       |
+                               |   Game Screen    |
+                               |    (Dumb in      |
+                               | Stepping Stage)  |
+                               \------------------/
+                                        |
+                                        |---->in stepstag, routing to a source selector of Mid-Screen
+                                        |        only for output some diag. text, 
+                                        |
+                       ------------------------------------
+                       |              Video               |
+                       | Sysctrl Programmable Resolution  |
+                       |                                  |
+                       |          Main-CPU Board          |
+                       |    Tetrisp2/Rockn Like Board     |
+                       |                                  |
+                       ------------------------------------
+*/
 
 void stepstag_state::stepstag(machine_config &config)
 {
 	M68000(config, m_maincpu, XTAL(12'000'000));	// unknown
 	m_maincpu->set_addrmap(AS_PROGRAM, &stepstag_state::stepstag_map);
 
-	constexpr XTAL subxtal = XTAL(13'500'000);	// 2x ntsc mpeg-1 clock
+	constexpr XTAL subxtal = XTAL(13'500'000);	// NTSC MPEG-1
 	constexpr XTAL sub_pixel_clock = subxtal/2;
 
 	M68000(config, m_subcpu, subxtal);
@@ -1983,15 +1954,17 @@ void stepstag_state::stepstag(machine_config &config)
 
 	// video hardware
 
-	// The mid-CRT is supposed to have a video switcher to choose one from two sources:
-	// In normal game operation mode, a 352*240*29.97Hz video from the sub cpu board;
-	// While in POST/test mode, a 320x224*60.6Hz from the main cpu board, similar to Rock'n Tread series
-	// TODO: Where is the switching signal from, sysctrl?
+	// The m_screen has a video input selector (2-to-1 MUX) to choose from two sources with different scanning rate:
+	// In normal game operation mode, a 352*240*59.94Hz mpeg-1 standard video from the sub-cpu-board;
+	// While in POST/test mode, from the main-cpu-board, a board similar to Rock'n Tread series
+	// TODO: Where is the selection signal from, sysctrl?
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_orientation(ROT0);
 	// TODO: connected to the non sysctrl CRTC anyway?
+	// TODO: the real resolution is supposed to be doubled to 352*480 interlaced, since each palette entry contains 2 pixels (UYVY).
+	// 		it needs a new tile-drawing routine
 	m_screen->set_raw(XTAL(48'000'000)/8, 384, 0, 320, 263, 0, 224);
-///	m_screen->set_raw(sub_pixel_clock, 429, 0, 352, 525, 0, 240);	// should be 0-479 interlaced
+//	m_screen->set_raw(sub_pixel_clock, 429, 0, 352, 525, 0, 240);	// should be 0-479 interlaced
 	m_screen->set_screen_update(FUNC(stepstag_state::screen_update_stepstag_mid));
 
 	screen_device &lscreen(SCREEN(config, "lscreen", SCREEN_TYPE_RASTER));
@@ -1999,11 +1972,6 @@ void stepstag_state::stepstag(machine_config &config)
 	setup_non_sysctrl_screen(config, &lscreen, sub_pixel_clock);
 	lscreen.set_screen_update(FUNC(stepstag_state::screen_update_stepstag_left));
 
-/*	screen_device &mscreen(SCREEN(config, "mscreen", SCREEN_TYPE_RASTER));
-	mscreen.set_orientation(ROT0);
-	setup_non_sysctrl_screen(config, &mscreen, sub_pixel_clock);
-	mscreen.set_screen_update(FUNC(stepstag_state::screen_update_stepstag_mid));
-*/
 	screen_device &rscreen(SCREEN(config, "rscreen", SCREEN_TYPE_RASTER));
 	rscreen.set_orientation(ROT270);
 	setup_non_sysctrl_screen(config, &rscreen, sub_pixel_clock);

--- a/src/mame/includes/tetrisp2.h
+++ b/src/mame/includes/tetrisp2.h
@@ -6,6 +6,7 @@
 #include "video/ms32_sprite.h"
 #include "emupal.h"
 #include "tilemap.h"
+#include "sound/ymz280b.h"
 
 class tetrisp2_state : public driver_device
 {
@@ -214,6 +215,10 @@ public:
 		, m_vj_paletteram_m(*this, "paletteram2")
 		, m_vj_paletteram_r(*this, "paletteram3")
 		, m_soundlatch(*this, "soundlatch")
+		, m_ymz(*this, "ymz")
+		, m_ymz1(*this, "ymz1")
+		, m_ymzram(*this, "ymz_ram")
+		, m_ymzram1(*this, "ymz_ram1")
 	{ }
 
 	void stepstag(machine_config &config);
@@ -227,6 +232,8 @@ private:
 	u16 stepstag_coins_r();
 	u16 vj_upload_idx;
 	bool vj_upload_fini;
+//	bool fg_ascii_mode;
+//	bool stepstag_mid_switcher;
 	void stepstag_b00000_w(u16 data);
 	void stepstag_b20000_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 	void stepstag_main2pc_w(u16 data);
@@ -251,6 +258,11 @@ private:
 	void stepstag_map(address_map &map);
 	void stepstag_sub_map(address_map &map);
 	void vjdash_map(address_map &map);
+	void ymz280b_map(address_map &map);
+	void ymz280b_map1(address_map &map);
+
+	u16 m_stepstag_main2pc;
+	u16 m_stepstag_pc2main;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(field_cb);
 	void setup_non_sysctrl_screen(machine_config &config, screen_device *screen, const XTAL xtal);
@@ -268,5 +280,12 @@ private:
 	optional_shared_ptr<u16> m_vj_paletteram_m;
 	optional_shared_ptr<u16> m_vj_paletteram_r;
 	required_device<generic_latch_16_device> m_soundlatch;
+	required_device<ymz280b_device> m_ymz;
+	required_device<ymz280b_device> m_ymz1;
+	required_shared_ptr<u8> m_ymzram;
+	required_shared_ptr<u8> m_ymzram1;
+
 	void convert_yuv422_to_rgb888(palette_device *paldev, u16 *palram,u32 offset);
+	void simulate_pc();
+//	unsigned int load_sample(unsigned char* buffer, const char* path);
 };

--- a/src/mame/includes/tetrisp2.h
+++ b/src/mame/includes/tetrisp2.h
@@ -1,12 +1,12 @@
 // license:BSD-3-Clause
 // copyright-holders:Luca Elia
 
+#include "sound/ymz280b.h"
 #include "machine/gen_latch.h"
 #include "machine/jaleco_ms32_sysctrl.h"
 #include "video/ms32_sprite.h"
 #include "emupal.h"
 #include "tilemap.h"
-#include "sound/ymz280b.h"
 
 class tetrisp2_state : public driver_device
 {

--- a/src/mame/layout/stepstag.lay
+++ b/src/mame/layout/stepstag.lay
@@ -9,10 +9,10 @@ license:CC0
 			<bounds x="0" y="0" width="9" height="13.2" />
 		</screen>
 		<screen tag="screen">
-			<bounds x="9.1" y="0" width="16" height="13.2" />
+			<bounds x="9.1" y="0" width="19.36" height="13.2" />
 		</screen>
 		<screen tag="rscreen">
-			<bounds x="25.2" y="0" width="9" height="13.2" />
+			<bounds x="28.56" y="0" width="9" height="13.2" />
 		</screen>
 	</view>
 

--- a/src/mame/video/tc0780fpa.cpp
+++ b/src/mame/video/tc0780fpa.cpp
@@ -124,7 +124,7 @@ void tc0780fpa_renderer::render_texture_scan(int32_t scanline, const extent_t &e
 		}
 		else
 		{
-			iu = (tex_base_x + (((int)u >> 4) & 0x3f)) & 0x7ff;
+			iu = (tex_base_x + (((int)u >> 4) & ((0x08 << tex_wrap_x) - 1))) & 0x7ff;
 		}
 
 		if (!tex_wrap_y)
@@ -133,7 +133,7 @@ void tc0780fpa_renderer::render_texture_scan(int32_t scanline, const extent_t &e
 		}
 		else
 		{
-			iv = (tex_base_y + (((int)v >> 4) & 0x3f)) & 0x7ff;
+			iv = (tex_base_y + (((int)v >> 4) & ((0x08 << tex_wrap_y) - 1))) & 0x7ff;
 		}
 
 		texel = m_texture[(iv * 2048) + iu];
@@ -260,8 +260,8 @@ void tc0780fpa_renderer::render(uint16_t *polygon_fifo, int length)
 			extra.tex_base_x = ((texbase >> 0) & 0xff) << 4;
 			extra.tex_base_y = ((texbase >> 8) & 0xff) << 4;
 
-			extra.tex_wrap_x = (cmd & 0xc0) ? 1 : 0;
-			extra.tex_wrap_y = (cmd & 0x30) ? 1 : 0;
+			extra.tex_wrap_x = (cmd >> 6) & 3;
+			extra.tex_wrap_y = (cmd >> 4) & 3;
 
 			for (i=0; i < 3; i++)
 			{
@@ -362,8 +362,8 @@ void tc0780fpa_renderer::render(uint16_t *polygon_fifo, int length)
 			extra.tex_base_x = ((texbase >> 0) & 0xff) << 4;
 			extra.tex_base_y = ((texbase >> 8) & 0xff) << 4;
 
-			extra.tex_wrap_x = (cmd & 0xc0) ? 1 : 0;
-			extra.tex_wrap_y = (cmd & 0x30) ? 1 : 0;
+			extra.tex_wrap_x = (cmd >> 6) & 3;
+			extra.tex_wrap_y = (cmd >> 4) & 3;
 
 			for (i=0; i < 4; i++)
 			{
@@ -375,7 +375,7 @@ void tc0780fpa_renderer::render(uint16_t *polygon_fifo, int length)
 				vert[i].p[0] = (uint16_t)(polygon_fifo[ptr++]);
 			}
 
-			if (vert[0].p[0] < 0x8000 && vert[1].p[0] < 0x8000 && vert[2].p[0] < 0x8000 && vert[3].p[0] < 0x8000)
+			if (vert[0].p[0] < 0xc000 && vert[1].p[0] < 0xc000 && vert[2].p[0] < 0xc000 && vert[3].p[0] < 0xc000)
 			{
 				render_polygon<4>(m_cliprect, render_delegate(&tc0780fpa_renderer::render_texture_scan, this), 4, vert);
 			}

--- a/src/mame/video/tetrisp2.cpp
+++ b/src/mame/video/tetrisp2.cpp
@@ -647,9 +647,9 @@ u32 rocknms_state::screen_update_rocknms_right(screen_device &screen, bitmap_rgb
 // even-byte-tile seems to hava a higher priority (uses 0x0 instead of 0x20 as space code, for transparency?)
 //
 // When in game status(VJDash), the fg layer changes back to normal mode
-// fg layer might also have a clip window
-//
-// TODO: the mode-switching signal and clip data?
+// TODO: pinpoint how it swaps mode
+// TODO: fg layer might also have a clip window. pinpoint how it enables clipping, and clipping left/right/top/bottom data
+
 TILE_GET_INFO_MEMBER(stepstag_state::stepstag_get_tile_info_fg)
 {
 	u16 const code_hi = m_vram_fg[ 2 * tile_index ] >> 8;
@@ -676,7 +676,7 @@ VIDEO_START_MEMBER(stepstag_state,stepstag)
 
 u32 stepstag_state::screen_update_stepstag_left(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect)
 {
-	bitmap.fill(0, cliprect);	// m_vj_palette_l->pen(0x0000)	// chroma key green, for mixing with mpeg FMV underlayer
+	bitmap.fill(0, cliprect);
 	screen.priority().fill(0);
 
 	tetrisp2_draw_sprites(


### PR DESCRIPTION
Jaleco VJ and Stepping Stage hardware:
Added dual ymz280b audio IC configuration to support 4-channel stereo for vjdash and stepstag hardware;
Audio samples are not stored in ROM, but RAM. Sample files are loaded from harddisk of a Windows PC;
[Document] Bass/treble mixing setting for VJ, and volume setting for stepping stage;
Changed game screen pixel parameters according to MPEG-1 standard;
Patched vjdash to boot to game without sub code dumped;
[Document] Added system diagram, and note for mid-screen configuration of stepstag;
[Document] Discovered a new ascii byte-interleaved mode for fg layer;

Taito JC texture-mapping unit:
Added variable texture wrap size support, corrected in dendego the appearance of buildings alone Yamanote Line 山手線, for example.