### PR TITLE
toaplan_scu.cpp: Use single pass pdrawgfx for sprite vs tilemap priority

### DIFF
--- a/src/mame/drivers/toaplan1.cpp
+++ b/src/mame/drivers/toaplan1.cpp
@@ -1969,8 +1969,10 @@ void toaplan1_rallybik_state::rallybik(machine_config &config)
 	m_screen->screen_vblank().set(FUNC(toaplan1_rallybik_state::screen_vblank));
 
 	TOAPLAN_SCU(config, m_spritegen, 0);
+	m_spritegen->set_screen(m_screen);
 	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_xoffsets(31, 15);
+	m_spritegen->set_pri_callback(FUNC(toaplan1_rallybik_state::pri_cb));
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_rallybik);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, (64*16)+(64*16));

--- a/src/mame/drivers/twincobr.cpp
+++ b/src/mame/drivers/twincobr.cpp
@@ -688,8 +688,10 @@ void twincobr_state::twincobr(machine_config &config)
 	crtc.set_char_width(2);
 
 	TOAPLAN_SCU(config, m_spritegen, 0);
+	m_spritegen->set_screen(m_screen);
 	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_xoffsets(31, 15);
+	m_spritegen->set_pri_callback(FUNC(twincobr_state::pri_cb));
 
 	BUFFERED_SPRITERAM16(config, m_spriteram16);
 

--- a/src/mame/drivers/wardner.cpp
+++ b/src/mame/drivers/wardner.cpp
@@ -433,8 +433,10 @@ void wardner_state::wardner(machine_config &config)
 	crtc.set_char_width(2);
 
 	TOAPLAN_SCU(config, m_spritegen, 0);
+	m_spritegen->set_screen(m_screen);
 	m_spritegen->set_palette(m_palette);
 	m_spritegen->set_xoffsets(32, 14);
+	m_spritegen->set_pri_callback(FUNC(wardner_state::pri_cb));
 
 	BUFFERED_SPRITERAM8(config, m_spriteram8);
 

--- a/src/mame/includes/toaplan1.h
+++ b/src/mame/includes/toaplan1.h
@@ -178,6 +178,7 @@ private:
 	DECLARE_WRITE_LINE_MEMBER(coin_lockout_1_w);
 	DECLARE_WRITE_LINE_MEMBER(coin_lockout_2_w);
 	u16 tileram_r(offs_t offset);
+	void pri_cb(u8 priority, u32 &pri_mask);
 	u32 screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 	DECLARE_WRITE_LINE_MEMBER(screen_vblank);
 

--- a/src/mame/includes/twincobr.h
+++ b/src/mame/includes/twincobr.h
@@ -121,6 +121,7 @@ protected:
 	void wardner_videoram_w(offs_t offset, u8 data);
 	u8 wardner_sprite_r(offs_t offset);
 	void wardner_sprite_w(offs_t offset, u8 data);
+	void pri_cb(u8 priority, u32 &pri_mask);
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
 	TILE_GET_INFO_MEMBER(get_fg_tile_info);
 	TILE_GET_INFO_MEMBER(get_tx_tile_info);

--- a/src/mame/video/toaplan_scu.cpp
+++ b/src/mame/video/toaplan_scu.cpp
@@ -1,8 +1,8 @@
 // license:BSD-3-Clause
 // copyright-holders:Quench
 /* Toaplan Sprite Controller 'SCU'
- used by video/twincobr.c (including wardner)
- and rallybik in toaplan1.c
+ used by video/twincobr.cpp (including wardner)
+ and rallybik in toaplan1.cpp
 */
 
 
@@ -32,31 +32,28 @@ GFXDECODE_END
 toaplan_scu_device::toaplan_scu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, TOAPLAN_SCU, tag, owner, clock)
 	, device_gfx_interface(mconfig, *this, gfxinfo)
+	, device_video_interface(mconfig, *this)
+	, m_pri_cb(*this)
 {
 }
 
 void toaplan_scu_device::device_start()
 {
+	m_pri_cb.resolve();
 }
 
 void toaplan_scu_device::device_reset()
 {
 }
 
-void toaplan_scu_device::alloc_sprite_bitmap(screen_device &screen)
-{
-	screen.register_screen_bitmap(m_temp_spritebitmap);
-}
-
 /***************************************************************************
     Sprite Handlers
 ***************************************************************************/
 
-void toaplan_scu_device::draw_sprites_to_tempbitmap(const rectangle &cliprect, u16* spriteram, u32 bytes)
+template<class BitmapClass>
+void toaplan_scu_device::draw_sprites_common(BitmapClass &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes)
 {
-	m_temp_spritebitmap.fill(0, cliprect);
-
-	for (int offs = 0; offs < bytes / 2; offs += 4)
+	for (int offs = (bytes / 2) - 4; offs >= 0; offs -= 4)
 	{
 		const u16 attribute = spriteram[offs + 1];
 		const int priority  = (attribute & 0x0c00) >> 10;
@@ -69,49 +66,34 @@ void toaplan_scu_device::draw_sprites_to_tempbitmap(const rectangle &cliprect, u
 		{
 			const u32 sprite = spriteram[offs] & 0x7ff;
 			u32 color        = attribute & 0x3f;
-			color |= priority << 6; // encode colour
+			u32 pri_mask     = 0; // priority mask
+			if (!m_pri_cb.isnull())
+				m_pri_cb(priority, pri_mask);
 
 			int sx          = spriteram[offs + 2] >> 7;
 			const int flipx = attribute & 0x100;
 			if (flipx) sx  -= m_xoffs_flipped;
 
 			const int flipy = attribute & 0x200;
-			gfx(0)->transpen_raw(m_temp_spritebitmap, cliprect,
+			gfx(0)->prio_transpen(bitmap, cliprect,
 				sprite,
-				color << 4 /* << 4 because using _raw */ ,
+				color,
 				flipx, flipy,
-				sx - m_xoffs, sy - 16, 0);
+				sx - m_xoffs, sy - 16, screen().priority(), pri_mask, 0);
 		}
 	}
-
 }
 
 
-/***************************************************************************
-    Draw the game screen in the given bitmap.
-***************************************************************************/
-
-void toaplan_scu_device::copy_sprites_from_tempbitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect, int priority)
+void toaplan_scu_device::draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes)
 {
-	pen_t const *const pens = &palette().pen(gfx(0)->colorbase());
-
-	for (int y = cliprect.min_y; y <= cliprect.max_y; y++)
-	{
-		u16 const *const srcline = &m_temp_spritebitmap.pix(y);
-		u32 *const dstline = &bitmap.pix(y);
-
-		for (int x = cliprect.min_x; x <= cliprect.max_x; x++)
-		{
-			const u16 pix = srcline[x];
-
-			if ((pix >> (4 + 6)) == priority)
-			{
-				if (pix & 0xf)
-				{
-					dstline[x] = pens[pix & 0x3ff];
-				}
-			}
-		}
-
-	}
+	draw_sprites_common(bitmap, cliprect, spriteram, bytes);
 }
+
+
+void toaplan_scu_device::draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes)
+{
+	draw_sprites_common(bitmap, cliprect, spriteram, bytes);
+}
+
+

--- a/src/mame/video/toaplan_scu.h
+++ b/src/mame/video/toaplan_scu.h
@@ -6,11 +6,12 @@
 
 #pragma once
 
-
-class toaplan_scu_device : public device_t, public device_gfx_interface
+class toaplan_scu_device : public device_t, public device_gfx_interface, public device_video_interface
 {
 public:
 	toaplan_scu_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	typedef device_delegate<void (u8 priority, u32 &pri_mask)> pri_cb_delegate;
 
 	// configuration
 	void set_xoffsets(int xoffs, int xoffs_flipped)
@@ -18,10 +19,11 @@ public:
 		m_xoffs = xoffs;
 		m_xoffs_flipped = xoffs_flipped;
 	}
+	template <typename... T> void set_pri_callback(T &&... args) { m_pri_cb.set(std::forward<T>(args)...); }
 
-	void draw_sprites_to_tempbitmap(const rectangle &cliprect, u16* spriteram, u32 bytes);
-	void copy_sprites_from_tempbitmap(bitmap_rgb32 &bitmap, const rectangle &cliprect, int priority);
-	void alloc_sprite_bitmap(screen_device &screen);
+	template<class BitmapClass> void draw_sprites_common(BitmapClass &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
+	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
 
 protected:
 	virtual void device_start() override;
@@ -31,7 +33,7 @@ private:
 	static const gfx_layout spritelayout;
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 
-	bitmap_ind16 m_temp_spritebitmap;
+	pri_cb_delegate m_pri_cb;
 	int m_xoffs;
 	int m_xoffs_flipped;
 };

--- a/src/mame/video/toaplan_scu.h
+++ b/src/mame/video/toaplan_scu.h
@@ -21,7 +21,6 @@ public:
 	}
 	template <typename... T> void set_pri_callback(T &&... args) { m_pri_cb.set(std::forward<T>(args)...); }
 
-	template<class BitmapClass> void draw_sprites_common(BitmapClass &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
 	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
 	void draw_sprites(bitmap_rgb32 &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
 
@@ -30,6 +29,8 @@ protected:
 	virtual void device_reset() override;
 
 private:
+	template<class BitmapClass> void draw_sprites_common(BitmapClass &bitmap, const rectangle &cliprect, u16* spriteram, u32 bytes);
+
 	static const gfx_layout spritelayout;
 	DECLARE_GFXDECODE_MEMBER(gfxinfo);
 


### PR DESCRIPTION
Use device specific delegate for priority mask
Use device_video_interface for screen interface
Add/Fix notes
Remove unnecessary functions and values
toaplan1.cpp, twincobr.cpp: Add notes