### PR TITLE
bus/nes: Corrected VRC4/6/7 IRQ pseudo-scanline counter.

### DIFF
--- a/src/devices/bus/nes/konami.cpp
+++ b/src/devices/bus/nes/konami.cpp
@@ -174,7 +174,7 @@ void nes_konami_vrc4_device::pcb_reset()
 	chr8(0, m_chr_source);
 
 	m_irq_mode = 0;
-	m_irq_prescale = 341;
+	m_irq_prescale = 0;
 	m_irq_enable = 0;
 	m_irq_enable_latch = 0;
 	m_irq_count = 0;
@@ -214,7 +214,7 @@ void nes_konami_vrc7_device::pcb_reset()
 	chr8(0, m_chr_source);
 
 	m_irq_mode = 0;
-	m_irq_prescale = 341;
+	m_irq_prescale = 0;
 	m_irq_enable = 0;
 	m_irq_enable_latch = 0;
 	m_irq_count = 0;
@@ -468,6 +468,19 @@ void nes_konami_vrc4_device::device_timer(emu_timer &timer, device_timer_id id, 
 	}
 }
 
+void nes_konami_vrc4_device::irq_ctrl_w(uint8_t data)
+{
+	m_irq_mode = data & 0x04;
+	m_irq_enable = data & 0x02;
+	m_irq_enable_latch = data & 0x01;
+	if (m_irq_enable)
+	{
+		m_irq_count = m_irq_count_latch;
+		m_irq_prescale = 341;
+	}
+	set_irq_line(CLEAR_LINE);
+}
+
 void nes_konami_vrc4_device::set_prg()
 {
 	if (m_latch & 0x02)
@@ -534,12 +547,7 @@ void nes_konami_vrc4_device::write_h(offs_t offset, uint8_t data)
 					m_irq_count_latch = (m_irq_count_latch & 0x0f) | ((data & 0x0f) << 4);
 					break;
 				case 0x200:
-					m_irq_mode = data & 0x04;
-					m_irq_enable = data & 0x02;
-					m_irq_enable_latch = data & 0x01;
-					if (data & 0x02)
-						m_irq_count = m_irq_count_latch;
-					set_irq_line(CLEAR_LINE);
+					irq_ctrl_w(data);
 					break;
 				case 0x300:
 					m_irq_enable = m_irq_enable_latch;
@@ -608,12 +616,7 @@ void nes_konami_vrc6_device::write_h(offs_t offset, uint8_t data)
 					m_irq_count_latch = data;
 					break;
 				case 0x100:
-					m_irq_mode = data & 0x04;
-					m_irq_enable = data & 0x02;
-					m_irq_enable_latch = data & 0x01;
-					if (data & 0x02)
-						m_irq_count = m_irq_count_latch;
-					set_irq_line(CLEAR_LINE);
+					irq_ctrl_w(data);
 					break;
 				case 0x200:
 					m_irq_enable = m_irq_enable_latch;
@@ -719,12 +722,7 @@ void nes_konami_vrc7_device::write_h(offs_t offset, uint8_t data)
 			m_irq_count_latch = data;
 			break;
 		case 0x7000:
-			m_irq_mode = data & 0x04;
-			m_irq_enable = data & 0x02;
-			m_irq_enable_latch = data & 0x01;
-			if (data & 0x02)
-				m_irq_count = m_irq_count_latch;
-			set_irq_line(CLEAR_LINE);
+			irq_ctrl_w(data);
 			break;
 		case 0x7008: case 0x7010: case 0x7018:
 			m_irq_enable = m_irq_enable_latch;

--- a/src/devices/bus/nes/konami.h
+++ b/src/devices/bus/nes/konami.h
@@ -109,7 +109,8 @@ protected:
 	uint8_t m_latch, m_mmc_prg_bank;
 
 	void irq_tick();
-	uint16_t m_irq_count, m_irq_count_latch;
+	void irq_ctrl_w(uint8_t data);
+	uint8_t m_irq_count, m_irq_count_latch;
 	int m_irq_enable, m_irq_enable_latch;
 	int m_irq_mode;
 	int m_irq_prescale;


### PR DESCRIPTION
- This eliminates the constant shaking in TMNT2J and Akumajo Special's status bars and full screen shaking in some vertical stages (Clock Tower at least) in Akumajo Densetsu.