### PR TITLE
Upd7220 area fill rework

### DIFF
--- a/src/devices/bus/compis/hrg.cpp
+++ b/src/devices/bus/compis/hrg.cpp
@@ -34,14 +34,14 @@ DEFINE_DEVICE_TYPE(COMPIS_UHRG, compis_uhrg_device, "compis_uhrg", "Compis UHRG"
 
 void compis_hrg_device::hrg_map(address_map &map)
 {
-	map.global_mask(0x7fff);
-	map(0x00000, 0x7fff).ram().share("video_ram");
+	map.global_mask(0x3fff);
+	map(0x00000, 0x3fff).ram().share("video_ram");
 }
 
 void compis_uhrg_device::uhrg_map(address_map &map)
 {
-	map.global_mask(0x1ffff);
-	map(0x00000, 0x1ffff).ram().share("video_ram");
+	map.global_mask(0xffff);
+	map(0x00000, 0xffff).ram().share("video_ram");
 }
 
 
@@ -51,7 +51,7 @@ void compis_uhrg_device::uhrg_map(address_map &map)
 
 UPD7220_DISPLAY_PIXELS_MEMBER( compis_hrg_device::display_pixels )
 {
-	uint16_t const gfx = m_video_ram[(address & 0x7fff) >> 1];
+	uint16_t const gfx = m_video_ram[(address & 0x3fff)];
 	pen_t const *const pen = m_palette->pens();
 
 	for(uint16_t i=0; i<16; i++)
@@ -65,7 +65,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( compis_hrg_device::display_pixels )
 
 UPD7220_DISPLAY_PIXELS_MEMBER( compis_uhrg_device::display_pixels )
 {
-	uint16_t const gfx = m_video_ram[(address & 0x1ffff) >> 1];
+	uint16_t const gfx = m_video_ram[(address & 0xffff)];
 	pen_t const *const pen = m_palette->pens();
 
 	for(uint16_t i=0; i<16; i++)

--- a/src/devices/bus/isa/num9rev.cpp
+++ b/src/devices/bus/isa/num9rev.cpp
@@ -26,11 +26,11 @@ UPD7220_DISPLAY_PIXELS_MEMBER( isa8_number_9_rev_device::hgdc_display_pixels )
 	{
 		rgb_t color(0);
 		uint16_t overlay;
-		if(((address << 3) + 0xc0016) > (1024*1024))
+		if(((address << 4) + 0xc0016) > (1024*1024))
 			return;
 		for(int i = 0; i < 16; i++)
 		{
-			uint32_t addr = (address << 3) + i;
+			uint32_t addr = (address << 4) + i;
 			overlay = m_ram[addr + 0xc0000] << 1;
 			overlay = m_overlay[overlay + ((m_mode & 8) ? 512 : 0)] | (m_overlay[overlay + 1 + ((m_mode & 8) ? 512 : 0)] << 8);
 			color.set_r(pal->entry_color(m_ram[addr] | ((overlay & 0xf) << 8)).r());
@@ -41,7 +41,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( isa8_number_9_rev_device::hgdc_display_pixels )
 	}
 	else
 	{
-		if(((address << 3) + 16) > (1024*1024))
+		if(((address << 4) + 16) > (1024*1024))
 			return;
 		for(int i = 0; i < 16; i++)
 			bitmap.pix(y, x + i) = pal->entry_color(m_ram[(address << 4) + i]);

--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -481,7 +481,7 @@ inline void upd7220_device::rdat(uint8_t type, uint8_t mod)
 //-------------------------------------------------
 //  write_vram -
 //-------------------------------------------------
-inline void upd7220_device::write_vram(uint8_t type, uint8_t mod, uint16_t data)
+inline void upd7220_device::write_vram(uint8_t type, uint8_t mod, uint16_t data, uint16_t mask)
 {
 	uint16_t current = readword(m_ead);
 
@@ -489,41 +489,38 @@ inline void upd7220_device::write_vram(uint8_t type, uint8_t mod, uint16_t data)
 	{
 		case 0x00: //replace
 			if(type == 0)
-				current = data;
+				current = (current & (~mask)) | (data & mask);
 			if(type == 2)
-				current = (current & 0xff00) | (data & 0xff);
+				current = (current & ~(mask & 0xff)) | (data & (mask & 0xff));
 			if(type == 3)
-				current = (current & 0xff) | (data & 0xff00);
+				current = (current & ~(mask & 0xff00)) | (data & (mask & 0xff00));
 			break;
 		case 0x01: //complement
 			if(type == 0)
-				current = current ^ data;
+				current = current ^ (data & mask);
 			if(type == 2)
-				current = current ^ (data & 0xff);
+				current = current ^ (data & (mask & 0xff));
 			if(type == 3)
-				current = current ^ (data & 0xff00);
+				current = current ^ (data & (mask & 0xff00));
 			break;
 		case 0x02: //reset to zero
 			if(type == 0)
-				current = current & ~data;
+				current = current & ~(data & mask);
 			if(type == 2)
-				current = current & ~(data & 0xff);
+				current = current & ~(data & (mask & 0xff));
 			if(type == 3)
-				current = current & ~(data & 0xff00);
+				current = current & ~(data & (mask & 0xff00));
 			break;
 		case 0x03: //set to one
 			if(type == 0)
-				current = current | data;
+				current = current | (data & mask);
 			if(type == 2)
-				current = current | (data & 0xff);
+				current = current | (data & (mask & 0xff));
 			if(type == 3)
-				current = current | (data & 0xff00);
+				current = current | (data & (mask & 0xff00));
 			break;
 	}
 	writeword(m_ead, current);
-
-	m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
-	m_ead &= 0x3ffff;
 }
 
 inline void upd7220_device::wdat(uint8_t type, uint8_t mod)
@@ -560,6 +557,8 @@ inline void upd7220_device::wdat(uint8_t type, uint8_t mod)
 	for(int i = 0; i < m_figs.m_dc + 1; i++)
 	{
 		write_vram(type, mod, result);
+		m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+		m_ead &= 0x3ffff;
 	}
 }
 
@@ -609,6 +608,7 @@ upd7220_device::upd7220_device(const machine_config &mconfig, const char *tag, d
 	m_write_hsync(*this),
 	m_write_vsync(*this),
 	m_write_blank(*this),
+	m_pattern(0),
 	m_mask(0),
 	m_pitch(0),
 	m_ead(0),
@@ -704,6 +704,7 @@ void upd7220_device::device_start()
 	save_item(NAME(m_lad));
 	save_item(NAME(m_disp));
 	save_item(NAME(m_gchr));
+	save_item(NAME(m_pattern));
 	save_item(NAME(m_mask));
 	save_item(NAME(m_pitch));
 	save_item(NAME(m_ra_addr));
@@ -984,58 +985,150 @@ void upd7220_device::draw_rectangle(int x, int y)
 //  draw_char -
 //-------------------------------------------------
 
-void upd7220_device::draw_char(int x, int y)
+void upd7220_device::draw_char()
 {
-	int isize,psize;
-	uint16_t tile_data;
+	const int8_t dir_change[2][4] = {
+		{2, 2, -2, -2},
+		{1, 3, -3, -1}
+	};
+	const uint8_t type = (m_figs.m_figure_type & 0x10) >> 4;
 
-	LOG("uPD7220 char check: %d %d %02x %08x %d %d %02x\n",x,y,m_figs.m_dir,m_ead,m_figs.m_d,m_figs.m_dc,m_figs.m_figure_type);
 
-	/* QX10 may require upper bits for psize, VT240 requires the opposite */
-	isize = m_figs.m_d;
-	psize = m_figs.m_dc + 1;
+	LOG("uPD7220 char check: %08x %04x %02x %02x %d %d %02x\n",m_ead,m_mask,m_bitmap_mod,m_figs.m_dir,m_figs.m_d,m_figs.m_dc,m_figs.m_figure_type);
 
-	for(int pi = 0; pi < psize; pi++)
+	for (int i = 0, di = 0; i < (m_figs.m_dc + 1); ++i)
 	{
-		tile_data = (m_ra[15-(pi & 7)] << 8) | m_ra[15-(pi & 7)];
-		for(int pz = 0; pz <= m_gchr; pz++)
+		m_pattern = (m_ra[15 - (i & 7)] << 8) | m_ra[15 - (i & 7)];
+		for (int zdc = 0; zdc <= m_gchr; ++zdc, ++di)
 		{
-			int ii = 0, curpixel = 0;
-			if(pi & 1)
+			for (int j = 0; j < m_figs.m_d; ++j)
 			{
-				ii = isize - 1;
-				curpixel = (isize * (m_gchr + 1)) - 1;
-			}
-			while(pi & 1 ? ii >= 0 : ii < isize)
-			{
-				for(int iz = 0; iz <= m_gchr; iz++)
+				const uint16_t pattern = (di % 2) ? get_pattern(15-(j & 0xf)) : get_pattern((j & 0xf));
+				for (int zd = 0; zd <= m_gchr; ++zd)
 				{
-					draw_pixel(x + (curpixel * x_dir[m_figs.m_dir]), y + (curpixel * y_dir[m_figs.m_dir]), ii, tile_data);
-					if(pi & 1)
-						curpixel--;
-					else
-						curpixel++;
+					write_vram(0, m_bitmap_mod, pattern, m_mask);
+
+					if (j != (m_figs.m_d - 1) || zd != m_gchr)
+						next_pixel(m_figs.m_dir);
 				}
-				if(pi & 1)
-					ii--;
-				else
-					ii++;
 			}
-			if(m_figs.m_figure_type == 2)
-			{
-				x += x_dir[(m_figs.m_dir + 2) & 7];
-				y += y_dir[(m_figs.m_dir + 2) & 7];
-			}
-			else
-			{
-				x += x_dir[(m_figs.m_dir + 1) & 7];
-				y += y_dir[(m_figs.m_dir + 1) & 7];
-			}
+			m_figs.m_dir = (((uint16_t)m_figs.m_dir + dir_change[type][(di % 2) << 1]) & 7);
+			next_pixel(m_figs.m_dir);
+			m_figs.m_dir = (((uint16_t)m_figs.m_dir + dir_change[type][((di % 2) << 1)+1]) & 7);
 		}
 	}
+}
 
-	m_ead = (x >> 4) + (y * (m_pitch >> m_figs.m_gd));
-	m_dad = (x & 0xf);
+
+//-------------------------------------------------
+//  helper functions used to rotate a uint16_t
+//-------------------------------------------------
+
+static constexpr uint16_t rotate_right(uint16_t value)
+{
+	return (value>>1) | (value<<( (-1) & 0x0f ));
+}
+
+static constexpr uint16_t rotate_left(uint16_t value)
+{
+	return (value<<1) | (value>>( (-1) & 0x0f ));
+}
+
+
+//-------------------------------------------------
+//  get_pitch -
+//-------------------------------------------------
+
+uint16_t upd7220_device::get_pitch()
+{
+	bool mixed = ((m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_MIXED);
+
+	if (mixed)
+		return m_pitch >> m_figs.m_gd;
+
+	return m_pitch;
+}
+
+
+//-------------------------------------------------
+//  get_pattern -
+//-------------------------------------------------
+
+uint16_t upd7220_device::get_pattern(uint8_t cycle)
+{
+	bool mixed = ((m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_MIXED);
+	bool graphics = ((m_mode & UPD7220_MODE_DISPLAY_MASK) == UPD7220_MODE_DISPLAY_GRAPHICS);
+
+	if ((mixed && m_figs.m_gd) || graphics)
+	{
+		return ((m_pattern >> (cycle & 0xf)) & 1) * 0xffff;
+	}
+	return m_pattern;
+}
+
+
+//-------------------------------------------------
+//  next_pixel -
+//-------------------------------------------------
+
+void upd7220_device::next_pixel(int direction)
+{
+	switch(direction & 7)
+	{
+		case 0:
+			m_ead += get_pitch();
+			break;
+		case 1:
+			m_ead += get_pitch();
+			if (m_mask & 0x8000)
+			{
+				m_ead += 1;
+			}
+			m_mask = rotate_left(m_mask);
+			break;
+		case 2:
+			if (m_mask & 0x8000)
+			{
+				m_ead += 1;
+			}
+			m_mask = rotate_left(m_mask);
+			break;
+		case 3:
+			m_ead -= get_pitch();
+			if (m_mask & 0x8000)
+			{
+				m_ead += 1;
+			}
+			m_mask = rotate_left(m_mask);
+			break;
+		case 4:
+			m_ead -= get_pitch();
+			break;
+		case 5:
+			m_ead -= get_pitch();
+			if (m_mask & 0x1)
+			{
+				m_ead -= 1;
+			}
+			m_mask = rotate_right(m_mask);
+			break;
+		case 6:
+			if (m_mask & 0x1)
+			{
+				m_ead -= 1;
+			}
+			m_mask = rotate_right(m_mask);
+			break;
+		case 7:
+			m_ead += get_pitch();
+			if (m_mask & 0x1)
+			{
+				m_ead -= 1;
+			}
+			m_mask = rotate_right(m_mask);
+			break;
+	}
+	m_ead &= 0x3ffff;
 }
 
 
@@ -1278,8 +1371,10 @@ void upd7220_device::process_fifo()
 
 			if(m_param_ptr == 4)
 			{
-				m_dad = m_pr[3] >> 4;
+				m_dad = (m_pr[3] >> 4) & 0x0f;;
+				m_mask = 1 << m_dad;
 				LOG("uPD7220 DAD: %01x\n", m_dad);
+				LOG("uPD7220 MASK: %04x\n", m_mask);
 			}
 		}
 		break;
@@ -1388,7 +1483,7 @@ void upd7220_device::process_fifo()
 
 	case COMMAND_GCHRD: /* graphics character draw and area filling start */
 		if((m_figs.m_figure_type & 0xf) == 2)
-			draw_char(((m_ead % eff_pitch) << 4) | (m_dad & 0xf),(m_ead / eff_pitch));
+			draw_char();
 		else
 			logerror("uPD7220 Unimplemented command GCHRD %02x\n", m_figs.m_figure_type);
 
@@ -1567,6 +1662,8 @@ void upd7220_device::dack_w(uint8_t data)
 			{
 				m_dma_data = ((m_dma_data & 0xff) | data << 8) & m_mask;
 				write_vram(m_dma_type, m_dma_mod, m_dma_data);
+				m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+				m_ead &= 0x3ffff;
 			}
 			else
 			{
@@ -1576,10 +1673,14 @@ void upd7220_device::dack_w(uint8_t data)
 		case 2:
 			m_dma_data = data & (m_mask & 0xff);
 			write_vram(m_dma_type, m_dma_mod, m_dma_data);
+			m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+			m_ead &= 0x3ffff;
 			break;
 		case 3:
 			m_dma_data = (data << 8) & (m_mask & 0xff00);
 			write_vram(m_dma_type, m_dma_mod, m_dma_data);
+			m_ead += x_dir[m_figs.m_dir] + (y_dir[m_figs.m_dir] * m_pitch);
+			m_ead &= 0x3ffff;
 			break;
 		default:
 			logerror("uPD7220 Invalid DMA Transfer Type\n");

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -115,15 +115,18 @@ private:
 	inline void rdat(uint8_t type, uint8_t mod);
 	inline uint16_t read_vram();
 	inline void wdat(uint8_t type, uint8_t mod);
-	inline void write_vram(uint8_t type, uint8_t mod, uint16_t data);
+	inline void write_vram(uint8_t type, uint8_t mod, uint16_t data, uint16_t mask = 0xffff);
 	inline void get_text_partition(int index, uint32_t *sad, uint16_t *len, int *im, int *wd);
 	inline void get_graphics_partition(int index, uint32_t *sad, uint16_t *len, int *im, int *wd);
 
+	uint16_t get_pitch();
+	uint16_t get_pattern(uint8_t cycle);
+	void next_pixel(int direction);
 	void draw_pixel(int x, int y, int xi, uint16_t tile_data);
 	void draw_line(int x, int y);
 	void draw_rectangle(int x, int y);
 	void draw_arc(int x, int y);
-	void draw_char(int x, int y);
+	void draw_char();
 	int translate_command(uint8_t data);
 	void process_fifo();
 	void continue_command();
@@ -140,6 +143,8 @@ private:
 	devcb_write_line   m_write_hsync;
 	devcb_write_line   m_write_vsync;
 	devcb_write_line   m_write_blank;
+
+	uint16_t m_pattern;
 
 	uint8_t m_dma_type;               // DMA transfer type
 	uint8_t m_dma_mod;                // DMA transfer mode

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Angelo Salese, Miodrag Milanovic, Carl
+// copyright-holders:Angelo Salese, Miodrag Milanovic, Carl, Brian Johnson
 /**********************************************************************
 
     NEC uPD7220 Graphics Display Controller emulation
@@ -100,8 +100,6 @@ private:
 		TIMER_BLANK
 	};
 
-	inline uint8_t readbyte(offs_t address);
-	inline void writebyte(offs_t address, uint8_t data);
 	inline uint16_t readword(offs_t address);
 	inline void writeword(offs_t address, uint16_t data);
 	inline void fifo_clear();

--- a/src/mame/drivers/a5105.cpp
+++ b/src/mame/drivers/a5105.cpp
@@ -114,7 +114,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( a5105_state::hgdc_display_pixels )
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 
-	int const gfx = m_video_ram[(address & 0x1ffff) >> 1];
+	int const gfx = m_video_ram[(address & 0xffff)];
 
 	for (int xi = 0; xi < 16; xi++)
 	{

--- a/src/mame/drivers/dmv.cpp
+++ b/src/mame/drivers/dmv.cpp
@@ -309,9 +309,9 @@ UPD7220_DISPLAY_PIXELS_MEMBER( dmv_state::hgdc_display_pixels )
 	if (m_color_mode)
 	{
 		// 96KB videoram (32KB green + 32KB red + 32KB blue)
-		uint16_t green = m_video_ram[(0x00000 + (address & 0x7fff)) >> 1];
-		uint16_t red   = m_video_ram[(0x08000 + (address & 0x7fff)) >> 1];
-		uint16_t blue  = m_video_ram[(0x10000 + (address & 0x7fff)) >> 1];
+		uint16_t green = m_video_ram[(0x00000 + (address & 0x3fff))];
+		uint16_t red   = m_video_ram[(0x04000 + (address & 0x3fff))];
+		uint16_t blue  = m_video_ram[(0x08000 + (address & 0x3fff))];
 
 		for(int xi=0; xi<16; xi++)
 		{
@@ -328,7 +328,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( dmv_state::hgdc_display_pixels )
 		rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 
 		// 32KB videoram
-		uint16_t gfx = m_video_ram[(address & 0xffff) >> 1];
+		uint16_t gfx = m_video_ram[(address & 0x3fff)];
 
 		for(int xi=0;xi<16;xi++)
 		{
@@ -612,8 +612,8 @@ void dmv_state::kb_mcu_port2_w(uint8_t data)
 
 void dmv_state::upd7220_map(address_map &map)
 {
-	map.global_mask(0x1ffff);
-	map(0x00000, 0x1ffff).ram().share("video_ram");
+	map.global_mask(0xffff);
+	map(0x0000, 0xffff).ram().share("video_ram");
 }
 
 /* Input ports */

--- a/src/mame/drivers/hhtiger.cpp
+++ b/src/mame/drivers/hhtiger.cpp
@@ -184,9 +184,9 @@ GFXDECODE_END
 UPD7220_DISPLAY_PIXELS_MEMBER(hhtiger_state::display_pixels)
 {
 	/* 96KB video RAM (32KB green + 32KB red + 32KB blue) */
-	uint16_t const green = m_video_ram[(0x00000 + (address & 0x7fff)) >> 1];
-	uint16_t const red   = m_video_ram[(0x08000 + (address & 0x7fff)) >> 1];
-	uint16_t const blue  = m_video_ram[(0x10000 + (address & 0x7fff)) >> 1];
+	uint16_t const green = m_video_ram[(0x00000 + (address & 0x3fff))];
+	uint16_t const red   = m_video_ram[(0x04000 + (address & 0x3fff))];
+	uint16_t const blue  = m_video_ram[(0x08000 + (address & 0x3fff))];
 
 	for (int xi = 0; xi<16; xi++)
 	{

--- a/src/mame/drivers/if800.cpp
+++ b/src/mame/drivers/if800.cpp
@@ -45,7 +45,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( if800_state::hgdc_display_pixels )
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 
-	int gfx = m_video_ram[address >> 1];
+	int gfx = m_video_ram[address];
 
 	for(int xi=0;xi<16;xi++)
 	{

--- a/src/mame/drivers/mz6500.cpp
+++ b/src/mame/drivers/mz6500.cpp
@@ -51,7 +51,7 @@ private:
 UPD7220_DISPLAY_PIXELS_MEMBER( mz6500_state::hgdc_display_pixels )
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
-	int const gfx[3] = { m_vram[(address + 0x00000) >> 1], m_vram[(address + 0x10000) >> 1], m_vram[(address + 0x20000) >> 1] };
+	int const gfx[3] = { m_vram[(address + 0x00000)], m_vram[(address + 0x8000)], m_vram[(address + 0x10000)] };
 
 	for(u8 i=0; i<16; i++)
 	{

--- a/src/mame/drivers/qx10.cpp
+++ b/src/mame/drivers/qx10.cpp
@@ -210,16 +210,16 @@ UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
 {
 	rgb_t const *const palette = m_palette->palette()->entry_list_raw();
 	int gfx[3];
-	address &= 0x1ffff;
+	address &= 0xffff;
 	if(m_color_mode)
 	{
-		gfx[0] = m_video_ram[(address >> 1) + 0x00000];
-		gfx[1] = m_video_ram[(address >> 1) + 0x10000];
-		gfx[2] = m_video_ram[(address >> 1) + 0x20000];
+		gfx[0] = m_video_ram[address + 0x00000];
+		gfx[1] = m_video_ram[address + 0x10000];
+		gfx[2] = m_video_ram[address + 0x20000];
 	}
 	else
 	{
-		gfx[0] = m_video_ram[(address >> 1)];
+		gfx[0] = m_video_ram[address];
 		gfx[1] = 0;
 		gfx[2] = 0;
 	}
@@ -243,7 +243,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( qx10_state::hgdc_display_pixels )
 UPD7220_DRAW_TEXT_LINE_MEMBER( qx10_state::hgdc_draw_text )
 {
 	const rgb_t *palette = m_palette->palette()->entry_list_raw();
-	addr &= 0x1ffff;
+	addr &= 0xffff;
 
 	for (int x = 0; x < pitch; x++)
 	{
@@ -836,7 +836,7 @@ void qx10_state::vram_w(offs_t offset, uint16_t data, uint16_t mem_mask)
 
 void qx10_state::upd7220_map(address_map &map)
 {
-	map(0x00000, 0x1ffff).rw(FUNC(qx10_state::vram_r), FUNC(qx10_state::vram_w)).mirror(0x20000);
+	map(0x0000, 0xffff).rw(FUNC(qx10_state::vram_r), FUNC(qx10_state::vram_w)).mirror(0x30000);
 }
 
 static void keyboard(device_slot_interface &device)

--- a/src/mame/drivers/rainbow.cpp
+++ b/src/mame/drivers/rainbow.cpp
@@ -844,18 +844,18 @@ UPD7220_DISPLAY_PIXELS_MEMBER( rainbow_base_state::hgdc_display_pixels )
 	if (m_gdc_mode_register & GDC_MODE_HIGHRES)
 	{
 		address = ( m_gdc_scroll_buffer[ ((address & 0x7FC0) >> 7) & 0xff ] << 7) |  (address & 0x7F);
-		plane0 = m_video_ram[((address & 0x7fff) + 0x00000) >> 1];
-		plane1 = m_video_ram[((address & 0x7fff) + 0x10000) >> 1];
+		plane0 = m_video_ram[((address & 0x3fff) + 0x0000)];
+		plane1 = m_video_ram[((address & 0x3fff) + 0x8000)];
 		plane2 = plane3 = 0;
 	}
 	else
 	{
 		address = ( m_gdc_scroll_buffer[ ((address & 0x3FC0) >> 7) & 0xff ] << 7) |  (address & 0x7F);
 		// MED.RESOLUTION (4 planes, 4 color bits, 16 color map entries / 16 -or 4- MONOCHROME SHADES)
-		plane0 = m_video_ram[((address & 0x3fff) + 0x00000) >> 1];
-		plane1 = m_video_ram[((address & 0x3fff) + 0x10000) >> 1];
-		plane2 = m_video_ram[((address & 0x3fff) + 0x20000) >> 1];
-		plane3 = m_video_ram[((address & 0x3fff) + 0x30000) >> 1];
+		plane0 = m_video_ram[((address & 0x1fff) + 0x00000)];
+		plane1 = m_video_ram[((address & 0x1fff) + 0x08000)];
+		plane2 = m_video_ram[((address & 0x1fff) + 0x10000)];
+		plane3 = m_video_ram[((address & 0x1fff) + 0x18000)];
 	}
 
 	bool mono = (m_monitor_suggested == MONO_MONITOR) ? true : false; // 1 = MONO, 2 = COLOR, 3 = DUAL MONITOR; 4 = AUTO

--- a/src/mame/drivers/vt240.cpp
+++ b/src/mame/drivers/vt240.cpp
@@ -205,12 +205,12 @@ UPD7220_DISPLAY_PIXELS_MEMBER( vt240_state::hgdc_draw )
 
 	if(!BIT(m_reg0, 7))
 	{
-		vram_w(address >> 1, 0);
-		vram_w((0x20000 + address) >> 1, 0);
+		vram_w(address, 0);
+		vram_w((0x10000 + address), 0);
 	}
 
-	int const gfx1 = m_video_ram[(address & 0x7fff) >> 1];
-	int const gfx2 = m_video_ram[((address & 0x7fff) + 0x8000) >> 1];
+	int const gfx1 = m_video_ram[(address & 0x3fff)];
+	int const gfx2 = m_video_ram[((address & 0x3fff) + 0x4000)];
 
 	bool const color = m_monitor->read() ? true : false;
 	for(int xi=0;xi<16;xi++)

--- a/src/mame/video/mikromik.cpp
+++ b/src/mame/video/mikromik.cpp
@@ -71,7 +71,7 @@ void mm1_state::mm1_upd7220_map(address_map &map)
 
 UPD7220_DISPLAY_PIXELS_MEMBER( mm1_state::hgdc_display_pixels )
 {
-	uint16_t data = m_video_ram[address >> 1];
+	uint16_t data = m_video_ram[address];
 	for (int i = 0; i < 16; i++)
 	{
 		if (BIT(data, i)) bitmap.pix(y, x + i) = m_palette->pen(2);

--- a/src/mame/video/pc9801.cpp
+++ b/src/mame/video/pc9801.cpp
@@ -59,7 +59,7 @@ UPD7220_DISPLAY_PIXELS_MEMBER( pc9801_state::hgdc_display_pixels )
 			int res_x = x + xi;
 			int res_y = y;
 
-			uint8_t pen = ext_gvram[(address >> 1)*16+xi+(m_vram_disp*0x40000)];
+			uint8_t pen = ext_gvram[(address)*16+xi+(m_vram_disp*0x40000)];
 
 			bitmap.pix(res_y, res_x) = palette[pen + 0x20];
 		}
@@ -72,11 +72,11 @@ UPD7220_DISPLAY_PIXELS_MEMBER( pc9801_state::hgdc_display_pixels )
 			int res_y = y;
 
 			uint8_t pen;
-			pen = ((m_video_ram_2[((address & 0x7fff) + (0x08000) + (m_vram_disp*0x20000)) >> 1] >> xi) & 1) ? 1 : 0;
-			pen|= ((m_video_ram_2[((address & 0x7fff) + (0x10000) + (m_vram_disp*0x20000)) >> 1] >> xi) & 1) ? 2 : 0;
-			pen|= ((m_video_ram_2[((address & 0x7fff) + (0x18000) + (m_vram_disp*0x20000)) >> 1] >> xi) & 1) ? 4 : 0;
+			pen = ((m_video_ram_2[((address & 0x3fff) + (0x4000) + ((m_vram_disp*0x20000)>>1))] >> xi) & 1) ? 1 : 0;
+			pen|= ((m_video_ram_2[((address & 0x3fff) + (0x8000) + ((m_vram_disp*0x20000)>>1))] >> xi) & 1) ? 2 : 0;
+			pen|= ((m_video_ram_2[((address & 0x3fff) + (0xc000) + ((m_vram_disp*0x20000)>>1))] >> xi) & 1) ? 4 : 0;
 			if(m_ex_video_ff[ANALOG_16_MODE])
-				pen|= ((m_video_ram_2[((address & 0x7fff) + (0) + (m_vram_disp*0x20000)) >> 1] >> xi) & 1) ? 8 : 0;
+				pen|= ((m_video_ram_2[((address & 0x3fff) + (0) + ((m_vram_disp*0x20000)>>1))] >> xi) & 1) ? 8 : 0;
 			bitmap.pix(res_y, res_x) = palette[pen + colors16_mode];
 		}
 	}


### PR DESCRIPTION
These patches fix some issue in the implementation of the upd7220 GPU.

1. The first patch fixes the adress space to use a -1 address shift so that is actually word adressable. Without this the total amount of memory addressable was only 256k but the actually device should be able to address 512k of memory. In addition this cleans up memory accesses since we no longer need to multiple every address by 2 to get the correct word access.
2. This patch does a proper implementation of the GCHRD command using the ead/dad/mask as specified via the datasheet. This is ncessary since the previous implementation did not use the mask properly which was preventing the screen clearing routines on the QX-10 from working properly.

Tests ran:
QX-10: diag disk in color mode. (Works)
compis: bildspel.cmd (Works)
dmv: demo5 and demo50 (Works)
pc-98:  adventureland, quarth, xevious, dbuster (Works)
rainbow: graphics diag disk (Works)
vt240 emulation (Works)

All tests ran the same as before these patches.