### PR TITLE
nes.xml: Set correct board type for several games.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -58621,41 +58621,16 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="quanhr2" supported="no">
-		<description>Quan Huang R2 - Dashe Sitian Wang (Chi)</description>
-		<year>19??</year>
+	<software name="quanhr2">
+		<description>Quánhuáng R-2 - Dàshé Sìtiānwáng (China)</description>
+		<year>200?</year>
 		<publisher>Nanjing</publisher>
 		<info name="serial" value="NJ087"/>
-		<info name="alt_title" value="拳皇R2-大蛇四天王"/>
+		<info name="alt_title" value="拳皇R-2 大蛇四天王"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="nanjing" />
-			<feature name="pcb" value="UNL-NANJING" />
-			<feature name="mirroring" value="vertical" />
+			<feature name="slot" value="waixing_sgzlz" />
 			<dataarea name="prg" size="524288">
 				<rom name="[nj087] quan huang r-2 da she si tian wang (c).prg" size="524288" crc="4d0ae59b" sha1="a6ddea87888ea75899caaf0380ec11409b88cabc" offset="00000" />
-			</dataarea>
-			<!-- 8k VRAM on cartridge-->
-			<dataarea name="vram" size="8192">
-			</dataarea>
-			<!-- 8k WRAM on cartridge, battery backed up -->
-			<dataarea name="bwram" size="8192">
-				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- included only until we sort out what is wrong in the parent -->
-	<software name="quanhr2h" cloneof="quanhr2">
-		<description>Quan Huang R2 - Dashe Sitian Wang (Chi, Hacked)</description>
-		<year>19??</year>
-		<publisher>Nanjing</publisher>
-		<info name="serial" value="NJ087"/>
-		<info name="alt_title" value="拳皇R2-大蛇四天王"/>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="txc_commandos" />
-			<feature name="pcb" value="TXC-MXMDHTWO" />
-			<dataarea name="prg" size="524288">
-				<rom name="[nj087] quan huang r-2 da she si tian wang (c) [fix 241].prg" size="524288" crc="7f941e06" sha1="64f3b832d498e1aaeb3abde88488520278e77806" offset="00000" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge-->
 			<dataarea name="vram" size="8192">
@@ -58692,16 +58667,14 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 
 <!-- [NJ089] 笑傲江湖群侠记 ~ Xiao Ao Jian Ghu Xia Ji -->
 
-	<software name="yongzcs" supported="no">
-		<description>Yong Zhe Chuan Shuo (Chi)</description>
-		<year>19??</year>
+	<software name="yongzcs">
+		<description>Yǒngzhě Chuánshuō (China)</description>
+		<year>200?</year>
 		<publisher>Nanjing</publisher>
 		<info name="serial" value="NJ090"/>
 		<info name="alt_title" value="勇者传说"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="nanjing" />
-			<feature name="pcb" value="UNL-NANJING" />
-			<feature name="mirroring" value="vertical" />
+			<feature name="slot" value="waixing_sgzlz" />
 			<dataarea name="prg" size="524288">
 				<rom name="[nj090] yong zhe chuan shuo (c).prg" size="524288" crc="f814ec57" sha1="caa5b056c7cee9b8822647a69d2e9aa949e8e9c0" offset="00000" status="baddump" />
 			</dataarea>
@@ -58720,21 +58693,23 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 <!-- [NJ093] 鹿鼎记 ~ Lu Ding Ji -->
 
 <!-- rom with crc 3cf783af is hacked to run on mapper 241 -->
-	<software name="whangzws" supported="no">
-		<description>Whang Zhe Wu Shuang (Chi)</description>
-		<year>19??</year>
+	<software name="wangzws">
+		<description>Wángzhě Wúshuāng (China)</description>
+		<year>200?</year>
 		<publisher>Nanjing</publisher>
 		<info name="serial" value="NJ094"/>
 		<info name="alt_title" value="王者无双"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="unknown" />
-			<feature name="pcb" value="UNKNOWN" />
-			<feature name="mirroring" value="vertical" />
+			<feature name="slot" value="waixing_sgzlz" />
 			<dataarea name="prg" size="524288">
 				<rom name="[nj094] wang zhe wu shuang (c).prg" size="524288" crc="1dcc4a14" sha1="ca7366f3a4b80952d7690b02bd8b9c2a0d52bbae" offset="00000" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -65154,14 +65129,14 @@ We don't include these hacks because they were not burned into real carts nor so
 	</software>
 
 <!-- nointro -->
+<!-- For some reason this won't run from a cold boot and needs to be soft reset once. Once running game has no sound (probably same issue as dquest, which it appears to be derived from). -->
 	<software name="yingxion" supported="no">
-		<description>Ying Xiong Yuan Yi Jing Chuan Qi (Chi)</description>
+		<description>Yīngxióng Yuán Yìjīng Chuánqí (China)</description>
 		<year>19??</year>
 		<publisher>HengGedianzi</publisher>
 		<info name="alt_title" value="英雄源义经传奇"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="waixing_g" />
-			<feature name="pcb" value="WAIXING-G" />
+			<feature name="slot" value="txrom" />
 			<dataarea name="prg" size="262144">
 				<rom name="ying xiong yuan yi jing chuan qi (china) (unl).prg" size="262144" crc="dfad3f66" sha1="c4df1dff6ad1f6194bff1e5333073edf0c178d7d" offset="00000" status="baddump" />
 			</dataarea>


### PR DESCRIPTION
- Removed a "fixed" version of quanhr2, now that parent is working.

Software list items promoted to working
---------------------------------------
Quánhuáng R-2 - Dàshé Sìtiānwáng
Yǒngzhě Chuánshuō
Wángzhě Wúshuāng