### PR TITLE
bus/nes: Improved emulation of a SMB3 bootleg.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -73783,7 +73783,7 @@ resulting in tons of glitches? -->
 
 <!-- Hardware depends on NTSC timing and glitches heavily on PAL. -->
 	<software name="smb3h" cloneof="smb3">
-		<description>Super Mario Bros. 3 (Pirate)</description>
+		<description>Super Chaoji Sandai 3 (Super Mario Bros. 3 pirate)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<info name="alt_title" value="Super 超級三代 3"/>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -73781,23 +73781,25 @@ resulting in tons of glitches? -->
 		</part>
 	</software>
 
-<!-- could this be a hack?!? -->
+<!-- Hardware depends on NTSC timing and glitches heavily on PAL. -->
 	<software name="smb3h" cloneof="smb3">
 		<description>Super Mario Bros. 3 (Pirate)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
+		<info name="alt_title" value="Super 超級三代 3"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="smb3pirate" />
 			<feature name="pcb" value="BTL-SMB3" />
-			<dataarea name="chr" size="131072">
-				<rom name="super mario bros 3.chr" size="131072" crc="ee863734" sha1="cdd8f5aab615a58a8f5a8c679d7d9b22b7dc57cf" offset="00000" status="baddump" />
-			</dataarea>
+			<feature name="pcb_model" value="890418" />
 			<dataarea name="prg" size="262144">
-				<rom name="super mario bros 3.prg" size="262144" crc="50a2a17c" sha1="ee61c47097cf73753444b87a205993e4a1c6c992" offset="00000" status="baddump" />
+				<rom name="5601.rom-2" size="131072" crc="10f8a950" sha1="314964ca8adc79eb87f57c74fe3fc5df100b523f" offset="0x00000" status="baddump" />
+				<rom name="5602.rom-1" size="131072" crc="b9efea0b" sha1="26c5bd5f4dece2ad1250a3da2d3a8db6d70d8182" offset="0x20000" status="baddump" />
 			</dataarea>
-			<!-- 8k WRAM on cartridge, battery backed up -->
-			<dataarea name="bwram" size="8192">
-				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			<dataarea name="chr" size="131072">
+				<rom name="5600.rom-3" size="131072" crc="ee863734" sha1="cdd8f5aab615a58a8f5a8c679d7d9b22b7dc57cf" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192">
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/nes/bootleg.cpp
+++ b/src/devices/bus/nes/bootleg.cpp
@@ -84,7 +84,7 @@ nes_asn_device::nes_asn_device(const machine_config &mconfig, const char *tag, d
 {
 }
 
-nes_smb3p_device::nes_smb3p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_smb3p_device::nes_smb3p_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_SMB3PIRATE, tag, owner, clock), m_irq_count(0), m_irq_enable(0), irq_timer(nullptr)
 {
 }
@@ -284,15 +284,7 @@ void nes_smb3p_device::device_start()
 
 void nes_smb3p_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg8_89((m_prg_chunks << 1) - 1);
-	prg8_ab(0);
-	prg8_cd(0);
-	prg8_ef((m_prg_chunks << 1) - 1);
-	chr8(0, m_chr_source);
-
-	m_irq_enable = 0;
-	m_irq_count = 0;
+	// registers not cleared or initialized at reset
 }
 
 void nes_btl_dn_device::device_start()
@@ -844,54 +836,41 @@ void nes_smb3p_device::device_timer(emu_timer &timer, device_timer_id id, int pa
 {
 	if (id == TIMER_IRQ)
 	{
-		if (m_irq_enable)
-		{
-			if (m_irq_count == 0xffff)
-			{
-				hold_irq_line();
-				m_irq_enable = 0;
-			}
-			else
-				m_irq_count++;
-		}
+		// counter does not stop when interrupts are disabled
+		if (m_irq_count != 0xffff)
+			m_irq_count++;
+		else if (m_irq_enable)
+			set_irq_line(ASSERT_LINE);
 	}
 }
 
-void nes_smb3p_device::write_h(offs_t offset, uint8_t data)
+void nes_smb3p_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("btl_smb3_w, offset: %04x, data: %02x\n", offset, data));
+
 	switch (offset & 0x0f)
 	{
-		case 0x00:
-		case 0x02:
-			chr1_x(offset & 0x07, data & 0xfe, CHRROM);
+		case 0x00: case 0x01: case 0x02: case 0x03:
+			chr1_x(offset & 0x07, (data & 0x7e) | BIT(offset, 0), CHRROM);
 			break;
-		case 0x01:
-		case 0x03:
-			chr1_x(offset & 0x07, data | 0x01, CHRROM);
-			break;
-		case 0x04: case 0x05:
-		case 0x06: case 0x07:
-			chr1_x(offset & 0x07, data, CHRROM);
+		case 0x04: case 0x05: case 0x06: case 0x07:
+			chr1_x(offset & 0x07, data & 0x7f, CHRROM);
 			break;
 		case 0x08:
-			prg8_89(data | 0x10);
+		case 0x0b:
+			prg8_x(offset & 0x03, (data | 0x10) & 0x1f);
 			break;
 		case 0x09:
-			prg8_ab(data);
-			break;
 		case 0x0a:
-			prg8_cd(data);
-			break;
-		case 0x0b:
-			prg8_ef(data | 0x10);
+			prg8_x(offset & 0x03, data & 0x1f);
 			break;
 		case 0x0c:
-			set_nt_mirroring(BIT(data, 0) ?  PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
+			set_nt_mirroring(BIT(data, 0) ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
 			break;
 		case 0x0d:
 			m_irq_count = 0;
 			m_irq_enable = 0;
+			set_irq_line(CLEAR_LINE);
 			break;
 		case 0x0e:
 			m_irq_count = (m_irq_count & 0xff00) | data;

--- a/src/devices/bus/nes/bootleg.cpp
+++ b/src/devices/bus/nes/bootleg.cpp
@@ -282,6 +282,14 @@ void nes_smb3p_device::device_start()
 	save_item(NAME(m_irq_count));
 }
 
+void nes_smb3p_device::pcb_start(running_machine &machine, u8 *ciram_ptr, bool cart_mounted)
+{
+	device_nes_cart_interface::pcb_start(machine, ciram_ptr, cart_mounted);
+	// registers reliably boot up with all 1s according to hardware tests
+	for (int i = 0; i < 4; i++)
+		prg8_x(i, 0x1f);
+}
+
 void nes_smb3p_device::pcb_reset()
 {
 	// registers not cleared or initialized at reset

--- a/src/devices/bus/nes/bootleg.h
+++ b/src/devices/bus/nes/bootleg.h
@@ -107,9 +107,9 @@ class nes_smb3p_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_smb3p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_smb3p_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -119,7 +119,7 @@ protected:
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
 private:
-	uint16_t m_irq_count;
+	u16 m_irq_count;
 	int m_irq_enable;
 
 	static const device_timer_id TIMER_IRQ = 0;
@@ -513,6 +513,7 @@ protected:
 private:
 	uint8_t m_latch;
 };
+
 
 // ======================> nes_mmalee_device
 

--- a/src/devices/bus/nes/bootleg.h
+++ b/src/devices/bus/nes/bootleg.h
@@ -112,6 +112,7 @@ public:
 	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
+	virtual void pcb_start(running_machine &machine, u8 *ciram_ptr, bool cart_mounted) override;
 
 protected:
 	// device-level overrides


### PR DESCRIPTION
- Corrected IRQ behavior. Fixes almost all flickering on status bar divider line.
- Corrected various minor details that don't affect emulation but are accurate to PCB.
- PRG ROM is on two DIPs. Split image to reflect that.