### PR TITLE
ioprocsfilter: Fix private constructor inheritance

### DIFF
--- a/src/lib/util/ioprocsfilter.cpp
+++ b/src/lib/util/ioprocsfilter.cpp
@@ -107,7 +107,7 @@ class inflate_data : private zlib_data
 protected:
 	using zlib_data::zlib_data;
 
-	inflate_data(std::size_t buffer_size)
+	inflate_data(std::size_t buffer_size) noexcept
 		: zlib_data(buffer_size)
 	{
 	}

--- a/src/lib/util/ioprocsfilter.cpp
+++ b/src/lib/util/ioprocsfilter.cpp
@@ -107,6 +107,11 @@ class inflate_data : private zlib_data
 protected:
 	using zlib_data::zlib_data;
 
+	inflate_data(std::size_t buffer_size)
+		: zlib_data(buffer_size)
+	{
+	}
+
 	~inflate_data()
 	{
 		if (m_inflate_initialized)


### PR DESCRIPTION
This fixes the issue from my comment on the original commit: https://github.com/mamedev/mame/commit/e8bbea1fc6e94e14768509d322f6c624403ffb36#commitcomment-55509178.

VS2019 was throwing errors when trying to use the initializer for `inflate_data` since the initializer being inherited from `zlib_data` is becoming private due to the private inheritance. 