### PR TITLE
API cleanups and miscellaneous fixes.

### DIFF
--- a/docs/source/advanced/ctrlr_config.rst
+++ b/docs/source/advanced/ctrlr_config.rst
@@ -1,0 +1,229 @@
+.. _ctrlrcfg:
+
+Controller Configuration Files
+==============================
+
+.. contents:: :local:
+
+
+.. _ctrlrcfg-intro:
+
+Introduction
+------------
+
+Controller configuration files can be used to modify MAME’s default input
+settings.  Controller configuration files may be supplied with an input device
+to provide more suitable defaults, or used as profiles that can be selected for
+different situations.  MAME includes a few sample controller configuration files
+in the **ctrlr** folder, designed to provide useful defaults for certain
+arcade-style controllers.
+
+Controller configuration files are an XML application, using the ``.cfg``
+filename extension.  MAME searches for controller configuration files in the
+directories specified using the ``ctrlrpath`` option.  A controller
+configuration file is selected by setting the ``ctrlr`` option to its filename,
+excluding the ``.cfg`` extension (e.g. set the ``ctrlr`` option to
+``scorpionxg`` to use **scorpionxg.cfg**).  It is an error if the specified
+controller configuration file does not exist, or if it contains no sections
+applicable to the emulated system.
+
+Controller configuration files use implementation-dependent input tokens.  The
+values available and their precise meanings depend on the exact version of MAME
+used, the input devices connected, the selected input provider modules
+(``keyboardprovider``, ``mouseprovider``, ``lightgunprovider`` and
+``joystickprovider`` options), and possibly other settings.
+
+
+.. _ctrlrcfg-structure:
+
+Basic structure
+---------------
+
+Controller configuration files follow a similar format to the system
+configuration files that MAME uses to save things like input settings and
+bookkeeping data.  This example shows the overall structure of a controller
+configuration file:
+
+.. code-block:: XML
+
+    <?xml version="1.0"?>
+    <mameconfig version="10">
+        <system name="default">
+            <input>
+                <!-- settings affecting all emulated systems go here -->
+            </input>
+        </system>
+        <system name="neogeo">
+            <input>
+                <!-- settings affecting neogeo and clones go here -->
+            </input>
+        </system>
+        <system name="intellec4.cpp">
+            <input>
+                <!-- settings affecting all systems defined in intellec4.cpp go here -->
+            </input>
+        </system>
+    </mameconfig>
+
+The root of a controller configuration file must be a ``mameconfig`` element,
+with a ``version`` attribute specifying the configuration format version
+(currently ``10`` – MAME will not load a file using a different version).  The
+``mameconfig`` element contains one or more ``system`` elements, each of which
+has a ``name`` attribute specifying the system(s) it applies to.  Each
+``system`` element contains an ``input`` element which holds the actual
+``remap`` and ``port`` configuration elements, which will be described later.
+
+When launching an emulated system, MAME will apply configuration from ``system``
+elements where the value of the ``name`` attribute meets one of the following
+criteria:
+
+* If the ``name`` attribute has the value ``default``, it will always be applied
+  (including for the system/software selection menus).
+* If the value of the ``name`` attribute matches the system’s short name, the
+  short name of its parent system, or the short name of its BIOS system (if
+  applicable).
+* If the value of the ``name`` attribute matches the name of the source file
+  where the system is defined.
+
+For example, for the game “DaeJeon! SanJeon SuJeon (AJTUE 990412 V1.000)”,
+``system`` elements will be applied if their ``name`` attribute has the value
+``default`` (applies to all systems), ``sanjeon`` (short name of the system
+itself), ``sasissu`` (short name of the parent system), ``stvbios`` (short
+name of the BIOS system), or ``stv.cpp`` (source file where the system is
+defined).
+
+As another example, a ``system`` element whose ``name`` attribute has the value
+``zac2650.cpp`` will be applied for the systems “The Invaders”, “Super Invader
+Attack (bootleg of The Invaders)”, and “Dodgem”.
+
+Applicable ``system`` elements are applied in the order they appear in the
+controller configuration file.  Settings from elements that appear later in the
+file may modify or override settings from elements that appear earlier.  Within
+a ``system`` element, ``remap`` elements are applied before ``port`` elements.
+
+
+.. _ctrlrcfg-substitute:
+
+Substituting default controls
+-----------------------------
+
+You can use a ``remap`` element to substitute one host input for another in
+MAME’s default input configuration.  For example, this substitutes keys on the
+numeric keypad for the cursor direction keys:
+
+.. code-block:: XML
+
+    <input>
+        <remap origcode="KEYCODE_UP" newcode="KEYCODE_8PAD" />
+        <remap origcode="KEYCODE_DOWN" newcode="KEYCODE_2PAD" />
+        <remap origcode="KEYCODE_LEFT" newcode="KEYCODE_4PAD" />
+        <remap origcode="KEYCODE_RIGHT" newcode="KEYCODE_6PAD" />
+    </input>
+
+The ``origcode`` attribute specifies the token for the host input to be
+substituted, and the ``newcode`` attribute specifies the token for the
+replacement host input.  In this case, assignments using the cursor up, down,
+left and right arrows will be replaced with the numeric 8, 2, 4 and 6 keys on
+the numeric keypad, respectively.
+
+Note that substitutions specified using ``remap`` elements only apply to inputs
+that use MAME’s default assignment for the control type.  That is, they only
+apply to default assignments for control types set in the “Inputs (general)”
+menu.  They *do not* apply to default input assignments set in driver/device I/O
+port definitions (using the ``PORT_CODE`` macro).
+
+MAME applies ``remap`` elements found inside any applicable ``system`` element.
+
+
+.. _ctrlrcfg-typeoverride:
+
+Overriding defaults by control type
+-----------------------------------
+
+Use ``port`` elements with ``type`` attributes but without ``tag`` attributes to
+override the default host input assignments for a controls:
+
+.. code-block:: XML
+
+    <input>
+        <port type="UI_CONFIGURE">
+            <newseq type="standard">KEYCODE_TAB OR KEYCODE_1 KEYCODE_5</newseq>
+        </port>
+        <port type="UI_CANCEL">
+            <newseq type="standard">KEYCODE_ESC OR KEYCODE_2 KEYCODE_6</newseq>
+        </port>
+
+        <port type="P1_BUTTON1">
+            <newseq type="standard">KEYCODE_C OR JOYCODE_1_BUTTON1</newseq>
+        </port>
+        <port type="P1_BUTTON2">
+            <newseq type="standard">KEYCODE_LSHIFT OR JOYCODE_1_BUTTON2</newseq>
+        </port>
+        <port type="P1_BUTTON3">
+            <newseq type="standard">KEYCODE_Z OR JOYCODE_1_BUTTON3</newseq>
+        </port>
+        <port type="P1_BUTTON4">
+            <newseq type="standard">KEYCODE_X OR JOYCODE_1_BUTTON4</newseq>
+        </port>
+    </input>
+
+This sets the following default input assignments:
+
+Config Menu (User Interface)
+    Tab key, or 1 and 2 keys pressed simultaneously
+UI Cancel (User Interface)
+    Escape key, or 2 and 6 keys pressed simultaneously
+P1 Button 1 (Player 1 Controls)
+    C key, or joystick 1 button 1
+P1 Button 2 (Player 1 Controls)
+    Left Shift key, or joystick 1 button 2
+P1 Button 3 (Player 1 Controls)
+    Z key, or joystick 1 button 3
+P1 Button 4 (Player 1 Controls)
+    X key, or joystick 1 button 4
+
+Note that this will only apply for inputs that use MAME’s default assignment for
+the control type.  That is, ``port`` elements without ``tag`` attributes only
+override default assignments for control types set in the “Inputs (general)”
+menu.  They *do not* override default input assignments set in driver/device I/O
+port definitions (using the ``PORT_CODE`` macro).
+
+MAME applies ``port`` elements without ``tag`` attributes found inside any
+applicable ``system`` element.
+
+
+.. _ctrlrcfg-ctrloverride:
+
+Overriding defaults for specific controls
+-----------------------------------------
+
+Use ``port`` elements with ``tag``, ``type``, ``mask`` and ``defvalue``
+attributes to override defaults for specific controls.  These ``port`` elements
+should only occur inside ``system`` elements that apply to particular systems or
+source files (i.e. they should not occur inside ``system`` elements where the
+``name`` attribute has the value ``default``).  The default host input
+assignments can be overridden, as well as the toggle setting for digital
+controls.
+
+The ``tag``, ``type``, ``mask`` and ``defvalue`` are used to identify the
+affected input.  You can find out the values to use for a particular input by
+changing its assigned host input, exiting MAME, and checking the values in the
+system configuration file.  Note that these values are not guaranteed to be
+stable, and may change between MAME versions.
+
+Here’s an example that overrides defaults for 280-ZZZAP:
+
+.. code-block:: XML
+
+    <system name="280zzzap">
+        <input>
+            <port tag=":IN0" type="P1_BUTTON2" mask="16" defvalue="0" toggle="no" />
+            <port tag=":IN1" type="P1_PADDLE" mask="255" defvalue="127">
+                <newseq type="increment">KEYCODE_K</newseq>
+                <newseq type="decrement">KEYCODE_J</newseq>
+            </port>
+        </input>
+    </system>
+
+This sets the host inputs to steer left and right to the K and J keys,
+respectively, and disables the toggle setting for the gear shift input.

--- a/docs/source/advanced/index.rst
+++ b/docs/source/advanced/index.rst
@@ -2,13 +2,14 @@ Advanced configuration
 ----------------------
 
 .. toctree::
-	:titlesonly:
+    :titlesonly:
 
-	multiconfig
-	paths
-	shiftertoggle
-	bgfx
-	hlsl
-	glsl
-	devicemap
-	linux-lightguns
+    multiconfig
+    paths
+    shiftertoggle
+    bgfx
+    hlsl
+    glsl
+    ctrlr_config
+    devicemap
+    linux-lightguns

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -32,7 +32,6 @@ patterns to avoid having your shell try to expand them against filenames (e.g.
 
 .. _mame-commandline-paths:
 
-
 File Names and Directory Paths
 ------------------------------
 
@@ -1087,7 +1086,7 @@ Core Search Path Options
 
 .. _mame-commandline-artpath:
 
-**-artpath** *<path>* *<path>*
+**-artpath** *<path>*
 
     Specifies one or more paths within which to find external layout and artwork
     files.  Multiple paths can be specified by separating them with semicolons.
@@ -1104,8 +1103,9 @@ Core Search Path Options
 
 **-ctrlrpath** *<path>*
 
-    Specifies one or more paths within which to find default input configuration
+    Specifies one or more paths within which to find controller configuration
     files.  Multiple paths can be specified by separating them with semicolons.
+    Used in conjunction with the ``-ctrlr`` option.
 
     The default is ``ctrlr`` (that is, a directory ``ctrlr`` in the current
     working directory).
@@ -2942,11 +2942,13 @@ Core Input Options
 
 **-ctrlr** *<controller>*
 
-    Enables support for special controllers. Configuration files are loaded from
-    the ctrlrpath.  They are in the same format as the .cfg files that are
-    saved, but only control configuration data is read from the file.
+    Specifies a controller configuration file, typically used to set more
+    suitable default input assignments for special controllers. Directories
+    specified using the ``ctrlrpath`` option are searched.  Controller
+    configuration files use a similar format to ``.cfg`` used to save system
+    settings. See :ref:`ctrlrcfg` for more details.
 
-    The default is ``NULL`` (no controller file).
+    The default is ``NULL`` (no controller configuration file).
 
     Example:
         .. code-block:: bash

--- a/src/devices/machine/laserdsc.h
+++ b/src/devices/machine/laserdsc.h
@@ -260,7 +260,7 @@ private:
 	void read_track_data();
 	static void *read_async_static(void *param, int threadid);
 	void process_track_data();
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// configuration

--- a/src/emu/bookkeeping.cpp
+++ b/src/emu/bookkeeping.cpp
@@ -39,7 +39,9 @@ bookkeeping_manager::bookkeeping_manager(running_machine &machine)
 	machine.save().save_item(NAME(m_dispensed_tickets));
 
 	// register for configuration
-	machine.configuration().config_register("counters", config_load_delegate(&bookkeeping_manager::config_load, this), config_save_delegate(&bookkeeping_manager::config_save, this));
+	machine.configuration().config_register("counters",
+			configuration_manager::load_delegate(&bookkeeping_manager::config_load, this),
+			configuration_manager::save_delegate(&bookkeeping_manager::config_save, this));
 }
 
 
@@ -80,36 +82,30 @@ void bookkeeping_manager::increment_dispensed_tickets(int delta)
     and tickets
 -------------------------------------------------*/
 
-void bookkeeping_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void bookkeeping_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	util::xml::data_node const *coinnode, *ticketnode;
-
-	/* on init, reset the counters */
+	// on init, reset the counters
 	if (cfg_type == config_type::INIT)
 	{
 		memset(m_coin_count, 0, sizeof(m_coin_count));
 		m_dispensed_tickets = 0;
 	}
 
-	/* only care about game-specific data */
-	if (cfg_type != config_type::GAME)
+	// only care about system-specific data
+	if ((cfg_type != config_type::SYSTEM) || !parentnode)
 		return;
 
-	/* might not have any data */
-	if (parentnode == nullptr)
-		return;
-
-	/* iterate over coins nodes */
-	for (coinnode = parentnode->get_child("coins"); coinnode; coinnode = coinnode->get_next_sibling("coins"))
+	// iterate over coins nodes
+	for (util::xml::data_node const *coinnode = parentnode->get_child("coins"); coinnode; coinnode = coinnode->get_next_sibling("coins"))
 	{
 		int index = coinnode->get_attribute_int("index", -1);
 		if (index >= 0 && index < COIN_COUNTERS)
 			m_coin_count[index] = coinnode->get_attribute_int("number", 0);
 	}
 
-	/* get the single tickets node */
-	ticketnode = parentnode->get_child("tickets");
-	if (ticketnode != nullptr)
+	// get the single tickets node
+	util::xml::data_node const *const ticketnode = parentnode->get_child("tickets");
+	if (ticketnode)
 		m_dispensed_tickets = ticketnode->get_attribute_int("number", 0);
 }
 
@@ -121,19 +117,17 @@ void bookkeeping_manager::config_load(config_type cfg_type, util::xml::data_node
 
 void bookkeeping_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	int i;
-
-	/* only care about game-specific data */
-	if (cfg_type != config_type::GAME)
+	// only save system-specific data
+	if (cfg_type != config_type::SYSTEM)
 		return;
 
-	/* iterate over coin counters */
-	for (i = 0; i < COIN_COUNTERS; i++)
+	// iterate over coin counters
+	for (int i = 0; i < COIN_COUNTERS; i++)
 	{
 		if (m_coin_count[i] != 0)
 		{
-			util::xml::data_node *coinnode = parentnode->add_child("coins", nullptr);
-			if (coinnode != nullptr)
+			util::xml::data_node *const coinnode = parentnode->add_child("coins", nullptr);
+			if (coinnode)
 			{
 				coinnode->set_attribute_int("index", i);
 				coinnode->set_attribute_int("number", m_coin_count[i]);
@@ -141,11 +135,11 @@ void bookkeeping_manager::config_save(config_type cfg_type, util::xml::data_node
 		}
 	}
 
-	/* output tickets */
+	// output tickets
 	if (m_dispensed_tickets != 0)
 	{
-		util::xml::data_node *tickets = parentnode->add_child("tickets", nullptr);
-		if (tickets != nullptr)
+		util::xml::data_node *const tickets = parentnode->add_child("tickets", nullptr);
+		if (tickets)
 			tickets->set_attribute_int("number", m_dispensed_tickets);
 	}
 }

--- a/src/emu/bookkeeping.h
+++ b/src/emu/bookkeeping.h
@@ -57,7 +57,7 @@ public:
 	// getters
 	running_machine &machine() const { return m_machine; }
 private:
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// internal state

--- a/src/emu/config.cpp
+++ b/src/emu/config.cpp
@@ -39,14 +39,14 @@ configuration_manager::configuration_manager(running_machine &machine)
  *
  *************************************/
 
-void configuration_manager::config_register(const char* nodename, config_load_delegate load, config_save_delegate save)
+void configuration_manager::config_register(const char *nodename, load_delegate load, save_delegate save)
 {
 	config_element element;
 	element.name = nodename;
 	element.load = std::move(load);
 	element.save = std::move(save);
 
-	m_typelist.push_back(element);
+	m_typelist.emplace_back(std::move(element));
 }
 
 
@@ -57,72 +57,69 @@ void configuration_manager::config_register(const char* nodename, config_load_de
  *
  *************************************/
 
-int configuration_manager::load_settings()
+bool configuration_manager::load_settings()
 {
-	const char *controller = machine().options().ctrlr();
-	int loaded = 0;
-
-	/* loop over all registrants and call their init function */
+	// loop over all registrants and call their init function
 	for (const auto &type : m_typelist)
-		type.load(config_type::INIT, nullptr);
+		type.load(config_type::INIT, config_level::DEFAULT, nullptr);
 
-	/* now load the controller file */
-	if (controller[0] != 0)
+	// now load the controller file
+	const char *controller = machine().options().ctrlr();
+	if (controller && *controller)
 	{
-		/* open the config file */
+		// open the config file
 		emu_file file(machine().options().ctrlr_path(), OPEN_FLAG_READ);
-		osd_printf_verbose("Attempting to parse: %s.cfg\n",controller);
+		osd_printf_verbose("Attempting to parse: %s.cfg\n", controller);
 		osd_file::error filerr = file.open(std::string(controller) + ".cfg");
 
 		if (filerr != osd_file::error::NONE)
-			throw emu_fatalerror("Could not load controller file %s.cfg", controller);
+			throw emu_fatalerror("Could not open controller file %s.cfg", controller);
 
-		/* load the XML */
+		// load the XML
 		if (!load_xml(file, config_type::CONTROLLER))
 			throw emu_fatalerror("Could not load controller file %s.cfg", controller);
 	}
 
-	/* next load the defaults file */
+	// next load the defaults file
 	emu_file file(machine().options().cfg_directory(), OPEN_FLAG_READ);
 	osd_file::error filerr = file.open("default.cfg");
 	osd_printf_verbose("Attempting to parse: default.cfg\n");
 	if (filerr == osd_file::error::NONE)
 		load_xml(file, config_type::DEFAULT);
 
-	/* finally, load the game-specific file */
+	// finally, load the game-specific file
 	filerr = file.open(machine().basename() + ".cfg");
 	osd_printf_verbose("Attempting to parse: %s.cfg\n",machine().basename());
-	if (filerr == osd_file::error::NONE)
-		loaded = load_xml(file, config_type::GAME);
+	const bool loaded = (osd_file::error::NONE == filerr) && load_xml(file, config_type::SYSTEM);
 
-	/* loop over all registrants and call their final function */
+	// loop over all registrants and call their final function
 	for (const auto &type : m_typelist)
-		type.load(config_type::FINAL, nullptr);
+		type.load(config_type::FINAL, config_level::DEFAULT, nullptr);
 
-	/* if we didn't find a saved config, return 0 so the main core knows that it */
-	/* is the first time the game is run and it should display the disclaimer. */
+	// if we didn't find a saved config, return false so the main core knows that it
+	// is the first time the game is run and it should display the disclaimer.
 	return loaded;
 }
 
 
 void configuration_manager::save_settings()
 {
-	/* loop over all registrants and call their init function */
+	// loop over all registrants and call their init function
 	for (const auto &type : m_typelist)
 		type.save(config_type::INIT, nullptr);
 
-	/* save the defaults file */
+	// save the defaults file
 	emu_file file(machine().options().cfg_directory(), OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 	osd_file::error filerr = file.open("default.cfg");
 	if (filerr == osd_file::error::NONE)
 		save_xml(file, config_type::DEFAULT);
 
-	/* finally, save the game-specific file */
+	// finally, save the system-specific file
 	filerr = file.open(machine().basename() + ".cfg");
 	if (filerr == osd_file::error::NONE)
-		save_xml(file, config_type::GAME);
+		save_xml(file, config_type::SYSTEM);
 
-	/* loop over all registrants and call their final function */
+	// loop over all registrants and call their final function
 	for (const auto &type : m_typelist)
 		type.save(config_type::FINAL, nullptr);
 }
@@ -135,24 +132,33 @@ void configuration_manager::save_settings()
  *
  *************************************/
 
-int configuration_manager::load_xml(emu_file &file, config_type which_type)
+bool configuration_manager::load_xml(emu_file &file, config_type which_type)
 {
-	/* read the file */
+	// read the file
 	util::xml::file::ptr const root(util::xml::file::read(file, nullptr));
 	if (!root)
-		return 0;
+	{
+		osd_printf_verbose("Error parsing XML configuration file %s\n", file.filename());
+		return false;
+	}
 
-	/* find the config node */
+	// find the config node
 	util::xml::data_node const *const confignode = root->get_child("mameconfig");
 	if (!confignode)
-		return 0;
+	{
+		osd_printf_verbose("Could not find root mameconfig element in configuration file %s\n", file.filename());
+		return false;
+	}
 
-	/* validate the config data version */
+	// validate the config data version
 	int const version = confignode->get_attribute_int("version", 0);
 	if (version != CONFIG_VERSION)
-		return 0;
+	{
+		osd_printf_verbose("Configuration file %s has unsupported version %d\n", file.filename(), version);
+		return false;
+	}
 
-	/* strip off all the path crap from the source filename */
+	// strip off all the path crap from the source filename
 	const char *srcfile = strrchr(machine().system().type.source(), '/');
 	if (!srcfile)
 		srcfile = strrchr(machine().system().type.source(), '\\');
@@ -163,38 +169,67 @@ int configuration_manager::load_xml(emu_file &file, config_type which_type)
 	else
 		srcfile++;
 
-	/* loop over all system nodes in the file */
+	// loop over all system nodes in the file
 	int count = 0;
 	for (util::xml::data_node const *systemnode = confignode->get_child("system"); systemnode; systemnode = systemnode->get_next_sibling("system"))
 	{
-		/* look up the name of the system here; skip if none */
+		// look up the name of the system here; skip if none
 		const char *name = systemnode->get_attribute_string("name", "");
 
-		/* based on the file type, determine whether we have a match */
+		// based on the file type, determine whether we have a match
+		config_level level = config_level::DEFAULT;
 		switch (which_type)
 		{
-		case config_type::GAME:
-			/* only match on the specific game name */
-			if (strcmp(name, machine().system().name) != 0)
+		case config_type::SYSTEM:
+			// only match on the specific system name
+			if (strcmp(name, machine().system().name))
+			{
+				osd_printf_verbose("Ignoring configuration for system %s in system configuration file %s\n", name, file.filename());
 				continue;
+			}
+			level = config_level::SYSTEM;
 			break;
 
 		case config_type::DEFAULT:
-			/* only match on default */
-			if (strcmp(name, "default") != 0)
+			// only match on default
+			if (strcmp(name, "default"))
+			{
+				osd_printf_verbose("Ignoring configuration for system %s in default configuration file %s\n", name, file.filename());
 				continue;
+			}
+			level = config_level::DEFAULT;
 			break;
 
 		case config_type::CONTROLLER:
 			{
+				// match on: default, system name, source file name, parent name, grandparent name
 				int clone_of;
-				/* match on: default, game name, source file name, parent name, grandparent name */
-				if (strcmp(name, "default") != 0 &&
-					strcmp(name, machine().system().name) != 0 &&
-					strcmp(name, srcfile) != 0 &&
-					((clone_of = driver_list::clone(machine().system())) == -1 || strcmp(name, driver_list::driver(clone_of).name) != 0) &&
-					(clone_of == -1 || ((clone_of = driver_list::clone(clone_of)) == -1) || strcmp(name, driver_list::driver(clone_of).name) != 0))
+				if (!strcmp(name, "default"))
+				{
+					osd_printf_verbose("Applying default configuration from controller configuration file %s\n", file.filename());
+					level = config_level::DEFAULT;
+				}
+				else if (!strcmp(name, machine().system().name))
+				{
+					osd_printf_verbose("Applying configuration for system %s from controller configuration file %s\n", name, file.filename());
+					level = config_level::SYSTEM;
+				}
+				else if (!strcmp(name, srcfile))
+				{
+					osd_printf_verbose("Applying configuration for source file %s from controller configuration file %s\n", name, file.filename());
+					level = config_level::SOURCE;
+				}
+				else if (
+						((clone_of = driver_list::clone(machine().system())) != -1 && !strcmp(name, driver_list::driver(clone_of).name)) ||
+						(clone_of != -1 && ((clone_of = driver_list::clone(clone_of)) != -1) && !strcmp(name, driver_list::driver(clone_of).name)))
+				{
+					osd_printf_verbose("Applying configuration for parent/BIOS %s from controller configuration file %s\n", name, file.filename());
+					level = (driver_list::driver(clone_of).flags & MACHINE_IS_BIOS_ROOT) ? config_level::BIOS : config_level::PARENT;
+				}
+				else
+				{
 					continue;
+				}
 				break;
 			}
 
@@ -202,21 +237,18 @@ int configuration_manager::load_xml(emu_file &file, config_type which_type)
 			break;
 		}
 
-		/* log that we are processing this entry */
+		// log that we are processing this entry
 		if (DEBUG_CONFIG)
 			osd_printf_debug("Entry: %s -- processing\n", name);
 
-		/* loop over all registrants and call their load function */
+		// loop over all registrants and call their load function
 		for (const auto &type : m_typelist)
-			type.load(which_type, systemnode->get_child(type.name.c_str()));
+			type.load(which_type, level, systemnode->get_child(type.name.c_str()));
 		count++;
 	}
 
-	/* error if this isn't a valid game match */
-	if (count == 0)
-		return 0;
-
-	return 1;
+	// error if this isn't a valid match
+	return count != 0;
 }
 
 
@@ -227,43 +259,41 @@ int configuration_manager::load_xml(emu_file &file, config_type which_type)
  *
  *************************************/
 
-int configuration_manager::save_xml(emu_file &file, config_type which_type)
+bool configuration_manager::save_xml(emu_file &file, config_type which_type)
 {
+	// if we cant't create a root node, bail
 	util::xml::file::ptr root(util::xml::file::create());
-
-	/* if we don't have a root, bail */
 	if (!root)
-		return 0;
+		return false;
 
-	/* create a config node */
+	// create a config node
 	util::xml::data_node *const confignode = root->add_child("mameconfig", nullptr);
 	if (!confignode)
-		return 0;
+		return false;
 	confignode->set_attribute_int("version", CONFIG_VERSION);
 
-	/* create a system node */
+	// create a system node
 	util::xml::data_node *const systemnode = confignode->add_child("system", nullptr);
 	if (!systemnode)
-		return 0;
+		return false;
 	systemnode->set_attribute("name", (which_type == config_type::DEFAULT) ? "default" : machine().system().name);
 
-	/* create the input node and write it out */
-	/* loop over all registrants and call their save function */
+	// loop over all registrants and call their save function
 	for (const auto &type : m_typelist)
 	{
 		util::xml::data_node *const curnode = systemnode->add_child(type.name.c_str(), nullptr);
 		if (!curnode)
-			return 0;
+			return false;
 		type.save(which_type, curnode);
 
-		/* if nothing was added, just nuke the node */
+		// if nothing was added, just nuke the node
 		if (!curnode->get_value() && !curnode->get_first_child() && !curnode->count_attributes())
 			curnode->delete_node();
 	}
 
-	/* flush the file */
+	// flush the file
 	root->write(file);
 
-	/* free and get out of here */
-	return 1;
+	// free and get out of here
+	return true;
 }

--- a/src/emu/config.h
+++ b/src/emu/config.h
@@ -15,60 +15,58 @@
 
 #include "xmlfile.h"
 
-/*************************************
- *
- *  Constants
- *
- *************************************/
 
-#define CONFIG_VERSION          10
-
-enum class config_type
+enum class config_type : int
 {
-	INIT = 0,       // opportunity to initialize things first
+	INIT,           // opportunity to initialize things first
 	CONTROLLER,     // loading from controller file
 	DEFAULT,        // loading from default.cfg
-	GAME,           // loading from game.cfg
+	SYSTEM,         // loading from system.cfg
 	FINAL           // opportunity to finish initialization
 };
 
-/*************************************
- *
- *  Type definitions
- *
- *************************************/
+enum class config_level : int
+{
+	DEFAULT,
+	SOURCE,
+	BIOS,
+	PARENT,
+	SYSTEM
+};
 
-typedef delegate<void (config_type, util::xml::data_node const *)> config_load_delegate;
-typedef delegate<void (config_type, util::xml::data_node *)> config_save_delegate;
-
-// ======================> configuration_manager
 
 class configuration_manager
 {
-	struct config_element
-	{
-		std::string          name;              // node name
-		config_load_delegate load;              // load callback
-		config_save_delegate save;              // save callback
-	};
-
 public:
+	typedef delegate<void (config_type, config_level, util::xml::data_node const *)> load_delegate;
+	typedef delegate<void (config_type, util::xml::data_node *)> save_delegate;
+
+	static inline constexpr int CONFIG_VERSION = 10;
+
 	// construction/destruction
 	configuration_manager(running_machine &machine);
 
-	void config_register(const char* nodename, config_load_delegate load, config_save_delegate save);
-	int load_settings();
+	void config_register(const char *nodename, load_delegate load, save_delegate save);
+	bool load_settings();
 	void save_settings();
 
 	// getters
 	running_machine &machine() const { return m_machine; }
+
 private:
-	int load_xml(emu_file &file, config_type which_type);
-	int save_xml(emu_file &file, config_type which_type);
+	struct config_element
+	{
+		std::string     name;              // node name
+		load_delegate   load;              // load callback
+		save_delegate   save;              // save callback
+	};
+
+	bool load_xml(emu_file &file, config_type which_type);
+	bool save_xml(emu_file &file, config_type which_type);
 
 	// internal state
 	running_machine &   m_machine;                  // reference to our machine
 	std::vector<config_element> m_typelist;
 };
 
-#endif  /* MAME_EMU_CONFIG_H */
+#endif // MAME_EMU_CONFIG_H

--- a/src/emu/crsshair.cpp
+++ b/src/emu/crsshair.cpp
@@ -248,8 +248,8 @@ void render_crosshair::update_position()
 {
 	// read all the lightgun values
 	bool gotx = false, goty = false;
-	for (auto &port : m_machine.ioport().ports())
-		for (ioport_field &field : port.second->fields())
+	for (auto const &port : m_machine.ioport().ports())
+		for (ioport_field const &field : port.second->fields())
 			if (field.player() == m_player && field.crosshair_axis() != CROSSHAIR_AXIS_NONE && field.enabled())
 			{
 				// handle X axis
@@ -357,7 +357,7 @@ crosshair_manager::crosshair_manager(running_machine &machine)
 
 	/* determine who needs crosshairs */
 	for (auto &port : machine.ioport().ports())
-		for (ioport_field &field : port.second->fields())
+		for (ioport_field const &field : port.second->fields())
 			if (field.crosshair_axis() != CROSSHAIR_AXIS_NONE)
 			{
 				int player = field.player();
@@ -374,7 +374,11 @@ crosshair_manager::crosshair_manager(running_machine &machine)
 
 	/* register callbacks for when we load/save configurations */
 	if (m_usage)
-		machine.configuration().config_register("crosshairs", config_load_delegate(&crosshair_manager::config_load, this), config_save_delegate(&crosshair_manager::config_save, this));
+	{
+		machine.configuration().config_register("crosshairs",
+				configuration_manager::load_delegate(&crosshair_manager::config_load, this),
+				configuration_manager::save_delegate(&crosshair_manager::config_save, this));
+	}
 
 	/* register the animation callback */
 	screen_device *first_screen = screen_device_enumerator(machine.root_device()).first();
@@ -445,19 +449,15 @@ void crosshair_manager::render(screen_device &screen)
     configuration file
 -------------------------------------------------*/
 
-void crosshair_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void crosshair_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	/* Note: crosshair_load() is only registered if croshairs are used */
+	// Note: crosshair_load() is only registered if croshairs are used
 
-	/* we only care about game files */
-	if (cfg_type != config_type::GAME)
+	// we only care about system-specific configuration
+	if ((cfg_type != config_type::SYSTEM) || !parentnode)
 		return;
 
-	/* might not have any data */
-	if (parentnode == nullptr)
-		return;
-
-	/* loop and get player crosshair info */
+	// loop and get player crosshair info
 	for (util::xml::data_node const *crosshairnode = parentnode->get_child("crosshair"); crosshairnode; crosshairnode = crosshairnode->get_next_sibling("crosshair"))
 	{
 		int const player = crosshairnode->get_attribute_int("player", -1);
@@ -474,8 +474,7 @@ void crosshair_manager::config_load(config_type cfg_type, util::xml::data_node c
 				if (mode >= CROSSHAIR_VISIBILITY_OFF && mode <= CROSSHAIR_VISIBILITY_AUTO)
 				{
 					crosshair.set_mode(u8(mode));
-					/* set visibility as specified by mode */
-					/* auto mode starts with visibility off */
+					// set visibility as specified by mode - auto mode starts with visibility off
 					crosshair.set_visible(mode == CROSSHAIR_VISIBILITY_ON);
 				}
 
@@ -485,7 +484,7 @@ void crosshair_manager::config_load(config_type cfg_type, util::xml::data_node c
 		}
 	}
 
-	/* get, check, and store auto visibility time */
+	// get, check, and store auto visibility time
 	util::xml::data_node const *crosshairnode = parentnode->get_child("autotime");
 	if (crosshairnode)
 	{
@@ -503,10 +502,10 @@ void crosshair_manager::config_load(config_type cfg_type, util::xml::data_node c
 
 void crosshair_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	/* Note: crosshair_save() is only registered if crosshairs are used */
+	// Note: crosshair_save() is only registered if crosshairs are used
 
-	/* we only care about game files */
-	if (cfg_type != config_type::GAME)
+	// we only create system-specific configuration
+	if (cfg_type != config_type::SYSTEM)
 		return;
 
 	for (int player = 0; player < MAX_PLAYERS; player++)
@@ -515,7 +514,7 @@ void crosshair_manager::config_save(config_type cfg_type, util::xml::data_node *
 
 		if (crosshair.is_used())
 		{
-			/* create a node */
+			// create a node
 			util::xml::data_node *const crosshairnode = parentnode->add_child("crosshair", nullptr);
 
 			if (crosshairnode != nullptr)
@@ -537,20 +536,19 @@ void crosshair_manager::config_save(config_type cfg_type, util::xml::data_node *
 					changed = true;
 				}
 
-				/* if nothing changed, kill the node */
+				// if nothing changed, kill the node
 				if (!changed)
 					crosshairnode->delete_node();
 			}
 		}
 	}
 
-	/* always store autotime so that it stays at the user value if it is needed */
+	// always store autotime so that it stays at the user value if it is needed
 	if (m_auto_time != CROSSHAIR_VISIBILITY_AUTOTIME_DEFAULT)
 	{
-		/* create a node */
+		// create a node
 		util::xml::data_node *const crosshairnode = parentnode->add_child("autotime", nullptr);
-
-		if (crosshairnode != nullptr)
+		if (crosshairnode)
 			crosshairnode->set_attribute_int("val", m_auto_time);
 	}
 

--- a/src/emu/crsshair.h
+++ b/src/emu/crsshair.h
@@ -118,7 +118,7 @@ private:
 	void exit();
 	void animate(screen_device &device, bool vblank_state);
 
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_lvl, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// internal state

--- a/src/emu/emufwd.h
+++ b/src/emu/emufwd.h
@@ -69,7 +69,8 @@ class address_map_entry;
 class bookkeeping_manager;
 
 // declared in config.h
-enum class config_type;
+enum class config_type : int;
+enum class config_level : int;
 class configuration_manager;
 
 // declared in crsshair.h

--- a/src/emu/image.cpp
+++ b/src/emu/image.cpp
@@ -86,7 +86,10 @@ image_manager::image_manager(running_machine &machine)
 		}
 	}
 
-	machine.configuration().config_register("image_directories", config_load_delegate(&image_manager::config_load, this), config_save_delegate(&image_manager::config_save, this));
+	machine.configuration().config_register(
+			"image_directories",
+			configuration_manager::load_delegate(&image_manager::config_load, this),
+			configuration_manager::save_delegate(&image_manager::config_save, this));
 }
 
 //-------------------------------------------------
@@ -105,9 +108,9 @@ void image_manager::unload_all()
 	}
 }
 
-void image_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void image_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	if ((cfg_type == config_type::GAME) && (parentnode != nullptr))
+	if ((cfg_type == config_type::SYSTEM) && parentnode)
 	{
 		for (util::xml::data_node const *node = parentnode->get_child("device"); node; node = node->get_next_sibling("device"))
 		{
@@ -136,8 +139,8 @@ void image_manager::config_load(config_type cfg_type, util::xml::data_node const
 
 void image_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	/* only care about game-specific data */
-	if (cfg_type == config_type::GAME)
+	// only save system-specific data
+	if (cfg_type == config_type::SYSTEM)
 	{
 		for (device_image_interface &image : image_interface_enumerator(machine().root_device()))
 		{

--- a/src/emu/image.h
+++ b/src/emu/image.h
@@ -30,7 +30,7 @@ public:
 	std::string setup_working_directory();
 
 private:
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	void options_extract();

--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -1313,15 +1313,12 @@ void input_manager::seq_from_tokens(input_seq &seq, std::string_view string)
 //  controller based on device map table
 //-------------------------------------------------
 
-bool input_manager::map_device_to_controller(const devicemap_table_type *devicemap_table)
+bool input_manager::map_device_to_controller(const devicemap_table_type &devicemap_table)
 {
-	if (nullptr == devicemap_table)
-		return true;
-
-	for (devicemap_table_type::const_iterator it = devicemap_table->begin(); it != devicemap_table->end(); it++)
+	for (const auto &it : devicemap_table)
 	{
-		std::string_view deviceid = it->first;
-		std::string_view controllername = it->second;
+		std::string_view deviceid = it.first;
+		std::string_view controllername = it.second;
 
 		// tokenize the controller name into device class and index (i.e. controller name should be of the form "GUNCODE_1")
 		std::string token[2];
@@ -1360,7 +1357,7 @@ bool input_manager::map_device_to_controller(const devicemap_table_type *devicem
 		for (int devnum = 0; devnum <= input_devclass->maxindex(); devnum++)
 		{
 			input_device *device = input_devclass->device(devnum);
-			if (device != nullptr && device->match_device_id(deviceid))
+			if (device && device->match_device_id(deviceid))
 			{
 				// remap devindex
 				input_devclass->remap_device_index(device->devindex(), devindex);

--- a/src/emu/input.h
+++ b/src/emu/input.h
@@ -526,7 +526,7 @@ public:
 	void seq_from_tokens(input_seq &seq, std::string_view _token);
 
 	// misc
-	bool map_device_to_controller(const devicemap_table_type *devicemap_table = nullptr);
+	bool map_device_to_controller(const devicemap_table_type &devicemap_table);
 
 private:
 	// internal helpers

--- a/src/emu/network.cpp
+++ b/src/emu/network.cpp
@@ -26,7 +26,10 @@
 network_manager::network_manager(running_machine &machine)
 	: m_machine(machine)
 {
-	machine.configuration().config_register("network", config_load_delegate(&network_manager::config_load, this), config_save_delegate(&network_manager::config_save, this));
+	machine.configuration().config_register(
+			"network",
+			configuration_manager::load_delegate(&network_manager::config_load, this),
+			configuration_manager::save_delegate(&network_manager::config_save, this));
 }
 
 //-------------------------------------------------
@@ -34,9 +37,9 @@ network_manager::network_manager(running_machine &machine)
 //  configuration file
 //-------------------------------------------------
 
-void network_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void network_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	if ((cfg_type == config_type::GAME) && (parentnode != nullptr))
+	if ((cfg_type == config_type::SYSTEM) && parentnode)
 	{
 		for (util::xml::data_node const *node = parentnode->get_child("device"); node; node = node->get_next_sibling("device"))
 		{
@@ -71,13 +74,13 @@ void network_manager::config_load(config_type cfg_type, util::xml::data_node con
 
 void network_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	/* only care about game-specific data */
-	if (cfg_type == config_type::GAME)
+	// only save about system-specific data
+	if (cfg_type == config_type::SYSTEM)
 	{
 		for (device_network_interface &network : network_interface_enumerator(machine().root_device()))
 		{
 			util::xml::data_node *const node = parentnode->add_child("device", nullptr);
-			if (node != nullptr)
+			if (node)
 			{
 				node->set_attribute("tag", network.device().tag());
 				node->set_attribute_int("interface", network.get_interface());

--- a/src/emu/network.h
+++ b/src/emu/network.h
@@ -23,7 +23,7 @@ public:
 	// getters
 	running_machine &machine() const { return m_machine; }
 private:
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_lvl, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// internal state

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -3057,7 +3057,10 @@ render_manager::render_manager(running_machine &machine)
 	, m_ui_container(new render_container(*this))
 {
 	// register callbacks
-	machine.configuration().config_register("video", config_load_delegate(&render_manager::config_load, this), config_save_delegate(&render_manager::config_save, this));
+	machine.configuration().config_register(
+			"video",
+			configuration_manager::load_delegate(&render_manager::config_load, this),
+			configuration_manager::save_delegate(&render_manager::config_save, this));
 
 	// create one container per screen
 	for (screen_device &screen : screen_device_enumerator(machine.root_device()))
@@ -3312,10 +3315,10 @@ void render_manager::container_free(render_container *container)
 //  configuration file
 //-------------------------------------------------
 
-void render_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void render_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	// we only care about game files with matching nodes
-	if ((cfg_type != config_type::GAME) || !parentnode)
+	// we only care about system-specific configuration with matching nodes
+	if ((cfg_type != config_type::SYSTEM) || !parentnode)
 		return;
 
 	// check the UI target
@@ -3368,8 +3371,8 @@ void render_manager::config_load(config_type cfg_type, util::xml::data_node cons
 
 void render_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	// we only care about game files
-	if (cfg_type != config_type::GAME)
+	// we only save system-specific configuration
+	if (cfg_type != config_type::SYSTEM)
 		return;
 
 	// write out the interface target

--- a/src/emu/render.h
+++ b/src/emu/render.h
@@ -701,7 +701,7 @@ private:
 	void container_free(render_container *container);
 
 	// config callbacks
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_lvl, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// internal state

--- a/src/emu/rendlay.cpp
+++ b/src/emu/rendlay.cpp
@@ -4659,7 +4659,7 @@ void layout_view::item::resolve_tags()
 		if (m_input_port)
 		{
 			// if there's a matching unconditional field, cache it
-			for (ioport_field &field : m_input_port->fields())
+			for (ioport_field const &field : m_input_port->fields())
 			{
 				if (field.mask() & m_input_mask)
 				{

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -1090,7 +1090,10 @@ sound_manager::sound_manager(running_machine &machine) :
 #endif
 
 	// register callbacks
-	machine.configuration().config_register("mixer", config_load_delegate(&sound_manager::config_load, this), config_save_delegate(&sound_manager::config_save, this));
+	machine.configuration().config_register(
+			"mixer",
+			configuration_manager::load_delegate(&sound_manager::config_load, this),
+			configuration_manager::save_delegate(&sound_manager::config_save, this));
 	machine.add_notifier(MACHINE_NOTIFY_PAUSE, machine_notify_delegate(&sound_manager::pause, this));
 	machine.add_notifier(MACHINE_NOTIFY_RESUME, machine_notify_delegate(&sound_manager::resume, this));
 	machine.add_notifier(MACHINE_NOTIFY_RESET, machine_notify_delegate(&sound_manager::reset, this));
@@ -1356,14 +1359,10 @@ void sound_manager::resume()
 //  configuration file
 //-------------------------------------------------
 
-void sound_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void sound_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	// we only care about game files
-	if (cfg_type != config_type::GAME)
-		return;
-
-	// might not have any data
-	if (parentnode == nullptr)
+	// we only care system-specific configuration
+	if ((cfg_type != config_type::SYSTEM) || !parentnode)
 		return;
 
 	// iterate over channel nodes
@@ -1388,29 +1387,28 @@ void sound_manager::config_load(config_type cfg_type, util::xml::data_node const
 
 void sound_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
-	// we only care about game files
-	if (cfg_type != config_type::GAME)
+	// we only save system-specific configuration
+	if (cfg_type != config_type::SYSTEM)
 		return;
 
 	// iterate over mixer channels
-	if (parentnode != nullptr)
-		for (int mixernum = 0; ; mixernum++)
-		{
-			mixer_input info;
-			if (!indexed_mixer_input(mixernum, info))
-				break;
-			float newvol = info.stream->input(info.inputnum).user_gain();
+	for (int mixernum = 0; ; mixernum++)
+	{
+		mixer_input info;
+		if (!indexed_mixer_input(mixernum, info))
+			break;
 
-			if (newvol != 1.0f)
+		float const newvol = info.stream->input(info.inputnum).user_gain();
+		if (newvol != 1.0f)
+		{
+			util::xml::data_node *const channelnode = parentnode->add_child("channel", nullptr);
+			if (channelnode)
 			{
-				util::xml::data_node *const channelnode = parentnode->add_child("channel", nullptr);
-				if (channelnode != nullptr)
-				{
-					channelnode->set_attribute_int("index", mixernum);
-					channelnode->set_attribute_float("newvol", newvol);
-				}
+				channelnode->set_attribute_int("index", mixernum);
+				channelnode->set_attribute_float("newvol", newvol);
 			}
 		}
+	}
 }
 
 

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -808,7 +808,7 @@ private:
 	void resume();
 
 	// handle configuration load/save
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_lvl, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 
 	// helper to adjust scale factor toward a goal

--- a/src/emu/validity.h
+++ b/src/emu/validity.h
@@ -74,9 +74,9 @@ private:
 	void validate_rgb();
 	void validate_driver(device_t &root);
 	void validate_roms(device_t &root);
-	void validate_analog_input_field(ioport_field &field);
-	void validate_dip_settings(ioport_field &field);
-	void validate_condition(ioport_condition &condition, device_t &device);
+	void validate_analog_input_field(const ioport_field &field);
+	void validate_dip_settings(const ioport_field &field);
+	void validate_condition(const ioport_condition &condition, device_t &device);
 	void validate_inputs(device_t &root);
 	void validate_devices(machine_config &config);
 	void validate_device_types();

--- a/src/frontend/mame/infoxml.cpp
+++ b/src/frontend/mame/infoxml.cpp
@@ -548,7 +548,7 @@ void output_header(std::ostream &out, bool dtd)
 			"\" mameconfig=\"%d\">\n",
 			XML_ROOT,
 			normalize_string(emulator_info::get_build_version()),
-			CONFIG_VERSION);
+			configuration_manager::CONFIG_VERSION);
 }
 
 
@@ -1269,7 +1269,7 @@ void output_input(std::ostream &out, const ioport_list &portlist)
 	{
 		int ctrl_type = CTRL_DIGITAL_BUTTONS;
 		bool ctrl_analog = false;
-		for (ioport_field &field : port.second->fields())
+		for (ioport_field const &field : port.second->fields())
 		{
 			// track the highest player number
 			if (nplayer < field.player() + 1)

--- a/src/frontend/mame/luaengine_input.cpp
+++ b/src/frontend/mame/luaengine_input.cpp
@@ -334,7 +334,7 @@ void lua_engine::initialize_input(sol::table &emu)
 			[this] (ioport_field &f)
 			{
 				sol::table result = sol().create_table();
-				for (ioport_setting &setting : f.settings())
+				for (ioport_setting const &setting : f.settings())
 					if (setting.enabled())
 						result[setting.value()] = setting.name();
 				return result;

--- a/src/frontend/mame/ui/devopt.cpp
+++ b/src/frontend/mame/ui/devopt.cpp
@@ -221,7 +221,7 @@ void menu_device_config::populate(float &customtop, float &custombottom)
 			{
 				dips++;
 				bool def(false);
-				for (ioport_setting &setting : field.settings())
+				for (ioport_setting const &setting : field.settings())
 				{
 					if (setting.value() == field.defvalue())
 					{
@@ -237,7 +237,7 @@ void menu_device_config::populate(float &customtop, float &custombottom)
 			{
 				confs++;
 				bool def(false);
-				for (ioport_setting &setting : field.settings())
+				for (ioport_setting const &setting : field.settings())
 				{
 					if (setting.value() == field.defvalue())
 					{

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -218,8 +218,8 @@ void mame_ui_manager::init()
 	machine().add_notifier(MACHINE_NOTIFY_EXIT, machine_notify_delegate(&mame_ui_manager::exit, this));
 	machine().configuration().config_register(
 			"ui_warnings",
-			config_load_delegate(&mame_ui_manager::config_load, this),
-			config_save_delegate(&mame_ui_manager::config_save, this));
+			configuration_manager::load_delegate(&mame_ui_manager::config_load, this),
+			configuration_manager::save_delegate(&mame_ui_manager::config_save, this));
 
 	// create mouse bitmap
 	uint32_t *dst = &m_mouse_bitmap.pix(0);
@@ -258,10 +258,10 @@ void mame_ui_manager::exit()
 //  config_load - load configuration data
 //-------------------------------------------------
 
-void mame_ui_manager::config_load(config_type cfg_type, util::xml::data_node const *parentnode)
+void mame_ui_manager::config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
 	// make sure it's relevant and there's data available
-	if (config_type::GAME == cfg_type)
+	if (config_type::SYSTEM == cfg_type)
 	{
 		m_unemulated_features.clear();
 		m_imperfect_features.clear();
@@ -302,7 +302,7 @@ void mame_ui_manager::config_load(config_type cfg_type, util::xml::data_node con
 void mame_ui_manager::config_save(config_type cfg_type, util::xml::data_node *parentnode)
 {
 	// only save system-level configuration when times are valid
-	if ((config_type::GAME == cfg_type) && (std::time_t(-1) != m_last_launch_time) && (std::time_t(-1) != m_last_warning_time))
+	if ((config_type::SYSTEM == cfg_type) && (std::time_t(-1) != m_last_launch_time) && (std::time_t(-1) != m_last_warning_time))
 	{
 		parentnode->set_attribute_int("launched", static_cast<long long>(m_last_launch_time));
 		parentnode->set_attribute_int("warned", static_cast<long long>(m_last_warning_time));

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -257,7 +257,7 @@ private:
 
 	// private methods
 	void exit();
-	void config_load(config_type cfg_type, util::xml::data_node const *parentnode);
+	void config_load(config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode);
 	void config_save(config_type cfg_type, util::xml::data_node *parentnode);
 	template <typename... Params> void slider_alloc(Params &&...args) { m_sliders.push_back(std::make_unique<slider_state>(std::forward<Params>(args)...)); }
 

--- a/src/lib/util/unicode.cpp
+++ b/src/lib/util/unicode.cpp
@@ -281,18 +281,21 @@ int uchar_from_utf16f(char32_t *uchar, const char16_t *utf16char, size_t count)
 //  into a Unicode string
 //-------------------------------------------------
 
-std::u32string ustr_from_utf8(const std::string &utf8str)
+std::u32string ustr_from_utf8(std::string_view utf8str)
 {
 	std::u32string result;
-	char const *utf8char(utf8str.c_str());
-	size_t remaining(utf8str.length());
-	while (remaining)
+	if (!utf8str.empty())
 	{
-		char32_t ch;
-		int const consumed(uchar_from_utf8(&ch, utf8char, remaining));
-		result.append(1, (consumed > 0) ? ch : char32_t(0x00fffdU));
-		utf8char += (consumed > 0) ? consumed : 1;
-		remaining -= (consumed > 0) ? consumed : 1;
+		char const *utf8char(&utf8str[0]);
+		auto remaining(utf8str.length());
+		while (remaining)
+		{
+			char32_t ch;
+			int const consumed(uchar_from_utf8(&ch, utf8char, remaining));
+			result.append(1, (consumed > 0) ? ch : char32_t(0x00fffdU));
+			utf8char += (consumed > 0) ? consumed : 1;
+			remaining -= (consumed > 0) ? consumed : 1;
+		}
 	}
 	return result;
 }
@@ -477,17 +480,6 @@ std::string utf8_from_wstring(const std::wstring &string)
 	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
 	return converter.to_bytes(string);
 #endif
-}
-
-
-//-------------------------------------------------
-//  normalize_unicode - uses utf8proc to normalize
-//  unicode
-//-------------------------------------------------
-
-std::string normalize_unicode(const std::string &s, unicode_normalization_form normalization_form, bool fold_case)
-{
-	return internal_normalize_unicode(s.c_str(), s.length(), normalization_form, fold_case, false);
 }
 
 

--- a/src/lib/util/unicode.h
+++ b/src/lib/util/unicode.h
@@ -59,7 +59,7 @@ int uchar_from_utf8(char32_t *uchar, const char *utf8char, size_t count);
 int uchar_from_utf8(char32_t *uchar, std::string_view utf8str);
 int uchar_from_utf16(char32_t *uchar, const char16_t *utf16char, size_t count);
 int uchar_from_utf16f(char32_t *uchar, const char16_t *utf16char, size_t count);
-std::u32string ustr_from_utf8(const std::string &utf8str);
+std::u32string ustr_from_utf8(std::string_view utf8str);
 
 // converting 32-bit Unicode chars to strings
 int utf8_from_uchar(char *utf8string, size_t count, char32_t uchar);
@@ -72,7 +72,6 @@ std::wstring wstring_from_utf8(const std::string &utf8string);
 std::string utf8_from_wstring(const std::wstring &string);
 
 // unicode normalization
-std::string normalize_unicode(const std::string &s, unicode_normalization_form normalization_form, bool fold_case = false);
 std::string normalize_unicode(const char *s, unicode_normalization_form normalization_form, bool fold_case = false);
 std::string normalize_unicode(std::string_view s, unicode_normalization_form normalization_form, bool fold_case = false);
 

--- a/src/osd/modules/debugger/debugosx.mm
+++ b/src/osd/modules/debugger/debugosx.mm
@@ -71,7 +71,7 @@ public:
 private:
 	void create_console();
 	void build_menus();
-	void config_load(config_type cfgtype, util::xml::data_node const *parentnode);
+	void config_load(config_type cfgtype, config_level cfglevel, util::xml::data_node const *parentnode);
 	void config_save(config_type cfgtype, util::xml::data_node *parentnode);
 
 	running_machine *m_machine;
@@ -129,8 +129,8 @@ void debugger_osx::init_debugger(running_machine &machine)
 	m_machine = &machine;
 	machine.configuration().config_register(
 			"debugger",
-			config_load_delegate(&debugger_osx::config_load, this),
-			config_save_delegate(&debugger_osx::config_save, this));
+			configuration_manager::load_delegate(&debugger_osx::config_load, this),
+			configuration_manager::save_delegate(&debugger_osx::config_save, this));
 }
 
 
@@ -305,9 +305,9 @@ void debugger_osx::build_menus()
 //  restore state based on configuration XML
 //============================================================
 
-void debugger_osx::config_load(config_type cfgtype, util::xml::data_node const *parentnode)
+void debugger_osx::config_load(config_type cfgtype, config_level cfglevel, util::xml::data_node const *parentnode)
 {
-	if ((config_type::GAME == cfgtype) && parentnode)
+	if ((config_type::SYSTEM == cfgtype) && parentnode)
 	{
 		if (m_console)
 		{
@@ -331,7 +331,7 @@ void debugger_osx::config_load(config_type cfgtype, util::xml::data_node const *
 
 void debugger_osx::config_save(config_type cfgtype, util::xml::data_node *parentnode)
 {
-	if ((config_type::GAME == cfgtype) && m_console)
+	if ((config_type::SYSTEM == cfgtype) && m_console)
 	{
 		NSAutoreleasePool *const pool = [[NSAutoreleasePool alloc] init];
 		NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:[NSValue valueWithPointer:m_machine],

--- a/src/osd/modules/debugger/debugqt.cpp
+++ b/src/osd/modules/debugger/debugqt.cpp
@@ -79,21 +79,17 @@ MainWindow *mainQtWindow = nullptr;
 std::vector<std::unique_ptr<WindowQtConfig> > xmlConfigurations;
 
 
-void xml_configuration_load(running_machine &machine, config_type cfg_type, util::xml::data_node const *parentnode)
+void xml_configuration_load(running_machine &machine, config_type cfg_type, config_level cfg_level, util::xml::data_node const *parentnode)
 {
-	// We only care about game files
-	if (cfg_type != config_type::GAME)
-		return;
-
-	// Might not have any data
-	if (!parentnode)
+	// We only care about system configuration files
+	if ((cfg_type != config_type::SYSTEM) || !parentnode)
 		return;
 
 	xmlConfigurations.clear();
 
 	// Configuration load
 	util::xml::data_node const *wnode = nullptr;
-	for (wnode = parentnode->get_child("window"); wnode != nullptr; wnode = wnode->get_next_sibling("window"))
+	for (wnode = parentnode->get_child("window"); wnode; wnode = wnode->get_next_sibling("window"))
 	{
 		WindowQtConfig::WindowType type = (WindowQtConfig::WindowType)wnode->get_attribute_int("type", WindowQtConfig::WIN_TYPE_UNKNOWN);
 		switch (type)
@@ -114,8 +110,8 @@ void xml_configuration_load(running_machine &machine, config_type cfg_type, util
 
 void xml_configuration_save(running_machine &machine, config_type cfg_type, util::xml::data_node *parentnode)
 {
-	// We only write to game configurations
-	if (cfg_type != config_type::GAME)
+	// We only save system configuration
+	if (cfg_type != config_type::SYSTEM)
 		return;
 
 	for (int i = 0; i < xmlConfigurations.size(); i++)
@@ -269,8 +265,8 @@ void debug_qt::init_debugger(running_machine &machine)
 	m_machine = &machine;
 	// Setup the configuration XML saving and loading
 	machine.configuration().config_register("debugger",
-			config_load_delegate(&xml_configuration_load, &machine),
-			config_save_delegate(&xml_configuration_save, &machine));
+			configuration_manager::load_delegate(&xml_configuration_load, &machine),
+			configuration_manager::save_delegate(&xml_configuration_save, &machine));
 }
 
 


### PR DESCRIPTION
emu/ioport.cpp: Allow controller files to override input sequences for inputs that don't use defaults, and to override the toggle setting for digital inputs.

emu/config.cpp: Expose configuration level (mostly matters for controller files), improved verbose diagnostic messages, and moved a few things out of the global and preprocessor namespaces.

docs: Added documentation for some controller configuration file features.  The device mapping feature documentation will be merged in at some point.

util/unicode.cpp, emu/input.cpp: API cleanups.