### PR TITLE
smc91c96 updates ( apple2e, a2osx w/ lancegs)

### DIFF
--- a/src/devices/machine/smc91c9x.h
+++ b/src/devices/machine/smc91c9x.h
@@ -258,7 +258,7 @@ private:
 	int m_rx_active;
 	int m_tx_retry_count;
 	u8 m_rx_hash;
-	u8 m_loopback_result;
+	int m_loopback_result;
 
 	void update_ethernet_irq();
 	void update_stats();


### PR DESCRIPTION
1. m_loopback_result needs to be a signed int so negative results remain negative.
2. FDSE bit was masked out
3. when Full Duplex Switched Ethernet is active, deferral and collision logic is not in effect
4. implement AUTO_RELEASE mode

The receive collision detection seems problematic to me.  If it were a real hardware on a real half-duplex network, the sender would detect the collision and resend, AIUI. Currently, the 91c9x discards the packet and it will never be resent.