### PR TITLE
New working clones

### DIFF
--- a/src/mame/drivers/mcatadv.cpp
+++ b/src/mame/drivers/mcatadv.cpp
@@ -514,6 +514,34 @@ ROM_START( mcatadv )
 	ROM_LOAD( "mca-u53.bin", 0x00000, 0x80000, CRC(64c76e05) SHA1(379cef5e0cba78d0e886c9cede41985850a3afb7) )
 ROM_END
 
+ROM_START( mcatadvz ) // Hack made over original PCB by a local Spanish operator to show his company name by changing M68000 program code
+	ROM_REGION( 0x100000, "maincpu", 0 ) /* M68000 */
+	ROM_LOAD16_BYTE( "mca-u30z", 0x00000, 0x80000, CRC(009ae1b3) SHA1(7bee7d3a9a6fd67d09acdfbef49f3e2be6db4712) ) // Same code as mcatadv set, except some little changes to show different company name in title screen and attract mode
+	ROM_LOAD16_BYTE( "mca-u29z", 0x00001, 0x80000, CRC(7fd27089) SHA1(c97f5ce13d8dfeaaed94ec621037e030f7a7cec7) ) // there is also a change in the region warning text to remove the word "JAPAN" on it. However, that text is never used in mcatadv set
+
+	ROM_REGION( 0x020000, "soundcpu", 0 ) /* Z80-A */
+	ROM_LOAD( "u9.bin", 0x00000, 0x20000, CRC(fda05171) SHA1(2c69292573ec35034572fa824c0cae2839d23919) )
+
+	ROM_REGION( 0x800000, "sprdata", ROMREGION_ERASEFF ) /* Sprites */
+	ROM_LOAD16_BYTE( "mca-u82.bin", 0x000000, 0x100000, CRC(5f01d746) SHA1(11b241456e15299912ee365eedb8f9d5e5ca875d) )
+	ROM_LOAD16_BYTE( "mca-u83.bin", 0x000001, 0x100000, CRC(4e1be5a6) SHA1(cb19aad42dba54d6a4a33859f27254c2a3271e8c) )
+	ROM_LOAD16_BYTE( "mca-u84.bin", 0x200000, 0x080000, CRC(df202790) SHA1(f6ae54e799af195860ed0ab3c85138cf2f10efa6) )
+	ROM_LOAD16_BYTE( "mca-u85.bin", 0x200001, 0x080000, CRC(a85771d2) SHA1(a1817cd72f5bf0a4f24a37c782dc63ecec3b8e68) )
+	ROM_LOAD16_BYTE( "mca-u86e",    0x400000, 0x080000, CRC(017bf1da) SHA1(f6446a7219275c0eff62129f59fdfa3a6a3e06c8) )
+	ROM_LOAD16_BYTE( "mca-u87e",    0x400001, 0x080000, CRC(bc9dc9b9) SHA1(f525c9f994d5107752aa4d3a499ee376ec75f42b) )
+
+	ROM_REGION( 0x080000, "bg0", 0 ) /* BG0 */
+	ROM_LOAD( "mca-u58.bin", 0x000000, 0x080000, CRC(3a8186e2) SHA1(129c220d72608a8839f779ce1a6cfec8646dbf23) )
+
+	ROM_REGION( 0x280000, "bg1", 0 ) /* BG1 */
+	ROM_LOAD( "mca-u60.bin", 0x000000, 0x100000, CRC(c8942614) SHA1(244fccb9abbb04e33839dd2cd0e2de430819a18c) )
+	ROM_LOAD( "mca-u61.bin", 0x100000, 0x100000, CRC(51af66c9) SHA1(1055cf78ea286f02003b0d1bf08c2d7829b36f90) )
+	ROM_LOAD( "mca-u100",    0x200000, 0x080000, CRC(b273f1b0) SHA1(39318fe2aaf2792b85426ec6791b3360ac964de3) )
+
+	ROM_REGION( 0x80000, "ymsnd:adpcma", 0 ) /* Samples */
+	ROM_LOAD( "mca-u53.bin", 0x00000, 0x80000, CRC(64c76e05) SHA1(379cef5e0cba78d0e886c9cede41985850a3afb7) )
+ROM_END
+
 ROM_START( mcatadvj )
 	ROM_REGION( 0x100000, "maincpu", 0 ) /* M68000 */
 	ROM_LOAD16_BYTE( "u30.bin", 0x00000, 0x80000, CRC(05762f42) SHA1(3675fb606bf9d7be9462324e68263f4a6c2fea1c) )
@@ -660,6 +688,7 @@ ROM_END
 
 
 GAME( 1993, mcatadv,  0,       mcatadv, mcatadv, mcatadv_state, empty_init, ROT0,   "Wintechno", "Magical Cat Adventure",         MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
+GAME( 1993, mcatadvz, mcatadv, mcatadv, mcatadv, mcatadv_state, empty_init, ROT0,   "Wintechno", "Magical Cat Adventure (Recreativos Zara,S.L.)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 GAME( 1993, mcatadvj, mcatadv, mcatadv, mcatadv, mcatadv_state, empty_init, ROT0,   "Wintechno", "Magical Cat Adventure (Japan)", MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 GAME( 1993, catt,     mcatadv, mcatadv, mcatadv, mcatadv_state, empty_init, ROT0,   "Wintechno", "Catt (Japan)",                  MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )
 GAME( 1993, nost,     0,       nost,    nost,    mcatadv_state, empty_init, ROT270, "Face",      "Nostradamus",                   MACHINE_NO_COCKTAIL | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -22574,6 +22574,7 @@ mc8030                          // MC 80.3x
 @source:mcatadv.cpp
 catt                            // (c) 1993 Wintechno
 mcatadv                         // (c) 1993 Wintechno
+mcatadvz                        // hack
 mcatadvj                        // (c) 1993 Wintechno
 nost                            // (c) 1993 Face
 nostj                           // (c) 1993 Face


### PR DESCRIPTION
------------------
Magical Cat Adventure (Recreativos Zara,S.L.) [Nebula, Recreativos Piscis]

Found it in an original Wintechno PCB with custom eprom labels. This is a picture of the actual pcb: https://twitter.com/Recre_Piscis/status/1434467129525510146
It is actually a hack made over "mcatadv" by a spanish local operator to put his name in attract mode and title screen (added notes for it in code inline-comments).
Only 68k program roms are altered a bit to make that.
No further changes in the gameplay.