### PR TITLE
sdl ui: fix choosing the root path

### DIFF
--- a/src/lib/util/zippath.cpp
+++ b/src/lib/util/zippath.cpp
@@ -205,7 +205,7 @@ osd_file::error zippath_resolve(std::string_view path, osd::directory::entry::en
 	bool went_up = false;
 	do
 	{
-		if(!is_root(apath))
+		if (!is_root(apath))
 		{
 			// trim the path of trailing path separators
 			auto i = apath.find_last_not_of(PATH_SEPARATOR);
@@ -213,6 +213,7 @@ osd_file::error zippath_resolve(std::string_view path, osd::directory::entry::en
 				break;
 			apath = apath.substr(0, i + 1);
 		}
+
 		apath_trimmed = apath;
 
 		// stat the path

--- a/src/lib/util/zippath.cpp
+++ b/src/lib/util/zippath.cpp
@@ -48,14 +48,16 @@ int is_path_separator(char c)
 
 bool is_root(std::string_view path)
 {
-	// FIXME: get rid of the assumption that paths are DOS-like
-
+#if defined(OSD_WINDOWS)
 	// skip drive letter
 	if (path.length() >= 2 && isalpha(path[0]) && (path[1] == ':'))
 		path.remove_prefix(2);
 
 	// skip path separators
 	return path.find_first_not_of(PATH_SEPARATOR) == std::string_view::npos;
+#else
+	return (path.length() == 1) && (path[0] == '/');
+#endif
 }
 
 
@@ -203,11 +205,14 @@ osd_file::error zippath_resolve(std::string_view path, osd::directory::entry::en
 	bool went_up = false;
 	do
 	{
-		// trim the path of trailing path separators
-		auto i = apath.find_last_not_of(PATH_SEPARATOR);
-		if (i == std::string::npos)
-			break;
-		apath = apath.substr(0, i + 1);
+		if(!is_root(apath))
+		{
+			// trim the path of trailing path separators
+			auto i = apath.find_last_not_of(PATH_SEPARATOR);
+			if (i == std::string::npos)
+				break;
+			apath = apath.substr(0, i + 1);
+		}
 		apath_trimmed = apath;
 
 		// stat the path


### PR DESCRIPTION
Choosing the root path in the ui (on the SDL platforms) would cause an "Error accessing '/'" problem. This fixes this it.
I have also done full testing in Windows to be sure this doesn't break that operating system.