### PR TITLE
upd7220: During a GCHRD command always start with pram[15]

### DIFF
--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -1012,7 +1012,7 @@ void upd7220_device::draw_char(int x, int y)
 
 	for(int pi = 0; pi < psize; pi++)
 	{
-		tile_data = (m_ra[((psize-1-pi) & 7) | 8] << 8) | m_ra[((psize-1-pi) & 7) | 8];
+		tile_data = (m_ra[15-(pi & 7)] << 8) | m_ra[15-(pi & 7)];
 		for(int pz = 0; pz <= m_gchr; pz++)
 		{
 			int ii = 0, curpixel = 0;


### PR DESCRIPTION
When rendering the pattern in pram[8]-pram[15] the gchrd command should always start with pram[15]. Currently it will start at pram[8+n], where n is the height of your fill area. This works fine when the height is a multiple of 8, but otherwise the wrong bytes of the pattern buffer are accessed.

This fixes some display bugs on the QX-10 system when using mfbasic.com