### PR TITLE
bus/nes: fix broken graphics for mapper 226 (two multicart pirate carts)

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -79714,12 +79714,11 @@ be better to redump them properly. -->
 
 	<software name="mc_76">
 		<description>76 in 1</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
+		<year>1990</year>
+		<publisher>Tsang Hai</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="bmc_76in1" />
 			<feature name="pcb" value="BMC-76IN1" />
-			<feature name="mirroring" value="vertical" />
 			<dataarea name="prg" size="2097152">
 				<rom name="76 in 1.prg" size="2097152" crc="147733df" sha1="39499923c8970b089e359ac256e71fb75ae3c0de" offset="00000" status="baddump" />
 			</dataarea>
@@ -80881,15 +80880,15 @@ to check why this is different -->
 		</part>
 	</software>
 
-	<software name="mc_s42" supported="partial">
-		<description>Super 42 in 1 - 22 Games</description>
+	<software name="mc_s42">
+		<description>Super 42 in 1</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="bmc_s42in1" />
 			<feature name="pcb" value="BMC-SUPER42IN1" />
 			<dataarea name="prg" size="1048576">
-				<rom name="super 42 in 1 - 22 games.prg" size="1048576" crc="c9f92bd9" sha1="6060eb360b9b4ae7aca024c00ace5b472371d721" offset="00000" status="baddump" />
+				<rom name="super 42 in 1.prg" size="1048576" crc="c9f92bd9" sha1="6060eb360b9b4ae7aca024c00ace5b472371d721" offset="00000" status="baddump" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -713,7 +713,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	uint8_t m_latch1, m_latch2;
+	uint8_t m_reg[2];
 };
 
 


### PR DESCRIPTION
- fixes the menu in mc_s42 so you can actually tell what you are selecting
- fixes the menu in mc_76 so it refreshes when returning from submenu pages to main menu
- fixes graphics glitches too numerous to list (anything with scrolling was heavily glitched to unplayable)
- simplifies the code a bit