### PR TITLE
tapperb eprom update

### DIFF
--- a/src/mame/drivers/mcr.cpp
+++ b/src/mame/drivers/mcr.cpp
@@ -2569,10 +2569,10 @@ ROM_END
 
 ROM_START( tapperb )
 	ROM_REGION( 0x10000, "maincpu", 0 )
-	ROM_LOAD( "tapper_c.p.u._pg_0_1c.1c",   0x00000, 0x4000, CRC(127171d1) SHA1(373e9a9d73b71e100c02862662d025f5ead2f94d) ) /* Date for these program ROMs are unknown */
-	ROM_LOAD( "tapper_c.p.u._pg_1_2c.1c",   0x04000, 0x4000, CRC(9d6a47f7) SHA1(e493e46fc70a765e54bfdd7ba7ca570e6a5c79d6) ) /* Either this set is the first release at 12/7/83 */
-	ROM_LOAD( "tapper_c.p.u._pg_2_3c.3c",   0x08000, 0x4000, CRC(3a1f8778) SHA1(cb46a2248289ced7282b1463f433dcb970c42c1a) ) /* Or it sits in between the other 2 sets */
-	ROM_LOAD( "tapper_c.p.u._pg_3_4c.4c",   0x0c000, 0x2000, CRC(e8dcdaa4) SHA1(45bf1571a2418c7dc00ccc7061a3e04e65cb6bff) )
+	ROM_LOAD( "tapper_c.p.u._pg_0_1c.1c",   0x00000, 0x4000, CRC(127171d1) SHA1(373e9a9d73b71e100c02862662d025f5ead2f94d) ) /* labeled TAPPER C.P.U. PRO 0 1C 1/12/84 */
+	ROM_LOAD( "tapper_c.p.u._pg_1_2c.1c",   0x04000, 0x4000, CRC(9d6a47f7) SHA1(e493e46fc70a765e54bfdd7ba7ca570e6a5c79d6) ) /* labeled TAPPER C.P.U. PRO 1 2C 1/12/84 */
+	ROM_LOAD( "tapper_c.p.u._pg_2_3c.3c",   0x08000, 0x4000, CRC(3a1f8778) SHA1(cb46a2248289ced7282b1463f433dcb970c42c1a) ) /* labeled TAPPER C.P.U. PRO 2 3C 1/12/84 */
+	ROM_LOAD( "tapper_c.p.u._pg_3_4c.4c",   0x0c000, 0x2000, CRC(e8dcdaa4) SHA1(45bf1571a2418c7dc00ccc7061a3e04e65cb6bff) ) /* labeled TAPPER C.P.U. PRO 3 4C 1/12/84 */
 
 	ROM_REGION( 0x10000, "ssio:cpu", 0 )
 	ROM_LOAD( "tapper_sound_snd_0_a7_12-7-83.a7",   0x0000, 0x1000, CRC(0e8bb9d5) SHA1(9e281c340b7702523c86d56317efad9e3688e585) ) /* labeled TAPPER SOUND SND 0 A7 12/7/83 */
@@ -3078,7 +3078,7 @@ GAME(  1983, journey,   0,        mcr_91475,     journey,   mcr_state,         i
 GAME(  1983, tapper,    0,        mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Budweiser, 1/27/84)", MACHINE_SUPPORTS_SAVE ) /* Date from program ROM labels - Newest version */
 GAME(  1983, tapperg,   tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Budweiser, 1/27/84 - Alternate graphics)", MACHINE_SUPPORTS_SAVE ) /* Date from program ROM labels - Newest version */
 GAME(  1983, tappera,   tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Budweiser, 12/9/83)", MACHINE_SUPPORTS_SAVE ) /* Date from program ROM labels - The oldest set? */
-GAME(  1983, tapperb,   tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Budweiser, Date Unknown)", MACHINE_SUPPORTS_SAVE ) /* First release at 12/7/83? or in between the other two? */
+GAME(  1983, tapperb,   tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Budweiser, 1/12/84)", MACHINE_SUPPORTS_SAVE ) /* Date from program ROM labels */
 GAME(  1983, sutapper,  tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Suntory)", MACHINE_SUPPORTS_SAVE )
 GAME(  1984, rbtapper,  tapper,   mcr_91490,     tapper,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Tapper (Root Beer)", MACHINE_SUPPORTS_SAVE )
 GAME(  1984, timber,    0,        mcr_91490,     timber,    mcr_state,         init_mcr_91490, ROT0,  "Bally Midway", "Timber", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
Recently had a board sent to me with dates not found in MAME for tapper. After reading in the EPROMS, the data matched the tapperb set.  Updated the code with the dates found on the EPROMs.

Let me know if you'd like to have the EPROMs renamed to match the others. If so, I believe they should be:

tapper_c.p.u._pg_0_1c_1-12-84.1c
tapper_c.p.u._pg_1_2c_1-12-84.2c
tapper_c.p.u._pg_2_3c_1-12-84.3c
tapper_c.p.u._pg_3_4c_1-12-84.4c

![tapperb](https://user-images.githubusercontent.com/10748638/126185920-2cab5028-3e7f-4772-96b1-c858bb385aeb.jpg)
