### PR TITLE
bus/nes: Updates for BMC-70IN1 and BMC-800IN1 boards.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -79374,6 +79374,21 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_35hm">
+		<description>35 in 1 (HM5511)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_70in1" />
+			<dataarea name="prg" size="131072">
+				<rom name="35-in-1 (hm5511) [p1][u].prg" size="131072" crc="1df62cd7" sha1="3d7a103eb07fd939a053aa6f54532030cb3b4971" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="65536">
+				<rom name="35-in-1 (hm5511) [p1][u].chr" size="65536" crc="10852729" sha1="53b9a1ec244a85bd0c9585b05ddc68cc52dc4c22" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_35k36">
 		<description>35 in 1 (K-3036)</description>
 		<year>19??</year>
@@ -80851,6 +80866,21 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="mc_68hm">
+		<description>68 in 1 (HM5511)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="bmc_70in1" />
+			<dataarea name="prg" size="131072">
+				<rom name="68-in-1 (hm5511) [p1][u].prg" size="131072" crc="c3008f57" sha1="64cc33defb3371d99a6d76c623676ac6386cef4b" status="baddump" />
+			</dataarea>
+			<dataarea name="chr" size="65536">
+				<rom name="68-in-1 (hm5511) [p1][u].chr" size="65536" crc="90ee9ab8" sha1="f3432c7d5330bd26dbebf7e32cfdc16c68f02d44" status="baddump" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="mc_7k603">
 		<description>7 in 1 (K7603)</description>
 		<year>19??</year>
@@ -80915,7 +80945,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_70" supported="no">
+	<software name="mc_70">
 		<description>70 in 1</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -81259,7 +81289,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_800" supported="no">
+	<software name="mc_800">
 		<description>800 in 1</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -78568,7 +78568,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_15" supported="no">
+	<software name="mc_15">
 		<description>15 in 1</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
@@ -79185,7 +79185,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_3" supported="no">
+	<software name="mc_3">
 		<description>3 in 1</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -81080,13 +81080,12 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mc_76a" supported="no">
-		<description>76 in 1 (Alt Games)</description>
+	<software name="mc_76a">
+		<description>76 in 1 (alt games)</description>
 		<year>19??</year>
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="bmc_1200in1" />
-			<feature name="pcb" value="BMC-1200IN1" />
+			<feature name="slot" value="bmc_60311c" />
 			<dataarea name="prg" size="2097152">
 				<rom name="76 in 1[a1].prg" size="2097152" crc="2eed2e34" sha1="71f8548373650583a8e9b9d7829f9047b0ffc129" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes/event.h
+++ b/src/devices/bus/nes/event.h
@@ -1,7 +1,7 @@
 // license:BSD-3-Clause
 // copyright-holders:Fabio Priuli
-#ifndef MAEM_BUS_NES_EVENT_H
-#define MAEM_BUS_NES_EVENT_H
+#ifndef MAME_BUS_NES_EVENT_H
+#define MAME_BUS_NES_EVENT_H
 
 #pragma once
 
@@ -46,4 +46,4 @@ protected:
 // device type definition
 DECLARE_DEVICE_TYPE(NES_EVENT, nes_event_device)
 
-#endif // MAEM_BUS_NES_EVENT_H
+#endif // MAME_BUS_NES_EVENT_H

--- a/src/devices/bus/nes/mmc3_clones.cpp
+++ b/src/devices/bus/nes/mmc3_clones.cpp
@@ -278,8 +278,8 @@ nes_bmc_8in1_device::nes_bmc_8in1_device(const machine_config &mconfig, const ch
 {
 }
 
-nes_bmc_15in1_device::nes_bmc_15in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_txrom_device(mconfig, NES_BMC_15IN1, tag, owner, clock)
+nes_bmc_15in1_device::nes_bmc_15in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_txrom_device(mconfig, NES_BMC_15IN1, tag, owner, clock), m_jumper(0)
 {
 }
 
@@ -657,10 +657,7 @@ void nes_bmc_8in1_device::pcb_reset()
 void nes_bmc_15in1_device::pcb_reset()
 {
 	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	mmc3_common_initialize(0x1f, 0xff, 0);
-	m_prg_base = 0x10;  // this board has a diff prg_base
-	set_prg(m_prg_base, m_prg_mask);
 }
 
 void nes_bmc_sbig7_device::pcb_reset()
@@ -2235,30 +2232,32 @@ void nes_bmc_8in1_device::write_h(offs_t offset, u8 data)
 
 /*-------------------------------------------------
 
- BMC-15IN1
+ BMC-15IN1 (PCB JC-016-2?)
 
- Unknown Bootleg Multigame Board
  Games: 3 in 1, 15 in 1
 
- iNES: mapper 205, MMC3 clone
+ MMC3 clone with banking for multigame menu.
 
- In MESS: Supported.
+ iNES: mapper 205
+
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_bmc_15in1_device::write_m(offs_t offset, uint8_t data)
+void nes_bmc_15in1_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("bmc_15in1 write_m, offset: %04x, data: %02x\n", offset, data));
 
-	if (offset & 0x0800)
-	{
-		m_prg_base = (data & 0x03) << 4;
-		m_prg_mask = (data & 0x02) ? 0x0f : 0x1f;
-		m_chr_base = (data & 0x03) << 7;
-		m_chr_mask = (data & 0x02) ? 0x7f : 0xff;
-		set_prg(m_prg_base, m_prg_mask);
-		set_chr(m_chr_source, m_chr_base, m_chr_mask);
-	}
+	if (data & 1)
+		data |= m_jumper;    // TODO: add jumper settings, m_jumper is 0 for now
+
+	m_prg_base = (data & 0x03) << 4;
+	m_prg_mask = 0x1f >> BIT(data, 1);
+	set_prg(m_prg_base, m_prg_mask);
+
+	m_chr_base = m_prg_base << 3;
+	m_chr_mask = 0xff >> BIT(data, 1);
+	set_chr(m_chr_source, m_chr_base, m_chr_mask);
 }
 
 /*-------------------------------------------------

--- a/src/devices/bus/nes/mmc3_clones.h
+++ b/src/devices/bus/nes/mmc3_clones.h
@@ -651,12 +651,15 @@ class nes_bmc_15in1_device : public nes_txrom_device
 {
 public:
 	// construction/destruction
-	nes_bmc_15in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_15in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
+
+private:
+	u8 m_jumper;
 };
 
 

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -790,20 +790,40 @@ class nes_bmc_70in1_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_bmc_70in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_bmc_70in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_h(offs_t offset) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual u8 read_h(offs_t offset) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
+	// construction/destruction
+	nes_bmc_70in1_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
 	// device-level overrides
 	virtual void device_start() override;
 
+	virtual void update_banks();
+	void update_prg(u8 bank);
+
+	u8 m_latch[2];
+
 private:
-	uint8_t m_mode;
-	uint8_t m_reg[2];
+	u8 m_jumper;
+};
+
+
+// ======================> nes_bmc_800in1_device
+
+class nes_bmc_800in1_device : public nes_bmc_70in1_device
+{
+public:
+	// construction/destruction
+	nes_bmc_800in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual void update_banks() override;
 };
 
 
@@ -874,29 +894,6 @@ public:
 	nes_bmc_500in1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual void write_h(offs_t offset, u8 data) override;
-};
-
-
-// ======================> nes_bmc_800in1_device
-
-class nes_bmc_800in1_device : public nes_nrom_device
-{
-public:
-	// construction/destruction
-	nes_bmc_800in1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual uint8_t read_h(offs_t offset) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
-
-private:
-	uint8_t m_mode;
-	uint8_t m_reg[2];
 };
 
 

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -269,7 +269,7 @@ static const nes_mmc mmc_list[] =
 	{ 233, BMC_42IN1RESET },
 	{ 234, AVE_MAXI15 },
 	{ 235, BMC_GOLD150 },   // 235 Golden Game x-in-1 - Unsupported
-	// 236 Game 800-in-1 - Unsupported, Realtec boards 8031 and 8155
+	{ 236, BMC_70IN1 },
 	// 237 Teletubbies 420-in-1 multicart. Dump available?
 	{ 238, UNL_603_5052 },
 	// 239 Unused
@@ -903,6 +903,11 @@ void nes_cart_slot_device::call_load_ines()
 				m_pcb_id = UNL_8237A;
 			break;
 
+		case BMC_70IN1:
+			if (vrom_size == 0)
+				m_pcb_id = BMC_800IN1;
+			break;
+
 		case RCM_GS2004:
 			if (prg_size >= 0x50000)
 				m_pcb_id = RCM_GS2013;
@@ -1239,6 +1244,11 @@ const char * nes_cart_slot_device::get_default_card_ines(get_default_card_softwa
 		case UNL_8237:                                 // Mapper 215 is used for 2 diff boards
 			if (submapper == 1)
 				pcb_id = UNL_8237A;
+			break;
+
+		case BMC_70IN1:                                // Mapper 236 is used for 2 diff boards
+			if (ROM[5] == 0)
+				pcb_id = BMC_800IN1;
 			break;
 
 		case RCM_GS2004:                               // Mapper 283 is used for 2 diff boards

--- a/src/devices/bus/nes/pirate.cpp
+++ b/src/devices/bus/nes/pirate.cpp
@@ -36,8 +36,8 @@
 
 DEFINE_DEVICE_TYPE(NES_AGCI_50282,  nes_agci_device,        "nes_agci50282",   "NES Cart AGCI 50282 PCB")
 DEFINE_DEVICE_TYPE(NES_DREAMTECH01, nes_dreamtech_device,   "nes_dreamtech",   "NES Cart Dreamtech01 PCB")
-DEFINE_DEVICE_TYPE(NES_FUKUTAKE,    nes_fukutake_device,    "nes_futuremedia", "NES Cart Fukutake Study Box PCB")
-DEFINE_DEVICE_TYPE(NES_FUTUREMEDIA, nes_futuremedia_device, "nes_fukutake",    "NES Cart FutureMedia PCB")
+DEFINE_DEVICE_TYPE(NES_FUKUTAKE,    nes_fukutake_device,    "nes_fukutake",    "NES Cart Fukutake Study Box PCB")
+DEFINE_DEVICE_TYPE(NES_FUTUREMEDIA, nes_futuremedia_device, "nes_futuremedia", "NES Cart FutureMedia PCB")
 DEFINE_DEVICE_TYPE(NES_MAGSERIES,   nes_magseries_device,   "nes_magseries",   "NES Cart Magical Series PCB")
 DEFINE_DEVICE_TYPE(NES_DAOU306,     nes_daou306_device,     "nes_daou306",     "NES Cart Daou 306 PCB")
 DEFINE_DEVICE_TYPE(NES_CC21,        nes_cc21_device,        "nes_cc21",        "NES Cart CC-21 PCB")


### PR DESCRIPTION
- Reimplemented these related boards as class/subclass.
- Corrected missing iNES loader support.

New working software list additions (nes.xml)
-----------------------------------
35 in 1 (HM5511) [anonymous]
68 in 1 (HM5511) [anonymous]

Software list items promoted to working (nes.xml)
---------------------------------------
15 in 1
3 in 1
70 in 1
76 in 1 (alt games)
800 in 1