### PR TITLE
Enable flexible structure saving

### DIFF
--- a/src/devices/video/voodoo.cpp
+++ b/src/devices/video/voodoo.cpp
@@ -203,18 +203,18 @@ inline s64 float_to_int64(u32 data, int fixedbits)
 //  register_save - save live state
 //-------------------------------------------------
 
-void voodoo_regs::register_save(save_proxy &save)
+void voodoo_regs::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_regs));
-	save.save_item(NAME(m_starts));
-	save.save_item(NAME(m_startt));
-	save.save_item(NAME(m_startw));
-	save.save_item(NAME(m_dsdx));
-	save.save_item(NAME(m_dtdx));
-	save.save_item(NAME(m_dwdx));
-	save.save_item(NAME(m_dsdy));
-	save.save_item(NAME(m_dtdy));
-	save.save_item(NAME(m_dwdy));
+	save.reg(NAME(m_regs));
+	save.reg(NAME(m_starts));
+	save.reg(NAME(m_startt));
+	save.reg(NAME(m_startw));
+	save.reg(NAME(m_dsdx));
+	save.reg(NAME(m_dtdx));
+	save.reg(NAME(m_dwdx));
+	save.reg(NAME(m_dsdy));
+	save.reg(NAME(m_dtdy));
+	save.reg(NAME(m_dwdy));
 }
 
 
@@ -343,11 +343,11 @@ void tmu_state::init(int index, shared_tables const &share, u8 *ram, u32 size)
 //  register_save - register for save states
 //-------------------------------------------------
 
-void tmu_state::register_save(save_proxy &save)
+void tmu_state::register_save(save_registrar &save)
 {
 	// register state
-	save.save_class(NAME(m_reg));
-	save.save_item(NAME(m_palette));
+	save.reg(NAME(m_reg));
+	save.reg(NAME(m_palette));
 }
 
 
@@ -491,11 +491,11 @@ void memory_fifo::configure(u32 *base, u32 size)
 //  register_save - register for save states
 //-------------------------------------------------
 
-void memory_fifo::register_save(save_proxy &save)
+void memory_fifo::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_size));
-	save.save_item(NAME(m_in));
-	save.save_item(NAME(m_out));
+	save.reg(NAME(m_size));
+	save.reg(NAME(m_in));
+	save.reg(NAME(m_out));
 }
 
 
@@ -1025,8 +1025,7 @@ void voodoo_1_device::device_start()
 	soft_reset();
 
 	// register for save states
-	save_proxy save(*this);
-	register_save(save, total_allocation);
+	register_save(total_allocation);
 }
 
 
@@ -1090,56 +1089,55 @@ ALLOW_SAVE_TYPE(reg_init_en);
 ALLOW_SAVE_TYPE(voodoo_regs::register_data);
 ALLOW_SAVE_TYPE(voodoo_1_device::stall_state);
 
-void voodoo_1_device::register_save(save_proxy &save, u32 total_allocation)
+void voodoo_1_device::register_save(u32 total_allocation)
 {
 	// PCI state/FIFOs
-	save.save_item(NAME(m_init_enable));
-	save.save_item(NAME(m_stall_state));
-	save.save_item(NAME(m_operation_end));
-	save.save_class(NAME(m_pci_fifo));
-	save.save_class(NAME(m_fbmem_fifo));
+	save_item(NAME(m_init_enable));
+	save_item(NAME(m_stall_state));
+	save_item(NAME(m_operation_end));
+	save_item(NAME(m_pci_fifo));
+	save_item(NAME(m_fbmem_fifo));
 
 	// allocated memory
-	save.save_pointer(NAME(m_fbram), 1024 * 1024 * total_allocation);
-	save.save_class(NAME(*m_renderer.get()));
+	save_pointer(NAME(m_fbram), 1024 * 1024 * total_allocation);
+	save_item(NAME(*m_renderer.get()));
 
 	// video buffer configuration
-	save.save_item(NAME(m_rgboffs));
-	save.save_item(NAME(m_auxoffs));
-	save.save_item(NAME(m_frontbuf));
-	save.save_item(NAME(m_backbuf));
+	save_item(NAME(m_rgboffs));
+	save_item(NAME(m_auxoffs));
+	save_item(NAME(m_frontbuf));
+	save_item(NAME(m_backbuf));
 
 	// linear frame buffer access configuration
-	save.save_item(NAME(m_lfb_stride));
+	save_item(NAME(m_lfb_stride));
 
 	// video configuration
-	save.save_item(NAME(m_width));
-	save.save_item(NAME(m_height));
-	save.save_item(NAME(m_xoffs));
-	save.save_item(NAME(m_yoffs));
-	save.save_item(NAME(m_vsyncstart));
-	save.save_item(NAME(m_vsyncstop));
+	save_item(NAME(m_width));
+	save_item(NAME(m_height));
+	save_item(NAME(m_xoffs));
+	save_item(NAME(m_yoffs));
+	save_item(NAME(m_vsyncstart));
+	save_item(NAME(m_vsyncstop));
 
 	// VBLANK/swapping state
-	save.save_item(NAME(m_swaps_pending));
-	save.save_item(NAME(m_vblank));
-	save.save_item(NAME(m_vblank_count));
-	save.save_item(NAME(m_vblank_swap_pending));
-	save.save_item(NAME(m_vblank_swap));
-	save.save_item(NAME(m_vblank_dont_swap));
+	save_item(NAME(m_swaps_pending));
+	save_item(NAME(m_vblank));
+	save_item(NAME(m_vblank_count));
+	save_item(NAME(m_vblank_swap_pending));
+	save_item(NAME(m_vblank_swap));
+	save_item(NAME(m_vblank_dont_swap));
 
 	// register state
-	save.save_class(NAME(m_reg));
-	save.save_class(NAME(m_tmu[0]));
-	save.save_class(NAME(m_tmu[1]));
-	save.save_item(NAME(m_dac_reg));
-	save.save_item(NAME(m_dac_read_result));
+	save_item(NAME(m_reg));
+	save_item(NAME(m_tmu));
+	save_item(NAME(m_dac_reg));
+	save_item(NAME(m_dac_read_result));
 
 	// memory for PCI FIFO
-	save.save_item(NAME(m_pci_fifo_mem));
+	save_item(NAME(m_pci_fifo_mem));
 
 	// pens and CLUT
-	save.save_item(NAME(m_clut));
+	save_item(NAME(m_clut));
 }
 
 

--- a/src/devices/video/voodoo.h
+++ b/src/devices/video/voodoo.h
@@ -18,7 +18,6 @@
 
 // forward declarations
 class voodoo_1_device;
-namespace voodoo { class save_proxy; }
 
 
 //**************************************************************************
@@ -68,54 +67,6 @@ static constexpr bool LOG_CMDFIFO_VERBOSE = false;
 namespace voodoo
 {
 
-// ======================> save_proxy
-
-// save_proxy is a helper class to make hierarchical state saving more manageable;
-class save_proxy
-{
-public:
-	// constructor
-	save_proxy(device_t &device) :
-		m_device(device)
-	{
-	}
-
-	// save an item; append the current prefix and pass through
-	template<typename T>
-	void save_item(T &&item, char const *name)
-	{
-		std::string fullname = m_prefix;
-		fullname += name;
-		m_device.save_item(std::forward<T>(item), fullname.c_str());
-	}
-
-	// save a pointer item; append the current prefix and pass through
-	template<typename T>
-	void save_pointer(T &&item, char const *name, u32 count)
-	{
-		std::string fullname = m_prefix;
-		fullname += name;
-		m_device.save_pointer(std::forward<T>(item), fullname.c_str(), count);
-	}
-
-	// save a class; update the prefix then call the register_save method on the class
-	template<typename T>
-	void save_class(T &item, char const *name)
-	{
-		std::string orig = m_prefix;
-		m_prefix += name;
-		m_prefix += "/";
-		item.register_save(*this);
-		m_prefix = orig;
-	}
-
-private:
-	// internal state
-	device_t &m_device;
-	std::string m_prefix;
-};
-
-
 // ======================> shared_tables
 
 // shared_tables are global tables that are shared between different components
@@ -156,7 +107,7 @@ public:
 	void set_baseaddr_mask_shift(u32 mask, u8 shift) { m_basemask = mask; m_baseshift = shift; }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 	void post_load();
 
 	// simple getters
@@ -216,7 +167,7 @@ public:
 	void configure(u32 *base, u32 size);
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// basic queries
 	bool configured() const { return (m_size != 0); }
@@ -509,7 +460,7 @@ protected:
 
 	// system management
 	virtual void soft_reset();
-	virtual void register_save(voodoo::save_proxy &save, u32 total_allocation);
+	virtual void register_save(u32 total_allocation);
 
 	// buffer accessors
 	virtual u16 *draw_buffer_indirect(int index);

--- a/src/devices/video/voodoo_2.cpp
+++ b/src/devices/video/voodoo_2.cpp
@@ -57,17 +57,17 @@ command_fifo::command_fifo(voodoo_2_device &device) :
 //  register_save - register for save states
 //-------------------------------------------------
 
-void command_fifo::register_save(save_proxy &save)
+void command_fifo::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_enable));
-	save.save_item(NAME(m_count_holes));
-	save.save_item(NAME(m_ram_base));
-	save.save_item(NAME(m_ram_end));
-	save.save_item(NAME(m_read_index));
-	save.save_item(NAME(m_address_min));
-	save.save_item(NAME(m_address_max));
-	save.save_item(NAME(m_depth));
-	save.save_item(NAME(m_holes));
+	save.reg(NAME(m_enable));
+	save.reg(NAME(m_count_holes));
+	save.reg(NAME(m_ram_base));
+	save.reg(NAME(m_ram_end));
+	save.reg(NAME(m_read_index));
+	save.reg(NAME(m_address_min));
+	save.reg(NAME(m_address_max));
+	save.reg(NAME(m_depth));
+	save.reg(NAME(m_holes));
 }
 
 
@@ -848,16 +848,14 @@ void voodoo_2_device::soft_reset()
 //  register_save - register for save states
 //-------------------------------------------------
 
-void voodoo_2_device::register_save(save_proxy &save, u32 total_allocation)
+void voodoo_2_device::register_save(u32 total_allocation)
 {
-	voodoo_1_device::register_save(save, total_allocation);
+	voodoo_1_device::register_save(total_allocation);
 
 	// Voodoo 2 stuff
-	save.save_item(NAME(m_sverts));
-	save.save_class(NAME(m_svert[0]));
-	save.save_class(NAME(m_svert[1]));
-	save.save_class(NAME(m_svert[2]));
-	save.save_class(NAME(m_cmdfifo));
+	save_item(NAME(m_sverts));
+	save_item(NAME(m_svert));
+	save_item(NAME(m_cmdfifo));
 }
 
 

--- a/src/devices/video/voodoo_2.h
+++ b/src/devices/video/voodoo_2.h
@@ -40,7 +40,7 @@ public:
 	void init(u8 *ram, u32 size) { m_ram = (u32 *)ram; m_mask = (size / 4) - 1; }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// getters
 	bool enabled() const { return m_enable; }
@@ -128,22 +128,22 @@ private:
 struct setup_vertex
 {
 	// state saving
-	void register_save(save_proxy &save)
+	void register_save(save_registrar &save)
 	{
-		save.save_item(NAME(x));
-		save.save_item(NAME(y));
-		save.save_item(NAME(z));
-		save.save_item(NAME(wb));
-		save.save_item(NAME(r));
-		save.save_item(NAME(g));
-		save.save_item(NAME(b));
-		save.save_item(NAME(a));
-		save.save_item(NAME(s0));
-		save.save_item(NAME(t0));
-		save.save_item(NAME(w0));
-		save.save_item(NAME(s1));
-		save.save_item(NAME(t1));
-		save.save_item(NAME(w1));
+		save.reg(NAME(x));
+		save.reg(NAME(y));
+		save.reg(NAME(z));
+		save.reg(NAME(wb));
+		save.reg(NAME(r));
+		save.reg(NAME(g));
+		save.reg(NAME(b));
+		save.reg(NAME(a));
+		save.reg(NAME(s0));
+		save.reg(NAME(t0));
+		save.reg(NAME(w0));
+		save.reg(NAME(s1));
+		save.reg(NAME(t1));
+		save.reg(NAME(w1));
 	}
 
 	float x, y;               // X, Y coordinates
@@ -194,7 +194,7 @@ protected:
 
 	// system management
 	virtual void soft_reset() override;
-	virtual void register_save(voodoo::save_proxy &save, u32 total_allocation) override;
+	virtual void register_save(u32 total_allocation) override;
 
 	// mapped writes
 	void map_register_w(offs_t offset, u32 data, u32 mem_mask = ~0);

--- a/src/devices/video/voodoo_banshee.cpp
+++ b/src/devices/video/voodoo_banshee.cpp
@@ -43,9 +43,9 @@ using namespace voodoo;
 //  register_save - register for save states
 //-------------------------------------------------
 
-void banshee_2d_regs::register_save(save_proxy &save)
+void banshee_2d_regs::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_regs));
+	save.reg(NAME(m_regs));
 }
 
 
@@ -70,9 +70,9 @@ char const *const banshee_2d_regs::s_names[0x20] =
 //  register_save - register for save states
 //-------------------------------------------------
 
-void banshee_io_regs::register_save(save_proxy &save)
+void banshee_io_regs::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_regs));
+	save.reg(NAME(m_regs));
 }
 
 
@@ -105,9 +105,9 @@ char const *const banshee_io_regs::s_names[0x40] =
 //  register_save - register for save states
 //-------------------------------------------------
 
-void banshee_cmd_agp_regs::register_save(save_proxy &save)
+void banshee_cmd_agp_regs::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_regs));
+	save.reg(NAME(m_regs));
 }
 
 
@@ -156,14 +156,14 @@ char const *const banshee_cmd_agp_regs::s_names[0x80] =
 //  register_save - register for save states
 //-------------------------------------------------
 
-void banshee_vga_regs::register_save(save_proxy &save)
+void banshee_vga_regs::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_regs));
-	save.save_item(NAME(m_crtc));
-	save.save_item(NAME(m_seq));
-	save.save_item(NAME(m_gc));
-	save.save_item(NAME(m_attr));
-	save.save_item(NAME(m_attr_flip_flop));
+	save.reg(NAME(m_regs));
+	save.reg(NAME(m_crtc));
+	save.reg(NAME(m_seq));
+	save.reg(NAME(m_gc));
+	save.reg(NAME(m_attr));
+	save.reg(NAME(m_attr_flip_flop));
 }
 
 
@@ -493,31 +493,31 @@ void voodoo_banshee_device::soft_reset()
 //  register_save - register for save states
 //-------------------------------------------------
 
-void voodoo_banshee_device::register_save(save_proxy &save, u32 total_allocation)
+void voodoo_banshee_device::register_save(u32 total_allocation)
 {
-	voodoo_2_device::register_save(save, total_allocation);
+	voodoo_2_device::register_save(total_allocation);
 
 	// Voodoo Banshee stuff
-	save.save_class(NAME(m_cmdfifo2));
-	save.save_class(NAME(m_io_regs));
-	save.save_class(NAME(m_cmd_agp_regs));
-	save.save_class(NAME(m_vga_regs));
-	save.save_class(NAME(m_2d_regs));
-	save.save_item(NAME(m_blt_dst_base));
-	save.save_item(NAME(m_blt_dst_x));
-	save.save_item(NAME(m_blt_dst_y));
-	save.save_item(NAME(m_blt_dst_width));
-	save.save_item(NAME(m_blt_dst_height));
-	save.save_item(NAME(m_blt_dst_stride));
-	save.save_item(NAME(m_blt_dst_bpp));
-	save.save_item(NAME(m_blt_cmd));
-	save.save_item(NAME(m_blt_src_base));
-	save.save_item(NAME(m_blt_src_x));
-	save.save_item(NAME(m_blt_src_y));
-	save.save_item(NAME(m_blt_src_width));
-	save.save_item(NAME(m_blt_src_height));
-	save.save_item(NAME(m_blt_src_stride));
-	save.save_item(NAME(m_blt_src_bpp));
+	save_item(NAME(m_cmdfifo2));
+	save_item(NAME(m_io_regs));
+	save_item(NAME(m_cmd_agp_regs));
+	save_item(NAME(m_vga_regs));
+	save_item(NAME(m_2d_regs));
+	save_item(NAME(m_blt_dst_base));
+	save_item(NAME(m_blt_dst_x));
+	save_item(NAME(m_blt_dst_y));
+	save_item(NAME(m_blt_dst_width));
+	save_item(NAME(m_blt_dst_height));
+	save_item(NAME(m_blt_dst_stride));
+	save_item(NAME(m_blt_dst_bpp));
+	save_item(NAME(m_blt_cmd));
+	save_item(NAME(m_blt_src_base));
+	save_item(NAME(m_blt_src_x));
+	save_item(NAME(m_blt_src_y));
+	save_item(NAME(m_blt_src_width));
+	save_item(NAME(m_blt_src_height));
+	save_item(NAME(m_blt_src_stride));
+	save_item(NAME(m_blt_src_bpp));
 }
 
 

--- a/src/devices/video/voodoo_banshee.h
+++ b/src/devices/video/voodoo_banshee.h
@@ -75,7 +75,7 @@ protected:
 
 	// system management
 	virtual void soft_reset() override;
-	virtual void register_save(voodoo::save_proxy &save, u32 total_allocation) override;
+	virtual void register_save(u32 total_allocation) override;
 
 	// buffer accessors
 	virtual u16 *lfb_buffer_indirect(int index) override;

--- a/src/devices/video/voodoo_regs.h
+++ b/src/devices/video/voodoo_regs.h
@@ -1014,7 +1014,7 @@ public:
 	}
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// register aliasing
 	static u32 alias(u32 regnum) { return (regnum < 0x40) ? s_alias_map[regnum] : regnum; }
@@ -1180,7 +1180,7 @@ public:
 	banshee_2d_regs() { reset(); }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// reset
 	void reset() { std::fill_n(&m_regs[0], std::size(m_regs), 0); }
@@ -1280,7 +1280,7 @@ public:
 	banshee_io_regs() { reset(); }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// reset
 	void reset() { std::fill_n(&m_regs[0], std::size(m_regs), 0); }
@@ -1341,7 +1341,7 @@ public:
 	banshee_cmd_agp_regs() { reset(); }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// reset
 	void reset() { std::fill_n(&m_regs[0], std::size(m_regs), 0); }
@@ -1391,7 +1391,7 @@ public:
 	banshee_vga_regs() { reset(); }
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// reset
 	void reset()

--- a/src/devices/video/voodoo_render.cpp
+++ b/src/devices/video/voodoo_render.cpp
@@ -1265,12 +1265,12 @@ voodoo_renderer::voodoo_renderer(running_machine &machine, u16 tmu_config, const
 //  register_save - register for saving states
 //-------------------------------------------------
 
-void voodoo_renderer::register_save(save_proxy &save)
+void voodoo_renderer::register_save(save_registrar &save)
 {
-	save.save_item(NAME(m_rowpixels));
-	save.save_item(NAME(m_yorigin));
-	save.save_item(NAME(m_fogblend));
-	save.save_item(NAME(m_fogdelta));
+	save.reg(NAME(m_rowpixels));
+	save.reg(NAME(m_yorigin));
+	save.reg(NAME(m_fogblend));
+	save.reg(NAME(m_fogdelta));
 }
 
 

--- a/src/devices/video/voodoo_render.h
+++ b/src/devices/video/voodoo_render.h
@@ -506,7 +506,7 @@ public:
 	voodoo_renderer(running_machine &machine, u16 tmu_config, const rgb_t *rgb565, voodoo_regs &fbi_regs, voodoo_regs *tmu0_regs, voodoo_regs *tmu1_regs);
 
 	// state saving
-	void register_save(save_proxy &save);
+	void register_save(save_registrar &save);
 
 	// simple getters
 	s32 yorigin() const { return m_yorigin; }

--- a/src/emu/attotime.cpp
+++ b/src/emu/attotime.cpp
@@ -8,9 +8,8 @@
 
 ***************************************************************************/
 
-#include "emucore.h"
-#include "eminline.h"
-#include "attotime.h"
+#include "emu.h"
+
 
 //**************************************************************************
 //  GLOBAL VARIABLES
@@ -169,4 +168,16 @@ std::string attotime::to_string() const
 	}
 	int nsec = t.attoseconds() / ATTOSECONDS_PER_NANOSECOND;
 	return util::string_format("%s%04d.%03d,%03d,%03d", sign, int(t.seconds()), nsec/1000000, (nsec/1000)%1000, nsec % 1000);
+}
+
+
+//-------------------------------------------------
+//  register_save - register for save states
+//-------------------------------------------------
+
+void attotime::register_save(save_registrar &save)
+{
+	// use names without m_ prefix for backwards compatibility
+	save.reg(m_attoseconds, "attoseconds");
+	save.reg(m_seconds, "seconds");
 }

--- a/src/emu/attotime.h
+++ b/src/emu/attotime.h
@@ -164,6 +164,8 @@ public:
 	attotime &operator*=(u32 factor);
 	attotime &operator/=(u32 factor);
 
+	void register_save(save_registrar &save);
+
 	// members
 	seconds_t       m_seconds;
 	attoseconds_t   m_attoseconds;

--- a/src/emu/emufwd.h
+++ b/src/emu/emufwd.h
@@ -210,6 +210,9 @@ class rom_entry;
 // declared in romload.h
 class rom_load_manager;
 
+// declared in save.h
+class save_registrar;
+
 // declared in schedule.h
 class device_scheduler;
 class emu_timer;


### PR DESCRIPTION
This change introduces the ability to save arbitrary structures. To make a structure eligible for saving, it must implement a new method `register_save(save_registrar &)`. Structs can then save their members directly via the provided save_registrar. Nested structs and arrays of structs are supported in this manner.

Note that state registration is not done via a virtual method or mix-in interface because doing so would convert lightweight structures away from being POD, and lightweight structures are one of the most common situations where this system can be leveraged in MAME.

As a first example, the `attotime` struct has been changed to support this mechanism for saving, allowing us to remove the special cases for attotimes currently in save_manager. The voodoo code has also been ported to use this in place of a temporary mechanism that had similar behavior.

(It might be tempting to do the same for `bitmap_t`, but bitmaps are defined in lib/util and can't take a dependency on save.h so those special cases will remain.)

This is a prologue to full hierarchical save state support, which I am working on in another branch. The `save_registrar` class name and `reg()` signatures match current work on that branch, so any changes made to existing code to leverage struct saving in this way will port over cleanly.