### PR TITLE
batman.cpp - layers need some offsets to align with real PCB videos

### DIFF
--- a/src/mame/drivers/batman.cpp
+++ b/src/mame/drivers/batman.cpp
@@ -206,7 +206,7 @@ void batman_state::batman(machine_config &config)
 	TILEMAP(config, "vad:alpha", "gfxdecode", 2, 8, 8, TILEMAP_SCAN_ROWS, 64, 32, 0).set_info_callback(FUNC(batman_state::get_alpha_tile_info));
 
 	ATARI_MOTION_OBJECTS(config, m_mob, 0, m_screen, batman_state::s_mob_config).set_gfxdecode("gfxdecode");
-	m_mob->set_xoffset(1);
+	m_mob->set_xoffset(-1);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_video_attributes(VIDEO_UPDATE_BEFORE_VBLANK);

--- a/src/mame/drivers/batman.cpp
+++ b/src/mame/drivers/batman.cpp
@@ -199,10 +199,14 @@ void batman_state::batman(machine_config &config)
 
 	ATARI_VAD(config, m_vad, 0, m_screen);
 	m_vad->scanline_int_cb().set_inputline(m_maincpu, M68K_IRQ_4);
+	m_vad->set_xoffsets(2, 6);
+
 	TILEMAP(config, "vad:playfield", "gfxdecode", 2, 8, 8, TILEMAP_SCAN_COLS, 64, 64).set_info_callback(FUNC(batman_state::get_playfield_tile_info));
 	TILEMAP(config, "vad:playfield2", "gfxdecode", 2, 8, 8, TILEMAP_SCAN_COLS, 64, 64, 0).set_info_callback(FUNC(batman_state::get_playfield2_tile_info));
 	TILEMAP(config, "vad:alpha", "gfxdecode", 2, 8, 8, TILEMAP_SCAN_ROWS, 64, 32, 0).set_info_callback(FUNC(batman_state::get_alpha_tile_info));
-	ATARI_MOTION_OBJECTS(config, "vad:mob", 0, m_screen, batman_state::s_mob_config).set_gfxdecode("gfxdecode");
+
+	ATARI_MOTION_OBJECTS(config, m_mob, 0, m_screen, batman_state::s_mob_config).set_gfxdecode("gfxdecode");
+	m_mob->set_xoffset(1);
 
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 	m_screen->set_video_attributes(VIDEO_UPDATE_BEFORE_VBLANK);

--- a/src/mame/includes/batman.h
+++ b/src/mame/includes/batman.h
@@ -25,7 +25,8 @@ public:
 		m_maincpu(*this, "maincpu"),
 		m_screen(*this, "screen"),
 		m_jsa(*this, "jsa"),
-		m_vad(*this, "vad")
+		m_vad(*this, "vad"),
+		m_mob(*this, "vad:mob")
 	{ }
 
 	void init_batman();
@@ -46,6 +47,7 @@ private:
 	required_device<screen_device> m_screen;
 	required_device<atari_jsa_iii_device> m_jsa;
 	required_device<atari_vad_device> m_vad;
+	required_device<atari_motion_objects_device> m_mob;
 
 	uint16_t          m_latch_data;
 	uint8_t           m_alpha_tile_bank;

--- a/src/mame/video/atarimo.cpp
+++ b/src/mame/video/atarimo.cpp
@@ -439,7 +439,7 @@ void atari_motion_objects_device::render_object(bitmap_ind16 &bitmap, const rect
 	// extract data from the various words
 	int code = m_codelookup[rawcode];
 	int color = m_colorlookup[m_colormask.extract(entry)];
-	int xpos = m_xposmask.extract(entry) - m_xoffset;
+	int xpos = m_xposmask.extract(entry) + m_xoffset;
 	int ypos = -m_yposmask.extract(entry);
 	int hflip = m_hflipmask.extract(entry);
 	int vflip = m_vflipmask.extract(entry);

--- a/src/mame/video/atarimo.cpp
+++ b/src/mame/video/atarimo.cpp
@@ -150,6 +150,7 @@ atari_motion_objects_device::atari_motion_objects_device(const machine_config &m
 	, m_activelast(nullptr)
 	, m_last_xpos(0)
 	, m_next_xpos(0)
+	, m_xoffset(0)
 	, m_gfxdecode(*this, finder_base::DUMMY_TAG)
 {
 }
@@ -438,7 +439,7 @@ void atari_motion_objects_device::render_object(bitmap_ind16 &bitmap, const rect
 	// extract data from the various words
 	int code = m_codelookup[rawcode];
 	int color = m_colorlookup[m_colormask.extract(entry)];
-	int xpos = m_xposmask.extract(entry);
+	int xpos = m_xposmask.extract(entry) - m_xoffset;
 	int ypos = -m_yposmask.extract(entry);
 	int hflip = m_hflipmask.extract(entry);
 	int vflip = m_vflipmask.extract(entry);

--- a/src/mame/video/atarimo.h
+++ b/src/mame/video/atarimo.h
@@ -83,6 +83,7 @@ public:
 	// configuration
 	template <typename T> void set_gfxdecode(T &&tag) { m_gfxdecode.set_tag(std::forward<T>(tag)); }
 	void set_config(const atari_motion_objects_config &config) { static_cast<atari_motion_objects_config &>(*this) = config; }
+	void set_xoffset(int xoffset) { m_xoffset = xoffset; }
 
 	// getters
 	int bank() const { return m_bank; }
@@ -217,6 +218,9 @@ private:
 
 	uint32_t                m_last_xpos;          // (during processing) the previous X position
 	uint32_t                m_next_xpos;          // (during processing) the next X position
+
+	int                     m_xoffset;            // global xoffset for sprites
+
 	required_device<gfxdecode_device> m_gfxdecode;
 };
 

--- a/src/mame/video/atarivad.cpp
+++ b/src/mame/video/atarivad.cpp
@@ -44,6 +44,8 @@ atari_vad_device::atari_vad_device(const machine_config &mconfig, const char *ta
 	, m_pf1_yscroll(0)
 	, m_mo_xscroll(0)
 	, m_mo_yscroll(0)
+	, m_pf_xoffset(0)
+	, m_pf2_xoffset(4)
 {
 }
 
@@ -362,11 +364,10 @@ void atari_vad_device::internal_control_write(offs_t offset, uint16_t newword)
 
 inline void atari_vad_device::update_pf_xscrolls()
 {
-	m_playfield_tilemap->set_scrollx(0, m_pf0_xscroll_raw + ((m_pf1_xscroll_raw) & 7));
+	m_playfield_tilemap->set_scrollx(0, m_pf0_xscroll_raw + ((m_pf1_xscroll_raw) & 7) + m_pf_xoffset);
 	if (m_playfield2_tilemap != nullptr)
-		m_playfield2_tilemap->set_scrollx(0, m_pf1_xscroll_raw + 4);
+		m_playfield2_tilemap->set_scrollx(0, m_pf1_xscroll_raw + m_pf2_xoffset);
 }
-
 
 //-------------------------------------------------
 //  update_parameter: Update parameters, shared

--- a/src/mame/video/atarivad.h
+++ b/src/mame/video/atarivad.h
@@ -38,6 +38,7 @@ public:
 
 	// configuration helpers
 	auto scanline_int_cb() { return m_scanline_int_cb.bind(); }
+	void set_xoffsets(int xoffset, int xoffset2) { m_pf_xoffset = xoffset; m_pf2_xoffset = xoffset2; }
 
 	// getters
 	tilemap_device &alpha() const { return *m_alpha_tilemap; }
@@ -102,6 +103,9 @@ private:
 	uint32_t              m_mo_yscroll;              // sprite xscroll
 
 	uint16_t              m_control[0x40/2];          // control data
+
+	int m_pf_xoffset;
+	int m_pf2_xoffset;
 };
 
 


### PR DESCRIPTION
my point of reference is https://youtu.be/IyDdq5B8R9g which is a video of a PCB being repaired.

this clearly shows the tilemaps were previously misaligned by 2 pixels vs. the hardware output (check the extreme right of the car dashboard at 8:50, see which pixels are visible, also note MAME was rendering 2 unwanted flashing columns on the left during the same scene which are gone with the shift)

sprite alignment against the background can be seen at 4:42 when batman is pressing against the crate, there's a single pixel gap between his foot and the crate

text layer alignment can be compared to other layers in various place

furthest back layer is not 100% verified against the video.

I don't know if the number of layers enabled or similar has an effect on the offsets, but these cases where you need 1-2 pixel adjustments on layers seem common with arcade games.

It is interesting to note that the enemy movements don't quite match the PCB footage, the enemy on the opposite side of the wall when batman is pressing against the crate stops on a different frame, but that's probably a screen timing / irq timing thing (or possibly even an undumped revision, we only have 1 set)