### PR TITLE
saturn.xml: update "zico" set description

### DIFF
--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -23466,7 +23466,7 @@ Olympic Soccer (Fra) T-7904H-09
 
 	<!-- Identifying Isto E Zico - Zico no Kangaeru Soccer (T-18802G)... -->
 	<software name="zico" supported="no">
-		<description>Isto E Zico - Zico no Kangaeru Soccer (Jpn)</description>
+		<description>Isto é Zico - Zico no Kangaeru Soccer (Jpn)</description>
 		<year>1996</year>
 		<publisher>Mizuki</publisher>
 		<info name="serial" value="T-18802G"/>


### PR DESCRIPTION
corrected the description of the "zico" set to "Isto é Zico - Zico no Kangaeru Soccer (Jpn)"

Source: https://segaretro.org/Isto_%C3%A9_Zico:_Zico_no_Kangaeru_Soccer