### PR TITLE
c64_cass.xml: Change 720 degrees game title name to match arcade vers…

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -395,7 +395,7 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
-	<software name="720">
+	<software name="720 Degrees">
 		<description>720</description>
 		<year>1987</year>
 		<publisher>U.S. Gold</publisher>

--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -395,8 +395,8 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
-	<software name="720 Degrees">
-		<description>720</description>
+	<software name="720">
+		<description>720 Degrees</description>
 		<year>1987</year>
 		<publisher>U.S. Gold</publisher>
 


### PR DESCRIPTION
…ion for consistency

I recently added 720 degrees arcade port to c64_cass.xml.  This change to game title now matches the arcade version.