### PR TITLE
bus/nes: Fixed graphics issues in BB Car clones.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -11069,7 +11069,7 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="elite">
+	<software name="elite" supported="no">
 		<description>Elite (Euro)</description>
 		<year>1992</year>
 		<publisher>Imagineering</publisher>
@@ -46320,7 +46320,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="eliteu" cloneof="elite">
+	<software name="eliteu" cloneof="elite" supported="no">
 		<description>Elite (NTSC Demo?)</description>
 		<year>1992</year>
 		<publisher>Ian Bell</publisher>
@@ -58159,7 +58159,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="quanhr2">
+	<software name="quanhr2" supported="no">
 		<description>Quan Huang R2 - Dashe Sitian Wang (Chi)</description>
 		<year>19??</year>
 		<publisher>Nanjing</publisher>
@@ -61936,7 +61936,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 	<software name="mihunche" cloneof="bbcar">
 		<description>Mi Hun Che (Chi)</description>
-		<year>19??</year>
+		<year>1988</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="cc21" />
@@ -61950,9 +61950,9 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="scche" cloneof="bbcar" supported="partial">
+	<software name="scche" cloneof="bbcar">
 		<description>Super Car (Chi)</description>  <!-- This is not the correct title! -->
-		<year>19??</year>
+		<year>1988</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="cc21" />
@@ -73393,7 +73393,7 @@ Other
 		</part>
 	</software>
 
-	<software name="lordkinga" cloneof="astyanax">
+	<software name="lordkinga" cloneof="astyanax" supported="no">
 		<description>The Lord of King (Asia, Pirate)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>

--- a/src/devices/bus/nes/pirate.cpp
+++ b/src/devices/bus/nes/pirate.cpp
@@ -83,7 +83,7 @@ nes_daou306_device::nes_daou306_device(const machine_config &mconfig, const char
 {
 }
 
-nes_cc21_device::nes_cc21_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_cc21_device::nes_cc21_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_CC21, tag, owner, clock)
 {
 }
@@ -233,18 +233,6 @@ void nes_daou306_device::pcb_reset()
 	set_nt_mirroring(PPU_MIRROR_LOW);
 
 	memset(m_reg, 0, sizeof(m_reg));
-}
-
-void nes_cc21_device::device_start()
-{
-	common_start();
-}
-
-void nes_cc21_device::pcb_reset()
-{
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg32(0);
-	chr8(0, m_chr_source);
 }
 
 void nes_xiaozy_device::device_start()
@@ -739,16 +727,19 @@ void nes_daou306_device::write_h(offs_t offset, uint8_t data)
 
  Games: Mi Hun Che
 
- In MESS: Supported
+ iNES: mapper 27 (overlaps with incompatible World Hero)
+
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_cc21_device::write_h(offs_t offset, uint8_t data)
+void nes_cc21_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("cc21 write_h, offset: %04x, data: %02x\n", offset, data));
 
-	set_nt_mirroring(BIT(offset, 1) ? PPU_MIRROR_HIGH : PPU_MIRROR_LOW);
-	chr8((offset & 0x01), CHRROM);
+	set_nt_mirroring(BIT(offset, 0) ? PPU_MIRROR_HIGH : PPU_MIRROR_LOW);
+	chr4_0(BIT(offset, 0), CHRROM);
+	chr4_4(BIT(offset, 0), CHRROM);
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/nes/pirate.h
+++ b/src/devices/bus/nes/pirate.h
@@ -138,15 +138,9 @@ class nes_cc21_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_cc21_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_cc21_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 


### PR DESCRIPTION
- Graphics issues were in sets mihunche, mihunchea, and scche.
- Separately, demoted several non-working games to not supported.