### PR TITLE
Correctly count and report romsets not found.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-
+[Please see MameDev.org submission guidelines](https://wiki.mamedev.org/index.php/Submitting_Source_Code)

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -132,12 +132,7 @@ void print_summary(
 		unsigned &correct, unsigned &incorrect, unsigned &notfound,
 		util::ovectorstream &buffer)
 {
-	if (summary == media_auditor::NOTFOUND)
-	{
-		// if not found, count that and leave it at that
-		++notfound;
-	}
-	else if (record_none_needed || (summary != media_auditor::NONE_NEEDED))
+	if (record_none_needed || (summary != media_auditor::NONE_NEEDED))
 	{
 		// output the summary of the audit
 		buffer.clear();
@@ -172,6 +167,7 @@ void print_summary(
 
 		case media_auditor::NOTFOUND:
 			osd_printf_info("not found\n");
+			++notfound;
 			return;
 		}
 		assert(false);
@@ -988,9 +984,9 @@ void cli_frontend::verifyroms(const std::vector<std::string> &args)
 	{
 		// otherwise, print a summary
 		if (incorrect > 0)
-			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "%u romsets found, %u were OK.\n", correct + incorrect, correct);
+			throw emu_fatalerror(EMU_ERR_MISSING_FILES, "%u romsets not found, %u romsets found, %u were OK.\n", notfound, correct + incorrect, correct);
 		else
-			osd_printf_info("%u romsets found, %u were OK.\n", correct, correct);
+			osd_printf_info("%u romsets not found, %u romsets found, %u were OK.\n", notfound, correct, correct);
 	}
 }
 


### PR DESCRIPTION
The counting and reporting of romsets not found doesn't output correctly.  These changes will count the not found romsets correctly and add a not found count to the output.

To see what I mean,  Take original Mame, remove (or rename temporarily) at least two romsets and do a -verifyroms on those sets.  Then do it with my changes implemented.

For example:

        z:\Mame\cd roms
        
        z:\Mame\roms>ren timeplt.zip timeplt.zip-save
        
        z:\Mame\roms>ren timecris.zip timecris.zip-save
        
        z:\Mame\roms>cd ..
        
        z:\Mame>orig_mame.exe -verifyroms timeplt timecris
        0 romsets found, 0 were OK.
        
        z:\Mame>modified_mame.exe -verifyroms timeplt timecris
        romset timecris not found
        romset timeplt not found
        2 romsets not found, 0 romsets found, 0 were OK.

Then, if we put one back

        z:\Mame>cd roms
        
        z:\Mame\roms>ren timeplt.zip-save timeplt.zip
        
        z:\Mame\roms>cd ..
        
        z:\Mame>orig_mame.exe -verifyroms timeplt timecris
        romset timeplt is good
        1 romsets found, 1 were OK.
        
        z:\Mame>modified_mame.exe -verifyroms timeplt timecris
        romset timecris not found
        romset timeplt is good
        1 romsets not found, 1 romsets found, 1 were OK.

Then, if we put the other one back:

        z:\Mame>cd roms
        
        z:\Mame\roms>ren timecris.zip-save timecris.zip
        
        z:\Mame\roms>cd ..
        
        z:\Mame>orig_mame.exe -verifyroms timeplt timecris
        romset timecris is good
        romset timeplt is good
        2 romsets found, 2 were OK.
        
        z:\Mame>modified_mame.exe -verifyroms timeplt timecris
        romset timecris is good
        romset timeplt is good
        0 romsets not found, 2 romsets found, 2 were OK.