### PR TITLE
bus/nes: Improved support for various RCM multicarts.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -81949,15 +81949,34 @@ to check why this is different -->
 		</part>
 	</software>
 
-	<software name="mc_tf6" supported="no">
+	<software name="mc_tf5" cloneof="mc_tf6">
+		<description>Tetris Family 5 in 1</description>
+		<year>199?</year>
+		<publisher>RCM</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="gs2004" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="270336">
+				<rom name="tetris family 5-in-1.prg0" size="262144" crc="0ab2e826" sha1="b813808fc4ac25fbb9bd829410ab1a8d39c56576" offset="0x00000" status="baddump" />
+				<rom name="tetris family 5-in-1.prg1" size="8192" crc="255bc6ed" sha1="6226ec49d548a92d8abefb619efc52fe08a08899" offset="0x40000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mc_tf6">
 		<description>Tetris Family 6 in 1 (GS-2004)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>199?</year>
+		<publisher>RCM</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="gs2004" />
 			<feature name="pcb" value="BMC-GS-2004" />
-			<dataarea name="prg" size="262144">
-				<rom name="tetris family 6-in-1 (gs-2004) [u].prg" size="262144" crc="0ab2e826" sha1="b813808fc4ac25fbb9bd829410ab1a8d39c56576" offset="00000" status="baddump" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="270336">
+				<rom name="tetris family 6-in-1 (gs-2004).prg0" size="262144" crc="0ab2e826" sha1="b813808fc4ac25fbb9bd829410ab1a8d39c56576" offset="0x00000" status="baddump" />
+				<rom name="tetris family 6-in-1 (gs-2004).prg1" size="8192" crc="08e73de1" sha1="1ff9bdf51482adfcd040c81fa0243c75c0f0536f" offset="0x40000" status="baddump" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -81967,8 +81986,8 @@ to check why this is different -->
 
 	<software name="mc_tf9">
 		<description>Tetris Family 9 in 1</description>
-		<year>19??</year>
-		<publisher>&lt;pirate&gt;</publisher>
+		<year>1991</year>
+		<publisher>RCM</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="tf9in1" />
 			<feature name="pcb" value="RCM-TETRISFAMILY" />
@@ -81981,13 +82000,14 @@ to check why this is different -->
 		</part>
 	</software>
 
-	<software name="mc_tf12" supported="no">
+	<software name="mc_tf12">
 		<description>Tetris Family 12 in 1 (GS-2013)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1991</year>
+		<publisher>RCM</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="gs2013" />
 			<feature name="pcb" value="BMC-GS-2013" />
+			<feature name="mirroring" value="vertical" />
 			<dataarea name="prg" size="327680">
 				<rom name="tetris family 12-in-1 (gs-2013) [u].prg" size="327680" crc="8cde7cb9" sha1="0119413febd9a6c5a7c4f0673c42356247a4ade8" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -318,7 +318,7 @@ static const nes_mmc mmc_list[] =
 	// 280 Unused
 	// 281 seems to be mc_sh4b and many other JY multicarts not in nes.xml?
 	// 282 more JY multicarts not in nes.xml?
-	// 283 RCM_GS2004 and RCM_GS2013 (why are these RCM?), these are in nes.xml
+	{ 283, RCM_GS2004 },           // and RCM_GS2013
 	// 284 UNL_DRIPGAME, not in nes.xml
 	{ 285, BMC_A65AS },
 	{ 286, BMC_BENSHIENG },
@@ -896,6 +896,11 @@ void nes_cart_slot_device::call_load_ines()
 				m_pcb_id = UNL_DH08;
 			break;
 
+		case RCM_GS2004:
+			if (prg_size >= 0x50000)
+				m_pcb_id = RCM_GS2013;
+			break;
+
 		case HES_BOARD:
 			if (crc_hack)
 				m_cart->set_pcb_ctrl_mirror(true);    // Mapper 113 is used for 2 diff boards
@@ -1207,6 +1212,7 @@ const char * nes_cart_slot_device::get_default_card_ines(get_default_card_softwa
 			if (crc_hack)
 				pcb_id = BTL_AISENSHINICOL;    // Mapper 42 is used for 2 diff boards
 			break;
+
 		case UNL_LH28_LH54:                            // Mapper 108 is used for 4 diff boards
 			if (ROM[5])
 				pcb_id = (ROM[5] == 2) ? UNL_LE05 : UNL_LH31;
@@ -1214,6 +1220,10 @@ const char * nes_cart_slot_device::get_default_card_ines(get_default_card_softwa
 				pcb_id = UNL_DH08;
 			break;
 
+		case RCM_GS2004:                               // Mapper 283 is used for 2 diff boards
+			if (ROM[4] >= 20)
+				pcb_id = RCM_GS2013;
+			break;
 	}
 
 	return nes_get_slot(pcb_id);

--- a/src/devices/bus/nes/rcm.h
+++ b/src/devices/bus/nes/rcm.h
@@ -34,33 +34,27 @@ class nes_gs2004_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_gs2004_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_gs2004_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 protected:
-	// device-level overrides
-	virtual void device_start() override;
+	// construction/destruction
+	nes_gs2004_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, int bank);
+
+private:
+	u32 m_base;
 };
 
 
 // ======================> nes_gs2013_device
 
-class nes_gs2013_device : public nes_nrom_device
+class nes_gs2013_device : public nes_gs2004_device
 {
 public:
 	// construction/destruction
-	nes_gs2013_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	nes_gs2013_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 
@@ -70,15 +64,9 @@ class nes_tf9_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_tf9_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_tf9_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -106,9 +94,9 @@ private:
 
 
 // device type definition
-DECLARE_DEVICE_TYPE(NES_GS2015,  nes_gs2015_device)
 DECLARE_DEVICE_TYPE(NES_GS2004,  nes_gs2004_device)
 DECLARE_DEVICE_TYPE(NES_GS2013,  nes_gs2013_device)
+DECLARE_DEVICE_TYPE(NES_GS2015,  nes_gs2015_device)
 DECLARE_DEVICE_TYPE(NES_TF9IN1,  nes_tf9_device)
 DECLARE_DEVICE_TYPE(NES_3DBLOCK, nes_3dblock_device)
 


### PR DESCRIPTION
- Got boards gs2004 and gs2013 working and merged them into related classes (they differ solely by a fixed bank number).
- Simplified tf9in1 board and fixed its graphics issues (sets mc_20a, mc_tf9).

New working software list additions (nes.xml)
-----------------------------------
Tetris Family 5 in 1 [NewRisingSun]

Software list items promoted to working (nes.xml)
---------------------------------------
Tetris Family 6 in 1 (GS-2004)
Tetris Family 12 in 1 (GS-2013)