### PR TITLE
fixed one-shot paddle timers in Apple II and clones

### DIFF
--- a/src/mame/drivers/agat.cpp
+++ b/src/mame/drivers/agat.cpp
@@ -585,10 +585,24 @@ uint8_t agat_base_state::controller_strobe_r()
 
 void agat_base_state::controller_strobe_w(uint8_t data)
 {
-	m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_joy1x->read();
-	m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_joy1y->read();
-	m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_joy2x->read();
-	m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_joy2y->read();
+	// 555 monostable one-shot timers; a running timer cannot be restarted
+	if (machine().time().as_double() >= m_joystick_x1_time) 
+	{
+		m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_joy1x->read();
+	}
+	if (machine().time().as_double() >= m_joystick_y1_time) 
+	{
+		m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_joy1y->read();
+	}
+	if (machine().time().as_double() >= m_joystick_x2_time) 
+	{
+		m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_joy2x->read();
+	}
+	if (machine().time().as_double() >= m_joystick_y2_time) 
+	{
+		m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_joy2y->read();
+	}
+
 }
 
 uint8_t agat_base_state::c080_r(offs_t offset)

--- a/src/mame/drivers/apple2.cpp
+++ b/src/mame/drivers/apple2.cpp
@@ -677,10 +677,24 @@ u8 apple2_state::controller_strobe_r()
 
 void apple2_state::controller_strobe_w(u8 data)
 {
-	m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
-	m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
-	m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
-	m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+	// 558 monostable one-shot timers; a running timer cannot be restarted
+	if (machine().time().as_double() >= m_joystick_x1_time) 
+	{
+		m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
+	}
+	if (machine().time().as_double() >= m_joystick_y1_time) 
+	{
+		m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
+	}
+	if (machine().time().as_double() >= m_joystick_x2_time) 
+	{
+		m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
+	}
+	if (machine().time().as_double() >= m_joystick_y2_time) 
+	{
+		m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+	}
+
 }
 
 u8 apple2_state::c080_r(offs_t offset)

--- a/src/mame/drivers/apple2e.cpp
+++ b/src/mame/drivers/apple2e.cpp
@@ -1903,10 +1903,23 @@ void apple2e_state::do_io(int offset, bool is_iic)
 				accel_normal_speed();
 			}
 
-			m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
-			m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
-			m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
-			m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+			// 558 monostable one-shot timers; a running timer cannot be restarted
+			if (machine().time().as_double() >= m_joystick_x1_time) 
+			{
+				m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
+			}
+			if (machine().time().as_double() >= m_joystick_y1_time) 
+			{
+				m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
+			}
+			if (machine().time().as_double() >= m_joystick_x2_time) 
+			{
+				m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
+			}
+			if (machine().time().as_double() >= m_joystick_y2_time) 
+			{
+				m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+			}
 			break;
 
 		default:

--- a/src/mame/drivers/apple2gs.cpp
+++ b/src/mame/drivers/apple2gs.cpp
@@ -2187,10 +2187,23 @@ void apple2gs_state::do_io(int offset)
 				accel_normal_speed();
 			}
 
-			m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
-			m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
-			m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
-			m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+			// 558 monostable one-shot timers; a running timer cannot be restarted
+			if (machine().time().as_double() >= m_joystick_x1_time) 
+			{
+				m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
+			}
+			if (machine().time().as_double() >= m_joystick_y1_time) 
+			{
+				m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
+			}
+			if (machine().time().as_double() >= m_joystick_x2_time) 
+			{
+				m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
+			}
+			if (machine().time().as_double() >= m_joystick_y2_time) 
+			{
+				m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+			}
 			break;
 
 		default:
@@ -2627,10 +2640,24 @@ u8 apple2gs_state::c000_r(offs_t offset)
 					accel_normal_speed();
 				}
 
-				m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
-				m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
-				m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
-				m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+				// 558 monostable one-shot timers; a running timer cannot be restarted
+				if (machine().time().as_double() >= m_joystick_x1_time) 
+				{
+					m_joystick_x1_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl0_r();
+				}
+				if (machine().time().as_double() >= m_joystick_y1_time) 
+				{
+					m_joystick_y1_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl1_r();
+				}
+				if (machine().time().as_double() >= m_joystick_x2_time) 
+				{
+					m_joystick_x2_time = machine().time().as_double() + m_x_calibration * m_gameio->pdl2_r();
+				}
+				if (machine().time().as_double() >= m_joystick_y2_time) 
+				{
+					m_joystick_y2_time = machine().time().as_double() + m_y_calibration * m_gameio->pdl3_r();
+				}
+
 			}
 
 			return m_rom[offset + 0x3c000];


### PR DESCRIPTION
This fix reproduces some usually undesirable behavior with the game I/O port. The way an Apple II analog input (joystick or paddle) works is the potentiometer in the controller becomes part of a 555-style monostable timer circuit on the motherboard (the actual chip is a 558 quad timer). A timer start running when the game port is strobed. The more resistance supplied by a potentiometer, the longer a timer runs. When a timer expires, its output is asserted. By continuously polling an output in software, the elapsed time is measured, yielding a controller position.

There are a couple of subtleties to this circuit. First, when a timer is started, it cannot be restarted until it expires. Second, all of the timers use a common strobe signal. If you want to read a two-axis joystick this can get you into trouble.

Typically, for each axis, you strobe the game I/O port (PTRIG) and then you poll an output (PADDL0,X) until it asserts itself (or the routine times out). That's what this Apple II ROM code does:

```
fb1e: ad 70 c0     PREAD       lda     PTRIG
fb21: a0 00                    ldy     #$00
fb23: ea                       nop
fb24: ea                       nop
fb25: bd 64 c0     PREAD2      lda     PADDL0,x
fb28: 10 04                    bpl     RTS2D
fb2a: c8                       iny
fb2b: d0 f8                    bne     PREAD2
fb2d: 88                       dey
fb2e: 60           RTS2D       rts
```

The problem happens when you go to read the next axis. If the resistance of the first axis is less than the resistance of the second axis, the second timer may still be running from when it was strobed for the first axis. A second strobe will have no effect and the timer will appear to expire prematurely, giving the wrong result. BASIC is slow enough this is never an issue but it can be a pain in the neck for machine language programmers. 

MAME's Apple II drivers always restart the timers when strobed. That means a controller is read perfectly every time. It is not sufficiently broken and the "fix" is to not restart a timer if it is already running. I'm unaware of any software that exploits this glitch but reproducing it improves emulation accuracy.

See _Apple IIe Tech Note #6: The Apple II Paddle Circuits_ for a more thorough discussion of this anomaly.

Demonstration code:
```
1000 HOME:GOSUB 3000
1010 PRINT "THIS DOES FOUR CONSECUTIVE PREADS"
1020 PRINT "---------------------------------"
1030 PRINT "IN MANY PADDLE/JOYSTICK POSITIONS"
1040 PRINT "X1/X2 AND Y1/Y2 PAIRS WILL BE THE"
1050 PRINT "SAME VALUE. OTHER POSITIONS CAUSE"
1060 PRINT "ONE OR BOTH PAIRS TO SHOW GREATLY"
1070 PRINT "DIFFERENT VALUES. THIS GLITCH CAN"
1080 PRINT "BE SEEN WHEN X < 100 AND Y > 100."
1090 PRINT "THIS IS PRODUCED BY CALLING PREAD"
1100 PRINT "BEFORE THE PADDLE TIMERS HAVE ALL"
1110 PRINT "EXPIRED. A SIMILAR GLITCH HAPPENS"
1120 PRINT "WHEN X OR Y ARE PUSHED PAST THEIR"
1130 PRINT "MAXIMUM EXTENT. THIS IS CAUSED BY"
1140 PRINT "PREAD RETURNING BEFORE THE TIMERS"
1150 PRINT "HAVE EXPIRED. BOTH GLITCHES ARE A"
1160 PRINT "RESULT OF PADDLE TIMERS NOT BEING"
1170 PRINT "RESET BECAUSE THEY ARE ACTIVE."

2000 CALL 768
2010 X1 = PEEK(796): X2 = PEEK(797)
2020 Y1 = PEEK(798): Y2 = PEEK(799)
2030 VTAB 19
2040 PRINT "    X1: ";X1;"  "
2050 PRINT "    X2: ";X2;"  "
2060 PRINT 
2070 PRINT "    Y1: ";Y1;"  "
2080 PRINT "    Y2: ";Y2;"  "
2090 GOTO 2000

3000 FOR I=768 TO 795
3010 READ J:POKE I,J
3020 NEXT
3030 RETURN
3100 DATA 162,0,32,30,251,140,28,3,32,30,251,140,29,3,232,32,30,251,140,30,3,32,30,251,140,31,3,96
3110 REM 300- LDX #$00
3120 REM 302- JSR $FB1E PREAD
3130 REM 305- STY $031C    
3140 REM 308- JSR $FB1E PREAD
3150 REM 30B- STY $031D    
3160 REM 30E- INX
3170 REM 30F- JSR $FB1E PREAD
3180 REM 312- STY $031E    
3190 REM 315- JSR $FB1E PREAD
3200 REM 318- STY $031F    
3210 REM 31B- RTS
```

A note about Agat-7 and Agat-9 clones: I do not have access to this hardware but I spent a couple of hours reverse engineering PCBs from photos. I believe they use an equivalent circuit implemented with a pair of 1006BИ1 timer chips (the Soviet equivalent of an NE555). It also appears to me from looking at several motherboards and reading some documentation that these machines only support two paddles. The MAME driver supports four like a regular Apple II. I fixed the timers but I have not removed two extra inputs. I'll leave that so someone more knowledgeable of the machines and the emulation code. I was unable to load BASIC into the Agat-7 to run the demonstration code. I tried it in another Agat-7 emulator and it runs with some modification (PREAD is at a different location in firmware).

