### PR TITLE
nes.xml: SMB2 FDS bootleg (and related PCB) additions/clean-up.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -66575,7 +66575,8 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		<publisher>Kaiser</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="ks7032" />
-			<feature name="pcb" value="UNL-KS7032" />
+			<feature name="pcb" value="KAISER-KS7032" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="131072">
 				<rom name="bubble bobble (fds conversion) (unl) [u].prg" size="131072" crc="96defabe" sha1="98b78ec4bc3e166642e536bb84476ba4591868ad" offset="00000" status="baddump" />
 			</dataarea>
@@ -66688,6 +66689,23 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 			<feature name="pcb" value="KAISER-KS7016" />
 			<dataarea name="prg" size="131072">
 				<rom name="exciting basket (fds conversion)[u].prg" size="131072" crc="6aa23323" sha1="3fb2ef872b2c18ce5b39c478d6bfd8084bb07f25" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="exsoccer">
+		<description>Exciting Soccer - Konami Cup (Asia, FDS conversion)</description>
+		<year>19??</year>
+		<publisher>Kaiser</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="ks7032" />
+			<feature name="pcb" value="KAISER-KS7032" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="131072">
+				<rom name="exciting soccer konami cup (kaiser).prg" size="131072" crc="4b8992a5" sha1="2d1d73caf83bc5e27240dda886004d3ed91732e6" status="baddump" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -66904,23 +66922,6 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="mrmary2" cloneof="smb2fds" supported="no">
-		<description>Mr. Mary 2 (Asia)</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="smb2j" />
-			<feature name="pcb" value="BTL-SMB2C" />
-			<feature name="mirroring" value="vertical" />
-			<dataarea name="prg" size="81920">
-				<rom name="mr mary 2 (asia).prg" size="81920" crc="756631b2" sha1="1a9f31844d0d2780ddcde06b6883f6138fa9daba" offset="00000" status="baddump" />
-			</dataarea>
-			<!-- 8k VRAM on cartridge -->
-			<dataarea name="vram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="nazomfds" supported="no">
 		<description>Nazo no Murasamejou (Asia, FDS conversion)</description>
 		<year>19??</year>
@@ -66956,40 +66957,6 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 			</dataarea>
 			<dataarea name="prg" size="32768">
 				<rom name="prowres (fds conversion, le05 simplified)(unl)[u].prg" size="32768" crc="7d219257" sha1="d46a9d1752204069cb4e0cc04338b5aa4ca54568" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smb2lf" cloneof="smb2fds">
-		<description>Super Mario Bros. 2 (LF36)</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="smb2j" />
-			<feature name="pcb" value="BTL-SMB2C" />
-			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="8192">
-				<rom name="super mario bros. 2 (j) (lf36).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="81920">
-				<rom name="super mario bros. 2 (j) (lf36).prg" size="81920" crc="25e0b714" sha1="7e7711b911f10b4ef325b7b25a770e1de188fe27" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smb2k" cloneof="smb2fds">
-		<description>Super Mario Bros. 2 (Kaiser)</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="ks7032" />
-			<feature name="pcb" value="UNL-KS7032" />
-			<feature name="mirroring" value="vertical" />
-			<dataarea name="prg" size="131072">
-				<rom name="super mario bros. 2 (j) (kaiser).prg" size="131072" crc="281326ed" sha1="dc8ddb78cbb575623b701954df951f05e81388ea" offset="00000" status="baddump" />
-			</dataarea>
-			<!-- 8k VRAM on cartridge -->
-			<dataarea name="vram" size="8192">
 			</dataarea>
 		</part>
 	</software>
@@ -67074,33 +67041,53 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="smb2fdsa" cloneof="smb2fds">
-		<description>Super Mario Bros. 2 (FDS conversion)</description>
+	<software name="smb2fds">
+		<description>Super Mario Bros. 2 (LF36)</description>
 		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
+		<publisher>Whirlwind Manu</publisher>
+		<info name="serial" value="LF36"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="smb2ja" />
+			<feature name="slot" value="smb2ja" /> <!-- mapper 40 -->
+			<feature name="pcb" value="BTL-SMB2A" />
+			<feature name="pcb_model" value="2722" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="65536">
+				<rom name="super mario bros. 2 (2722).prg" size="65536" crc="7be76daf" sha1="f49bf2ccdc810c6d2979b6f9d9621f01936f79a9" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="super mario bros. 2 (2722).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="smb2fdsa" cloneof="smb2fds">
+		<description>Super Mario Bros. II+ (Hey Sung)</description>
+		<year>19??</year>
+		<publisher>Hey Sung</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="smb2ja" /> <!-- mapper 40 -->
 			<feature name="pcb" value="BTL-SMB2A" />
 			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="8192">
-				<rom name="super mario bros 2 (lost levels) (unl).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
-			</dataarea>
 			<dataarea name="prg" size="65536">
-				<rom name="super mario bros 2 (lost levels) (unl).prg" size="65536" crc="bead254c" sha1="167e2b9629edefadea54564accaeceb4c08afc55" offset="00000" status="baddump" />
+				<rom name="super mario bros. 2 (hey sung).prg" size="65536" crc="bead254c" sha1="167e2b9629edefadea54564accaeceb4c08afc55" offset="00000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="super mario bros. 2 (hey sung).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
 
 	<software name="smb2fdsb" cloneof="smb2fds">
-		<description>Super Mario Bros. 2 (FDS conversion, Alt PCB)</description>
+		<description>Super Mario Bros. 2 (N-32)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="smb2jb" />
+			<feature name="slot" value="smb2jb" /> <!-- mapper 50 -->
 			<feature name="pcb" value="BTL-SMB2B" />
+			<feature name="pcb_model" value="761214" />
 			<feature name="mirroring" value="vertical" />
 			<dataarea name="prg" size="131072">
-				<rom name="super mario bros. (alt levels).prg" size="131072" crc="313491ed" sha1="0ffe5aa3fbee72601bd629849a30379937d170d7" offset="00000" status="baddump" />
+				<rom name="super mario bros. 2 (n-32).prg" size="131072" crc="313491ed" sha1="0ffe5aa3fbee72601bd629849a30379937d170d7" offset="00000" status="baddump" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -67108,20 +67095,123 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="smb2fdsd" cloneof="smb2fds" supported="no">
-		<description>Super Mario Bros. 2 (FDS conversion, Alt PCB 2)</description>
+	<software name="smb2fdsc" cloneof="smb2fds">
+		<description>Super Mario Bros. 2 (TONY-I)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="09034a" />
+			<feature name="slot" value="smb2j" /> <!-- mapper 43 -->
+			<feature name="pcb" value="BTL-SMB2J" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="81920">
+				<rom name="super mario bros. 2 (tony-i).prg0" size="32768" crc="c7b95575" sha1="e04e13d59a4fbf0aad62c89e294db4da9f3e6525" offset="0x00000" status="baddump" />
+				<rom name="super mario bros. 2 (tony-i).prg1" size="32768" crc="854c6b6a" sha1="75b2262812bf13d1b5d261a024fdbbe00ae61e15" offset="0x08000" status="baddump" />
+				<rom name="super mario bros. 2 (tony-i).prg2" size="2048" crc="0159a2a3" sha1="b6524a11dbd3509f249a61080674528b971d4c20" offset="0x10000" status="baddump" />
+				<rom size="2048" offset="0x10800" loadflag="reload" />
+				<rom size="2048" offset="0x11000" loadflag="reload" />
+				<rom size="2048" offset="0x11800" loadflag="reload" />
+				<rom name="super mario bros. 2 (tony-i).prg3" size="8192" crc="c54c6d7c" sha1="88eb8d11e702827458f94f9e498df8dcd31ef519" offset="0x12000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="super mario bros. 2 (tony-i).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- TODO: This dump needs PRG split into 32K + 32K + 2K (repeated like TONY-I above) + 8K. This is either a rom hack of YS-612 or there exist two pirate variants, as the PRG binary blob seems to have four different pages for the 2K page? -->
+	<software name="smb2fdsd" cloneof="smb2fds">
+		<description>Super Mario Bros. 2 (YS-612)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="smb2j" /> <!-- mapper 43 -->
+			<feature name="pcb" value="BTL-SMB2J" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="81920">
+				<rom name="super mario bros. 2 (ys-612).prg" size="81920" crc="25e0b714" sha1="7e7711b911f10b4ef325b7b25a770e1de188fe27" offset="00000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="super mario bros. 2 (ys-612).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- Whirlwind Manu has at least two version: LE10 and LF36. This earlier version apparently hangs at the end of world 4-4 on real hardware. -->
+	<software name="smb2fdse" cloneof="smb2fds" supported="no">
+		<description>Super Mario Bros. 2 (LE10)</description>
+		<year>19??</year>
+		<publisher>Whirlwind Manu</publisher>
+		<info name="serial" value="LE10"/>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="09034a" /> <!-- mapper 304 -->
 			<feature name="pcb" value="UNL-SMB2J" />
 			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="8192">
-				<rom name="super mario bros. 2j (alt)(unl)[u].chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
-			</dataarea>
 			<dataarea name="prg" size="40960">
-				<rom name="super mario bros. 2j (alt)(unl)[u].prg0" size="32768" crc="2aa304c9" sha1="8ba24400812ab6716158b65ee1905ab82157d8b3" offset="0x0000" status="baddump" />
-				<rom name="super mario bros. 2j (alt)(unl)[u].prg1" size="8192" crc="18c8e2e7" sha1="69837df1a8f0980d57430f2b9c0eecef9bedf2b3" offset="0x8000" status="baddump" />
+				<rom name="super mario bros. 2 (le10).prg0" size="32768" crc="2aa304c9" sha1="8ba24400812ab6716158b65ee1905ab82157d8b3" offset="0x0000" status="baddump" />
+				<rom name="super mario bros. 2 (le10).prg1" size="8192" crc="18c8e2e7" sha1="69837df1a8f0980d57430f2b9c0eecef9bedf2b3" offset="0x8000" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="super mario bros. 2 (le10).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="smb2fdsk" cloneof="smb2fds">
+		<description>Super Mario Bros. 2 (Kaiser)</description>
+		<year>19??</year>
+		<publisher>Kaiser</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="ks7032" /> <!-- mapper 142 -->
+			<feature name="pcb" value="KAISER-KS7032" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="131072">
+				<rom name="super mario bros. 2 (kaiser).prg" size="131072" crc="281326ed" sha1="dc8ddb78cbb575623b701954df951f05e81388ea" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="smb2fdsy" cloneof="smb2fds" supported="no">
+		<description>Super Mario Bros. 2 (YUNG-08)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="yung08" /> <!-- mapper 368 -->
+			<feature name="pcb" value="YUNG-08" />
+			<dataarea name="prg" size="73728">
+				<rom name="mali4dai.prg0" size="32768" crc="473b9553" sha1="5b3a5752229cfadb41b2ae8a1fe3eff2b7132a17" offset="0x00000" status="baddump" /> <!-- original label: 瑪琍4代 -->
+				<rom name="mali4dai.prg1" size="32768" crc="8d188ef2" sha1="44b76a77c3d2ffd582a510516a9da6e58aaecc92" offset="0x08000" status="baddump" /> <!-- original label: 瑪琍4代 -->
+				<rom name="mali4dai.prg2" size="2048" crc="9f098abf" sha1="d295e4e882c21dcbda6b4923e54d1e924b557fa4" offset="0x10000" status="baddump" /> <!-- no label -->
+				<rom size="2048" offset="0x10800" loadflag="reload" />
+				<rom size="2048" offset="0x11000" loadflag="reload" />
+				<rom size="2048" offset="0x11800" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="mali4dai.chr" size="8192" crc="7e18b265" sha1="060d715bfc5d6cf4536e12279dfcc16cc64c7d44" offset="00000" status="baddump" /> <!-- original label: 瑪琍4代 -->
+			</dataarea>
+		</part>
+	</software>
+
+<!-- Two boards turned up with the same silkscreen YUNG-08, and this one for whatever reason had different ROMs with the protection check patched out but with the hardware to support it still intact. -->
+	<software name="smb2fdsy1" cloneof="smb2fds" supported="no">
+		<description>Super Mario Bros. 2 (YUNG-08, no protection)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="yung08" /> <!-- mapper 368 -->
+			<feature name="pcb" value="YUNG-08" />
+			<dataarea name="prg" size="73728">
+				<rom name="mali4dai (alt).prg0" size="32768" crc="473b9553" sha1="5b3a5752229cfadb41b2ae8a1fe3eff2b7132a17" offset="0x00000" status="baddump" />
+				<rom name="mali4dai (alt).prg1" size="32768" crc="8d188ef2" sha1="44b76a77c3d2ffd582a510516a9da6e58aaecc92" offset="0x08000" status="baddump" />
+				<rom name="mali4dai (alt).prg2" size="2048" crc="c9fbd397" sha1="21c72e06ff861bda4b8bf81541c1eb665e88d27e" offset="0x10000" status="baddump" />
+				<rom size="2048" offset="0x10800" loadflag="reload" />
+				<rom size="2048" offset="0x11000" loadflag="reload" />
+				<rom size="2048" offset="0x11800" loadflag="reload" />
+			</dataarea>
+			<dataarea name="chr" size="8192">
+				<rom name="mali4dai (alt).chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -67160,10 +67250,11 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="vballfds" cloneof="volley" supported="no">
-		<description>Volleyball (Asia, FDS conversion, Alt)</description>
+	<software name="vballfds" cloneof="volley">
+		<description>Volleyball (Asia, FDS conversion)</description>
 		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
+		<publisher>Whirlwind Manu</publisher>
+		<info name="serial" value="LE08"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="09034a" />
 			<feature name="pcb" value="UNL-SMB2J" />
@@ -67182,6 +67273,7 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		<description>Zanac (Asia, FDS conversion)</description>
 		<year>19??</year>
 		<publisher>Whirlwind Manu</publisher>
+		<info name="serial" value="LF11"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="09034a" />
 			<feature name="pcb" value="UNL-SMB2J" />
@@ -67350,7 +67442,7 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="smb2fds" supported="no">
+	<software name="smb2fdsf" cloneof="smb2fds" supported="no">
 		<description>Super Mario Bros. 2 (Asia, FDS conversion)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
@@ -67366,7 +67458,7 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="smb2fdse" cloneof="smb2fds" supported="no">
+	<software name="smb2fdsg" cloneof="smb2fds" supported="no">
 		<description>Super Mario Bros. 2 (Asia, FDS conversion, Alt 4)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
@@ -67381,23 +67473,6 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192">
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="smb2fdsc" cloneof="smb2fds" supported="no">
-		<description>Super Mario Bros. 2 (FDS pirate, Alt 3)</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="smb2j" />
-			<feature name="pcb" value="UNL-SMB2J" />
-			<feature name="mirroring" value="vertical" />
-			<dataarea name="chr" size="8192">
-				<rom name="super mario bros. 2j (unl) [u].chr" size="8192" crc="f9fe2697" sha1="f5ec342a44c909d99d46ae311a4b77ed00e645eb" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="81920">
-				<rom name="super mario bros. 2j (unl) [u].prg" size="81920" crc="04f65d2f" sha1="1168f5f0642dc5473c1fa5ff6ca3091cd33da860" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -67419,7 +67494,7 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 	</software>
 
 	<software name="vballfdsa" cloneof="volley" supported="no">
-		<description>Volleyball (Asia, FDS conversion)</description>
+		<description>Volleyball (Asia, FDS conversion, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -78837,6 +78912,21 @@ be better to redump them properly. -->
 			</dataarea>
 			<dataarea name="prg" size="524288">
 				<rom name="4-in-1 (kt-3445ab)[p1].prg" size="524288" crc="ec34291b" sha1="7d8919948f98f6933f771b1bedd1a18ab9fe8e68" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mc_4mary" supported="no">
+		<description>4 in 1 (Mr. Mary 2)</description>
+		<year>19??</year>
+		<publisher>Bit Corp</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bitcorp_4602" />
+			<dataarea name="prg" size="524288">
+				<rom name="icromn3041" size="524288" crc="6c30d765" sha1="bba9e93a69401af283019fcdfa007e92b325eb71" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Added new parent smb2fds from verified LF36 cart.
- Old mistaken LF36 corrected to its known PCB label YS-612 (smb2lf renamed smb2fdsd).
- Old parent set renamed smb2fdsf (and maybe is a candidate for future removal).
- Replaced known bad dump of smb2fdsc (TONY-I).
- Removed mrmary2 multicart extract in favor of its source 4-in-1 multicart.
- Promoted vballfds since it doesn't use the IRQ causing trouble in the related smb2fdse.

New working software list additions
-----------------------------------
Exciting Soccer - Konami Cup (Asia, FDS conversion) [famiac]
Super Mario Bros. 2 (LF36) [krzysiobal, NewRisingSun]

Software list items promoted to working
---------------------------------------
Super Mario Bros. 2 (TONY-I) [krzysiobal, NewRisingSun]
Volleyball (Asia, FDS conversion)

New NOT_WORKING software list additions
---------------------------------------
4 in 1 (Mr. Mary 2) [krzysiobal, NewRisingSun]
Super Mario Bros. 2 (YUNG-08)  [krzysiobal, NewRisingSun]
Super Mario Bros. 2 (YUNG-08, no protection)  [krzysiobal, NewRisingSun]