### PR TITLE
coco3: adjust $FEXX constant RAM setting 

### DIFF
--- a/src/mame/video/gime.cpp
+++ b/src/mame/video/gime.cpp
@@ -529,19 +529,16 @@ void gime_device::update_memory(int bank)
 
 	// bank 8 is really $FE00-$FEFF; it is weird so adjust for it
 	offs_t offset;
-	bool force_ram;
 	bool enable_mmu = (m_gime_registers[0] & 0x40) ? true : false;
 	if (bank == 8)
 	{
 		bank = 7;
 		offset = 0x1E00;
-		force_ram = (m_gime_registers[0] & 0x08);
 		enable_mmu = enable_mmu && !(m_gime_registers[0] & 0x08);
 	}
 	else
 	{
 		offset = 0x0000;
-		force_ram = false;
 	}
 
 	// is the MMU enabled at $FF90?
@@ -566,7 +563,7 @@ void gime_device::update_memory(int bank)
 	// are we actually in ROM?
 	uint8_t *memory;
 	bool is_read_only;
-	if (((block & 0x3F) >= 0x3C) && !(m_sam_state & SAM_STATE_TY) && !force_ram)
+	if (((block & 0x3F) >= 0x3C) && !(m_sam_state & SAM_STATE_TY))
 	{
 		// we're in ROM
 		const uint8_t rom_mode = m_gime_registers[0] & 3;


### PR DESCRIPTION
Force constant RAM at $FEXX does not override ROM settings. This fixes the splash screen in Demon Attack.