### PR TITLE
a800: fixes writing antic DLISTL and DLISTH to only affect the high a…

### DIFF
--- a/src/mame/video/antic.cpp
+++ b/src/mame/video/antic.cpp
@@ -1227,16 +1227,14 @@ void antic_device::write(offs_t offset, uint8_t data)
 	case  2:
 		LOG("ANTIC 02 write DLISTL $%02X\n", data);
 		m_w.dlistl = data;
-		temp = (m_w.dlisth << 8) + m_w.dlistl;
-		m_dpage = temp & DPAGE;
-		m_doffs = temp & DOFFS;
+		m_doffs = (m_doffs & 0x300) | (data & 0xff);  // keep bits 9 and 8 of m_doffs
 		break;
 	case  3:
 		LOG("ANTIC 03 write DLISTH $%02X\n", data);
 		m_w.dlisth = data;
 		temp = (m_w.dlisth << 8) + m_w.dlistl;
 		m_dpage = temp & DPAGE;
-		m_doffs = temp & DOFFS;
+		m_doffs = (m_doffs & 0xff) | (temp & 0x300);  // keep bits 7 to 0 of m_doffs
 		break;
 	case  4:
 		if( data == m_w.hscrol )
@@ -1853,12 +1851,14 @@ void antic_device::linerefresh()
 		if( (m_cmd & 0x0f) == 2 || (m_cmd & 0x0f) == 3 )
 		{
 			artifacts_txt(src, (uint8_t*)(dst + 3), HCHARS);
+			draw_scanline8(*m_bitmap, 12, y, std::min(size_t(m_bitmap->width() - 12), sizeof(scanline)), (const uint8_t *) scanline, nullptr);
 			return;
 		}
 		else
 			if( (m_cmd & 0x0f) == 15 )
 			{
 				artifacts_gfx(src, (uint8_t*)(dst + 3), HCHARS);
+				draw_scanline8(*m_bitmap, 12, y, std::min(size_t(m_bitmap->width() - 12), sizeof(scanline)), (const uint8_t *) scanline, nullptr);
 				return;
 			}
 	}


### PR DESCRIPTION
…nd low byte component that is spread between m_dpage and m_doffs

(this fixes choplifter since it flips screen pages by writing DLISTH to change the display list)

also adds draw_scanline8 calls to render artifact colors in modes 2,3, and 15



Choplifter seems to swap it's double buffer pages by having two display lists, one at 2000 and another at 2100.  When it wants to flip pages, it just writes DLISTH and also modifies the shadow display list registers.  Before this fix, it would modify both m_doffs and m_dpage on a write to DLISTH.

Also, if you selected Artifact Colors ON in the configuration, the display would stop updating when modes 2,3 and 15 were on.
This fixes that also.
