### PR TITLE
video/upd7220: Update FIGD to use ead and mask to calculate drawing location

### DIFF
--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -28,8 +28,6 @@
     - honor visible area
     - wide mode (32-bit access)
     - light pen
-    - dad and mask are the same, in figd dad is shifted every step and when msb or lsb are 1 ead is advanced in x dir
-
 */
 
 #include "emu.h"
@@ -612,7 +610,6 @@ upd7220_device::upd7220_device(const machine_config &mconfig, const char *tag, d
 	m_mask(0),
 	m_pitch(0),
 	m_ead(0),
-	m_dad(0),
 	m_lad(0),
 	m_ra_addr(0),
 	m_sr(UPD7220_SR_FIFO_EMPTY),
@@ -700,7 +697,6 @@ void upd7220_device::device_start()
 	save_item(NAME(m_ctop));
 	save_item(NAME(m_cbot));
 	save_item(NAME(m_ead));
-	save_item(NAME(m_dad));
 	save_item(NAME(m_lad));
 	save_item(NAME(m_disp));
 	save_item(NAME(m_gchr));
@@ -1150,7 +1146,6 @@ void upd7220_device::process_fifo()
 			m_ra[0] = m_ra[1] = m_ra[2] = 0;
 			m_ra[3] = 0x19;
 			m_ead = 0;
-			m_dad = 0;
 			m_mask = 0;
 			break;
 
@@ -1289,9 +1284,7 @@ void upd7220_device::process_fifo()
 
 			if(m_param_ptr == 4)
 			{
-				m_dad = (m_pr[3] >> 4) & 0x0f;;
-				m_mask = 1 << m_dad;
-				LOG("uPD7220 DAD: %01x\n", m_dad);
+				m_mask = 1 << ((m_pr[3] >> 4) & 0x0f);
 				LOG("uPD7220 MASK: %04x\n", m_mask);
 			}
 		}
@@ -1420,14 +1413,13 @@ void upd7220_device::process_fifo()
 
 	case COMMAND_CURD: /* cursor address read */
 	{
-		uint16_t dad = 1 << m_dad;
 		fifo_set_direction(FIFO_READ);
 
 		queue(m_ead & 0xff, 0);
 		queue((m_ead >> 8) & 0xff, 0);
 		queue(m_ead >> 16, 0);
-		queue(dad & 0xff, 0);
-		queue(dad >> 8, 0);
+		queue(m_mask & 0xff, 0);
+		queue(m_mask >> 8, 0);
 
 		m_sr |= UPD7220_SR_DATA_READY;
 		break;

--- a/src/devices/video/upd7220.cpp
+++ b/src/devices/video/upd7220.cpp
@@ -424,9 +424,9 @@ inline void upd7220_device::reset_figs_param()
 {
 	m_figs.m_dc = 0x0000;
 	m_figs.m_d = 0x0008;
-	m_figs.m_d1 = 0x0008;
-	m_figs.m_d2 = 0x0000;
-	m_figs.m_dm = 0x0000;
+	m_figs.m_d1 = 0xffff;
+	m_figs.m_d2 = 0x0008;
+	m_figs.m_dm = 0xffff;
 	m_figs.m_gd = 0;
 }
 

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -125,7 +125,7 @@ private:
 	void draw_pixel(int x, int y, int xi, uint16_t tile_data);
 	void draw_line();
 	void draw_rectangle();
-	void draw_arc(int x, int y);
+	void draw_arc();
 	void draw_char();
 	int translate_command(uint8_t data);
 	void process_fifo();

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -123,7 +123,7 @@ private:
 	uint16_t get_pattern(uint8_t cycle);
 	void next_pixel(int direction);
 	void draw_pixel(int x, int y, int xi, uint16_t tile_data);
-	void draw_line(int x, int y);
+	void draw_line();
 	void draw_rectangle();
 	void draw_arc(int x, int y);
 	void draw_char();

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -122,7 +122,7 @@ private:
 	uint16_t get_pitch();
 	uint16_t get_pattern(uint8_t cycle);
 	void next_pixel(int direction);
-	void draw_pixel(int x, int y, int xi, uint16_t tile_data);
+	void draw_pixel();
 	void draw_line();
 	void draw_rectangle();
 	void draw_arc();

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -124,7 +124,7 @@ private:
 	void next_pixel(int direction);
 	void draw_pixel(int x, int y, int xi, uint16_t tile_data);
 	void draw_line(int x, int y);
-	void draw_rectangle(int x, int y);
+	void draw_rectangle();
 	void draw_arc(int x, int y);
 	void draw_char();
 	int translate_command(uint8_t data);

--- a/src/devices/video/upd7220.h
+++ b/src/devices/video/upd7220.h
@@ -154,7 +154,6 @@ private:
 	uint16_t m_mask;                  // mask register
 	uint8_t m_pitch;                  // number of word addresses in display memory in the horizontal direction
 	uint32_t m_ead;                   // execute word address
-	uint16_t m_dad;                   // dot address within the word
 	uint32_t m_lad;                   // light pen address
 
 	uint8_t m_ra[16];                 // parameter RAM


### PR DESCRIPTION
This patchset fixes the FIGD drawing to use m_ead/m_mask instead of an x/y cordinate system. This patchset, mutch like my previous one for teh GCHRD command, makes the FIGD command behave as it would on a real upd7220. It also fixes up the inital values for FIGS which did not match what was specified in the datasheet.

Tested on the following systems with no noticable regressions: qx10, compis, dmv, pc-98, vt240, rainbow