### PR TITLE
MAKE_INT_8 fails on GCC/ARM

### DIFF
--- a/src/devices/cpu/spc700/spc700.cpp
+++ b/src/devices/cpu/spc700/spc700.cpp
@@ -74,17 +74,7 @@ Address  Function Register  R/W  When Reset          Remarks
 /* ==================== ARCHITECTURE-DEPENDANT DEFINES ==================== */
 /* ======================================================================== */
 
-#undef int8
-
-/* Allow for architectures that don't have 8-bit sizes */
-#if UCHAR_MAX == 0xff
-#define int8 char
-#define MAKE_INT_8(A) (int8)((A)&0xff)
-#else
-#define int8   int
-static inline int MAKE_INT_8(int A) {return (A & 0x80) ? A | ~0xff : A & 0xff;}
-#endif /* UCHAR_MAX == 0xff */
-
+#define MAKE_INT_8(A) (int8_t)((A)&0xff)
 #define MAKE_UINT_8(A) ((A)&0xff)
 #define MAKE_UINT_16(A) ((A)&0xffff)
 


### PR DESCRIPTION
The old MAKE_INT_8 macro failed (added 0x100 displacement in the BRANCH method) on gcc-arm-none-eabi-10-2020-q4-major since by default __CHAR_UNSIGNED__ is defined on that platform. Now there might be a better solution to this. Figured this is 2021 and int8_t should be available everywhere. Fixes works on MSVC2017, (gcc-arm) and XCode12 (llvm). Now MAME may use -fsigned-char when compiling and this change makes no sense. I am using this file outside and took me a while to find this issue.