### PR TITLE
Work around bgfx build failure

### DIFF
--- a/3rdparty/bgfx/3rdparty/dxsdk/include/pix3.h
+++ b/3rdparty/bgfx/3rdparty/dxsdk/include/pix3.h
@@ -26,7 +26,7 @@
 //
 // The PIX event/marker APIs compile to nothing on retail builds and on x86 builds
 //
-#if (!defined(USE_PIX)) && ((defined(_DEBUG) || DBG || (defined(PROFILE) && !defined(FASTCAP)) || defined(PROFILE_BUILD)) && !defined(i386) && defined(_AMD64_) && !defined(_PREFAST_))
+#if (!defined(USE_PIX)) && ((defined(_DEBUG) || (defined(DBG) && DBG) || (defined(PROFILE) && !defined(FASTCAP)) || defined(PROFILE_BUILD)) && !defined(i386) && defined(_AMD64_) && !defined(_PREFAST_))
 #define USE_PIX
 #endif
 


### PR DESCRIPTION
Since the updates to bx/bgfx, completely clean Windows debug builds fail to build bgfx with this error:
```
In file included from ../../../../../3rdparty/bgfx/src/renderer_d3d12.h:76,
                 from ../../../../../3rdparty/bgfx/src/renderer_d3d12.cpp:9:
../../../../../3rdparty/bgfx/3rdparty/dxsdk/include/pix3.h:29:49: error: "DBG" is not defined, evaluates to 0 [-Werror=undef]
   29 | #if (!defined(USE_PIX)) && ((defined(_DEBUG) || DBG || (defined(PROFILE) && !defined(FASTCAP)) || defined(PROFILE_BUILD)) && !defined(i386) && defined(_AMD64_) && !defined(_PREFAST_))
      |                                                 ^~~
```

We need a fix or workaround for this before freeze.  This is clearly a workaround/hack.