### PR TITLE
nes.xml: Updated PCB details for A Ressha de Ikou.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -9086,7 +9086,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="doordoor">
+<!-- Game has no sound and freezes as soon as you get killed by any enemy -->
+	<software name="doordoor" supported="no">
 		<description>Door Door (Jpn)</description>
 		<year>1985</year>
 		<publisher>Enix</publisher>
@@ -10064,7 +10065,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="dquest" cloneof="dwarr">
+<!-- Game has no sound and freezes once you win any battle -->
+	<software name="dquest" cloneof="dwarr" supported="no">
 		<description>Dragon Quest (Jpn)</description>
 		<year>1986</year>
 		<publisher>Enix</publisher>
@@ -44464,7 +44466,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 	</software>
 
 	<software name="aressha">
-		<description>A Ressha de Ikou (Jpn)</description>
+		<description>A Ressha de Ikou (Japan)</description>
 		<year>1991</year>
 		<publisher>Pony Canyon</publisher>
 		<info name="serial" value="PHF-IX (R78V10005)"/>
@@ -44472,12 +44474,20 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 		<info name="alt_title" value="A列車で行こう"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
-			<feature name="pcb" value="NES-SLROM" />
-			<dataarea name="chr" size="16384">
-				<rom name="a ressha de ikou (japan).chr" size="16384" crc="dda12121" sha1="c7cfd5246626fc582c8e136780c7f4f866a2aedb" offset="00000" status="baddump" />
-			</dataarea>
+			<feature name="pcb_model" value="HVC-SZROM-01" />
+			<feature name="mmc1_type" value="MMC1B2" />
 			<dataarea name="prg" size="131072">
-				<rom name="a ressha de ikou (japan).prg" size="131072" crc="30ca59c8" sha1="8b51c00dfe05a806f61e28e9d031234fe3b933a2" offset="00000" status="baddump" />
+				<rom name="phf-ix-0 prg" size="131072" crc="30ca59c8" sha1="8b51c00dfe05a806f61e28e9d031234fe3b933a2" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="16384">
+				<rom name="phf-ix-0 chr" size="16384" crc="dda12121" sha1="c7cfd5246626fc582c8e136780c7f4f866a2aedb" status="baddump" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge -->
+			<dataarea name="wram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -68954,7 +68964,8 @@ Also notice that VRAM & WRAM are probably incorrect for some of these sets, at t
 		</part>
 	</software>
 
-	<software name="doordoorh" cloneof="doordoor">
+<!-- Game has no sound and freezes as soon as you get killed by any enemy -->
+	<software name="doordoorh" cloneof="doordoor" supported="no">
 		<description>Door Door (FMG pirate)</description>
 		<year>1987</year>
 		<publisher>FMG</publisher>


### PR DESCRIPTION
- Beyond metadata this gives aressha WRAM, making it playable now.
- Separately, demoted Enix games dquest and doordoor due to game crashing bugs.