### PR TITLE
bus/nes: VRC2 only supports two mirroring modes.

### DIFF
--- a/src/devices/bus/nes/konami.cpp
+++ b/src/devices/bus/nes/konami.cpp
@@ -324,13 +324,7 @@ void nes_konami_vrc2_device::write_h(offs_t offset, uint8_t data)
 			prg8_ab(data);
 			break;
 		case 0x1000:
-			switch (data & 0x03)
-			{
-				case 0x00: set_nt_mirroring(PPU_MIRROR_VERT); break;
-				case 0x01: set_nt_mirroring(PPU_MIRROR_HORZ); break;
-				case 0x02: set_nt_mirroring(PPU_MIRROR_LOW); break;
-				case 0x03: set_nt_mirroring(PPU_MIRROR_HIGH); break;
-			}
+			set_nt_mirroring(data & 1 ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
 			break;
 		case 0x3000:
 		case 0x4000:


### PR DESCRIPTION
- Fixes several graphics glitches in Wai Wai World.