### PR TITLE
32x.xml: add Euro parent set for zaxxon2k

### DIFF
--- a/hash/32x.xml
+++ b/hash/32x.xml
@@ -2489,6 +2489,19 @@ license:CC0
 	</software>
 
 	<software name="zaxxon2k">
+		<description>Motherbase (Euro)</description>
+		<year>1995</year>
+		<publisher>Sega</publisher>
+		<info name="serial" value="84512-50"/>
+		<sharedfeat name="compatibility" value="PAL"/>
+		<part name="cart" interface="_32x_cart">
+			<dataarea name="rom" size="2097152">
+				<rom name="motherbase (europe).bin" size="2097152" crc="0d6523a3" sha1="00792570c459637d46f26d0ceb301ed9d83f0098" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zaxxon2kju" cloneof="zaxxon2k">
 		<description>Parasquad (Jpn) ~ Zaxxon's Motherbase 2000 (USA)</description>
 		<year>1995</year>
 		<publisher>Sega</publisher>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Motherbase (Euro) [Xenon]