### PR TITLE
nes.xml: Fixes for Magic Carpet clones.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -65628,10 +65628,11 @@ All musics were removed in this game.
 
 	<software name="magicarps" cloneof="magicarp">
 		<description>Magic Carpet 1001 (Spa, Rev. 1)</description>
-		<year>19??</year>
+		<year>1991</year>
 		<publisher>Gluk Video</publisher>
 		<info name="alt_title" value="La Alfombra Magica (on the cart label)"/>
 		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="cnrom" />
 			<dataarea name="chr" size="32768">
 				<rom name="alfombra magica, la (spain) (rev 1) (gluk video).chr" size="32768" crc="c2901a91" sha1="28f22d6fdc90c0f23da5e4744981ccd3be9cb85b" offset="00000" status="baddump" />
 			</dataarea>
@@ -65641,32 +65642,19 @@ All musics were removed in this game.
 		</part>
 	</software>
 
+<!-- CHR differs in 5 bytes from magicarps above. It causes lines on the genie's cloud on the title screen and what else? Bad dump? -->
 	<software name="magicarps1" cloneof="magicarp">
 		<description>Magic Carpet 1001 (Spa, Rev. 1, Unlicensed?)</description>
-		<year>19??</year>
+		<year>1991</year>
 		<publisher>Gluk Video</publisher>
 		<info name="alt_title" value="La Alfombra Magica (on the cart label)"/>
 		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="cnrom" />
 			<dataarea name="chr" size="32768">
 				<rom name="alfombra magica, la (spain) (rev 1) (gluk video) (unl).chr" size="32768" crc="39a920c1" sha1="3dbbfa0be006b8b60aaa7ef81356665c27a6d56e" offset="00000" status="baddump" />
 			</dataarea>
 			<dataarea name="prg" size="32768">
 				<rom name="alfombra magica, la (spain) (rev 1) (gluk video) (unl).prg" size="32768" crc="6b80d3de" sha1="4c5cbdc84d8ad820d69130d02a71e1e8e0ce8249" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="magicarps2" cloneof="magicarp">
-		<description>Magic Carpet 1001 (Spa)</description>
-		<year>19??</year>
-		<publisher>Gluk Video</publisher>
-		<info name="alt_title" value="La Alfombra Magica (on the cart label)"/>
-		<part name="cart" interface="nes_cart">
-			<dataarea name="chr" size="32768">
-				<rom name="alfombra magica, la (spain) (gluk video) (unl).chr" size="32768" crc="39a920c1" sha1="3dbbfa0be006b8b60aaa7ef81356665c27a6d56e" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="32768">
-				<rom name="alfombra magica, la (spain) (gluk video) (unl).prg" size="32768" crc="6b80d3de" sha1="4c5cbdc84d8ad820d69130d02a71e1e8e0ce8249" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Hooked clones up to an appropriate cart device. Fixes in-game graphics.
- Removed magicarps2 which was an identical dump to magicarps1.