### PR TITLE
megadriv.xml: Replaced dump for s19in1.

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -31412,7 +31412,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 
 <!-- dumps which need ad hoc handlers to be installed in the emulator -->
 
-<!-- This cart is missing the higher bank containing Dragon Ball game -->
+	<!-- This cart is missing the higher bank containing Dragon Ball game -->
 	<software name="12in1">
 		<description>12 in 1 (Incomplete Dump)</description>
 		<year>199?</year>
@@ -31497,7 +31497,7 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
-	<!-- // this contains only the first bank, so most of the games are missing -->
+	<!-- This contains only the first bank, so most of the games are missing -->
 	<software name="golden10" supported="partial">
 		<description>Golden 10 in 1 (Incomplete Dump)</description>
 		<year>199?</year>
@@ -31710,14 +31710,16 @@ Notice that these are not working on real hardware due to bugged code with VDP i
 		</part>
 	</software>
 
+
+	<!-- This dump is incomplete and is missing the entire second half -->
 	<software name="s19in1" supported="partial">
 		<description>Super 19 in 1 (Pirate)</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="megadriv_cart">
 			<feature name="slot" value="rom_mcpir"/>
-			<dataarea name="rom" width="16" endianness="big" size="4194304">
-				<rom name="super 19-in-1 (pirate).bin" size="4194304" crc="0ad2b342" sha1="e1c041ba69da087c428dcda16850159f3caebd4b" offset="00000"/>
+			<dataarea name="rom" width="16" endianness="big" size="2097152">
+				<rom name="super 19-in-1 (pirate).bin" size="2097152" crc="52224f30" sha1="b4c822f8a36083b282cec7c6353ce6bcbc063972" offset="00000" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- This multicart doesn't fully work because it's a bad dump--the second 2MB is missing and is a repeat of the first half. New checksums are for the first 2MB.