### PR TITLE
bus/nes: Added emulation for A Winner is You homebrew cart.

### DIFF
--- a/src/devices/bus/nes/nes_carts.cpp
+++ b/src/devices/bus/nes/nes_carts.cpp
@@ -457,6 +457,7 @@ void nes_cart(device_slot_interface &device)
 	device.option_add_internal("cufrom",           NES_CUFROM);
 	device.option_add_internal("unrom512",         NES_UNROM512);
 	device.option_add_internal("2a03pur",          NES_2A03PURITANS);
+	device.option_add_internal("dpcmcart",         NES_DPCMCART);
 // other unsupported...
 	device.option_add_internal("unl_dance",        NES_NROM);    // UNSUPPORTED
 	device.option_add_internal("onebus",           NES_NROM);    // UNSUPPORTED

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -644,7 +644,7 @@ void nes_cart_slot_device::call_load_ines()
 		// read submappers (based on 20140116 specs)
 		submapper = (header[8] & 0xf0) >> 4;
 
-		// NES 2.0's extended exponential sizes, needed for loading 64MB PRG/CHR chunks. These bizarrely go up to 7 * 2^63!
+		// NES 2.0's extended exponential sizes, needed for loading PRG >= 64MB, CHR >= 32MB. These bizarrely go up to 7 * 2^63!
 		auto expsize = [] (u8 byte) { return (2*(byte & 0x03) + 1) * std::pow(2.0, byte >> 2); };
 
 		if ((header[9] & 0x0f) == 0x0f)

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -660,7 +660,7 @@ void nes_cart_slot_device::call_load_ines()
 		{
 			vrom_size = expsize(header[5]);
 			if (vrom_size == 0)    // 0 only on overflow
-				fatalerror("NES 2.0 PRG size >= 4GB is unsupported.\n");
+				fatalerror("NES 2.0 CHR size >= 4GB is unsupported.\n");
 		}
 		else
 			vrom_size += ((header[9] & 0xf0) << 4) * 0x2000;

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -367,6 +367,7 @@ static const nes_pcb pcb_list[] =
 	{ "cufrom",           UNL_CUFROM },
 	{ "unrom512",         UNL_UNROM512 },
 	{ "2a03pur",          UNL_2A03PURITANS },
+	{ "dpcmcart",         UNL_DPCMCART },
 	{ "ffe3",             FFE3_BOARD },
 	{ "ffe4",             FFE4_BOARD },
 	{ "ffe8",             FFE8_BOARD },

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -144,7 +144,11 @@ enum
 	// homebrew PCBs
 	NOCASH_NOCHR,   // homebrew PCB design which uses NTRAM for CHRRAM
 	UNL_ACTION53,   // homebrew PCB for homebrew multicarts
-	BATMAP_000, BATMAP_SRRX, UNL_CUFROM, UNL_UNROM512, UNL_2A03PURITANS,
+	UNL_2A03PURITANS,
+	// Batlab Electronics
+	BATMAP_000, BATMAP_SRRX,
+	// Sealie
+	UNL_CUFROM, UNL_UNROM512, UNL_DPCMCART,
 	// FFE boards, for mappers 6, 8, 17
 	FFE3_BOARD, FFE4_BOARD, FFE8_BOARD, TEST_BOARD,
 	// Unsupported (for place-holder boards, with no working emulation) & no-board (at init)

--- a/src/devices/bus/nes/sealie.cpp
+++ b/src/devices/bus/nes/sealie.cpp
@@ -9,6 +9,7 @@
  Here we emulate the following homebrew PCBs
 
  * SEALIE RET-CUFROM [mapper 29]
+ * SEALIE DPCMcart [mapper 409]
  * SEALIE UNROM 512 [mapper 30]
 
  ***********************************************************************************************************/
@@ -32,11 +33,17 @@
 //-------------------------------------------------
 
 DEFINE_DEVICE_TYPE(NES_CUFROM,   nes_cufrom_device,   "nes_cufrom",   "NES Cart Sealie RET-CUFROM PCB")
+DEFINE_DEVICE_TYPE(NES_DPCMCART, nes_dpcmcart_device, "nes_dpcmcart", "NES Cart Sealie DPCMcart PCB")
 DEFINE_DEVICE_TYPE(NES_UNROM512, nes_unrom512_device, "nes_unrom512", "NES Cart Sealie UNROM 512 PCB")
 
 
 nes_cufrom_device::nes_cufrom_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_CUFROM, tag, owner, clock)
+{
+}
+
+nes_dpcmcart_device::nes_dpcmcart_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_nrom_device(mconfig, NES_DPCMCART, tag, owner, clock)
 {
 }
 
@@ -48,6 +55,13 @@ nes_unrom512_device::nes_unrom512_device(const machine_config &mconfig, const ch
 
 
 void nes_cufrom_device::pcb_reset()
+{
+	prg16_89ab(0);
+	prg16_cdef(m_prg_chunks - 1);
+	chr8(0, CHRRAM);
+}
+
+void nes_dpcmcart_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
@@ -91,6 +105,29 @@ void nes_cufrom_device::write_h(offs_t offset, u8 data)
 
 	prg16_89ab((data >> 2) & 0x07);
 	chr8(data & 0x03, CHRRAM);
+}
+
+/*-------------------------------------------------
+
+ Sealie DPCMcart board
+
+ Games: A Winner is You
+
+ This homebrew mapper supports a whopping 64MB which
+ is paged in 16K chucks at 0x8000. 0xc000 is fixed.
+
+ NES 2.0: mapper 409
+
+ In MAME: Partially supported.
+
+ TODO: Controls other than 'next track' don't work.
+
+ -------------------------------------------------*/
+
+void nes_dpcmcart_device::write_h(offs_t offset, u8 data)
+{
+	LOG_MMC(("dpcmcart write_h, offset: %04x, data: %02x\n", offset, data));
+	prg16_89ab(offset & 0x0fff);
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/nes/sealie.h
+++ b/src/devices/bus/nes/sealie.h
@@ -22,6 +22,20 @@ public:
 };
 
 
+// ======================> nes_dpcmcart_device
+
+class nes_dpcmcart_device : public nes_nrom_device
+{
+public:
+	// construction/destruction
+	nes_dpcmcart_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+	virtual void write_h(offs_t offset, u8 data) override;
+
+	virtual void pcb_reset() override;
+};
+
+
 // ======================> nes_unrom512_device
 
 class nes_unrom512_device : public nes_nrom_device
@@ -38,6 +52,7 @@ public:
 
 // device type definition
 DECLARE_DEVICE_TYPE(NES_CUFROM,   nes_cufrom_device)
+DECLARE_DEVICE_TYPE(NES_DPCMCART, nes_dpcmcart_device)
 DECLARE_DEVICE_TYPE(NES_UNROM512, nes_unrom512_device)
 
 #endif // MAME_BUS_NES_SEALIE_H


### PR DESCRIPTION
- Enabled support for NES 2.0 PRG chunks >= 64MB and CHR chunks >= 32MB.