### PR TITLE
fmtowns_cd.xml: 16 new dumps, 7 replacements, add missing floppies

### DIFF
--- a/hash/fmtowns_cd.xml
+++ b/hash/fmtowns_cd.xml
@@ -27,7 +27,6 @@ Aesop World Dai-2-shuu (Denshi Ehon)                          Fujitsu           
 Aishuu to Netsujou no Chouwa                                  Fujitsu                           1995/4     CD
 Alice in Wonderland                                           DynEd Japan                       1993/3     SET(CD+FD)
 Akiko Gold                                                    Fairytale (Red Zone)              1995/1     SET(CD+FD)
-* Amaranth III                                                Fuga System                       1994/11    SET(CD+FD)
 Amour Ver. 1.0                                                Kozu System                       1989/11    SET(CD+FD)
 AniVox Eiken 3-4-kyuu Hatsuon-Accent Ban                      Unity                             1992/6     SET(CD+FD)
 Anne no Tea Party                                             Dennou Shoukai                    1993/6     CD
@@ -66,7 +65,6 @@ City Lights                                                   Raison            
 ClearMind: Shimoguchi Yuuzan no Shuuchuuryoku Kaihatsu        CSK Research Institute (CRI)      1989/8     CD
 Config Rom                                                    Glams                             1995/12    CD
 * Crayonnage                                                  CSK Research Institute (CRI)      1991/8     SET(CD+FD)
-CRI Postman                                                   CSK Research Institute (CRI)      1990/3     CD
 CRI StacCard                                                  CSK Research Institute (CRI)      1991/5     SET(CD+FD)
 Cutie Queen                                                   Crystal Eizou                     1995/2     CD
 CyberSculpt (HMC-140)                                         Fujitsu                           1991/11    CD
@@ -109,12 +107,12 @@ Dynamic English 1A Pack                                       DynEd Japan       
 Dynamic English 1B Pack                                       DynEd Japan                       1991/5     SET(CD+FD)
 Dynamic English 1B Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
 Dynamic English 1C Pack                                       DynEd Japan                       1991/6     SET(CD+FD)
-Dynamic English 2A Pack                                       DynEd Japan                       1991/7     SET(CD+FD)
+* Dynamic English 2A Pack                                     DynEd Japan                       1991/7     SET(CD+FD)
 Dynamic English 2A Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
 Dynamic English 2B Pack                                       DynEd Japan                       1991/7     SET(CD+FD)
 Dynamic English 2B Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
 Dynamic English 2C Pack                                       DynEd Japan                       1991/7     SET(CD+FD)
-Dynamic English 3A Pack                                       DynEd Japan                       1991/10    SET(CD+FD)
+* Dynamic English 3A Pack                                     DynEd Japan                       1991/10    SET(CD+FD)
 Dynamic English 3A Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
 Dynamic English 3B Pack                                       DynEd Japan                       1991/10    SET(CD+FD)
 Dynamic English 3B Pack                                       DynEd Japan                       1994/4     SET(CD+FD)
@@ -147,7 +145,6 @@ FM Towns Appli Jikkou Set                                     Fujitsu           
 FM Towns de Manabu School-Ace Alpha                           Fujitsu                           1993/4     CD
 FM Towns Free Ware Collection (EYE COM-ban)                   Fujitsu                           1989/11    CD
 FM Towns Paso-Rika Ver. 3                                     Maris                             1993/11    CD
-FM Towns Shougaku Ongaku (5-6-nensei You)                     Kyouiku Shuppan                   1991/5     SET(CD+FD)
 FM Towns-ban Dyna-pers                                        Dynaware                          1989/12    CD
 * Fujitsu Habitat V1.1                                        Fujitsu                           1990/1     SET(CD+FD)
 Fujitsu Habitat V2.1 L11                                      Fujitsu                           1994/?     SET(CD+FD)
@@ -196,8 +193,6 @@ HomeSTUDIO V1.1                                               Fujitsu           
 Hot de Art na Barcelona                                       Media Art                         1991/9     CD
 Hyoutan Shima Kouryaku-ki                                     Nihon Dennou Koubou               1994/?     ?
 * Hyper Address Ver. 2.0                                      Datt Japan                        1991/4     SET(CD+FD)
-Hyper Aquarium Kaisui-hen                                     Inter Limited Logic               1992/4     CD
-Hyper Aquarium Tansui-hen                                     Inter Limited Logic               1992/1     CD
 Hyper Asobi Meijin                                            Corpus                            1989/11    SET(CD+FD)
 Hyper Asobi Meijin 2                                          Corpus                            1991/11    SET(CD+FD)
 Hyper Chuugokugo Nyuumon-hen (Ge) Pekingo Gengakuin-hen       SofMedia                          1991/3     CD
@@ -228,7 +223,6 @@ Hyper Planet Shiki Vol. 3: Uraraka na Haru no Seiza Hen       Datt Japan        
 Hyper Planet Shiki Vol. 4: Fukamari Yuku Aki no Seiza Hen     Datt Japan                        1994/11    CD
 Hyper Touhouku Kikou                                          Nanken Koubou                     1991/12    SET(CD+FD)
 Hyper Wide Ban Rekishi Shiryoushuu                            Shingakusha                       1993/7     CD
-Igo Doujou Yaburi: Menkyo Kaiden!! Mezase 7-kyuu              Fujitsu OA                        1990/10    CD
 Image Art System                                              Raison                            1990/6     CD
 Image Art System Pro                                          Raison                            1990/8     CD
 Interactive Business English 1                                DynEd Japan                       1992/7     SET(CD+FD)
@@ -239,7 +233,6 @@ Interactive Business English 5                                DynEd Japan       
 Interactive Business English 6                                DynEd Japan                       1992/7     SET(CD+FD)
 Iwanami Bungakukan: Natsume Souseki                           Iwanami Shoten                    1994/2     CD
 Iwanami Denshi Nihon Sougou Nendo CD-ROM                      Fujitsu                           1993/10    CD
-J.League Professional Soccer 1994                             Victor Entertainment              1994/9     CD
 JAF Drive Guide                                               JAF Shuppansha                    1990/8     SET(CD+FD)
 JAF Drive Guide - Best Ski 150 (Resort-hen)                   JAF Shuppansha                    1990/12    SET(CD+FD)
 JAF Drive Guide (Ver. 2)                                      JAF Shuppansha                    1992/2     SET(CD+FD)
@@ -325,7 +318,6 @@ Nazoraa 5-nen                                                 Infortech         
 Nazoraa 6-nen                                                 Infortech                         1993/4     SET(CD+FD)
 New Century Eiwa                                              Fujitsu                           1990/5     CD
 New Century Eiwa / Shin Crown Waei Jiten                      Fujitsu                           1993/11    CD
-New Crown 1-nen                                               Uchida Youkou                     1993/8     CD
 New Horizon CD Learning System 2 2-nen                        Tokyo Shoseki                     1993/5     CD
 New Horizon CD Learning System 2 3-nen                        Tokyo Shoseki                     1993/5     CD
 New Horizon CD Running System 1-nen                           Tokyo Shoseki                     1990/7     SET(CD+FD)
@@ -341,13 +333,11 @@ Nihon no Chou (Marty-compatible)                              Fujitsu Social Sci
 Nihon no Kaisuigyo                                            Inter Limited Logic               1995/10    CD
 Nihon no Kusabana                                             Fujitsu Social Science Laboratory 1997/10    CD
 Nihon no Rekishi 4-hen Set                                    Uchida Youkou                     1993/8     CD×04
-Nihon no Rekishi: Sengoku-hen                                 CSK Research Institute (CRI)      1990/6     CD
 Nihon no Tansuigyo                                            Inter Limited Logic               1995/12    CD
 Nihon no Tenki                                                Uchida Youkou                     1992/9     CD
 Nihon no Tori 1994                                            Inter Limited Logic               1995/6     CD
 Nihon Rettou Kumitate Daizukan                                Digital Media                     1993/8     CD
 Nihongo MS Windows V3.0 with Multimedia Extensions V1.0       Fujitsu                           1992/11    SET(CD+FD)
-Nihongo Nyuumon Dai-1-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-2-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-3-kan                                     Infortech                         1991/4     CD
 Nihongo Nyuumon Dai-4-kan                                     Infortech                         1991/4     CD
@@ -414,7 +404,6 @@ Soudai Naru Jokyoku no Doyomeki                               Fujitsu           
 Speed Eiyou Check                                             Top Business System               1992/4     CD
 Speed Eiyou Check (?)                                         Top Business System               1992/4     SET(CD+FD)
 Star Wars: Rebel Assault                                      Victor Entertainment              1994/9     CD
-Steepia                                                       Fujitsu                           1993/6     CD
 Stingo Monogatari ST-1: Stingo to Gohoubi no Ki               Technos Yashima                   1995/1     CD
 Stingo Monogatari ST-2: Stingo no Atarashii Otomodachi        Technos Yashima                   1995/1     CD
 Stingo Monogatari ST-3: Stingo Umi ni Iku                     Technos Yashima                   1995/1     CD
@@ -448,7 +437,6 @@ The Yachtman                                                  Raison            
 Think Read: Chuugaku Series                                   Catena                            ?          SET(CD+FD)
 Think Read: Shougaku Series                                   Catena                            ?          SET(CD+FD)
 Total English 1-nen                                           Uchida Youkou                     1993/9     CD
-Touch the Music by Casiopea                                   Fujitsu                           1994/3     SET(CD+FD)
 * Toukyou Genshikai - Tokyo Sexy Ave.                         HOP                               1994/7     SET(CD+FD)
 Towns Amone                                                   Kozu System                       1990/4     SET(CD+FD)
 Towns Chiri Shizen no Naritachi                               Fujitsu Ooita Software Laboratory 1991/9     CD
@@ -461,7 +449,6 @@ Towns Magazine for School Vol. 2                              Fujitsu           
 Towns Magazine for School Vol. 3                              Fujitsu                           ?          CD
 Towns Magazine for School Vol. 4                              Fujitsu                           ?          CD
 Towns Meikyoku Master                                         Fujitsu Ooita Software Laboratory 1991/9     CD
-Towns Meikyoku Master (Marty-compatible)                      Fujitsu Ooita Software Laboratory 1993/3     CD
 Towns Spirit                                                  Uchida Youkou                     1993/4     CD
 Towns Spirit                                                  Uchida Youkou                     1993/4     CD
 TownsFullcolor V1.1                                           Fujitsu                           1993/3     CD
@@ -655,11 +642,30 @@ User/save disks that can be created from the game itself are not included.
 		<description>Master CD - Install Model-you</description>
 		<year>1994</year>
 		<publisher>富士通 (Fujitsu)</publisher>
-		<info name="alt_title" value="Master CD （インストールモデル用）" />
+		<info name="alt_title" value="Ｍａｓｔｅｒ　ＣＤ　（インストールモデル用）" />
 		<info name="usage" value="Run DO.BAT from the command line" />
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="master cd - install model-you (japan)" sha1="d079314ee10e0e21933b839d8387d51d8b54c602" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- This seems to be an updated version of the other master CD that includes more software -->
+	<software name="mastercd2">
+		<!--
+		Origin: redump.org
+		<rom name="Master CD - Fresh Series-you (Japan).bin" size="497426832" crc="1614d6de" sha1="faa8cd1236554ec8a77d90c3d9631180f9c970d9"/>
+		<rom name="Master CD - Fresh Series-you (Japan).cue" size="102" crc="38f24ae6" sha1="66f7208f101b735d4bcc0aef487624f0675ee26e"/>
+		 -->
+		<description>Master CD - Fresh Series-you</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="alt_title" value="Ｍａｓｔｅｒ　ＣＤ　（Ｆｒｅｓｈシリーズ用）" />
+		<info name="usage" value="Run DO.BAT from the command line" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="master cd - fresh series-you (japan)" sha1="4a3a0ad499a8bc2f77b7af44a8ef78f51b5a52d9" />
 			</diskarea>
 		</part>
 	</software>
@@ -2419,10 +2425,10 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Includes a floppy disk that is currently undumped. The game boots without it, but it's unclear if it can save. -->
+	<!-- The floppy disk is bootable and the files are slightly newer than the CD, probably meant as a last-minute patch for the game -->
 	<software name="amarant3">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / akira_2020 (floppy)
 		<rom name="Amaranth III (Japan).bin" size="15273888" crc="51e8352b" sha1="e7a686d8515506e8e3f3ce3d662f6ad616eaf1b0"/>
 		<rom name="Amaranth III (Japan).cue" size="86" crc="5c24fa31" sha1="f6fc63c2d018cf353636725295342a154014d075"/>
 		-->
@@ -2432,6 +2438,12 @@ User/save disks that can be created from the game itself are not included.
 		<info name="serial" value="MTC-1111"/>
 		<info name="alt_title" value="アマランスIII" />
 		<info name="release" value="199411xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Kidou / Save Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="amaranth_iii.hdm" size="1261568" crc="05955c2f" sha1="dd81ce76b439af9b93f7c524dce4dab12c31e728" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="amaranth iii (japan)" sha1="70f1d4340f71b53e0aeedb263e60b98f59538407" />
@@ -4044,7 +4056,7 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="calxpart">
 		<!--
-		Origin: redump.org (CD) / al32gabby (floppy)
+		Origin: redump.org (CD) / verified from multiple sources (floppy)
 		<rom name="California X Party - Joshi Daisei Himitsu Club (Japan).bin" size="634687200" crc="3f4541f7" sha1="272750c47a91bc69c716b8aa09983cdf7bb76048"/>
 		<rom name="California X Party - Joshi Daisei Himitsu Club (Japan).cue" size="120" crc="070f75ff" sha1="f7665700c0a1ccd31b31f602040c56dc4ad99652"/>
 		-->
@@ -6372,6 +6384,55 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dungeon master ii - skullkeep (japan)" sha1="39c047d39140b49fab30c216c0edd2ec45e4041b" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing a floppy disk and the second CD -->
+	<software name="dyneng2b" supported="no">
+		<!--
+		Origin: redump.org
+		<rom name="Dynamic English 2 - Basic (Japan) (Disc 1) (Track 1).bin" size="20109600" crc="19443663" sha1="baa737677914578c9f36fe87a9f996be319c8d02"/>
+		<rom name="Dynamic English 2 - Basic (Japan) (Disc 1) (Track 2).bin" size="762753600" crc="c9a2efdc" sha1="f274614fcbcdd5bd058656b290cdc47090279479"/>
+		<rom name="Dynamic English 2 - Basic (Japan) (Disc 1).cue" size="254" crc="c740f078" sha1="ff0027d4ce226243a05e025829393d0698cdc552"/>
+		-->
+		<description>Dynamic English 2 - Basic</description>
+		<year>1991</year>
+		<publisher>ダインエドジャパン (DynEd Japan)</publisher>
+		<info name="serial" value="CDAC 008000"/>
+		<info name="alt_title" value="ダイナミック　イングリッシュ　２　（基礎）" />
+		<info name="release" value="199107xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="dynamic english 2 - basic (japan) (disc 1)" sha1="70306cc6c13c2100fcec2fda629e95073b738dff" />
+			</diskarea>
+		</part>
+	</software>
+
+	<!-- Missing the second CD -->
+	<software name="dyneng3ub" supported="partial">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Dynamic English 3 - Upper Basic (Japan) (Disc 1) (Version 1.0) (Track 1).bin" size="20109600" crc="b10ff20f" sha1="0b76828619ed37fceade9d124191a3431be14efd"/>
+		<rom name="Dynamic English 3 - Upper Basic (Japan) (Disc 1) (Version 1.0) (Track 2).bin" size="762753600" crc="77216819" sha1="2596199c6ee7df15e25201f197e72173acde0ba7"/>
+		<rom name="Dynamic English 3 - Upper Basic (Japan) (Disc 1) (Version 1.0).cue" size="294" crc="036318ed" sha1="c0641e63804964838480a680adad3bdda04e01be"/>
+		-->
+		<description>Dynamic English 3 - Upper Basic</description>
+		<year>1991</year>
+		<publisher>ダインエドジャパン (DynEd Japan)</publisher>
+		<info name="serial" value="FDE-34 / CDAC 009701"/>
+		<info name="alt_title" value="ダイナミック　イングリッシュ　３　（上級基礎）" />
+		<info name="release" value="199110xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="dynamic_english_3_upper_basic.hdm" size="1261568" crc="e1a17802" sha1="e68855807a82dfa02c09aeed3fdc67f9096092ce" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="dynamic english 3 - upper basic (japan) (disc 1) (version 1.0)" sha1="0c50213706c1508dbc7d6e63d8371faefc9fd80e" />
 			</diskarea>
 		</part>
 	</software>
@@ -10430,32 +10491,99 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- These CDs are probably supposed to be self-bootable but they are missing the IPL sector. Marked as bad dumps until they are redumped. -->
 	<software name="highlt20">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Highlight CD 20 (Disc 1).ccd" size="5478" crc="bd7bc4d7" sha1="2b8773d97ec2803ef8688286a26b5eeeba807609"/>
-		<rom name="Highlight CD 20 (Disc 1).cue" size="2026" crc="f2b48b64" sha1="d144fb1ac862470dfde66842f51edbc409f3b68a"/>
-		<rom name="Highlight CD 20 (Disc 1).img" size="691664400" crc="e95a1518" sha1="0ed7aad0a968c0bd47fea87d70871bfeb6347dc2"/>
-		<rom name="Highlight CD 20 (Disc 1).sub" size="28231200" crc="ebd9485f" sha1="c100dfa6bb6cf861fcad77f93260c62ebb439c2c"/>
+		Origin: redump.org
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 01).bin" size="115542000" crc="11cacbb9" sha1="99ae239f7b79001ad891b0085b5186eef3c37e92"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 02).bin" size="1764000" crc="f735f191" sha1="408d2bd2e89e93c256d43e8f2112744ec94cb6a8"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 03).bin" size="1764000" crc="00793be7" sha1="d5649c227c09b1a7369bf50f6f95c1582b23b42a"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 04).bin" size="8467200" crc="51fe1fa3" sha1="ba53f8b20224496d6d6e8d7e1135df284bd83a21"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 05).bin" size="17287200" crc="9275a27d" sha1="b31f9ecd33f23a95d70dec64f9185c5cd2cd7b69"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 06).bin" size="7408800" crc="c8d33305" sha1="af3444474cd8dbd1af098f3bd96b9edc4a8a9170"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 07).bin" size="21344400" crc="421566cd" sha1="7c845dc61a9ef8509365611958c462292bf80a25"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 08).bin" size="10584000" crc="483a10d2" sha1="80b1615b196e44209bdf1e47ed194ab46d8a3fc3"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 09).bin" size="12348000" crc="cc458b30" sha1="66289871bc2388fdbe3ea65350ca9b51a78e1190"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 10).bin" size="17463600" crc="c443164e" sha1="3e1462461d222015b1cda879fefc922a9703e083"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 11).bin" size="4856880" crc="80f631c8" sha1="3424491c8ca165b3852b781bdcfd6b9afaa044c8"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 12).bin" size="8996400" crc="299bcf9d" sha1="bb44d57e1d2b81edb42dc9e9b6b3220aea94fa3e"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 13).bin" size="11642400" crc="d05cba90" sha1="46cd86f50938411cd757e5f0a4f2eba42f42b4ee"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 14).bin" size="8725920" crc="e1956c54" sha1="5253cb085779e737c6b208bfecca1b07969d8e45"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 15).bin" size="1058400" crc="58ebbecc" sha1="4431db7e7812b52780a90a310d69e7c46fce8f0e"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 16).bin" size="10936800" crc="787f9196" sha1="200da402aa5844492eef717b4fdce61647b4d753"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 17).bin" size="94374000" crc="79c9dd4f" sha1="8056c5826546e5bb3a4d1c93adfdf61c72c1d752"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 18).bin" size="6809040" crc="10d27bbb" sha1="0de944f1445332742350c73b83ae1956e602bfb4"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 19).bin" size="23150736" crc="358f64cc" sha1="779d32f84a94bb68ab572f588bd74eb4348ebe99"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 20).bin" size="10435824" crc="967982c8" sha1="f6d67e10668632230310772cfa090eed36b10fdf"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 21).bin" size="16758000" crc="67cd289b" sha1="f0852a80cbced196aad61a876558891605d233fa"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 22).bin" size="5997600" crc="12260ed6" sha1="0b8859678066cb7c87c00788ec7674d319f77a50"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 23).bin" size="31928400" crc="ae34d5ca" sha1="54a533ab30fb56e15a3bbc4685eed6301837b49f"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 24).bin" size="31752000" crc="027e0652" sha1="695bafd43b676aca4f4b8892b73fefa0365c8b57"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 25).bin" size="5644800" crc="4aa1f852" sha1="78325b2eeb8c226fac4aff39b52647aaf3fdf109"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 26).bin" size="47980800" crc="f38fc867" sha1="226b62e5649493d80859575b65f4f041834b6c97"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 27).bin" size="63680400" crc="2e5750ae" sha1="0124c562dee8737112b11c8a2c6d31e764fcac75"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 28).bin" size="8932896" crc="ff619918" sha1="e7b6c979084c0153b191655c85d05319e5a21979"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 29).bin" size="16473408" crc="cf88bd28" sha1="b0b1596e3849034ea5cfae415a80cf269bb8e380"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 30).bin" size="15612576" crc="7bc1d4fb" sha1="58ede60ed71de0935661d4120f4a3c23e99b76a2"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1) (Track 31).bin" size="51943920" crc="756cd12d" sha1="ba8f2003a4983b6cbd4e1ccb966a0c4d39d812c7"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 1).cue" size="3919" crc="c4a61120" sha1="55c1cff99e8ea35d75a4f1671c42e50da958912b"/>
 
-		<rom name="Highlight CD 20 (Disc 2).ccd" size="7090" crc="85d224a6" sha1="2c9c79a63a1c793b7aa2d7296477239670b4cc54"/>
-		<rom name="Highlight CD 20 (Disc 2).cue" size="2666" crc="f44303c5" sha1="7243db079e678d8e55b439b8c284282a1771b23f"/>
-		<rom name="Highlight CD 20 (Disc 2).img" size="623750400" crc="7bc5ec07" sha1="44573f4b1ae8e3e2f8a9ec1fc8ec7c6dd2657727"/>
-		<rom name="Highlight CD 20 (Disc 2).sub" size="25459200" crc="14817dc8" sha1="2b5a4dc5b1aa53aa5dab10ea56052b9d86ab0b4a"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 01).bin" size="253834896" crc="25343efc" sha1="532911d28ac6f5939af5188c6e10a8506dd3b5be"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 02).bin" size="3901968" crc="081ff88b" sha1="0f626ba5ea3e265404d95338718481d08d35560e"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 03).bin" size="7408800" crc="431ac0b4" sha1="40a64b949eb433e9b45c85f372e520fd9e3e1246"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 04).bin" size="1361808" crc="ea356f69" sha1="700d78d47e3cf23a25b584f43659de46b037a8fd"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 05).bin" size="18865392" crc="c24b43ad" sha1="ae122eb7925c54a0092e1bf5c6b91c52bd911a26"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 06).bin" size="18863040" crc="99872129" sha1="601b204ad82ace79da04bca4bb02c2acb4d9dec5"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 07).bin" size="1361808" crc="3573d4c2" sha1="49ab87b4fd2c22a8a348bf9a37b3259e5f91d869"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 08).bin" size="1361808" crc="c1bae318" sha1="bfc39ecac0ece070c5b48b90eb973a53a9b9cbff"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 09).bin" size="1361808" crc="4daccfe7" sha1="9a3033e31e9b87eb34336b00ceadad8cd1f090c7"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 10).bin" size="1361808" crc="f28a4450" sha1="47d266c7201b24ed6345d8caa5bf149524d8233f"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 11).bin" size="1361808" crc="cd56ba6d" sha1="b5073b64af2c0ab682189d58b03bdd0eedd1c568"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 12).bin" size="1361808" crc="058d81bd" sha1="e0193d5852c024445688981e7dd7f308f8e28b04"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 13).bin" size="1361808" crc="f03abdd7" sha1="2af93b076dc2547776a22aef6be0e97fae321aea"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 14).bin" size="1361808" crc="e9b6802d" sha1="9cb28ae394366851ca1f71225325f9a1df9737f5"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 15).bin" size="28572096" crc="f3db108d" sha1="2ed4059acc0ddf697c80bb3614d6fd93617814c1"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 16).bin" size="1361808" crc="eb7d255f" sha1="044f7f419551027d6a609855ef78431b43295779"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 17).bin" size="1361808" crc="cd85e295" sha1="1d9d28b7fe1a6fb55763cfb6840d52e783ac37da"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 18).bin" size="1361808" crc="72c029ca" sha1="db40b7a44cb23ed5ea67790fc05449321069eeaf"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 19).bin" size="1361808" crc="b8f423a1" sha1="69079660dbea133e2ed2586a572834d049791fd3"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 20).bin" size="1361808" crc="d06f8466" sha1="bfd14d9928047f77ac77d7582a1610f7e90b4a55"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 21).bin" size="1361808" crc="8ef547c8" sha1="95f0078945d456c68e8bc4717ad81f056dd49f55"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 22).bin" size="1361808" crc="c25cce6a" sha1="8b7697897edba92e16682e3edbc7bd318e663e91"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 23).bin" size="1361808" crc="2eab16ac" sha1="cf6045e4c53afa508149c9698a3fec1e040248ff"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 24).bin" size="1168944" crc="53a0ccd0" sha1="1946289975b09478e517d7747a0c495249bfd68a"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 25).bin" size="1168944" crc="49b48e85" sha1="9d1d7ec40eb4bc2e4d20d11fad3096d22ff9f89e"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 26).bin" size="1168944" crc="3e099e2b" sha1="4c3d127a690e2057948cca7618a58c1cefc15fc1"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 27).bin" size="1509984" crc="31c8673f" sha1="a483f79e2e15a10fe244510fb276e7ba3cb6dc04"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 28).bin" size="1168944" crc="e2e16f28" sha1="cfd2e01e25e076fdd2938e75e38eede1f201b855"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 29).bin" size="1168944" crc="b8365384" sha1="9bf8bae1488f859f607acaf280229b492365bab1"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 30).bin" size="1166592" crc="c5357bc3" sha1="2b9acaa643d48eba06a942d066cc091301d0927c"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 31).bin" size="6562080" crc="91a469b1" sha1="2ae5f8d88b5f762abf8af3109bb6fbeca4f962ad"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 32).bin" size="53802000" crc="b3efc1d5" sha1="bc80878fee728ebbe194f769f0a8d4385b9c9725"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 33).bin" size="7251216" crc="8c1b456f" sha1="0a7eb906893cc080ca041d4ec771567b15b86510"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 34).bin" size="3363360" crc="ca662fc4" sha1="d15eb1da9801e9a6ba1fd5d52405b7f12004ff71"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 35).bin" size="10654560" crc="71d49246" sha1="970c1d898029a225953116f28e8c82dc0e011c4c"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 36).bin" size="10007760" crc="b829d452" sha1="1c13fbf74a9695f18973ceeb9f9f88c1e32402b3"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 37).bin" size="70383600" crc="91933cf8" sha1="77a2f43d2704f03795f191c02765b84f9a1cdd1c"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 38).bin" size="12348000" crc="89a44c94" sha1="2b3c6b22769c970ca8ce100872d958d5d7dee7ef"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 39).bin" size="40219200" crc="fef448fa" sha1="d7201bf386007c55d7ebcbf6159542be416fe8a3"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 40).bin" size="12877200" crc="519bff02" sha1="74c379136fcc5e91610da8340c8dc81c435aa35f"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2) (Track 41).bin" size="33163200" crc="a3930720" sha1="391312ce1fe9ffbb90e3955b58e035d06e0ae0b2"/>
+		<rom name="Highlight CD 20 (Japan) (Disc 2).cue" size="5189" crc="3f3b596d" sha1="6ef6fdabc58506bb57098029a23a837f97befcc8"/>
 		-->
 		<description>Highlight CD 20</description>
 		<year>1993</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-924-1 / HME-924-2"/>
+		<info name="alt_title" value="ハイライトＣＤ２０" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="highlight cd 20 (disc 1)" sha1="50be2720db6e121f744d12641a09168a80e330b5" status="baddump" />
+				<disk name="highlight cd 20 (disc 1)" sha1="a0ef91dca608cbc40207b2e84ccdec862de949eb" />
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="highlight cd 20 (disc 2)" sha1="b7251d8531bf3a18e32beec3e9d836de203052ac" status="baddump" />
+				<disk name="highlight cd 20 (disc 2)" sha1="955cf09e0e6789cc24eb804622513313ff92a310" />
 			</diskarea>
 		</part>
 	</software>
@@ -10657,6 +10785,112 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hoshi no suna monogatari 3 (japan)" sha1="f1e43060237558610d7f924e6c0d8fc4ff5ed39f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hypaquak">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 01).bin" size="497095200" crc="b21fefd2" sha1="4c2f08aa6516782cde42059e3bc2aab1809f6708"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 02).bin" size="352800" crc="7abe247f" sha1="cbe29e0bd725ef1194f8c47619dd42078e841de2"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 03).bin" size="15346800" crc="b5b4581f" sha1="bf9ef01e7ecf9016dea846ebf3840058458b023b"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 04).bin" size="20815200" crc="f60ce7ab" sha1="b42d8b40ad0807b5f2182cbbd643f5d3a7511aa7"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 05).bin" size="176400" crc="769282bb" sha1="a729763f6ca2b4a559a1eddf61b92d28fb78edc4"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 06).bin" size="5468400" crc="2dbe3658" sha1="789d063c83e5d1dbbb3fb8db29e9e3fd17408d21"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 07).bin" size="9702000" crc="ccf13942" sha1="bcc1465eb14671561da596c7126377d3bfd4c344"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 08).bin" size="7585200" crc="803eef10" sha1="1abed3a6e6d410718c89a5fb275bacc36c284cc3"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 09).bin" size="4410000" crc="c61a1eb8" sha1="af21713cd0a4da19d8b43afe1938d5ff6429f901"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 10).bin" size="6350400" crc="13719e0c" sha1="ddaaa253eb96165be7d29b13fbb4284941638e00"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 11).bin" size="7585200" crc="96403b24" sha1="7f69fe3110107c8cb0ba88bd2caa9fe460b2f47a"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 12).bin" size="8820000" crc="6d0704b6" sha1="eee0265414f88cd27f421b0d2b48c1723ae34d16"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 13).bin" size="4586400" crc="97636088" sha1="31935cbc655b92b4d146f91bdc4347728c243b5a"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 14).bin" size="6350400" crc="86c170c9" sha1="a46dcab8d6243d7310908f5fdf7c7b3eb4bd9254"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 15).bin" size="10054800" crc="e457f6d9" sha1="f72773222feb3b7d653fd588f13306b65d887d5c"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 16).bin" size="4939200" crc="1245de2b" sha1="b858d44c3103750bf5d80225922767b9cab15abe"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 17).bin" size="10936800" crc="7ea13f16" sha1="a78241615126e380edb00955ed35ded040b28a06"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 18).bin" size="6703200" crc="02e0995a" sha1="b5f49465f9b4de7e9f2a6ae676791fcf86060300"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 19).bin" size="7056000" crc="87abce42" sha1="de953fe60459e25000bfaa17a473a58414771b13"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 20).bin" size="9349200" crc="29950d2c" sha1="9cc1ed45a6db54fb9cd702cd4ebdb3fbcac47e4a"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 21).bin" size="4410000" crc="e3bc7427" sha1="d53a17cf8da03375f0a36691ef2beb4c061c8efc"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 22).bin" size="6879600" crc="fdf53d86" sha1="7e9bc0334f3601e52e33a242588d4aa0810aad97"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 23).bin" size="6350400" crc="98ab092f" sha1="36073c66213732922620871e74a99e3b4c548023"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 24).bin" size="8643600" crc="b3b46a17" sha1="57d9c8aadb0589b50e9e8edeb7e4e31414ea2532"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 25).bin" size="4586400" crc="e97737b1" sha1="0ed0aa5e15d6f192458aa0ee48b8057eb55bd817"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 26).bin" size="5997600" crc="6954fd69" sha1="53cd7024baf4475af9e5eb255b2ae32181fb25e9"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 27).bin" size="4939200" crc="e9b6e697" sha1="8b55e6aad653eb1dde427e13cb5c9827ced55f38"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 28).bin" size="8996400" crc="5cfdc56b" sha1="7c63b493cdc238c7158d2b956ed1ede4ba7ae947"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 29).bin" size="5997600" crc="eeb9e211" sha1="9a9b7c41d842216adc8e22a766f10c0e8c698fdf"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan) (Track 30).bin" size="6350400" crc="9501b6bc" sha1="5aaf6b030766e22c40496d5d439ce95fa26dd6aa"/>
+		<rom name="Hyper Aquarium - Kaisui-hen (Japan).cue" size="3813" crc="b8f70e56" sha1="d14e6f1b009bb7054e5009d9e0052ae25aa76785"/>
+		-->
+		<description>Hyper Aquarium - Kaisui-hen</description>
+		<year>1992</year>
+		<publisher>インターリミテッドロジック (Inter Limited Logic)</publisher>
+		<info name="serial" value="HMD-127"/>
+		<info name="alt_title" value="ハイパー・アクアリウム　【海水編】" />
+		<info name="release" value="199204xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper aquarium - kaisui-hen (japan)" sha1="c6b705c9f8e81aaea49e8eb4c3060cd2b388b62a" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="hypaquat">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 01).bin" size="370087200" crc="74332525" sha1="cd3f8875d1b7ef402a09e6d0d2832245115f1515"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 02).bin" size="23284800" crc="1402b419" sha1="f5dbccc3782e80b547c64c6d7eefa4240162278d"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 03).bin" size="15346800" crc="5655a90f" sha1="7b6c041161ab70b481d0bf83a292247e1dfc2b13"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 04).bin" size="28224000" crc="c9cf6686" sha1="e8b04da0a7cb24a281870a4adcc73f11af789797"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 05).bin" size="21168000" crc="df24f75f" sha1="556fd920630310046d397041671c1fedd2882704"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 06).bin" size="11113200" crc="5e70cd04" sha1="1d9c982c6f799e5ee0b224aac0714c54d897c6c4"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 07).bin" size="5644800" crc="584bd89a" sha1="3eeff6661c4d9d04f466e67ffa7b7a2446d0c553"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 08).bin" size="5997600" crc="88cc12f9" sha1="709ee61ef7e5170178df5f63e22d0d10443fb343"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 09).bin" size="6174000" crc="ffddff87" sha1="3332a9c71f06f2359cd9eb5e16dda2083f12b280"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 10).bin" size="5468400" crc="7c344179" sha1="02b5e1932c0db4042fe35abdb1300ad2e199dc1e"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 11).bin" size="7056000" crc="ade80a58" sha1="c53ec5f93cf40c109e8dba8e2e3e786997b89bc3"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 12).bin" size="5468400" crc="527341ee" sha1="2a045843a4a619f600e83e0ead2434a293e50cba"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 13).bin" size="5997600" crc="19e6612b" sha1="d43eb5d47a4eddff83f3601aac18cb40c26fc5bf"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 14).bin" size="4586400" crc="84f0f728" sha1="88a0f9f1cc5468300126a3e6146144f017b3b73f"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 15).bin" size="6879600" crc="a6c608d4" sha1="0b88e8b75bf8f82140a38463542cd1cf9ba3c339"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 16).bin" size="7938000" crc="6faa4103" sha1="679387b9ba5321196eb1d9bbccd5657cda139d66"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 17).bin" size="6526800" crc="ffc80be2" sha1="e38a3fbdab89f15562232241c5a60a7336fd88ea"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 18).bin" size="4410000" crc="9adef18e" sha1="943c2fcc729ef7c440b32764cf4bb4429e9bc5c5"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 19).bin" size="6703200" crc="31777442" sha1="1767e1215093ca1d72a364b5155aee648e7ce173"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 20).bin" size="6174000" crc="7e3ffcea" sha1="cd741207482635f40721ca0f7a578071deb0d203"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 21).bin" size="5821200" crc="597543bf" sha1="d576fa144d26c48bd26548eec5b728e0c30ae5ff"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 22).bin" size="7056000" crc="8c3579f3" sha1="f689e21b6e6cd346f5215f366833665c3bcbd242"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 23).bin" size="6174000" crc="f7fcaa3a" sha1="c067bc955ba8e7b1cc5f743a916449fff2cc2a88"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 24).bin" size="5644800" crc="0209b488" sha1="a055b22c2d0f6d74996d8533efc100cb6de0d471"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 25).bin" size="6350400" crc="5ee62fc8" sha1="a5eb4afc508e84572f45064a87e2862fc5b69ed9"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 26).bin" size="5468400" crc="c0b38abc" sha1="09f7d57da5a736b97640d6f9917d96e6cd05d434"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 27).bin" size="8290800" crc="75b9115e" sha1="470212a8aedb4751803a149622aa4bdeb0ad8414"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 28).bin" size="6174000" crc="95f00446" sha1="4110d3b7679ecb3e55846aa923de5971ed3cf4fc"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 29).bin" size="7761600" crc="df479910" sha1="e641950eb5ea8c8928ab740881bcc97e636675dc"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 30).bin" size="6879600" crc="d186118e" sha1="a35da8298a9ad34a6114a2155b76ff9b011974bd"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 31).bin" size="9349200" crc="1ddcb129" sha1="0a1429f0e07b32e952f1d44d0fb469a536e03fdd"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 32).bin" size="5644800" crc="6684179d" sha1="c847deead2a2443327f9d9b464df54818d19da36"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 33).bin" size="8996400" crc="6c400197" sha1="5f4007d1004f24e6b8e7edd40d5fc66420ae7d79"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 34).bin" size="6350400" crc="76ef4d8e" sha1="a15eb2a33bae6eeed69449cf2c2cf3d06626cc74"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 35).bin" size="7761600" crc="c2ea1ab3" sha1="aa688a7575cf7434a173db869ff483e4c2f9987a"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 36).bin" size="7056000" crc="9fcaddf9" sha1="a76f080c4d4e4861f9a51249ab04aa4f293f9aeb"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 37).bin" size="7761600" crc="9804f928" sha1="64eed93c22a36046af68e33665fd034e0f718be0"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 38).bin" size="4762800" crc="174e9274" sha1="78aa238c48af62bb6332f1a7f5272139c3f76492"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 39).bin" size="6879600" crc="af76eb26" sha1="80a9e55479ca677d2c394efbb87a51dca7138e98"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan) (Track 40).bin" size="12877200" crc="a9a3d5b2" sha1="452bc9d57561741a7873aaabb3a52aa1a12956e2"/>
+		<rom name="Hyper Aquarium - Tansui-hen (Japan).cue" size="5182" crc="b48fed4c" sha1="f3cebfaf63f1b4b1460b8c249af2dc165061a19c"/>
+		-->
+		<description>Hyper Aquarium - Tansui-hen</description>
+		<year>1992</year>
+		<publisher>インターリミテッドロジック (Inter Limited Logic)</publisher>
+		<info name="serial" value="HMC-184"/>
+		<info name="alt_title" value="ハイパー・アクアリウム　【淡水編】" />
+		<info name="release" value="199201xx" />
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper aquarium - tansui-hen (japan)" sha1="fa5df399ef25bb0dbfe304e915160f2a1a88d918" />
 			</diskarea>
 		</part>
 	</software>
@@ -11052,10 +11286,9 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<!-- Missing a floppy disk -->
-	<software name="hypnote" supported="no">
+	<software name="hypnote">
 		<!--
-		Origin: redump.org
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
 		<rom name="Hyper Note (Japan) (Track 1).bin" size="52567200" crc="714c1354" sha1="9b3c06bc68e85334830b47aebad2abea578810a6"/>
 		<rom name="Hyper Note (Japan) (Track 2).bin" size="68541984" crc="221a1e77" sha1="f32722e72ad66639e6a6d0915d9dd526b6282d95"/>
 		<rom name="Hyper Note (Japan) (Track 3).bin" size="24185616" crc="add5dddc" sha1="350757204339196703eeabe95f75e4139db4df43"/>
@@ -11066,6 +11299,11 @@ User/save disks that can be created from the game itself are not included.
 		<publisher>ダットジャパン (Datt Japan)</publisher>
 		<info name="serial" value="HMC-166"/>
 		<info name="release" value="199112xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="hyper_note.hdm" size="1261568" crc="985f94b6" sha1="af4704239151af3b1e80b528d11ad5d9198f99f3" offset="000000" />
+			</dataarea>
+		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="hyper note (japan)" sha1="23e86c388f7ef78bcbd63b3fc6abaee5d5d4081f" />
@@ -11550,6 +11788,65 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="igo doujou shodan (japan) (rev a)" sha1="c1327c0705c839c5380e3900d188983ce5a11534" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="igoyabu">
+		<!--
+		Origin: redump.org
+		<rom name="Igo Doujou Yaburi (Japan) (Track 01).bin" size="35632800" crc="ffc3a47e" sha1="5845fce5101555fbecc2a1567b0b17537a38af0c"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 02).bin" size="9819600" crc="27bd967c" sha1="2e01804171dc680bcdaa59ca89b47b451ecee36f"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 03).bin" size="6014064" crc="6ebc530a" sha1="22bc6d652a25be61f85f5c4b41bc406bef0bd374"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 04).bin" size="6997200" crc="4d0d0a00" sha1="339ca68e2ece9a876132f7869f63a4fd207eba1c"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 05).bin" size="9026976" crc="d557dd86" sha1="9c7459b21faf0e4c75c8b2e7cd15fe59f96ad680"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 06).bin" size="8683584" crc="a3853adb" sha1="0703293bbb94573c810ef557feddeddb307d0ced"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 07).bin" size="8290800" crc="8bb041b1" sha1="f03c03959a650a52a6146e1a86b3466874793089"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 08).bin" size="6380976" crc="239cec29" sha1="3e541ad3b25308471bd3d2fb3df22edbf58b930d"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 09).bin" size="2474304" crc="fabc21ea" sha1="a2d98ae0d8f3358a5a94ab8867951338c71990b3"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 10).bin" size="5769456" crc="0cb16f84" sha1="0cd6b8e94546b87eaf98cd0a69b28a9c563da3d0"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 11).bin" size="3727920" crc="4fa792c4" sha1="218c134aeaa9f58de21a08cdeaa1c540c1b3960e"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 12).bin" size="3339840" crc="11fae55f" sha1="3adb9cdd314f06bbef7bd8adc05214a88112d328"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 13).bin" size="2575440" crc="f4877c6b" sha1="889d70f59d26dd3fb11159e684ae383e9329b2b5"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 14).bin" size="2646000" crc="3aab0660" sha1="361e6cd87d2c13a9894b5539dde396033a5ff47f"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 15).bin" size="2845920" crc="f17d84a2" sha1="01e3c53a5b623ec935d5f348e5cf782620d8bd13"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 16).bin" size="2968224" crc="dce60265" sha1="6fe5dbb2d4231f44ba9e5071caf06391447f8395"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 17).bin" size="2229696" crc="02655d4b" sha1="88b26d9ec1d7bb0d0f6d0a30e0690d52a678e5ec"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 18).bin" size="2763600" crc="810bb356" sha1="5061fe02953fcdb9cc69bf6151b300c67799fc85"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 19).bin" size="2262624" crc="3a9dacde" sha1="ecc216f4602dca8c34130bf9fec6c2e2ca594bce"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 20).bin" size="2488416" crc="57fbe480" sha1="00caa27a77527378cc9493f9de49c0198b170dea"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 21).bin" size="1898064" crc="637106ae" sha1="eafeb9dc21a3806cac45500a654bd5f04e3f46fd"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 22).bin" size="2293200" crc="195a64c7" sha1="0a77ef0d888561f200a2f2289ccce5c966d07275"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 23).bin" size="2058000" crc="a0ee69b8" sha1="2ccccc4d70064aa62a10dcae1329c598428df5ec"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 24).bin" size="2018016" crc="1d1098f1" sha1="6ed06cb6fa5f5c7e2e8e559e439a47bc72967e9a"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 25).bin" size="2916480" crc="9cde4d55" sha1="f042cb50aecad9f289e0e7f3dd3c6ec4821048ad"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 26).bin" size="1728720" crc="aef827c2" sha1="3a17c44cb5b8e3a1f139233330baa61814f33718"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 27).bin" size="1392384" crc="a63815ec" sha1="9305233422f2a8b8a6c9c8753aa918de038ab13a"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 28).bin" size="1324176" crc="9844e5a3" sha1="f25bdccf14c95b7c086d42736fbf0894f75058d3"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 29).bin" size="8801184" crc="51f94c0f" sha1="a575a5b43c8b24dbf6aa21e30076374e778c8eaf"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 30).bin" size="1688736" crc="1a16e0d8" sha1="c0f992cb236cadcbb694047b5f1601620ef18006"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 31).bin" size="3756144" crc="1c667a06" sha1="599583dcf32c8d76798d5580c6775d0a9f7f48ea"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 32).bin" size="1305360" crc="2d83736f" sha1="807d1ce95c7e8cbfc18db6e184e8bc3dd432b33c"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 33).bin" size="2664816" crc="4ada00fa" sha1="7efae2a220207ed37d0265b13db8a39234b9b6aa"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 34).bin" size="2140320" crc="c5f8d6ea" sha1="5afe88b28c8371bb72a81c5f49c25c00b076c2e0"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 35).bin" size="3139920" crc="6571a666" sha1="486f31ccf751d11b5e0df05304773ac3cce43713"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 36).bin" size="3963120" crc="7773b487" sha1="64038cf20e091b7c53f22e46c83c92d723885602"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 37).bin" size="1787520" crc="7dd4d9b5" sha1="adce6a40a7e4e18bbc83bcde44b1d2c0449f8b55"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 38).bin" size="3292800" crc="8eb20e1e" sha1="481c5296431ef180c0234b5e3bb4ce966da3467a"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 39).bin" size="1286544" crc="894f78fe" sha1="2ca85dc419310e2f2a2d7e823c55a41234f09636"/>
+		<rom name="Igo Doujou Yaburi (Japan) (Track 40).bin" size="1771056" crc="4ca44410" sha1="424c88427298dd5f2ea128d4e52c31ff07afd11d"/>
+		<rom name="Igo Doujou Yaburi (Japan).cue" size="3908" crc="adda2e13" sha1="03de900c19e3f7a852f63c9531b21f2285c8e71c"/>
+		-->
+		<description>Igo Doujou Yaburi - Menkyo Kaiden!! Mezase 7-kyuu</description>
+		<year>1990</year>
+		<publisher>富士通OA (Fujitsu OA)</publisher>
+		<info name="serial" value="HMB-173"/>
+		<info name="alt_title" value="囲碁道場破り 免許皆伝！！めざせ７級" />
+		<info name="release" value="199010xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="igo doujou yaburi (japan)" sha1="bda0e95f336bfaaf13ecce27606561fb7e9b46b4" />
 			</diskarea>
 		</part>
 	</software>
@@ -12297,6 +12594,37 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="joshikousei shoujo hatsunetsu (japan)" sha1="154bf04fafea22bc136ce1823dee37397c08e1bb" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="jleag94">
+		<!--
+		Origin: redump.org
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 01).bin" size="10231200" crc="5be5bd6e" sha1="8b558282bab5d92ab0c5dbff831996db3cf9df67"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 02).bin" size="4059552" crc="e971471a" sha1="278fe7b4d9ad9982b37ed22857783810ebb3d0de"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 03).bin" size="28047600" crc="dd2e20a5" sha1="3794b5d4bc462e55c6e487407eeab3e0bdb80c5e"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 04).bin" size="2293200" crc="b660df3d" sha1="8f7f1f6fe9d900229157d046728152647b1881f3"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 05).bin" size="2293200" crc="a592750b" sha1="aa5f617ebac05f48911fb5f81bfda265914c6450"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 06).bin" size="2293200" crc="efb0033d" sha1="162a4b70768e1ac407f584429f5f4a760e1eb73b"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 07).bin" size="1940400" crc="b2816a77" sha1="489e4c352abd10b853d237323bcc71701e50c2d1"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 08).bin" size="35456400" crc="69c4136e" sha1="d5633390f93d1d02615e8a499ae4868f1b31757c"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 09).bin" size="4233600" crc="6a57ab0e" sha1="545a5e33c34e701d827f897c587804232a291e0f"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 10).bin" size="20991600" crc="61d23a6d" sha1="3dd725bed3108fe722acaff69b52badd2fec17ac"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 11).bin" size="7585200" crc="3986206e" sha1="c5407ed755aab22be49b0412900f02db7f86c111"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan) (Track 12).bin" size="11466000" crc="889facb0" sha1="c5f4709b3ac23d5dc87a3a822d7d704d7f1ae431"/>
+		<rom name="Japan Professional Football League - J.League 1994 Professional Soccer (Japan).cue" size="2081" crc="db0d70fc" sha1="1b70a418010b313ae0fbe6fdcf9d4f74be5c4e42"/>
+		-->
+		<description>J.League 1994 Professional Soccer</description>
+		<year>1994</year>
+		<publisher>ビクター音楽産業 (Victor Musical Industries)</publisher>
+		<info name="serial" value="HMF-169 / F-5516"/>
+		<info name="alt_title" value="Ｊリーグ１９９４　プロフェッショナル・サッカー" />
+		<info name="release" value="199409xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="japan professional football league - j.league 1994 professional soccer (japan)" sha1="72b221b297ed968a4bbb8a3925a5e8ab073e55f6" />
 			</diskarea>
 		</part>
 	</software>
@@ -14845,6 +15173,124 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="meikyoku">
+		<!--
+		Origin: redump.org
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 01).bin" size="10231200" crc="0a9f983a" sha1="931ce8aa5159a2fe2dd603097995c003343d19fb"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 02).bin" size="6867840" crc="dbf966e1" sha1="9ca393ca173091485bf64c57efa220277ff71bb4"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 03).bin" size="7415856" crc="195b75ae" sha1="f583f41aeb17d8a90cf83bafda29901dc343f64f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 04).bin" size="4668720" crc="46d9213f" sha1="cd6e0aae6b30102a8c996833e668daf00863f27f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 05).bin" size="6978384" crc="917887d5" sha1="384667ea81333e70db572ff918cd1d5521772e0b"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 06).bin" size="7310016" crc="38deeac1" sha1="f3e8af43142b1bcf29afa8e27088fa063b2a645b"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 07).bin" size="7213584" crc="57a30978" sha1="cec889efa9f240e84bdad61e245edb9e3cc00de9"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 08).bin" size="7204176" crc="26625c1e" sha1="0475e4752481df659c0e9d75bd43b91f65b59b34"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 09).bin" size="8142624" crc="0a7494f9" sha1="ed30db5ebc453745862e642f53092e0aefb120b8"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 10).bin" size="5785920" crc="cd2f0857" sha1="43cbf1a5826d247cdd6675ce6bd849740a2621a8"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 11).bin" size="5832960" crc="80ca1ff3" sha1="1e76b9cbc3d002d21319979676bf3c4a7fe1d23c"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 12).bin" size="7173600" crc="7850eb13" sha1="aa0db6d5a9d5308e717d2c3f68ff8e042ea8f5d3"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 13).bin" size="7326480" crc="c355545e" sha1="1a9e61593764f45e9af6fea520e1bfe7fcd01051"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 14).bin" size="6397440" crc="531e91e7" sha1="92f1b564bd8b3f1c0c437aa00b30968208a13dfc"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 15).bin" size="6997200" crc="495678b4" sha1="56e1589e3e45d0c1ccd0b3f8a787b767fe1839b3"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 16).bin" size="6769056" crc="1fe8593c" sha1="97347519488334e3e32fe44e85afbfdb197269e9"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 17).bin" size="6237504" crc="42bea869" sha1="8b62ba276c141e79e3c16dc2f34417850474b0f1"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 18).bin" size="6385680" crc="c2213588" sha1="9533dfab5bc0465c30b3307ddf4ee67e626d0825"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 19).bin" size="6985440" crc="e19d226f" sha1="c539df7a0b35cc4f9641f2b75685fb6f28adecd6"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 20).bin" size="6663216" crc="413cf74d" sha1="610f0ec91961d6c2416ec28226f580ba1263c756"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 21).bin" size="8373120" crc="b780dedd" sha1="659d57febb391e114ac2adf781b167f5a0024d98"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 22).bin" size="7542864" crc="cda51555" sha1="1df7ff4237d74eefedfb8029f99391dbbfcd0dfa"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 23).bin" size="4499376" crc="85620b47" sha1="220ee28dc38aa6f6d102e6031b82e343a01553c2"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 24).bin" size="7319424" crc="f6db1181" sha1="b412318cfd682942d1939d787ed406745a2d88f2"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 25).bin" size="7491120" crc="821c699e" sha1="8ac29a28f2aef982d4fa717584e3d4179cad6832"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 26).bin" size="8239056" crc="166e7261" sha1="4485840f3a6fcd916f89fe349ef586188f615bec"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 27).bin" size="7613424" crc="a06c920c" sha1="f2fc3265020109f35486bc144f39150135280ce5"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 28).bin" size="7267680" crc="4130fb5f" sha1="4d47b6dd087105fa54128a243b02dfb5d568092f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 29).bin" size="8239056" crc="3253a24e" sha1="e28b0472586223b34ea8678646d0d6f279c1cfd0"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 30).bin" size="5421360" crc="d265ca1d" sha1="47fdb5878d49d0a06cde949362cefb1a3cd0fc21"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 31).bin" size="5955264" crc="bfb69aea" sha1="9f8bf40d2294e5f515775469fb9c70a5dd17936f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 32).bin" size="5409600" crc="903abdd8" sha1="3993b70dc8d7e2bf2d339d27e11083dca82f50dd"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 33).bin" size="7298256" crc="11ea8867" sha1="e0afc73e8d585aaec3afc1d4685550fc3d3f2626"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 34).bin" size="8001504" crc="6ed79a1a" sha1="c7b28ae7563755b5d9f071de9f2fe05fb6eeb4ad"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 35).bin" size="8290800" crc="efac6b61" sha1="48ba9d72fa2cbdd5329f5e9e9fd09db4bad44424"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 36).bin" size="8697696" crc="f59e27b8" sha1="b10be64ef451c40a4f70a026a30a073a632723a9"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 37).bin" size="7166544" crc="b37a743a" sha1="8311c6b47513d96f9108d409b5625528d51da7b9"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 38).bin" size="7996800" crc="5e5293f0" sha1="798061d87a1e7efa2b54877cbbd2f0ce07d638ee"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 39).bin" size="7792176" crc="918bc106" sha1="5cc63c4c124e598f47420f9359f85c8e20c10672"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 40).bin" size="6308064" crc="9f3e81ec" sha1="a4480b395c0369cc3f0aa435022a4dc97b4c2091"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 41).bin" size="6456240" crc="7c8213d3" sha1="9ad6c71d693ceee5e82472d09cc1c96179a55647"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 42).bin" size="7286496" crc="b45bafb0" sha1="3dea8c8ae984d08d219a1a2af8747e227e161ed9"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 43).bin" size="8036784" crc="7159da38" sha1="dd40271be3c86d2acfcaf04cfb16b6c84d02538d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 44).bin" size="6298656" crc="d322f30c" sha1="41e7a16777be02619b090b18047b911ef4ea2128"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 45).bin" size="6138720" crc="a232b835" sha1="92321dc799eba01275aaa9adb1ee9447b8e71a14"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 46).bin" size="8754144" crc="5c418c38" sha1="c95815269b3ea4278a039ac8124c4a917690986f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 47).bin" size="7310016" crc="f77bf8a5" sha1="b9c9d9392224b9ef1de1ff4b4c9774c396f97fbe"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 48).bin" size="6468000" crc="16cb5d35" sha1="3dfb380850148b87b0d81c62a6a8309851e3c1ed"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 49).bin" size="7095984" crc="dd540ce5" sha1="712c3352e3e5b697fd013299cafbc8acf23e2f7d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 50).bin" size="7298256" crc="c0be0c3f" sha1="3e9c4539a3d1964ab7b8e2d385895849d9e51824"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 51).bin" size="7314720" crc="bb27ca30" sha1="7bc37246dcf7f6c7c029a398f0990d22e7c3b807"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 52).bin" size="7126560" crc="a03c1c6f" sha1="323659e6bf367619d58632f53abd598379318731"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 53).bin" size="7279440" crc="b9549db6" sha1="2d8cc8a3dc4f33ab751d2899f876dc490f6e860d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 54).bin" size="8279040" crc="5563fc6e" sha1="5b122f64189671a334ef4303b890c3431753e433"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 55).bin" size="7272384" crc="9cae7cb5" sha1="4a0433f15333b60ee8ce103b06ac7b8d83301fd3"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 56).bin" size="7204176" crc="61fc48e3" sha1="a9c6335a70fb15c114f1b8c507d0f6da8820870d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 57).bin" size="7220640" crc="25b5f410" sha1="8ca60c77ff8c97d5b6108e28cb299e2cd25b3f91"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 58).bin" size="7366464" crc="c8baf47a" sha1="12dab2d584d3b759f289ac82e6dfcd595cec07b0"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 59).bin" size="7345296" crc="d67a3472" sha1="2a6628735d2fd13051183b9b2888173d4ae8daa4"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 60).bin" size="7008960" crc="d3097d21" sha1="52498749ef4b9782dd8fa35f3d9b703bf54c2f13"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 61).bin" size="5978784" crc="fb3c3a97" sha1="188b0832389366d8c4cd38159b8fb5b8cdfabda8"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 62).bin" size="7832160" crc="5ca0cf61" sha1="41e95e4722258967105f3861495560b51c6f06b1"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 63).bin" size="7244160" crc="3123977e" sha1="f05a4bfd58eb9d5601556d3252470fcf3a919884"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 64).bin" size="8086176" crc="48e30ecd" sha1="3e17402f4a2c82b32856637d479c0bdb96ee1076"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 65).bin" size="8777664" crc="cd932bb6" sha1="fcd92a43e61901f627b04c0e42f27b288bbb0ad6"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 66).bin" size="6350400" crc="d933928e" sha1="dcfa2683f0d876727eabae9908ec03e815a96de8"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 67).bin" size="6404496" crc="d9022926" sha1="e44eebaaad17066bb47ce68712cb64906c4eeaf7"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 68).bin" size="5908224" crc="00acf531" sha1="6d7196813e51b091715c9815ab70488fe8632553"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 69).bin" size="7368816" crc="458adead" sha1="a4f64829e73fd1b8be7b659b60ec5c56e3f9c255"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 70).bin" size="6954864" crc="35ccf0a5" sha1="f9743045106ea61d18f6b024593e4f53f98ae2dc"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 71).bin" size="7333536" crc="bb1fe79b" sha1="917504e989b68db05c896904aec612c83d43fe6d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 72).bin" size="6138720" crc="586190db" sha1="a0ceca2c5a94f4ac82e0f1da97e9568b8e50414d"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 73).bin" size="6378624" crc="fa046487" sha1="1c712ce68d50b682fb2ccc0724380f610e299eb5"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 74).bin" size="8003856" crc="54710926" sha1="70cbbc2fb6c1a47d33b22352d437534da979e4d1"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 75).bin" size="6420960" crc="295fd95e" sha1="25296762a0524504942c22afdb80ed497a1dd602"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 76).bin" size="7789824" crc="a98ee424" sha1="a987f091e333bae6147abade5e44b41f46bcc9a0"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 77).bin" size="7157136" crc="1da866bc" sha1="59537688bbe9fcaf1b93caefdc38b3d33a2fb9e1"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 78).bin" size="6025824" crc="7dde796b" sha1="1e7ebc65f92dc5b6e755e982a26b37bb6b15c34b"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 79).bin" size="5357856" crc="7c3b29ea" sha1="673829957a6ec31492e235f152c8a9f925f920c2"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 80).bin" size="6985440" crc="16d29c96" sha1="372ca2a83ec20d612a51fb0f791fc453dedd4ed0"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 81).bin" size="7060704" crc="7edee432" sha1="df82526c9d23bf391d2e6cec507f4bc584f61bf0"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 82).bin" size="7321776" crc="4c1ea07c" sha1="d5ec74fb918fe477a0af7c7eb8bf33351016a674"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 83).bin" size="6503280" crc="e8700826" sha1="2436257de8b399927ffbfcc4415c9b36fcbb6d63"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 84).bin" size="6590304" crc="74123fa6" sha1="7a62f904fa2956560d8d5b33ce35babaebce819f"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 85).bin" size="7286496" crc="eedf01d8" sha1="b253152c30e44cc5725024da1e0c3fe23174090c"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 86).bin" size="6178704" crc="50bf0caf" sha1="bb302df4566d8bafe7c4b8f4d91ad7a6a0fe4c95"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 87).bin" size="6439776" crc="db6314dd" sha1="2a0f8beaae8c097f5ddfc61c51a2e3f08cd6e669"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 88).bin" size="6385680" crc="9cec9130" sha1="6d323cf9e61b7b920e036f232b4732c312fad090"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 89).bin" size="7413504" crc="79015151" sha1="1e76814237c87abcfe2a30d52c755d11a68c8190"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 90).bin" size="7133616" crc="4c9aa248" sha1="0d742170cf77dccad1092b72ce01a4fb1387a8e7"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 91).bin" size="7389984" crc="94cb0c1a" sha1="1a33abe9a840eabf1aaa9f2804539349be359994"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 92).bin" size="7333536" crc="ed966669" sha1="c5dc1f873f3e0b4c65cec4c16b5a478e44eb38c4"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 93).bin" size="7020720" crc="bf21d6b4" sha1="cfc0c9897becd10c0363b9338ea2e854b2dfa678"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 94).bin" size="6355104" crc="c672f43a" sha1="03596edb334d991379db6096a073aa12d93f5e6b"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 95).bin" size="8638896" crc="1a3deee7" sha1="b3a5aabfccc5cebbef05b9fd12ebbf0448de79da"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 96).bin" size="6797280" crc="57ff25cb" sha1="7c3b0696b2ff7fb36bbfe3a7e79757db45913f5c"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 97).bin" size="9001104" crc="bc1c27d9" sha1="d87fce1014bd4226764612102a2f783bccc98637"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 98).bin" size="5903520" crc="c2b585e0" sha1="d1871e69bec2d7ff0934fb07541e667fad2af246"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty) (Track 99).bin" size="6632640" crc="79082a1c" sha1="caee5b0938559edb6a08dd81c944b972b650028c"/>
+		<rom name="Meikyoku Master (Japan) (FM Towns Marty).cue" size="13347" crc="59a89315" sha1="64f141798ffa8700c8901f4ac0ebc72207bbd044"/>
+		-->
+		<description>Meikyoku Master (FM Towns Marty version)</description>
+		<year>1993</year>
+		<publisher>富士通大分ソフトウェアラボラトリ (Fujitsu Ooita Software Laboratory)</publisher>
+		<info name="serial" value="HME-113"/>
+		<info name="alt_title" value="名曲ますた～" />
+		<info name="release" value="199303xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="meikyoku master (japan) (fm towns marty)" sha1="7d40b881218625c45100a35a40e1bc86c1159dff" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="mjdepon">
 		<!--
 		Origin: redump.org
@@ -16809,6 +17255,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="ncrown1">
+		<!--
+		Origin: redump.org
+		<rom name="Hyper Eigo Gakushuu System - New Crown English Series 1 (Japan) (Rev A) (Track 1).bin" size="10231200" crc="fac30099" sha1="8c83f28218a48e7e01e137ae9dc3aa9e2804b89c"/>
+		<rom name="Hyper Eigo Gakushuu System - New Crown English Series 1 (Japan) (Rev A) (Track 2).bin" size="604170000" crc="a359beec" sha1="87d08b0548aed927a0ed1206a60a58198aa00cc2"/>
+		<rom name="Hyper Eigo Gakushuu System - New Crown English Series 1 (Japan) (Rev A).cue" size="312" crc="8bebf09f" sha1="270adcf9e4e181419fa3f024ddeaf69b0d9c0229"/>
+		-->
+		<description>Hyper Eigo Gakushuu System - New Crown English Series 1</description>
+		<year>1993</year>
+		<publisher>内田洋行 (Uchida Youkou)</publisher>
+		<info name="serial" value="HMD-230A / 146-080857"/>
+		<info name="alt_title" value="ハイパー英語学習システム　ＮＥＷ　ＣＲＯＷＮ　①" />
+		<info name="release" value="199308xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="hyper eigo gakushuu system - new crown english series 1 (japan) (rev a)" sha1="237fcc96575d78a27e849ec07c101684e408dd03" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="ncrown2">
 		<!--
 		Origin: redump.org
@@ -16816,7 +17283,7 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Hyper Eigo Gakushuu System - New Crown English Series 2 (Japan) (Rev B) (Track 2).bin" size="661676400" crc="4b5ee89d" sha1="2e9d2042a0df7f6228d599906c4fc5ee7b258e51"/>
 		<rom name="Hyper Eigo Gakushuu System - New Crown English Series 2 (Japan) (Rev B).cue" size="335" crc="4bab8980" sha1="e1d1bcb77d48f9fcf36b84bd85abf04284ce2e45"/>
 		-->
-		<description>Hyper Eigo Gakushuu System - New Crown Series 2</description>
+		<description>Hyper Eigo Gakushuu System - New Crown English Series 2</description>
 		<year>1993</year>
 		<publisher>内田洋行 (Uchida Youkou)</publisher>
 		<info name="serial" value="HMD-231B / 146-080858"/>
@@ -17597,6 +18064,27 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="nihongo1">
+		<!--
+		Origin: redump.org
+		<rom name="Nihongo Nyuumon Dai-1-kan - Fundamental Japanese (Japan) (Track 1).bin" size="20462400" crc="38d4331e" sha1="aa0462cdc6b0c638cd8ec234f3bf1eddb61ea59c"/>
+		<rom name="Nihongo Nyuumon Dai-1-kan - Fundamental Japanese (Japan) (Track 2).bin" size="323275344" crc="a498acdd" sha1="5f96d07a651e74a0dbf804a3826c3a230b804b58"/>
+		<rom name="Nihongo Nyuumon Dai-1-kan - Fundamental Japanese (Japan).cue" size="282" crc="b675564e" sha1="b7d2e12629d1d97cc93e17d3a0437b026ee00927"/>
+		-->
+		<description>Nihongo Nyuumon Dai-1-kan - Fundamental Japanese</description>
+		<year>1991</year>
+		<publisher>インフォーテック (Infortech)</publisher>
+		<info name="serial" value="HMB-232"/>
+		<info name="alt_title" value="日本語入門　第１巻　Ｆｕｎｄａｍｅｎｔａｌ　Ｊａｐａｎｅｓｅ" />
+		<info name="release" value="199104xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nihongo nyuumon dai-1-kan - fundamental japanese (japan)" sha1="794eaf0895b6d590945bc26e684e56a8edff047e" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="nihonmb1">
 		<!--
 		Origin: redump.org
@@ -17977,12 +18465,75 @@ User/save disks that can be created from the game itself are not included.
 		<year>1990</year>
 		<publisher>CRI</publisher>
 		<info name="serial" value="HMB-127 / T2016-005"/>
-		<info name="alt_title" value="日本の歴史 古代編" />
+		<info name="alt_title" value="日本の歴史　古代編　～日本誕生～" />
 		<info name="release" value="199007xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="nihon no rekishi - kodai-hen - nihon tanjou (japan)" sha1="b0753ac0f059edea3f159533a80061e7158058e4" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="nihonrse">
+		<!--
+		Origin: redump.org
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 01).bin" size="62798400" crc="ff4ae2c7" sha1="b28aa99a6148fc2f7a90216ae08612c5537490da"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 02).bin" size="11176704" crc="b71288fe" sha1="7fe9bac3b0b4023d1fd0823cc731753679dd31be"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 03).bin" size="14119056" crc="94e15238" sha1="86e3fd8bdc0f008f1adc4dc0d98d24f384c43123"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 04).bin" size="13018320" crc="58838fdc" sha1="4ee366072da749d941c3c77683e219f774bcbfcc"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 05).bin" size="10948560" crc="2b230a48" sha1="e7744e39e09962cfadd62bf3c32e6a4f2213bc6c"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 06).bin" size="12406800" crc="aa23b573" sha1="a7bb93b06d6e0e557373dd6d5000952cef633e46"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 07).bin" size="13794480" crc="07c94df4" sha1="3140e4ee0025f790f5d7b668697db5485f0b8cc0"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 08).bin" size="11842320" crc="2979142f" sha1="b1b7aa20e4d4d61d8e30b8a6d99d0843dd88aab5"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 09).bin" size="15593760" crc="ef0fec7a" sha1="8523e14b315c7c178b0c7fbda1c742fde4594516"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 10).bin" size="13394640" crc="fb3889d7" sha1="798568100e9625344682d187d4b82a2a473f4122"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 11).bin" size="11724720" crc="00a0c2f5" sha1="b8dfb3e37f9bbcec67d47c317468df38287d0335"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 12).bin" size="12458544" crc="94523562" sha1="baa9d9b4e80c2a61f62efb0e55d8979633d86336"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 13).bin" size="16746240" crc="a613f967" sha1="9f1a2747382aed10b4742aafc5478101d1392f82"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 14).bin" size="13912080" crc="503851e6" sha1="8116424296a5efe65df4820cacbad58878e6045e"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 15).bin" size="13171200" crc="c079fac1" sha1="9ceb37fd763bd9564d6a16cf7bc587ce5735ca54"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 16).bin" size="12672576" crc="4a2060db" sha1="aa384b56d1b2876575ab3a9d2b6e9cdf10f657b4"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 17).bin" size="12364464" crc="8bda47cd" sha1="55d6cce8f2e6db684ca1f56160aca10314492b61"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 18).bin" size="18681936" crc="f6856536" sha1="d76e55498740f5bce9f1761e2df61b2353bf9896"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 19).bin" size="12223344" crc="de4a8e04" sha1="782acb4b7df45133b7a27e39b3f3dc9dd5389863"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 20).bin" size="13006560" crc="65565c7a" sha1="473ac5c173fcd67800e6d54c23cf68ea140c5fed"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 21).bin" size="20297760" crc="01fd837f" sha1="756b09fbe56fec29885ab3d7193a55000549b5e5"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 22).bin" size="22955520" crc="bb9e08b0" sha1="aa11e35c98b2302a256a5a790381f18492c80c51"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 23).bin" size="2794176" crc="21e155c5" sha1="b3a54a001cbab28e8369536dcf4d428bf5ddc274"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 24).bin" size="13335840" crc="4421de20" sha1="08909fb63e6a29aca81821515065a46bd22c1845"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 25).bin" size="10623984" crc="98f293c8" sha1="238e89b8779c43ea87cceb7359d208d29da5abac"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 26).bin" size="11132016" crc="d54cafef" sha1="16e3cdca94f110191337e79e7c1ef443cfe49775"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 27).bin" size="11647104" crc="738b1614" sha1="46f1bfe37132c7ae173147406af13a4e7f86cbc0"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 28).bin" size="12312720" crc="00651282" sha1="145eccaed6bd8dee7b5769e635b898e62a9747f3"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 29).bin" size="13806240" crc="2cc32229" sha1="27463bd270eb2e4c6f5296be99b1a3557a6045c9"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 30).bin" size="17494176" crc="0e0c8670" sha1="d4a40bf074590024cdf69cb487dfd415d66c3298"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 31).bin" size="13258224" crc="269b27c9" sha1="c38555f20430b4e18db4f97b318b26cfeada97dd"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 32).bin" size="11242560" crc="b73fe401" sha1="d03fde2d3d8196499f263bb1c728510e50487e02"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 33).bin" size="14394240" crc="5ccabc85" sha1="69d072ef3b91c402e1cfe25ac18ee32efc2950c2"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 34).bin" size="11919936" crc="279ce344" sha1="c0d44f5126dabef8ecacbf3ef51272a28e29531f"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 35).bin" size="12583200" crc="0356599d" sha1="e1768b3e84f8cb53854834a9aacdeeb2a2720265"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 36).bin" size="12611424" crc="c934553e" sha1="ab0b09538e4a22ba7b771038a6d188d1e0ebf2c3"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 37).bin" size="11901120" crc="34a08bae" sha1="16b5bf676a17476ec3f5bd80ccb51d4a6972204c"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 38).bin" size="11955216" crc="ce27746b" sha1="8eb8d0b4d64c7ad1a321365bad5a0b843c920b93"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 39).bin" size="10454640" crc="00ce0192" sha1="c6d0e125883e39da9c8b383628855758542a4c1d"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 40).bin" size="13147680" crc="b4d927dc" sha1="89db1e6df341aa1713b71f7a01a1e53ac5f306d0"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 41).bin" size="10854480" crc="a1913951" sha1="dea603e08eb9937049c6dc4a9dd0b0ee68b83d24"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 42).bin" size="11811744" crc="788a0acb" sha1="929196cf68e920d6dfa80b3da2c994da4198e30b"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 43).bin" size="11778816" crc="6611a20a" sha1="11703335e6b4f58038906f4c0e248517252e5079"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan) (Track 44).bin" size="15349152" crc="1dd0ab34" sha1="872ac224e477cfcd41a8a75f11ab1de5e67e65a3"/>
+		<rom name="Nihon no Rekishi - Sengoku-hen - Oda Nobunaga (Japan).cue" size="5574" crc="f9559530" sha1="67864b2af9416f5669ca62705227191ad8729a2d"/>
+		-->
+		<description>Nihon no Rekishi - Sengoku-hen - Oda Nobunaga</description>
+		<year>1990</year>
+		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-124"/>
+		<info name="alt_title" value="日本の歴史　戦国編　～織田信長～" />
+		<info name="release" value="199006xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="nihon no rekishi - sengoku-hen - oda nobunaga (japan)" sha1="8c67cd9205d5d28f115be5aa2bda9577260f1a7c" />
 			</diskarea>
 		</part>
 	</software>
@@ -18514,34 +19065,34 @@ User/save disks that can be created from the game itself are not included.
 	<software name="noyama">
 		<!--
 		Origin: redump.org
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 01).bin" size="210974400" crc="912cd85d" sha1="1fcc9a03257f8da957b1f13a41a196a13a8f8bbc"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 02).bin" size="19921440" crc="ce7c9a3c" sha1="fe96b4a85024e72b160f4b68f171a9025c8ac659"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 03).bin" size="22073520" crc="cf6ea0de" sha1="125628aeb4f1459e382693d2ce0c4105bf86b3f4"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 04).bin" size="21250320" crc="05894adf" sha1="25226c0369f9fb359b5abbe5f4795d2277aae3f7"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 05).bin" size="19921440" crc="5e466771" sha1="5d9d0ea8bad03d994cadcf088b19197b8e13215d"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 06).bin" size="18792480" crc="c1904d7a" sha1="0c5b99f8953687e5095b91e7c94b0ec257ad47a7"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 07).bin" size="32551680" crc="e16a7998" sha1="205f302ed57d5cee844170c69617c87c858a72a9"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 08).bin" size="29788080" crc="a0633aa1" sha1="28962295f7f030ae4aee3350c197a8769083fc6a"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 09).bin" size="7067760" crc="685c3aee" sha1="27495e6bfe3b0fa3df2c2c176a2ec4aa83d1c100"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 10).bin" size="42053760" crc="70317a9f" sha1="4fbe707875d631e53027b1034fa1e63ec242c1a1"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 11).bin" size="34416816" crc="c89e431a" sha1="98784304849df2ef6ea6873711af1cff0cea5b5e"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 12).bin" size="22301664" crc="f3f9027e" sha1="b9c7d7995d04b213ef46d6e6909b63cc03d1191e"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 13).bin" size="11842320" crc="e1eb9416" sha1="7ed3da735fdd88b88cd074647d994b88e37b563b"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 14).bin" size="12300960" crc="8afa350f" sha1="d902b52a05fd88f6c0f17fe3081a6f7c73c8ff14"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 15).bin" size="14001456" crc="4170366a" sha1="b9fc66cb5673827abe3dda75120225f73e743ab8"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 16).bin" size="12928944" crc="01874196" sha1="07d5f49c5edc830031548f4929494835a143d28c"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 17).bin" size="12994800" crc="2cb83927" sha1="0d10e5d7c89dc268f4d2eca12420f748872135af"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 18).bin" size="6773760" crc="520bfe2c" sha1="34ecb061ab008cd026c990236060329e07471392"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 19).bin" size="7780416" crc="38b89564" sha1="1b8a5ae950e6b12209a458bcc7afe6f52047f706"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 20).bin" size="9553824" crc="807c346d" sha1="57958a4f4ec16661a6f158030721e7cd412c92c1"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 21).bin" size="12159840" crc="31e91a18" sha1="0b3dbcaa2dc6fdca511268329108899678a02f0d"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 22).bin" size="11614176" crc="ccffa9d2" sha1="88cb8e710dac8ae714a7db0fa043b0a8821c05da"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 23).bin" size="15269184" crc="87111756" sha1="e2410a4db017f3993e4dad5cc7d2ff3746433546"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 24).bin" size="11884656" crc="c9c9d170" sha1="fcbd71095de4228d7af317684f34f662ac62db00"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan) (Track 25).bin" size="11952864" crc="dc1bc7ae" sha1="77bf0a35dc38c4bcf599c2ea8ecc8280aed1abac"/>
-		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka (Japan).cue" size="4055" crc="775b09d8" sha1="ac2b8519a222a23a9f12a4dfeb2e41fd979e8fe1"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 01).bin" size="210974400" crc="912cd85d" sha1="1fcc9a03257f8da957b1f13a41a196a13a8f8bbc"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 02).bin" size="19921440" crc="ce7c9a3c" sha1="fe96b4a85024e72b160f4b68f171a9025c8ac659"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 03).bin" size="22073520" crc="cf6ea0de" sha1="125628aeb4f1459e382693d2ce0c4105bf86b3f4"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 04).bin" size="21250320" crc="05894adf" sha1="25226c0369f9fb359b5abbe5f4795d2277aae3f7"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 05).bin" size="19921440" crc="5e466771" sha1="5d9d0ea8bad03d994cadcf088b19197b8e13215d"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 06).bin" size="18792480" crc="c1904d7a" sha1="0c5b99f8953687e5095b91e7c94b0ec257ad47a7"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 07).bin" size="32551680" crc="e16a7998" sha1="205f302ed57d5cee844170c69617c87c858a72a9"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 08).bin" size="29788080" crc="a0633aa1" sha1="28962295f7f030ae4aee3350c197a8769083fc6a"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 09).bin" size="7067760" crc="685c3aee" sha1="27495e6bfe3b0fa3df2c2c176a2ec4aa83d1c100"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 10).bin" size="42053760" crc="70317a9f" sha1="4fbe707875d631e53027b1034fa1e63ec242c1a1"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 11).bin" size="34416816" crc="c89e431a" sha1="98784304849df2ef6ea6873711af1cff0cea5b5e"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 12).bin" size="22301664" crc="f3f9027e" sha1="b9c7d7995d04b213ef46d6e6909b63cc03d1191e"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 13).bin" size="11842320" crc="e1eb9416" sha1="7ed3da735fdd88b88cd074647d994b88e37b563b"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 14).bin" size="12300960" crc="8afa350f" sha1="d902b52a05fd88f6c0f17fe3081a6f7c73c8ff14"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 15).bin" size="14001456" crc="4170366a" sha1="b9fc66cb5673827abe3dda75120225f73e743ab8"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 16).bin" size="12928944" crc="01874196" sha1="07d5f49c5edc830031548f4929494835a143d28c"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 17).bin" size="12994800" crc="2cb83927" sha1="0d10e5d7c89dc268f4d2eca12420f748872135af"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 18).bin" size="6773760" crc="520bfe2c" sha1="34ecb061ab008cd026c990236060329e07471392"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 19).bin" size="7780416" crc="38b89564" sha1="1b8a5ae950e6b12209a458bcc7afe6f52047f706"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 20).bin" size="9553824" crc="807c346d" sha1="57958a4f4ec16661a6f158030721e7cd412c92c1"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 21).bin" size="12159840" crc="31e91a18" sha1="0b3dbcaa2dc6fdca511268329108899678a02f0d"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 22).bin" size="11614176" crc="ccffa9d2" sha1="88cb8e710dac8ae714a7db0fa043b0a8821c05da"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 23).bin" size="15269184" crc="87111756" sha1="e2410a4db017f3993e4dad5cc7d2ff3746433546"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 24).bin" size="11884656" crc="c9c9d170" sha1="fcbd71095de4228d7af317684f34f662ac62db00"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan) (Track 25).bin" size="11952864" crc="dc1bc7ae" sha1="77bf0a35dc38c4bcf599c2ea8ecc8280aed1abac"/>
+		<rom name="Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka (Japan).cue" size="4080" crc="e7b2c3c2" sha1="c604500c5d23c0fac12f1bd5047cc2cc2176aa6a"/>
 		-->
-		<description>Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kensakuka</description>
+		<description>Mirumiru Sagasu Konchuu Series Vol. 4 - Noyama no Kenchikuka</description>
 		<year>1995</year>
 		<publisher>富士通ソーシアルサイエンスラボラトリ (Fujitsu Social Science Laboratory)</publisher>
 		<info name="serial" value="HMF-197"/>
@@ -18627,22 +19178,22 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<!-- Bundled with the book of the same title (ISBN 4-89052-596-3) -->
 	<software name="okitgear">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Okiraku Towns Gear.ccd" size="770" crc="249d986e" sha1="1194b9bc2c45e7f644db73953e5f624d7e601582"/>
-		<rom name="Okiraku Towns Gear.cue" size="82" crc="90bcbb60" sha1="9136453d0e572f07529de02f4f3c9dc8d6da44a4"/>
-		<rom name="Okiraku Towns Gear.img" size="148634640" crc="0c87970a" sha1="71bbb684500958f53cec63ccfb34f1c7849b46fc"/>
-		<rom name="Okiraku Towns Gear.sub" size="6066720" crc="9b7be459" sha1="cdbb88125716c57a1f9dc92e6cbd0a8a40d10deb"/>
+		Origin: redump.org
+		<rom name="Okiraku TownsGEAR (Japan).bin" size="148634640" crc="0c87970a" sha1="71bbb684500958f53cec63ccfb34f1c7849b46fc"/>
+		<rom name="Okiraku TownsGEAR (Japan).cue" size="91" crc="6c749988" sha1="1291af6439714efa2ce2dd70fbba39d3fba74ed0"/>
 		-->
 		<description>Okiraku TownsGEAR</description>
 		<year>1994</year>
 		<publisher>ソフトバンク (SoftBank)</publisher>
-		<info name="alt_title" value="お気楽 TownsGEAR" />
+		<info name="serial" value="SBHW-00002"/>
+		<info name="alt_title" value="お気楽　ＴｏｗｎｓＧＥＡＲ" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="okiraku towns gear" sha1="a614a4471c91a19fe33bf903a5f699907bad813e" />
+				<disk name="okiraku townsgear (japan)" sha1="a9c781218324c388ff31c0b6ed514f83fa133d92" />
 			</diskarea>
 		</part>
 	</software>
@@ -18938,6 +19489,80 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="ongaku56">
+		<!--
+		Origin: redump.org
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 01).bin" size="31399200" crc="5e657cb6" sha1="a883eb2daa7150049063337da814ed43d8106295"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 02).bin" size="165303264" crc="22906ac8" sha1="bd346380dcc9336bd274dc8c05eae97e31ae95df"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 03).bin" size="8561280" crc="51280e05" sha1="a5dd263425928d4b5658f159b54622c566a443ba"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 04).bin" size="7157136" crc="d79292c4" sha1="0030a29de9ad49e6527b05033c8bc5573f9046c1"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 05).bin" size="5256720" crc="a2458fee" sha1="6f42b284ef3b63d41d492cf54a635f149f7faba6"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 06).bin" size="5437824" crc="d44b1a48" sha1="ce7cadf84e9951b87d63cff91b091d9929f9200c"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 07).bin" size="6827856" crc="c05da524" sha1="5dfd36f24f9cf0738b08afe5fcc07046d60ee3f2"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 08).bin" size="5891760" crc="a353cbac" sha1="a32f0c50b2cd9335f365250cc398266e19300946"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 09).bin" size="5997600" crc="e8723393" sha1="88fa8a7deb1b882f55ee0e6661c5cd0b6d6a2866"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 10).bin" size="5461344" crc="9853ed64" sha1="84be177ba0c9c060ff9d7a30c16232c6fc70279d"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 11).bin" size="5891760" crc="01dcf1f7" sha1="50976badb6a9f3228b1ece22c201ebf44594e7d4"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 12).bin" size="5386080" crc="07d6ad48" sha1="72cb30538d7de5ca967af55a6b940b525c44f9ca"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 13).bin" size="7103040" crc="30b859be" sha1="fc3ae0ae72a4c750bba635d023e934dde3e35cab"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 14).bin" size="6832560" crc="d6e641e9" sha1="10194d10212e2e1196e47f87c0168fb9c88e2d41"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 15).bin" size="8196720" crc="c3519bd6" sha1="2db06816b292b1c44eede96a4eab1ad02e868eed"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 16).bin" size="7639296" crc="60cc7a48" sha1="81c6ee94a5fc6a749412224e873cf5f960d90b7c"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 17).bin" size="7248864" crc="b210d7c1" sha1="ea278a8f4cae1a68ca0bd76361513fae2b562a75"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 18).bin" size="7427616" crc="27445ae0" sha1="88d05d68c728d8fad42492f35f1ac53baa90856f"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 19).bin" size="6778464" crc="008d13b2" sha1="aa3a4388a2ee21b97bec3c70361e9ab072e2d648"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 20).bin" size="8161440" crc="28dfc2f8" sha1="19508b9adfaa1d51c0fde9001ead9bb2d71c8b38"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 21).bin" size="6809040" crc="87f2460a" sha1="af09ed0817d92c1497269c578a878ded34540cf4"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 22).bin" size="5209680" crc="0d9e3c17" sha1="576f2bef6bfe93a3fbc70d636781cf22b0127ab9"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 23).bin" size="3370416" crc="9832b941" sha1="2e1aeea5a9d6048f353b614eb1fe84450e2d22f4"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 24).bin" size="3469200" crc="a99ac91b" sha1="c042daa5dc5f5dec52c04ce120dc7b1358b4256a"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 25).bin" size="5696544" crc="28b7c280" sha1="b2123437d0461b6ac406a32b09caaeebf6d5a2d4"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 26).bin" size="6251616" crc="27cace8c" sha1="c778dd4fb3565420efd5cbd39a6dc3febfaf3547"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 27).bin" size="5680080" crc="62c71495" sha1="6ae1ef1e661e82fd6fafac578c3f8dfef00060dc"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 28).bin" size="5049744" crc="fce18f56" sha1="e17ecfa6fe32c14616cb0f99c7cfe9ff300e2711"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 29).bin" size="4958016" crc="603445e9" sha1="0d1660490c565dbd3020e261a707be918ab58ae7"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 30).bin" size="5868240" crc="3c0105d8" sha1="ffc481987481ffb39b4f3aaf71267869e0b821b2"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 31).bin" size="4179504" crc="cc922e1d" sha1="88f2baf82ebc53d1b8a1d75e4a4caacc8e9b1400"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 32).bin" size="5157936" crc="cf678df9" sha1="561d862951a86da5e2a0fe9b9b35ff018a67fc08"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 33).bin" size="3109344" crc="294c7f56" sha1="b6af0e16c89b67c279935ac7e6b4651af0fdd4af"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 34).bin" size="2704800" crc="00109a66" sha1="e866d7bc963fe7a59ef112bd29b96818e5f8f22a"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 35).bin" size="2994096" crc="6837667b" sha1="b396121830b9fe1cb3605ef3077870da209ffba2"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 36).bin" size="2874144" crc="00b9dc1e" sha1="c8e0ac029da8bf017919646d2fed5d27ca51d027"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 37).bin" size="2500176" crc="124fae8d" sha1="ee4d419d72995bd21e59e330ba5fb7b79bfb7e43"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 38).bin" size="4927440" crc="e7e47826" sha1="ee6fd85c3cdfa3be94b239c2a9252a47a6ef0499"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 39).bin" size="5292000" crc="cdf607bd" sha1="54cce473c0be5ff6f8e52b5c97eb1a8782c44749"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 40).bin" size="3139920" crc="dbd885ac" sha1="940378b825ba048376a10c0daa0d45dca50412df"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 41).bin" size="3897264" crc="013128ef" sha1="034f87fc793ba02900f675a7c8da6397d3d42914"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 42).bin" size="5621280" crc="5cfa4ed1" sha1="6d2c5ca58f9815a9d5d96ff58145db3333e59e6d"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 43).bin" size="5851776" crc="50c81708" sha1="16dfe5488828fd666bf272c93314611d9b90ee5f"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 44).bin" size="4668720" crc="0c1a5161" sha1="c2e8a006f320653e048cd2534bfee9262a8766c1"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 45).bin" size="2791824" crc="4cca5769" sha1="0c2f8cd1ba79df16d6e8fc3c473369cff80006e2"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 46).bin" size="4562880" crc="f81c4e87" sha1="239c789e1e6e6a270fb79e2bf4adc1073b204ff1"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 47).bin" size="3288096" crc="9a7b1a8f" sha1="c6960078978f51766da7896a68a3e2ec13b72175"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 48).bin" size="2869440" crc="997241a5" sha1="be189cfc52b3c6ef59972a3de1fcfacfad69fa24"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 49).bin" size="2815344" crc="8ca86cce" sha1="0125d16577ff7ab1a53bfd2670f191b71bf24abe"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A) (Track 50).bin" size="2987040" crc="3c3c780d" sha1="988de805f6dea13f116e06d84d67d1ca4f71c0ac"/>
+		<rom name="Shougaku Ongaku (5-6-nensei-you) (Japan) (Rev A).cue" size="7132" crc="ab8e366a" sha1="a6bf0feb43133fa88ec94b5b73b25ed8af1d9b9d"/>
+		-->
+		<description>FM Towns Shougaku Ongaku (5-6-nensei-you)</description>
+		<year>1991</year>
+		<publisher>教育出版 (Kyouiku Shuppan)</publisher>
+		<info name="serial" value="HMB-512A"/>
+		<info name="alt_title" value="ＦＭ　ＴＯＷＮＳ　小学音楽　(5・6年生用)" />
+		<info name="release" value="199105xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="shougaku_ongaku_5-6.hdm" size="1261568" crc="bc8592f0" sha1="e831950f62852b978fab34dc92e8961265bcadbe" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="shougaku ongaku (5-6-nensei-you) (japan) (rev a)" sha1="43d3f3af5529ed6c5b4ea52c1fa1971cd65a2001" />
+			</diskarea>
+		</part>
+	</software>
+
 	<!-- Windows / PC-9801 / FM Towns hybrid -->
 	<software name="onlyyou">
 		<!--
@@ -19077,11 +19702,30 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="oshacook">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Oshare Cooking.ccd" size="4746" crc="d0a44b7f" sha1="28a145333fc404047066f95a99824c09def8e545"/>
-		<rom name="Oshare Cooking.cue" size="910" crc="0069795d" sha1="1a3fd4c2a597a86125304dc8c260b86b9ffdef51"/>
-		<rom name="Oshare Cooking.img" size="156996000" crc="2169e657" sha1="29e33ef9962844540b6ecc9d790e6047bca1dd98"/>
-		<rom name="Oshare Cooking.sub" size="6408000" crc="fc1997ee" sha1="322b2a01714f7cb0c84bf1758bc98b7af04dbaaa"/>
+		Origin: redump.org
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 01).bin" size="105134400" crc="9f70ca90" sha1="376f099981bd9ea2f9d5595f947e33466e287a68"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 02).bin" size="3880800" crc="196795e9" sha1="0e5f62a55952a85c49bfe2974fc028c455506534"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 03).bin" size="1234800" crc="a9877c50" sha1="2af586f7639fddfeda7f78e07ac6d66887c066f7"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 04).bin" size="1234800" crc="d356ca68" sha1="8545189df0a62c6d8be982ea041267d38ea34989"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 05).bin" size="1234800" crc="b6af81d5" sha1="0af7d28bc1580fb542b04f03f450dda6f0c5e077"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 06).bin" size="2293200" crc="0fdb7cf5" sha1="f6d3b5d47062d74903ccf948cb383fdaf8e840c8"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 07).bin" size="2293200" crc="a61e5f22" sha1="556bfb8bafb254055f241596e48028e3029cf77b"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 08).bin" size="2293200" crc="c83703b3" sha1="c77812f9f4ff05a7b00e76c86b09b660dcfaba41"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 09).bin" size="2469600" crc="9de457e6" sha1="eb5f1449363a1b57fb990b4f7e58502bdee1c6e0"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 10).bin" size="1234800" crc="14a97c09" sha1="dd46e96a83f8a98d4ce258d41d12b6f199702ed8"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 11).bin" size="1234800" crc="5bbe0c09" sha1="99cfb69138e3d2dde22e1672fb3779c82bdb218d"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 12).bin" size="1234800" crc="087e8415" sha1="73b97b572b03cc477e6ead5d79db29772fffd88b"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 13).bin" size="1234800" crc="1bbd66dd" sha1="0eed303b2ed0a8386eea89862e746544c72ef63d"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 14).bin" size="2293200" crc="f1417430" sha1="ce2421ad7debd2998b0cef91d5c828f46c72f767"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 15).bin" size="1058400" crc="60058559" sha1="45939d6a23cdf12857bfb72ba7d2bf95a0bec3af"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 16).bin" size="1058400" crc="fd5c6f4c" sha1="ce3aaf7de7b7bfd090cdb99b5a8106f65caae480"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 17).bin" size="882000" crc="a9619d3b" sha1="4dfc5e44c5e8565a8fd730ce97e8f821d637ef29"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 18).bin" size="1058400" crc="acd428de" sha1="f18c1f089662711f1f9fe0b19274c2a24ee83f24"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 19).bin" size="1058400" crc="1545a73c" sha1="79e6c651e31b68f5c8b55c42dcfe336a89449fe6"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 20).bin" size="882000" crc="1744f3c2" sha1="4bdfb7cfef2fa7cdb4a6248cc11e359a480326c8"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 21).bin" size="10760400" crc="600066e5" sha1="18cb9f6e4d26db7d12bc7e11d1f808c0e2389871"/>
+		<rom name="Oshare Cooking (Japan) (Rev A) (Track 22).bin" size="10936800" crc="284ab800" sha1="a7582938fc882ee0d12935972c62a14841c1c75b"/>
+		<rom name="Oshare Cooking (Japan) (Rev A).cue" size="2732" crc="ea2b06bf" sha1="7a5f1a2f0f28408afbbd3a17fc3592bb2a0097f6"/>
 		-->
 		<description>Oshare Cooking</description>
 		<year>1989</year>
@@ -19092,7 +19736,7 @@ User/save disks that can be created from the game itself are not included.
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="oshare cooking" sha1="d6175d9a81760fbd9e497e6a396dbaf2aad6d57c" />
+				<disk name="oshare cooking (japan) (rev a)" sha1="5d0cb03cd7c2aa86805001de2c0dccf17ae3dbc5" />
 			</diskarea>
 		</part>
 	</software>
@@ -19613,6 +20257,10 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="Planet's Edge (Japan) (Track 26).bin" size="10525200" crc="9bd09bcb" sha1="4b639a200b6d0ac8d87f64f9f44ef83e9fd3e42f"/>
 		<rom name="Planet's Edge (Japan) (Track 27).bin" size="22532160" crc="e0362d78" sha1="e215c3aebf00fb9f885942ff49721af0ef1a076c"/>
 		<rom name="Planet's Edge (Japan).cue" size="3114" crc="7f6bd9ff" sha1="2853d442afc5939d0a23a7b6f932d46bfaa90e1a"/>
+
+		<rom name="Dream On Bang2 Project (Japan) (Track 1).bin" size="45381840" crc="5d6da427" sha1="29cb97a51072bd1218842f5bd2d8c553dbc40be0"/>
+		<rom name="Dream On Bang2 Project (Japan) (Track 2).bin" size="45511200" crc="f80fe756" sha1="342c15b5f806610c66a5716c63f4d9c055acccad"/>
+		<rom name="Dream On Bang2 Project (Japan).cue" size="225" crc="60d37110" sha1="1ded6462174562b8545f9f07bd734fd06c8d7ecb"/>
 		-->
 		<description>Planet's Edge</description>
 		<year>1993</year>
@@ -19621,9 +20269,34 @@ User/save disks that can be created from the game itself are not included.
 		<info name="alt_title" value="プラネッツ・エッジ" />
 		<info name="release" value="199309xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
-		<part name="cdrom" interface="fmt_cdrom">
+		<part name="cdrom1" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="planet's edge (japan)" sha1="a5906fac0d1efaef2d82551fe0e89d27a4680987" />
+			</diskarea>
+		</part>
+		<part name="cdrom2" interface="fmt_cdrom">
+			<feature name="part_id" value="Dream On Bang2 Project" />
+			<diskarea name="cdrom">
+				<disk name="dream on bang2 project (japan)" sha1="d576aeb5737c63644852c41b1cdab5316e3f0b4f" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="postman">
+		<!--
+		Origin: redump.org
+		<rom name="CRI Postman (Japan).bin" size="57036000" crc="a153c006" sha1="e662112476f0fdc81e0a1b11bbcfee0b430ab248"/>
+		<rom name="CRI Postman (Japan).cue" size="108" crc="ea72007d" sha1="9a8cad1a0dd5b21ad30025ea81a882904da36acf"/>
+		-->
+		<description>CRI Postman</description>
+		<year>1990</year>
+		<publisher>CRI</publisher>
+		<info name="serial" value="HMB-104"/>
+		<info name="release" value="199003xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="cri postman (japan)" sha1="f0c55c9d2e156ab43e4b00745d0889fbcc042dee" />
 			</diskarea>
 		</part>
 	</software>
@@ -21321,11 +21994,24 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="sangoku2">
 		<!--
-		Origin: Private dump (Reuental)
-		<rom name="SANGOKUSHI_2.ccd" size="3832" crc="6bbbdec6" sha1="1ad024f2e10d5ba0d5eb95281e1e94879a741a25"/>
-		<rom name="SANGOKUSHI_2.cue" size="920" crc="8dd872dc" sha1="540efad426d2a82dfe547f8424115db6465cf093"/>
-		<rom name="SANGOKUSHI_2.img" size="445635792" crc="a82468d9" sha1="68064b8a3cfbfe1e5c7e0c38d7e9c3b24e51fa45"/>
-		<rom name="SANGOKUSHI_2.sub" size="18189216" crc="4042bd7b" sha1="9df79c40b18cbaf2c8e3ab89e444a2f0e6b8932f"/>
+		Origin: redump.org (CD) / Reuental (floppy)
+		<rom name="Sangokushi II (Japan) (Track 01).bin" size="10231200" crc="8d6ca7bc" sha1="20846d285dc2ff0321a39df5960431cd64edbbc4"/>
+		<rom name="Sangokushi II (Japan) (Track 02).bin" size="32363520" crc="39a63f3b" sha1="177dd15ac1425c24558bb7cdd4c438f5fc84a2c6"/>
+		<rom name="Sangokushi II (Japan) (Track 03).bin" size="38812704" crc="c554fc99" sha1="f3bd4fd65cfcaa306ed8578d830b1e52889e1864"/>
+		<rom name="Sangokushi II (Japan) (Track 04).bin" size="41759760" crc="3e27e93e" sha1="e477c1719684b7dc2dcdeab4ebc9a956eadbbe28"/>
+		<rom name="Sangokushi II (Japan) (Track 05).bin" size="32958576" crc="2547d231" sha1="ac863eaa580bbb687064a807a37bb1b9558262bb"/>
+		<rom name="Sangokushi II (Japan) (Track 06).bin" size="8702400" crc="72a514c8" sha1="e9067e057c90dd8efa62d6367057a0251bb995b1"/>
+		<rom name="Sangokushi II (Japan) (Track 07).bin" size="11106144" crc="4408c277" sha1="8a2f6c1b7ffd1a9ec108bfc36b13a9fcd9293a86"/>
+		<rom name="Sangokushi II (Japan) (Track 08).bin" size="34644960" crc="ddd2559d" sha1="87fcb2112d2449dd68b126c880ad3607b0b805de"/>
+		<rom name="Sangokushi II (Japan) (Track 09).bin" size="22656816" crc="20b5271b" sha1="6269eabba31536e2729f97fd8bf1edbfffe21398"/>
+		<rom name="Sangokushi II (Japan) (Track 10).bin" size="40106304" crc="e3dc01a8" sha1="2a2fc77069b78e40c596c214c4365e76560c4923"/>
+		<rom name="Sangokushi II (Japan) (Track 11).bin" size="15382080" crc="5859622e" sha1="4b71e28cd96b222733907fbf252c11970dba6f38"/>
+		<rom name="Sangokushi II (Japan) (Track 12).bin" size="23061360" crc="e05c0294" sha1="3483e86e8084d7f951e3f506079d86e9866746fb"/>
+		<rom name="Sangokushi II (Japan) (Track 13).bin" size="20810496" crc="2df9f33f" sha1="d77ee5bc246ec663b09350282edc529871c24322"/>
+		<rom name="Sangokushi II (Japan) (Track 14).bin" size="59380944" crc="8fb120bf" sha1="c9034766a58c80cf4dd849ba04ff2a87bbca4b91"/>
+		<rom name="Sangokushi II (Japan) (Track 15).bin" size="16358160" crc="aa3f59c3" sha1="a211bd3e80f4bbf44f1f00a7a6f96c114ccf4834"/>
+		<rom name="Sangokushi II (Japan) (Track 16).bin" size="37300368" crc="6cfdf8f0" sha1="eb1b372668363f35090e9709300a45aba78f9a51"/>
+		<rom name="Sangokushi II (Japan).cue" size="1792" crc="d795a6d3" sha1="1663b2b356cd9f4efaa8ece62a65fd76851f7495"/>
 		-->
 		<description>Sangokushi II</description>
 		<year>1990</year>
@@ -21341,7 +22027,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sangokushi_2" sha1="f4ecb67518eb27c0ba5d6d01b945f89aa056535d" />
+				<disk name="sangokushi ii (japan)" sha1="f85c7dd00594c2061de3ecff376960ad1e7dc71a" />
 			</diskarea>
 		</part>
 	</software>
@@ -22435,20 +23121,34 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="simcity">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="SimCity.ccd" size="3615" crc="8cfd3c43" sha1="73bbff1ab3f4815dba59a4d06efbe924a584ec15"/>
-		<rom name="SimCity.cue" size="663" crc="0144bbeb" sha1="627f73edfbe12a485c85ae0b2c667b9df1fb32a2"/>
-		<rom name="SimCity.img" size="319100544" crc="9022bcdf" sha1="d2887ae8facca5a04b2b8a2b3e32135e10358b26"/>
-		<rom name="SimCity.sub" size="13024512" crc="4ce721ca" sha1="5783d0c685299b4f86b6325d2a0bfd7f0df5db64"/>
+		Origin: redump.org
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 01).bin" size="4410000" crc="248f0adc" sha1="39d20b568ff8ebef965a5fb3cd42d0f685fc2f44"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 02).bin" size="10459344" crc="36e62675" sha1="c51b803c0ed1462f3317764bda007cc1b610baf4"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 03).bin" size="10113600" crc="b17cce2d" sha1="f347b1ae69ca87cc210ea76970ff5218a431e8fa"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 04).bin" size="2410800" crc="b49e9111" sha1="bf097015646a52596be2f089f6deb382a0d46e94"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 05).bin" size="5169696" crc="cdc1a354" sha1="264d28c945553d7cfa8a168ee695fe3a0e12dad6"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 06).bin" size="15727824" crc="e730113a" sha1="732c7570b5c65cab6f4f53254cb28892b233f80b"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 07).bin" size="3798480" crc="b7907c08" sha1="2ee0ee55142bcafe3727aa5578fc73421da35774"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 08).bin" size="14464800" crc="4dbc9684" sha1="62f554727de3f74085b392706afbdd73fb2224b5"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 09).bin" size="9850176" crc="5bd33475" sha1="cd2eb1966f7636e155acdc2261c259a50fe6edfb"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 10).bin" size="13611024" crc="5e0bcc0f" sha1="17167e990bf071ce969cc5ce5e91bf0da6e5983c"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 11).bin" size="38274096" crc="fcc9c781" sha1="5c6e1d01fa61cf94d9fb3bf6daff575172f0dcb0"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 12).bin" size="38149440" crc="6b64b386" sha1="ef9195c1bc5c540e42349e15c4ae91ce627fffef"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 13).bin" size="38165904" crc="c5ab9912" sha1="921c9435cb814a9084ca088cff64fa2e42497473"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 14).bin" size="38109456" crc="21d2cada" sha1="0e5a5a6db6665bece32da32989a82bafd7a3f827"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 15).bin" size="38184720" crc="c196c4de" sha1="626893cf881675376928771aa6ac0c4f92defc2e"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A) (Track 16).bin" size="38201184" crc="1252e318" sha1="f9ab6cef3097b0970bd296301c15fae56250d5e6"/>
+		<rom name="SimCity (Japan) (En,Ja) (Rev A).cue" size="1998" crc="5b571b37" sha1="cb95555e26028e52c3ff9f09f11b8305b69e1948"/>
 		-->
-		<description>SimCity (1992-01-24)</description>
+		<description>SimCity (HMB-121A)</description>
 		<year>1992</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-121A / A27600A0 / TSC060"/>
 		<info name="alt_title" value="シムシティ" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="simcity" sha1="4f161a7cd9d5fb27f2ebd6d544310e2c42d26da6" />
+				<disk name="simcity (japan) (en,ja) (rev a)" sha1="481515a5053b9540666293482de5102f74a155a7" />
 			</diskarea>
 		</part>
 	</software>
@@ -22474,7 +23174,7 @@ User/save disks that can be created from the game itself are not included.
 		<rom name="SimCity (Japan) (Track 16).bin" size="38474016" crc="224f5ba7" sha1="e31bf51f20a78ec13f2479772ed94358345638c2"/>
 		<rom name="SimCity (Japan).cue" size="1742" crc="9916d448" sha1="5d4ae1bd618b527c927db9437834fe9a667abe93"/>
 		-->
-		<description>SimCity (1990-03-05)</description>
+		<description>SimCity (HMB-121)</description>
 		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="serial" value="HMB-121 / A27600A0 / TSC060"/>
@@ -23798,6 +24498,32 @@ User/save disks that can be created from the game itself are not included.
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
 				<disk name="oto to e no deru eigo jisho no. 1 - start with words (japan)" sha1="382da5387582bc8119dfd22ab165193058aaf9d2" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="steepia">
+		<!--
+		Origin: redump.org
+		<rom name="Steepia (Japan) (Track 1).bin" size="20815200" crc="c58d1206" sha1="e9f7dfa0aadc1b90e5b65f45086374918db4d001"/>
+		<rom name="Steepia (Japan) (Track 2).bin" size="43218000" crc="1b2404b5" sha1="0b72085bb39a53d05328462b246050ba35e58613"/>
+		<rom name="Steepia (Japan) (Track 3).bin" size="58917600" crc="7daa3525" sha1="7bed9bdb6c4368781180925fef8271d733f95d5d"/>
+		<rom name="Steepia (Japan) (Track 4).bin" size="51508800" crc="717465dc" sha1="085ffe800277e144060287b465fa3ee00d57f7df"/>
+		<rom name="Steepia (Japan) (Track 5).bin" size="34927200" crc="d224025c" sha1="b379c173d52b94ef59e321fd2b3c8776f833ec4e"/>
+		<rom name="Steepia (Japan) (Track 6).bin" size="53449200" crc="0a8f6aac" sha1="60c759eae8c5540c5383a0fe731449f72f7cf871"/>
+		<rom name="Steepia (Japan) (Track 7).bin" size="32104800" crc="5be91f40" sha1="a4b05003bed6f473a9a8a2cef74a447a54509738"/>
+		<rom name="Steepia (Japan).cue" size="745" crc="82c8ff93" sha1="30cf0f24bdd5868956ec72f11254ae80050283b0"/>
+		-->
+		<description>Steepia</description>
+		<year>1993</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMD-179 / TSC230"/>
+		<info name="alt_title" value="スティーピア" />
+		<info name="release" value="199306xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="steepia (japan)" sha1="196fce1343f9db195bb197d01bd114e7600629b6" />
 			</diskarea>
 		</part>
 	</software>
@@ -25270,6 +25996,110 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
+	<software name="touchmus">
+		<!--
+		Origin: redump.org (CD) / cyo.the.vile (floppy)
+		<rom name="Touch the Music by Casiopea (Japan) (Track 01).bin" size="243079200" crc="4133c8e8" sha1="e1c2f75acdea9afa350679143799193e559a4425"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 02).bin" size="2116800" crc="d68994ef" sha1="c4f192ad21e36bffa47eb9035741eaeb820756cc"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 03).bin" size="1058400" crc="636f0c93" sha1="68e59add43ba91bc84eb3ffc72d14625761c2c18"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 04).bin" size="1234800" crc="17f1db79" sha1="128108c46e1db696862c3a1d062dccc3d7d5552f"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 05).bin" size="1058400" crc="23bf0b45" sha1="6c875da7a7208af7471ff1acd0ee9960b1254586"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 06).bin" size="1058400" crc="ae2f3383" sha1="25f0d164741124b229f5851df8c78a300750fefc"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 07).bin" size="1058400" crc="a09e8830" sha1="58ee9cf4d699e2bd08458c9e23fe4a3c8b7f8028"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 08).bin" size="1058400" crc="031e13d3" sha1="9c2ea491ba131706c44b538a1656c987eda3d132"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 09).bin" size="1058400" crc="f9b3e9e3" sha1="2d53e673003b6539e2387d004d3e9b129a87e49c"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 10).bin" size="1234800" crc="2970050e" sha1="baa4e962e32f475e5bdebeda076e0e6e96f193bf"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 11).bin" size="1058400" crc="f9e48cd7" sha1="2c2de7da039d7df212a707921ebd730d3a17f89e"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 12).bin" size="1234800" crc="834b2f2e" sha1="a353e506fa4152ff7ceb2bafddc7081a89ea393f"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 13).bin" size="1234800" crc="3ba718ca" sha1="a82edc28a53eecc2f6cd5b4ee5aa0589c8ef7ee9"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 14).bin" size="1058400" crc="08d6f4b9" sha1="fd5b3fdfd6e8444809d4052713e4cf44c9503bdf"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 15).bin" size="1058400" crc="4c92e241" sha1="6de716eefc22749ce74fa4b298a4190d44f15209"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 16).bin" size="1058400" crc="dc1fc40b" sha1="989910e1f65d2173bd2f15dcaa7aee1e62af57e8"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 17).bin" size="1058400" crc="74da552e" sha1="65b12e4f2aad67b3bb56ef70f4929f195933e39b"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 18).bin" size="1058400" crc="56888227" sha1="7b79a4bfb4b3394badd0d77977040b6e06a62bb1"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 19).bin" size="1058400" crc="c33f1bb0" sha1="f72182f33fabca541967c005c1ec6fe8a3459267"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 20).bin" size="1058400" crc="ec609b2e" sha1="b9cb0b15281bc7b4673bb4142dfdc0a69a8eab47"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 21).bin" size="1058400" crc="8f35e913" sha1="540c21ca6107a4b8d25b9c5539865d57cedbce68"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 22).bin" size="1234800" crc="9165088e" sha1="18be9632d75d3441f56b5e64447f62b7f4017878"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 23).bin" size="1058400" crc="43bd9c93" sha1="92c222bc41347dc16ac4b63205a497f508591031"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 24).bin" size="1058400" crc="567a9ce7" sha1="8fc6f38b26b459faa316095f39eca47b50af5278"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 25).bin" size="1058400" crc="2d9cf40e" sha1="cf41b4fc4a7a54f8ef2930e47ae803184008cf61"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 26).bin" size="1234800" crc="260e723a" sha1="5df494ca0b254cc4e76048e013fd26b01f42c5c2"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 27).bin" size="1234800" crc="68af8744" sha1="c12db13871314ea89093be0fcb384fd39cca8db4"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 28).bin" size="1058400" crc="79d5d83e" sha1="fb2302ef271b627fba4ed17c6bfaa38311a9dcc5"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 29).bin" size="1058400" crc="6d0d0a9b" sha1="3ac18ab21ed35acad396fe8f08384d9b3009e7a7"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 30).bin" size="5292000" crc="b2138b1a" sha1="c2ffae6c84e6c08a4e848a704dc4788cb392e090"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 31).bin" size="4586400" crc="eab51b17" sha1="eb277558f8f8c29a3aaf1a353ca1a0d5c0a64c64"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 32).bin" size="4233600" crc="c3f950c1" sha1="e2969721c1cf63b1ce8e2c728f1a2733eaa21417"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 33).bin" size="4410000" crc="0acc1341" sha1="d02229cccf8a651618342d5fca25d96c9e45d1f4"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 34).bin" size="4410000" crc="daaced98" sha1="3e997b6e79b24bea6043ba4dccc873f47f28fbd4"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 35).bin" size="5115600" crc="11ecd0a6" sha1="a319e03db6b4be4071ffa0ed5085e90eee3d3dfb"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 36).bin" size="4410000" crc="f0eeeaa9" sha1="366a6a38c3f1185555d434c7909e0f643fd19cd5"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 37).bin" size="5292000" crc="cf69d999" sha1="7c5635d58644991e8547a6a6a97a45f921c21461"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 38).bin" size="5292000" crc="a4f079d3" sha1="80dcbf7bafe40e02e65deb9b3806ce794dcf41a0"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 39).bin" size="5468400" crc="9f26d704" sha1="f7fe0c3014efb70ca4b044d89a1efac85f2d5d58"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 40).bin" size="5292000" crc="2d90d805" sha1="b8d986228af1ee0ac2b3308c9368ce5153461359"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 41).bin" size="4233600" crc="c99b1258" sha1="8cd52a6653e643eb9acdd7ffa618b21cf16bf135"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 42).bin" size="4939200" crc="7656446a" sha1="b1c2b67432b24ebb77926f95584a407c5e27c763"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 43).bin" size="6350400" crc="b033dd1e" sha1="596235c106c764541db1172e4a400bd7cc85d308"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 44).bin" size="6174000" crc="218c0351" sha1="77113efda47b48d41bb480370f3c54e91e48b83d"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 45).bin" size="5821200" crc="8d7941bd" sha1="ab3a774c4d48ab7cc49c1f2e9a4dd173304494de"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 46).bin" size="7232400" crc="f6beb743" sha1="13b623e63f6031ae8133e88c9566d665c994292a"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 47).bin" size="3880800" crc="fc86ac0d" sha1="06c393405f60e52d755d3a46a027e616e5622c1a"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 48).bin" size="4410000" crc="069c263c" sha1="e854001b8f26d489d6d2de565159d529a76350ee"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 49).bin" size="4762800" crc="cfc96876" sha1="60952e072d9788c8e461bf6e817f3012e76de4db"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 50).bin" size="5292000" crc="17447ef0" sha1="44c7eb7e906caf7b7247fbaacde9ceebdb91b0e1"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 51).bin" size="4762800" crc="4ac85eef" sha1="4ac28a9f44b1cc1e260889b78ee352a5925821ec"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 52).bin" size="4762800" crc="31141cad" sha1="5cf49bf1206d7d491b8b5baf0d8f5372f4e29878"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 53).bin" size="4586400" crc="f09ca290" sha1="a09d1146cbbaf84f51e753070f692316dd822285"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 54).bin" size="4586400" crc="fe7684b9" sha1="be6b5bb4eaadc0f9ab8b2fa4de433804772d24d3"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 55).bin" size="4762800" crc="580a114b" sha1="a77e141db95c9571195da04d05e9c942813a1ead"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 56).bin" size="5115600" crc="56bfffc2" sha1="561e82205ca9285f84056559f7ddd616a69866a6"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 57).bin" size="4410000" crc="d8599789" sha1="cab409cd44ddfa2cbe4b0d8ee4ee076c234ff3dc"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 58).bin" size="5292000" crc="4aa1fc49" sha1="8bfc4352811b0bff685b86460e0fbf837f7aa5e6"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 59).bin" size="5821200" crc="84207742" sha1="712733e17f1d865f885baa1940ea7f249ae4c766"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 60).bin" size="4762800" crc="bb4ac7e7" sha1="1869a506d0caf06777130524a312195267000b43"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 61).bin" size="4586400" crc="e455fc72" sha1="2bd8cb4c2f02a961095538e730e7e164e6a18c7a"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 62).bin" size="4939200" crc="6db00583" sha1="05a16d5e4b95a7009b90675627bc8df26ea2ee6d"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 63).bin" size="4939200" crc="c3463cf9" sha1="f25e43312c8ae48bf513004d6fbd275532625626"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 64).bin" size="4939200" crc="9504eadf" sha1="ef91adce203387d70d77cf3f651dd01bed6a685e"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 65).bin" size="47804400" crc="4b8dc618" sha1="8c2fcaf99c98f4a78a1640dcbbe62309192bc1fc"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 66).bin" size="2116800" crc="758aee8d" sha1="bb35f90ed9ee2893128a63087f17493a911af832"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 67).bin" size="1940400" crc="14422684" sha1="0c6db27282ba3e6f5c0bce97a064df481eb95034"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 68).bin" size="1764000" crc="4a41fbe7" sha1="117e365d3232fc71b4980a42b45eba370b8055f0"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 69).bin" size="1940400" crc="8f51ae34" sha1="2c41a4f71ba45794191f3a5dd461a9cbc417c167"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 70).bin" size="1940400" crc="320e9aad" sha1="926b06ae94c5abf1bc3ef6d5c423aa6694f3d3bf"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 71).bin" size="1940400" crc="7566ed28" sha1="cfc01a093db13f19b6721b2f863f308b00cf4bb2"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 72).bin" size="1940400" crc="7b3ab027" sha1="2e816bc872df8b8234d269238747b81c2e22229d"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 73).bin" size="1940400" crc="e8c48ea7" sha1="2e2c7e6ec0aaf8ab63bd64c9794aa13ab3ced01a"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 74).bin" size="1764000" crc="266d0d4b" sha1="e650346132c7db37184b06fddc8c0420b1b8bac6"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 75).bin" size="1940400" crc="81432e71" sha1="1d5086a8e5661856d37edd3601b6aaa9ab9b4f65"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 76).bin" size="1764000" crc="b67ea3e4" sha1="c207da3b9656690688c635d14336db7c38fe73e6"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 77).bin" size="47628000" crc="18cc4b04" sha1="0ee546a45915e61ab5bb05b74182bccee869bec3"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 78).bin" size="47628000" crc="d9499fd7" sha1="7372b726498161fe1b93d4e88ec4e624caa584ce"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 79).bin" size="47628000" crc="bc10ae07" sha1="b251327158811541308e4c55fe911bd772ab3ccd"/>
+		<rom name="Touch the Music by Casiopea (Japan) (Track 80).bin" size="47628000" crc="047861ac" sha1="20bcc9aeb30ea64ee6a43d59403a4983b8b4e8e4"/>
+		<rom name="Touch the Music by Casiopea (Japan).cue" size="10405" crc="2d6d3993" sha1="5723c1ba139b2309709d854f74dec68b34b2b2e8"/>
+		-->
+		<description>Touch the Music by Casiopea</description>
+		<year>1994</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HME-187 / A2760500"/>
+		<info name="release" value="199403xx" />
+		<info name="usage" value="Requires 2 MB RAM"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Key Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="touch_the_music_key_disk.hdm" size="1261568" crc="36eb0122" sha1="5936f982ffb13e3dd14e0ae9a9cfc0213c9fc9ba" offset="000000" />
+			</dataarea>
+		</part>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="touch the music by casiopea (japan)" sha1="983684515a021eaa1b350ebb250977e773951d79" />
+			</diskarea>
+		</part>
+	</software>
+
 	<software name="toukou1">
 		<!--
 		Origin: redump.org
@@ -25451,7 +26281,24 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="tpaint10">
+	<software name="tpaint">
+		<!--
+		Origin: redump.org
+		<rom name="Towns Paint V1.1 L22 (Japan).bin" size="40748400" crc="90e5222d" sha1="14ad868cee4d35a38b8593e3ee531c5fc911dee9"/>
+		<rom name="Towns Paint V1.1 L22 (Japan).cue" size="117" crc="c3696262" sha1="15613ac271a2f5a6efd0d8d971f44eb2d48ed1e0"/>
+		-->
+		<description>TownsPAINT V1.1 L22</description>
+		<year>1991</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="B276D010"/>
+		<part name="cdrom" interface="fmt_cdrom">
+			<diskarea name="cdrom">
+				<disk name="towns paint v1.1 l22 (japan)" sha1="b0197f0a286103d74267816400aee18366fffcd6" />
+			</diskarea>
+		</part>
+	</software>
+
+	<software name="tpaint10" cloneof="tpaint">
 		<!--
 		Origin: redump.org
 		<rom name="Towns Paint V1.1L10 (Japan).bin" size="20286000" crc="f0e255e0" sha1="832f5ccd13e0c7f79410089564f799b05f828091"/>
@@ -25469,7 +26316,7 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="tpaint20">
+	<software name="tpaint20" cloneof="tpaint">
 		<!--
 		Origin: redump.org
 		<rom name="Towns Paint V1.1L20 (Japan).bin" size="39337200" crc="a384a685" sha1="d1ba91cffb50916c04d2cce54b5622a0181df451"/>
@@ -25486,19 +26333,19 @@ User/save disks that can be created from the game itself are not included.
 		</part>
 	</software>
 
-	<software name="tpaint22">
+	<software name="tpaint21" cloneof="tpaint">
 		<!--
 		Origin: redump.org
-		<rom name="Towns Paint V1.1 L22 (Japan).bin" size="40748400" crc="90e5222d" sha1="14ad868cee4d35a38b8593e3ee531c5fc911dee9"/>
-		<rom name="Towns Paint V1.1 L22 (Japan).cue" size="117" crc="c3696262" sha1="15613ac271a2f5a6efd0d8d971f44eb2d48ed1e0"/>
+		<rom name="Towns Paint V1.1 L21 (Japan).bin" size="41454000" crc="5ea6cbfb" sha1="30e2d2c97367702fa9d01684bce7cceee3b7cf8e"/>
+		<rom name="Towns Paint V1.1 L21 (Japan).cue" size="117" crc="f96e0d38" sha1="c60064bb6b13340ae88949827806a1c539d269ca"/>
 		-->
-		<description>TownsPAINT V1.1 L22</description>
-		<year>1991</year>
+		<description>TownsPAINT V1.1 L21</description>
+		<year>1990</year>
 		<publisher>富士通 (Fujitsu)</publisher>
 		<info name="serial" value="B276D010"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="towns paint v1.1 l22 (japan)" sha1="b0197f0a286103d74267816400aee18366fffcd6" />
+				<disk name="towns paint v1.1 l21 (japan)" sha1="7e4f01c6ba8ae56670c40a954456578f5474dbe0" />
 			</diskarea>
 		</part>
 	</software>
@@ -25969,27 +26816,25 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="uwaki">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Uwaki na Anata.ccd" size="772" crc="945be786" sha1="978bcc2ea2b3609048c103382ef794d6d22f1332"/>
-		<rom name="Uwaki na Anata.cue" size="78" crc="0b767425" sha1="08ebc0f26da61a75c9b16b91c58958b8771329b5"/>
-		<rom name="Uwaki na Anata.img" size="329837424" crc="83d4184b" sha1="472e75e5585630c6b3c9da876f51427f76b01de9"/>
-		<rom name="Uwaki na Anata.sub" size="13462752" crc="e93ef365" sha1="022b39a867b7f36d042822d5b982e41f43c0359f"/>
+		Origin: redump.org (CD) / Neo Kobe Collection (floppy)
+		<rom name="Uwaki na Anata - Switch o Irete (Japan).bin" size="329837424" crc="83d4184b" sha1="472e75e5585630c6b3c9da876f51427f76b01de9"/>
+		<rom name="Uwaki na Anata - Switch o Irete (Japan).cue" size="128" crc="fc8d1e60" sha1="9b2d482b3ebb2cfa070ae0f97dde5f43657046e2"/>
 		-->
-		<description>Uwaki na Anata - Switch wo Irete</description>
+		<description>Uwaki na Anata - Switch o Irete</description>
 		<year>1994</year>
 		<publisher>エイチオーピー (HOP)</publisher>
-		<info name="alt_title" value="浮気なあ・な・たスイッチをい・れ・て" />
+		<info name="serial" value="HOP-401"/>
+		<info name="alt_title" value="浮気なあ・な・た　～スイッチをい・れ・て～" />
 		<info name="release" value="199406xx" />
 		<info name="usage" value="Requires 4 MB RAM"/>
 		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1261568">
 				<rom name="uwaki na anata (boot disk).hdm" size="1261568" crc="27b0fc8b" sha1="4010114d203a210175b59e3d4dc46df0cf805f03" offset="000000" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="uwaki na anata" sha1="881aa47e943a6491b0cace4761b169ff9ed9532c" />
+				<disk name="uwaki na anata - switch o irete (japan)" sha1="3897df054019f7d1bd839452398783b89f1d950f" />
 			</diskarea>
 		</part>
 	</software>
@@ -27548,18 +28393,42 @@ User/save disks that can be created from the game itself are not included.
 
 	<software name="zak">
 		<!--
-		Origin: Neo Kobe Collection
-		<rom name="Zak McKracken.mdf" size="759834720" crc="a1351dd7" sha1="3661d59a79d0adf97d6443da733bd5f46e40020a"/>
-		<rom name="Zak McKracken.mds" size="3304" crc="a006e8da" sha1="7df4355cd7dc90405930880e06c6aec4235c6e8d"/>
+		Origin: redump.org
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 01).bin" size="54331200" crc="68733f99" sha1="a4ffaa88b3c83a9f8df5e0c3a1cb1f7c11e8509e"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 02).bin" size="7056000" crc="8f0b286e" sha1="171d42e3189173b3ed415d54a512c117f37c13cc"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 03).bin" size="43387344" crc="c3ec7639" sha1="5a89810c38b7fa1218ec87735daf3a3263d4e911"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 04).bin" size="43989456" crc="5981bff7" sha1="938f59bb0158c65ea49f94321130ebf71b8f4c70"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 05).bin" size="18357360" crc="11f64385" sha1="1bfdbbba6a478fd70691e11e0f07b463b05eba71"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 06).bin" size="15186864" crc="f8359da7" sha1="db270ac7987d1a569f5263adf290c7d16b798ba8"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 07).bin" size="42495936" crc="40254b67" sha1="99d240fff9c923558e22228df4e7d76124faa8ab"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 08).bin" size="29023680" crc="03f5e31c" sha1="8b9a5b0fe6314e7ee40655143c858a1a4c83da52"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 09).bin" size="32986800" crc="a86754a6" sha1="f652665ddd5f022b48b5ab485bde29559cd296ae"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 10).bin" size="43547280" crc="ddabaa1e" sha1="01b8caab578ac0ee7f4f08c95e57e909d81c1615"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 11).bin" size="46903584" crc="7b07e878" sha1="071e8d26131a96a8ef6bc3395e35bbbfb3a26a18"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 12).bin" size="12336240" crc="57f1f493" sha1="17cf1319858829a8f2cfaba75d703bad09c20421"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 13).bin" size="12554976" crc="9f1aff7b" sha1="f42149de6764c8c928720abeba2908b007f67f74"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 14).bin" size="6543264" crc="c12c99e2" sha1="e8691a5a33c22813ee282a4e64a1ee53b89bafe2"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 15).bin" size="27254976" crc="7305fb98" sha1="63a33dedb32ac8813322249ab1d9baec889c8b5b"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 16).bin" size="20902224" crc="6269430c" sha1="0cf6bbddf96eef2fd27445d60bd8a8dfa022fd8e"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 17).bin" size="33770016" crc="6b40e354" sha1="dcb70719adae5940437500543b76892359e78521"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 18).bin" size="43806000" crc="5bb3f7a8" sha1="dd46ba6b1a75533904d4bba35bdedfa6e24d4b7b"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 19).bin" size="43664880" crc="cebcf140" sha1="4fc264465e23e2335fc383266e94a07b00a31fcd"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 20).bin" size="26848080" crc="3e1a7e3f" sha1="fa0a7490608123c3b6afcbee00ef02e4be65773e"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 21).bin" size="45287760" crc="89c85d0b" sha1="ad51379da4f10f653390c9f4b01dd19ece4a8277"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 22).bin" size="25312224" crc="114fee88" sha1="d45cd8886344fe4efab06770294b060ce905bad4"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 23).bin" size="6545616" crc="ccb158e0" sha1="903d3a5456d1ee8b456d98292c314fc08897a860"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A) (Track 24).bin" size="48298320" crc="b2387930" sha1="370a0ec9fecb03608aae2ad91f21926925155ddb"/>
+		<rom name="Zak McKracken and the Alien Mindbenders (Japan) (En,Ja) (Rev A).cue" size="3774" crc="db8b3998" sha1="423e0b8a4cd48d7fc2dbe8d98223cababbc13d3d"/>
 		-->
 		<description>Zak McKracken and The Alien Mindbenders</description>
-		<year>1990</year>
+		<year>1991</year>
 		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="serial" value="HMB-218A / A2760090 / TSC100"/>
 		<info name="release" value="199102xx" />
 		<info name="usage" value="Requires 2 MB RAM"/>
 		<part name="cdrom" interface="fmt_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zak mckracken" sha1="0a06dcd3aaebcd79ec3c03dd0b179b9047e2bccd" />
+				<disk name="zak mckracken and the alien mindbenders (japan) (en,ja) (rev a)" sha1="b815f0592ae756a58cf5b8bd34b630b55279c6e9" />
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Added the missing floppy disk to amarant3 [akira_2020]
- Added the missing floppy disk to hypnote [cyo.the.vile]
- Added the Planet's Edge bonus audio CD [redump.org]
- Removed the floppy part_id from uwaki, as it's not part of the floppy label

New working software list additions
-----------------------------------
CRI Postman [redump.org]
Dynamic English 3 - Upper Basic [redump.org, cyo.the.vile]
FM Towns Shougaku Ongaku (5-6-nensei-you) [redump.org, cyo.the.vile]
Hyper Aquarium - Kaisui-hen [redump.org]
Hyper Aquarium - Tansui-hen [redump.org]
Hyper Eigo Gakushuu System - New Crown Series 1 [redump.org]
Igo Doujou Yaburi - Menkyo Kaiden!! Mezase 7-kyuu [redump.org]
J.League 1994 Professional Soccer [redump.org]
Master CD - Fresh Series-you [redump.org]
Meikyoku Master (FM Towns Marty version) [redump.org]
Nihon no Rekishi - Sengoku-hen - Oda Nobunaga [redump.org]
Nihongo Nyuumon Dai-1-kan - Fundamental Japanese [redump.org]
Steepia [redump.org]
Touch the Music by Casiopea [redump.org, cyo.the.vile]
TownsPAINT V1.1 L21 [redump.org]

New not working software list additions
---------------------------------------
Dynamic English 2 - Basic [redump.org]

Replaced software list items
----------------------------
Highlight CD 20 [redump.org]
Okiraku TownsGEAR [redump.org]
Oshare Cooking [redump.org]
Sangokushi II [redump.org]
SimCity (HMB-121A) [redump.org]
Uwaki na Anata - Switch o Irete [redump.org]
Zak McKracken and The Alien Mindbenders [redump.org]

Software list items promoted to working
---------------------------------------
Hyper Note [cyo.the.vile]