### PR TITLE
bus/nes: Slightly more accurate Sunsoft 3 boards.

### DIFF
--- a/src/devices/bus/nes/sunsoft.h
+++ b/src/devices/bus/nes/sunsoft.h
@@ -61,6 +61,7 @@ protected:
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
 private:
 	uint16_t m_irq_count;
 	int m_irq_enable, m_irq_toggle;
@@ -95,6 +96,7 @@ protected:
 
 	int m_reg, m_latch1, m_latch2, m_wram_enable;
 };
+
 
 // ======================> nes_sunsoft_fme7_device
 


### PR DESCRIPTION
IRQs now cleared in the correct place, simplified the code a bit, and added exact bank-size masks based on pin counts.