### PR TITLE
softlist.cpp: Add support for a 'notes' field to store information ab…

### DIFF
--- a/hash/softwarelist.dtd
+++ b/hash/softwarelist.dtd
@@ -9,7 +9,6 @@
 		<!ELEMENT description (#PCDATA)>
 		<!ELEMENT year (#PCDATA)>
 		<!ELEMENT publisher (#PCDATA)>
-		<!ELEMENT notes (#PCDATA)>
 		<!ELEMENT info EMPTY>
 			<!ATTLIST info name CDATA #REQUIRED>
 			<!ATTLIST info value CDATA #IMPLIED>

--- a/hash/softwarelist.dtd
+++ b/hash/softwarelist.dtd
@@ -1,13 +1,15 @@
-<!ELEMENT softwarelist (software+)>
+<!ELEMENT softwarelist (notes?, software+)>
 	<!ATTLIST softwarelist name CDATA #REQUIRED>
 	<!ATTLIST softwarelist description CDATA #IMPLIED>
-	<!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>
+	<!ELEMENT notes (#PCATA)>
+	<!ELEMENT software (description, year, publisher, notes?, info*, sharedfeat*, part*)>
 		<!ATTLIST software name CDATA #REQUIRED>
 		<!ATTLIST software cloneof CDATA #IMPLIED>
 		<!ATTLIST software supported (yes|partial|no) "yes">
 		<!ELEMENT description (#PCDATA)>
 		<!ELEMENT year (#PCDATA)>
 		<!ELEMENT publisher (#PCDATA)>
+		<!ELEMENT notes (#PCDATA)>
 		<!ELEMENT info EMPTY>
 			<!ATTLIST info name CDATA #REQUIRED>
 			<!ATTLIST info value CDATA #IMPLIED>

--- a/hash/softwarelist.dtd
+++ b/hash/softwarelist.dtd
@@ -1,7 +1,7 @@
 <!ELEMENT softwarelist (notes?, software+)>
 	<!ATTLIST softwarelist name CDATA #REQUIRED>
 	<!ATTLIST softwarelist description CDATA #IMPLIED>
-	<!ELEMENT notes (#PCATA)>
+	<!ELEMENT notes (#PCDATA)>
 	<!ELEMENT software (description, year, publisher, notes?, info*, sharedfeat*, part*)>
 		<!ATTLIST software name CDATA #REQUIRED>
 		<!ATTLIST software cloneof CDATA #IMPLIED>

--- a/hash/wswan.xml
+++ b/hash/wswan.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
 <!--
 license:CC0
-
+-->
+<softwarelist name="wswan" description="Bandai Wonderswan cartridges">
+	<notes><![CDATA[
 This is a full list of known WonderSwan and WonderSwan Color games.
 +===+=====+==========+============+=====+================================================================================================+
 | D | ROM |   CRC    |   Serial   | Rev |                                    Name                                                        |
@@ -281,9 +283,7 @@ game will boot up and start to initialize the save area.
 
 The GIZA chip used on a lot of cartridges is a sram voltage switch.
 
--->
-
-<softwarelist name="wswan" description="Bandai Wonderswan cartridges">
+]]></notes>
 	<software name="anchorz">
 		<description>Anchorz Field</description>
 		<year>1999</year>
@@ -523,10 +523,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="choaniki">
-		<!-- Rev 4 -->
 		<description>Chou Aniki - Otoko no Tamafuda</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
+		<notes>Revision from header: Rev 4</notes>
 		<info name="serial" value="SWJ-BAN023"/>
 		<info name="release" value="20000210"/>
 		<info name="alt_title" value="超兄貴 男の魂札"/>
@@ -546,10 +546,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="youfumak">
-		<!-- Rev 3 -->
 		<description>Chou Denki Card Game - Youfu Makai - Kikuchi Shuukou</description>
 		<year>1999</year>
 		<publisher>Kobunsha</publisher>
+		<notes>Revision from header: Rev 3</notes>
 		<info name="serial" value="SWJ-KBS002"/>
 		<info name="release" value="19991216"/>
 		<info name="alt_title" value="超伝奇カードバトル 妖符魔界 菊地秀行"/>
@@ -569,10 +569,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="clocktow">
-		<!-- Rev 1 -->
 		<description>Clock Tower for WonderSwan</description>
 		<year>1999</year>
 		<publisher>Kaga Tech</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-KGT002"/>
 		<info name="release" value="19991209"/>
 		<info name="alt_title" value="クロックタワー フォー ワンダースワン"/>
@@ -611,10 +611,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="dendego">
-		<!-- Rev 1 -->
 		<description>Densha de Go!</description>
 		<year>1999</year>
 		<publisher>Taito</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-TAT001"/>
 		<info name="release" value="19990304"/>
 		<info name="alt_title" value="電車でGO!"/>
@@ -762,12 +762,11 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 	-->
 
-  <!-- how to play? -->
 	<software name="digimon">
-		<!-- Rev 1 -->
 		<description>Digital Monster - Ver. WonderSwan</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BAN005"/>
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="デジタルモンスター バージョン ワンダースワン"/>
@@ -787,7 +786,6 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="digimon1" cloneof="digimon">
-		<!-- Alt title: -->
 		<description>Digimon - Ver. WonderSwan (Asia)</description>
 		<year>19??</year>
 		<publisher>Bandai</publisher>
@@ -980,10 +978,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="fireprow">
-		<!-- Rev 5 -->
 		<description>Fire Pro Wrestling for WonderSwan</description>
 		<year>2000</year>
 		<publisher>Kaga Tech</publisher>
+		<notes>Revision from header: Rev 5</notes>
 		<info name="serial" value="SWJ-KGT007"/>
 		<info name="release" value="20000831"/>
 		<info name="alt_title" value="ファイヤープロレスリング フォー ワンダースワン"/>
@@ -1063,10 +1061,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="gorakuta">
-		<!-- Rev 2 -->
 		<description>Goraku Ou Tango!</description>
 		<year>1999</year>
 		<publisher>Moebius</publisher>
+		<notes>Revision from header: Rev 2</notes>
 		<info name="serial" value="SWJ-PAW001"/>
 		<info name="release" value="19990401"/>
 		<info name="alt_title" value="語楽王 タンゴ !"/>
@@ -1186,11 +1184,11 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		</part>
 	</software>
 
-  <!-- background incorrect during bot transform? -->
 	<software name="harobots">
 		<description>Harobots (Rev 1)</description>
 		<year>1999</year>
 		<publisher>Sunrise Interactive</publisher>
+		<notes>background incorrect during bot transform?</notes>
 		<info name="serial" value="SWJ-SRV001"/>
 		<info name="release" value="19991007"/>
 		<info name="alt_title" value="ハロボッツ"/>
@@ -1339,10 +1337,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="kissyori">
-		<!-- Rev 2 -->
 		<description>Kiss Yori... - Seaside Serenade</description>
 		<year>1999</year>
 		<publisher>Kid</publisher>
+		<notes>Revision from header: Rev 2</notes>
 		<info name="serial" value="SWJ-KDX001"/>
 		<info name="release" value="19991202"/>
 		<info name="alt_title" value="キスより... ～シーサイドセレナーデ～"/>
@@ -1406,10 +1404,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="kyousoub">
-		<!-- Rev 1 -->
 		<description>Kyousouba Ikusei Simulation - Keiba</description>
 		<year>1999</year>
 		<publisher>BEC</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BEC001"/>
 		<info name="release" value="19991118"/>
 		<info name="alt_title" value="競走馬育成シミュレーション ケイバ"/>
@@ -1429,10 +1427,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="langriss">
-		<!-- Rev 1 -->
 		<description>Langrisser Millennium WS - The Last Century</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BAN024"/>
 		<info name="release" value="20000309"/>
 		<info name="alt_title" value="ラングリッサーミレニアム WS ～The LastCentury～"/>
@@ -1516,11 +1514,11 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		</part>
 	</software>
 
-	<!-- Small graphics glitch between 4th and 5th column -->
 	<software name="magdrop" supported="partial">
 		<description>Magical Drop for WonderSwan</description>
 		<year>1999</year>
 		<publisher>Data East Corp.</publisher>
+		<notes>Small graphics glitch between 4th and 5th column</notes>
 		<info name="serial" value="SWJ-DTE002"/>
 		<info name="release" value="19991014"/>
 		<info name="alt_title" value="マジカルドロップ for ワンダースワン"/>
@@ -1691,10 +1689,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="mingmagn">
-		<!-- Rev 1 -->
 		<description>Mingle Magnet</description>
 		<year>1999</year>
 		<publisher>Hal Corporation</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-HAL002"/>
 		<info name="release" value="19991102"/>
 		<info name="alt_title" value="ミングルマグネット"/>
@@ -1711,10 +1709,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="mjkiwame">
-		<!-- Rev 1 -->
 		<description>Pro Mahjong Kiwame for WonderSwan</description>
 		<year>1999</year>
 		<publisher>Athena</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-ATN001"/>
 		<info name="release" value="19991007"/>
 		<info name="alt_title" value="プロ麻雀 極 フォー ワンダースワン"/>
@@ -1734,10 +1732,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="mjtetsu">
-		<!-- Rev 2 -->
 		<description>Nihon Pro Mahjong Renmei Kounin Tetsuman</description>
 		<year>1999</year>
 		<publisher>Kaga Tech</publisher>
+		<notes>Revision from header: Rev 2</notes>
 		<info name="serial" value="SWJ-KGT001"/>
 		<info name="release" value="19990715"/>
 		<info name="alt_title" value="日本プロ麻雀連盟公認 徹萬"/>
@@ -1756,12 +1754,11 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		</part>
 	</software>
 
-	<!-- wondergate hardware is not emulated yet -->
 	<software name="mobilewg" supported="partial">
-		<!-- Rev 1 -->
 		<description>MobileWonderGate (Rev 1)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<notes>wondergate hardware is not emulated yet</notes>
 		<info name="serial" value="SWJ-SCC001"/>
 		<part name="cart" interface="wswan_cart">
 			<feature name="pcb" value="PTS-0110 or PTS-0105" />
@@ -1866,10 +1863,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="niceon">
-		<!-- Rev 1 -->
 		<description>Nice On</description>
 		<year>1999</year>
 		<publisher>Sammy</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-SUM002"/>
 		<info name="release" value="19990408"/>
 		<info name="alt_title" value="ナイスオン"/>
@@ -2060,6 +2057,7 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		<description>Ring Infinity (alt)</description>
 		<year>2000</year>
 		<publisher>Kid</publisher>
+		<notes>The roms in this are a simple split of mh32m16e119b.u3. It needs to be verified whether this is correct.</notes>
 		<info name="serial" value="SWJ-KDK001"/>
 		<info name="release" value="20000810"/>
 		<info name="alt_title" value="リング インフィニティ"/>
@@ -2071,7 +2069,6 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 			<feature name="u5" value="ROM (on PTS-0120)" />
 			<feature name="slot" value="ws_eeprom" />
 			<dataarea name="rom" size="4194304" width="16" endianness="little">
-				<!-- these roms are a simple split of mh32m16e119b.u3. Need to be verified -->
 				<rom name="mh16m16e114b.u4" size="2097152" crc="1bed45b0" sha1="46eff2164d8fccac161b0fd1cde8098e3bc08fd6" offset="000000" status="baddump" />
 				<rom name="mh16m16e115b.u5" size="2097152" crc="baeb4a36" sha1="d5d8220dadc41e5dbaa13ac188d642dacbed68c3" offset="2097152" status="baddump" />
 			</dataarea>
@@ -2212,15 +2209,15 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		</part>
 	</software>
 
-	<!--
-	The Robot Works cartridge has an integrated infrared port for programming an
-	external robot (the Wonder Borg).
-	The Wonder Borg itself uses an Elan EM78P451AQ MCU (undumped).
-	-->
 	<software name="robworks" supported="partial">
 		<description>Wonder Borg Robot Works</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
+		<notes><![CDATA[
+The Robot Works cartridge has an integrated infrared port for programming an
+external robot (the Wonder Borg).
+The Wonder Borg itself uses an Elan EM78P451AQ MCU (undumped).
+]]></notes>
 		<info name="serial" value="SWJ-BAN033"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ワンダーボーグ 完"/>
@@ -2240,17 +2237,20 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 		</part>
 	</software>
 
-	<!--
-	The Robot Works cartridge has an integrated infrared port for programming an
-	external robot (the Wonder Borg).
-	The Wonder Borg itself uses an Elan EM78P451AQ MCU (undumped).
-	-->
 	<software name="robworks1" cloneof="robworks" supported="partial">
-		<!-- Rev 1 -->
 		<description>Robot Works (Asia)</description>
 		<year>2000</year>
 		<publisher>Bandai</publisher>
-		<info name="serial" value="SWJ-BAN033"/> <!-- Same ROM as cart SWJ-BAN034 (labeled "Ver.1.5") -->
+		<notes><![CDATA[
+Revision from header: Rev 1
+
+Same ROM as cart SWJ-BAN034 (labeled "Ver.1.5")
+
+The Robot Works cartridge has an integrated infrared port for programming an
+external robot (the Wonder Borg).
+The Wonder Borg itself uses an Elan EM78P451AQ MCU (undumped).
+]]></notes>
+		<info name="serial" value="SWJ-BAN033"/>
 		<info name="release" value="20000804"/>
 		<info name="alt_title" value="ワンダーボーグ 完"/>
 		<part name="cart" interface="wswan_cart">
@@ -2506,10 +2506,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="sprowres">
-		<!-- Rev 1 -->
 		<description>Shin Nihon Pro Wrestling Toukon Retsuden</description>
 		<year>1999</year>
 		<publisher>Tomy</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-TMY001"/>
 		<info name="release" value="19990304"/>
 		<info name="alt_title" value="新日本プロレスリング 闘魂烈伝"/>
@@ -2609,10 +2609,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="sotsugyo">
-		<!-- Rev 1 -->
 		<description>Sotsugyou for WonderSwan</description>
 		<year>1999</year>
 		<publisher>Bandai Visual</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BVL002"/>
 		<info name="release" value="19991216"/>
 		<info name="alt_title" value="卒業 フォー ワンダースワン"/>
@@ -2695,10 +2695,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="tanjodeb">
-		<!-- Rev 1 -->
 		<description>Tanjou Debut for WonderSwan</description>
 		<year>2000</year>
 		<publisher>Bandai Visual</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BVL003"/>
 		<info name="release" value="20000224"/>
 		<info name="alt_title" value="誕生 デビュー フォー ワンダースワン"/>
@@ -2848,10 +2848,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="trumpcl2">
-		<!-- Rev 1 -->
 		<description>Trump Collection 2 - Bottom-Up Teki Sekaiisshuu no Tabi</description>
 		<year>2000</year>
 		<publisher>Bottom Up</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BTM002"/>
 		<info name="release" value="20000928"/>
 		<info name="alt_title" value="トランプコレクション ボトムアップ的トランプ生活"/>
@@ -2868,10 +2868,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="trumpcol">
-		<!-- Rev 1 -->
 		<description>Trump Collection - Bottom-Up Teki Trump Seikatsu</description>
 		<year>1999</year>
 		<publisher>Bottom Up</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BTM001"/>
 		<info name="release" value="19990701"/>
 		<info name="alt_title" value="トランプコレクション2 ボトムアップ的世界一周の旅"/>
@@ -2928,10 +2928,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="uzumaki">
-		<!-- Rev 4 -->
 		<description>Uzumaki - Denshi Kaiki Hen</description>
 		<year>2000</year>
 		<publisher>Omage Micott, Inc.</publisher>
+		<notes>Revision from header: Rev 4</notes>
 		<info name="serial" value="SWJ-OMM001"/>
 		<info name="release" value="20000203"/>
 		<info name="alt_title" value="うずまき ～電視怪奇篇～"/>
@@ -2950,10 +2950,10 @@ The GIZA chip used on a lot of cartridges is a sram voltage switch.
 	</software>
 
 	<software name="vaitzbla">
-		<!-- Rev 1 -->
 		<description>Vaitz Blade</description>
 		<year>1999</year>
 		<publisher>Bandai</publisher>
+		<notes>Revision from header: Rev 1</notes>
 		<info name="serial" value="SWJ-BAN00C"/>
 		<info name="release" value="19990624"/>
 		<info name="alt_title" value="ヴァイツブレイド"/>

--- a/scripts/minimaws/lib/htmltmpl.py
+++ b/scripts/minimaws/lib/htmltmpl.py
@@ -252,6 +252,10 @@ SOFTWARE_PROLOGUE = string.Template(
         '    <tr><th>Year:</th><td>${year}</td></tr>\n' \
         '    <tr><th>Publisher:</th><td>${publisher}</td></tr>\n');
 
+SOFTWARE_EPILOGUE = string.Template(
+        '<h2>Notes</h2>\n' \
+        '<p><pre>${notes}<p></pre>\n');
+
 SOFTWARE_CLONES_PROLOGUE = string.Template(
         '<h2>Clones</h2>\n' \
         '<table id="tbl-clones">\n' \
@@ -321,6 +325,10 @@ SOFTWARELIST_PROLOGUE = string.Template(
         '        <td style="text-align: right">(${unsupportedpc}%)</td>\n' \
         '    </tr>\n' \
         '</table>\n')
+
+SOFTWARELIST_EPILOGUE = string.Template(
+        '<h2>Notes</h2>\n' \
+        '<p><pre>${notes}<p></pre>\n')
 
 SOFTWARELIST_MACHINE_TABLE_HEADER = string.Template(
         '<h2>Machines</h2>\n' \

--- a/scripts/minimaws/lib/wsgiserve.py
+++ b/scripts/minimaws/lib/wsgiserve.py
@@ -674,6 +674,9 @@ class SoftwareListHandler(QueryPageHandler):
         else:
             yield htmltmpl.SORTABLE_TABLE_EPILOGUE.substitute(id='tbl-software').encode('utf-8')
 
+        if (softwarelist_info['notes']):
+            yield htmltmpl.SOFTWARELIST_EPILOGUE.substitute(notes=htmlescape(softwarelist_info['notes'])).encode('utf-8')
+
         yield '</body>\n</html>\n'.encode('utf-8')
 
     def software_page(self, software_info):
@@ -716,6 +719,9 @@ class SoftwareListHandler(QueryPageHandler):
             for name, value in self.dbcurs.get_softwarepart_features(id):
                 yield ('    <tr><th>%s:</th><td>%s</td>\n' % (htmlescape(name), htmlescape(value))).encode('utf-8')
             yield '</table>\n\n'.encode('utf-8')
+
+        if (software_info['notes']):
+            yield htmltmpl.SOFTWARE_EPILOGUE.substitute(notes=htmlescape(software_info['notes'])).encode('utf-8')
 
         yield '</body>\n</html>\n'.encode('utf-8')
 

--- a/src/emu/softlist.cpp
+++ b/src/emu/softlist.cpp
@@ -196,6 +196,7 @@ public:
 			std::string_view filename,
 			std::string &listname,
 			std::string &description,
+			std::string &notes,
 			std::list<software_info> &infolist,
 			std::ostream &errors);
 
@@ -236,6 +237,7 @@ private:
 	void parse_soft_start(const char *tagname, const char **attributes);
 	void parse_part_start(const char *tagname, const char **attributes);
 	void parse_data_start(const char *tagname, const char **attributes);
+	void parse_main_end(const char *tagname);
 	void parse_soft_end(const char *name);
 
 	// internal parsing state
@@ -247,6 +249,7 @@ private:
 	bool                        m_done;
 	std::string &               m_listname;
 	std::string &               m_description;
+	std::string &               m_notes;
 	bool                        m_data_accum_expected;
 	std::string                 m_data_accum;
 	software_info *             m_current_info;
@@ -264,6 +267,7 @@ softlist_parser::softlist_parser(
 		std::string_view filename,
 		std::string &listname,
 		std::string &description,
+		std::string &notes,
 		std::list<software_info> &infolist,
 		std::ostream &errors) :
 	m_file(file),
@@ -273,6 +277,7 @@ softlist_parser::softlist_parser(
 	m_done(false),
 	m_listname(listname),
 	m_description(description),
+	m_notes(notes),
 	m_data_accum_expected(false),
 	m_current_info(nullptr),
 	m_current_part(nullptr),
@@ -474,6 +479,7 @@ void softlist_parser::end_handler(void *data, const char *name)
 			break;
 
 		case POS_MAIN:
+			state->parse_main_end(name);
 			state->m_current_info = nullptr;
 			break;
 
@@ -565,13 +571,25 @@ void softlist_parser::parse_main_start(const char *tagname, const char **attribu
 		else
 			parse_error("No name defined for item");
 	}
+	// <notes>
+	else if (strcmp(tagname, "notes") == 0)
+	{
+		m_data_accum_expected = true;
+	}
 	else
 		unknown_tag(tagname);
 }
 
 
+void softlist_parser::parse_main_end(const char *tagname)
+{
+	if (strcmp(tagname, "notes") == 0)
+		m_notes = m_data_accum;
+}
+
+
 //-------------------------------------------------
-//  parse_main_start - handle tag start within
+//  parse_soft_start - handle tag start within
 //  a software tag
 //-------------------------------------------------
 
@@ -594,6 +612,10 @@ void softlist_parser::parse_soft_start(const char *tagname, const char **attribu
 
 	// <publisher>
 	else if (strcmp(tagname, "publisher") == 0)
+		m_data_accum_expected = true;
+
+	// <notes>
+	else if (strcmp(tagname, "notes") == 0)
 		m_data_accum_expected = true;
 
 	// <info name='' value=''>
@@ -861,6 +883,10 @@ void softlist_parser::parse_soft_end(const char *tagname)
 	else if (strcmp(tagname, "publisher") == 0)
 		m_current_info->m_publisher = m_data_accum;
 
+	// <notes>
+	else if (strcmp(tagname, "notes") == 0)
+		m_current_info->m_notes = m_data_accum;
+
 	// </part>
 	else if (strcmp(tagname, "part") == 0)
 	{
@@ -889,10 +915,11 @@ void parse_software_list(
 		std::string_view filename,
 		std::string &listname,
 		std::string &description,
+		std::string &notes,
 		std::list<software_info> &infolist,
 		std::ostream &errors)
 {
-	detail::softlist_parser(file, filename, listname, description, infolist, errors);
+	detail::softlist_parser(file, filename, listname, description, notes, infolist, errors);
 }
 
 

--- a/src/emu/softlist.h
+++ b/src/emu/softlist.h
@@ -120,6 +120,7 @@ public:
 	const std::string &parentname() const { return m_parentname; }
 	const std::string &year() const { return m_year; }
 	const std::string &publisher() const { return m_publisher; }
+	const std::string &notes() const { return m_notes; }
 	const std::list<feature_list_item> &other_info() const { return m_other_info; }
 	const std::list<feature_list_item> &shared_info() const { return m_shared_info; }
 	software_support supported() const { return m_supported; }
@@ -137,6 +138,7 @@ private:
 	std::string             m_parentname;
 	std::string             m_year;           // Copyright year on title screen, actual release dates can be tracked in external resources
 	std::string             m_publisher;
+	std::string             m_notes;
 	std::list<feature_list_item> m_other_info;   // Here we store info like developer, serial #, etc. which belong to the software entry as a whole
 	std::list<feature_list_item> m_shared_info;  // Here we store info like TV standard compatibility, or add-on requirements, etc. which get inherited
 												// by each part of this software entry (after loading these are stored in partdata->featurelist)
@@ -152,6 +154,7 @@ void parse_software_list(
 		std::string_view filename,
 		std::string &listname,
 		std::string &description,
+		std::string &notes,
 		std::list<software_info> &infolist,
 		std::ostream &errors);
 

--- a/src/emu/softlist_dev.cpp
+++ b/src/emu/softlist_dev.cpp
@@ -89,7 +89,8 @@ software_list_device::software_list_device(const machine_config &mconfig, const 
 	m_list_type(softlist_type::ORIGINAL_SYSTEM),
 	m_filter(nullptr),
 	m_parsed(false),
-	m_description("")
+	m_description(""),
+	m_notes("")
 {
 }
 
@@ -180,6 +181,7 @@ void software_list_device::release()
 	m_filename.clear();
 	m_shortname.clear();
 	m_description.clear();
+	m_notes.clear();
 	m_errors.clear();
 	m_infolist.clear();
 }
@@ -294,7 +296,7 @@ void software_list_device::parse()
 	{
 		// parse if no error
 		std::ostringstream errs;
-		parse_software_list(file, m_filename, m_shortname, m_description, m_infolist, errs);
+		parse_software_list(file, m_filename, m_shortname, m_description, m_notes, m_infolist, errs);
 		file.close();
 		m_errors = errs.str();
 	}

--- a/src/emu/softlist_dev.h
+++ b/src/emu/softlist_dev.h
@@ -118,6 +118,7 @@ public:
 
 	// getters that may trigger a parse
 	const std::string &description() { if (!m_parsed) parse(); return m_description; }
+	const std::string &notes() { if (!m_parsed) parse(); return m_notes; }
 	bool valid() { if (!m_parsed) parse(); return !m_infolist.empty(); }
 	const char *errors_string() { if (!m_parsed) parse(); return m_errors.c_str(); }
 	const std::list<software_info> &get_info() { if (!m_parsed) parse(); return m_infolist; }
@@ -154,6 +155,7 @@ private:
 	std::string                 m_filename;
 	std::string                 m_shortname;
 	std::string                 m_description;
+	std::string                 m_notes;
 	std::string                 m_errors;
 	std::list<software_info>    m_infolist;
 };

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1059,16 +1059,18 @@ const char cli_frontend::s_softlist_xml_dtd[] =
 				"<?xml version=\"1.0\"?>\n" \
 				"<!DOCTYPE softwarelists [\n" \
 				"<!ELEMENT softwarelists (softwarelist*)>\n" \
-				"\t<!ELEMENT softwarelist (software+)>\n" \
+				"\t<!ELEMENT softwarelist (notes?, software+)>\n" \
 				"\t\t<!ATTLIST softwarelist name CDATA #REQUIRED>\n" \
 				"\t\t<!ATTLIST softwarelist description CDATA #IMPLIED>\n" \
-				"\t\t<!ELEMENT software (description, year, publisher, info*, sharedfeat*, part*)>\n" \
+				"\t\t<!ELEMENT notes (#PCDATA)>\n" \
+				"\t\t<!ELEMENT software (description, year, publisher, notes?, info*, sharedfeat*, part*)>\n" \
 				"\t\t\t<!ATTLIST software name CDATA #REQUIRED>\n" \
 				"\t\t\t<!ATTLIST software cloneof CDATA #IMPLIED>\n" \
 				"\t\t\t<!ATTLIST software supported (yes|partial|no) \"yes\">\n" \
 				"\t\t\t<!ELEMENT description (#PCDATA)>\n" \
 				"\t\t\t<!ELEMENT year (#PCDATA)>\n" \
 				"\t\t\t<!ELEMENT publisher (#PCDATA)>\n" \
+				"\t\t\t<!ELEMENT notes (#PCDATA)>\n" \
 				"\t\t\t<!ELEMENT info EMPTY>\n" \
 				"\t\t\t\t<!ATTLIST info name CDATA #REQUIRED>\n" \
 				"\t\t\t\t<!ATTLIST info value CDATA #IMPLIED>\n" \
@@ -1116,6 +1118,8 @@ const char cli_frontend::s_softlist_xml_dtd[] =
 void cli_frontend::output_single_softlist(std::ostream &out, software_list_device &swlistdev)
 {
 	util::stream_format(out, "\t<softwarelist name=\"%s\" description=\"%s\">\n", swlistdev.list_name(), util::xml::normalize_string(swlistdev.description().c_str()));
+	if (!swlistdev.notes().empty())
+		util::stream_format(out, "\t\t<notes>%s</notes>\n", util::xml::normalize_string(swlistdev.notes().c_str()));
 	for (const software_info &swinfo : swlistdev.get_info())
 	{
 		util::stream_format(out, "\t\t<software name=\"%s\"", util::xml::normalize_string(swinfo.shortname().c_str()));
@@ -1129,6 +1133,8 @@ void cli_frontend::output_single_softlist(std::ostream &out, software_list_devic
 		util::stream_format(out, "\t\t\t<description>%s</description>\n", util::xml::normalize_string(swinfo.longname().c_str()));
 		util::stream_format(out, "\t\t\t<year>%s</year>\n", util::xml::normalize_string(swinfo.year().c_str()));
 		util::stream_format(out, "\t\t\t<publisher>%s</publisher>\n", util::xml::normalize_string(swinfo.publisher().c_str()));
+		if (!swinfo.notes().empty())
+			util::stream_format(out, "\t\t\t<notes>%s</notes>\n", util::xml::normalize_string(swinfo.notes().c_str()));
 
 		for (const feature_list_item &flist : swinfo.other_info())
 			util::stream_format(out, "\t\t\t<info name=\"%s\" value=\"%s\"/>\n", flist.name(), util::xml::normalize_string(flist.value().c_str()));


### PR DESCRIPTION
…out a software list or software list item.  [Wilbert Pol]

There is quite a lot of information regarding software for a system, why/how a software list item is broken, or how to use a software list item in the current software lists. Yet this information is only available in xml comments.

By moving this information into a xml tag the information becomes available for a frontend/ui and could be presented to the user.
Having the information in a tag will also allow us to change from xml to a different format without losing any information if we ever want to do so.

As an example I changed the wswan software list as part of this PR.
