### PR TITLE
-util/delegate.cpp: One less level of indirection for functoid delegates.

### DIFF
--- a/scripts/target/mame/tiny.lua
+++ b/scripts/target/mame/tiny.lua
@@ -127,7 +127,6 @@ files{
 	MAME_DIR .. "src/mame/includes/exidy.h",
 	MAME_DIR .. "src/mame/audio/exidy.cpp",
 	MAME_DIR .. "src/mame/audio/exidy.h",
-	MAME_DIR .. "src/mame/video/exidy.cpp",
 	MAME_DIR .. "src/mame/audio/exidy440.cpp",
 	MAME_DIR .. "src/mame/audio/exidy440.h",
 	MAME_DIR .. "src/mame/audio/nl_fireone.h",

--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -18,6 +18,7 @@
 #define MAME_EMU_EMUMEM_H
 
 #include <optional>
+#include <set>
 #include <type_traits>
 
 using s8 = std::int8_t;
@@ -476,7 +477,6 @@ template<int Width, int AddrShift> class memory_units_descriptor;
 // =====================-> The root class of all handlers
 
 // Handlers the refcounting as part of the interface
-#include <set>
 class handler_entry
 {
 	DISABLE_COPYING(handler_entry);

--- a/src/emu/gamedrv.h
+++ b/src/emu/gamedrv.h
@@ -392,7 +392,7 @@ extern game_driver const GAME_NAME(NAME)                                \
 ///   avoid repetition.  Screen orientation flags may be included here.
 /// \sa GAME GAMEL COMP SYST
 #define CONS(YEAR, NAME, PARENT, COMPAT, MACHINE, INPUT, CLASS, INIT, COMPANY, FULLNAME, FLAGS) \
-GAME_DRIVER_TRAITS(NAME,FULLNAME)                                       \
+GAME_DRIVER_TRAITS(NAME, FULLNAME)                                      \
 extern game_driver const GAME_NAME(NAME)                                \
 {                                                                       \
 	GAME_DRIVER_TYPE(NAME, CLASS, FLAGS),                               \
@@ -457,8 +457,8 @@ extern game_driver const GAME_NAME(NAME)                                \
 ///   all systems implemented using the class in the class itself to
 ///   avoid repetition.  Screen orientation flags may be included here.
 /// \sa GAME GAMEL CONS SYST
-#define COMP(YEAR,NAME,PARENT,COMPAT,MACHINE,INPUT,CLASS,INIT,COMPANY,FULLNAME,FLAGS) \
-GAME_DRIVER_TRAITS(NAME,FULLNAME)                                       \
+#define COMP(YEAR, NAME, PARENT, COMPAT, MACHINE, INPUT, CLASS, INIT, COMPANY, FULLNAME, FLAGS) \
+GAME_DRIVER_TRAITS(NAME, FULLNAME)                                      \
 extern game_driver const GAME_NAME(NAME)                                \
 {                                                                       \
 	GAME_DRIVER_TYPE(NAME, CLASS, FLAGS),                               \
@@ -523,8 +523,8 @@ extern game_driver const GAME_NAME(NAME)                                \
 ///   all systems implemented using the class in the class itself to
 ///   avoid repetition.  Screen orientation flags may be included here.
 /// \sa GAME GAMEL CONS COMP
-#define SYST(YEAR,NAME,PARENT,COMPAT,MACHINE,INPUT,CLASS,INIT,COMPANY,FULLNAME,FLAGS) \
-GAME_DRIVER_TRAITS(NAME,FULLNAME)                                       \
+#define SYST(YEAR, NAME, PARENT, COMPAT, MACHINE, INPUT, CLASS, INIT, COMPANY, FULLNAME, FLAGS) \
+GAME_DRIVER_TRAITS(NAME, FULLNAME)                                      \
 extern game_driver const GAME_NAME(NAME)                                \
 {                                                                       \
 	GAME_DRIVER_TYPE(NAME, CLASS, FLAGS),                               \

--- a/src/emu/save.h
+++ b/src/emu/save.h
@@ -51,18 +51,36 @@ enum save_error
 typedef named_delegate<void ()> save_prepost_delegate;
 
 
-// use this to declare a given type is a simple, non-pointer type that can be
-// saved; in general, this is intended only to be used for specific enum types
-// defined by your device
+/// \brief Declare a type as safe to automatically save/restore
+///
+/// Use this to declare that a given type is a simple, non-pointer type
+/// that can be saved and restored.  In general, this should only be
+/// be used for specific enum types that have fixed width integer types
+/// as their storage classes.
+/// \param TYPE The name of the type to declare safe to save.
+/// \sa ALLOW_SAVE_TYPE_AND_VECTOR
 #define ALLOW_SAVE_TYPE(TYPE) \
 	template <> struct save_manager::is_atom<TYPE> : public std::true_type { };
 
-// use this as above, but also to declare that std::vector<TYPE> is safe as well
+/// \brief Declare a type as safe to automatically save/restore,
+///   including in \c std::vector instances
+///
+/// Used the same way as #ALLOW_SAVE_TYPE, but also declares that
+/// \c std::vector instances containing the type are safe to save.
+/// that can be saved and restored.  This must not be used if
+/// \c std::vector is specialised in an incompatible way.
+/// \param TYPE The name of the type to declare safe to save.
+/// \sa ALLOW_SAVE_TYPE
 #define ALLOW_SAVE_TYPE_AND_VECTOR(TYPE) \
 	ALLOW_SAVE_TYPE(TYPE) \
 	template <> struct save_manager::is_vector_safe<TYPE> : public std::true_type { };
 
-// use this for saving members of structures in arrays
+/// \brief Helper for referring to members of structures in arrays
+///
+/// Expands to the necessary reference, pointer to member and name to
+/// refer to a structure member.
+/// \param s Reference to a C array or \c std::array of structures.
+/// \param m Name of the structure member to refer to.
 #define STRUCT_MEMBER(s, m) s, &save_manager::pointer_unwrap<decltype(s)>::underlying_type::m, #s "." #m
 
 

--- a/src/lib/util/delegate.cpp
+++ b/src/lib/util/delegate.cpp
@@ -2,16 +2,27 @@
 // copyright-holders:Aaron Giles
 /***************************************************************************
 
-    delegate.c
+    delegate.cpp
 
     Templates and classes to enable delegates for callbacks.
 
 ***************************************************************************/
 
-#include <cassert>
-#include <cstdint>
-#include <cstdio>
 #include "delegate.h"
+
+#include <cstdio>
+
+
+//**************************************************************************
+//  MACROS
+//**************************************************************************
+
+#if defined(LOG_DELEGATES)
+#define LOG(...) printf(__VA_ARGS__)
+#else
+#define LOG(...) do { if (false) printf(__VA_ARGS__); } while (false)
+#endif
+
 
 
 //**************************************************************************
@@ -20,7 +31,7 @@
 
 #if (USE_DELEGATE_TYPE == DELEGATE_TYPE_COMPATIBLE)
 
-delegate_mfp::raw_mfp_data delegate_mfp::s_null_mfp = { {0 }};
+delegate_mfp::raw_mfp_data delegate_mfp::s_null_mfp = { { 0 } };
 
 #endif
 
@@ -40,10 +51,9 @@ delegate_mfp::raw_mfp_data delegate_mfp::s_null_mfp = { {0 }};
 delegate_generic_function delegate_mfp::convert_to_generic(delegate_generic_class *&object) const
 {
 #if defined(__arm__) || defined(__ARMEL__) || defined(__aarch64__) || defined(__MIPSEL__) || defined(__mips_isa_rev) || defined(__mips64) || defined(__EMSCRIPTEN__)
-	if ((m_this_delta & 1) == 0) {
-#if defined(LOG_DELEGATES)
-		printf("Calculated Addr = %08x\n", (uintptr_t)(void*)(m_function));
-#endif
+	if ((m_this_delta & 1) == 0)
+	{
+		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(uintptr_t(m_function)));
 		object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object) + m_this_delta);
 		return reinterpret_cast<delegate_generic_function>(m_function);
 	}
@@ -51,27 +61,22 @@ delegate_generic_function delegate_mfp::convert_to_generic(delegate_generic_clas
 
 	// otherwise, it is the byte index into the vtable where the actual function lives
 	std::uint8_t *vtable_base = *reinterpret_cast<std::uint8_t **>(object);
-#if defined(LOG_DELEGATES)
-	printf("Calculated Addr = %08x (VTAB)\n", (uintptr_t)(void*)(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function + m_this_delta - 1)));
-#endif
+	LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void const *>(uintptr_t(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function + m_this_delta - 1))));
 	return *reinterpret_cast<delegate_generic_function *>(vtable_base + m_function + m_this_delta - 1);
 #else
 	// apply the "this" delta to the object first
 	object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object) + m_this_delta);
 
 	// if the low bit of the vtable index is clear, then it is just a raw function pointer
-	if (!(m_function & 1)) {
-#if defined(LOG_DELEGATES)
-		printf("Calculated Addr = %08x\n", (uintptr_t)(void*)(m_function));
-#endif
+	if (!(m_function & 1))
+	{
+		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(uintptr_t(m_function)));
 		return reinterpret_cast<delegate_generic_function>(m_function);
 	}
 
 	// otherwise, it is the byte index into the vtable where the actual function lives
 	std::uint8_t *vtable_base = *reinterpret_cast<std::uint8_t **>(object);
-#if defined(LOG_DELEGATES)
-	printf("Calculated Addr = %08x (VTAB)\n", (uintptr_t)(void*)(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function - 1)));
-#endif
+	LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void *>(uintptr_t(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function - 1))));
 	return *reinterpret_cast<delegate_generic_function *>(vtable_base + m_function - 1);
 #endif
 }

--- a/src/lib/util/delegate.h
+++ b/src/lib/util/delegate.h
@@ -77,9 +77,12 @@
 
 #pragma once
 
-// standard C++ includes
+#include <any>
+#include <cassert>
+#include <cstdint>
 #include <cstring>
-#include <functional>
+#include <exception>
+#include <type_traits>
 #include <typeinfo>
 #include <utility>
 
@@ -571,9 +574,54 @@ class delegate<ReturnType (Params...)> : public delegate_base<ReturnType, Params
 {
 private:
 	using basetype = delegate_base<ReturnType, Params...>;
-	using functional_type = std::function<ReturnType (Params...)>;
+	using functoid_setter = void (*)(delegate &);
 
-	functional_type m_std_func;
+	template <typename T> static constexpr bool matching_non_const_call(T &&) { return false; }
+	template <typename T> static constexpr bool matching_non_const_call(ReturnType (T::*)(Params...)) { return true; }
+	template <typename T> static constexpr bool matching_const_call(T &&) { return false; }
+	template <typename T> static constexpr bool matching_const_call(ReturnType (T::*)(Params...) const) { return true; }
+
+	template <typename T>
+	static functoid_setter make_functoid_setter()
+	{
+		using unwrapped_type = std::remove_cv_t<std::remove_reference_t<T> >;
+		if constexpr (matching_non_const_call(&T::operator()))
+		{
+			return
+					[] (delegate &obj)
+					{
+						obj.basetype::operator=(
+								basetype(
+									static_cast<ReturnType (unwrapped_type::*)(Params...)>(&unwrapped_type::operator()),
+									std::any_cast<unwrapped_type>(&obj.m_functoid)));
+					};
+		}
+		else if constexpr (matching_const_call(&T::operator()))
+		{
+			return
+					[] (delegate &obj)
+					{
+						obj.basetype::operator=(
+								basetype(
+									static_cast<ReturnType (unwrapped_type::*)(Params...) const>(&unwrapped_type::operator()),
+									std::any_cast<unwrapped_type>(&obj.m_functoid)));
+					};
+		}
+		else
+		{
+			return
+					[] (delegate &obj)
+					{
+						obj.basetype::operator=(
+								basetype(
+									[] (unwrapped_type &f, Params... args) { return ReturnType(f(std::forward<Params>(args)...)); },
+									std::any_cast<unwrapped_type>(&obj.m_functoid)));
+					};
+		}
+	}
+
+	std::any m_functoid;
+	functoid_setter m_set_functoid = nullptr;
 
 protected:
 	template <class FunctionClass> using traits = typename basetype::template traits<FunctionClass>;
@@ -581,34 +629,84 @@ protected:
 	template <class FunctionClass> using const_member_func_type = typename traits<FunctionClass>::const_member_func_type;
 	template <class FunctionClass> using static_ref_func_type = typename traits<FunctionClass>::static_ref_func_type;
 
+	template <typename T> using suitable_functoid = std::is_convertible<std::invoke_result_t<T, Params...>, ReturnType>;
+
 public:
-	// create a standard set of constructors
 	delegate() : basetype() { }
-	delegate(delegate const &src) : basetype(src.m_std_func ? basetype(&functional_type::operator(), &m_std_func) : static_cast<basetype const &>(src)), m_std_func(src.m_std_func) { }
-	delegate(delegate &&src) : basetype(src.m_std_func ? basetype(&functional_type::operator(), &m_std_func) : std::move(static_cast<basetype &>(src))), m_std_func(std::move(src.m_std_func)) { }
-	delegate(delegate const &src, delegate_late_bind &object) : basetype(src.m_std_func ? basetype(&functional_type::operator(), &m_std_func) : basetype(src, object)), m_std_func(src.m_std_func) { }
+
+	delegate(delegate const &src)
+		: basetype(src.m_functoid.has_value() ? static_cast<const basetype &>(basetype()) : src)
+		, m_functoid(src.m_functoid)
+		, m_set_functoid(src.m_set_functoid)
+	{
+		if (m_functoid.has_value())
+			m_set_functoid(*this);
+	}
+
+	delegate(delegate &&src)
+		: basetype(src.m_functoid.has_value() ? basetype() : std::move(src))
+		, m_functoid(std::move(src.m_functoid))
+		, m_set_functoid(std::move(src.m_set_functoid))
+	{
+		if (m_functoid.has_value())
+			m_set_functoid(*this);
+	}
+
+	delegate(delegate const &src, delegate_late_bind &object)
+		: basetype(src.m_functoid.has_value() ? basetype() : basetype(src, object))
+		, m_functoid(src.m_functoid)
+		, m_set_functoid(src.m_set_functoid)
+	{
+		if (m_functoid.has_value())
+			m_set_functoid(*this);
+	}
+
 	template <class FunctionClass> delegate(member_func_type<FunctionClass> funcptr, FunctionClass *object) : basetype(funcptr, object) { }
 	template <class FunctionClass> delegate(const_member_func_type<FunctionClass> funcptr, FunctionClass *object) : basetype(funcptr, object) { }
-	explicit delegate(functional_type &&functoid) : basetype(&functional_type::operator(), &m_std_func), m_std_func(std::move(functoid)) { }
 	template <class FunctionClass> delegate(static_ref_func_type<FunctionClass> funcptr, FunctionClass *object) : basetype(funcptr, object) { }
+
+	template <typename T>
+	explicit delegate(T &&functoid, std::enable_if_t<suitable_functoid<T>::value, int> = 0)
+		: basetype()
+		, m_functoid(std::forward<T>(functoid))
+		, m_set_functoid(make_functoid_setter<T>())
+	{
+		m_set_functoid(*this);
+	}
+
+	delegate &operator=(std::nullptr_t) noexcept
+	{
+		reset();
+		return *this;
+	}
 
 	delegate &operator=(delegate const &src)
 	{
-		if (src.m_std_func)
-			basetype::operator=(basetype(&functional_type::operator(), &m_std_func));
+		m_functoid = src.m_functoid;
+		m_set_functoid = src.m_set_functoid;
+		if (m_functoid.has_value())
+			m_set_functoid(*this);
 		else
 			basetype::operator=(src);
-		m_std_func = src.m_std_func;
 		return *this;
 	}
+
 	delegate &operator=(delegate &&src)
 	{
-		if (src.m_std_func)
-			basetype::operator=(basetype(&functional_type::operator(), &m_std_func));
+		m_functoid = std::move(src.m_functoid);
+		m_set_functoid = std::move(src.m_set_functoid);
+		if (m_functoid.has_value())
+			m_set_functoid(*this);
 		else
 			basetype::operator=(std::move(src));
-		m_std_func = std::move(src.m_std_func);
 		return *this;
+	}
+
+	void reset() noexcept
+	{
+		basetype::operator=(basetype());
+		m_functoid.reset();
+		m_set_functoid = nullptr;
 	}
 };
 


### PR DESCRIPTION
If a delegate is set to a functoid (e.g. a lambda) with a signature that is an exact match for the delegate's signature, it will be bound directly.  If arguments or the return value need conversion, a static adaptor will be generated.  This removes unnecessary indirection through the out-of-line `std::function::operator()`.

There’s no flexibility lost, you can still be a bit sloppy with lambda signatures, but it means if you’re strict with your lambda signatures, one small performance penalty is removed.  You still have an extra level of indirection through the captured `this` pointer when accessing members, but that’s not as bad as the flow control indirection.