### PR TITLE
some Namco posirq kludges [David Haywood] + Final Lap R sprite position fix [Ryan Holtz]

### DIFF
--- a/src/mame/drivers/namconb1.cpp
+++ b/src/mame/drivers/namconb1.cpp
@@ -311,7 +311,7 @@ TIMER_DEVICE_CALLBACK_MEMBER(namconb1_state::scantimer)
 
 	if (scanline == posirq_scanline)
 	{
-		m_screen->update_partial(posirq_scanline);
+		m_screen->update_partial(m_update_to_line_before_posirq ? posirq_scanline-1 : posirq_scanline);
 
 		if (m_pos_irq_level != 0)
 			m_maincpu->set_input_line(m_pos_irq_level, ASSERT_LINE);
@@ -894,6 +894,7 @@ INPUT_PORTS_END
 void namconb1_state::init_nebulray()
 {
 	m_gametype = NAMCONB1_NEBULRAY;
+	m_update_to_line_before_posirq = true; // needed or there is a bad line on the right of the screen, and some stars don't scroll correctly
 } /* nebulray */
 
 void namconb1_state::init_gslgr94u()

--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -1760,8 +1760,8 @@ TIMER_DEVICE_CALLBACK_MEMBER(namcos2_state::screen_scanline)
 	{
 		m_master_intc->pos_irq_trigger();
 		m_slave_intc->pos_irq_trigger();
-		// TODO: wrong place!
-		m_screen->update_partial(param);
+		// TODO: should be when video registers are updated (and/or latched) but that makes things worse
+		m_screen->update_partial(m_update_to_line_before_posirq ? param-1 : param);
 	}
 }
 
@@ -5488,6 +5488,7 @@ void namcos2_state::init_assaultp()
 void namcos2_state::init_burnforc()
 {
 	m_gametype = NAMCOS2_BURNING_FORCE;
+	m_update_to_line_before_posirq = true; // prevents bad line on horizon
 }
 
 void namcos2_state::init_cosmogng()
@@ -5680,6 +5681,7 @@ void namcos2_state::init_suzuka8h()
 void namcos2_state::init_suzuk8h2()
 {
 	m_gametype = NAMCOS2_SUZUKA_8_HOURS_2;
+	m_update_to_line_before_posirq = true; // needed for tunnels, see 2nd attract demo
 }
 
 void namcos2_state::init_valkyrie()

--- a/src/mame/includes/namconb1.h
+++ b/src/mame/includes/namconb1.h
@@ -46,7 +46,8 @@ public:
 		m_spritebank32(*this, "spritebank32"),
 		m_tilebank32(*this, "tilebank32"),
 		m_rozbank32(*this, "rozbank32"),
-		m_namconb_shareram(*this, "namconb_share")
+		m_namconb_shareram(*this, "namconb_share"),
+		m_update_to_line_before_posirq(false)
 	{ }
 
 	void namconb1(machine_config &config);
@@ -118,6 +119,7 @@ private:
 	u8 m_port6;
 	u32 m_tilemap_tile_bank[4];
 	std::unique_ptr<u32[]> m_spritebank32_delayed;
+	bool m_update_to_line_before_posirq;
 
 	u32 randgen_r();
 	void srand_w(u32 data);

--- a/src/mame/includes/namcos2.h
+++ b/src/mame/includes/namcos2.h
@@ -39,6 +39,7 @@ public:
 	namcos2_state(const machine_config &mconfig, device_type type, const char *tag) :
 		driver_device(mconfig, type, tag),
 		m_gametype(0),
+		m_update_to_line_before_posirq(false),
 		m_maincpu(*this, "maincpu"),
 		m_slave(*this, "slave"),
 		m_audiocpu(*this, "audiocpu"),
@@ -174,6 +175,8 @@ enum
 	};
 
 	int m_gametype;
+	bool m_update_to_line_before_posirq;
+
 	required_device<cpu_device> m_maincpu;
 	required_device<cpu_device> m_slave;
 	required_device<cpu_device> m_audiocpu;

--- a/src/mame/video/namco_c355spr.cpp
+++ b/src/mame/video/namco_c355spr.cpp
@@ -432,11 +432,8 @@ void namco_c355spr_device::get_single_sprite(const u16 *pSource, c355_sprite *sp
 	}
 	u32 zoomy = (vsize << 16) / (num_rows * 16);
 	dy = (dy * zoomy + 0x8000) >> 16;
-	if (flipy)
-	{
-		vpos += dy;
-	}
-	else
+
+	if (!flipy)
 	{
 		vpos -= dy;
 	}


### PR DESCRIPTION
- some Namco posirq kludges [David Haywood]

This fixes some graphics in Burning Force, Suzuka 8 Hours 2, and Nebulusray

In reality this probably needs correct emulation of when each layer latches values / renders scanlines (with some layers being linebuffered, and others not etc.) but I think identifying the problematic cases, and the fact that they are IRQ related helps for now, and Burning Force's regression keeps being reported.

- fix remaining finalapr sprite positions [Ryan Holtz]

This seems to cause a slight issue with Solvalou's top display, but Namco S21 positions are somewhat kludged anyway, and that's an unusual case with a mirror effect over the screen cropping off the top, so needs it's own research.