### PR TITLE
bus/nes: Improved IRQ emulation for Kaiser KS202 and KS7032.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -74628,8 +74628,8 @@ Other
 		</part>
 	</software>
 
-	<software name="smb3h1" cloneof="smb3" supported="partial">
-		<description>Super Mario Bros. 3 (Pirate, Alt)</description>
+	<software name="smb3h1" cloneof="smb3">
+		<description>Super Mario Bros. 3 (pirate, alt)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">

--- a/src/devices/bus/nes/kaiser.h
+++ b/src/devices/bus/nes/kaiser.h
@@ -73,27 +73,28 @@ class nes_ks7032_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_ks7032_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ks7032_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	void ks7032_write(offs_t offset, uint8_t data);
-	virtual void write_h(offs_t offset, uint8_t data) override { ks7032_write(offset, data); }
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
-	nes_ks7032_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	// construction/destruction
+	nes_ks7032_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
 
+	u8 m_reg[8];
+
+private:
 	void prg_update();
+	u8 m_latch;
 
-	uint8_t m_latch;
-	uint8_t m_reg[8];
-
-	uint16_t m_irq_count;
+	u16 m_irq_count, m_irq_count_latch;
 	int m_irq_enable;
 
 	static const device_timer_id TIMER_IRQ = 0;
@@ -107,11 +108,10 @@ class nes_ks202_device : public nes_ks7032_device
 {
 public:
 	// construction/destruction
-	nes_ks202_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ks202_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	// device-level overrides
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -129,6 +129,7 @@ public:
 	virtual void pcb_reset() override;
 
 protected:
+	// construction/destruction
 	nes_ks7016_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u8 mask);
 
 	// device-level overrides


### PR DESCRIPTION
- Corrected IRQ behavior based on more recent PCB observations. Fixes some flickering on World X-Y interlevel screens in SMB2J bootleg.
- Corrected SMB3 bootleg's banking, also per PCB analysis.