### PR TITLE
Do not build with -m64 on riscv64

### DIFF
--- a/makefile
+++ b/makefile
@@ -406,6 +406,7 @@ endif
 endif
 
 ifeq ($(findstring riscv64,$(UNAME)),riscv64)
+ARCHITECTURE :=
 ifndef FORCE_DRC_C_BACKEND
 	FORCE_DRC_C_BACKEND := 1
 endif


### PR DESCRIPTION
It is not supported by gcc on this architecture.
This worked prior to 6e1bbe8