### PR TITLE
saturn.cpp: Add Korean BIOS placeholder

### DIFF
--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -10522,9 +10522,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<!-- Pings [CD-Block] HIRM register, no noticeable effect? -->
-	<!-- Moans about modem not connected off the bat, pings [CD-Block] specific I/O for status -->
+	<!-- Moans about modem not connected off the bat, pings [CD-Block] specific I/O for status (kludged to work) -->
+	<!-- With -drc on it moans that the "backup RAM is unformatted", it actually tries to access wrong pointers and eventually corrupts it out -->
 	<!-- Title screen drawing cuts off backgrounds with black pens [VDP2] -->
 	<!-- Options menu doesn't show background layer(s) [VDP2] -->
 	<!-- Keyboard inputs doesn't work -->

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -2605,7 +2605,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Alone in the Dark 2 (Japan)... -->
+	<!-- Black screen, enables [SCU] Timer 1 -->
 	<software name="aitd2j" cloneof="aitd2" supported="no">
 		<description>Alone in the Dark 2 (Jpn)</description>
 		<year>1996</year>
@@ -2653,7 +2653,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Aquazone - Desktop Life (Japan)... -->
+	<!-- Hardlocks at boot, caused by [SCU] DMA-ing with max sizes -->
 	<software name="aquazone" supported="no">
 		<description>Aquazone - Desktop Life (Jpn)</description>
 		<year>1996</year>
@@ -2911,7 +2911,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Bio Hazard (Japan)... -->
+	<!-- No text in main menu [VDP1/VDP2] -->
+	<!-- No background layer in inventory screen, [VDP1] inverted window -->
+	<!-- Options menu is too large [VDP1], sports [VDP1] zooming error for the background zombie, has no back layer drawing [VDP2] -->
 	<software name="biohaz" cloneof="revil" supported="no">
 		<description>Bio Hazard (Jpn)</description>
 		<year>1997</year>
@@ -2927,7 +2929,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Black Matrix (Japan) (Reprint)... -->
+	<!-- Black screen after selecting new game, [CD-Block] reads FAD=165482 then jumps to lalaland -->
 	<software name="blckmtxa" cloneof="blckmtx" supported="no">
 		<description>Black/Matrix (Jpn, Reprint)</description>
 		<year>1998</year>
@@ -2991,7 +2993,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Capcom Generation - Dai 1 Shuu Gekitsui Ou no Jidai (Japan)... -->
+	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
 	<software name="capgen1" supported="no">
 		<description>Capcom Generation - Dai-1-Shuu - Gekitsui Ou no Jidai (Jpn)</description>
 		<year>1998</year>
@@ -3039,7 +3041,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Capcom Generation - Dai 4 Shuu Kokou no Eiyuu (Japan)... -->
+	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
+	<!-- Plays wrong sounds in all games, [CD-Block]? -->
+	<!-- Title select screen draws transparent instead of opaque [VDP2] -->
+	<!-- All games uses unemulated [VDP1] framebuffer rotation in Yoko screen mode, sprites are slightly glitchy in Tate mode. -->
 	<software name="capgen4" supported="no">
 		<description>Capcom Generation - Dai-4-Shuu - Kokou no Eiyuu (Jpn)</description>
 		<year>1998</year>
@@ -3055,7 +3060,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Capcom Generation - Dai 5 Shuu Kakutou ke Tachi (Japan)... -->
+	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
 	<software name="capgen5" supported="no">
 		<description>Capcom Generation - Dai-5-Shuu - Kakutou ke Tachi (Jpn)</description>
 		<year>1998</year>
@@ -3087,7 +3092,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Chibi Maruko-chan no Taisen Puzzledama (Japan)... -->
+	<!-- Konami FMV logo sound is off-sync [CD-Block] -->
+	<!-- Black screen after FMV with -drc option -->
+	<!-- In-game speech and redbook audio are off-sync [CD-Block] -->
 	<software name="cpuzldam" supported="no">
 		<description>Chibi Maruko-chan no Taisen Puzzledama (Jpn)</description>
 		<year>1995</year>
@@ -3173,8 +3180,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Command &amp; Conquer (Japan) (Disc 1) (GDI Disc)... -->
-	<!-- Identifying Command &amp; Conquer (Japan) (Disc 2) (NOD Disc)... -->
+	<!-- Black screen (and SIGSEGV with -drc) on FMVs, [CD-Block] transfers 1 sector at a time but actual transfers are way ahead. -->
 	<software name="cncj" cloneof="cnc" supported="no">
 		<description>Command &amp; Conquer (Jpn)</description>
 		<year>1997</year>
@@ -3245,7 +3251,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Cyberbots - Fullmetal Madness (Japan) (1M)... -->
+	<!-- Hangs at Now loading screens, expects [VDP1] CEF to be 1 (in manual mode, without writing to the port first) -->
 	<software name="cybots" supported="no">
 		<description>Cyberbots - Fullmetal Madness (Jpn, 1M)</description>
 		<year>1997</year>
@@ -3322,7 +3328,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Darius Gaiden (Japan) (3M)... -->
+	<!-- Several sprites in intro have wrong colors (cfr. first mech exiting the planet, lasers when Silver Hawk is introduced, Golden Ogre) [VDP1] -->
 	<software name="dariusgj" cloneof="dariusg" supported="no">
 		<description>Darius Gaiden (Jpn, 3M)</description>
 		<year>1995</year>
@@ -3402,7 +3408,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying DecAthlete (Japan) (1M)... -->
+	<!-- Sega Sports logo has few glitchy tiles on bottom of screen [VDP2] -->
+	<!-- [SCSP] CPU often crashes during boot -->
+	<!-- Incorrectly blends ROZ layer [VDP2] -->
+	<!-- main menu/gameplay performance is poor [VDP2?] -->
 	<software name="decathltj" cloneof="athlking" supported="no">
 		<description>DecAthlete (Jpn, 1M)</description>
 		<year>1996</year>
@@ -3669,7 +3678,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying DoDonPachi (Japan)... -->
+	<!-- Hangs at now loading screen with Cave logo with -drc on -->
+	<!-- Right edge of screen has empty blue line on gameplay [VDP2] -->
+	<!-- Setting game in Tate Mode will often black screen Arcade Mode attract, sometimes gameplay too. -->
+	<!-- First boss initial GFX composition diverges compared to Arcade version [VDP1] -->
 	<software name="ddonpach" supported="no">
 		<description>DoDonPachi (Jpn)</description>
 		<year>1997</year>
@@ -3739,7 +3751,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Doukyuusei if (Japan) (1M, 2M)... -->
+	<!-- Fade in/out effect is reversed on title screen, enables [VDP2] Color Calculation -->
 	<software name="dokyuif" supported="no">
 		<description>Doukyuusei If (Jpn, 1M, 2M)</description>
 		<year>1996</year>
@@ -3836,7 +3848,9 @@ Olympic Soccer (Fra) T-7904H-09
 	</software>
 
 	<!-- The Dungeons and Dragons collection is a 2 disk set, but each disk is an independent game so I've left them separate -->
-	<!-- Identifying Dungeons &amp; Dragons Collection (Japan) (Disc 1) (Tower of Doom)... -->
+	<!-- Glitchy sprites [VDP1] -->
+	<!-- No SFXs [CD-Block/SCSP] -->
+	<!-- Hangs often -->
 	<software name="ddtod" supported="no">
 		<description>Dungeon's &amp; Dragons - Tower of Doom (Dungeons &amp; Dragons Collection Disc 1) (Jpn)</description>
 		<year>1999</year>
@@ -3853,6 +3867,7 @@ Olympic Soccer (Fra) T-7904H-09
 	</software>
 
 	<!-- Identifying Dungeons &amp; Dragons Collection (Japan) (Disc 2) (Shadow over Mystara)... -->
+	<!-- Glitchy sprites [VDP1] -->
 	<software name="ddsom" supported="no">
 		<description>Dungeons &amp; Dragons - Shadow over Mystara (Dungeons &amp; Dragons Collection Disc 2) (Jpn)</description>
 		<year>1999</year>
@@ -4063,7 +4078,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Dragon Slayer crashes in DRC after being selected, with NODRC sound eventually dies during gameplay. -->
+	<!-- Dragon Slayer crashes with -drc during the initial loading -->
+	<!-- [SCSP] sound eventually dies during gameplay. -->
 	<software name="falcom1" supported="no">
 		<description>Falcom Classics (Jpn)</description>
 		<year>1997</year>
@@ -4079,7 +4095,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Falcom Classics II (Japan)... -->
+	<!-- Doesn't recognize start button on title screen, known to be related with [CD-Block] -->
 	<software name="falcom2" supported="no">
 		<description>Falcom Classics II (Jpn)</description>
 		<year>1998</year>
@@ -4111,8 +4127,11 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Fighter's History Dynamite (Japan)... -->
-	<software name="fhdyna" supported="no"> <!-- karnovr -->
+	<!-- On gameplay most characters draw garbage, [CD-Block] never starts most transfers -->
+	<!-- redbook audio don't playback, probably related to above. -->
+	<!-- Clears [VDP1] framebuffer every 2 frames, intentional? -->
+	<!-- Accesses ROM space at first boot, disabled debugging code? -->
+	<software name="fhdyna" supported="no">
 		<description>Fighter's History Dynamite (Jpn)</description>
 		<year>1997</year>
 		<publisher>Sega</publisher>
@@ -4120,6 +4139,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<info name="release" value="19970704"/>
 		<info name="alt_title" value="ファイターズヒストリー・ダイナマイト"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<!-- TODO: 1 Mbit RAM? -->
 		<sharedfeat name="requirement" value="sat_cart:ram32"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
@@ -4179,11 +4199,11 @@ Olympic Soccer (Fra) T-7904H-09
 	<!-- Identifying Fighting Vipers (Korea)... -->
 	<software name="fvipersk" cloneof="fvipers" supported="no">
 		<description>Fighting Vipers (Kor)</description>
-		<year>1996</year>
+		<year>1996?</year>
 		<publisher>Samsung</publisher>
 		<info name="serial" value="MK81041-08"/>
 		<info name="alt_title" value="파이팅바이퍼즈"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-K,NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="fighting vipers (korea)" sha1="f5bc2c13ab82d18529426f70e460534b118d41c8" />
@@ -4223,7 +4243,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Fishing Koushien (Japan)... -->
+	<!-- title screen effect glitches out [VDP1] -->
 	<software name="fishk" supported="no">
 		<description>Fishing Koushien (Jpn)</description>
 		<year>1996</year>
@@ -4288,7 +4308,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gakkou no Kaidan (Japan)... -->
+	<!-- Black screen, [CD-Block] uses fnum reject filter -->
 	<software name="gakkokai" supported="no">
 		<description>Gakkou no Kaidan (Jpn)</description>
 		<year>1995</year>
@@ -4304,7 +4324,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Galaxy Fight - Universal Warriors (Japan)... -->
+	<!-- Glitchy sprites [VDP1] -->
 	<software name="galaxyfgj" cloneof="galaxyfg" supported="no">
 		<description>Galaxy Fight - Universal Warriors (Jpn)</description>
 		<year>1995</year>
@@ -4320,7 +4340,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gale Racer (Japan) (En,Ja) (1A)... -->
+	<!-- Gameplay car HUD becomes transparent when tilting on slopes [VDP2] -->
 	<software name="galerace" supported="no">
 		<description>Gale Racer (Jpn, 1A)</description>
 		<year>1994</year>
@@ -4336,7 +4356,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gals Panic SS (Japan)... -->
+	<!-- Gals select screen sports unmasked text layer over box, [VDP2] enables window logic OR on NBG2 with only one window enabled -->
 	<software name="gpanicss" supported="no">
 		<description>Gals Panic SS (Jpn)</description>
 		<year>1996</year>
@@ -4352,8 +4372,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Game Basic for SegaSaturn (Japan) (Windows CD)... -->
-	<!-- Identifying Game Basic for SegaSaturn (Japan)... -->
+	<!-- Keyboard inputs doesn't work properly (regression) -->
 	<software name="gamebas" supported="no">
 		<description>Game Basic for SegaSaturn (Jpn)</description>
 		<year>1998</year>
@@ -4362,6 +4381,8 @@ Olympic Soccer (Fra) T-7904H-09
 		<info name="release" value="19980625"/>
 		<info name="alt_title" value="ゲームベーシック フォー セガサターン"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<!-- TODO: in port 2? -->
+		<info name="usage" value="Needs keyboard connected"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game basic for segasaturn (japan)" sha1="bda219fae902fbe1c5bc5c95226b038fc2733031" />
@@ -4454,7 +4475,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gokujou Parodius Da! Deluxe Pack (Japan) (Rev A)... -->
+	<!-- Stop BGMs sound playback during gameplay in both games, [CD-Block] uses curfad filter rejection -->
 	<software name="gokuparo" cloneof="parodius" supported="no">
 		<description>Gokujou Parodius Da! Deluxe Pack (Jpn, Rev. A)</description>
 		<year>1995</year>
@@ -4470,7 +4491,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Golden Axe - The Duel (Japan) (2M)... -->
+	<!-- Returns to Sega MultiPlayer menu after [CD-Block] reads FAD=474 (COLOR.BIN) a second time around (upload failed?) -->
 	<software name="gaxeduelj" cloneof="gaxeduel" supported="no">
 		<description>Golden Axe - The Duel (Jpn, 2M)</description>
 		<year>1995</year>
@@ -4568,7 +4589,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Grandia - Digital Museum (Japan) (Rev A)... -->
+	<!-- Hangs on Sega logo with [CD-Block] keeps looping with command 0x51 (regression) -->
 	<software name="granddm" supported="no">
 		<description>Grandia - Digital Museum (Jpn, Rev. A)</description>
 		<year>1998</year>
@@ -5244,7 +5265,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying King of Boxing, The (Japan)... -->
+	<!-- FMV playback is very glitchy [CD-Block] -->
+	<!-- main menu/gameplay performance is poor (caused by the polygon rasterizer) [VDP1] -->
+	<!-- Gameplay back layer still shows the main menu instead of being black filled [VDP2] -->
 	<software name="kingbox" cloneof="vicboxin" supported="no">
 		<description>The King of Boxing (Jpn)</description>
 		<year>1995</year>
@@ -5311,7 +5334,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Kisuishou Densetsu Astal (Japan) (4M)... -->
+	<!-- Black screen, caused by cache RAM setting a value of 0xf to [SCU] irq mask -->
+	<!-- Afterwards: black screen after FMV, [CD-Block] loops with commands 0x45 -> 0x43 -->
 	<software name="astalj" cloneof="astal" supported="no">
 		<description>Kisuishou Densetsu Astal (Jpn, 4M)</description>
 		<year>1995</year>
@@ -6006,7 +6030,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<publisher>Wooyoung</publisher>
 		<info name="serial" value="T-26801H-08"/>
 		<info name="alt_title" value="미스트"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-K,NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="myst (korea)" sha1="8a23e3c30758ddee048bb07229024c281adf7b8b" />
@@ -7230,7 +7254,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sega Ages - Columns Arcade Collection (Japan)... -->
+	<!-- Doesn't draw the Sega Ages logo at boot [VDP2?] -->
+	<!-- Pings [CD-Block] HIRM register, no noticeable effect? -->
 	<software name="columns" supported="no">
 		<description>Sega Ages - Columns Arcade Collection (Jpn)</description>
 		<year>1997</year>
@@ -7246,7 +7271,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sega Ages - Fantasy Zone (Japan)... -->
+	<!-- TODO: Verify initial Sega logo animation -->
+	<!-- BGMs are mostly silent, never completes underlying [CD-Block] transfer -->
 	<software name="fantzone" supported="no">
 		<description>Sega Ages - Fantasy Zone (Jpn)</description>
 		<year>1997</year>
@@ -7326,7 +7352,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Phantasy Star 2 (at least) has not working BGMs (repeats a very short chunk over and over) -->
+	<!-- PS2 (at least) has not working BGMs (repeats a very short chunk over and over) (Update: fixed by now, or random bug?) -->
+	<!-- PS2 sports wrong priority on gameplay (sprites going above buildings, menuing etc.) [VDP1/VDP2] -->
+	<!-- TODO: verify PS1/PS3/PS4 -->
 	<software name="pstarcol" supported="no">
 		<description>Sega Ages - Phantasy Star Collection (Jpn)</description>
 		<year>1998</year>
@@ -7397,7 +7425,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<publisher>Samsung</publisher>
 		<info name="serial" value="MK81207-08"/>
 		<info name="alt_title" value="세가 랠리"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-K,NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="sega rally championship (korea)" sha1="5ae79ef9b176075c4ee422bc8e631f70aa6e13ca" />
@@ -7453,8 +7481,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 1)... -->
-	<!-- Identifying Sengoku Blade - Sengoku Ace Episode II (Japan) (Disc 2) (Omake CD)... -->
+	<!-- Black screen, [CD-Block] doesn't read root directory properly -->
 	<software name="sengblad" supported="no">
 		<description>Sengoku Blade - Sengoku Ace Episode II (Jpn)</description>
 		<year>1996</year>
@@ -7475,8 +7502,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 1) (Rev A) (10M)... -->
-	<!-- Identifying Senkutsu Katsuryu Taisen - Chaos Seed (Japan) (Disc 2) (Omake CD)... -->
+	<!-- Black screen, [CD-Block] doesn't read root directory properly -->
 	<software name="chaossd" supported="no">
 		<description>Senkutsu Katsuryu Taisen - Chaos Seed (Jpn, Rev A)</description>
 		<year>1998</year>
@@ -9219,7 +9245,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Whizz (Japan)... -->
+	<!-- black screen at boot, [CD-Block] never completes first FMV transfer after FAD=5561 -->
 	<software name="whizzj" cloneof="whizz" supported="no">
 		<description>Whizz (Jpn)</description>
 		<year>1997</year>
@@ -9395,14 +9421,15 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Worldwide Soccer - Sega International Victory Goal Edition (Korea)... -->
+	<!-- Trips some illegal sprites during transitions [VDP1] -->
+	<!-- Has sprite zooming errors (cfr. VS flags before matches) [VDP1] -->
 	<software name="intvgoalk" cloneof="intvgoal" supported="no">
 		<description>Worldwide Soccer - Sega International Victory Goal Edition (Kor)</description>
-		<year>199?</year>
+		<year>1995?</year>
 		<publisher>Samsung</publisher>
 		<info name="serial" value="MK81105-08"/>
 		<info name="alt_title" value="월드 와이드 사커"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-K,NTSC-U"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="worldwide soccer - sega international victory goal edition (korea)" sha1="1db5e4e0e06bc2d7dec752ec15cfefc835c01f8d" />
@@ -9808,7 +9835,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Big Ichigeki! Pachi-slot Daikouryaku (JAP) (v1.000) (DW0472)... -->
+	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
 	<software name="bigichig" supported="no">
 		<description>Big Ichigeki! Pachi-slot Daikouryaku (Jpn, v1.000)</description>
 		<year>1996</year>
@@ -9988,7 +10015,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Clockwork Knight - Pepperouchau's Adventure Gekan (JAP) (DW0440)... -->
+	<!-- FMV playbacks are jumpy [CD-Block] -->
+	<!-- Crashes in -drc after FMV playback -->
+	<!-- Can trip illegal sprite entries at FMV playback after beating prologue boss [VDP1] -->
+	<!-- [VDP2] window effect is doubled in X axis on world map, it also doesn't sport the leftmost unmasked line (real HW bug) -->
 	<software name="cknight2j" cloneof="cknight2" supported="no">
 		<description>Clockwork Knight - Pepperouchau no Daibouken Gekan (Jpn)</description>
 		<year>1995</year>
@@ -10072,7 +10102,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Daina Airan - Dinosaur Island (JAP) (DW0633)... -->
+	<!-- Main menu and several video items incorrectly blends [VDP2] -->
 	<software name="dinoisl" supported="no">
 		<description>Daina Airan (Jpn)</description>
 		<year>1997</year>
@@ -10136,7 +10166,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Dark Seed II (JAP) (DW0617)... -->
+	<!-- Hangs at now loading screen, [SH2] $60ffc13 comms -->
 	<software name="darksed2" supported="no">
 		<description>Darkseed II (Jpn)</description>
 		<year>1997</year>
@@ -10253,9 +10283,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Derby Analyst (JAP) (DW0471)... -->
+	<!-- (Verify main menu GFXs) -->
 	<software name="derbyana" supported="no">
-		<description>Derby Analist (Jpn)</description>
+		<description>Derby Analyst (Jpn)</description>
 		<year>1997</year>
 		<publisher>Media Entertainment</publisher>
 		<info name="serial" value="T-20505G"/>
@@ -10407,7 +10437,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Doukoku Soshite... (JAP) (DW0313)... -->
+	<!-- Inside the bus sports unblended handlebars compared to the full screen [VDP1/VDP2] -->
 	<software name="doukokus" supported="no">
 		<description>Doukoku Soshite... (Jpn)</description>
 		<year>1998</year>
@@ -10494,7 +10524,13 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Dragon's Dream (JAP) (DW0874)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- Pings [CD-Block] HIRM register, no noticeable effect? -->
+	<!-- Moans about modem not connected off the bat, pings [CD-Block] specific I/O for status -->
+	<!-- Title screen drawing cuts off backgrounds with black pens [VDP2] -->
+	<!-- Options menu doesn't show background layer(s) [VDP2] -->
+	<!-- Keyboard inputs doesn't work -->
+	<!-- Presumably dies when actually accessing Nifty Serve details  -->
 	<software name="dragndrm" supported="no">
 		<description>Dragon's Dream (Jpn)</description>
 		<year>1997?</year>
@@ -10503,6 +10539,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<info name="release" value="19971220?"/>
 		<info name="alt_title" value="ドラゴンズドリーム"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<info name="usage" value="Needs Netlink modem and keyboard connected to port 2"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dragon's dream (jpn) (dw0874)" sha1="7fa6b9bd0c8d3f03420290bc2f0909186c18d2bd" />
@@ -10740,7 +10777,13 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Fire Pro Gaiden Blazing Tornado (JAP) (DW0502)... -->
+	<!-- Sound balancing on main menu is quite off bass wise (verified on real HW) [SCSP] -->
+	<!-- Shows incorrect tilemap wrapping transitions on main menu [VDP2] -->
+	<!-- SIGSEGV in Circuit Mode before the "now loading" screen with -drc -->
+	<!-- Shows inaccurate fully transparent blending for lights on the Circuit Mode "now loading" screens [VDP1/VDP2] -->
+	<!-- Circuit Mode "now loading" background meshes for wrestlers have wrong patterns (expected: squared NxN, actual: oblique, verified on real HW) [VDP1] -->
+	<!-- Circuit Mode "now loading" start skip is available too early (expected: around the second character to be presented, actual: in the middle of first character, verified on real HW) [CD-Block] -->
+	<!-- Elimination Mode presentation screens shows HUD for 1 frame then layer gets erased [VDP1] -->
 	<software name="blaztorn" supported="no">
 		<description>Fire Pro Gaiden Blazing Tornado (Jpn)</description>
 		<year>1995</year>
@@ -10772,7 +10815,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn ~Ochikadzuki-hen~ (JAP) (DW0878)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshssoh" supported="no">
 		<description>Flash Sega Saturn - Ochikadzuki-hen (Jpn)</description>
 		<year>1996</year>
@@ -10856,7 +10899,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gakkou no Kowai Uwasa - Hanako-san ga Kita!! (JAP) (DW0639)... -->
+	<!-- Black screen after Capcom FMV logo, enables [SCU] Timer 0 + HBlank irqs and loops reading 0x6055670 -->
 	<software name="gakkokow" supported="no">
 		<description>Gakkou no Kowai Uwasa - Hanako-san ga Kita!! (Jpn)</description>
 		<year>1995</year>
@@ -11027,7 +11070,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Goiken Muyou ~Anarchy in the Nippon~ Taikenban (JAP) (DW0895)... -->
+	<!-- Voice samples are too high pitched [SCSP] -->
+	<!-- gameplay performance is poor [VDP1/VDP2] -->
 	<software name="anarchytai" cloneof="anarchy" supported="no">
 		<description>Goiken Muyou - Anarchy in the Nippon Taikenban (Jpn)</description>
 		<year>1997</year>
@@ -11393,7 +11437,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Java Tea Original Virtua Fighter Kids (JAP) (DW0887)... -->
+	<!-- has no audio redbook playback [CD-Block] -->
 	<software name="vfkidsjj" cloneof="vfkids" supported="no">
 		<description>Virtua Fighter Kids (Jpn, Java Tea Original version)</description>
 		<year>1996</year>
@@ -12894,8 +12938,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sengoku Blade (Disc 1 of 2) (JAP) (DW0190)... -->
-	<!-- Identifying Sengoku Blade (Disc 2 of 2) (JAP) (DW0190)... -->
+	<!-- Black screen, [CD-Block] doesn't read root directory properly -->
 	<software name="sengblada" cloneof="sengblad" supported="no">
 		<description>Sengoku Blade - Sengoku Ace Episode II (Jpn, Alt)</description>
 		<year>1996</year>
@@ -13498,7 +13541,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Tactics Ogre (JAP) (DW0432)... -->
+	<!-- New game character select has offset window sprite [VDP1/VDP2] -->
+	<!-- Intro GFXs are offset and doubled in X axis [VDP2] -->
+	<!-- Dialogue portraits are cut off if drawn to the right part of screen, [VDP2] window? -->
 	<software name="tactogre" supported="no">
 		<description>Tactics Ogre (Jpn)</description>
 		<year>1996</year>
@@ -14334,7 +14379,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Virtua Fighter Kids (JAP) (DW0142)... -->
+	<!-- has no audio redbook playback [CD-Block] -->
 	<software name="vfkidsj" cloneof="vfkids" supported="no">
 		<description>Virtua Fighter Kids (Jpn)</description>
 		<year>1996</year>
@@ -14886,7 +14931,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Alone in the Dark 2 (T-10602G)... -->
+	<!-- Black screen, enables [SCU] Timer 1 -->
 	<software name="aitd2ja" cloneof="aitd2" supported="no">
 		<description>Alone in the Dark 2 (Jpn, Alt)</description>
 		<year>1996</year>
@@ -14902,7 +14947,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Amagi Shien (J) (T-1513G)... -->
+	<!-- Hangs at Sega logo, expects [CD-Block] status change from PAUSE (Double PAUSE -> STANDBY?) -->
 	<software name="amagishi" supported="no">
 		<description>Amagi Shien (Jpn)</description>
 		<year>1997</year>
@@ -15290,7 +15335,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Big Ichigeki PachiSlot Daikoryaku Universal Museum (J) (T-16704G)... -->
+	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
 	<software name="bigichiga" cloneof="bigichig" supported="no">
 		<description>Big Ichigeki! Pachi-Slot Daikouryaku (Jpn, Alt)</description>
 		<year>1996</year>
@@ -15471,7 +15516,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Brain Battle Q (J) (T-25701G)... -->
+	<!-- Voice samples are too high pitched [SCSP] -->
 	<software name="bbq" supported="no">
 		<description>Brain Battle Q (Jpn)</description>
 		<year>1996</year>
@@ -15653,7 +15698,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Chibi Maruko-Chan no Taisen Pazurudama (T-9507G)... -->
+	<!-- Konami FMV logo sound is off-sync [CD-Block] -->
+	<!-- Black screen after FMV with -drc option -->
+	<!-- In-game speech and redbook audio are off-sync [CD-Block] -->
 	<software name="cpuzldama" cloneof="cpuzldam" supported="no">
 		<description>Chibi Maruko-Chan no Taisen Puzzledama (Jpn, Alt)</description>
 		<year>1995</year>
@@ -15841,7 +15888,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Croc ~Pau-Pau Island~ (T-26410G)... -->
+	<!-- No sound [CD-Block/SCSP] -->
+	<!-- "Window enabled for RGB555 Zoom" [VDP2] -->
 	<software name="crocj" cloneof="croc" supported="no">
 		<description>Croc - Pau-Pau Island (Jpn)</description>
 		<year>1998</year>
@@ -15959,7 +16007,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying D-Xhird (T-10307G)... -->
+	<!-- Opening FMV has visible screen tearing [CD-Block] -->
 	<software name="dxhird" supported="no">
 		<description>D-Xhird (Jpn)</description>
 		<year>1997</year>
@@ -16356,7 +16404,7 @@ Olympic Soccer (Fra) T-7904H-09
 
 	<!-- Identifying Derby Analist (T-20505G)... -->
 	<software name="derbyanaa" cloneof="derbyana" supported="no">
-		<description>Derby Analist (Jpn, Alt)</description>
+		<description>Derby Analyst (Jpn, Alt)</description>
 		<year>1997</year>
 		<publisher>Media Entertainment</publisher>
 		<info name="serial" value="T-20505G"/>
@@ -16497,7 +16545,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Digital Pinball Last Gladiators Ver 9.7 (T-18903G)... -->
+	<!-- Black screen after Kaze logo with -drc option. -->
 	<software name="digipinj97" cloneof="digipin" supported="no">
 		<description>Digital Pinball - Last Gladiators Ver. 9.7 (Jpn)</description>
 		<year>1997</year>
@@ -16653,7 +16701,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Druid - Yami e no Tsuiseki Sha (T-7670G)... -->
+	<!-- Glitchy sprites [VDP1] -->
 	<software name="druid" supported="no">
 		<description>Druid - Yami e no Tsuiseki Sha (Jpn)</description>
 		<year>1998</year>
@@ -16933,7 +16981,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying FIFA Soccer 96 (J) (T-10606G)... -->
+	<!-- FMV playback is very glitchy [CD-Block] -->
 	<software name="fifa96j" cloneof="fifa96" supported="no">
 		<description>FIFA Soccer 96 (Jpn)</description>
 		<year>1996</year>
@@ -17057,7 +17105,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn - Ochikadzuki Hen (610-6166-99)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshssoha" cloneof="flshssoh" supported="no">
 		<description>Flash Sega Saturn - Ochikadzuki-hen (Jpn, Alt)</description>
 		<year>1996</year>
@@ -17072,7 +17120,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn Vol 4 (610-6166-04)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshss4" supported="no">
 		<description>Flash Sega Saturn Vol. 4 (Jpn)</description>
 		<year>1996</year>
@@ -17087,7 +17135,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn Vol 7 (610-6166-07)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshss7" supported="no">
 		<description>Flash Sega Saturn Vol. 7 (Jpn)</description>
 		<year>1996</year>
@@ -17102,7 +17150,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn Vol 8 (610-6166-08)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshss8" supported="no">
 		<description>Flash Sega Saturn Vol. 8 (Jpn)</description>
 		<year>1996</year>
@@ -17117,7 +17165,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Flash Sega Saturn Vol 10 (610-6166-10)... -->
+	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
 	<software name="flshss10" supported="no">
 		<description>Flash Sega Saturn Vol. 10 (Jpn)</description>
 		<year>1996</year>
@@ -17218,7 +17266,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Full Cowl Mini Yonku Super Factory (T-26408G)... -->
+	<!-- black screen at boot, master-slave comms at PC=601f776 (happens multiple times) -->
+	<!-- gameplay performance is poor [VDP1/VDP2] -->
 	<software name="fullcowl" supported="no">
 		<description>Full Cowled Mini Yonku Super Factory (Jpn)</description>
 		<year>1997</year>
@@ -17329,7 +17378,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gakkou no Kaidan (GS-9026)... -->
+	<!-- Initial FMV skips a lot (still uses [CD-Block] fnum reject but works here?) -->
+	<!-- Options menu has corrupt background layer, [VDP2] VRAM linescroll wraparound? -->
 	<software name="gakkokaia" cloneof="gakkokai" supported="no">
 		<description>Gakkou no Kaidan (Jpn, Alt)</description>
 		<year>1995</year>
@@ -17390,7 +17440,7 @@ Olympic Soccer (Fra) T-7904H-09
 	  = game basic for segasaturn (japan) (windows cd)  sat_jp:gamebasi Game Basic for SegaSaturn (Japan) (Windows CD)
 	</software>-->
 
-	<!-- Identifying Game de Seishun (T-19711G)... -->
+	<!-- Hangs at "now loading" screen, [SH2] $60ffc13 comms -->
 	<software name="gameseis" supported="no">
 		<description>Game de Seishun (Jpn)</description>
 		<year>1998</year>
@@ -17438,7 +17488,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Game no Tatsujin 2 (T-1509G)... -->
+	<!-- Hangs at Sega logo, expects [CD-Block] status change from PAUSE (Double PAUSE -> STANDBY?) -->
 	<software name="gametat2" supported="no">
 		<description>Game no Tatsujin 2 (Jpn)</description>
 		<year>1996</year>
@@ -17556,7 +17606,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gekitotu Koshien (J) (T-6701G)... -->
+	<!-- After selecting new game and the prefecture sports corrupt background layer [VDP2] -->
 	<software name="gekikosh" supported="no">
 		<description>Gekitotsu Koushien (Jpn)</description>
 		<year>1997</year>
@@ -17572,7 +17622,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gekka no Kishi - Ouryussen (T-20606G)... -->
+	<!-- main menu sports solid GFX selection [VDP2] -->
+	<!-- Voice samples are too high pitched [SCSP] -->
+	<!-- Gameplay performance is quite poor [VDP1/VDP2] -->
+	<!-- Gameplay has no text, and enables undocumented [VDP2] layer BGON with bit 6!? -->
 	<software name="gekkakis" supported="no">
 		<description>Gekka no Kishi - Ouryuusen (Jpn)</description>
 		<year>1996</year>
@@ -17700,7 +17753,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Crashes at KSS logo with DRC -->
+	<!-- SIGSEGV at KSS logo or during intro with -drc on -->
+	<!-- Voice samples are too high pitched [SCSP] -->
 	<software name="anarchy" supported="no">
 		<description>Goiken Muyou - Anarchy in the Nippon (Jpn)</description>
 		<year>1997</year>
@@ -22485,7 +22539,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Actua Golf (T-18710G)... -->
+	<!-- black screen at boot, spurious [SMPC] irq -->
 	<software name="actuagolj" cloneof="actuagol" supported="no">
 		<description>Actua Golf (Jpn)</description>
 		<year>1997</year>
@@ -22517,7 +22571,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Assault Rigs (T-18606G)... -->
+	<!-- Draws invalid polygon vertices [VDP1] (regression?) -->
 	<software name="assrigs" supported="no">
 		<description>Assault Rigs (Jpn)</description>
 		<year>1997</year>
@@ -23041,7 +23095,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Greatest Nine (J) (GS-9017)... -->
+	<!-- Hangs on first frame after loading match, trips illegal opcode, [CD-Block] misloads? -->
+	<!-- Selected flags sports zooming errors [VDP1] -->
 	<software name="gnine" supported="no">
 		<description>Kanzen Chuukei Pro Yakyuu Greatest Nine (Jpn)</description>
 		<year>1995</year>
@@ -23434,9 +23489,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Idol Maajan Final Romance R Audio Disc (T-16703G)... -->
+	<!-- Mini CD, [CD-Block] doesn't playback in driver, expected length of 13:54 matches  -->
+	<!-- TODO: comes with T-16703G main disc, according to http://redump.org/disc/9318/ should be same as T-16705G-01 minus the changed serial -->
 	<software name="fromancra" cloneof="fromancr" supported="no">
-		<description>Idol Mahjong Final Romance R Audio Disc (Jpn)</description>
+		<description>Idol Mahjong Final Romance R Mini Drama CD (Jpn)</description>
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="serial" value="T-16703G"/>
@@ -25992,7 +26048,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sugobenchah - Dragon Master Silk Gaiden (T-19505G)... -->
+	<!-- Text layer incorrectly blends [VDP2] -->
 	<software name="drgmstsi" supported="no">
 		<description>Sugobencha - Dragon Master Silk Gaiden (Jpn)</description>
 		<year>1998</year>
@@ -28211,7 +28267,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Blast Wind (Japan)... -->
+	<!-- Black screen after Techno Soft logo with -drc option and Machine Config comms hack disabled. -->
 	<software name="blastwnd" supported="no">
 		<description>Blast Wind (Jpn)</description>
 		<year>1997</year>
@@ -28290,7 +28346,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Chaos Control Remix (T-7006G)... -->
+	<!-- Black screen, enables [SCU] Timer 1 -->
 	<!-- Box Art shows 'Remix' Title, game reprogrammed from previous version -->
 	<software name="chaoscrm" supported="no">
 		<description>Chaos Control Remix (Jpn)</description>
@@ -28361,7 +28417,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying CourierCrisis... -->
+	<!-- Hangs after FMV playback opening, [CD-Block] expects a FAD + 1 on pause? -->
 	<software name="ccrisisj" cloneof="ccrisis" supported="no">
 		<description>Courier Crisis (Jpn)</description>
 		<year>1998</year>
@@ -28489,7 +28545,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Defcon 5 (Japan) [T-24101G]... -->
+	<!-- Hangs on FMV opening, [CD-Block] never completes transfer after FAD=3460 -->
 	<software name="defcon5j" cloneof="defcon5" supported="no">
 		<description>Defcon 5 (Jpn)</description>
 		<year>1996</year>
@@ -28537,10 +28593,14 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Doom (T-18610G) Japan... -->
 	<!-- There are rumours that the Japan version should be different (containing Williams logos and such)
 	     I believe rumours to be false.  If you watch the movie linked from http://www.segagagadomain.com/saturn10/doom.htm
 	     it does not have a Williams logo ingame, and the footage is taken from a genuine Japanese CD -->
+	<!-- Black screen after GT Interactive logo, expects [VDP1] CEF to be 1 (in manual mode, without writing to the port first) -->
+	<!-- Title screen flames are white for the first few frames, [VDP2] -->
+	<!-- Hangs during gameplay expecting Work RAM H $260666b0 to be zero, cache access? -->
+	<!-- Incorrectly blends several polygons -->
+	<!-- gameplay performance is poor [VDP2?] -->
 	<software name="doomj" cloneof="doom" supported="no">
 		<description>Doom (Jpn)</description>
 		<year>1997</year>
@@ -28588,7 +28648,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Elevator Action Returns (J)... -->
+	<!-- Glitchy sprites [VDP1] -->
+	<!-- Lights uses unemulated raster effect with [VDP2] color offset registers -->
 	<software name="elevact2" supported="no">
 		<description>Elevator Action² Returns (Jpn)</description>
 		<year>1997</year>
@@ -28673,7 +28734,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Final Fight Revenge (Japan)... -->
+	<!-- Status bars incorrectly blends [VDP2] -->
 	<software name="ffreveng" supported="no">
 		<description>Final Fight Revenge (Jpn)</description>
 		<year>2000</year>
@@ -29842,7 +29903,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Hangs during some scenes -->
+	<!-- Locks up during Ecseco FMV logo, [CD-Block] uses curfad filter rejection -->
+	<!-- Locks up on several scenes, fills buffer and never reaches target FAD. -->
 	<software name="timegal" supported="no">
 		<description>Time Gal (Time Gal &amp; Ninja Hayate Disc 1) (Jpn)</description>
 		<year>1997</year>
@@ -29890,14 +29952,15 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Virtua_Fighter_Kids(Kor)[!]... -->
+	<!-- Doesn't boot with -drc -->
+	<!-- has no audio redbook playback [CD-Block] -->
 	<software name="vfkidsk" cloneof="vfkids" supported="no">
 		<description>Virtua Fighter Kids (Kor)</description>
-		<year>199?</year>
+		<year>1996?</year>
 		<publisher>Samsung</publisher>
 		<info name="serial" value="MK-81049-08"/>
 		<info name="alt_title" value="버쳐파이터키즈"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-K,NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="virtua_fighter_kids(kor)" sha1="48bbdd59caa47e3a950bfb1610b4e86656a0e08e" />
@@ -37818,7 +37881,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying dw-sat-0820-Three_Dirty_Dwarves-usa... -->
+	<!-- Gymhouse boss has incorrect shadow priority [VDP1/VDP2] -->
+	<!-- Continuing at Bronx by Day stage color glitches knight sprites [VDP1] -->
+	<!-- Eventually locks up with no player sprites at The Stadium boss stage (recheck) -->
 	<software name="3dwarvesu" cloneof="3dwarves" supported="no">
 		<description>Three Dirty Dwarves (USA)</description>
 		<year>1997</year>
@@ -38742,7 +38807,7 @@ Olympic Soccer (Fra) T-7904H-09
 		<description>Three Dirty Dwarves (Prototype 19960417)</description>
 		<year>1997</year>
 		<publisher>Sega</publisher>
-		<sharedfeat name="compatibility" value="NTSC-U, NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-U,NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="three_dirty_dwarves_cd-1-1_mk8103300_v0.003_04171996_[jut]" sha1="16ad09ea3b81734e9833a4f38694b246a4506063" />

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -10528,7 +10528,8 @@ Olympic Soccer (Fra) T-7904H-09
 	<!-- Title screen drawing cuts off backgrounds with black pens [VDP2] -->
 	<!-- Options menu doesn't show background layer(s) [VDP2] -->
 	<!-- Keyboard inputs doesn't work -->
-	<!-- Presumably dies when actually accessing Nifty Serve details  -->
+	<!-- Presumably dies when actually accessing Nifty Serve details -->
+	<!-- Attract mode draws only skill names and attribute bars over a black BG, enables [VDP2] Sprite Window -->
 	<software name="dragndrm" supported="no">
 		<description>Dragon's Dream (Jpn)</description>
 		<year>1997?</year>

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -2993,8 +2993,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
-	<software name="capgen1" supported="no">
+	<software name="capgen1" supported="yes">
 		<description>Capcom Generation - Dai-1-Shuu - Gekitsui Ou no Jidai (Jpn)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
@@ -3009,7 +3008,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Capcom Generation - Dai 2 Shuu Makai to Kishi (Japan)... -->
+	<!-- DaiMakaiMura BGM playbacks misses one instrument starting from stage 2 (only in-game, works fine in sound test), [SCSP] key on/off issue? -->
+	<!-- Wrong [VDP2] tilemap [VDP1] sprite priorities, particularly noticeable in ChohMakaiMura -->
+	<!-- Missing [VDP2] mosaic for ChohMakaiMura on map transitions -->
 	<software name="capgen2" supported="no">
 		<description>Capcom Generation - Dai-2-Shuu - Makai to Kishi (Jpn)</description>
 		<year>1998</year>
@@ -3041,9 +3042,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
-	<!-- Plays wrong sounds in all games, [CD-Block]? -->
-	<!-- Title select screen draws transparent instead of opaque [VDP2] -->
+	<!-- Plays wrong sound/BGMs in all games, [CD-Block]? -->
+	<!-- Capcon Generation "Title Select" screen draws transparent instead of opaque [VDP2] -->
 	<!-- All games uses unemulated [VDP1] framebuffer rotation in Yoko screen mode, sprites are slightly glitchy in Tate mode. -->
 	<software name="capgen4" supported="no">
 		<description>Capcom Generation - Dai-4-Shuu - Kokou no Eiyuu (Jpn)</description>
@@ -3060,8 +3060,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
-	<software name="capgen5" supported="no">
+	<software name="capgen5" supported="yes">
 		<description>Capcom Generation - Dai-5-Shuu - Kakutou ke Tachi (Jpn)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
@@ -4380,9 +4379,9 @@ Olympic Soccer (Fra) T-7904H-09
 		<info name="serial" value="T-2111G"/>
 		<info name="release" value="19980625"/>
 		<info name="alt_title" value="ゲームベーシック フォー セガサターン"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<!-- TODO: in port 2? -->
 		<info name="usage" value="Needs keyboard connected"/>
+		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="game basic for segasaturn (japan)" sha1="bda219fae902fbe1c5bc5c95226b038fc2733031" />
@@ -7353,7 +7352,7 @@ Olympic Soccer (Fra) T-7904H-09
 	</software>
 
 	<!-- PS2 (at least) has not working BGMs (repeats a very short chunk over and over) (Update: fixed by now, or random bug?) -->
-	<!-- PS2 sports wrong priority on gameplay (sprites going above buildings, menuing etc.) [VDP1/VDP2] -->
+	<!-- PS2 sports wrong tilemap-sprite priorities on gameplay (sprites going above buildings, menuing etc.) [VDP1/VDP2] -->
 	<!-- TODO: verify PS1/PS3/PS4 -->
 	<software name="pstarcol" supported="no">
 		<description>Sega Ages - Phantasy Star Collection (Jpn)</description>
@@ -9835,8 +9834,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Hangs at Sega logo, uses [SMPC] command 0x0e via BIOS and SLEEP (expecting NMI to be unconditionally requested?) -->
-	<software name="bigichig" supported="no">
+	<software name="bigichig" supported="yes">
 		<description>Big Ichigeki! Pachi-slot Daikouryaku (Jpn, v1.000)</description>
 		<year>1996</year>
 		<publisher>ASK Kodansha</publisher>
@@ -10538,8 +10536,8 @@ Olympic Soccer (Fra) T-7904H-09
 		<info name="serial" value="GS-7114"/>
 		<info name="release" value="19971220?"/>
 		<info name="alt_title" value="ドラゴンズドリーム"/>
-		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<info name="usage" value="Needs Netlink modem and keyboard connected to port 2"/>
+		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="sat_cdrom">
 			<diskarea name="cdrom">
 				<disk name="dragon's dream (jpn) (dw0874)" sha1="7fa6b9bd0c8d3f03420290bc2f0909186c18d2bd" />

--- a/hash/saturn.xml
+++ b/hash/saturn.xml
@@ -2701,7 +2701,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Arcade Gears Vol.4 - Image Fight &amp; X-Multiply (Japan)... -->
+	<!-- Image Fight has serious [VDP1/VDP2] video bugs (missing layers, misaligned layers, no options text is displayed ...) -->
 	<software name="imgftxm" supported="no">
 		<description>Arcade Gears Vol. 4 - Image Fight &amp; X-Multiply (Jpn)</description>
 		<year>1998</year>
@@ -4410,7 +4410,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Game-Ware Vol. 3 (Japan)... -->
+	<!-- Black screen after "Lotte Green Gum" FMV with -drc -->
+	<!-- Triggers fnum rejects [CD-Block] -->
 	<software name="gware3" supported="no">
 		<description>Game-Ware Vol. 3 (Jpn)</description>
 		<year>1996</year>
@@ -4554,10 +4555,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Grandia (Japan) (Disc 1) (1M)... -->
-	<!-- Identifying Grandia (Japan) (Disc 1) (2M)... -->
-	<!-- Identifying Grandia (Japan) (Disc 2) (3M)... -->
-	<!-- Identifying Grandia (Japan) (Disc 2) (4M)... -->
+	<!-- Hangs on Sega logo with [CD-Block] keeps looping with command 0x51 (regression) -->
 	<software name="grandia" supported="no">
 		<description>Grandia (Jpn, 1M)</description>
 		<year>1997</year>
@@ -4620,7 +4618,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Greatest Nine '96 (Japan) (2M)... -->
+	<!-- SIGSEGV with -drc after starting a game -->
+	<!-- Selected team flags and in-game shadows sports zooming errors [VDP1] -->
+	<!-- Stadium select wireframes sports stippled oblique polylines [VDP1] -->
 	<software name="gnine96" supported="no">
 		<description>Greatest Nine '96 (Jpn, 2M)</description>
 		<year>1996</year>
@@ -4668,7 +4668,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gunbird (Japan)... -->
+	<!--  Doesn't read file ID of "Illust Gallery" / "Charactor Index" / ending(s?), [CD-Block] doesn't read root directory properly -->
 	<software name="gunbird" supported="no">
 		<description>Gunbird (Jpn)</description>
 		<year>1995</year>
@@ -4700,7 +4700,10 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gussun Oyoyo S (Japan)... -->
+	<!-- Options Mode has a slight garbage line on top, [VDP2] -->
+	<!-- Intro redbook audio is offset compared to video [CD-Block] -->
+	<!-- Some SFX volumes are really quiet (namely the piece swap) [SCSP] -->
+	<!-- TODO: check all on real HW -->
 	<software name="gussun" supported="no">
 		<description>Gussun Oyoyo S (Jpn)</description>
 		<year>1996</year>
@@ -4780,7 +4783,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying House of the Dead, The (Japan)... -->
+	<!-- Black screen after Sega logo with -drc -->
+	<!-- "Hold Your Fire" screen has empty last screen line, TODO: verify on real HW -->
 	<software name="hotdj" cloneof="hotd" supported="no">
 		<description>The House of the Dead (Jpn)</description>
 		<year>1998</year>
@@ -5018,7 +5022,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Jikkyou Oshaberi Parodius - Forever with Me (Japan)... -->
+	<!-- Black screen waiting for an irq event buffer to happen, culprit is [VDP1] irq? -->
 	<software name="jikkparo" supported="no">
 		<description>Jikkyou Oshaberi Parodius - Forever with Me (Jpn)</description>
 		<year>1996</year>
@@ -6516,7 +6520,7 @@ Olympic Soccer (Fra) T-7904H-09
 	</software>
 
 	<!-- Identifying Pro Yakyuu Greatest Nine '97 - Make Miracle (Japan)... -->
-	<software name="gnine97ma" cloneof="gnine97" supported="no">
+	<software name="gnine97ma" cloneof="gnine97m" supported="no">
 		<description>Pro Yakyuu Greatest Nine '97 - Make Miracle (Jpn, Alt)</description>
 		<year>1997</year>
 		<publisher>Sega</publisher>
@@ -7902,7 +7906,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying SimCity 2000 (Japan) (Rev A)... -->
+	<!-- Black screen, expects [VDP1] CEF to be 1 -->
 	<software name="simcit2kj" cloneof="simcit2k" supported="no">
 		<description>Sim City 2000 (Jpn, Rev A)</description>
 		<year>1995</year>
@@ -10814,7 +10818,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshssoh" supported="no">
 		<description>Flash Sega Saturn - Ochikadzuki-hen (Jpn)</description>
 		<year>1996</year>
@@ -12958,8 +12962,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Shichisei Toushin Guyferd (JAP) (DW0546)... -->
-	<software name="guyferd" supported="no">
+	<software name="guyferd" supported="yes">
 		<description>Shichisei Toushin Guyferd - Crown Kaimetsu Sakusen (Jpn)</description>
 		<year>1998</year>
 		<publisher>Capcom</publisher>
@@ -17104,7 +17107,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshssoha" cloneof="flshssoh" supported="no">
 		<description>Flash Sega Saturn - Ochikadzuki-hen (Jpn, Alt)</description>
 		<year>1996</year>
@@ -17119,7 +17122,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshss4" supported="no">
 		<description>Flash Sega Saturn Vol. 4 (Jpn)</description>
 		<year>1996</year>
@@ -17134,7 +17137,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshss7" supported="no">
 		<description>Flash Sega Saturn Vol. 7 (Jpn)</description>
 		<year>1996</year>
@@ -17149,7 +17152,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshss8" supported="no">
 		<description>Flash Sega Saturn Vol. 8 (Jpn)</description>
 		<year>1996</year>
@@ -17164,7 +17167,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Pings Netlink [SMPC] commands, black screens waiting for command to complete -->
+	<!-- TODO: check all games in it -->
 	<software name="flshss10" supported="no">
 		<description>Flash Sega Saturn Vol. 10 (Jpn)</description>
 		<year>1996</year>
@@ -17865,7 +17868,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Groove on Fight ~Gouketsuji Ichizoku 3~ (Doukonban) (T-14413G)... -->
+	<!-- AI never moves, not even at "Abnormal" difficulty. [CD-Block] skips loading a file? -->
+	<!-- Ready text on start of round sports zooming errors [VDP1] -->
 	<software name="groovef" supported="no">
 		<description>Groove on Fight - Gouketsuji Ichizoku 3 - Kakuchou Ram Cartridge-tsuki! (Jpn)</description>
 		<year>1997</year>
@@ -17974,7 +17978,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Hattrick Hero S (T-1103G)... -->
+	<!-- No crowd is shown, particularly noticeable in intro (where performance dips) [VDP2] -->
 	<software name="htheros" supported="no">
 		<description>HatTrick Hero S (Jpn)</description>
 		<year>1995</year>
@@ -18146,8 +18150,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Houma Hunter Lime Perfect Collection Disc 1 (T-2001G)... -->
-	<!-- Identifying Houma Hunter Lime Perfect Collection Disc 2 (T-2001G)... -->
+	<!-- Fade in/out effect is reversed on title screen, enables [VDP2] Color Calculation -->
 	<software name="hhuntpc" supported="no">
 		<description>Houma Hunter Lime Perfect Collection (Jpn)</description>
 		<year>1995</year>
@@ -18168,7 +18171,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Hyper 3D Pinball (T-7007G)... -->
+	<!-- TODO: triggered "always nudge even with shoulder" presses bug once but cannot reproduce -->
 	<software name="h3dpinj" cloneof="tilt" supported="no">
 		<description>Hyper 3D Pinball (Jpn)</description>
 		<year>1997</year>
@@ -21022,7 +21025,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying The Hyper Golf - Devil's Course (T-2301G)... -->
+	<!-- Throws "Error Trap Vector 4" with -drc off the bat -->
+	<!-- Has garbage pixels all over the place [VDP1/VDP2] -->
+	<!-- Swing animation draws sprite transparent most of the time [VDP1] or [SCU] Timer 1 -->
 	<software name="hyprgolf" cloneof="valora" supported="no">
 		<description>The Hyper Golf - Devil's Course (Jpn)</description>
 		<year>1995</year>
@@ -23046,7 +23051,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Greatest Nine '97 (J) (GS-9139)... -->
+	<!-- Black screen after Sega Sports logo, buggy handshake bug with [SMPC] commands cfr. PC=6004FC0 (buggy [SH2] delay slot or command should just be faster?) -->
 	<software name="gnine97" supported="no">
 		<description>Pro Yakyuu Greatest Nine '97 (Jpn)</description>
 		<year>1997</year>
@@ -23062,7 +23067,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Greatest Nine '97 Make Miracle (J) (GS-9171)... -->
+	<!-- Black screen after Sega Sports logo, buggy handshake bug with [SMPC] commands cfr. PC=6004FC0 (buggy [SH2] delay slot or command should just be faster?) -->
 	<software name="gnine97m" supported="no">
 		<description>Pro Yakyuu Greatest Nine '97 - Make Miracle (Jpn)</description>
 		<year>1997</year>
@@ -23095,7 +23100,7 @@ Olympic Soccer (Fra) T-7904H-09
 	</software>
 
 	<!-- Hangs on first frame after loading match, trips illegal opcode, [CD-Block] misloads? -->
-	<!-- Selected flags sports zooming errors [VDP1] -->
+	<!-- Selected team flags sports zooming errors [VDP1] -->
 	<software name="gnine" supported="no">
 		<description>Kanzen Chuukei Pro Yakyuu Greatest Nine (Jpn)</description>
 		<year>1995</year>
@@ -23111,7 +23116,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Greatest Nine 98 (J) (GS-9185)... -->
+	<!-- Black screen after Sega Sports logo, buggy handshake bug with [SMPC] commands cfr. PC=6004FC0 (buggy [SH2] delay slot or command should just be faster?) -->
 	<software name="gnine98" supported="no">
 		<description>Pro Yakyuu Greatest Nine '98 (Jpn)</description>
 		<year>1998</year>
@@ -23175,7 +23180,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Habitat II (GS-7105)... -->
+	<!-- NetLink game -->
+	<!-- Black screen on -drc when accessing "NIFTY" option on title menu -->
+	<!-- Triggers "0 trans no cc zoom" [VDP2] message -->
 	<software name="habitat2" supported="no">
 		<description>Habitat II (Jpn)</description>
 		<year>1996</year>
@@ -23271,7 +23278,9 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Hissatsu Pachinko Collection (J) (T-1503G)... -->
+	<!-- Hangs at Sega logo, expects to change [CD-Block] status after every loading phase -->
+	<!-- Draws no text in menu [VDP1/VDP2] -->
+	<!-- Has Nifty Serve option -> NetLink support? -->
 	<software name="hisspach" supported="no">
 		<description>Hissatsu Pachinko Collection (Jpn)</description>
 		<year>1996</year>
@@ -23535,8 +23544,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Jantei Battle Cos-Player Disc 1 (T-34601G)... -->
-	<!-- Identifying Jantei Battle Cos-Player Disc 2 (T-34601G)... -->
+	<!-- Story Mode sometimes have transformation FMVs with no redbook audio [CD-Block] -->
 	<software name="jantbcp" supported="no">
 		<description>Jantei Battle Cos-Player (Jpn)</description>
 		<year>1997</year>
@@ -25636,7 +25644,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Sega Saturn Internet Vol 1 (T-31301G)... -->
+	<!-- Returns to Sega MultiPlayer menu just after first transfer at FAD=172, bad [CD-Block] file parsing? -->
 	<software name="intrnet1" supported="no">
 		<description>Sega Saturn Internet Vol. 1 (Jpn)</description>
 		<year>1997</year>
@@ -27564,7 +27572,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Rouka ni Ichidant-R (GS-9043)... -->
+	<!-- TODO: Quiz Rouka ni Tattenasai black screen once before game over, cannot repro (stage 2?) -->
+	<!-- TODO: test Ichidant-R -->
 	<software name="ichidntr" supported="no">
 		<description>Sega Ages - Rouka ni Ichidant-R (Jpn)</description>
 		<year>1996</year>
@@ -28798,7 +28807,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Gunblaze S (Japan) [T-19710G].. -->
+	<!-- Black screen, branches over [VDP1] CEF/BEF status at vblank-out while in PTM idle mode -->
 	<software name="gunblaze" supported="no">
 		<description>GunBlaze S (Jpn)</description>
 		<year>1998</year>
@@ -28906,7 +28915,8 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Irem Arcade Classics... -->
+	<!-- Hangs at "Now loading" screen with -drc, trips illegal opcode -->
+	<!-- 10 Yard Fight doesn't show sprites on the left portion of screen [VDP1] -->
 	<software name="iremac" supported="no">
 		<description>Irem Arcade Classics</description>
 		<year>1996</year>
@@ -29231,7 +29241,7 @@ Olympic Soccer (Fra) T-7904H-09
 		</part>
 	</software>
 
-	<!-- Identifying Oracle no Houseki (T-1511G)... -->
+	<!-- Sports opaque black pixels as transparent during gameplay [VDP1] -->
 	<software name="jeworaclj" cloneof="jeworacl" supported="no">
 		<description>Oracle no Houseki (Jpn)</description>
 		<year>1996</year>

--- a/src/devices/machine/smpc.cpp
+++ b/src/devices/machine/smpc.cpp
@@ -614,10 +614,6 @@ void smpc_hle_device::device_timer(emu_timer &timer, device_timer_id id, int par
 				case 0x0f: // CKCHG320
 					m_dotsel(m_comreg & 1);
 
-					// send a NMI to Master SH2 if enabled
-					if(m_NMI_reset == false)
-						master_sh2_nmi();
-
 					// assert Slave SH2 line
 					m_sshres(1);
 					// clear PLL system halt
@@ -625,6 +621,12 @@ void smpc_hle_device::device_timer(emu_timer &timer, device_timer_id id, int par
 
 					// setup the new dot select
 					m_cur_dotsel = (m_comreg & 1) ^ 1;
+
+					// send a NMI to Master SH2 if enabled
+					// it is unconditionally requested:
+					// bigichig, capgen1, capgen4 and capgen5 triggers a SLEEP opcode from BIOS call and expects this to wake them up.
+					//if(m_NMI_reset == false)
+					master_sh2_nmi();
 					break;
 
 				case 0x10: // INTBACK

--- a/src/devices/machine/smpc.cpp
+++ b/src/devices/machine/smpc.cpp
@@ -594,11 +594,17 @@ void smpc_hle_device::device_timer(emu_timer &timer, device_timer_id id, int par
 					// ...
 					m_command_in_progress = false;
 					m_oreg[31] = m_comreg;
-					sf_ack(true); //clear hand-shake flag (TODO: diagnostic wants this to have bit 3 high)
+					// TODO: diagnostic also wants this to have bit 3 high
+					sf_ack(true); //set hand-shake flag
 					return;
 
-//              case 0x0a: // NETLINKON
-//              case 0x0b: // NETLINKOFF
+                case 0x0a: // NETLINKON
+					// TODO: understand where NetLink actually lies and implement delegation accordingly
+					// (is it really an SH1 device like suggested by the space access or it overlays on CS2 bus?)
+					popmessage("%s: NetLink enabled", this->tag());
+					 [[fallthrough]];
+                case 0x0b: // NETLINKOFF
+					break;
 
 				case 0x0d: // SYSRES
 					// send a 1 -> 0 to device reset lines
@@ -661,7 +667,7 @@ void smpc_hle_device::device_timer(emu_timer &timer, device_timer_id id, int par
 					break;
 
 				default:
-					logerror("%s unemulated %02x command\n",this->tag(),m_comreg);
+					logerror("%s: unemulated %02x command\n",this->tag(),m_comreg);
 					return;
 			}
 

--- a/src/devices/machine/stvcd.cpp
+++ b/src/devices/machine/stvcd.cpp
@@ -221,14 +221,14 @@ inline u32 stvcd_device::dataxfer_long_r()
 					transpart->size -= xferdnum;
 					transpart->numblks -= xfersectnum;
 
-					/* TODO: is this correct? */
+					// TODO: is this correct?
 					xfertype32 = XFERTYPE32_INVALID;
 				}
 			}
 			break;
 
 		default:
-			osd_printf_error("CD: unhandled 32-bit transfer type\n");
+			osd_printf_error("CD: unhandled 32-bit transfer type %d\n", (int)xfertype32);
 			break;
 	}
 
@@ -269,7 +269,7 @@ inline void stvcd_device::dataxfer_long_w(u32 data)
 			break;
 
 		default:
-			printf("CD: unhandled 32-bit transfer type write\n");
+			printf("CD: unhandled 32-bit transfer type write %d\n", (int)xfertype32);
 			break;
 	}
 }
@@ -462,7 +462,9 @@ void stvcd_device::stvcd_w(offs_t offset, uint32_t data, uint32_t mem_mask)
  */
 int stvcd_device::get_timing_command(void)
 {
-	/* TODO: calculate timings based off command params */
+	// TODO: calculate timings based off command params
+	// given the CMOK returns it looks like SH2 expects way slower responses
+	// (loops for 0x7xx times at most, max number of iterations is 0x240000)
 	return 16667;
 }
 
@@ -769,7 +771,7 @@ void stvcd_device::cmd_play_disc()
 			}
 			else
 			{
-				/* TODO: Waku Waku 7 sets up track 0, that basically doesn't make any sense. Just skip it for now. */
+				// FIXME: Waku Waku 7 sets up track 0, that basically doesn't make any sense. Just skip it for now.
 				popmessage("Warning: track mode == 0, contact MAMEdev");
 				cr_standard_return(cd_stat);
 				hirqreg |= (CMOK);
@@ -814,9 +816,12 @@ void stvcd_device::cmd_play_disc()
 		else
 		{
 			/* resume from a pause state */
-			/* TODO: Galaxy Fight calls 10ff ffff ffff ffff, but then it calls 0x04->0x02->0x06->0x11->0x04->0x02->0x06 command sequence
-			   (and current implementation nukes start/end FAD addresses at 0x04). I'm sure that this doesn't work like this, but there could
-			   be countless possible combinations ... */
+			// FIXME: verify implementation with Galaxy Fight
+			// it calls 10ff ffff ffff ffff, but then it follows up with
+			// 0x04->0x02->0x06->0x11->0x04->0x02->0x06 command sequence
+			// (and current implementation nukes start/end FAD addresses at 0x04). 
+			// I'm sure that this doesn't work like this, but there could
+			// be countless possible combinations ...
 			if(fadstoplay == 0)
 			{
 				cd_curfad = cdrom_get_track_start(cdrom, cur_track-1);
@@ -1130,7 +1135,8 @@ void stvcd_device::cmd_get_filter_mode()
 void stvcd_device::cmd_set_filter_connection()
 {
 	// Set Filter Connection
-	/* TODO: maybe condition false is cr3 low? */
+	// FIXME: verify usage of cr3 LSB
+	// (false condition?)
 	uint8_t fnum = (cr3>>8)&0xff;
 
 	LOG("%s:CD: Set Filter Connection %x => mode %x parm %04x\n", machine().describe_context(), fnum, cr1 & 0xf, cr2);
@@ -1181,7 +1187,7 @@ void stvcd_device::cmd_reset_selector()
 	}
 
 	/* reset false filter output conditions */
-	/* TODO: check these two. */
+	/// TODO: verify default value for these two
 	if(cr1 & 0x80)
 	{
 		for(i=0;i<MAX_FILTERS;i++)
@@ -1396,8 +1402,9 @@ void stvcd_device::cmd_get_sector_data()
 
 	if (bufnum >= MAX_FILTERS)
 	{
+		// TODO: find actual SW that does this
+		// (may conceal a bigger issue)
 		osd_printf_error("CD: invalid buffer number\n");
-		/* TODO: why this is happening? */
 		cr_standard_return(CD_STAT_REJECT);
 		hirqreg |= (CMOK|EHST);
 		return;
@@ -1439,14 +1446,15 @@ void stvcd_device::cmd_delete_sector_data()
 
 	if (bufnum >= MAX_FILTERS)
 	{
+		// TODO: mustn't happen
 		osd_printf_error("CD: invalid buffer number\n");
-		/* TODO: why this is happening? */
 		cr_standard_return(CD_STAT_REJECT);
 		hirqreg |= (CMOK|EHST);
 		return;
 	}
 
-	/* TODO: Phantasy Star 2 throws this one. */
+	// pstarcol PS2 does this
+	// TODO: verify if implementation is correct
 	if (partitions[bufnum].numblks == 0)
 	{
 		osd_printf_error("CD: buffer is already empty\n");
@@ -1459,10 +1467,15 @@ void stvcd_device::cmd_delete_sector_data()
 
 	for (i = sectofs; i < (sectofs + sectnum); i++)
 	{
-		partitions[bufnum].size -= partitions[bufnum].blocks[i]->size;
-		cd_free_block(partitions[bufnum].blocks[i]);
-		partitions[bufnum].blocks[i] = (blockT *)nullptr;
-		partitions[bufnum].bnum[i] = 0xff;
+		// pstarcol PS2 tries to delete partial partitions,
+		// need to guard against it (otherwise it would crash after first attract cycle)
+		if (partitions[bufnum].size > 0)
+		{
+			partitions[bufnum].size -= partitions[bufnum].blocks[i]->size;
+			cd_free_block(partitions[bufnum].blocks[i]);
+			partitions[bufnum].blocks[i] = (blockT *)nullptr;
+			partitions[bufnum].bnum[i] = 0xff;
+		}
 	}
 
 	cd_defragblocks(&partitions[bufnum]);
@@ -1492,14 +1505,15 @@ void stvcd_device::cmd_get_and_delete_sector_data()
 
 	if (bufnum >= MAX_FILTERS)
 	{
+		// TODO: mustn't happen
 		osd_printf_error("CD: invalid buffer number\n");
-		/* TODO: why this is happening? */
 		cr_standard_return(CD_STAT_REJECT);
 		hirqreg |= (CMOK|EHST);
 		return;
 	}
 
 	/* Yoshimoto Mahjong uses the REJECT status to verify when the data is ready. */
+	// TODO: verify again if it's really REJECT or something else
 	if (partitions[bufnum].numblks < sectnum)
 	{
 		osd_printf_error("CD: buffer is not full %08x %08x\n",partitions[bufnum].numblks,sectnum);
@@ -1708,7 +1722,11 @@ void stvcd_device::cmd_get_target_file_info()
 		cr3 = 0;
 		cr4 = 0;
 
-		printf("%08x %08x\n",curdir[temp].firstfad,curdir[temp].length);
+		// TODO: chaossd and sengblad does this
+		// (iso9660 parsing doesn't read beyond the first sector)
+		if (curdir[temp].firstfad == 0 || curdir[temp].length == 0)
+			throw emu_fatalerror("File ID not found in XFERTYPE_FILEINFO_1");
+//		printf("%08x %08x\n",curdir[temp].firstfad,curdir[temp].length);
 		// first 4 bytes = FAD
 		finfbuf[0] = (curdir[temp].firstfad>>24)&0xff;
 		finfbuf[1] = (curdir[temp].firstfad>>16)&0xff;
@@ -1723,6 +1741,7 @@ void stvcd_device::cmd_get_target_file_info()
 		finfbuf[9] = curdir[temp].file_unit_size;
 		finfbuf[10] = temp;
 		finfbuf[11] = curdir[temp].flags;
+
 
 		xfertype = XFERTYPE_FILEINFO_1;
 		xfercount = 0;
@@ -1988,8 +2007,9 @@ TIMER_DEVICE_CALLBACK_MEMBER( stvcd_device::stv_sector_cb )
 	else
 		m_sector_timer->adjust(attotime::from_hz(75*cd_speed));   // 75 / 150 sectors / second = 150 / 300kBytes/second
 
-	/* TODO: doesn't boot if a disk isn't in? */
-	/* TODO: Check out when this really happens. (Daytona USA original version definitely wants it to be on).*/
+	// TODO: Saturn refuses to boot with this if a disk isn't in and condition is applied!?
+	// TODO: Check out actual timing of SCDQ acquisition.
+	// (Daytona USA original version definitely wants it to be on).
 	//if(((cd_stat & 0x0f00) != CD_STAT_NODISC) && ((cd_stat & 0x0f00) != CD_STAT_OPEN))
 	hirqreg |= SCDQ;
 

--- a/src/devices/machine/stvcd.cpp
+++ b/src/devices/machine/stvcd.cpp
@@ -137,8 +137,8 @@ void stvcd_device::io_regs(address_map &map)
 	map(0x90024, 0x90027).mirror(0x08000).rw(FUNC(stvcd_device::cr4_r), FUNC(stvcd_device::cr4_w)).umask32(0xffffffff);
 
 	// NetLink access
-	// dragndrm expects this
-	map(0x8502a, 0x8502a).lr8(NAME([this] () { return 0x11; }));
+	// dragndrm expects this value, most likely for status
+	map(0x8502a, 0x8502a).lr8(NAME([] () -> u8 { return 0x11; }));
 }
 
 u32 stvcd_device::datatrns_r(offs_t offset, uint32_t mem_mask)

--- a/src/devices/machine/stvcd.cpp
+++ b/src/devices/machine/stvcd.cpp
@@ -135,6 +135,10 @@ void stvcd_device::io_regs(address_map &map)
 	map(0x9001c, 0x9001f).mirror(0x08000).rw(FUNC(stvcd_device::cr2_r), FUNC(stvcd_device::cr2_w)).umask32(0xffffffff);
 	map(0x90020, 0x90023).mirror(0x08000).rw(FUNC(stvcd_device::cr3_r), FUNC(stvcd_device::cr3_w)).umask32(0xffffffff);
 	map(0x90024, 0x90027).mirror(0x08000).rw(FUNC(stvcd_device::cr4_r), FUNC(stvcd_device::cr4_w)).umask32(0xffffffff);
+
+	// NetLink access
+	// dragndrm expects this
+	map(0x8502a, 0x8502a).lr8(NAME([this] () { return 0x11; }));
 }
 
 u32 stvcd_device::datatrns_r(offs_t offset, uint32_t mem_mask)

--- a/src/mame/drivers/saturn.cpp
+++ b/src/mame/drivers/saturn.cpp
@@ -463,18 +463,43 @@ public:
 	void saturnjp(machine_config &config);
 	void saturneu(machine_config &config);
 	void saturnus(machine_config &config);
+	void saturnkr(machine_config &config);
 
-	void init_saturnus();
-	void init_saturneu();
-	void init_saturnjp();
+	template <bool is_pal> void init_saturn();
 
 	DECLARE_INPUT_CHANGED_MEMBER(tray_open);
 	DECLARE_INPUT_CHANGED_MEMBER(tray_close);
 
 private:
-
 	DECLARE_MACHINE_START(saturn);
 	DECLARE_MACHINE_RESET(saturn);
+
+	// SMPC region codes, hardwired via jumper setting.
+	// - Given the scheme bit 3 should determine if the region is PAL or NTSC.
+	// - 0 and F are "prohibited", others are "Sega reserved".
+	// - Documentation states that 2 is "TAIWAN" and 6 is "KOREA",
+	//   but games on latter definitely wants 2 rather than 6.
+	//   We currently swap, former actual slot needs to be confirmed.
+	enum {
+		REGION_NTSC_0 = 0,
+		REGION_NTSC_JAPAN,
+//		REGION_NTSC_TAIWAN,
+		REGION_NTSC_KOREA,
+		REGION_NTSC_3,
+		REGION_NTSC_USA, // & Canada, Mexico
+		REGION_NTSC_BRAZIL,
+//		REGION_NTSC_KOREA,
+		REGION_NTSC_TAIWAN, // & Philippines
+		REGION_NTSC_7,
+		REGION_PAL_8,
+		REGION_PAL_9,
+		REGION_PAL_ASIA, // China, Middle East, East Asia not covered above
+		REGION_PAL_B,
+		REGION_PAL_EUROPE, // Australia, South Africa
+		REGION_PAL_AMERICA, // Non-NTSC Central/South America
+		REGION_PAL_E,
+		REGION_PAL_F
+	};
 
 	uint8_t saturn_cart_type_r();
 	uint32_t abus_dummy_r(offs_t offset);
@@ -482,7 +507,6 @@ private:
 	uint32_t saturn_null_ram_r();
 	void saturn_null_ram_w(uint32_t data);
 
-	void saturn_init_driver(int rgn);
 	uint8_t saturn_pdr1_direct_r();
 	uint8_t saturn_pdr2_direct_r();
 	void saturn_pdr1_direct_w(uint8_t data);
@@ -548,7 +572,7 @@ void sat_console_state::saturn_mem(address_map &map)
 	map(0x05f80000, 0x05fbffff).rw(FUNC(sat_console_state::saturn_vdp2_regs_r), FUNC(sat_console_state::saturn_vdp2_regs_w));
 	map(0x05fe0000, 0x05fe00cf).m(m_scu, FUNC(sega_scu_device::regs_map)); //rw(FUNC(sat_console_state::saturn_scu_r), FUNC(sat_console_state::saturn_scu_w));
 	map(0x06000000, 0x060fffff).ram().mirror(0x21f00000).share("workram_h");
-	map(0x45000000, 0x46ffffff).nopw();
+	map(0x40000000, 0x46ffffff).nopw(); // associative purge page
 	map(0x60000000, 0x600003ff).nopw(); // cache address array
 	map(0xc0000000, 0xc0000fff).ram(); // cache data array, Dragon Ball Z sprites relies on this
 }
@@ -884,7 +908,7 @@ void sat_console_state::saturnus(machine_config &config)
 	SATURN_CART_SLOT(config, "exp", saturn_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("sat_cart");
 
-	m_smpc_hle->set_region_code(4);
+	m_smpc_hle->set_region_code(REGION_NTSC_USA);
 }
 
 void sat_console_state::saturneu(machine_config &config)
@@ -897,7 +921,7 @@ void sat_console_state::saturneu(machine_config &config)
 	SATURN_CART_SLOT(config, "exp", saturn_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("sat_cart");
 
-	m_smpc_hle->set_region_code(12);
+	m_smpc_hle->set_region_code(REGION_PAL_EUROPE);
 }
 
 void sat_console_state::saturnjp(machine_config &config)
@@ -910,13 +934,27 @@ void sat_console_state::saturnjp(machine_config &config)
 	SATURN_CART_SLOT(config, "exp", saturn_cart, nullptr);
 	SOFTWARE_LIST(config, "cart_list").set_original("sat_cart");
 
-	m_smpc_hle->set_region_code(1);
+	m_smpc_hle->set_region_code(REGION_NTSC_JAPAN);
+}
+
+void sat_console_state::saturnkr(machine_config &config)
+{
+	saturn(config);
+	SATURN_CDB(config, "saturn_cdb", 16000000);
+
+	SOFTWARE_LIST(config, "cd_list").set_original("saturn").set_filter("NTSC-K");
+
+	SATURN_CART_SLOT(config, "exp", saturn_cart, nullptr);
+	SOFTWARE_LIST(config, "cart_list").set_original("sat_cart");
+
+	m_smpc_hle->set_region_code(REGION_NTSC_KOREA);
 }
 
 
-void sat_console_state::saturn_init_driver(int rgn)
+template <bool is_pal> void sat_console_state::init_saturn()
 {
-	m_vdp2.pal = (rgn == 12) ? 1 : 0;
+	// TODO: setter for (missing) VDP2 device
+	m_vdp2.pal = is_pal;
 
 	// set compatible options
 	m_maincpu->sh2drc_set_options(SH2DRC_STRICT_VERIFY|SH2DRC_STRICT_PCREL);
@@ -939,25 +977,8 @@ void sat_console_state::saturn_init_driver(int rgn)
 	m_backupram = make_unique_clear<uint8_t[]>(0x8000);
 }
 
-void sat_console_state::init_saturnus()
-{
-	saturn_init_driver(4);
-}
-
-void sat_console_state::init_saturneu()
-{
-	saturn_init_driver(12);
-}
-
-void sat_console_state::init_saturnjp()
-{
-	saturn_init_driver(1);
-}
-
-
-/* Japanese Saturn */
-ROM_START(saturnjp)
-	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF ) /* SH2 code */
+ROM_START( saturnjp )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
 	ROM_SYSTEM_BIOS(0, "101", "Japan v1.01 (941228)")
 	ROMX_LOAD("sega_101.bin", 0x00000000, 0x00080000, CRC(224b752c) SHA1(df94c5b4d47eb3cc404d88b33a8fda237eaf4720), ROM_BIOS(0))
 	ROM_SYSTEM_BIOS(1, "1003", "Japan v1.003 (941012)")
@@ -966,9 +987,8 @@ ROM_START(saturnjp)
 	ROMX_LOAD("sega_100.bin", 0x00000000, 0x00080000, CRC(2aba43c2) SHA1(2b8cb4f87580683eb4d760e4ed210813d667f0a2), ROM_BIOS(2))
 ROM_END
 
-/* Overseas Saturn */
-ROM_START(saturn)
-	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF ) /* SH2 code */
+ROM_START( saturn )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
 	ROM_SYSTEM_BIOS(0, "101a", "Overseas v1.01a (941115)")
 	/* Confirmed by ElBarto */
 	ROMX_LOAD("mpr-17933.bin", 0x00000000, 0x00080000, CRC(4afcf0fa) SHA1(faa8ea183a6d7bbe5d4e03bb1332519800d3fbc3), ROM_BIOS(0))
@@ -976,8 +996,8 @@ ROM_START(saturn)
 	ROMX_LOAD("sega_100a.bin", 0x00000000, 0x00080000, CRC(f90f0089) SHA1(3bb41feb82838ab9a35601ac666de5aacfd17a58), ROM_BIOS(1))
 ROM_END
 
-ROM_START(saturneu)
-	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF ) /* SH2 code */
+ROM_START( saturneu )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
 	ROM_SYSTEM_BIOS(0, "101a", "Overseas v1.01a (941115)")
 	/* Confirmed by ElBarto */
 	ROMX_LOAD("mpr-17933.bin", 0x00000000, 0x00080000, CRC(4afcf0fa) SHA1(faa8ea183a6d7bbe5d4e03bb1332519800d3fbc3), ROM_BIOS(0))
@@ -985,13 +1005,20 @@ ROM_START(saturneu)
 	ROMX_LOAD("sega_100a.bin", 0x00000000, 0x00080000, CRC(f90f0089) SHA1(3bb41feb82838ab9a35601ac666de5aacfd17a58), ROM_BIOS(1))
 ROM_END
 
-ROM_START(vsaturn)
-	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF ) /* SH2 code */
+ROM_START( saturnkr )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
+	// undumped, uses Japanese VA1 motherboard with v1.02a BIOS rev,
+	// with extra checks for region jumpers that disables Japanese language if setting matches '2' (no Korea option tho)
+	ROM_LOAD("sega_101.bin", 0x00000000, 0x00080000, BAD_DUMP CRC(224b752c) SHA1(df94c5b4d47eb3cc404d88b33a8fda237eaf4720) )
+ROM_END
+
+ROM_START( vsaturn )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
 	ROM_LOAD("vsaturn.bin", 0x00000000, 0x00080000, CRC(e4d61811) SHA1(4154e11959f3d5639b11d7902b3a393a99fb5776))
 ROM_END
 
-ROM_START(hisaturn)
-	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF ) /* SH2 code */
+ROM_START( hisaturn )
+	ROM_REGION32_BE( 0x80000, "bios", ROMREGION_ERASEFF )
 	ROM_SYSTEM_BIOS(0, "102", "v1.02 (950519)")
 	ROMX_LOAD("mpr-18100.bin", 0x000000, 0x080000, CRC(3408dbf4) SHA1(8a22710e09ce75f39625894366cafe503ed1942d), ROM_BIOS(0))
 	ROM_SYSTEM_BIOS(1, "101", "v1.01 (950130)")
@@ -999,8 +1026,9 @@ ROM_START(hisaturn)
 ROM_END
 
 /*    YEAR  NAME      PARENT  COMPAT  MACHINE   INPUT   CLASS              INIT           COMPANY    FULLNAME            FLAGS */
-CONS( 1994, saturn,   0,      0,      saturnus, saturn, sat_console_state, init_saturnus, "Sega",    "Saturn (USA)",     MACHINE_NOT_WORKING )
-CONS( 1994, saturnjp, saturn, 0,      saturnjp, saturn, sat_console_state, init_saturnjp, "Sega",    "Saturn (Japan)",   MACHINE_NOT_WORKING )
-CONS( 1994, saturneu, saturn, 0,      saturneu, saturn, sat_console_state, init_saturneu, "Sega",    "Saturn (PAL)",     MACHINE_NOT_WORKING )
-CONS( 1995, vsaturn,  saturn, 0,      saturnjp, saturn, sat_console_state, init_saturnjp, "JVC",     "V-Saturn",         MACHINE_NOT_WORKING )
-CONS( 1995, hisaturn, saturn, 0,      saturnjp, saturn, sat_console_state, init_saturnjp, "Hitachi", "HiSaturn",         MACHINE_NOT_WORKING )
+CONS( 1994, saturn,   0,      0,      saturnus, saturn, sat_console_state, init_saturn<false>, "Sega",    "Saturn (USA)",     MACHINE_NOT_WORKING )
+CONS( 1994, saturnjp, saturn, 0,      saturnjp, saturn, sat_console_state, init_saturn<false>, "Sega",    "Saturn (Japan)",   MACHINE_NOT_WORKING )
+CONS( 1994, saturneu, saturn, 0,      saturneu, saturn, sat_console_state, init_saturn<true>,  "Sega",    "Saturn (PAL)",     MACHINE_NOT_WORKING )
+CONS( 1995, saturnkr, saturn, 0,      saturnkr, saturn, sat_console_state, init_saturn<false>, "Samsung", "Saturn (Korea)",   MACHINE_NOT_WORKING )
+CONS( 1995, vsaturn,  saturn, 0,      saturnjp, saturn, sat_console_state, init_saturn<false>, "JVC",     "V-Saturn",         MACHINE_NOT_WORKING )
+CONS( 1995, hisaturn, saturn, 0,      saturnjp, saturn, sat_console_state, init_saturn<false>, "Hitachi", "HiSaturn",         MACHINE_NOT_WORKING )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -36931,6 +36931,7 @@ hisaturn                        // Hitachi HiSaturn
 saturn                          // 1995 Sega Saturn (USA)
 saturneu                        // 1995 Sega Saturn (Europe)
 saturnjp                        // 1994 Sega Saturn (Japan)
+saturnkr                        // 1995 Samsung Saturn (Korea)
 vsaturn                         // JVC V-Saturn
 
 @source:sauro.cpp


### PR DESCRIPTION
- stvcd.cpp: guard against deleting partial sectors in cmd_delete_sector_data, fixes pstarcol Phantasy Star 2 crash after first attract cycle;
- smpc.cpp: NMI is unconditionally requested for screen clock change commands, fixes booting in bigichig, capgen1, capgen4, capgen5;
- stvcd.cpp: add fixed status for NetLink, allow dragndrm to actually boot (with -nodrc);



