### PR TITLE
bus/nes: More fixes for various multicart types.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -80281,7 +80281,7 @@ be better to redump them properly. -->
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="bmc_d1038" />
+			<feature name="slot" value="bmc_vt5201" />
 			<feature name="pcb" value="BMC-D1038" />
 			<dataarea name="chr" size="65536">
 				<rom name="46-in-1 (d1038) [p1][u].chr" size="65536" crc="a2f2b37b" sha1="4cd8720e70762038b4a9cf2dec92dde0e38698d6" offset="00000" status="baddump" />
@@ -80707,7 +80707,7 @@ be better to redump them properly. -->
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="bmc_d1038" />
+			<feature name="slot" value="bmc_vt5201" />
 			<feature name="pcb" value="BMC-D1038" />
 			<dataarea name="chr" size="65536">
 				<rom name="65-in-1 (nt766) [p1][u].chr" size="65536" crc="e1d03e4a" sha1="13c52b601ee0a9e3fe4030562e86118b7a5c9d62" offset="00000" status="baddump" />
@@ -80938,7 +80938,7 @@ be better to redump them properly. -->
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="bmc_d1038" />
+			<feature name="slot" value="bmc_vt5201" />
 			<feature name="pcb" value="BMC-D1038" />
 			<dataarea name="chr" size="65536">
 				<rom name="74-in-1 (nt886) [p1][u].chr" size="65536" crc="b2f00487" sha1="f21320df2d199887a4e9b231c7bf3afcc77ac9ec" offset="00000" status="baddump" />
@@ -80992,7 +80992,7 @@ be better to redump them properly. -->
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="bmc_d1038" />
+			<feature name="slot" value="bmc_vt5201" />
 			<feature name="pcb" value="BMC-D1038" />
 			<dataarea name="chr" size="65536">
 				<rom name="77-in-1 (nt141) [p1][u].chr" size="65536" crc="3f03ecaf" sha1="1e65bb75da9f008bf37a0a2c058f9771ac09caac" offset="00000" status="baddump" />
@@ -81016,6 +81016,7 @@ be better to redump them properly. -->
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="bmc_21in1" />
 			<feature name="pcb" value="BMC-21IN1" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="32768">
 				<rom name="8-in-1 [p1].chr" size="32768" crc="a1f6c479" sha1="888834d627637e75d2636a7f34d6a0ff234e8929" offset="00000" status="baddump" />
 			</dataarea>
@@ -81915,6 +81916,21 @@ to check why this is different -->
 		</part>
 	</software>
 
+	<software name="mc_s190">
+		<description>Super 190 in 1</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_s700" />
+			<dataarea name="prg" size="2097152">
+				<rom name="super 190-in-1.prg" size="2097152" crc="8dae13b2" sha1="cd36b113a0091666621c3248601ae5ca33d0605d" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="1048576">
+				<rom name="super 190-in-1.chr" size="1048576" crc="47abdc9f" sha1="289ae7628687dc4b370adee42f3a97034ce6ed2b" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 <!-- If you select the keyboard it does not work due to missing data -->
 	<software name="mc_s200" supported="partial">
 		<description>Super 200 in 1 MD-8802 (Incomplete?)</description>
@@ -82089,7 +82105,6 @@ to check why this is different -->
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="bmc_vt5201" />
 			<feature name="pcb" value="BMC-VT5201" />
-			<feature name="mirroring" value="high" />
 			<dataarea name="chr" size="65536">
 				<rom name="super 35 in 1 (6 in 1 vt5201).chr" size="65536" crc="a3d8d9dd" sha1="34703a76b76c7244a21237e41b8aed7a1ef95cae" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -265,10 +265,10 @@ class nes_vt5201_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_vt5201_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_vt5201_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_h(offs_t offset) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual u8 read_h(offs_t offset) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -277,7 +277,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	uint8_t m_latch, m_dipsetting;
+	u8 m_latch, m_jumper;
 };
 
 
@@ -645,15 +645,9 @@ class nes_bmc_s700_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_bmc_s700_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_s700_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -753,15 +747,9 @@ class nes_bmc_20in1_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_bmc_20in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_20in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -771,15 +759,9 @@ class nes_bmc_21in1_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_bmc_21in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_21in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/nes_carts.cpp
+++ b/src/devices/bus/nes/nes_carts.cpp
@@ -367,8 +367,7 @@ void nes_cart(device_slot_interface &device)
 	device.option_add_internal("novel2",           NES_NOVEL2); // mapper 213... same as BMC-NOVELDIAMOND9999999IN1 board?
 	device.option_add_internal("studyngame",       NES_STUDYNGAME); // mapper 39
 	device.option_add_internal("sgun20in1",        NES_SUPERGUN20IN1);
-	device.option_add_internal("bmc_vt5201",       NES_VT5201); // mapper 59?
-	device.option_add_internal("bmc_d1038",        NES_VT5201); // mapper 59?
+	device.option_add_internal("bmc_vt5201",       NES_VT5201); // mapper 59
 	device.option_add_internal("bmc_60311c",       NES_BMC_60311C);
 	device.option_add_internal("bmc_80013b",       NES_BMC_80013B);
 	device.option_add_internal("bmc_810544c",      NES_BMC_810544C);

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -91,7 +91,7 @@ static const nes_mmc mmc_list[] =
 	{ 56, KAISER_KS202 },
 	{ 57, BMC_GKA },
 	{ 58, BMC_GKB },
-	// 59 BMC-T3H53 and BMC-D1038
+	{ 59, BMC_VT5201 },   // and BMC-T3H53, BMC-D1038
 	{ 60, BMC_4IN1RESET },
 	{ 61, RCM_TF9IN1 },
 	{ 62, BMC_SUPER_700IN1 },

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -252,8 +252,7 @@ static const nes_pcb pcb_list[] =
 	{ "novel2",           BMC_NOVEL2 },  // mapper 213... same as BMC-NOVELDIAMOND9999999IN1 board?
 	{ "studyngame",       UNL_STUDYNGAME },  // mapper 39
 	{ "sgun20in1",        BMC_SUPERGUN_20IN1 },
-	{ "bmc_vt5201",       BMC_VT5201 },  // mapper 59?
-	{ "bmc_d1038",        BMC_VT5201 },  // mapper 59?
+	{ "bmc_vt5201",       BMC_VT5201 },  // mapper 59
 	{ "bmc_60311c",       BMC_60311C },
 	{ "bmc_80013b",       BMC_80013B },
 	{ "bmc_810544c",      BMC_810544C },

--- a/src/devices/bus/nes/nes_unif.hxx
+++ b/src/devices/bus/nes/nes_unif.hxx
@@ -114,7 +114,7 @@ static const unif unif_list[] =
 	{ "UNL-YOKO",                   0,    0, CHRRAM_0,  YOKO_BOARD}, // similar to mapper 83, but not the same
 	{ "UNL-FS304",                  0,    8, CHRRAM_8,  WAIXING_FS304}, // used in Zelda 3 by Waixing
 	{ "UNL-43272",                  0,    0, CHRRAM_0,  UNL_43272}, // used in Gaau Hok Gwong Cheung
-	{ "BTL-MARIO1-MALEE2",          0,    0, CHRRAM_0,  UNL_MMALEE}, // mapper 55?
+	{ "BTL-MARIO1-MALEE2",          0,    0, CHRRAM_0,  UNL_MMALEE}, // mapper 55
 	{ "BMC-FK23C",                  0,    0, CHRRAM_0,  BMC_FK23C},
 	{ "BMC-FK23CA",                 0,    0, CHRRAM_0,  BMC_FK23CA},
 	{ "BMC-GHOSTBUSTERS63IN1",      0,    0, CHRRAM_8,  BMC_G63IN1 },
@@ -123,7 +123,7 @@ static const unif unif_list[] =
 	{ "BMC-411120-C",               0,    0, CHRRAM_0,  BMC_411120C},
 	{ "BMC-8157",                   0,    0, CHRRAM_8,  BMC_8157},
 	{ "BMC-830118C",                0,    0, CHRRAM_0,  BMC_830118C},
-	{ "BMC-D1038",                  0,    0, CHRRAM_0,  BMC_VT5201}, // mapper 60?
+	{ "BMC-D1038",                  0,    0, CHRRAM_0,  BMC_VT5201}, // mapper 59
 	{ "BMC-SUPERVISION16IN1",       0,    0, CHRRAM_0,  SVISION16_BOARD}, // mapper 53
 	{ "BMC-NTD-03",                 0,    0, CHRRAM_0,  BMC_NTD_03},
 	{ "UNL-AC08",                   0,    0, CHRRAM_0,  UNL_AC08},


### PR DESCRIPTION
- Fixed graphics glitches in the following boards: BMC-20IN1 (Kaiser 20 in 1), BMC-SUPER700IN1 (700 in 1, 190 in 1), BMC-VT5201 (six multicarts).
- Simplified BMC-21IN1 board (21 in 1, 8 in 1).

New working software list additions (nes.xml)
-----------------------------------
Super 190 in 1 [anonymous]