### PR TITLE
amiga_workbench: new software list additions

### DIFF
--- a/hash/amiga_workbench.xml
+++ b/hash/amiga_workbench.xml
@@ -500,6 +500,345 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Version 3.1.4 -->
+
+	<software name="amigos314">
+		<description>AmigaOS 3.1.4</description>
+		<year>2008</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Install 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="Install3_1_4.adf" size="901120" crc="84364ca6" sha1="5c8af775b312125646639e8579593980a8bbc739"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Workbench 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="Workbench3_1_4.adf" size="901120" crc="242c519d" sha1="5893bca6aab0746acad0ff4bdcfb3eda0bd329b2"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Locale 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="Locale.adf" size="901120" crc="8dc7f27f" sha1="10b0269376db03db59a155c5db42d8c5fd210eb5"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="Extras 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="Extras3_1_4.adf" size="901120" crc="912cfc53" sha1="7067536c1d7032c692651ebe2a03ef51e168b166"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts 3.1.4 (A500, A600, A2000)" />
+			<dataarea name="flop" size="901120">
+				<rom name="Fonts.adf" size="901120" crc="b5ef9ad7" sha1="95468b46e1355850fc0d5eeed9cf8fec57f8d591"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts 3.1.4 (A1200)" />
+			<dataarea name="flop" size="901120">
+				<rom name="FontsA1200.adf" size="901120" crc="954dfae7" sha1="1f14ac1988ad7259648f3fab94234d848944b491"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Storage 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="Storage3_1_4.adf" size="901120" crc="7aa1c338" sha1="22cb93f66cbfb9695c53c029069dbbaa8eeca6c6"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A500 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="ModulesA500_3.1.4.adf" size="901120" crc="d2a44b89" sha1="8bcbdc2129a463551e8ede636e75b5763b7a990a"/>
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A600 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="ModulesA600_3.1.4.adf" size="901120" crc="535d06c2" sha1="8be0381e5befa875129682bd3e84ec147f48d390"/>
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A1200 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="ModulesA1200_3.1.4.adf" size="901120" crc="17d35e9f" sha1="e62dfedbd4ba6973146ab359f0c06be0a42f29b7"/>
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A2000 3.1.4" />
+			<dataarea name="flop" size="901120">
+				<rom name="ModulesA2000_3.1.4.adf" size="901120" crc="0608073a" sha1="9c3ff9e9bf8db7e6976fc4cab06032f4311d7853"/>
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="BestWB 1" />
+			<dataarea name="flop" size="901120">
+				<rom name="BestWB1.adf" size="901120" crc="f3cb8e8f" sha1="185aebd03be2e4d0ca0cd93d8532a362abf2b11e"/>
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="BestWB 2" />
+			<dataarea name="flop" size="901120">
+				<rom name="BestWB2.adf" size="901120" crc="e0ce56c2" sha1="8464b092fa0097bf1752a98aa38103d275b301d6"/>
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="BestWB 3" />
+			<dataarea name="flop" size="901120">
+				<rom name="BestWB3.adf" size="901120" crc="9fb18e94" sha1="5ff3127418a3b579702d22c9c350faa7d23e98e4"/>
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="BestWB 4" />
+			<dataarea name="flop" size="901120">
+				<rom name="BestWB4.adf" size="901120" crc="7e868108" sha1="241a6558a6140735749f85587035f6d7a3e2cbb1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="amigos3141">
+		<description>AmigaOS 3.1.4.1 (Update)</description>
+		<year>2019</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="flop" interface="floppy_3_5">
+			<feature name="part_id" value="Update 3.1.4.1" />
+			<dataarea name="flop" size="901120">
+				<rom name="Update3.1.4.1.adf" size="901120" crc="d3eb5e8f" sha1="8c23d9b6f6de484ecc83670d1b4ae5518db2c6a6"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Version 3.2 -->
+
+	<software name="amigos32">
+		<description>AmigaOS 3.2</description>
+		<year>2021</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="cdrom" interface="cdrom">
+			<diskarea name="cdrom">
+				<disk name="amigaos3_2cd" sha1="64be48a09f6bc69a87dfc90133a19584fcd19ef7"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="amigos32_35" cloneof="amigos32">
+		<description>AmigaOS 3.2 (3.5" floppies)</description>
+		<year>2021</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="HDSetup 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="hdsetup3.2.adf" size="901120" crc="5a751a83" sha1="3c3da19ae5121fdf5c4809197ebeb4170fc155d8"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Install 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="install3.2.adf" size="901120" crc="83dcd5f6" sha1="e2bfb9fde37f30479295a8bb597a956e7f593040"/>
+			</dataarea>
+		</part>
+		<part name="flop3" interface="floppy_3_5">
+			<feature name="part_id" value="Workbench 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="workbench3.2.adf" size="901120" crc="a889b4d7" sha1="5529ea1b616889220a7d52722d1b8fe4b965dae1"/>
+			</dataarea>
+		</part>
+		<part name="flop4" interface="floppy_3_5">
+			<feature name="part_id" value="DiskDoctor 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="diskdoctor.adf" size="901120" crc="79b3b7c7" sha1="6650262968c4fa91bd7af7e096afc646ab92d90f"/>
+			</dataarea>
+		</part>
+		<part name="flop5" interface="floppy_3_5">
+			<feature name="part_id" value="Locale 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale.adf" size="901120" crc="27271f3d" sha1="ed190714c4b29f99445a8774ac12441c047a6300"/>
+			</dataarea>
+		</part>
+		<part name="flop6" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-DE 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-de.adf" size="901120" crc="a995c021" sha1="52aaf3d985da19aeb70bd197dc2a3106cefaa0e6"/>
+			</dataarea>
+		</part>
+		<part name="flop7" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-DK 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-dk.adf" size="901120" crc="34f06be2" sha1="3fe9b65717e61e55746b94ea7aca412acaea17ce"/>
+			</dataarea>
+		</part>
+		<part name="flop8" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-EN 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-en.adf" size="901120" crc="6fcf1f01" sha1="d06c09422dfc2b1993de702e1594610754b18391"/>
+			</dataarea>
+		</part>
+		<part name="flop9" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-ES 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-es.adf" size="901120" crc="a2b7d2e9" sha1="f6ef76a2230aa4cf1c34549ed6ed0f3f7273096f"/>
+			</dataarea>
+		</part>
+		<part name="flop10" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-FR 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-fr.adf" size="901120" crc="bc5b2ff3" sha1="30b9c704355eaa07d892ca224483863332a38b89"/>
+			</dataarea>
+		</part>
+		<part name="flop11" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-GR 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-gr.adf" size="901120" crc="b5bd80b4" sha1="1170f13725cd3605ecc300768e0c4c0a90d65031"/>
+			</dataarea>
+		</part>
+		<part name="flop12" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-IT 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-it.adf" size="901120" crc="58f16caa" sha1="5a348f58ddc43cbc2b15ec723d81426bc0c1ee54"/>
+			</dataarea>
+		</part>
+		<part name="flop13" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-NL 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-nl.adf" size="901120" crc="e9ac160f" sha1="eb712535c9a394a2ee5dad8ca8288bac2061fdd4"/>
+			</dataarea>
+		</part>
+		<part name="flop14" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-NO 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-no.adf" size="901120" crc="c9234f4d" sha1="5b6df0f9d3c51533d165b4c30cffdf53ab2aa097"/>
+			</dataarea>
+		</part>
+		<part name="flop15" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-PL 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-pl.adf" size="901120" crc="62f3d7ff" sha1="959857d4b606b924b2924d6aee720aa8f0ccb466"/>
+			</dataarea>
+		</part>
+		<part name="flop16" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-PT 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-pt.adf" size="901120" crc="a90f8c19" sha1="4f3590d72320c54de19404073fb6c501e7c873d2"/>
+			</dataarea>
+		</part>
+		<part name="flop17" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-RU 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-ru.adf" size="901120" crc="a6b82296" sha1="44244ac2458f6118107ab76c4b279b86b2dae622"/>
+			</dataarea>
+		</part>
+		<part name="flop18" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-SE 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-se.adf" size="901120" crc="2191579b" sha1="c869252702ba68a8c7417a0544b54691fb01dea0"/>
+			</dataarea>
+		</part>
+		<part name="flop19" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-TR 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-tr.adf" size="901120" crc="21b608fe" sha1="e5203f82138b7b4087f7477e647d980d864202a5"/>
+			</dataarea>
+		</part>
+		<part name="flop20" interface="floppy_3_5">
+			<feature name="part_id" value="Locale-UK 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="locale-uk.adf" size="901120" crc="68cf8b86" sha1="df184b6c27908c8dfea063ce2c640f80d4ea9833"/>
+			</dataarea>
+		</part>
+		<part name="flop21" interface="floppy_3_5">
+			<feature name="part_id" value="Extras 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="extras3.2.adf" size="901120" crc="2085648d" sha1="c3ed6361d223d65cd571c9a5023aeb4cd632d53e"/>
+			</dataarea>
+		</part>
+		<part name="flop22" interface="floppy_3_5">
+			<feature name="part_id" value="Classes 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="classes3.2.adf" size="901120" crc="5babef5c" sha1="8c056c0f378037fec952e5f3f4366199e101cf83"/>
+			</dataarea>
+		</part>
+		<part name="flop23" interface="floppy_3_5">
+			<feature name="part_id" value="Fonts 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="fonts.adf" size="901120" crc="9218fb23" sha1="dd94c5cab0dd340ef190d4c3c22e30b7e2ca73ac"/>
+			</dataarea>
+		</part>
+		<part name="flop24" interface="floppy_3_5">
+			<feature name="part_id" value="Storage 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="storage3.2.adf" size="901120" crc="115841b9" sha1="abe0d3bf073819f88e0140182fdf38602e19febc"/>
+			</dataarea>
+		</part>
+		<part name="flop25" interface="floppy_3_5">
+			<feature name="part_id" value="Backdrops 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="backdrops3.2.adf" size="901120" crc="d69df1de" sha1="270ec3d9b4e5ba546030ae4e408ff4a85ff9b1b9"/>
+			</dataarea>
+		</part>
+		<part name="flop26" interface="floppy_3_5">
+			<feature name="part_id" value="GlowIcons 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="glowicons3.2.adf" size="901120" crc="3aecb488" sha1="a35a197b7ef9bd91b17e6cddb32fde44b1992af1"/>
+			</dataarea>
+		</part>
+		<part name="flop27" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A500 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa500_3.2.adf" size="901120" crc="912736b0" sha1="fff57c357b6bfb37bfc115859f507be16cb3e648"/>
+			</dataarea>
+		</part>
+		<part name="flop28" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A600 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa600_3.2.adf" size="901120" crc="7722cae4" sha1="b68bd8de9a8e464fe944c43ef513677375ea503a"/>
+			</dataarea>
+		</part>
+		<part name="flop29" interface="floppy_3_5">
+			<feature name="part_id" value="Modules CD32 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulescd32_3.2.adf" size="901120" crc="dd02e76a" sha1="e223c50db1dd860a51800a72a46fcb01b0b75bb4"/>
+			</dataarea>
+		</part>
+		<part name="flop30" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A1200 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa1200_3.2.adf" size="901120" crc="ffaf8275" sha1="c920b8a8a74490853895ebb911ca2ba4241146c3"/>
+			</dataarea>
+		</part>
+		<part name="flop31" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A2000 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa2000_3.2.adf" size="901120" crc="86894edd" sha1="457405a4f8b85dd7c0a4b182d09b5731065a12b5"/>
+			</dataarea>
+		</part>
+		<part name="flop32" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A3000 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa3000_3.2.adf" size="901120" crc="f8634acb" sha1="8262b55441dead773e6ec883413038338dcc0a06"/>
+			</dataarea>
+		</part>
+		<part name="flop33" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A4000D 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa4000d_3.2.adf" size="901120" crc="c216bc15" sha1="e977b7d1038325e251d1973bb62447891513129e"/>
+			</dataarea>
+		</part>
+		<part name="flop34" interface="floppy_3_5">
+			<feature name="part_id" value="Modules A4000T 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="modulesa4000t_3.2.adf" size="901120" crc="75b0009b" sha1="78066e6f9d44c56d9a8a464edc9ac490bcf40424"/>
+			</dataarea>
+		</part>
+		<part name="flop35" interface="floppy_3_5">
+			<feature name="part_id" value="MMULibs 3.2" />
+			<dataarea name="flop" size="901120">
+				<rom name="mmulibs.adf" size="901120" crc="1d3e0dae" sha1="8e8e02223bd288b5b09859b805c1f79a3b985a0e"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Version 3.5 -->
 
 	<software name="amigos35">
@@ -509,6 +848,62 @@ license:CC0
 		<part name="disc" interface="cdrom">
 			<diskarea name="disc">
 				<disk name="amigaos35" sha1="6dcf1e5821717128ac2e763064f1ef31dee3ce8c"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Version 3.9 -->
+
+	<software name="amigos39">
+		<description>AmigaOS 3.9</description>
+		<year>2000</year>
+		<publisher>Haage &amp; Partner</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: archive.org -->
+			<diskarea name="cdrom">
+				<disk name="amigaos39" sha1="c7917402016b3627e533d11b998e21dec2a31029"/>
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Version 4.0 -->
+
+	<software name="amigos40" supported="no">
+		<description>AmigaOS 4.0 Classic</description>
+		<year>2007</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="cdrom" interface="cdrom">
+			<!-- Origin: fsck.technology -->
+			<feature name="part_id" value="Classic Installation Disc" />
+			<diskarea name="cdrom">
+				<disk name="amiga_os4_0_classic_52_21" sha1="39570993166af8a26d84d4f91d4725b508aa8942"/>
+			</diskarea>
+		</part>
+	</software>
+
+
+	<!-- Version 4.1 -->
+
+	<software name="amigos41" supported="no">
+		<description>AmigaOS 4.1 Final Edition for Classic</description>
+		<year>2016</year>
+		<publisher>Hyperion Entertainment</publisher>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Boot Floppy" />
+			<dataarea name="flop" size="901120">
+				<rom name="bootfloppy.adf" size="901120" crc="68be3763" sha1="9227700a9088efb7dd296c90cffd63c21e643d51"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="GREX Boot Floppy" />
+			<dataarea name="flop" size="901120">
+				<rom name="grexbootdisk.adf" size="901120" crc="191eeb3c" sha1="2e7a1204cbfd15914bc94cd05a736b449ef4f5a4"/>
+			</dataarea>
+		</part>
+		<part name="cdrom3" interface="cdrom">
+			<feature name="part_id" value="Installation CD" />
+			<diskarea name="cdrom">
+				<disk name="classicinstallcd_53_71" sha1="deb7cb84ce317dd92e945e35d1b1636a9f6dff60"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
-----------------------------------
AmigaOS 3.1.4 [Davide Cavalca]
AmigaOS 3.1.4.1 (Update) [Davide Cavalca]
AmigaOS 3.2 [Davide Cavalca]
AmigaOS 3.2 (3.5" floppies) [Davide Cavalca]
AmigaOS 3.9 [archive.org]

New NOT_WORKING software list additions
---------------------------------------
AmigaOS 4.0 Classic [fsck.technology]
AmigaOS 4.1 Final Edition for Classic [Davide Cavalca]