### PR TITLE
util/delegate.cpp: Fixed multiple issues

### DIFF
--- a/src/lib/util/delegate.cpp
+++ b/src/lib/util/delegate.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Aaron Giles
+// copyright-holders:Aaron Giles,Vas Crabb
 /***************************************************************************
 
     delegate.cpp
@@ -23,6 +23,18 @@
 #define LOG(...) do { if (false) printf(__VA_ARGS__); } while (false)
 #endif
 
+// some architectures use function descriptor pointers
+// usually this is a global pointer value along with the branch target
+// other platforms using this convention include:
+// * AIX, Classic MacOS and WinNT on 32-bit POWER/PowerPC
+// * pretty much anything on Itanium
+#if (defined(__ppc64__) || (defined(__PPC64__))) && !defined(__APPLE__)
+#define MAME_DELEGATE_VT_DESCRIPTOR 1
+#endif
+#ifndef MAME_DELEGATE_VT_DESCRIPTOR
+#define MAME_DELEGATE_VT_DESCRIPTOR 0
+#endif
+
 
 namespace util::detail {
 
@@ -30,11 +42,7 @@ namespace util::detail {
 //  GLOBAL VARIABLES
 //**************************************************************************
 
-#if (USE_DELEGATE_TYPE == DELEGATE_TYPE_COMPATIBLE)
-
-const delegate_mfp::raw_mfp_data delegate_mfp::s_null_mfp = { { 0 } };
-
-#endif
+const delegate_mfp_compatible::raw_mfp_data delegate_mfp_compatible::s_null_mfp = { { 0 } };
 
 
 
@@ -42,46 +50,56 @@ const delegate_mfp::raw_mfp_data delegate_mfp::s_null_mfp = { { 0 } };
 //  INTERNAL DELEGATE HELPERS
 //**************************************************************************
 
-#if (USE_DELEGATE_TYPE == DELEGATE_TYPE_INTERNAL)
-
 //-------------------------------------------------
 //  delegate_convert_raw - given an object and an raw function, adjust the object base
 //  and return the actual final code pointer
 //-------------------------------------------------//
 
-delegate_generic_function delegate_mfp::convert_to_generic(delegate_generic_class *&object) const
+delegate_generic_function delegate_mfp_itanium::convert_to_generic(delegate_generic_class *&object) const
 {
-#if defined(__arm__) || defined(__ARMEL__) || defined(__aarch64__) || defined(__MIPSEL__) || defined(__mips_isa_rev) || defined(__mips64) || defined(__EMSCRIPTEN__)
-	if ((m_this_delta & 1) == 0)
+#if MAME_DELEGATE_ITANIUM_ARM
+	// apply the "this" delta to the object first - remember to shift right one bit position
+	object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object) + (m_this_delta >> 1));
+	if (!(m_this_delta & 1))
 	{
-		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(uintptr_t(m_function)));
-		object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object) + m_this_delta);
+		// if the low bit of the 'this' delta is clear, the pointer is a conventional function pointer
+		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(m_function));
 		return reinterpret_cast<delegate_generic_function>(m_function);
 	}
-	object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object));
-
-	// otherwise, it is the byte index into the vtable where the actual function lives
-	std::uint8_t *vtable_base = *reinterpret_cast<std::uint8_t **>(object);
-	LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void const *>(uintptr_t(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function + m_this_delta - 1))));
-	return *reinterpret_cast<delegate_generic_function *>(vtable_base + m_function + m_this_delta - 1);
-#else
+	else
+	{
+		// otherwise, it is the byte index into the vtable where the actual function lives
+		std::uint8_t const *const vtable_ptr = *reinterpret_cast<std::uint8_t const *const *>(object) + m_function;
+#if MAME_DELEGATE_VT_DESCRIPTOR
+		delegate_generic_function const result = reinterpret_cast<delegate_generic_function>(uintptr_t(vtable_ptr));
+#else // MAME_DELEGATE_VT_DESCRIPTOR
+		delegate_generic_function const result = *reinterpret_cast<delegate_generic_function const *>(vtable_ptr);
+#endif // MAME_DELEGATE_VT_DESCRIPTOR
+		LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void const *>(uintptr_t(result)));
+		return result;
+	}
+#else // MAME_DELEGATE_ITANIUM_ARM
 	// apply the "this" delta to the object first
 	object = reinterpret_cast<delegate_generic_class *>(reinterpret_cast<std::uint8_t *>(object) + m_this_delta);
-
-	// if the low bit of the vtable index is clear, then it is just a raw function pointer
 	if (!(m_function & 1))
 	{
-		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(uintptr_t(m_function)));
+		// if the low bit of the pointer is clear, then it is a conventional function pointer
+		LOG("Calculated Addr = %p\n", reinterpret_cast<void const *>(m_function));
 		return reinterpret_cast<delegate_generic_function>(m_function);
 	}
-
-	// otherwise, it is the byte index into the vtable where the actual function lives
-	std::uint8_t *vtable_base = *reinterpret_cast<std::uint8_t **>(object);
-	LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void *>(uintptr_t(*reinterpret_cast<delegate_generic_function *>(vtable_base + m_function - 1))));
-	return *reinterpret_cast<delegate_generic_function *>(vtable_base + m_function - 1);
-#endif
+	else
+	{
+		// otherwise, it is the byte index into the vtable where the actual function lives
+		std::uint8_t const *const vtable_ptr = *reinterpret_cast<std::uint8_t const *const *>(object) + m_function - 1;
+#if MAME_DELEGATE_VT_DESCRIPTOR
+		delegate_generic_function const result = reinterpret_cast<delegate_generic_function>(uintptr_t(vtable_ptr));
+#else // MAME_DELEGATE_VT_DESCRIPTOR
+		delegate_generic_function const result = *reinterpret_cast<delegate_generic_function const *>(vtable_ptr);
+#endif // MAME_DELEGATE_VT_DESCRIPTOR
+		LOG("Calculated Addr = %p (VTAB)\n", reinterpret_cast<void const *>(uintptr_t(result)));
+		return result;
+	}
+#endif // MAME_DELEGATE_ITANIUM_ARM
 }
-
-#endif
 
 } // namespace util::detail


### PR DESCRIPTION
* Fixed `this` pointer displacement being reapplied after delegates are copied – caused issues with classes with multiple inheritance.  Each time you assigned or copied a delegate containing a member function pointer with a non-zero `this` pointer displacement, the `this` pointer would walk into the weeds a bit more.  This did not affect “compatible” delegates, only the optimised versions.
* Made null member function pointer test conformant with Itanium C++ ABI specification.  The specification only requires that the pointer be a null function pointer for the “standard” variant, or that the pointer be a null function pointer and the least significant bit of the `this` pointer displacement be clear.  Previously, the pointer and entire `this` pointer displacement were being compared to zero.  This only affected the “internal” implementation.
* Corrected size of this pointer displacement – fixes issues on big Endian targets.  The `this` pointer displacement was being interpreted as an `int` rather than a `ptrdiff_t`.  This is not immediately obvious on little Endian platforms, because in practice, the value is never too large for the range of an `int`, and the least significant part of the value will be used.  However, on big Endian platforms, the most significant part of the value will be used, so it would always appear to be zero or negative one on big Endian targets with 32-bit `int` and 64-bit `ptrdiff_t` (e.g. PPC64, AArch64 or MIPS64 in big Endian mode).  This only affected the “internal” implementation.
* Fixed function addresses for virtual member functions on targets where function pointers point to descriptors (e.g. Linux PPC64, or Itanium).  On these platforms, vtables contain function descriptors, so you obtain a canonical function pointer just by adding the offset to the vptr.  This only affected the “internal” implementation.
* Applied shift to `this` pointer displacement for targets that use the ARM variant of the Itanium ABI.  On these platforms, the `this` pointer displacement is shifted left by one bit position to make space for the virtual function flag bit and must be arithmetically shifted to the right by one bit position before being applied to compensate.  This only affected the “internal” implementation.
* Fixed `this` pointer displacement not being applied for virtual member functions on targets using ARM variant of the Itanium ABI.  The `this` pointer displacement must be applied before fetching the vptr on these platforms.  Previously it was not applied to the `this` pointer at all for virtual member functions.  This only affected the “internal” implementation.
* Fixed `this` pointer displacement being incorrectly applied to the vptr on targets using the ARM variant of the Itanium ABI.  The `this` pointer displacement was being erroneously applied to the vptr when obtaining a virtual member function address.  This only affected the “internal” implementation.
* Renamed the “internal” implementation to “Itanium” as it works with two variants of the [Itanium C++ ABI](https://itanium-cxx-abi.github.io/cxx-abi/abi.html#member-pointers).
* Added support for “unknown inheritance” pointers in MSVC implementation.  This allows delegates to work when MSVC is invoked with the `/vmg` option.
* Renamed most macros to have a `MAME_DELEGATE_` prefix for crude namespacing, and made less code conditionally compiled.  All the member function pointer wrappers are now compiled all the time, and the appropriate one is selected with a type alias.  This makes it easier to catch errors without needing to recompile for multiple targets.