### PR TITLE
bus/nes: Improved emulation for T-262 board and related multicarts.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -78175,6 +78175,21 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_11a42">
+		<description>11 in 1 (A-042)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="t262" />
+			<dataarea name="prg" size="1048576">
+				<rom name="11-in-1 (a-042).prg" size="1048576" crc="77e9ee96" sha1="e4b61c2da62d2854e3ab3ac4e27edc4af68e646c" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_11bal">
 		<description>11 in 1 Ball Series</description>
 		<year>19??</year>
@@ -79293,6 +79308,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+<!-- Jackal and Rush'n Attack are swapped in menu. Is this a cartridge bug or due to bad dump? -->
 	<software name="mc_4d10">
 		<description>4 in 1 (D-010)</description>
 		<year>19??</year>
@@ -80331,6 +80347,21 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_6a17">
+		<description>1994 Super HiK 6 in 1 (A-017)</description>
+		<year>1994</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="t262" />
+			<dataarea name="prg" size="655360">
+				<rom name="1994 super hik 6-in-1 (a-017).prg" size="655360" crc="d7c794d9" sha1="1ec64b3162a75a12f33a3e2b88c345e18121290b" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_6a30">
 		<description>Super HiK 6 in 1 (A-030)</description>
 		<year>199?</year>
@@ -80346,7 +80377,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_6et40" supported="partial">
+	<software name="mc_6et40">
 		<description>6 in 1 (ET40, 840726c, 43-203)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -80894,8 +80925,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-<!-- Issues with Side Pocket gfx -->
-	<software name="mc_8et40" supported="partial">
+	<software name="mc_8et40">
 		<description>8 in 1 (ET40, 821242c)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>

--- a/src/devices/bus/nes/multigame.cpp
+++ b/src/devices/bus/nes/multigame.cpp
@@ -150,8 +150,8 @@ nes_a65as_device::nes_a65as_device(const machine_config &mconfig, const char *ta
 {
 }
 
-nes_t262_device::nes_t262_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_nrom_device(mconfig, NES_T262, tag, owner, clock), m_latch1(0), m_latch2(0)
+nes_t262_device::nes_t262_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_nrom_device(mconfig, NES_T262, tag, owner, clock), m_latch(0)
 {
 }
 
@@ -547,19 +547,16 @@ void nes_a65as_device::pcb_reset()
 void nes_t262_device::device_start()
 {
 	common_start();
-	save_item(NAME(m_latch1));
-	save_item(NAME(m_latch2));
+	save_item(NAME(m_latch));
 }
 
 void nes_t262_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, m_chr_source);
+	chr8(0, CHRRAM);
 
-	m_latch1 = 0;
-	m_latch2 = 0;
+	m_latch = 0;
 }
 
 void nes_novel1_device::device_start()
@@ -1446,33 +1443,41 @@ void nes_a65as_device::write_h(offs_t offset, uint8_t data)
 
  Board BMC-T-262
 
- Games: 4-in-1 (D-010), 8-in-1 (A-020)
+ Games: 4-in-1 (D-010), 8-in-1 (A-020), and others
 
- In MESS: Supported
+ NES 2.0: mapper 265
+
+ In MAME: Supported.
+
+ TODO: Gunsmoke on 8-in-1 (ET40) has invisible sprites
+ that suddenly appear closer to the bottom of the screen.
+ Mirroring is correct, so is this a bug on the cartridge?
 
  -------------------------------------------------*/
 
-void nes_t262_device::write_h(offs_t offset, uint8_t data)
+void nes_t262_device::write_h(offs_t offset, u8 data)
 {
-	uint8_t mmc_helper;
 	LOG_MMC(("t262 write_h, offset: %04x, data: %02x\n", offset, data));
 
-	if (m_latch2 || offset == 0)
+	if (!BIT(m_latch, 13))
 	{
-		m_latch1 = (m_latch1 & 0x38) | (data & 0x07);
-		prg16_89ab(m_latch1);
+		m_latch = offset;
+		set_nt_mirroring(BIT(m_latch, 1) ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
 	}
-	else
+
+	u8 bank = (m_latch & 0x300) >> 3 | (m_latch & 0x60) >> 2 | (data & 0x07);    // NesDev shows the high bit here, but is it correct? So far no cart is large enough to use this.
+	u8 mode = BIT(m_latch, 0);
+	if (BIT(m_latch, 7))    // NROM mode
 	{
-		m_latch2 = 1;
-		set_nt_mirroring(BIT(data, 1) ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
-		mmc_helper = ((offset >> 3) & 0x20) | ((offset >> 2) & 0x18);
-		m_latch1 = mmc_helper | (m_latch1 & 0x07);
-		prg16_89ab(m_latch1);
-		prg16_cdef(mmc_helper | 0x07);
+		prg16_89ab(bank & ~mode);
+		prg16_cdef(bank | mode);
+	}
+	else                    // UNROM mode
+	{
+		prg16_89ab(bank);
+		prg16_cdef(bank | 0x07);
 	}
 }
-
 
 /*-------------------------------------------------
 
@@ -1506,7 +1511,6 @@ void nes_novel2_device::write_h(offs_t offset, uint8_t data)
 	prg32(offset >> 1);
 	chr8(offset >> 3, CHRROM);
 }
-
 
 /*-------------------------------------------------
 

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -161,9 +161,9 @@ class nes_t262_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_t262_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_t262_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -172,7 +172,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	uint8_t m_latch1, m_latch2;
+	u16 m_latch;
 };
 
 


### PR DESCRIPTION
- Fixed games not loading in mc_6et40 and mc_11a42 and graphics issues with several games across the nine cartridges represented here.

New working software list additions
-----------------------------------
11 in 1 (A-042) [anonymous]
1994 Super HiK 6 in 1 (A-017) [anonymous]