### PR TITLE
New machine marked as NOT_WORKING

### DIFF
--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -1393,6 +1393,22 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/machine/gt913.h,MACHINES["GT913"] = true
+---------------------------------------------------
+
+if (MACHINES["GT913"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/machine/gt913.cpp",
+		MAME_DIR .. "src/devices/machine/gt913.h",
+		MAME_DIR .. "src/devices/machine/gt913_kbd.cpp",
+		MAME_DIR .. "src/devices/machine/gt913_kbd.h",
+		MAME_DIR .. "src/devices/machine/gt913_snd.cpp",
+		MAME_DIR .. "src/devices/machine/gt913_snd.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/machine/hd63450.h,MACHINES["HD63450"] = true
 ---------------------------------------------------
 

--- a/scripts/target/mame/mess.lua
+++ b/scripts/target/mame/mess.lua
@@ -530,6 +530,7 @@ MACHINES["ER2055"] = true
 MACHINES["EXORTERM"] = true
 MACHINES["F3853"] = true
 MACHINES["F4702"] = true
+MACHINES["GT913"] = true
 MACHINES["HD63450"] = true
 MACHINES["HD64610"] = true
 MACHINES["HP_DC100_TAPE"] = true
@@ -2022,6 +2023,7 @@ files {
 	MAME_DIR .. "src/mame/drivers/fp6000.cpp",
 	MAME_DIR .. "src/mame/machine/fp6000_kbd.cpp",
 	MAME_DIR .. "src/mame/machine/fp6000_kbd.h",
+	MAME_DIR .. "src/mame/drivers/ctk551.cpp",
 	MAME_DIR .. "src/mame/drivers/ht6000.cpp",
 	MAME_DIR .. "src/mame/drivers/pb1000.cpp",
 	MAME_DIR .. "src/mame/drivers/pv1000.cpp",

--- a/src/devices/cpu/h8/h8.cpp
+++ b/src/devices/cpu/h8/h8.cpp
@@ -40,6 +40,7 @@ void h8_device::device_start()
 {
 	space(AS_PROGRAM).cache(cache);
 	space(AS_PROGRAM).specific(program);
+	space(has_space(AS_OPCODES) ? AS_OPCODES : AS_PROGRAM).cache(opcodes);
 	space(AS_IO).specific(io);
 
 	uint32_t pcmask = mode_advanced ? 0xffffff : 0xffff;
@@ -342,6 +343,19 @@ void h8_device::state_string_export(const device_state_entry &entry, std::string
 		break;
 	}
 	}
+}
+
+uint16_t h8_device::read16op(uint32_t adr)
+{
+	icount--;
+	return opcodes.read_word(adr & ~1);
+}
+
+uint16_t h8_device::fetch_op()
+{
+	uint16_t res = read16op(PC);
+	PC += 2;
+	return res;
 }
 
 uint16_t h8_device::read16i(uint32_t adr)

--- a/src/devices/cpu/h8/h8.h
+++ b/src/devices/cpu/h8/h8.h
@@ -115,6 +115,7 @@ protected:
 	address_space_config program_config, io_config;
 	memory_access<32, 1, 0, ENDIANNESS_BIG>::cache cache;
 	memory_access<32, 1, 0, ENDIANNESS_BIG>::specific program;
+	memory_access<32, 1, 0, ENDIANNESS_BIG>::cache opcodes;
 	memory_access<16, 1, -1, ENDIANNESS_BIG>::specific io;
 	h8_dma_device *dma_device;
 	h8_dtc_device *dtc_device;
@@ -154,6 +155,8 @@ protected:
 	virtual int trapa_setup();
 	virtual void irq_setup() = 0;
 
+	uint16_t read16op(uint32_t adr);
+	uint16_t fetch_op();
 	uint16_t read16i(uint32_t adr);
 	uint16_t fetch();
 	inline void fetch(int slot) { IR[slot] = fetch(); }
@@ -165,7 +168,7 @@ protected:
 	inline void prefetch() { prefetch_start(); prefetch_done(); }
 	inline void prefetch_noirq() { prefetch_start(); prefetch_done_noirq(); }
 	inline void prefetch_noirq_notrace() { prefetch_start(); prefetch_done_noirq_notrace(); }
-	void prefetch_start() { NPC = PC & 0xffffff; PIR = fetch(); }
+	void prefetch_start() { NPC = PC & 0xffffff; PIR = fetch_op(); }
 	void prefetch_switch(uint32_t pc, uint16_t ir) { NPC = pc & 0xffffff; PC = pc+2; PIR = ir; }
 	void prefetch_done();
 	void prefetch_done_noirq();
@@ -334,7 +337,7 @@ protected:
 	O(divxu_b_r8h_r16l);
 	O(eepmov_b);
 	O(inc_b_one_r8l);
-	O(jmp_abs8i); O(jmp_abs16e);
+	O(jmp_abs8i); O(jmp_abs16e); O(jmp_r16h);
 	O(jsr_abs8i); O(jsr_abs16e); O(jsr_r16h);
 	O(ldc_imm8_ccr); O(ldc_r8l_ccr);
 	O(mov_b_abs16_r8l); O(mov_b_abs8_r8u); O(mov_b_imm8_r8u); O(mov_b_r8h_r8l); O(mov_b_r8l_abs16); O(mov_b_r8u_abs8); O(mov_b_r16ih_r8l); O(mov_b_r8l_r16ih); O(mov_b_r16d16h_r8l); O(mov_b_r8l_r16d16h); O(mov_b_r16ph_r8l); O(mov_b_r8l_pr16h);

--- a/src/devices/cpu/h8/h8.lst
+++ b/src/devices/cpu/h8/h8.lst
@@ -2,7 +2,7 @@
 # copyright-holders:Olivier Galibert
 macro bxx_any %cond
 	prefetch_start();
-	TMP2 = read16i(TMP1);
+	TMP2 = read16op(TMP1);
 	if(%cond)
 		prefetch_switch(TMP1, TMP2);
 	prefetch_done();
@@ -1646,6 +1646,11 @@ macro jsr32 %opc %spreg
 
 58f0         ffff         0 ble      rel16    -        h
 	bxx_16 (CCR & F_Z) || (CCR & (F_N|F_V)) == F_N || (CCR & (F_N|F_V)) == F_V
+
+5900         ff8f         0 jmp      r16h     -        o
+	fetch();
+	PC = r16_r(IR[0] >> 4);
+	prefetch();
 
 5900         ff8f         0 jmp      r32h     -        h
 	fetch();

--- a/src/devices/cpu/h8/h8make.py
+++ b/src/devices/cpu/h8/h8make.py
@@ -261,7 +261,7 @@ class DispatchStep:
         end = start + self.skip
         s = []
         for i in range(start, end+1):
-            s.append("\tIR[%d] = fetch();" % i)
+            s.append("\tIR[%d] = fetch_op();" % i)
         s.append("\tinst_state = 0x%x0000 | IR[%d];" % (self.id, end))
         return s
 

--- a/src/devices/machine/gt913.cpp
+++ b/src/devices/machine/gt913.cpp
@@ -1,0 +1,569 @@
+// license:BSD-3-Clause
+// copyright-holders:Devin Acker
+/***************************************************************************
+	Casio GT913
+
+	This chip powers several late-90s/early-2000s Casio keyboards.
+	It's based on the H8/300 instruction set, but with different encoding
+	for many opcodes, as well as:
+
+	- Dedicated bank switching instructions (20-bit external address bus)
+	- Simplified interrupt behavior compared to "real" H8 chips
+	- Two timers, three 8-bit ports, two 8-bit ADCs
+	- Keyboard controller w/ key velocity detection
+	- MIDI UART (currently emulated as an AY-3-1015)
+	- 24-voice PCM sound (currently not emulated / fully understood)
+
+	Earlier and later Casio keyboard models contain "uPD912" and "uPD914" chips,
+	which are presumably similar.
+
+	TODO:
+	- timer behavior is unverified (see comment in timer_control_w)
+	- various other unemulated registers
+
+***************************************************************************/
+
+#include "emu.h"
+#include "gt913.h"
+
+DEFINE_DEVICE_TYPE(GT913, gt913_device, "gt913", "Casio GT913F")
+
+gt913_device::gt913_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	h8_device(mconfig, GT913, tag, owner, clock, address_map_constructor(FUNC(gt913_device::map), this)),
+	opcodes_config("opcodes", ENDIANNESS_BIG, 16, 16, 0, address_map_constructor(FUNC(gt913_device::map_opcodes), this)),
+	m_rom(*this, DEVICE_SELF),
+	m_opcodes(*this, ":opcodes"),
+	m_bank(*this, "bank"),
+	m_sound(*this, "gt_sound"),
+	m_kbd(*this, "kbd"),
+	m_uart(*this, "uart"),
+	m_uart_clock(*this, "uart_clock"),
+	m_port(*this, "port%u", 1)
+{
+	m_nmi_vector = 3;
+	m_irq_base = 4;
+}
+
+device_memory_interface::space_config_vector gt913_device::memory_space_config() const
+{	
+	auto spaces = h8_device::memory_space_config();
+	spaces.emplace_back(AS_OPCODES, &opcodes_config);
+	return spaces;
+}
+
+void gt913_device::map(address_map &map)
+{
+//	map.unmap_value_high();
+
+	map(0x0000, 0x7fff).rom();
+	map(0x8000, 0xbfff).bankr("bank");
+	map(0xfac0, 0xffbf).ram(); // CTK-551 zeroes out this range at $0418
+
+	/* ffc0-ffcb: sound */
+	map(0xffc0, 0xffc5).rw(m_sound, FUNC(gt913_sound_hle_device::data_r), FUNC(gt913_sound_hle_device::data_w));
+	map(0xffc6, 0xffc7).w(m_sound, FUNC(gt913_sound_hle_device::command_w));
+	map(0xffca, 0xffcb).r(m_sound, FUNC(gt913_sound_hle_device::status_r));
+
+	/* ffd0-ffd5: key controller */
+	map(0xffd0, 0xffd1).r(m_kbd, FUNC(gt913_kbd_hle_device::read));
+	map(0xffd2, 0xffd3).rw(m_kbd, FUNC(gt913_kbd_hle_device::status_r), FUNC(gt913_kbd_hle_device::status_w));
+
+	/* ffd8-ffdf: timers */
+	map(0xffd8, 0xffd9).rw(FUNC(gt913_device::timer_control_r), FUNC(gt913_device::timer_control_w));
+	map(0xffdc, 0xffdd).w(FUNC(gt913_device::timer_rate0_w));
+	map(0xffdf, 0xffdf).w(FUNC(gt913_device::timer_rate1_w));
+
+	/* ffe0-ffe3: serial */
+	map(0xffe0, 0xffe0).w(FUNC(gt913_device::uart_rate_w));
+	map(0xffe1, 0xffe1).w(m_uart, FUNC(ay31015_device::transmit));
+	map(0xffe2, 0xffe2).rw(FUNC(gt913_device::uart_control_r), FUNC(gt913_device::uart_control_w));
+	map(0xffe3, 0xffe3).r(m_uart, FUNC(ay31015_device::receive));
+
+	/* ffe9-ffea: ADC */
+	map(0xffe9, 0xffe9).rw(FUNC(gt913_device::adc_control_r), FUNC(gt913_device::adc_control_w));
+	map(0xffea, 0xffea).r(FUNC(gt913_device::adc_data_r));
+
+	/* fff0-fff5: I/O ports */
+	map(0xfff0, 0xfff1).rw(FUNC(gt913_device::port_ddr_r), FUNC(gt913_device::port_ddr_w));
+	map(0xfff2, 0xfff2).rw(m_port[0], FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
+	map(0xfff3, 0xfff3).rw(m_port[1], FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
+//	map(0xfff4, 0xfff4).nopw(); probably not port 3 DDR - ctk551 writes 0x00 but uses port 3 for output only
+	map(0xfff5, 0xfff5).rw(m_port[2], FUNC(h8_port_device::port_r), FUNC(h8_port_device::dr_w));
+}
+
+void gt913_device::map_opcodes(address_map &map)
+{
+	map(0x0000, 0x7fff).rom().share(":opcodes");
+}
+
+void gt913_device::device_add_mconfig(machine_config &config)
+{
+	GT913_SOUND_HLE(config, m_sound, 0);
+
+	GT913_KBD_HLE(config, m_kbd, 0);
+	m_kbd->int_handler().set_inputline(DEVICE_SELF, INPUT_LINE_IRQ1);
+
+	AY31015(config, m_uart);
+	m_uart->write_fe_callback().set_inputline(DEVICE_SELF, INPUT_LINE_IRQ4);
+	m_uart->write_or_callback().set_inputline(DEVICE_SELF, INPUT_LINE_IRQ4);
+	m_uart->write_dav_callback().set_inputline(DEVICE_SELF, INPUT_LINE_IRQ5);
+	m_uart->write_tbmt_callback().set_inputline(DEVICE_SELF, INPUT_LINE_IRQ6);
+
+	CLOCK(config, m_uart_clock, 9600 * 16);
+	m_uart_clock->signal_handler().set(m_uart, FUNC(ay51013_device::write_tcp));
+	m_uart_clock->signal_handler().append(m_uart, FUNC(ay51013_device::write_rcp));
+
+	H8_PORT(config, m_port[0], h8_device::PORT_1, 0xff, 0x00);
+	H8_PORT(config, m_port[1], h8_device::PORT_2, 0xff, 0x00);
+	H8_PORT(config, m_port[2], h8_device::PORT_3, 0xff, 0x00);
+}
+
+
+void gt913_device::timer_control_w(offs_t offset, uint8_t data)
+{
+	assert(offset < 2);
+
+	if (!BIT(data, 4))
+		set_input_line(INPUT_LINE_IRQ2 + offset, CLEAR_LINE);
+	set_irq_enable(INPUT_LINE_IRQ2 + offset, BIT(data, 3));
+
+	m_timer_control[offset] = data;
+}
+
+uint8_t gt913_device::timer_control_r(offs_t offset)
+{
+	assert(offset < 2);
+	return m_timer_control[offset];
+}
+
+void gt913_device::timer_rate0_w(uint16_t data)
+{
+	m_timer_rate[0] = data;
+	adjust_timer(0);
+}
+
+void gt913_device::timer_rate1_w(uint8_t data)
+{
+	m_timer_rate[1] = data;
+	adjust_timer(1);
+}
+
+void gt913_device::adjust_timer(offs_t num)
+{
+	assert(num < 2);
+
+	/*
+	On the CTK-551, this behavior provides the expected rate for timer 0, which is the MIDI PPQN timer.
+	For timer 1, this is less certain, but it seems to provide an auto power off delay only a little
+	longer than the "about six minutes" mentioned in the user manual.
+	*/
+	u64 clocks = m_timer_rate[num];
+	if (!clocks)
+	{
+		m_timer[num]->adjust(attotime::never);
+	}
+	else
+	{
+		switch (m_timer_control[num] & 0x7)
+		{
+		default:
+			logerror("unknown timer %u prescaler %u (pc = %04x)\n", num, m_timer_control[num] & 0x7, pc());
+			[[fallthrough]];
+		case 0:
+			clocks <<= 1; break;
+		case 2:
+			clocks <<= 10; break;
+		}
+
+		attotime period = clocks_to_attotime(clocks);
+		m_timer[num]->adjust(period, 0, period);
+	}
+}
+
+void gt913_device::device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr)
+{
+	set_input_line(INPUT_LINE_IRQ2 + id, ASSERT_LINE);
+}
+
+void gt913_device::uart_rate_w(uint8_t data)
+{
+	m_uart_clock->set_clock(clock() / (data + 1));
+	logerror("uart_rate_w: %d bps\n", m_uart_clock->clock() / 16);
+}
+
+void gt913_device::uart_control_w(uint8_t data)
+{
+	m_uart_control = data;
+
+	// bit 7: clear Tx status
+	// bit 6: clear Rx status
+	m_uart->write_rdav(BIT(data, 6));
+	// bit 4-5: clear error status (ctk511 sets both to the same value)
+	m_uart->write_xr(BIT(data, 5) ? 0 : 1);
+	// bit 3: enable Tx interrupt
+	set_irq_enable(INPUT_LINE_IRQ6, BIT(data, 3));
+	// bit 2: enable Rx interrupt
+	set_irq_enable(INPUT_LINE_IRQ4, BIT(data, 2));
+	set_irq_enable(INPUT_LINE_IRQ5, BIT(data, 2));
+	// bit 1: enable Tx? (always 1)
+	// bit 0: enable Rx? (always 1)
+
+	// update IRQ 6 in case the TBMT callback isn't called (e.g. after a reset)
+	set_input_line(INPUT_LINE_IRQ6, m_uart->tbmt_r() ? ASSERT_LINE : CLEAR_LINE);
+}
+
+uint8_t gt913_device::uart_control_r()
+{
+	return (m_uart->tbmt_r() << 7) | (m_uart->dav_r() << 6) | (m_uart->or_r() << 5) | (m_uart->fe_r() << 4) | (m_uart_control & 0xf);
+}
+
+void gt913_device::adc_control_w(uint8_t data)
+{
+	m_adc_enable = BIT(data, 2);
+	m_adc_channel = BIT(data, 3);
+	if (m_adc_enable && BIT(data, 0))
+	{
+		if (!m_adc_channel)
+			m_adc_data[0] = io.read_word(h8_device::ADC_0);
+		else
+			m_adc_data[1] = io.read_word(h8_device::ADC_1);
+	}
+}
+
+uint8_t gt913_device::adc_control_r()
+{
+	return (m_adc_enable << 2) | (m_adc_channel << 3);
+}
+
+uint8_t gt913_device::adc_data_r()
+{
+	if (!m_adc_channel)
+		return m_adc_data[0];
+	else
+		return m_adc_data[1];
+}
+
+void gt913_device::port_ddr_w(offs_t offset, uint8_t data)
+{
+	m_port_ddr[offset & 1] = data;
+	m_port[offset & 1]->ddr_w(data);
+}
+
+uint8_t gt913_device::port_ddr_r(offs_t offset)
+{
+	return m_port_ddr[offset & 1];
+}
+
+void gt913_device::irq_setup()
+{
+	CCR |= F_I;
+}
+
+void gt913_device::update_irq_filter()
+{
+	int vector = 0;
+	bool nmi = false;
+
+	if (m_nmi_pending)
+	{
+		vector = m_nmi_vector;
+		nmi = true;
+	}
+	else if (!(CCR & F_I))
+	{
+		for (int i = INPUT_LINE_IRQ0; i < INPUT_LINE_IRQ7; i++)
+		{
+			if (BIT(m_irq_pending, i) && BIT(m_irq_enable, i))
+			{
+				vector = m_irq_base + i;
+				break;
+			}
+		}
+	}
+
+	set_irq(vector, 0, nmi);
+}
+
+void gt913_device::interrupt_taken()
+{
+	if (taken_irq_vector == m_nmi_vector)
+	{
+		m_nmi_pending = false;
+		standard_irq_callback(INPUT_LINE_NMI);
+	}
+	else if (taken_irq_vector >= m_irq_base)
+	{
+		standard_irq_callback(taken_irq_vector - m_irq_base);
+	}
+}
+
+void gt913_device::internal_update(uint64_t current_time)
+{
+	uint64_t event_time = 0;
+
+	recompute_bcount(event_time);
+}
+
+void gt913_device::execute_set_input(int inputnum, int state)
+{
+	if (inputnum == INPUT_LINE_NMI)
+	{
+		if (state == ASSERT_LINE && m_nmi_status != state)
+			m_nmi_pending = true;
+		state = m_nmi_status;
+	}
+	else if (inputnum <= INPUT_LINE_IRQ7)
+	{
+		if (state)
+			m_irq_pending |= (1 << inputnum);
+		else
+			m_irq_pending &= ~(1 << inputnum);
+	}
+	update_irq_filter();
+}
+
+void gt913_device::set_irq_enable(int inputnum, int state)
+{
+	if (state)
+		m_irq_enable |= (1 << inputnum);
+	else
+		m_irq_enable &= ~(1 << inputnum);
+
+	update_irq_filter();
+}
+
+void gt913_device::device_start()
+{
+	h8_device::device_start();
+
+	m_bank->configure_entries(0, m_rom->bytes() >> 12, m_rom->base(), 1 << 12);
+
+	m_timer[0] = timer_alloc(0);
+	m_timer[1] = timer_alloc(1);
+
+	decode_opcodes();
+
+	save_item(NAME(m_banknum));
+
+	save_item(NAME(m_nmi_pending));
+	save_item(NAME(m_nmi_status));
+	save_item(NAME(m_irq_pending));
+	save_item(NAME(m_irq_enable));
+
+	save_item(NAME(m_timer_control));
+	save_item(NAME(m_timer_rate));
+	save_item(NAME(m_uart_control));
+	save_item(NAME(m_adc_enable));
+	save_item(NAME(m_adc_channel));
+	save_item(NAME(m_adc_data));
+	save_item(NAME(m_port_ddr));
+}
+
+void gt913_device::device_reset()
+{
+	h8_device::device_reset();
+
+	m_banknum = 0;
+
+	m_nmi_pending = false;
+	m_nmi_status = CLEAR_LINE;
+	m_irq_pending = 0x00;
+	m_irq_enable = 0xff;
+
+	m_timer_control[0] = m_timer_control[1] = 0x00;
+	m_timer_rate[0] = m_timer_rate[1] = 0;
+
+	m_uart_control = 0x00;
+
+	m_adc_enable = false;
+	m_adc_channel = false;
+	m_adc_data[0] = m_adc_data[1] = 0;
+	m_port_ddr[0] = m_port_ddr[1] = 0;
+}
+
+void gt913_device::device_reset_after_children()
+{
+	h8_device::device_reset_after_children();
+
+	// MIDI UART, asynchronous 8/n/1
+	m_uart->write_xr(0);
+	m_uart->write_xr(1);
+	m_uart->write_swe(0);
+	m_uart->write_nb1(1);
+	m_uart->write_nb2(1);
+	m_uart->write_np(1);
+	m_uart->write_tsb(0);
+	m_uart->write_cs(1);
+}
+
+void gt913_device::do_exec_full()
+{
+	if ((inst_state & 0xfffb80) == 0x0380)
+	{
+		set_bank_num();
+		if (icount <= bcount) { inst_substate = 1; return; }
+		prefetch();
+	}
+	else
+	{
+		h8_device::do_exec_full();
+	}
+}
+
+void gt913_device::do_exec_partial()
+{
+	if ((inst_state & 0xfffb80) == 0x0380)
+	{
+		switch (inst_substate) {
+		case 0:
+			set_bank_num();
+			if (icount <= bcount) { inst_substate = 1; return; }
+			[[fallthrough]];
+		case 1:;
+			prefetch();
+			break;
+		}
+		inst_substate = 0;
+	}
+	else
+	{
+		h8_device::do_exec_partial();
+	}
+}
+
+void gt913_device::set_bank_num()
+{
+	if (BIT(IR[0], 10))
+		TMP1 = IR[0] & 0xf;
+	else
+		TMP1 = r8_r(IR[0]);
+
+	if (BIT(IR[0], 6))
+		m_banknum = (m_banknum & 0xfffc) | (TMP1 & 0x3);
+	else
+		m_banknum = (TMP1 << 2) | (m_banknum & 0x3);
+
+	m_bank->set_entry(m_banknum);
+}
+
+void gt913_device::decode_opcodes()
+{
+	auto rombase = &m_rom->as_u16();
+	const auto size = 0x8000 / 2;
+
+	for (offs_t offset = 0; offset < size; offset++)
+	{
+		uint16_t opcode = rombase[offset];
+
+		switch (opcode & 0xF800)
+		{
+		default:
+			// most opcodes are decoded normally
+			break;
+
+		case 0x0000:
+		case 0x0800:
+		case 0x1800:
+			switch (opcode & 0x1F00)
+			{
+			case 0x0100: // SLEEP
+				opcode = 0x0180;
+				break;
+
+			case 0x0200: // STC / LDC (or bank switching opcodes if bit 7 is set)
+			case 0x0300:
+				if (!BIT(opcode, 7))
+					opcode &= 0xff0f;
+				break;
+
+			case 0x0400: // ORC
+			case 0x0600: // ANDC
+				opcode = bitswap<16>(opcode, 15, 14, 13, 12, 11, 10, 9, 8, 5, 6, 7, 4, 3, 2, 1, 0);
+				break;
+
+			case 0x0F00: // MULXU
+				opcode = 0x5000 | (opcode & 0xFF);
+				break;
+
+			case 0x1B00: // SUBS.L (immediate value is inverted)
+				opcode ^= 0x80;
+				break;
+
+			case 0x1F00: // DIVXU
+				opcode = 0x5100 | (opcode & 0xFF);
+				break;
+			}
+			break;
+
+		case 0x5000:
+			// BSET, BCLR, BTST
+			opcode = bitswap<16>(opcode, 15, 14, 13, 8, 11, 12, 9, 10, 7, 6, 5, 4, 3, 2, 1, 0) ^ 0x3400;
+			break;
+
+		case 0x5800:
+			switch (opcode & 0x0F00)
+			{
+			case 0x0800: // RTS
+				opcode = 0x5470;
+				break;
+			case 0x0900: // RTE
+				opcode = 0x5670;
+				break;
+			case 0x0A00: // JMP
+				if (BIT(opcode, 7))
+					opcode = 0x5A00;
+				else
+					opcode = 0x5900 | (opcode & 0x70);
+				break;
+			case 0x0C00: // JSR
+				if (BIT(opcode, 7))
+					opcode = 0x5E00;
+				else
+					opcode = 0x5D00 | (opcode & 0x70);
+				break;
+			case 0x0E00: // BSR
+				opcode = 0x5500 | (opcode & 0xFF);
+				break;
+			case 0x0F00: // MOV.W #imm,Rn
+				opcode = 0x7900 | (opcode & 0x07);
+				break;
+			}
+			break;
+
+		case 0x6000:
+		case 0x7000:
+			switch (opcode & 0x1F00)
+			{
+			case 0x0600: // BTST #xx:3,@Rd
+				if (offset + 1 < size && (rombase[offset + 1] & 0xFF8F) == 0)
+				{
+					m_opcodes[offset] = (opcode & 0xFF) | 0x7C00;
+					offset++;
+					opcode = (rombase[offset] & 0xFF) | 0x7300;
+				}
+				break;
+
+			case 0x1000:
+			case 0x1200:
+				// BSET/BCLR #xx:3,@aa:8
+				if (offset + 1 < size && (rombase[offset + 1] & 0xFF8F) == 0)
+				{
+					m_opcodes[offset] = opcode | 0x7F00;
+					offset++;
+					opcode = (rombase[offset] & 0xFF) | (opcode & 0xFF00);
+				}
+				break;
+			}
+			break;
+
+		case 0x6800:
+		case 0x7800:
+			// MOV.B, MOV.W
+			opcode = bitswap<16>(opcode, 15, 14, 13, 7, 11, 9, 10, 8, 12, 6, 5, 4, 3, 2, 1, 0);
+			break;
+
+		}
+
+		m_opcodes[offset] = opcode;
+	}
+}

--- a/src/devices/machine/gt913.h
+++ b/src/devices/machine/gt913.h
@@ -1,0 +1,113 @@
+// license:BSD-3-Clause
+// copyright-holders:Devin Acker
+/***************************************************************************
+
+    gt913.h
+
+    Casio GT913
+
+***************************************************************************/
+
+#ifndef MAME_CPU_H8_GT913_H
+#define MAME_CPU_H8_GT913_H
+
+#pragma once
+
+#include "cpu/h8/h8.h"
+#include "cpu/h8/h8_port.h"
+#include "machine/ay31015.h"
+#include "machine/clock.h"
+#include "gt913_kbd.h"
+#include "gt913_snd.h"
+
+class gt913_device : public h8_device {
+public:
+	gt913_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	void timer_control_w(offs_t offset, uint8_t data);
+	uint8_t timer_control_r(offs_t offset);
+	void timer_rate0_w(uint16_t data);
+	void timer_rate1_w(uint8_t data);
+
+	void uart_rate_w(uint8_t data);
+	void uart_control_w(uint8_t data);
+	uint8_t uart_control_r();
+
+	void adc_control_w(uint8_t data);
+	uint8_t adc_control_r();
+	uint8_t adc_data_r();
+
+	void port_ddr_w(offs_t offset, uint8_t data);
+	uint8_t port_ddr_r(offs_t offset);
+
+protected:
+	void adjust_timer(offs_t num);
+
+	virtual void update_irq_filter() override;
+	virtual void interrupt_taken() override;
+	virtual void internal_update(uint64_t current_time) override;
+	virtual void irq_setup() override;
+	virtual void execute_set_input(int inputnum, int state) override;
+	void set_irq_enable(int inputnum, int state);
+	
+	virtual void device_add_mconfig(machine_config &config) override;
+	void map(address_map &map);
+	void map_opcodes(address_map &map);
+
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_reset_after_children() override;
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+
+	/* handle bank switching instructions */
+	virtual void do_exec_full() override;
+	virtual void do_exec_partial() override;
+	void set_bank_num();
+	/* translate other opcodes which match normal H8 instructions */
+	void decode_opcodes();
+	
+	virtual space_config_vector memory_space_config() const override;
+	
+	address_space_config opcodes_config;
+	
+	required_memory_region        m_rom;
+	required_shared_ptr<uint16_t> m_opcodes;
+
+	required_memory_bank m_bank;
+	uint16_t             m_banknum;
+
+	int m_nmi_vector;
+	int m_irq_base;
+	int m_nmi_status;
+	bool m_nmi_pending;
+	uint8_t m_irq_pending;
+	uint8_t m_irq_enable;
+
+	/* sound */
+	required_device<gt913_sound_hle_device> m_sound;
+	
+	/* key controller */
+	required_device<gt913_kbd_hle_device> m_kbd;
+
+	/* timers */
+	uint8_t m_timer_control[2];
+	uint16_t m_timer_rate[2];
+	emu_timer *m_timer[2];
+
+	/* serial port */
+	uint8_t m_uart_control;
+	required_device<ay31015_device> m_uart;
+	required_device<clock_device> m_uart_clock;
+
+	/* 2x ADC */
+	bool m_adc_enable, m_adc_channel;
+	uint8_t m_adc_data[2];
+
+	/* 3x 8-bit I/O ports */
+	required_device_array<h8_port_device, 3> m_port;
+	uint8_t m_port_ddr[2]; // only used for the first two ports
+};
+
+DECLARE_DEVICE_TYPE(GT913, gt913_device)
+
+#endif // MAME_CPU_H8_GT913_H

--- a/src/devices/machine/gt913_kbd.cpp
+++ b/src/devices/machine/gt913_kbd.cpp
@@ -1,0 +1,110 @@
+// license:BSD-3-Clause
+// copyright-holders:Devin Acker
+/***************************************************************************
+	Casio GT913 keyboard controller (HLE)
+
+	This is the keyboard controller portion of the GT913.
+	The actual keyboard keys (as opposed to console buttons) have two
+	contacts per key, which allows the controller to detect the velocity
+	of the keypress. The detected velocity is read as a 7-bit value
+	from the data port, along with the actual key scan code.
+
+	Right now, velocity is just simulated using an (optional) analog
+	control. The keyboard FIFO size is also basically a guess based on
+	the CTK-551's 16-key polyphony.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "gt913_kbd.h"
+#include "keyboard.ipp"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(GT913_KBD_HLE, gt913_kbd_hle_device, "gt913_kbd_hle", "Casio GT913F keyboard controller (HLE)")
+
+gt913_kbd_hle_device::gt913_kbd_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, GT913_KBD_HLE, tag, owner, clock),
+	device_matrix_keyboard_interface(mconfig, *this, "KO0", "KO1", "KO2", "KO3", "KO4", "KO5", "KO6", "KO7", "KO8", "KO9", "KO10", "KO11", "KO12"),
+	m_int_handler(*this),
+	m_velocity(*this, "VELOCITY")
+{
+}
+
+void gt913_kbd_hle_device::device_start()
+{
+	m_int_handler.resolve_safe();
+	
+	save_item(NAME(m_status));
+	save_item(NAME(m_fifo));
+	save_item(NAME(m_fifo_read));
+	save_item(NAME(m_fifo_write));
+}
+
+void gt913_kbd_hle_device::device_reset()
+{
+	m_int_handler(0);
+	m_status = 0x0000;
+	std::memset(m_fifo, 0xff, sizeof(m_fifo));
+	m_fifo_read = m_fifo_write = 0;
+
+	reset_key_state();
+	start_processing(attotime::from_hz(1200));
+}
+
+void gt913_kbd_hle_device::key_add(uint8_t row, uint8_t column, int state)
+{
+	m_fifo[m_fifo_write] = (row << 3) | (column & 7);
+	if (state)
+		m_fifo[m_fifo_write] |= 0x80;
+
+	if (((m_fifo_write + 1) & 15) != m_fifo_read)
+	{
+		(++m_fifo_write) &= 15;
+		update_status();
+	}
+}
+
+void gt913_kbd_hle_device::update_status()
+{
+	if (m_fifo_read == m_fifo_write)
+		m_status &= 0x7fff;
+	else
+		m_status |= 0x8000;
+
+	if (!m_int_handler.isnull())
+	{
+		if (BIT(m_status, 15) && BIT(m_status, 14))
+			m_int_handler(ASSERT_LINE);
+		else
+			m_int_handler(CLEAR_LINE);
+	}
+}
+
+uint16_t gt913_kbd_hle_device::read()
+{
+	if (m_fifo_read == m_fifo_write)
+		return 0xff00;
+
+	uint16_t data = (m_fifo[m_fifo_read] << 8) | m_velocity.read_safe(0x7f);
+
+	if (!machine().side_effects_disabled())
+	{
+		if (m_fifo_read != m_fifo_write)
+		{
+			(++m_fifo_read) &= 15;
+			update_status();
+		}
+	}
+
+	return data;
+}
+
+void gt913_kbd_hle_device::status_w(uint16_t data)
+{
+	m_status = data;
+	update_status();
+}

--- a/src/devices/machine/gt913_kbd.h
+++ b/src/devices/machine/gt913_kbd.h
@@ -1,0 +1,56 @@
+// license:BSD-3-Clause
+// copyright-holders: Devin Acker
+/***************************************************************************
+	Casio GT913 keyboard controller (HLE)
+***************************************************************************/
+
+#ifndef MAME_MACHINE_GT913_KBD_H
+#define MAME_MACHINE_GT913_KBD_H
+
+#pragma once
+
+#include "keyboard.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> gt913_kbd_hle_device
+
+class gt913_kbd_hle_device : public device_t, protected device_matrix_keyboard_interface<13>
+{
+public:
+	// construction/destruction
+	gt913_kbd_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	// callbacks
+	auto int_handler() { return m_int_handler.bind(); }
+
+	uint16_t read();
+	void status_w(uint16_t data);
+	uint16_t status_r() { return m_status; }
+
+protected:
+	// device_t overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// device_matrix_keyboard_interface overrides
+	virtual void key_make(uint8_t row, uint8_t column) override  { key_add(row, column, 0); }
+	virtual void key_break(uint8_t row, uint8_t column) override { key_add(row, column, 1); }
+
+	void key_add(uint8_t row, uint8_t column, int state);
+	void update_status();
+private:
+	devcb_write_line m_int_handler;
+	optional_ioport m_velocity;
+
+	uint16_t m_status;
+	uint8_t m_fifo[16];
+	uint8_t m_fifo_read, m_fifo_write;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(GT913_KBD_HLE, gt913_kbd_hle_device)
+
+#endif // MAME_MACHINE_GT913_KBD_H

--- a/src/devices/machine/gt913_snd.cpp
+++ b/src/devices/machine/gt913_snd.cpp
@@ -1,0 +1,167 @@
+// license:BSD-3-Clause
+// copyright-holders:Devin Acker
+/***************************************************************************
+	Casio GT913 sound (HLE)
+
+	This is the sound portion of the GT913.
+	Up to 24 voices can be mixed into a 16-bit stereo serial bitstream,
+	which is then input to either a serial DAC or a HG51B-based DSP,
+	depending on the model of keyboard.
+
+	Currently, the actual sample format in ROM is unknown.
+	The serial output is twos-complement 16-bit PCM, but the data in ROM
+	doesn't seem to be - reading it as such produces sounds that are
+	somewhat recognizable, but highly distorted.
+
+	For now, all known (and unknown) register writes are just logged
+	without generating any sound.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "gt913_snd.h"
+
+
+//**************************************************************************
+//  DEVICE DEFINITIONS
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(GT913_SOUND_HLE, gt913_sound_hle_device, "gt913_sound_hle", "Casio GT913F sound (HLE)")
+
+gt913_sound_hle_device::gt913_sound_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, GT913_SOUND_HLE, tag, owner, clock)
+{
+}
+
+void gt913_sound_hle_device::device_start()
+{
+	save_item(NAME(m_gain));
+	save_item(NAME(m_data));
+
+	save_item(NAME(m_volume_target));
+	save_item(NAME(m_volume_rate));
+}
+
+void gt913_sound_hle_device::device_reset()
+{
+	m_gain = 0;
+	std::memset(m_data, 0, sizeof(m_data));
+	std::memset(m_volume_target, 0, sizeof(m_volume_target));
+	std::memset(m_volume_rate, 0, sizeof(m_volume_rate));
+}
+
+void gt913_sound_hle_device::data_w(offs_t offset, uint16_t data)
+{
+	assert(offset < 3);
+	m_data[offset] = data;
+}
+
+uint16_t gt913_sound_hle_device::data_r(offs_t offset)
+{
+	assert(offset < 3);
+	return m_data[offset];
+}
+
+void gt913_sound_hle_device::command_w(uint16_t data)
+{
+	uint8_t voicenum = (data & 0x1f00) >> 8;
+	uint16_t voicecmd = data & 0x60ff;
+
+	if (data == 0x0012)
+	{
+		uint8_t gain = m_data[0] & 0x3f;
+		if (gain != m_gain)
+			logerror("gain %u\n", gain);
+		m_gain = gain;
+	}
+	else if (voicenum >= 24)
+	{
+		return;
+	}
+	else if (voicecmd == 0x0008)
+	{
+		/*
+		Set the voice's sample start point as a ROM address.
+		This is usually word-aligned, but not always
+		(e.g. ctk551's lowest piano sample is at address 0x5a801)
+		*/
+		uint32_t samplestart = (m_data[1] | (m_data[2] << 16)) & 0xfffff;
+		logerror("voice %u sample start 0x%06x\n", voicenum, samplestart);
+	}
+	else if (voicecmd == 0x0000)
+	{
+		/*
+		Set the voice's sample end point as a ROM address.
+		*/
+		uint32_t sampleend = (m_data[0] | (m_data[1] << 16)) & 0xfffff;
+		logerror("voice %u sample end   0x%06x\n", voicenum, sampleend);
+	}
+	else if (voicecmd == 0x2000)
+	{
+		/*
+		Set the voice's sample loop point as a ROM address.
+		*/
+		uint32_t sampleloop = (m_data[0] | (m_data[1] << 16)) & 0xfffff;
+		logerror("voice %u sample loop  0x%06x\n", voicenum, sampleloop);
+	}
+	else if (voicecmd == 0x200b)
+	{
+		/*
+		Turn this voice on/off.
+		ctk551 turns output off before assigning a new note or instrument to this voice,
+		then turns output back on afterward
+		*/
+		logerror("voice %u output %s\n", voicenum, BIT(m_data[2], 7) ? "on" : "off");
+	}
+	else if (voicecmd == 0x4004)
+	{
+		/*
+		Set this voice's panning, in the form of left and right volume levels (3 bits each)
+		*/
+		uint8_t left = (m_data[1] & 0xe0) >> 5;
+		uint8_t right = (m_data[1] & 0x1c) >> 2;
+		logerror("voice %u left %u right %u\n", voicenum, left, right);
+	}
+	else if (voicecmd == 0x4005)
+	{
+		/*
+		Set the current pitch of this voice.
+		The actual format of the value is unknown, but presumably some kind of fixed point
+		*/
+		uint32_t pitch = (m_data[0] << 8) | (m_data[1] >> 8);
+		logerror("voice %u pitch 0x%06x\n", voicenum, pitch);
+	}
+	else if (voicecmd == 0x6007)
+	{
+		/*
+		Raise or lower the volume to a specified level at a specified rate.
+		The actual volume level is probably 7.8 fixed point or something like that, but this command
+		only sets the most significant bits.
+		*/
+		logerror("voice %u volume %u rate %u\n", voicenum, (m_data[0] >> 8) & 0x7f, m_data[0] & 0xff);
+		m_volume_target[voicenum] = m_data[0] & 0x7f00;
+		m_volume_rate[voicenum] = m_data[0] & 0xff;
+	}
+	else if (voicecmd == 0x2028)
+	{
+		/*
+		ctk551 issues this command and then reads the voice's current volume from data0
+		to determine if it's time to start the next part of the volume envelope or not.
+		For now, just return the "target" volume immediately
+		(TODO: also figure out what it expects to be returned in data1)
+		*/
+		m_data[0] = m_volume_target[voicenum];
+		m_data[1] = 0;
+	}
+	else
+	{
+		logerror("unknown sound write %04x (data: %04x %04x %04x)\n", data, m_data[0], m_data[1], m_data[2]);
+	}
+}
+
+uint16_t gt913_sound_hle_device::status_r()
+{
+	/* ctk551 reads the current gain level out of the lower 6 bits and ignores the rest
+	it's unknown what, if anything, the other bits are supposed to contain */
+	return m_gain & 0x3f;
+}

--- a/src/devices/machine/gt913_snd.h
+++ b/src/devices/machine/gt913_snd.h
@@ -1,0 +1,45 @@
+// license:BSD-3-Clause
+// copyright-holders: Devin Acker
+/***************************************************************************
+	Casio GT913 sound (HLE)
+***************************************************************************/
+
+#ifndef MAME_AUDIO_GT913_H
+#define MAME_AUDIO_GT913_H
+
+#pragma once
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> gt913_sound_hle_device
+
+class gt913_sound_hle_device : public device_t
+{
+public:
+	// construction/destruction
+	gt913_sound_hle_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+
+	void data_w(offs_t offset, uint16_t data);
+	uint16_t data_r(offs_t offset);
+	void command_w(uint16_t data);
+	uint16_t status_r();
+
+protected:
+	// device_t overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	
+private:
+	uint8_t m_gain;
+	uint16_t m_data[3];
+
+	uint16_t m_volume_target[24];
+	uint8_t m_volume_rate[24];
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(GT913_SOUND_HLE, gt913_sound_hle_device)
+
+#endif // MAME_AUDIO_GT913_H

--- a/src/mame/drivers/ctk551.cpp
+++ b/src/mame/drivers/ctk551.cpp
@@ -1,0 +1,356 @@
+// license:BSD-3-Clause
+// copyright-holders:Devin Acker
+/*
+	Casio CTK-551 keyboard (and related models)
+
+	Casio released several keyboard models with the same main board.
+	As usual, some of them were also rebranded by Radio Shack.
+
+	- CTK-531, CTK-533
+	  Basic 61-key model
+	- CTK-541, Optimus MD-1150
+	  Adds velocity-sensitive keys
+	- CTK-551, CTK-558, Radio Shack MD-1160
+	  Adds pitch wheel and different selection of demo songs
+
+	Main board (JCM456-MA1M):
+
+	LSI1: CPU (Casio GT913F)
+	      Custom chip based on H8/300 instruction set, built in peripheral controllers & sound generator
+
+	LSI2: 8Mbit ROM (OKI MSM538002E)
+
+	LSI3: LCD controller (HD44780 compatible)
+	      May be either a Samsung KS0066U-10B or Epson SED1278F2A.
+
+	IC1:  stereo DAC (NEC uPD6379GR)
+
+	CTK-541 service manual with schematics, pinouts, etc.:
+	https://revenant1.net/ctk541.pdf
+
+	To access the test mode (not mentioned in the service manual):
+	Hold the "Start/Stop" and keypad 0 buttons together when turning on the keyboard.
+	Afterwards, press one of these buttons:
+	- Tone: LCD test (press repeatedly)
+	- Keypad 0: switch test (press all front panel buttons in a specific order, generally left to right)
+	- Keypad 1 or Rhythm: pedal and key test
+	- Keypad 2: ROM test
+	- Keypad 4/5/6: sound volume test
+	- Keypad 7/8: stereo test
+	- Keypad 9: MIDI loopback test
+	- Keypad + or Song Bank: power source test
+	- Keypad -: pitch wheel test
+	- FFWD: exit test mode
+	- Stop: power off
+
+ */
+
+#include "emu.h"
+
+#include "bus/midi/midiinport.h"
+#include "bus/midi/midioutport.h"
+#include "machine/gt913.h"
+#include "video/hd44780.h"
+#include "emupal.h"
+#include "screen.h"
+
+namespace {
+
+class ctk551_state : public driver_device
+{
+public:
+	ctk551_state(machine_config const &mconfig, device_type type, char const *tag)
+		: driver_device(mconfig, type, tag)
+		, m_maincpu(*this, "maincpu")
+		, m_lcdc(*this, "lcdc")
+		, m_led_touch(*this, "led_touch")
+	{
+	}
+
+	void ctk551(machine_config &config);
+
+	DECLARE_CUSTOM_INPUT_MEMBER(lcd_r)     { return m_lcdc->db_r() >> 4; }
+	DECLARE_WRITE_LINE_MEMBER(lcd_w)       { m_lcdc->db_w(state << 4); }
+
+	DECLARE_CUSTOM_INPUT_MEMBER(switch_r)  { return m_switch; }
+	DECLARE_INPUT_CHANGED_MEMBER(switch_w);
+
+	DECLARE_WRITE_LINE_MEMBER(led_touch_w) { m_led_touch = state; }
+	DECLARE_WRITE_LINE_MEMBER(apo_w);
+
+private:
+	void ctk551_io_map(address_map &map);
+
+	virtual void driver_start() override;
+
+	HD44780_PIXEL_UPDATE(lcd_update);
+	void palette_init(palette_device &palette);
+
+	required_device<gt913_device> m_maincpu;
+	required_device<hd44780_device> m_lcdc;
+
+	output_finder<> m_led_touch;
+
+	ioport_value m_switch;
+};
+
+
+INPUT_CHANGED_MEMBER(ctk551_state::switch_w)
+{
+	logerror("switch_w: %0x\n", param);
+	if (!oldval && newval)
+	{
+		if (m_switch == 0x1 && param != m_switch)
+			m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
+		else
+			m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
+
+		m_switch = param;
+	}
+}
+
+WRITE_LINE_MEMBER(ctk551_state::apo_w)
+{
+	logerror("apo_w: %0x\n", state);
+	/* TODO: when 1, this should turn off the LCD, speakers, etc.
+	the CPU will go to sleep until the power switch triggers a NMI */
+}
+
+HD44780_PIXEL_UPDATE(ctk551_state::lcd_update)
+{
+	if (x < 6 && y < 8 && line < 2 && pos < 8)
+		bitmap.pix(line * 8 + y, pos * 6 + x) = state;
+}
+
+void ctk551_state::palette_init(palette_device &palette)
+{
+	palette.set_pen_color(0, rgb_t(255, 255, 255));
+	palette.set_pen_color(1, rgb_t(0, 0, 0));
+}
+
+void ctk551_state::ctk551_io_map(address_map &map)
+{
+	map(h8_device::PORT_1, h8_device::PORT_1).portr("P1_R").portw("P1_W").umask16(0x00ff);
+	map(h8_device::PORT_2, h8_device::PORT_2).portrw("P2").umask16(0x00ff);
+	map(h8_device::PORT_3, h8_device::PORT_3).portrw("P3").umask16(0x00ff);
+	map(h8_device::ADC_0,  h8_device::ADC_0).portr("AN0");
+	map(h8_device::ADC_1,  h8_device::ADC_1).portr("AN1");
+}
+
+void ctk551_state::driver_start()
+{
+	m_led_touch.resolve();
+
+	m_switch = 0x2;
+
+	save_item(NAME(m_switch));
+}
+
+void ctk551_state::ctk551(machine_config &config)
+{
+	// CPU
+	GT913(config, m_maincpu, 30'000'000);
+	m_maincpu->set_addrmap(AS_IO, &ctk551_state::ctk551_io_map);
+
+	// MIDI
+	auto &mdin(MIDI_PORT(config, "mdin"));
+	midiin_slot(mdin);
+	mdin.rxd_handler().set("maincpu:uart", FUNC(ay31015_device::write_si));
+
+	auto &mdout(MIDI_PORT(config, "mdout"));
+	midiout_slot(mdout);
+	m_maincpu->subdevice<ay31015_device>("uart")->write_so_callback().set(mdout, FUNC(midi_port_device::write_txd));
+
+	// LCD
+	HD44780(config, m_lcdc, 0);
+	m_lcdc->set_lcd_size(2, 8);
+	m_lcdc->set_pixel_update_cb(FUNC(ctk551_state::lcd_update));
+
+	// screen (for testing only)
+	// TODO: the actual LCD with custom segments
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_LCD));
+	screen.set_refresh_hz(60);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	screen.set_screen_update("lcdc", FUNC(hd44780_device::screen_update));
+	screen.set_size(6 * 8, 8 * 2);
+	screen.set_visarea_full();
+	screen.set_palette("palette");
+
+	PALETTE(config, "palette", FUNC(ctk551_state::palette_init), 2);
+}
+
+INPUT_PORTS_START(ctk551)
+	PORT_START("maincpu:kbd:KO0")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C2")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C2#")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D2")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D2#")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("E2")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F2")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F2#")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G2")
+
+	PORT_START("maincpu:kbd:KO1")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G2#")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A2")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A2#")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("B2")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C3")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C3#")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D3")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D3#")
+
+	PORT_START("maincpu:kbd:KO2")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("E3")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F3")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F3#")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G3")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G3#")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A3")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A3#")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("B3")
+
+	PORT_START("maincpu:kbd:KO3")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C4")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C4#")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D4")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D4#")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("E4")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F4")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F4#")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G4")
+
+	PORT_START("maincpu:kbd:KO4")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G4#")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A4")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A4#")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("B4")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C5")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C5#")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D5")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D5#")
+
+	PORT_START("maincpu:kbd:KO5")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("E5")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F5")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F5#")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G5")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G5#")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A5")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A5#")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("B5")
+
+	PORT_START("maincpu:kbd:KO6")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C6")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C6#")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D6")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("D6#")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("E6")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F6")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("F6#")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G6")
+
+	PORT_START("maincpu:kbd:KO7")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("G6#")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A6")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("A6#")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("B6")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("C7")
+	PORT_BIT( 0xe0, IP_ACTIVE_HIGH, IPT_UNUSED )
+
+	PORT_START("maincpu:kbd:KO8")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 9") PORT_CODE(KEYCODE_9_PAD)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 8") PORT_CODE(KEYCODE_8_PAD)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 7") PORT_CODE(KEYCODE_7_PAD)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad +") PORT_CODE(KEYCODE_PLUS_PAD)
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Touch Response")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Song Bank")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Rhythm")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Tone")
+	
+	PORT_START("maincpu:kbd:KO9")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 6") PORT_CODE(KEYCODE_6_PAD)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 5") PORT_CODE(KEYCODE_5_PAD)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 4") PORT_CODE(KEYCODE_4_PAD)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad -") PORT_CODE(KEYCODE_MINUS_PAD)
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Accomp Volume")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Transpose / Tune / MIDI")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Chord Book")
+
+	PORT_START("maincpu:kbd:KO10")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 3") PORT_CODE(KEYCODE_3_PAD)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 2") PORT_CODE(KEYCODE_2_PAD)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 1") PORT_CODE(KEYCODE_1_PAD)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Keypad 0") PORT_CODE(KEYCODE_0_PAD)
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Play / Pause")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Rewind")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Start / Stop")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Sync / Fill In")
+
+	PORT_START("maincpu:kbd:KO11")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Right Hand On/Off")
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Left Hand On/Off")
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Fast Forward")
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Stop")
+	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Tempo Down")
+	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Volume Down")
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Tempo Up")
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Volume Up")
+
+	PORT_START("maincpu:kbd:KO12")
+	PORT_BIT( 0x0f, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0xf0, IP_ACTIVE_HIGH, IPT_CUSTOM ) PORT_CUSTOM_MEMBER(ctk551_state, switch_r)
+
+	PORT_START("maincpu:kbd:VELOCITY")
+	PORT_BIT( 0x7f, 0x7f, IPT_POSITIONAL ) PORT_NAME("Key Velocity") PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_CENTERDELTA(0)
+
+	PORT_START("SWITCH")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Power Off")   PORT_CHANGED_MEMBER(DEVICE_SELF, ctk551_state, switch_w, 0x1)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Normal")      PORT_CHANGED_MEMBER(DEVICE_SELF, ctk551_state, switch_w, 0x2)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Casio Chord") PORT_CHANGED_MEMBER(DEVICE_SELF, ctk551_state, switch_w, 0x4)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OTHER )  PORT_NAME("Fingered")    PORT_CHANGED_MEMBER(DEVICE_SELF, ctk551_state, switch_w, 0x8)
+
+	PORT_START("P1_R")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x02, IP_ACTIVE_LOW,  IPT_OTHER )   PORT_NAME("Pedal")
+	PORT_BIT( 0x0c, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0xf0, IP_ACTIVE_HIGH, IPT_CUSTOM )  PORT_CUSTOM_MEMBER(ctk551_state, lcd_r)
+
+	PORT_START("P1_W")
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_MEMBER(ctk551_state, led_touch_w)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_UNUSED )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OUTPUT )  // unknown
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_DEVICE_MEMBER("lcdc", hd44780_device, e_w)
+	PORT_BIT( 0xf0, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_MEMBER(ctk551_state, lcd_w)
+
+	PORT_START("P2")
+	PORT_BIT( 0x03, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_DEVICE_MEMBER("lcdc", hd44780_device, rs_w)
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_DEVICE_MEMBER("lcdc", hd44780_device, rw_w)
+	PORT_BIT( 0xf0, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+
+	PORT_START("P3")
+	PORT_BIT( 0x3f, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_OUTPUT )  PORT_WRITE_LINE_MEMBER(ctk551_state, apo_w)
+	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_UNKNOWN )
+
+	PORT_START("AN0")
+	PORT_CONFNAME( 0xff, 0x00, "Power Source" )
+	PORT_CONFSETTING(    0x00, "AC Adapter" )
+	PORT_CONFSETTING(    0xff, "Battery" )
+
+	PORT_START("AN1")
+	PORT_BIT( 0xff, 0x7f, IPT_PADDLE ) PORT_NAME("Pitch Wheel") PORT_SENSITIVITY(100) PORT_KEYDELTA(10) PORT_MINMAX(0x00, 0xff)
+
+INPUT_PORTS_END
+
+ROM_START(ctk551)
+	ROM_REGION(0x100000, "maincpu", 0)
+	ROM_LOAD16_WORD_SWAP("ctk551.lsi2", 0x000000, 0x100000, CRC(66fc34cd) SHA1(47e9559edc106132f8a83462ed17a6c5c3872157))
+ROM_END
+
+} // anonymous namespace
+
+//    YEAR  NAME     PARENT  COMPAT  MACHINE  INPUT   CLASS         INIT        COMPANY  FULLNAME     FLAGS
+SYST( 1999, ctk551,  0,      0,      ctk551,  ctk551, ctk551_state, empty_init, "Casio", "CTK-551",   MACHINE_NO_SOUND | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -11556,6 +11556,9 @@ cswat                           // (c) 1984
 @source:ct486.cpp
 ct486                           // 1993? 486 with CS4031
 
+@source:ctk551.cpp
+ctk551                          //
+
 @source:cubeqst.cpp
 cubeqst                         // (c) 1983 Simutrek Inc.
 cubeqsta                        // (c) 1983 Simutrek Inc.

--- a/src/mame/mess.flt
+++ b/src/mame/mess.flt
@@ -207,6 +207,7 @@ crei680.cpp
 crimson.cpp
 crvision.cpp
 ct486.cpp
+ctk551.cpp
 cvicny.cpp
 cxg_ch2001.cpp
 cxg_dominator.cpp


### PR DESCRIPTION
----------------------------------
Casio CTK-551 [Devin Acker]

This is a new driver for the Casio CTK-551 keyboard, which runs on a custom H8/300-based CPU.

The main "not working" part at this point is the sound; I've figured out most of the register behavior but not the actual sample format. The LCD will also need to be turned into a SVG at some point, but right now it's just emulated as a regular 2-line LCD instead for testing purposes.

(I also made some small additions to `h8_device`, i.e. adding `AS_OPCODES` support and a missing jump instruction)