### PR TITLE
fix m_readbuf_state being in undefined state

### DIFF
--- a/src/osd/modules/debugger/debuggdbstub.cpp
+++ b/src/osd/modules/debugger/debuggdbstub.cpp
@@ -421,6 +421,7 @@ class debug_gdbstub : public osd_module, public debug_module
 public:
 	debug_gdbstub()
 	: osd_module(OSD_DEBUG_PROVIDER, "gdbstub"), debug_module(),
+	    m_readbuf_state(PACKET_START),
 		m_machine(nullptr),
 		m_maincpu(nullptr),
 		m_state(nullptr),


### PR DESCRIPTION
The `m_readbuf_state` variable's default value in `gdbstub` is uninitialized. Depending on the compiler, this can result to debugger not working.