### PR TITLE
machine/spg_renderer.cpp: Fix blend level handling for tile layers

### DIFF
--- a/src/devices/machine/spg_renderer.cpp
+++ b/src/devices/machine/spg_renderer.cpp
@@ -467,7 +467,11 @@ void spg_renderer_device::draw_page(bool read_from_csspace, bool has_extended_ti
 	const uint32_t bits_per_row = nc_bpp * tile_w / 16;
 	//const uint32_t words_per_tile = bits_per_row * tile_h;
 	const bool row_scroll = (ctrl & 0x0010);
-	uint8_t blendlevel = (m_video_regs_2a & 3) << 3;
+
+	// Max blend level (3) should result in 100% opacity, per docs
+	// Min blend level (0) should result in 25% opacity, per docs
+	static const uint8_t s_blend_levels[4] = { 0x08, 0x10, 0x18, 0x20 };
+	uint8_t blendlevel = s_blend_levels[m_video_regs_2a & 3];
 
 	uint32_t words_per_tile;
 


### PR DESCRIPTION
This PR copies the blend level fix that had already been done for sprites in https://github.com/mamedev/mame/commit/d919a1e095674c02679247d751e1c229b2b3e305 to the tile layer implementation. It has also been tested and verified on real hardware (V.Smile with [Disco-Cart](https://github.com/DiscoStarslayer/disco-cart)).