### PR TITLE
Create GitHub Action to rebuild and commit shaders

### DIFF
--- a/.github/workflows/rebuild-shaders.yml
+++ b/.github/workflows/rebuild-shaders.yml
@@ -13,6 +13,13 @@ jobs:
       with:
         install: git make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-libc++    
     - uses: actions/checkout@master
+    - name: Fix GLSL parser potential issues
+      run: |
+        touch 3rdparty/bgfx/3rdparty/glsl-optimizer/src/glsl/glcpp/glcpp-lex.c
+        touch 3rdparty/bgfx/3rdparty/glsl-optimizer/src/glsl/glcpp/glcpp-parse.c
+        touch 3rdparty/bgfx/3rdparty/glsl-optimizer/src/glsl/glcpp/glcpp-parse.h
+        touch 3rdparty/bgfx/3rdparty/glslang/glslang/MachineIndependent/glslang_tab.cpp
+        touch 3rdparty/bgfx/3rdparty/glslang/glslang/MachineIndependent/glslang_tab.cpp.h
     - name: Build
       env:
         MINGW64: "/mingw64"

--- a/.github/workflows/rebuild-shaders.yml
+++ b/.github/workflows/rebuild-shaders.yml
@@ -1,0 +1,23 @@
+name: Rebuild shaders
+
+on: workflow_dispatch
+
+jobs:
+  rebuild:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}    
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        install: git make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-libc++    
+    - uses: actions/checkout@master
+    - name: Build
+      env:
+        MINGW64: "/mingw64"
+      run: make shaders
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Rebuild shaders
+        repository: bgfx/shaders


### PR DESCRIPTION
This GitHub Action will checkout the current source, run `make shaders` to rebuild the shaders and commit the updated shaders back to the repository. It's not run automatically at this point, but must be manually triggered.

Example run using this workflow: https://github.com/startaq/mame/commit/d69d1a9722b925cadefc2236abedaf7c5f4b192b
