### PR TITLE
use namco_c355spr_device built in sprite buffering to pevent flickering gfx in suzuk8h2 [David Haywood]

### DIFF
--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -50,7 +50,7 @@ TODO:
     Metal Hawk
     - ROZ wraparound isn't implemented (see large battleship in 2nd stage)
 
-	Burning Force, Suzuka 8 Hours 2 (+ maybe others)
+	Burning Force (+ maybe others)
 	- POSIRQ is off-by-one, but adjusting it makes other cases worse
 	  (because some layers are line-buffered and some aren't, and we need proper scroll/data latch times for each layer type?)
 

--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -20,12 +20,15 @@ Final Lap Notes:
     To move through self test options, press gas pedal and change gear shift from low to high
     To change an option, move gear shift from low to high without touching the gas pedal
 
-known issues:
+TODO:
+	- Verify below still occur
+
+	General
     - sprite/tilemap orthogonality needed
-    - bad road colors in Final Lap and Suzuka series
+    - bad road colors in Final Lap and Suzuka series (just an overall gamma issue?)
 
     Final Lap & Final Lap 2:
-    - by default, the graphics are way too bright if compared to original PCB/monitor output
+    - by default, the graphics are way too bright if compared to original PCB/monitor output (just an overall gamma issue?)
 
     Finest Hour:
     - roz plane colors are bad in-game
@@ -45,7 +48,11 @@ known issues:
     - no artwork
 
     Metal Hawk
-    - ROZ wraparound isn't implemented
+    - ROZ wraparound isn't implemented (see large battleship in 2nd stage)
+
+	Burning Force, Suzuka 8 Hours 2 (+ maybe others)
+	- POSIRQ is off-by-one, but adjusting it makes other cases worse
+	  (because some layers are line-buffered and some aren't, and we need proper scroll/data latch times for each layer type?)
 
 The Namco System II board is a 5 ( only 4 are emulated ) CPU system. The
 complete system consists of two boards: CPU + GRAPHICS. It contains a large
@@ -809,7 +816,7 @@ void namcos2_state::common_suzuka8h_am(address_map &map)
 	namcos2_68k_default_cpu_board_am(map);
 	map(0x800000, 0x8141ff).rw(m_c355spr, FUNC(namco_c355spr_device::spriteram_r), FUNC(namco_c355spr_device::spriteram_w));
 	map(0x818000, 0x818001).noprw(); /* enable? */
-	map(0x81a000, 0x81a001).nopw(); /* enable? */
+	map(0x81a000, 0x81a001).nopw(); /* enable? - or maybe sprite DMA / buffering which is currently done automatically by setting m_c355spr->set_buffer(1); */
 	map(0x840000, 0x840001).nopr();
 	map(0x900000, 0x900007).rw(m_c355spr, FUNC(namco_c355spr_device::position_r), FUNC(namco_c355spr_device::position_w));
 	map(0xa00000, 0xa1ffff).rw(m_c45_road, FUNC(namco_c45_road_device::read), FUNC(namco_c45_road_device::write));
@@ -2050,8 +2057,11 @@ void namcos2_state::suzuka8h(machine_config &config)
 	configure_c116_standard(config);
 
 	m_screen->set_screen_update(FUNC(namcos2_state::screen_update_luckywld));
+	m_screen->screen_vblank().set(m_c355spr, FUNC(namco_c355spr_device::vblank));
 
 	configure_c355spr_standard(config);
+	m_c355spr->set_buffer(1);
+
 	configure_c123tmap_standard(config);
 	configure_c45road_standard(config);
 

--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -25,7 +25,6 @@ TODO:
 
 	General
     - sprite/tilemap orthogonality needed
-    - bad road colors in Final Lap and Suzuka series (just an overall gamma issue?)
 
     Final Lap & Final Lap 2:
     - by default, the graphics are way too bright if compared to original PCB/monitor output (just an overall gamma issue?)


### PR DESCRIPTION
since this isn't the standard Namco System 2 video board (different sprites) and the C355 sprite device has been shown to need buffering in other cases, I speculate there is buffering here.

it might be under CPU control as there are some interesting writes around the sprite area, but for the moment we're using the mechanism that is in place and used by other games.
