### PR TITLE
QX10 fix graphics scrolling

### DIFF
--- a/src/mame/drivers/qx10.cpp
+++ b/src/mame/drivers/qx10.cpp
@@ -210,11 +210,12 @@ UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 	int gfx[3];
+	address &= 0x1ffff;
 	if(m_color_mode)
 	{
 		gfx[0] = m_video_ram[(address >> 1) + 0x00000];
-		gfx[1] = m_video_ram[(address >> 1) + 0x20000];
-		gfx[2] = m_video_ram[(address >> 1) + 0x40000];
+		gfx[1] = m_video_ram[(address >> 1) + 0x10000];
+		gfx[2] = m_video_ram[(address >> 1) + 0x20000];
 	}
 	else
 	{
@@ -242,6 +243,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
 UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
+	addr &= 0x1ffff;
 
 	for (int x = 0; x < pitch; x++)
 	{
@@ -802,7 +804,7 @@ GFXDECODE_END
 void qx10_state::video_start()
 {
 	// allocate memory
-	m_video_ram = make_unique_clear<uint16_t[]>(0x60000);
+	m_video_ram = make_unique_clear<uint16_t[]>(0x30000);
 }
 
 void qx10_state::qx10_palette(palette_device &palette) const
@@ -818,7 +820,7 @@ uint16_t qx10_state::vram_r(offs_t offset)
 	else if(m_vram_bank & 2) { bank = 1; } // G
 	else if(m_vram_bank & 4) { bank = 2; } // R
 
-	return m_video_ram[offset + (0x20000 * bank)];
+	return m_video_ram[offset + (0x10000 * bank)];
 }
 
 void qx10_state::vram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
@@ -829,12 +831,12 @@ void qx10_state::vram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 	else if(m_vram_bank & 2) { bank = 1; } // G
 	else if(m_vram_bank & 4) { bank = 2; } // R
 
-	COMBINE_DATA(&m_video_ram[offset + (0x20000 * bank)]);
+	COMBINE_DATA(&m_video_ram[offset + (0x10000 * bank)]);
 }
 
 void qx10_state::upd7220_map(address_map &map)
 {
-	map(0x00000, 0x3ffff).rw(FUNC(qx10_state::vram_r), FUNC(qx10_state::vram_w));
+	map(0x00000, 0x1ffff).rw(FUNC(qx10_state::vram_r), FUNC(qx10_state::vram_w)).mirror(0x20000);
 }
 
 static void keyboard(device_slot_interface &device)


### PR DESCRIPTION
Update: Dropped second patch as I now have a better and more complete implementation of the the upd7220 draw_char routine. 

Reduces the QX10 video memoy allocation to 128k instead of 256k and setups mirroring in the memory map.

With these patches the following mfbasic program now works properly.
```
   10 print "Hello World!"
   20 goto 10
```
 Also running the diag disk in color mode now sucessfully works on the final scrolling text test.