### PR TITLE
Update avgdvg.cpp

### DIFF
--- a/src/mame/video/avgdvg.cpp
+++ b/src/mame/video/avgdvg.cpp
@@ -817,9 +817,13 @@ int avg_mhavoc_device::handler_7()  // mhavoc_strobe3
 				const u8 g = bit1 * 0xcb;
 				const u8 b = bit0 * 0xcb;
 
+				int x = m_xpos;
+				int y = m_ypos;
+				apply_flipping(x, y);
+
 				vg_add_point_buf(
-						m_xpos,
-						m_ypos,
+						x,
+						y,
 						rgb_t(r, g, b),
 						(((m_int_latch >> 1) == 1) ? m_intensity : m_int_latch & 0xe) << 4);
 				m_spkl_shift = (BIT(m_spkl_shift, 6) ^ BIT(m_spkl_shift, 5) ^ 1) | (m_spkl_shift << 1);
@@ -842,9 +846,13 @@ int avg_mhavoc_device::handler_7()  // mhavoc_strobe3
 			const u8 g = bit1 * 0xcb;
 			const u8 b = bit0 * 0xcb;
 
-			vg_add_point_buf(
-					m_xpos,
-					m_ypos,
+			int x = m_xpos;
+				int y = m_ypos;
+				apply_flipping(x, y);
+
+				vg_add_point_buf(
+						x,
+						y,
 					rgb_t(r, g, b),
 					(((m_int_latch >> 1) == 1) ? m_intensity : m_int_latch & 0xe) << 4);
 		}


### PR DESCRIPTION
Added XY flip which is technically supported by the production Atari hardware for Major Havoc, the software just didn't end up using it. Im going to support cocktail mode on Major Havoc - The Promised End (HBMAME) so this needs to be fixed over here in MAME to be accurate.