### PR TITLE
emu/video.cpp: Set file names via -snapname when exiting in -seconds_…

### DIFF
--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1765,7 +1765,7 @@ Core Performance Options
     other command line options, you can set up a consistent environment for
     benchmarking MAME's emulation performance.  In addition, upon exit, the
     **-str** option will write a screenshot to the system's snapshot directory
-    with the file name determined by **-snapname**.
+    with the file name determined by the **-snapname** option.
 
     Example:
         .. code-block:: bash

--- a/docs/source/commandline/commandline-all.rst
+++ b/docs/source/commandline/commandline-all.rst
@@ -1764,8 +1764,8 @@ Core Performance Options
     benchmarking and automated testing.  By combining this with a fixed set of
     other command line options, you can set up a consistent environment for
     benchmarking MAME's emulation performance.  In addition, upon exit, the
-    **-str** option will write a screenshot called ``final.png`` to the system's
-    snapshot directory.
+    **-str** option will write a screenshot to the system's snapshot directory
+    with the file name determined by **-snapname**.
 
     Example:
         .. code-block:: bash

--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -1007,7 +1007,7 @@ void video_manager::recompute_speed(const attotime &emutime)
 	{
 		// create a final screenshot
 		emu_file file(machine().options().snapshot_directory(), OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
-		std::error_condition filerr = file.open(machine().basename() + PATH_SEPARATOR "final.png");
+		std::error_condition const filerr = open_next(file, "png");
 		if (!filerr)
 			save_snapshot(nullptr, file);
 


### PR DESCRIPTION
…to_run.