### PR TITLE
Adding reset to ap2000, hooking up centronics init signal

### DIFF
--- a/src/devices/bus/centronics/epson_lx810l.cpp
+++ b/src/devices/bus/centronics/epson_lx810l.cpp
@@ -163,6 +163,7 @@ void epson_lx810l_device::device_add_mconfig(machine_config &config)
 	e05a30.centronics_perror().set(FUNC(epson_lx810l_device::e05a30_centronics_perror));
 	e05a30.centronics_fault().set(FUNC(epson_lx810l_device::e05a30_centronics_fault));
 	e05a30.centronics_select().set(FUNC(epson_lx810l_device::e05a30_centronics_select));
+	e05a30.cpu_reset().set(FUNC(epson_lx810l_device::e05a30_cpu_reset));
 
 	/* 256-bit eeprom */
 	EEPROM_93C06_16BIT(config, "eeprom");
@@ -189,6 +190,9 @@ static INPUT_PORTS_START( epson_lx810l )
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Load/Eject") PORT_CODE(KEYCODE_1_PAD)
 	PORT_START("PAPEREND")
 	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Paper End Sensor") PORT_CODE(KEYCODE_6_PAD)
+	PORT_START("RESET")
+	PORT_BIT(0x01, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Reset Printer") PORT_CODE(KEYCODE_2_PAD) PORT_CHANGED_MEMBER(DEVICE_SELF, epson_lx810l_device, reset_printer, 0)
+
 
 	/* DIPSW1 */
 	PORT_START("DIPSW1")
@@ -265,6 +269,17 @@ INPUT_CHANGED_MEMBER(epson_lx810l_device::online_sw)
 {
 	m_maincpu->set_input_line(UPD7810_INTF2, newval ? CLEAR_LINE : ASSERT_LINE);
 }
+
+INPUT_CHANGED_MEMBER(epson_lx810l_device::reset_printer)
+{
+	if (newval)
+	{
+		m_maincpu->pulse_input_line(INPUT_LINE_RESET, attotime::zero);  // reset cpu
+		m_e05a30->reset();  // this will generate an NMI interrupt when the e05a30 is ready (minimum 0.9 seconds after reset)
+	}
+}
+
+
 
 
 //**************************************************************************

--- a/src/devices/bus/centronics/epson_lx810l.h
+++ b/src/devices/bus/centronics/epson_lx810l.h
@@ -42,9 +42,13 @@ public:
 	virtual DECLARE_WRITE_LINE_MEMBER( input_data5 ) override { m_e05a30->centronics_input_data5(state); }
 	virtual DECLARE_WRITE_LINE_MEMBER( input_data6 ) override { m_e05a30->centronics_input_data6(state); }
 	virtual DECLARE_WRITE_LINE_MEMBER( input_data7 ) override { m_e05a30->centronics_input_data7(state); }
+	virtual DECLARE_WRITE_LINE_MEMBER( input_init ) override { m_e05a30->centronics_input_init(state); }
 
 	/* Panel buttons */
 	DECLARE_INPUT_CHANGED_MEMBER(online_sw);
+
+	/* Reset Printer (equivalent to turning power off and back on) */
+	DECLARE_INPUT_CHANGED_MEMBER(reset_printer);
 
 protected:
 	epson_lx810l_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
@@ -98,6 +102,8 @@ private:
 	DECLARE_WRITE_LINE_MEMBER(e05a30_centronics_perror) { output_perror(state); }
 	DECLARE_WRITE_LINE_MEMBER(e05a30_centronics_fault) { output_fault(state); }
 	DECLARE_WRITE_LINE_MEMBER(e05a30_centronics_select) { output_select(state); }
+
+	DECLARE_WRITE_LINE_MEMBER(e05a30_cpu_reset) { if (!state) m_maincpu->pulse_input_line(INPUT_LINE_RESET, attotime::zero); } // reset cpu
 
 	void lx810l_mem(address_map &map);
 

--- a/src/devices/machine/e05a30.cpp
+++ b/src/devices/machine/e05a30.cpp
@@ -29,9 +29,10 @@ e05a30_device::e05a30_device(const machine_config &mconfig, const char *tag, dev
 	m_write_centronics_perror(*this),
 	m_write_centronics_fault(*this),
 	m_write_centronics_select(*this),
+	m_write_cpu_reset(*this),
 	m_printhead(0),
 	m_pf_stepper(0),
-	m_cr_stepper(0), m_centronics_data(0), m_centronics_busy(0), m_centronics_nack(0), m_centronics_strobe(0), m_centronics_data_latch(0), m_centronics_data_latched(0)
+	m_cr_stepper(0), m_centronics_data(0), m_centronics_busy(0), m_centronics_nack(0), m_centronics_init(1), m_centronics_strobe(0), m_centronics_data_latch(0), m_centronics_data_latched(0)
 {
 }
 
@@ -51,6 +52,7 @@ void e05a30_device::device_start()
 	m_write_centronics_perror.resolve_safe();
 	m_write_centronics_fault.resolve_safe();
 	m_write_centronics_select.resolve_safe();
+	m_write_cpu_reset.resolve_safe();
 
 	/* register for state saving */
 	save_item(NAME(m_printhead));
@@ -156,6 +158,18 @@ WRITE_LINE_MEMBER( e05a30_device::centronics_input_strobe )
 	}
 
 	m_centronics_strobe = state;
+}
+
+
+WRITE_LINE_MEMBER( e05a30_device::centronics_input_init )
+{
+	if (m_centronics_init == 1 && state == 0) // when init goes low, do a reset cycle
+	{
+		m_write_cpu_reset(0);
+		m_write_cpu_reset(1);
+		device_reset(); // this will trigger an NMI after 0.9 seconds
+	}
+	m_centronics_init = state;
 }
 
 

--- a/src/devices/machine/e05a30.h
+++ b/src/devices/machine/e05a30.h
@@ -24,11 +24,13 @@ public:
 	auto centronics_perror() { return m_write_centronics_perror.bind(); }
 	auto centronics_fault() { return m_write_centronics_fault.bind(); }
 	auto centronics_select() { return m_write_centronics_select.bind(); }
+	auto cpu_reset() { return m_write_cpu_reset.bind(); }
 
 	void write(offs_t offset, uint8_t data);
 	uint8_t read(offs_t offset);
 
 	/* Centronics stuff */
+	DECLARE_WRITE_LINE_MEMBER( centronics_input_init );
 	DECLARE_WRITE_LINE_MEMBER( centronics_input_strobe );
 	DECLARE_WRITE_LINE_MEMBER( centronics_input_data0 ) { if (state) m_centronics_data |= 0x01; else m_centronics_data &= ~0x01; }
 	DECLARE_WRITE_LINE_MEMBER( centronics_input_data1 ) { if (state) m_centronics_data |= 0x02; else m_centronics_data &= ~0x02; }
@@ -57,6 +59,7 @@ private:
 	devcb_write_line m_write_centronics_perror;
 	devcb_write_line m_write_centronics_fault;
 	devcb_write_line m_write_centronics_select;
+	devcb_write_line m_write_cpu_reset;
 
 	void update_printhead(int pos, uint8_t data);
 	void update_pf_stepper(uint8_t data);
@@ -73,10 +76,12 @@ private:
 	uint8_t m_centronics_data;
 	int m_centronics_busy;
 	int m_centronics_nack;
+	uint8_t m_centronics_init;
 	uint8_t m_centronics_strobe;
 	uint8_t m_centronics_data_latch;
 	uint8_t m_centronics_data_latched;
 	uint32_t m_c000_shift_register;
+
 };
 
 DECLARE_DEVICE_TYPE(E05A30, e05a30_device)


### PR DESCRIPTION
ap2000 is reset when the maincpu is reset, and then gets an NMI signal a short while later (0.9 seconds minimum).

This adds printer reset from the keyboard and hooks up centronics init signal