### PR TITLE
SDL2 include cleanup

### DIFF
--- a/makefile
+++ b/makefile
@@ -1737,12 +1737,7 @@ generate: \
 		$(GEN_FOLDERS) \
 		$(GENDIR)/version.cpp \
 		$(patsubst %.po,%.mo,$(call rwildcard, language/, *.po)) \
-		$(patsubst $(SRC)/%.lay,$(GENDIR)/%.lh,$(LAYOUTS)) \
-		$(GENDIR)/includes/SDL2
-
-$(GENDIR)/includes/SDL2:
-	-$(call MKDIR,$@)
-	-$(call COPY,3rdparty/SDL2/include,$(GENDIR)/includes/SDL2)
+		$(patsubst $(SRC)/%.lay,$(GENDIR)/%.lh,$(LAYOUTS))
 
 ifneq ($(NEW_GIT_VERSION),$(OLD_GIT_VERSION))
 stale:

--- a/scripts/src/osd/sdl.lua
+++ b/scripts/src/osd/sdl.lua
@@ -253,7 +253,7 @@ end
 
 if _OPTIONS["with-bundled-sdl2"]~=nil then
 	includedirs {
-		GEN_DIR .. "includes",
+		MAME_DIR .. "3rdparty/SDL2/include",
 	}
 end
 if BASE_TARGETOS=="unix" then

--- a/scripts/src/osd/sdl_cfg.lua
+++ b/scripts/src/osd/sdl_cfg.lua
@@ -99,13 +99,14 @@ if BASE_TARGETOS=="unix" then
 			if _OPTIONS["USE_LIBSDL"]~="1" then
 				buildoptions {
 					"-F" .. _OPTIONS["SDL_FRAMEWORK_PATH"],
+					"-I" .. _OPTIONS["SDL_FRAMEWORK_PATH"] .. '/SDL2.framework/Headers',
 				}
 			else
 				defines {
 					"MACOSX_USE_LIBSDL",
 				}
 				buildoptions {
-					backtick(sdlconfigcmd() .. " --cflags | sed 's:/SDL2::'"),
+					backtick(sdlconfigcmd() .. " --cflags"),
 				}
 			end
 		end

--- a/src/osd/modules/font/font_sdl.cpp
+++ b/src/osd/modules/font/font_sdl.cpp
@@ -14,11 +14,7 @@
 #include "fileio.h"
 #include "unicode.h"
 
-#ifdef SDLMAME_EMSCRIPTEN
 #include <SDL_ttf.h>
-#else
-#include <SDL2/SDL_ttf.h>
-#endif
 #if !defined(SDLMAME_HAIKU) && !defined(SDLMAME_EMSCRIPTEN)
 #include <fontconfig/fontconfig.h>
 #endif

--- a/src/osd/modules/input/input_common.cpp
+++ b/src/osd/modules/input/input_common.cpp
@@ -29,7 +29,7 @@
 #define KEY_TRANS_ENTRY1(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii)     { ITEM_ID_##mame, KEY_ ## disc, virtual, ascii, "ITEM_ID_"#mame, (char*) #mame }
 #elif defined(OSD_SDL)
 // SDL include
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #define KEY_TRANS_ENTRY0(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii, UI) { ITEM_ID_##mame, SDL_SCANCODE_ ## sdlsc, ascii, "ITEM_ID_"#mame, (char *) UI }
 #define KEY_TRANS_ENTRY1(mame, sdlsc, sdlkey, disc, virtual, uwp, ascii)     { ITEM_ID_##mame, SDL_SCANCODE_ ## sdlsc, ascii, "ITEM_ID_"#mame, (char*) #mame }
 #elif defined(OSD_UWP)

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -17,7 +17,7 @@
 #if defined(SDLMAME_SDL2)
 
 // standard sdl header
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <cctype>
 // ReSharper disable once CppUnusedIncludeDirective
 #include <cstddef>

--- a/src/osd/modules/input/input_sdlcommon.cpp
+++ b/src/osd/modules/input/input_sdlcommon.cpp
@@ -14,7 +14,7 @@
 #if defined(OSD_SDL)
 
 // standard sdl header
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <cctype>
 #include <cstddef>
 #include <mutex>

--- a/src/osd/modules/input/input_x11.cpp
+++ b/src/osd/modules/input/input_x11.cpp
@@ -19,7 +19,7 @@
 #include <X11/Xutil.h>
 
 // standard sdl header
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <cctype>
 #include <cstddef>
 #include <mutex>

--- a/src/osd/modules/lib/osdlib_unix.cpp
+++ b/src/osd/modules/lib/osdlib_unix.cpp
@@ -12,7 +12,7 @@
 #include "osdcore.h"
 #include "osdlib.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <csignal>
 #include <cstdio>

--- a/src/osd/modules/monitor/monitor_sdl.cpp
+++ b/src/osd/modules/monitor/monitor_sdl.cpp
@@ -12,7 +12,7 @@
 #if defined(OSD_SDL)
 
 #include <algorithm>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "modules/osdwindow.h"
 #include "monitor_common.h"

--- a/src/osd/modules/opengl/osd_opengl.h
+++ b/src/osd/modules/opengl/osd_opengl.h
@@ -36,14 +36,14 @@
 		#include <OpenGL/gl.h>
 		#include <OpenGL/glext.h>
 	#else
-	#include <SDL2/SDL_version.h>
+	#include <SDL_version.h>
 
 	#if (SDL_VERSION_ATLEAST(1,2,10))
 	#if defined(SDLMAME_WIN32)
 		// Avoid that winnt.h (included via sdl_opengl.h, windows.h, windef.h includes intrin.h
 		#define __INTRIN_H_
 	#endif
-	#include <SDL2/SDL_opengl.h>
+	#include <SDL_opengl.h>
 	#endif
 	#endif
 

--- a/src/osd/modules/render/draw13.h
+++ b/src/osd/modules/render/draw13.h
@@ -23,7 +23,7 @@ typedef uint64_t HashT;
 #endif
 
 // standard SDL headers
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 struct quad_setup_data
 {

--- a/src/osd/modules/render/drawbgfx.cpp
+++ b/src/osd/modules/render/drawbgfx.cpp
@@ -12,13 +12,13 @@
 // standard windows headers
 #include <windows.h>
 #if defined(SDLMAME_WIN32)
-#include <SDL2/SDL_syswm.h>
+#include <SDL_syswm.h>
 #endif
 #else
 #if defined(OSD_MAC)
 extern void *GetOSWindow(void *wincontroller);
 #else
-#include <SDL2/SDL_syswm.h>
+#include <SDL_syswm.h>
 #endif
 #endif
 

--- a/src/osd/modules/render/drawogl.cpp
+++ b/src/osd/modules/render/drawogl.cpp
@@ -28,7 +28,7 @@
 #if !defined(OSD_WINDOWS) && !defined(OSD_MAC)
 // standard SDL headers
 #define TOBEMIGRATED 1
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 
 #include "modules/lib/osdlib.h"

--- a/src/osd/modules/render/drawsdl.cpp
+++ b/src/osd/modules/render/drawsdl.cpp
@@ -20,7 +20,7 @@
 #include "rendersw.hxx"
 
 // standard SDL headers
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 // OSD headers
 #include "osdsdl.h"

--- a/src/osd/modules/render/drawsdl.h
+++ b/src/osd/modules/render/drawsdl.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 /* renderer_sdl1 is the information about SDL for the current screen */
 class renderer_sdl1 : public osd_renderer

--- a/src/osd/modules/render/sdlglcontext.h
+++ b/src/osd/modules/render/sdlglcontext.h
@@ -13,7 +13,7 @@
 #ifndef __SDL_GL_CONTEXT__
 #define __SDL_GL_CONTEXT__
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "modules/opengl/osd_opengl.h"
 
 class sdl_gl_context : public osd_gl_context

--- a/src/osd/modules/sound/direct_sound.cpp
+++ b/src/osd/modules/sound/direct_sound.cpp
@@ -27,7 +27,7 @@
 
 #ifdef SDLMAME_WIN32
 #include "../../sdl/osdsdl.h"
-#include <SDL2/SDL_syswm.h>
+#include <SDL_syswm.h>
 #include "../../sdl/window.h"
 #else
 #include "winmain.h"

--- a/src/osd/modules/sound/sdl_sound.cpp
+++ b/src/osd/modules/sound/sdl_sound.cpp
@@ -14,7 +14,7 @@
 #if (defined(OSD_SDL) || defined(USE_SDL_SOUND))
 
 // standard sdl header
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 // MAME headers
 #include "emu.h"

--- a/src/osd/osdcore.cpp
+++ b/src/osd/osdcore.cpp
@@ -6,7 +6,7 @@
 #include <chrono>
 
 #if defined(SDLMAME_ANDROID)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 
 #ifdef _WIN32

--- a/src/osd/sdl/sdlmain.cpp
+++ b/src/osd/sdl/sdlmain.cpp
@@ -33,7 +33,7 @@
 #include <windows.h>
 #endif
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 // MAME headers
 #include "corestr.h"

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -7,7 +7,7 @@
 //  SDLMAME by Olivier Galibert and R. Belmont
 //
 //============================================================
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 // MAME headers
 #include "emu.h"

--- a/src/osd/sdl/window.cpp
+++ b/src/osd/sdl/window.cpp
@@ -13,8 +13,8 @@
 #endif
 
 // standard SDL headers
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_syswm.h>
+#include <SDL.h>
+#include <SDL_syswm.h>
 
 // standard C headers
 #include <cmath>

--- a/src/tools/testkeys.cpp
+++ b/src/tools/testkeys.cpp
@@ -12,7 +12,7 @@
 
 #include "osdcore.h"
 
-#include "SDL2/SDL.h"
+#include "SDL.h"
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Made our code use SDL2 from given include, not assuming that it is in SDL2 subdirectory.
We already use sdl2-config --cflags (that gives us proper include path) and on macOS we actually remove that. 
Have tried this already on linux, macos and asmjs with current build system (cmake one already have this change in it for a long time)