### PR TITLE
nes.xml: Set correct board type for several pirate games.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -76689,13 +76689,13 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="sf2a" cloneof="sf2" supported="no">
+<!-- Is this or the parent a bad dump? They differ in only one byte in CHR ROM. -->
+	<software name="sf2a" cloneof="sf2">
 		<description>Street Fighter II - The World Warrior (Asia, Alt)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1992</year>
+		<publisher>Yoko Soft</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="kof96" />
-			<feature name="pcb" value="UNL-KOF96" />
+			<feature name="slot" value="txc_tw" />
 			<dataarea name="chr" size="131072">
 				<rom name="street fighter ii - the world warrior (unl) [a1].chr" size="131072" crc="cb8b2ca2" sha1="2a9814350c33cb156b25e17ee46d3be9134e3b42" offset="00000" status="baddump" />
 			</dataarea>
@@ -76705,13 +76705,12 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="sf2b" cloneof="sf2" supported="no">
+	<software name="sf2b" cloneof="sf2">
 		<description>Street Fighter II - The World Warrior (Asia, Alt 2)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1992</year>
+		<publisher>Yoko Soft</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="kof96" />
-			<feature name="pcb" value="UNL-KOF96" />
+			<feature name="slot" value="txc_tw" />
 			<dataarea name="chr" size="131072">
 				<rom name="street fighter ii - the world warrior (unl) [a2].chr" size="131072" crc="d1390da0" sha1="d9f71c2f15cd020aebc6a799e9422fbe5b7de98b" offset="00000" status="baddump" />
 			</dataarea>
@@ -76721,13 +76720,12 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="sf2" supported="no">
+	<software name="sf2">
 		<description>Street Fighter II - The World Warrior (Asia)</description>
-		<year>19??</year>
+		<year>1992</year>
 		<publisher>Yoko Soft</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="kof96" />
-			<feature name="pcb" value="UNL-KOF96" />
+			<feature name="slot" value="txc_tw" />
 			<dataarea name="chr" size="131072">
 				<rom name="street fighter ii - the world warrior (unl).chr" size="131072" crc="533be7c5" sha1="08e0be7bcb44ff8b31c603cd20b0d0ed413777ed" offset="00000" status="baddump" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -66357,14 +66357,13 @@ All musics were removed in this game.
 		</part>
 	</software>
 
-	<software name="sk5" supported="no">
+	<software name="sk5">
 		<description>Sonic &amp; Knuckles 5 (Asia)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="Super Sonic 5 (on cart label)"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="txrom" />
-			<feature name="pcb" value="NES-TLROM" />
+			<feature name="slot" value="kay" />
 			<dataarea name="chr" size="262144">
 				<rom name="super sonic 5 (unl).chr" size="262144" crc="796303be" sha1="476cf4034fa5e69b8f74a33e8883cf9f96d47540" offset="00000" status="baddump" />
 			</dataarea>
@@ -77259,14 +77258,13 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="umk4" supported="no">
+	<software name="umk4" supported="partial">
 		<description>Ultimate Mortal Kombat 4 (Asia)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="NT-873"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="txrom" />
-			<feature name="pcb" value="NES-TLROM" />
+			<feature name="slot" value="kay" />
 			<dataarea name="chr" size="262144">
 				<rom name="ultimate mortal kombat 4 (unl).chr" size="262144" crc="06cd8beb" sha1="dd2bc817637805deacf0d19a81c434e0107e6a49" offset="00000" status="baddump" />
 			</dataarea>


### PR DESCRIPTION
Software list items promoted to working
---------------------------------------
Sonic & Knuckles 5 (Asia)
Street Fighter II - The World Warrior (Asia)
Street Fighter II - The World Warrior (Asia, Alt)
Street Fighter II - The World Warrior (Asia, Alt 2)
Ultimate Mortal Kombat 4 (Asia)