### PR TITLE
ibm5170_cdrom: new software list additions

### DIFF
--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -461,6 +461,20 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- OS/2 -->
+	<software name="apak_os2">
+		<description>IBM AttachPak for OS/2 Warp Connect</description>
+		<year>1995</year>
+		<publisher>IBM</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_number" value="27H9296"/>
+			<diskarea name="cdrom">
+				<disk name="apak_usa" sha1="ad7b97376326cad3665a65a711ef872c44a93120"/>
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="arampage">
 		<description>Alien Rampage (v1.13)</description>
 		<year>1996</year>
@@ -3060,10 +3074,188 @@ license:CC0
 		</part>
 	</software>
 
+    <!-- OS/2 -->
+	<software name="notes33exp_os2">
+		<description>Lotus Notes Express v3.30 for OS2, Special Promotion Copy NFR</description>
+		<year>1995</year>
+		<publisher>Lotus Development Corporation</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_number" value="27H9175"/>
+			<diskarea name="cdrom">
+				<disk name="lotus_notes_express_v3_30_for_os2_special_promotion_copy_nfr_27h9175_lotus_development_corporation_1995" sha1="00b6e6eb8132065c967ba4a967ea403fb3cec14d"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="odosmrs701">
+		<description>Caldera OpenDOS Machine Readable Source Kit (M.R.S) 7.01</description>
+		<year>1997</year>
+		<publisher>Caldera</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<!-- Reconstructed from a ZIP archive, needs redump -->
+			<diskarea name="cdrom">
+				<disk name="opendosmrs" sha1="f2fb6ad42d42aed26f54e2494ca92ba779458ace" status="baddump"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- OS/2 -->
+	<software name="os2demopkg">
+		<description>IBM DEMOpkg for OS2 - First Edition 99Q3</description>
+		<year>1999</year>
+		<publisher>IBM</publisher>
+		<part name="cdrom1" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="cd1_setup_installation" sha1="1ac98794670346b1fb0fb866f8060f61500fabf6"/>
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd2_data_management" sha1="caf7a162e7ebcb8ec822b6ec44caf400628ba2d7"/>
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd3_java" sha1="9b4d9fa06f682395ef6198a0a22b5269cf1e93ac"/>
+			</diskarea>
+		</part>
+		<part name="cdrom4" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd4_lotus_products" sha1="997e98788ac69a5a3d6e0d972ca3eee225552a7e"/>
+			</diskarea>
+		</part>
+		<part name="cdrom5" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd5_miscellaneous" sha1="92a4a37d96f064eeee3c4601cc64255d552fe3ac"/>
+			</diskarea>
+		</part>
+		<part name="cdrom6" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd6_networking" sha1="f0bcc3c1b75d14effe4656a8bde7ce62e1b94052"/>
+			</diskarea>
+		</part>
+		<part name="cdrom7" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd7_warp_server" sha1="4561f06b8c56a523e0e2b45cdc3c09aafd7f0b87"/>
+			</diskarea>
+		</part>
+		<part name="cdrom8" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd8_warp_server_installation" sha1="4dba7d9093a76fedb7a37b94c397c591db189bf5"/>
+			</diskarea>
+		</part>
+		<part name="cdrom9" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="cd9_workspace_on_demand" sha1="6a7906230637d67cff6560e61dbec6a336965a81"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- OS/2 -->
+	<software name="os2special">
+		<description>OS/2 Warp Special CD - november 1995</description>
+		<year>1995</year>
+		<publisher>IBM</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<!-- Reconstructed from a ZIP archive, needs redump -->
+			<diskarea name="cdrom">
+				<disk name="os2_warp_special_cd" sha1="0959b6949fc7baab26df6c162ddbd22856701db7" status="baddump"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="os2warp3">
+		<description>OS/2 Warp</description>
+		<year>1994</year>
+		<publisher>IBM</publisher>
+		<!-- Internal revision 8.162 (94/09/19), XR03000 -->
+		<info name="version" value="3.00"/>
+		<part name="cdrom1" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_id" value="OS/2 Warp"/>
+			<feature name="part_number" value="83G8450"/>
+			<diskarea name="cdrom">
+				<disk name="os2cdrom" sha1="e316dd95d88d6e63da84b3751dbf9521f87a6bc8"/>
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_id" value="BonusPak for OS/2 version 3"/>
+			<feature name="part_number" value="19H6166"/>
+			<diskarea name="cdrom">
+				<disk name="bonuspak" sha1="8c874361fd00458a9bdf730fe6b57cc56b2d840e"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="os2warp3b" cloneof="os2warp3">
+		<description>OS/2 Warp with Win-OS/2</description>
+		<year>1995</year>
+		<publisher>IBM</publisher>
+		<!-- Internal revision 8.200 (94/11/09), XR03001 -->
+		<part name="cdrom1" interface="cdrom">
+			<feature name="part_id" value="OS/2 Warp with Win-OS/2"/>
+			<diskarea name="cdrom">
+				<disk name="os2_cd_rom" sha1="8337e382b724ed398e98e881df91ef5d17fab237"/>
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<!-- Missing -->
+			<feature name="part_id" value="BonusPak for OS/2 version 3"/>
+			<diskarea name="cdrom">
+				<disk name="bonuspak" status="nodump"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="os2warp3cb">
+		<description>OS/2 Warp Connect with Win-OS/2</description>
+		<year>1995</year>
+		<publisher>IBM</publisher>
+		<info name="version" value="3.00"/>
+		<info name="serial" value="07H9798"/>
+		<part name="cdrom1" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_id" value="OS/2 Warp Connect with Win-OS/2"/>
+			<feature name="part_number" value="28H5357"/>
+			<diskarea name="cdrom">
+				<disk name="lanclnt" sha1="594cc9ce2788b51c43686eede95676100715773a"/>
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_id" value="BonusPak for OS/2 version 3"/>
+			<feature name="part_number" value="59H1710"/>
+			<diskarea name="cdrom">
+				<disk name="bpcdrom" sha1="d1bee4f3b18368fb9e811959e16f851460f143e2"/>
+			</diskarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<!-- Missing -->
+			<feature name="part_id" value="Lotus Notes Express release 3.30"/>
+			<feature name="part_number" value="28H5358"/>
+			<diskarea name="cdrom">
+				<disk name="lotusexpress" status="nodump"/>
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="os2warp4" supported="partial">
 		<description>OS/2 Warp 4</description>
 		<year>1996</year>
 		<publisher>IBM</publisher>
+		<!-- Internal revision 9.023, XR04000 -->
 		<info name="version" value="4.00" />
 
 		<part name="cdrom" interface="cdrom">
@@ -3072,6 +3264,19 @@ license:CC0
 			</diskarea>
 		</part>
 	</software>
+
+	<software name="pcdos7">
+		<description>PC DOS 7</description>
+		<year>1995</year>
+		<publisher>IBM</publisher>
+		<part name="cdrom" interface="cdrom">
+			<feature name="part_number" value="25H7021"/>
+			<diskarea name="cdrom">
+				<disk name="pcdos70" sha1="38004dc0ee6142ec0498034b09b493d2ca8c1e19"/>
+			</diskarea>
+		</part>
+	</software>
+
 
 	<software name="pcdos2k">
 		<description>PC DOS 2000</description>
@@ -3094,6 +3299,20 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="sb16" sha1="c87097c58d1c3fcea03e5e4b50d2cafdcb870f16" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- OS/2 -->
+	<software name="ssuite_os2">
+		<description>Lotus SmartSuite for OS/2 Warp 4</description>
+		<year>1998</year>
+		<publisher>Lotus Development Corporation</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<feature name="part_number" value="T14970"/>
+			<diskarea name="cdrom">
+				<disk name="ssuiteos2" sha1="0cd1718ee6ce9876c57e5c700122f1209d5ea2ae"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3258,6 +3477,30 @@ license:CC0
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="windows me (en 4.90.3000 retail full)" sha1="3bb9b89f2b5918b7dbe393d250a8f1a530a175ef" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt31w">
+		<description>Windows NT 3.1 Workstation (3.10.511.1)</description>
+		<year>1993</year>
+		<publisher>Microsoft</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: WinWorld -->
+			<diskarea name="cdrom">
+				<disk name="en_winnt_3_1_wks" sha1="0a542add03b6c9ab130421d24f94731c4992e0a7"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="winnt351w">
+		<description>Windows NT 3.51 Workstation (3.51.1057.1)</description>
+		<year>1995</year>
+		<publisher>Microsoft</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: WinWorld -->
+			<diskarea name="cdrom">
+				<disk name="en_winnt_3_51_wks" sha1="5a5d3cf9d244b6b24b007271be478b94a9c349f4"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Caldera OpenDOS Machine Readable Source Kit (M.R.S) 7.01 [archive.org, Davide Cavalca]
IBM AttachPak for OS/2 Warp Connect [archive.org]
IBM DEMOpkg for OS2 - First Edition 99Q3 [archive.org]
Lotus Notes Express v3.30 for OS2, Special Promotion Copy NFR [archive.org]
Lotus SmartSuite for OS/2 Warp 4 [archive.org]
OS/2 Warp [archive.org]
OS/2 Warp Connect with Win-OS/2 [archive.org]
OS/2 Warp Special CD - november 1995 [archive.org, Davide Cavalca]
OS/2 Warp with Win-OS/2 [archive.org]
PC DOS 7 [archive.org]
Windows NT 3.1 Workstation (3.10.511.1) [WinWorld]
Windows NT 3.51 Workstation (3.51.1057.1) [WinWorld]