### PR TITLE
bus/nes: Added support for Cartridge Story multicarts.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -62399,6 +62399,21 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
+	<software name="elfland">
+		<description>Elfland</description>
+		<year>1993</year>
+		<publisher>JungleTac</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="cnrom" />
+			<dataarea name="prg" size="32768">
+				<rom name="elfland.prg" size="32768" crc="806b719f" sha1="c6da7ca46dbf230ab14324f16d83190143eae9bc" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="32768">
+				<rom name="elfland.chr" size="32768" crc="fa19ef5a" sha1="8ef6a2486e0032fd4ae895d066b5b0d0b9130a10" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="erzhanzj">
 		<description>Er Zhan Zhi Jing Dian Zhan Yi (Chi)</description>
 		<year>19??</year>
@@ -78127,12 +78142,12 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_200" supported="no">
+	<software name="mc_200">
 		<description>200 in 1 - Elfland</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1992</year>
+		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="810544c" />
+			<feature name="slot" value="bmc_810544c" />
 			<feature name="pcb" value="BMC-810544-C-A1" />
 			<dataarea name="chr" size="131072">
 				<rom name="200-in-1 - elfland (unl)[u].chr" size="131072" crc="e37cbebe" sha1="f51e400680777d03dda49cf64f0ab67433c67dae" offset="00000" status="baddump" />
@@ -79875,6 +79890,21 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_72cs" cloneof="mc_90cs3">
+		<description>72 in 1 Cartridge Story</description>
+		<year>1990?</year>
+		<publisher>RCM Group</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_80013b" />
+			<dataarea name="prg" size="2097152">
+				<rom name="cartridge story.prg" size="2097152" crc="de81267f" sha1="12b41074bf66372164035609d82f36daca156b06" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_73">
 		<description>73 in 1</description>
 		<year>19??</year>
@@ -80068,6 +80098,22 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_80cs2" cloneof="mc_90cs3">
+		<description>80 in 1 Cartridge Story (II)</description>
+		<year>1991?</year>
+		<publisher>RCM Group</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_80013b" />
+			<dataarea name="prg" size="2113536">
+				<rom name="cartridge story ii.prg0" size="2097152" crc="de81267f" sha1="12b41074bf66372164035609d82f36daca156b06" offset="0x00000" status="baddump" />
+				<rom name="cartridge story ii.prg1" size="16384" crc="89b271f6" sha1="52cae18346767566db4291f328401d76bab68afb" offset="0x200000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_83">
 		<description>83 in 1</description>
 		<year>19??</year>
@@ -80194,6 +80240,22 @@ be better to redump them properly. -->
 			</dataarea>
 			<dataarea name="prg" size="524288">
 				<rom name="9-in-1 (860824 pcb)[p1].prg" size="524288" crc="9ccd7a04" sha1="a4e133664461082101cd2981460823b0a023c476" offset="00000" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mc_90cs3">
+		<description>90 in 1 Cartridge Story (III)</description>
+		<year>1991?</year>
+		<publisher>RCM Group</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_80013b" />
+			<dataarea name="prg" size="2162688">
+				<rom name="cartridge story iii.prg0" size="2097152" crc="de81267f" sha1="12b41074bf66372164035609d82f36daca156b06" offset="0x00000" status="baddump" />
+				<rom name="cartridge story iii.prg1" size="65536" crc="ebcc0646" sha1="8e24df36e3a8643268ff5d5375852d1fcad4899a" offset="0x200000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -249,15 +249,37 @@ private:
 };
 
 
-// ======================> nes_810544c_device
+// ======================> nes_bmc_80013b_device
 
-class nes_810544c_device : public nes_nrom_device
+class nes_bmc_80013b_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_810544c_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_80013b_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual void write_h(offs_t offset, uint8_t data) override;
+
+	virtual void pcb_reset() override;
+
+protected:
+	// device-level overrides
+	virtual void device_start() override;
+
+private:
+	void update_prg();
+	u8 m_latch, m_reg[2];
+};
+
+
+// ======================> nes_bmc_810544c_device
+
+class nes_bmc_810544c_device : public nes_nrom_device
+{
+public:
+	// construction/destruction
+	nes_bmc_810544c_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -1004,7 +1026,8 @@ DECLARE_DEVICE_TYPE(NES_NOVEL2,         nes_novel2_device)
 DECLARE_DEVICE_TYPE(NES_STUDYNGAME,     nes_studyngame_device)
 DECLARE_DEVICE_TYPE(NES_SUPERGUN20IN1,  nes_sgun20in1_device)
 DECLARE_DEVICE_TYPE(NES_VT5201,         nes_vt5201_device)
-DECLARE_DEVICE_TYPE(NES_810544C,        nes_810544c_device)
+DECLARE_DEVICE_TYPE(NES_BMC_80013B,     nes_bmc_80013b_device)
+DECLARE_DEVICE_TYPE(NES_BMC_810544C,    nes_bmc_810544c_device)
 DECLARE_DEVICE_TYPE(NES_NTD03,          nes_ntd03_device)
 DECLARE_DEVICE_TYPE(NES_BMC_CTC09,      nes_bmc_ctc09_device)
 DECLARE_DEVICE_TYPE(NES_BMC_GB63,       nes_bmc_gb63_device)

--- a/src/devices/bus/nes/nes_carts.cpp
+++ b/src/devices/bus/nes/nes_carts.cpp
@@ -359,9 +359,10 @@ void nes_cart(device_slot_interface &device)
 	device.option_add_internal("novel2",           NES_NOVEL2); // mapper 213... same as BMC-NOVELDIAMOND9999999IN1 board?
 	device.option_add_internal("studyngame",       NES_STUDYNGAME); // mapper 39
 	device.option_add_internal("sgun20in1",        NES_SUPERGUN20IN1);
-	device.option_add_internal("bmc_vt5201",       NES_VT5201); // mapper 60 otherwise
-	device.option_add_internal("bmc_d1038",        NES_VT5201); // mapper 60?
-	device.option_add_internal("810544c",          NES_810544C);
+	device.option_add_internal("bmc_vt5201",       NES_VT5201); // mapper 59?
+	device.option_add_internal("bmc_d1038",        NES_VT5201); // mapper 59?
+	device.option_add_internal("bmc_80013b",       NES_BMC_80013B);
+	device.option_add_internal("bmc_810544c",      NES_BMC_810544C);
 	device.option_add_internal("ntd03",            NES_NTD03);
 	device.option_add_internal("bmc_ctc09",        NES_BMC_CTC09);
 	device.option_add_internal("bmc_gb63",         NES_BMC_GB63);

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -295,7 +295,7 @@ static const nes_mmc mmc_list[] =
 	// 258 UNIF MAPR 158B?
 	// 259 UNIF MAPR F-15?
 	// 260 HP10xx/HP20xx multicarts?
-	{ 261, BMC_810544 },
+	{ 261, BMC_810544C },
 	{ 262, SACHEN_SHERO },
 	{ 263, UNL_KOF97 },
 	{ 264, YOKO_BOARD },
@@ -308,7 +308,7 @@ static const nes_mmc mmc_list[] =
 	// 271 TXC 4 in 1 MGC-026, not in nes.xml?
 	// 272 Akumajo Special bootleg not in nes.xml
 	// 273 Gremlins 2 bootleg, related to pirate gremlin2h or unk2?
-	// 274 BMC_80013B multicarts, not in nes.xml?
+	{ 274, BMC_80013B },
 	// 275 Unused
 	// 276 Unused
 	// 277 Unused

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -244,9 +244,10 @@ static const nes_pcb pcb_list[] =
 	{ "novel2",           BMC_NOVEL2 },  // mapper 213... same as BMC-NOVELDIAMOND9999999IN1 board?
 	{ "studyngame",       UNL_STUDYNGAME },  // mapper 39
 	{ "sgun20in1",        BMC_SUPERGUN_20IN1 },
-	{ "bmc_vt5201",       BMC_VT5201 },  // mapper 60 otherwise
-	{ "bmc_d1038",        BMC_VT5201 },  // mapper 60?
-	{ "810544c",          BMC_810544 },
+	{ "bmc_vt5201",       BMC_VT5201 },  // mapper 59?
+	{ "bmc_d1038",        BMC_VT5201 },  // mapper 59?
+	{ "bmc_80013b",       BMC_80013B },
+	{ "bmc_810544c",      BMC_810544C },
 	{ "ntd03",            BMC_NTD_03 },
 	{ "bmc_ctc09",        BMC_CTC09 },
 	{ "bmc_gb63",         BMC_G63IN1 },

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -95,7 +95,7 @@ enum
 	BMC_GOLDENCARD_6IN1, BMC_72IN1, BMC_SUPER_42IN1, BMC_76IN1,
 	BMC_31IN1, BMC_22GAMES, BMC_20IN1, BMC_110IN1,
 	BMC_70IN1, BMC_800IN1, BMC_1200IN1,
-	BMC_GKA, BMC_GKB, BMC_VT5201, BMC_BENSHIENG, BMC_810544,
+	BMC_GKA, BMC_GKB, BMC_VT5201, BMC_BENSHIENG, BMC_80013B, BMC_810544C,
 	BMC_NTD_03, BMC_G63IN1, BMC_FK23C, BMC_FK23CA, BMC_PJOY84,
 	BMC_POWERFUL_255, BMC_11160, BMC_G146, BMC_8157, BMC_830118C,
 	BMC_411120C, BMC_GOLD150, BMC_GOLD260, BMC_CH001, BMC_SUPER22,
@@ -121,7 +121,7 @@ enum
 	// Whirlwind Manu
 	UNL_DH08, UNL_LE05, UNL_LG25, UNL_LH10, UNL_LH28_LH54,
 	UNL_LH31, UNL_LH32, UNL_LH51, UNL_LH53,
-	/* Misc: these are needed to convert mappers to boards, I will sort them later */
+	// Misc: these are needed to convert mappers to boards, I will sort them later
 	OPENCORP_DAOU306, HES_BOARD, SVISION16_BOARD, RUMBLESTATION_BOARD, JYCOMPANY_A, JYCOMPANY_B, JYCOMPANY_C,
 	MAGICSERIES_MD, KASING_BOARD, FUTUREMEDIA_BOARD, FUKUTAKE_BOARD, SOMARI_SL12,
 	HENGG_SRICH, HENGG_XHZS, HENGG_SHJY3, SUBOR_TYPE0, SUBOR_TYPE1, SUBOR_TYPE2,
@@ -136,9 +136,9 @@ enum
 	NOCASH_NOCHR,   // homebrew PCB design which uses NTRAM for CHRRAM
 	UNL_ACTION53,   // homebrew PCB for homebrew multicarts
 	UNL_CUFROM, UNL_UNROM512, UNL_2A03PURITANS,   // homebrew PCBs
-	/* FFE boards, for mappers 6, 8, 17 */
+	// FFE boards, for mappers 6, 8, 17
 	FFE3_BOARD, FFE4_BOARD, FFE8_BOARD, TEST_BOARD,
-	/* Unsupported (for place-holder boards, with no working emulation) & no-board (at init) */
+	// Unsupported (for place-holder boards, with no working emulation) & no-board (at init)
 	UNSUPPORTED_BOARD, UNKNOWN_BOARD, NO_BOARD
 };
 

--- a/src/devices/bus/nes/nes_unif.hxx
+++ b/src/devices/bus/nes/nes_unif.hxx
@@ -119,7 +119,7 @@ static const unif unif_list[] =
 	{ "BMC-FK23CA",                 0,    0, CHRRAM_0,  BMC_FK23CA},
 	{ "BMC-GHOSTBUSTERS63IN1",      0,    0, CHRRAM_8,  BMC_G63IN1 },
 	{ "BMC-BS-5",                   0,    0, CHRRAM_0,  BMC_BENSHIENG},
-	{ "BMC-810544-C-A1",            0,    0, CHRRAM_0,  BMC_810544},
+	{ "BMC-810544-C-A1",            0,    0, CHRRAM_0,  BMC_810544C},
 	{ "BMC-411120-C",               0,    0, CHRRAM_0,  BMC_411120C},
 	{ "BMC-8157",                   0,    0, CHRRAM_8,  BMC_8157},
 	{ "BMC-830118C",                0,    0, CHRRAM_0,  BMC_830118C},


### PR DESCRIPTION
- Renamed Elfland 200-in-1's device with bmc- prefixes to be consistent with related multicarts. Promoted to working since everything is in working order.
- Throw in Elfland singleton cart since it's been separately dumped.

New working software list additions (nes.xml)
-----------------------------------
72 in 1 Cartridge Story [MLX]
80 in 1 Cartridge Story (II) [Yahweasel]
90 in 1 Cartridge Story (III) [MLX]
Elfland [NewRisingSun]

Software list items promoted to working (nes.xml)
---------------------------------------
200 in 1 - Elfland