### PR TITLE
nes.xml: Added a missing game from recent N625092 board improvements.

### DIFF
--- a/hash/famicom_flop.xml
+++ b/hash/famicom_flop.xml
@@ -1916,7 +1916,8 @@ Re-releases (probably the same as the original release, but listed while waiting
 		</part>
 	</software>
 
-	<software name="smb2">
+<!-- Does not respond to input on title screen -->
+	<software name="smb2" supported="no">
 		<description>Super Mario Bros. 2</description>
 		<year>1986</year>
 		<publisher>Nintendo</publisher>
@@ -2635,7 +2636,8 @@ Re-releases (probably the same as the original release, but listed while waiting
 		</part>
 	</software>
 
-	<software name="doremiko">
+<!-- This game uses an unemulated Konami piano keyboard -->
+	<software name="doremiko" supported="partial">
 		<description>Doremikko</description>
 		<year>1987</year>
 		<publisher>Konami</publisher>

--- a/hash/nes.hsi
+++ b/hash/nes.hsi
@@ -1045,7 +1045,7 @@ license:CC0
 
 	</hash>
 	<hash crc32="2eed2e34" sha1="71f8548373650583a8e9b9d7829f9047b0ffc129" name="76-in-1 [p1][a1]">
-		<extrainfo>227 0 128 0</extrainfo>
+		<extrainfo>289 0 128 0</extrainfo>
 
 	</hash>
 	<hash crc32="a6c5212c" sha1="bcaf1a5b607dc3af78455b92015395a677b0a126" name="76-in-1 [p1]">

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -11312,8 +11312,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="exboxing">
-		<description>Exciting Boxing (Jpn)</description>
+<!-- This game uses an unemulated punching bag controller -->
+	<software name="exboxing" supported="no">
+		<description>Exciting Boxing (Japan)</description>
 		<year>1987</year>
 		<publisher>Konami</publisher>
 		<info name="serial" value="KON-RC250"/>
@@ -37027,8 +37028,9 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="supermog">
-		<description>Super Mogura Tataki!! Pokkun Moguraa (Jpn)</description>
+<!-- This game uses an unemulated whack-a-mole pad -->
+	<software name="supermog" supported="no">
+		<description>Super Mogura Tataki!! Pokkun Moguraa (Japan)</description>
 		<year>1989</year>
 		<publisher>IGS</publisher>
 		<info name="serial" value="IGS-X1"/>
@@ -40227,13 +40229,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="toprider">
-		<description>Top Rider (Jpn)</description>
+<!-- This game uses an unemulated motorcycle handle controller -->
+	<software name="toprider" supported="partial">
+		<description>Top Rider (Japan)</description>
 		<year>1988</year>
 		<publisher>Varie</publisher>
 		<info name="serial" value="VRE-R1"/>
 		<info name="release" value="19881217"/>
 		<info name="alt_title" value="トップライダー"/>
+		<info name="usage" value="To use a standard controller, at the title screen press A, B, Right, Down, Left, Up, Right, B, A on controller 2."/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="HVC-SFROM" />
@@ -76857,7 +76861,7 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mk3" supported="partial">
+	<software name="mk3">
 		<description>Mortal Kombat 3 (Asia)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
@@ -77006,8 +77010,8 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
-	<software name="mk2blue" supported="partial">
-		<description>Mortal Kombat II (Asia, Blue Version)</description>
+	<software name="mk2blue">
+		<description>Mortal Kombat II (Asia, blue version)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="nes_cart">
@@ -78238,6 +78242,22 @@ be better to redump them properly. -->
 			<feature name="pcb" value="UNL-N625092" />
 			<dataarea name="prg" size="1048576">
 				<rom name="1000-in-1 (jpx72).prg" size="1048576" crc="f03bec60" sha1="3952f91686fee280ab73b9fe47b83fc2a32b65d0" offset="00000" status="baddump" />
+			</dataarea>
+			<!-- 8k VRAM on cartridge -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mc_1ka">
+		<description>1000 in 1 (alt games)</description>
+		<year>19??</year>
+		<publisher>&lt;pirate&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="n625092" />
+			<feature name="pcb" value="UNL-N625092" />
+			<dataarea name="prg" size="2097152">
+				<rom name="1000-in-1 (sun wukong title screen).prg" size="2097152" crc="a175ff8d" sha1="87358910929a2566ab65743610bd057184f143f7" status="baddump" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">

--- a/src/devices/bus/nes/multigame.cpp
+++ b/src/devices/bus/nes/multigame.cpp
@@ -3005,6 +3005,12 @@ void nes_bmc_k1029_device::write_h(offs_t offset, u8 data)
 
  In MAME: Supported.
 
+ TODO: Several games have incorrect mirroring bits
+ on all carts they appear on. It's subtle so it's
+ likely a BTANB? Noticeable in Flappy, Pacman, and
+ Warpman title scrolls and at bottom of screen in
+ Zippy Race in-game.
+
  -------------------------------------------------*/
 
 void nes_n625092_device::write_h(offs_t offset, u8 data)
@@ -3013,7 +3019,7 @@ void nes_n625092_device::write_h(offs_t offset, u8 data)
 
 	m_latch[BIT(offset, 14)] = offset;
 
-	u8 bank = (m_latch[0] & 0x200) >> 3 | (m_latch[0] & 0xe0) >> 2 | (m_latch[1] & 0x07);    // NesDev shows the high bit here, but is it correct? So far no cart is large enough to use this.
+	u8 bank = (m_latch[0] & 0x200) >> 3 | (m_latch[0] & 0xe0) >> 2 | (m_latch[1] & 0x07);
 	u8 mode = BIT(m_latch[0], 1);
 	if (mode && BIT(m_latch[0], 8))    // UNROM mode
 	{


### PR DESCRIPTION
- Updated support status of various NES/FDS titles.
- Fixed loading of mc_76a outside of software lists.

New working software list additions
-----------------------------------
1000 in 1 (alt games) [NewRisingSun]