### PR TITLE
namco_c355spr.cpp - mask with 0x7ff instead, vshoot needs it

### DIFF
--- a/src/mame/video/namco_c355spr.cpp
+++ b/src/mame/video/namco_c355spr.cpp
@@ -372,7 +372,7 @@ void namco_c355spr_device::get_single_sprite(const u16 *pSource, c355_sprite *sp
 	*/
 	const int link_mask = 0x7ff;
 
-	const u16 linkno = pSource[0] & link_mask;     /* LINKNO     0x000..0x3ff */
+	const u16 linkno = pSource[0] & link_mask; /* LINKNO (see note above) */
 	sprite_ptr->offset = pSource[1];         /* OFFSET */
 	int hpos           = pSource[2];         /* HPOS       0x000..0x7ff (signed) */
 	int vpos           = pSource[3];         /* VPOS       0x000..0x7ff (signed) */


### PR DESCRIPTION
(also added some notes for future reference in case we need to revisit this)