### PR TITLE
split existing c169 pergame hack into component parts to make research on speed racer easier

### DIFF
--- a/src/mame/drivers/namcofl.cpp
+++ b/src/mame/drivers/namcofl.cpp
@@ -554,10 +554,11 @@ void namcofl_state::namcofl(machine_config &config)
 
 	NAMCO_C169ROZ(config, m_c169roz, 0);
 	m_c169roz->set_palette(m_c116);
-	m_c169roz->set_is_namcofl(true);
 	m_c169roz->set_ram_words(0x20000/2);
 	m_c169roz->set_tile_callback(namco_c169roz_device::c169_tilemap_delegate(&namcofl_state::RozCB, this));
 	m_c169roz->set_color_base(0x1800);
+	m_c169roz->set_roz_tilemap_for_linemap(0);
+	m_c169roz->set_palette_mask(0x7);
 
 	NAMCO_C355SPR(config, m_c355spr, 0);
 	m_c355spr->set_screen(m_screen);
@@ -584,6 +585,14 @@ void namcofl_state::namcofl(machine_config &config)
 	//c352.add_route(2, "lspeaker", 1.00); // Second DAC not present.
 	//c352.add_route(3, "rspeaker", 1.00);
 }
+
+void namcofl_state::finalapr(machine_config &config)
+{
+	namcofl(config);
+	m_c169roz->set_disable_custom_draw(true); // bad gfx on titlescreen otherwise (because custom draw doesn't support wraparound disable?)
+}
+
+
 
 ROM_START( speedrcr )
 	ROM_REGION( 0x200000, "maincpu", 0 ) // i960 program
@@ -801,7 +810,7 @@ void namcofl_state::driver_init()
 GAME(  1995, speedrcr,          0, namcofl, speedrcr, namcofl_state, driver_init, ROT0, "Namco", "Speed Racer",                MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE )
 
 // Final Lap R was released 02/94, a 1993 copyright date is displayed on the title screen
-GAMEL( 1994, finalapr,          0, namcofl, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Rev. B)",       MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
-GAMEL( 1994, finalapr1,  finalapr, namcofl, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R",                MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
-GAMEL( 1994, finalaprj,  finalapr, namcofl, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Japan Rev. C)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
-GAMEL( 1994, finalaprj1, finalapr, namcofl, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Japan Rev. B)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
+GAMEL( 1994, finalapr,          0, finalapr, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Rev. B)",       MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
+GAMEL( 1994, finalapr1,  finalapr, finalapr, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R",                MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
+GAMEL( 1994, finalaprj,  finalapr, finalapr, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Japan Rev. C)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )
+GAMEL( 1994, finalaprj1, finalapr, finalapr, finalapr, namcofl_state, driver_init, ROT0, "Namco", "Final Lap R (Japan Rev. B)", MACHINE_IMPERFECT_GRAPHICS | MACHINE_NODEVICE_LAN | MACHINE_SUPPORTS_SAVE, layout_finalapr )

--- a/src/mame/drivers/namconb1.cpp
+++ b/src/mame/drivers/namconb1.cpp
@@ -1024,7 +1024,6 @@ void namconb1_state::namconb2(machine_config &config)
 
 	NAMCO_C169ROZ(config, m_c169roz);
 	m_c169roz->set_palette(m_c116);
-	m_c169roz->set_disable_custom_draw(false);
 	m_c169roz->set_ram_words(0x20000 / 2);
 	m_c169roz->set_color_base(0x1800);
 }

--- a/src/mame/drivers/namconb1.cpp
+++ b/src/mame/drivers/namconb1.cpp
@@ -1024,7 +1024,7 @@ void namconb1_state::namconb2(machine_config &config)
 
 	NAMCO_C169ROZ(config, m_c169roz);
 	m_c169roz->set_palette(m_c116);
-	m_c169roz->set_is_namcofl(false);
+	m_c169roz->set_disable_custom_draw(false);
 	m_c169roz->set_ram_words(0x20000 / 2);
 	m_c169roz->set_color_base(0x1800);
 }

--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -1777,7 +1777,6 @@ void namcos2_state::configure_c169roz_standard(machine_config &config)
 {
 	NAMCO_C169ROZ(config, m_c169roz);
 	m_c169roz->set_palette(m_c116);
-	m_c169roz->set_is_namcofl(false);
 	m_c169roz->set_ram_words(0x10000/2);
 	m_c169roz->set_color_base(0*256);
 }

--- a/src/mame/includes/namcofl.h
+++ b/src/mame/includes/namcofl.h
@@ -35,6 +35,7 @@ public:
 		m_shareram(*this, "shareram") { }
 
 	void namcofl(machine_config &config);
+	void finalapr(machine_config &config);
 
 	void driver_init() override;
 

--- a/src/mame/video/namco_c169roz.cpp
+++ b/src/mame/video/namco_c169roz.cpp
@@ -99,13 +99,65 @@ void namco_c169roz_device::unpack_params(const uint16_t *source, roz_parameters 
 {
 	const int xoffset = 36, yoffset = 3;
 
-	/**
-	 * x-------.-------- disable layer
-	 * ----x---.-------- wrap?
-	 * ------xx.-------- size
-	 * --------.xxxx---- priority
-	 * --------.----xxxx color
-	 */
+
+	/*
+
+	These tables are at
+	0x70e000  on NamcoNB1 (68k based)
+	0x30c0e000 on NamcoFL (i960 based)
+
+	the format seems to be the same as
+	m_control when not in line mode
+
+	is it possible the first line is taken from m_control?
+	as Final Lap R populates the final line as 'disbled'
+	this results in bad background tiles being visible.
+	 
+	source[0]
+
+	0x4000 = zoom only?
+	0x6000 = full roz?
+	0x0000 = ignore params? maybe use base params (probably not)
+
+	source[1]
+
+	x------- -------- disable layer
+	----x--- -------- wrap?
+	------xx -------- size
+	-------- xxxx---- priority
+	-------- ----xxxx color
+
+	source[2]
+
+	x------- -------- incxx sign bit
+	-xxx---- -------- left
+	----xxxx xxxxxxxx incxx magnitude
+
+	source[3]
+
+	x------- -------- incxy sign bit
+	-xxx---- -------- top
+	----xxxx xxxxxxxx incxy
+
+	source[4]
+
+	x------- -------- incyx sign bit
+	----xxxx xxxxxxxx inxyx
+
+	source[5]
+
+	x------- -------- incyy sign bit
+	----xxxx xxxxxxxx incyy
+
+	source[6]
+
+	xxxxxxxx xxxxxxxx xscroll
+
+	source[7]
+
+	yyyyyyyy yyyyyyyy yscroll
+
+	*/
 
 	uint16_t temp = source[1];
 	params.wrap = BIT(~temp, 11);

--- a/src/mame/video/namco_c169roz.h
+++ b/src/mame/video/namco_c169roz.h
@@ -15,7 +15,10 @@ public:
 	// construction/destruction
 	namco_c169roz_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock = 0);
 
-	void set_is_namcofl(bool state) { m_is_namcofl = state; }
+	void set_disable_custom_draw(bool state) { m_disable_custom_draw = state; }
+	void set_roz_tilemap_for_linemap(int num) { m_roz_tilemap_for_linemap = num; }
+	void set_palette_mask(int mask) { m_palette_mask = mask; }
+
 	void set_ram_words(uint32_t size) { m_ramsize = size; }
 	void set_color_base(int color) { m_color_base = color; }
 
@@ -61,7 +64,9 @@ private:
 	uint32_t m_ramsize;
 
 	// per-game hacks
-	bool m_is_namcofl;
+	bool m_disable_custom_draw;
+	bool m_roz_tilemap_for_linemap;
+	uint8_t m_palette_mask;
 
 	required_region_ptr<uint8_t> m_mask;
 };


### PR DESCRIPTION
the old code was hiding 3 different hacks behind a single 'm_is_namcofl' variable.

if I'm trying to phase these out individually, it makes sense to split that up
