### PR TITLE
added tzx to the sc-3000 formats

### DIFF
--- a/src/lib/formats/sc3000_bit.cpp
+++ b/src/lib/formats/sc3000_bit.cpp
@@ -9,6 +9,7 @@
 *********************************************************************/
 
 #include "sc3000_bit.h"
+#include "tzx_cas.h"
 
 
 /***************************************************************************
@@ -98,4 +99,5 @@ const cassette_image::Format sc3000_bit_format =
 
 CASSETTE_FORMATLIST_START( sc3000_cassette_formats )
 	CASSETTE_FORMAT(sc3000_bit_format)
+	CASSETTE_FORMAT(tzx_cassette_format)
 CASSETTE_FORMATLIST_END


### PR DESCRIPTION
Much of the SC-3000 tape software library cannot be encoded with the .bit format, while it can be easily encoded using tzx. Problem discussed here.
https://www.smspower.org/forums/15470-SC3000TapeSoftwareRestorationProject