### PR TITLE
imd_dsk.cpp: Fix segmentation fault saving FM track

### DIFF
--- a/src/lib/formats/imd_dsk.cpp
+++ b/src/lib/formats/imd_dsk.cpp
@@ -661,7 +661,7 @@ bool imd_format::save(io_generic *io, const std::vector<uint32_t> &variants, flo
 
 		bool fm = m_mode[i]< 3;
 
-		auto bitstream = generate_bitstream_from_track(m_track[i]*m_trackmult, head, 2000, image);
+		auto bitstream = generate_bitstream_from_track(m_track[i]*m_trackmult, head, fm ? 4000 : 2000, image);
 		std::vector<std::vector<uint8_t>> sectors;
 
 		if (fm)


### PR DESCRIPTION
Incorrect cell size for FM track results in empty bitstream that ultimately causes data.empty() to seg fault.