### PR TITLE
First pass in improving Amiga SW compatibility 

### DIFF
--- a/hash/amigaecs_flop.xml
+++ b/hash/amigaecs_flop.xml
@@ -10,7 +10,7 @@ license:CC0
     will not function.
 -->
 
-<softwarelist name="amigaecs_flop" description="Amiga ECS disk images">
+<softwarelist name="amigaecs_flop" description="Commodore Amiga ECS disk images">
 
 	<software name="cmang2up" supported="no">
 		<!-- SPS (CAPS) release 1997 -->

--- a/hash/amigaecs_flop.xml
+++ b/hash/amigaecs_flop.xml
@@ -645,13 +645,15 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="snapper" supported="no">
+	<!-- boot OK -->
+	<software name="snapper" supported="yes">
 		<!-- SPS (CAPS) release 2534 -->
 		<description>Snapperazzi (Euro)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, ECS, PAL) -->
 		<year>1993</year>
 		<publisher>Alternative Software</publisher>
+		<!-- TODO: is this truly a ECS exclusive game? Reports indicates this being OCS as well, it also works on vanilla a500 -->
 		<info name="usage" value="Requires ECS" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -11,6 +11,15 @@ license:CC0
 
     Most images for the initial import are from SPS / CAPS collections
 
+	ATK test notes refers to Amiga Test Kit v1.18:
+	https://github.com/keirf/Amiga-Stuff
+	Specifically the Floppy Drive Test Read Item, the test note refers 
+	to the flop1 been tested from DF1 up with a -bench 90:
+	- OK means that all tracks have been reported good;
+	- a generic "failed" means that most if not all tracks reports as bad (test didn't complete);
+	- C refers to the Track number(s), H is the (U)pper, (L)ower head (if not omitted),
+	  "1 Sector Bad" reports as one sector being bad, otherwise "Bad" [Track];
+
     todo (SPS):
     - see if it's possible to better verify these images, the SPS dat only lists the (highly insecure) CRC32s so we're relying on trust here
     that the images from which the SHA1s were generated haven't been faked.
@@ -83,6 +92,7 @@ license:CC0
 
 	<!-- Not listed in SPS? -->
 
+	<!-- ATK test: OK -->
 	<software name="hostile" supported="no">
 		<description>Hostile Breed (Euro, Prototype)</description>
 		<year>199?</year>
@@ -107,6 +117,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nobby" supported="no">
 		<description>Nobby the Aardvark (Euro, Prototype)</description>
 		<year>199?</year>
@@ -121,6 +132,7 @@ license:CC0
 
 	<!-- SPS / CAPS Releases -->
 
+	<!-- ATK test: failed -->
 	<software name="16bithit" supported="no">
 		<description>16 Bit Hit Machine (Euro)</description>
 		<!-- retail, standalone -->
@@ -150,6 +162,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="16bitkomix" supported="no">
 		<description>16 Bit Komix (Euro)</description>
 		<year>1991</year>
@@ -168,6 +181,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="1869" supported="no">
 		<!-- SPS (CAPS) release 417 -->
 		<description>1869 - Erlebte Geschichte Teil I (Euro)</description>
@@ -195,6 +209,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="1stdmang" supported="no">
 		<!-- SPS (CAPS) release 1800 -->
 		<description>1st Division Manager (Euro)</description>
@@ -209,6 +224,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="3dconkit" supported="no">
 		<!-- SPS (CAPS) release 1765 -->
 		<description>3D Construction Kit (Euro, r01.1000)</description>
@@ -223,6 +239,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="3dgalax" supported="no">
 		<!-- SPS (CAPS) release 1085 -->
 		<description>3D Galax (Euro)</description>
@@ -237,6 +254,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="3dpool" supported="no">
 		<!-- SPS (CAPS) release 621 -->
 		<description>3D Pool (Euro)</description>
@@ -251,6 +269,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="3dwboxin" supported="no">
 		<!-- SPS (CAPS) release 2223 -->
 		<description>3D World Boxing (Euro, Amiga Sports Pack)</description>
@@ -265,6 +284,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="3dwtenn" supported="no">
 		<!-- SPS (CAPS) release 2224 -->
 		<description>3D World Tennis (Euro, Amiga Sports Pack)</description>
@@ -279,6 +299,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="4dboxing" supported="no">
 		<!-- SPS (CAPS) release 421 -->
 		<description>4D Sports Boxing (Euro)</description>
@@ -300,6 +321,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="4ddrivin" supported="no">
 		<!-- SPS (CAPS) release 1461 -->
 		<description>4D Sports Driving (Euro, v1.2 19920110)</description>
@@ -321,6 +343,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="4inches" supported="no">
 		<!-- SPS (CAPS) release 1230 -->
 		<description>4th &amp; Inches (Euro)</description>
@@ -335,6 +358,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="4x4offrd" supported="no">
 		<!-- SPS (CAPS) release 1480 -->
 		<description>4x4 Off-Road Racing (USA)</description>
@@ -349,6 +373,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="500ccmm" supported="no">
 		<!-- SPS (CAPS) release 2670 -->
 		<description>500 c.c MotoManager (Euro, v1.0)</description>
@@ -363,6 +388,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="50ggames" supported="no">
 		<!-- SPS (CAPS) release 2796 -->
 		<description>50 Great Games (Euro)</description>
@@ -390,6 +416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="5thgear" supported="no">
 		<!-- SPS (CAPS) release 1001 -->
 		<description>5th Gear (Euro)</description>
@@ -404,6 +431,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="688atsub" supported="no">
 		<!-- SPS (CAPS) release 93 -->
 		<description>688 Attack Sub (Euro)</description>
@@ -418,6 +446,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="7colors" supported="no">
 		<!-- SPS (CAPS) release 956 -->
 		<description>7 Colors (Euro)</description>
@@ -432,6 +461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="a10tank" supported="no">
 		<!-- SPS (CAPS) release 1396 -->
 		<description>A-10 Tank Killer (Euro)</description>
@@ -453,6 +483,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atrain" supported="no">
 		<!-- SPS (CAPS) release 1010 -->
 		<description>A-Train (Euro, v1.01)</description>
@@ -475,6 +506,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atrainf" cloneof="atrain" supported="no">
 		<!-- SPS (CAPS) release 2579 -->
 		<description>A-Train (Fra, v1.01)</description>
@@ -496,6 +528,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atraing" cloneof="atrain" supported="no">
 		<!-- SPS (CAPS) release 428 -->
 		<description>A-Train (Ger, v1.01)</description>
@@ -517,6 +550,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atraincs" cloneof="atrain" supported="no">
 		<!-- SPS (CAPS) release 1469 -->
 		<description>A-Train Construction Set (Euro, v1.00)</description>
@@ -539,6 +573,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atraincsc" cloneof="atrain" supported="no">
 		<!-- SPS (CAPS) release 1468 -->
 		<description>A-Train Construction Set (Euro, v1.00, Classic)</description>
@@ -561,6 +596,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="a320air2" supported="no">
 		<!-- SPS (CAPS) release 1592 -->
 		<description>A320 Airbus Vol. 2 (Euro)</description>
@@ -575,6 +611,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="aaargh" supported="no">
 		<!-- SPS (CAPS) release 511 -->
 		<description>Aaargh! (Euro)</description>
@@ -589,6 +626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abanplc" supported="no">
 		<!-- SPS (CAPS) release 1000 -->
 		<description>Abandoned Places - A Time for Heroes (Euro)</description>
@@ -628,6 +666,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abanplcg" cloneof="abanplc" supported="no">
 		<!-- SPS (CAPS) release 999 -->
 		<description>Abandoned Places - A Time for Heroes (Ger)</description>
@@ -667,6 +706,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abanplcd" cloneof="abanplc" supported="no">
 		<!-- SPS (CAPS) release 1714 -->
 		<description>Abandoned Places Demo (Euro, v1.17)</description>
@@ -683,6 +723,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abanplc2" supported="no">
 		<!-- SPS (CAPS) release 2000 -->
 		<description>Abandoned Places 2 (Euro)</description>
@@ -722,6 +763,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abcfoot" supported="no">
 		<!-- SPS (CAPS) release 1495 -->
 		<description>ABC Monday Night Football (USA, v1.1)</description>
@@ -749,6 +791,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="abracada" supported="no">
 		<!-- SPS (CAPS) release 2451 -->
 		<description>Abracadabra (Euro)</description>
@@ -770,6 +813,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="accordio" supported="no">
 		<!-- SPS (CAPS) release 1894 -->
 		<description>Accordion (Euro, v1.1)</description>
@@ -784,6 +828,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="actionfg" supported="no">
 		<!-- SPS (CAPS) release 1243 -->
 		<description>Action Fighter (Euro, Les Fous du Volant)</description>
@@ -798,6 +843,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="actionfgk" cloneof="actionfg" supported="no">
 		<!-- SPS (CAPS) release 3040 -->
 		<description>Action Fighter (Euro, Budget)</description>
@@ -819,6 +865,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="actnserv" supported="no">
 		<!-- SPS (CAPS) release 1950 -->
 		<description>Action Service (Euro)</description>
@@ -833,6 +880,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="actnserved" cloneof="actnserv" supported="no">
 		<!-- SPS (CAPS) release 1949 -->
 		<description>Action Service (Euro, European Dreams)</description>
@@ -847,6 +895,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="actstat" supported="no">
 		<!-- SPS (CAPS) release 1002 -->
 		<description>Action Stations! (Euro, v1.48)</description>
@@ -868,6 +917,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="addfam" supported="no">
 		<!-- SPS (CAPS) release 419 -->
 		<description>The Addams Family (Euro)</description>
@@ -882,6 +932,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tiebreak" supported="no">
 		<!-- SPS (CAPS) release 2637 -->
 		<description>Adidas Championship Tie Break (Euro)</description>
@@ -896,6 +947,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="ads" supported="no">
 		<!-- SPS (CAPS) release 2151 -->
 		<description>ADS - Advanced Destroyer Simulator (Euro, v1.0)</description>
@@ -910,6 +962,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="adsf" cloneof="ads" supported="no">
 		<!-- SPS (CAPS) release 2406 -->
 		<description>ADS - Advanced Destroyer Simulator (Fra, v1.0)</description>
@@ -924,6 +977,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="advfruit" supported="no">
 		<!-- SPS (CAPS) release 622 -->
 		<description>Advanced Fruit Machine Simulator (Euro)</description>
@@ -938,6 +992,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="advski" supported="no">
 		<!-- SPS (CAPS) release 94 -->
 		<description>Advanced Ski Simulator (Euro)</description>
@@ -952,6 +1007,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="advski1" cloneof="advski" supported="no">
 		<!-- SPS (CAPS) release 1805 -->
 		<description>Advanced Ski Simulator (Euro, Alt)</description>
@@ -966,6 +1022,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="advtenn" supported="no">
 		<!-- SPS (CAPS) release 2261 -->
 		<description>Advantage Tennis (Euro)</description>
@@ -980,6 +1037,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="adventcs" supported="no">
 		<!-- SPS (CAPS) release 904 -->
 		<description>Adventure Construction Set (USA)</description>
@@ -994,6 +1052,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="advrobin" supported="no">
 		<!-- SPS (CAPS) release 1399 -->
 		<description>The Adventures of Robin Hood (Euro)</description>
@@ -1008,6 +1067,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="willybem" supported="no">
 		<!-- SPS (CAPS) release 1814 -->
 		<description>The Adventures of Willy Beamish (Euro, v1.0)</description>
@@ -1089,6 +1149,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="africanr" supported="no">
 		<!-- SPS (CAPS) release 1169 -->
 		<description>African Raiders-01 (Euro)</description>
@@ -1103,6 +1164,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aburner" supported="no">
 		<!-- SPS (CAPS) release 95 -->
 		<description>Afterburner (Euro)</description>
@@ -1124,6 +1186,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aburneru" cloneof="aburner" supported="no">
 		<!-- SPS (CAPS) release 947 -->
 		<description>Afterburner (USA)</description>
@@ -1138,6 +1201,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="afterwar" supported="no">
 		<!-- SPS (CAPS) release 1084 -->
 		<description>After the War (Euro, Magnum)</description>
@@ -1152,6 +1216,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="age" supported="no">
 		<!-- SPS (CAPS) release 2862 -->
 		<description>A.G.E (Euro)</description>
@@ -1174,6 +1239,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="agony" supported="no">
 		<!-- SPS (CAPS) release 960 -->
 		<description>Agony (Euro)</description>
@@ -1201,6 +1267,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="agonyu" cloneof="agony" supported="no">
 		<!-- SPS (CAPS) release 2701 -->
 		<description>Agony (USA)</description>
@@ -1228,6 +1295,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="aigledo2" supported="no">
 		<!-- SPS (CAPS) release 2600 -->
 		<description>L'Aigle d'Or - Le Retour (Fra)</description>
@@ -1255,6 +1323,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="airbucks" supported="no">
 		<!-- SPS (CAPS) release 1003 -->
 		<description>Air Bucks (Euro, v1.2)</description>
@@ -1276,6 +1345,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="airsuprt" supported="no">
 		<!-- SPS (CAPS) release 1320 -->
 		<description>Air Support (Euro)</description>
@@ -1297,6 +1367,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="airsuprtu" cloneof="airsuprt" supported="no">
 		<!-- SPS (CAPS) release 1325 -->
 		<description>Air Support (USA)</description>
@@ -1318,6 +1389,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="airborne" supported="no">
 		<!-- SPS (CAPS) release 100 -->
 		<description>Airborne Ranger (Euro)</description>
@@ -1332,6 +1404,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="airforce" supported="no">
 		<!-- SPS (CAPS) release 2679 -->
 		<description>AirForce Commander (Euro)</description>
@@ -1353,6 +1426,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alcatraz" supported="no">
 		<!-- SPS (CAPS) release 2073 -->
 		<description>Alcatraz (Euro)</description>
@@ -1374,6 +1448,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alert" supported="no">
 		<!-- SPS (CAPS) release 2087 -->
 		<description>Alert (Euro)</description>
@@ -1388,6 +1463,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alfred" supported="no">
 		<!-- SPS (CAPS) release 422 -->
 		<description>Alfred Chicken (Euro)</description>
@@ -1402,6 +1478,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alianatr" supported="no">
 		<!-- SPS (CAPS) release 1905 -->
 		<description>Alianator (Euro)</description>
@@ -1416,6 +1493,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="alien3" supported="no">
 		<!-- SPS (CAPS) release 261 -->
 		<description>Alien³ (Euro)</description>
@@ -1440,6 +1518,7 @@ license:CC0
 	<!-- Throws "amiga_fdc_device::live_run - cur_live.bit_counter > 8" after credits display -->
 	<!-- Motor keeps spinning badly on disk swap screen(s) (verify) -->
 	<!-- No player sprite, red dots incorrectly drawn on several elements during gameplay (namely alien enemies) -->
+	<!-- ATK test: OK -->
 	<software name="abreed" supported="no">
 		<!-- SPS (CAPS) release 998 -->
 		<description>Alien Breed (Euro)</description>
@@ -1467,6 +1546,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="abred92" supported="no">
 		<!-- SPS (CAPS) release 615 -->
 		<description>Alien Breed - Special Edition '92 (Euro)</description>
@@ -1488,6 +1568,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="abred2" supported="no">
 		<!-- SPS (CAPS) release 278 -->
 		<description>Alien Breed II - The Horror Continues (Euro)</description>
@@ -1515,6 +1596,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="abredtas" supported="no">
 		<!-- SPS (CAPS) release 2331 -->
 		<description>Alien Breed - Tower Assault (Euro, v1.1)</description>
@@ -1542,6 +1624,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="abredtas1" cloneof="abredtas" supported="no">
 		<!-- SPS (CAPS) release 279 -->
 		<description>Alien Breed - Tower Assault (Euro)</description>
@@ -1569,6 +1652,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="aliendrg" supported="no">
 		<!-- SPS (CAPS) release 1004 -->
 		<description>Alien Drug Lords - The Chyropian Connection (Euro, v1.0)</description>
@@ -1602,6 +1686,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alienfir" supported="no">
 		<!-- SPS (CAPS) release 2356 -->
 		<description>Alien Fires 2199 AD (USA)</description>
@@ -1623,6 +1708,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad, C:79 H:L Bad, C:79 H:U 1 Sector Bad -->
 	<software name="alienleg" supported="no">
 		<!-- SPS (CAPS) release 2859 -->
 		<description>Alien Legion (Euro)</description>
@@ -1637,6 +1723,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="astorm" supported="no">
 		<!-- SPS (CAPS) release 96 -->
 		<description>Alien Storm (Euro)</description>
@@ -1651,6 +1738,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="aliensyn" supported="no">
 		<!-- SPS (CAPS) release 2353 -->
 		<description>Alien Syndrome (USA)</description>
@@ -1665,6 +1753,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="aliensyn1" cloneof="aliensyn" supported="no">
 		<!-- SPS (CAPS) release 2352 -->
 		<description>Alien Syndrome (USA, Budget)</description>
@@ -1679,6 +1768,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="alienwrl" supported="no">
 		<!-- SPS (CAPS) release 1398 -->
 		<description>Alien World (Euro)</description>
@@ -1693,6 +1783,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:52 onward Bad -->
 	<software name="alloallo" supported="no">
 		<!-- SPS (CAPS) release 1005 -->
 		<description>'Allo 'Allo! Cartoon Fun. (Euro)</description>
@@ -1714,6 +1805,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alloallo1" cloneof="alloallo" supported="no">
 		<!-- SPS (CAPS) release 1213 -->
 		<description>'Allo 'Allo! Cartoon Fun. (Euro, Alt)</description>
@@ -1735,6 +1827,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alpha1" supported="no">
 		<!-- SPS (CAPS) release 1921 -->
 		<description>Alpha-1 (Euro)</description>
@@ -1749,6 +1842,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="alphawav" supported="no">
 		<!-- SPS (CAPS) release 626 -->
 		<description>Alpha Waves (Euro)</description>
@@ -1764,6 +1858,7 @@ license:CC0
 	</software>
 
 	<!-- Seldomly throw Guru Meditation (TODO: btanb? verify) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="altbeast" supported="partial">
 		<!-- SPS (CAPS) release 819 -->
 		<description>Altered Beast (Euro)</description>
@@ -1785,6 +1880,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="altdest" supported="no">
 		<!-- SPS (CAPS) release 237 -->
 		<description>Altered Destiny (Euro)</description>
@@ -1831,6 +1927,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK (tested English and Italian) -->
+	<!-- ATK test: OK -->
 	<software name="spidermn" supported="yes">
 		<!-- SPS (CAPS) release 1006 -->
 		<description>The Amazing Spider-Man (Euro)</description>
@@ -1846,6 +1943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ambermon" supported="no">
 		<!-- SPS (CAPS) release 2537 -->
 		<description>Ambermoon (Euro, v1.01 19931022)</description>
@@ -1909,6 +2007,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="amberstr" supported="no">
 		<!-- SPS (CAPS) release 1969 -->
 		<description>Amberstar (Euro, v1.96)</description>
@@ -1936,6 +2035,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="amberstrg" cloneof="amberstr" supported="no">
 		<!-- SPS (CAPS) release 2655 -->
 		<description>Amberstar (Ger, v1.73)</description>
@@ -1963,6 +2063,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="amegas" supported="no">
 		<!-- SPS (CAPS) release 1655 -->
 		<description>Amegas (Euro, Tenstar Pack)</description>
@@ -1977,6 +2078,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="amegas1" cloneof="amegas" supported="no">
 		<!-- SPS (CAPS) release 1656 -->
 		<description>Amegas (Euro, Tenstar Pack, Alt)</description>
@@ -1991,6 +2093,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tagteam" supported="no">
 		<!-- SPS (CAPS) release 2211 -->
 		<description>American Tag-Team Wrestling (Euro)</description>
@@ -2005,6 +2108,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="amicomp" supported="no">
 		<!-- SPS (CAPS) release 2196 -->
 		<description>Amiga Complete - Intrigue + Silhouette (Euro)</description>
@@ -2019,6 +2123,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="amigaenc" supported="no">
 		<!-- SPS (CAPS) release 651 -->
 		<description>Amiga Encounter (Euro)</description>
@@ -2033,6 +2138,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="amigakar" supported="no">
 		<!-- SPS (CAPS) release 45 -->
 		<description>Amiga Karate (USA)</description>
@@ -2047,6 +2153,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="amispiel" supported="no">
 		<!-- SPS (CAPS) release 1682 -->
 		<description>Amiga Spiele 1 - Wikinger + Bliff + Quadriga (Ger)</description>
@@ -2061,6 +2168,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="asband1" supported="no">
 		<!-- SPS (CAPS) release 2673 -->
 		<description>Amiga Spielesammlung Band 1 (Euro, v1.0)</description>
@@ -2082,6 +2190,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="amnios" supported="no">
 		<!-- SPS (CAPS) release 423 -->
 		<description>Amnios (Euro)</description>
@@ -2103,6 +2212,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="anarchy" supported="no">
 		<!-- SPS (CAPS) release 424 -->
 		<description>Anarchy (Euro)</description>
@@ -2117,6 +2227,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="aawskies" supported="no">
 		<!-- SPS (CAPS) release 1666 -->
 		<description>The Ancient Art of War in the Skies (Euro, v1.12)</description>
@@ -2150,6 +2261,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="anotherw" supported="no">
 		<!-- SPS (CAPS) release 425 -->
 		<description>Another World (Euro)</description>
@@ -2171,6 +2283,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="anotherwdc" cloneof="anotherw" supported="no">
 		<!-- SPS (CAPS) release 1881 -->
 		<description>Another World (Euro, The Delphine Collection)</description>
@@ -2192,6 +2305,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="anotherwf" cloneof="anotherw" supported="no">
 		<!-- SPS (CAPS) release 2377 -->
 		<description>Another World (Fra)</description>
@@ -2213,6 +2327,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="anstoss" supported="no">
 		<!-- SPS (CAPS) release 798 -->
 		<description>Anstoss - Die Fußball-Manager-Simulation (Euro)</description>
@@ -2252,6 +2367,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="antago" supported="no">
 		<!-- SPS (CAPS) release 857 -->
 		<description>Antago (Euro)</description>
@@ -2266,6 +2382,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="apache" supported="no">
 		<!-- SPS (CAPS) release 426 -->
 		<description>Apache &amp; Overdrive demo (Euro)</description>
@@ -2280,6 +2397,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="apb" supported="no">
 		<!-- SPS (CAPS) release 1240 -->
 		<description>APB (Euro)</description>
@@ -2295,6 +2413,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK but has serious GFX pitch issues on every other frame -->
+	<!-- ATK test: failed -->
 	<software name="apidya" supported="no">
 		<!-- SPS (CAPS) release 764 -->
 		<description>Apidya (Euro)</description>
@@ -2316,6 +2435,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="apidya1" cloneof="apidya" supported="no">
 		<!-- SPS (CAPS) release 2465 -->
 		<description>Apidya (Euro, Budget?)</description>
@@ -2337,6 +2457,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="apocalyp" supported="no">
 		<!-- SPS (CAPS) release 1813 -->
 		<description>Apocalypse (Euro)</description>
@@ -2364,6 +2485,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="apprent" supported="no">
 		<!-- SPS (CAPS) release 2288 -->
 		<description>Apprentice (Euro)</description>
@@ -2378,6 +2500,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="approach" supported="no">
 		<!-- SPS (CAPS) release 1264 -->
 		<description>Approach Trainer (Euro, v1.0)</description>
@@ -2392,6 +2515,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aquagame" supported="no">
 		<!-- SPS (CAPS) release 1351 -->
 		<description>The Aquatic Games Starring James Pond and the Aquabats (Euro)</description>
@@ -2406,6 +2530,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aquavent" supported="no">
 		<!-- SPS (CAPS) release 427 -->
 		<description>Aquaventura (Euro)</description>
@@ -2427,6 +2552,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aquaventu" cloneof="aquavent" supported="no">
 		<!-- SPS (CAPS) release 2330 -->
 		<description>Aquaventura (USA)</description>
@@ -2448,6 +2574,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arabian" supported="no">
 		<!-- SPS (CAPS) release 1454 -->
 		<description>Arabian Nights (Euro, v1.01 19930512)</description>
@@ -2469,6 +2596,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arcpool" supported="no">
 		<!-- SPS (CAPS) release 298 -->
 		<description>Arcade Pool (Euro)</description>
@@ -2483,6 +2611,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="arctriv" supported="no">
 		<!-- SPS (CAPS) release 936 -->
 		<description>Arcade Trivia Quiz (Euro)</description>
@@ -2497,6 +2626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="archerp" supported="no">
 		<!-- SPS (CAPS) release 1096 -->
 		<description>Archer MacLean Presents Pool (Euro)</description>
@@ -2511,6 +2641,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="archipel" supported="yes">
 		<!-- SPS (CAPS) release 627 -->
 		<description>Archipelagos (Euro)</description>
@@ -2527,6 +2658,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="archipelu" cloneof="archipel" supported="no">
 		<!-- SPS (CAPS) release 628 -->
 		<description>Archipelagos (USA)</description>
@@ -2541,6 +2673,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="archon" supported="no">
 		<!-- SPS (CAPS) release 2779 -->
 		<description>Archon (Euro, The Archon Collection)</description>
@@ -2556,6 +2689,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="archonu" cloneof="archon" supported="no">
 		<!-- SPS (CAPS) release 914 -->
 		<description>Archon (USA)</description>
@@ -2571,6 +2705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="adept" supported="no">
 		<!-- SPS (CAPS) release 905 -->
 		<description>Archon II: Adept (USA)</description>
@@ -2585,6 +2720,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="arctfox" supported="no">
 		<!-- SPS (CAPS) release 909 -->
 		<description>Arcticfox (USA)</description>
@@ -2599,6 +2735,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arena" supported="no">
 		<!-- SPS (CAPS) release 1191 -->
 		<description>Arena (Euro)</description>
@@ -2613,6 +2750,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arena1" cloneof="arena" supported="no">
 		<!-- SPS (CAPS) release 1642 -->
 		<description>Arena (Euro, Alt)</description>
@@ -2627,6 +2765,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arenau" cloneof="arena" supported="no">
 		<!-- SPS (CAPS) release 1190 -->
 		<description>Arena (USA)</description>
@@ -2641,6 +2780,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arkanoid" supported="no">
 		<!-- SPS (CAPS) release 954 -->
 		<description>Arkanoid (Euro, v1.04 19880228)</description>
@@ -2655,6 +2795,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="arkanoidu" cloneof="arkanoid" supported="no">
 		<!-- SPS (CAPS) release 1136 -->
 		<description>Arkanoid (USA, v1.05 19880331)</description>
@@ -2669,6 +2810,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arkanoidau1" cloneof="arkanoid" supported="no">
 		<!-- SPS (CAPS) release 1519 -->
 		<description>Arkanoid (USA, v1.05 19880331, ADOS)</description>
@@ -2683,6 +2825,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="arknoid2" supported="no">
 		<!-- SPS (CAPS) release 765 -->
 		<description>Arkanoid - Revenge of Doh (Euro)</description>
@@ -2697,6 +2840,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arknoid2b" cloneof="arknoid2" supported="no">
 		<!-- SPS (CAPS) release 1159 -->
 		<description>Arkanoid - Revenge of Doh (Euro, Budget)</description>
@@ -2711,6 +2855,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="armada" supported="no">
 		<!-- SPS (CAPS) release 1094 -->
 		<description>Armada (Euro)</description>
@@ -2725,6 +2870,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="armagman" supported="no">
 		<!-- SPS (CAPS) release 629 -->
 		<description>The Armageddon Man (Euro)</description>
@@ -2739,6 +2885,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="armalyte" supported="no">
 		<!-- SPS (CAPS) release 1686 -->
 		<description>Armalyte (Euro)</description>
@@ -2760,6 +2907,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="armged2" supported="no">
 		<!-- SPS (CAPS) release 97 -->
 		<description>Armour Geddon II (Euro)</description>
@@ -2788,6 +2936,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="armymove" supported="no">
 		<!-- SPS (CAPS) release 2442 -->
 		<description>Army Moves (Euro, CU Amiga)</description>
@@ -2802,6 +2951,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arnhem" supported="no">
 		<!-- SPS (CAPS) release 2925 -->
 		<description>Arnhem - The 'Market Garden' Operation (Euro, v1.0e)</description>
@@ -2818,6 +2968,7 @@ license:CC0
 
 	<!-- boot OK, verify clicking at the end of samples playbacks -->
 	<!-- can randomly lock up during gameplay -->
+	<!-- ATK test: OK -->
 	<software name="arnie" supported="no">
 		<!-- SPS (CAPS) release 1007 -->
 		<description>Arnie (Euro)</description>
@@ -2834,6 +2985,7 @@ license:CC0
 
 	<!-- black screen with continous floppy access [FDC] dsksync -->
 	<!-- (keeps jumping to empty area at PC=4d000 after failing a copy protection check at PC=70032, D0=0 D1=5d5 D2=67 D3=0) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="arnie2" supported="no">
 		<!-- SPS (CAPS) release 1924 -->
 		<description>Arnie 2 (Euro)</description>
@@ -2848,6 +3000,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arthur" supported="no">
 		<!-- SPS (CAPS) release 1401 -->
 		<description>Arthur: The Quest for Excalibur (USA, r54)</description>
@@ -2862,6 +3015,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="artguere" supported="no">
 		<!-- SPS (CAPS) release 2447 -->
 		<description>L'Art de la Guerre (Fra)</description>
@@ -2876,6 +3030,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="artofche" supported="no">
 		<!-- SPS (CAPS) release 1008 -->
 		<description>The Art of Chess (Euro)</description>
@@ -2890,6 +3045,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="artura" supported="no">
 		<!-- SPS (CAPS) release 1086 -->
 		<description>Artura (Euro, Action Amiga)</description>
@@ -2904,6 +3060,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ashempir" supported="no">
 		<!-- SPS (CAPS) release 794 -->
 		<description>Ashes of Empire (Euro, v22792G)</description>
@@ -2939,6 +3096,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="asparmgp" cloneof="gpmaster" supported="yes">
 		<!-- SPS (CAPS) release 1241 -->
 		<description>Aspar Master Grand Prix (Euro, Les Fous du Volant)</description>
@@ -2953,6 +3111,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="assassin" supported="no">
 		<!-- SPS (CAPS) release 1214 -->
 		<description>Assassin (Euro, v1)</description>
@@ -2974,6 +3133,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="assasse" supported="no">
 		<!-- SPS (CAPS) release 766 -->
 		<description>Assassin Special Edition (Euro)</description>
@@ -2995,6 +3155,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="associat" supported="no">
 		<!-- SPS (CAPS) release 1911 -->
 		<description>Associated (Euro)</description>
@@ -3009,6 +3170,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="astaroth" supported="no">
 		<!-- SPS (CAPS) release 1321 -->
 		<description>Astaroth (Euro)</description>
@@ -3023,6 +3185,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="astatin" supported="no">
 		<!-- SPS (CAPS) release 2159 -->
 		<description>Astatin (Euro)</description>
@@ -3037,6 +3200,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="asterog" supported="no">
 		<!-- SPS (CAPS) release 1009 -->
 		<description>Asterix - Operation Getafix (Euro)</description>
@@ -3051,6 +3215,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="asterogg" cloneof="asterix" supported="no">
 		<!-- SPS (CAPS) release 630 -->
 		<description>Asterix und Operation Hinkelstein (Euro)</description>
@@ -3065,6 +3230,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="asterix" supported="no">
 		<!-- SPS (CAPS) release 631 -->
 		<description>Asterix Im Morgenland (Euro)</description>
@@ -3079,6 +3245,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atax" supported="no">
 		<!-- SPS (CAPS) release 950 -->
 		<description>ATAX (Euro)</description>
@@ -3093,6 +3260,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="atf2" supported="no">
 		<!-- SPS (CAPS) release 2396 -->
 		<description>ATF II - Advanced Tactical Fighter II (Euro)</description>
@@ -3107,6 +3275,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="atf2a" cloneof="atf2" supported="no">
 		<!-- SPS (CAPS) release 1437 -->
 		<description>ATF II - Advanced Tactical Fighter II (Euro, Budget)</description>
@@ -3121,6 +3290,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="atomrobo" supported="no">
 		<!-- SPS (CAPS) release 2243 -->
 		<description>Atomic Robo-Kid (Euro)</description>
@@ -3142,6 +3312,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atomino" supported="no">
 		<!-- SPS (CAPS) release 632 -->
 		<description>Atomino (Euro)</description>
@@ -3156,6 +3327,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="atominou" cloneof="atomino" supported="no">
 		<!-- SPS (CAPS) release 1972 -->
 		<description>Atomino (USA)</description>
@@ -3170,6 +3342,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="atomix" supported="no">
 		<!-- SPS (CAPS) release 1356 -->
 		<description>Atomix (Euro)</description>
@@ -3184,6 +3357,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aufschwu" supported="no">
 		<!-- SPS (CAPS) release 429 -->
 		<description>Aufschwung Ost (Euro)</description>
@@ -3205,6 +3379,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="auntaadv" supported="no">
 		<!-- SPS (CAPS) release 1757 -->
 		<description>Aunt Arctic Adventure (Euro)</description>
@@ -3219,6 +3394,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="austerl" supported="no">
 		<!-- SPS (CAPS) release 238 -->
 		<description>Austerlitz (Euro)</description>
@@ -3233,6 +3409,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="australo" supported="no">
 		<!-- SPS (CAPS) release 809 -->
 		<description>Australo Piticus Mechanicus (Euro)</description>
@@ -3247,6 +3424,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="autoduel" supported="no">
 		<!-- SPS (CAPS) release 916 -->
 		<description>AutoDuel (Euro)</description>
@@ -3261,6 +3439,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="av8bharr" supported="no">
 		<!-- SPS (CAPS) release 430 -->
 		<description>AV8B Harrier Assault (Euro)</description>
@@ -3282,6 +3461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="moktar" supported="no">
 		<!-- SPS (CAPS) release 1636 -->
 		<description>Les Aventures de Moktar (Euro)</description>
@@ -3296,6 +3476,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="awesome" supported="no">
 		<!-- SPS (CAPS) release 431 -->
 		<description>Awesome (Euro)</description>
@@ -3323,6 +3504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="awesomed" cloneof="awesome" supported="no">
 		<!-- SPS (CAPS) release 1450 -->
 		<description>Awesome Demo (Euro)</description>
@@ -3337,6 +3519,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="axelmh" supported="no">
 		<!-- SPS (CAPS) release 432 -->
 		<description>Axel's Magic Hammer (Euro)</description>
@@ -3351,6 +3534,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bat" supported="no">
 		<!-- SPS (CAPS) release 2072 -->
 		<description>B.A.T. (Euro)</description>
@@ -3372,6 +3556,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="batf" cloneof="bat" supported="no">
 		<!-- SPS (CAPS) release 2641 -->
 		<description>B.A.T. (Fra)</description>
@@ -3393,6 +3578,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="batg" cloneof="bat" supported="no">
 		<!-- SPS (CAPS) release 2197 -->
 		<description>B.A.T. (Ger)</description>
@@ -3414,6 +3600,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bat2" supported="no">
 		<!-- SPS (CAPS) release 1835 -->
 		<description>B.A.T. II (Euro)</description>
@@ -3453,6 +3640,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bat2f" cloneof="bat2" supported="no">
 		<!-- SPS (CAPS) release 1635 -->
 		<description>B.A.T. II (Fra)</description>
@@ -3492,6 +3680,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bat2g" cloneof="bat2" supported="no">
 		<!-- SPS (CAPS) release 434 -->
 		<description>B.A.T. II (Ger)</description>
@@ -3531,6 +3720,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="b17fly" supported="no">
 		<!-- SPS (CAPS) release 1196 -->
 		<description>B17 Flying Fortress (Euro, v1.02)</description>
@@ -3558,6 +3748,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="baal" supported="no">
 		<!-- SPS (CAPS) release 1350 -->
 		<description>Baal (Euro)</description>
@@ -3572,6 +3763,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="babyjo" supported="no">
 		<!-- SPS (CAPS) release 2291 -->
 		<description>Baby Jo in "Going Home" (Euro)</description>
@@ -3586,6 +3778,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="backgamm" supported="no">
 		<!-- SPS (CAPS) release 1591 -->
 		<description>Backgammon (Euro, Magic Soft)</description>
@@ -3615,6 +3808,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="backlash" supported="no">
 		<!-- SPS (CAPS) release 1118 -->
 		<description>Backlash (Euro)</description>
@@ -3629,6 +3823,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="backtof2" supported="no">
 		<!-- SPS (CAPS) release 5 -->
 		<description>Back to the Future Part II (Euro)</description>
@@ -3643,6 +3838,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="backtof3" supported="no">
 		<!-- SPS (CAPS) release 265 -->
 		<description>Back to the Future Part III (Euro)</description>
@@ -3664,6 +3860,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="backtof3u" cloneof="backtof3" supported="no">
 		<!-- SPS (CAPS) release 1171 -->
 		<description>Back to the Future Part III (USA)</description>
@@ -3685,6 +3882,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="badcat" supported="no">
 		<!-- SPS (CAPS) release 976 -->
 		<description>Bad Cat (Euro, 5th Anniversary)</description>
@@ -3706,6 +3904,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="badcomp" supported="no">
 		<!-- SPS (CAPS) release 3002 -->
 		<description>Bad Company (Euro)</description>
@@ -3720,6 +3919,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="baddudes" supported="no">
 		<!-- SPS (CAPS) release 98 -->
 		<description>Bad Dudes vs. Dragon Ninja (Euro)</description>
@@ -3734,6 +3934,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="baddudesu" cloneof="baddudes" supported="no">
 		<!-- SPS (CAPS) release 2425 -->
 		<description>Bad Dudes (USA)</description>
@@ -3748,6 +3949,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="badlpete" supported="no">
 		<!-- SPS (CAPS) release 2521 -->
 		<description>Badlands Pete (Euro)</description>
@@ -3762,6 +3964,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="badlands" supported="no">
 		<!-- SPS (CAPS) release 1237 -->
 		<description>BadLands (Euro)</description>
@@ -3776,6 +3979,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="badlands1" cloneof="badlands" supported="no">
 		<!-- SPS (CAPS) release 1238 -->
 		<description>BadLands (Euro, Budget)</description>
@@ -3790,6 +3994,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="balpower" supported="no">
 		<!-- SPS (CAPS) release 2374 -->
 		<description>Balance of Power - Geopolitics in the Nuclear Age (USA)</description>
@@ -3804,6 +4009,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="balpow90" supported="no">
 		<!-- SPS (CAPS) release 1818 -->
 		<description>Balance of Power - The 1990 Edition (Euro)</description>
@@ -3818,6 +4024,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ballgame" supported="no">
 		<!-- SPS (CAPS) release 2051 -->
 		<description>The Ball Game (Euro)</description>
@@ -3832,6 +4039,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ballistx" supported="no">
 		<!-- SPS (CAPS) release 433 -->
 		<description>Ballistix (Euro)</description>
@@ -3846,6 +4054,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ballyhoo" supported="no">
 		<!-- SPS (CAPS) release 2682 -->
 		<description>Ballyhoo (Euro, r97)</description>
@@ -3860,6 +4069,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bambijag" supported="no">
 		<!-- SPS (CAPS) release 1914 -->
 		<description>Bambinours Solves a Jigsaw Puzzle (Euro)</description>
@@ -3874,6 +4084,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bandking" supported="no">
 		<!-- SPS (CAPS) release 2794 -->
 		<description>Bandit Kings of Ancient China (Euro)</description>
@@ -3896,6 +4107,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="bangkokk" supported="yes">
 		<!-- SPS (CAPS) release 1137 -->
 		<description>Bangkok Knights (Euro)</description>
@@ -3917,6 +4129,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="barbpsy" supported="no">
 		<!-- SPS (CAPS) release 1011 -->
 		<description>Barbarian (Euro, Psygnosis)</description>
@@ -3931,6 +4144,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="barbpsya" cloneof="barbpsy" supported="no">
 		<!-- SPS (CAPS) release 1643 -->
 		<description>Barbarian (Euro, Psygnosis, Alt)</description>
@@ -3946,6 +4160,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation during "The game is loading" phase [FDC] with adkcon=1100 -->
+	<!-- ATK test: OK -->
 	<software name="barbpal" supported="no">
 		<!-- SPS (CAPS) release 1784 -->
 		<description>Barbarian (Euro, v16.3.88, Palace)</description>
@@ -3962,6 +4177,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs at kickstart white screen [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="barb2psy" supported="no">
 		<!-- SPS (CAPS) release 611 -->
 		<description>Barbarian II (Euro, Psygnosis)</description>
@@ -3989,6 +4205,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="barb2psyd" cloneof="barb2psy" supported="no">
 		<!-- SPS (CAPS) release 1451 -->
 		<description>Barbarian II Demo (Euro, Psygnosis)</description>
@@ -4004,6 +4221,7 @@ license:CC0
 	</software>
 
 	<!-- Prompts to a CLI 2 (implicitly failing a copy protection?) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="barb2pal" supported="no">
 		<!-- SPS (CAPS) release 2264 -->
 		<description>Barbarian II (Euro, Palace, v4.8.89)</description>
@@ -4027,6 +4245,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="barb2paln4" cloneof="barb2pal" supported="yes">
 		<!-- SPS (CAPS) release 1828 -->
 		<description>Barbarian II (Euro, Palace, NRJ Vol. 4)</description>
@@ -4049,6 +4268,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="barb2palh" cloneof="barb2pal" supported="no">
 		<!-- SPS (CAPS) release 1829 -->
 		<description>Barbarian II (Euro, Palace, Heroes)</description>
@@ -4064,6 +4284,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="brdtale" supported="no">
 		<!-- SPS (CAPS) release 10 -->
 		<description>The Bard's Tale (Euro)</description>
@@ -4079,6 +4300,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="brdtaleu" cloneof="brdtale" supported="no">
 		<!-- SPS (CAPS) release 1978 -->
 		<description>The Bard's Tale (USA)</description>
@@ -4094,6 +4316,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brdtale2" supported="no">
 		<!-- SPS (CAPS) release 46 -->
 		<description>The Bard's Tale II - The Destiny Knight (Euro)</description>
@@ -4108,6 +4331,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brdtale3" supported="no">
 		<!-- SPS (CAPS) release 300 -->
 		<description>The Bard's Tale III - Thief of Fate (Euro)</description>
@@ -4129,6 +4353,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brdtalcc" supported="no">
 		<!-- SPS (CAPS) release 2919 -->
 		<description>The Bard's Tale Construction Set (Euro)</description>
@@ -4157,6 +4382,7 @@ license:CC0
 	</software>
 
 	<!-- Sport wrong pitch on Workbench loading for a500p -->
+	<!-- ATK test: OK -->
 	<software name="bargames" supported="no">
 		<!-- SPS (CAPS) release 2947 -->
 		<description>Bar Games (Euro)</description>
@@ -4180,6 +4406,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bargonat" supported="no">
 		<!-- SPS (CAPS) release 2486 -->
 		<description>Bargon Attack (Euro, Kings of Adventures 1)</description>
@@ -4213,6 +4440,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="barneysp" supported="no">
 		<!-- SPS (CAPS) release 2077 -->
 		<description>Barney Bear Goes to Space (Euro, v1.0)</description>
@@ -4234,6 +4462,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="baronbal" supported="no">
 		<!-- SPS (CAPS) release 2677 -->
 		<description>Baron Baldric - A Grave Adventure (Euro)</description>
@@ -4255,6 +4484,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="basejump" supported="yes">
 		<!-- SPS (CAPS) release 1799 -->
 		<description>Base Jumpers (Euro)</description>
@@ -4271,6 +4501,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="batman" supported="no">
 		<!-- SPS (CAPS) release 6 -->
 		<description>Batman (Euro)</description>
@@ -4293,6 +4524,7 @@ license:CC0
 	</software>
 
 	<!-- Black screen, [CIAB] fails on comparing a TOD 9 > 0x115 at PC=de4 -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="batman1" cloneof="batman" supported="no">
 		<!-- SPS (CAPS) release 19 -->
 		<description>Batman (Euro, Single Disk)</description>
@@ -4307,6 +4539,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batman2" cloneof="batman" supported="no">
 		<!-- SPS (CAPS) release 1730 -->
 		<description>Batman (Euro, Budget)</description>
@@ -4321,6 +4554,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="batmancc" supported="no">
 		<!-- SPS (CAPS) release 50 -->
 		<description>Batman - The Caped Crusader (Euro)</description>
@@ -4335,6 +4569,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batmancca" cloneof="batmancc" supported="no">
 		<!-- SPS (CAPS) release 1939 -->
 		<description>Batman - The Caped Crusader (Euro, Budget)</description>
@@ -4349,6 +4584,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="batmanrn" supported="no">
 		<!-- SPS (CAPS) release 99 -->
 		<description>Batman Returns (Euro)</description>
@@ -4370,6 +4606,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="btlchess" supported="no">
 		<!-- SPS (CAPS) release 263 -->
 		<description>Battle Chess (Euro)</description>
@@ -4384,6 +4621,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="btlchessa" cloneof="btlchess" supported="no">
 		<!-- SPS (CAPS) release 2368 -->
 		<description>Battle Chess (Euro, Alt)</description>
@@ -4398,6 +4636,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="btlches2" supported="no">
 		<!-- SPS (CAPS) release 264 -->
 		<description>Battle Chess II - Chinese Chess (Euro)</description>
@@ -4419,6 +4658,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="battlcmd" supported="no">
 		<!-- SPS (CAPS) release 858 -->
 		<description>Battle Command (Euro)</description>
@@ -4433,6 +4673,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="battlcmdu" cloneof="battlcmd" supported="no">
 		<!-- SPS (CAPS) release 2044 -->
 		<description>Battle Command (USA)</description>
@@ -4462,6 +4703,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batlisle" supported="no">
 		<!-- SPS (CAPS) release 1991 -->
 		<description>Battle Isle (Euro)</description>
@@ -4489,6 +4731,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batlisleg" cloneof="batlisle" supported="no">
 		<!-- SPS (CAPS) release 54 -->
 		<description>Battle Isle (Ger)</description>
@@ -4516,6 +4759,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batlisledd1" cloneof="batlisle" supported="no">
 		<!-- SPS (CAPS) release 460 -->
 		<description>Battle Isle Data Disk 1 (Euro)</description>
@@ -4531,6 +4775,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="batlisledd2" cloneof="batlisle" supported="no">
 		<!-- SPS (CAPS) release 667 -->
 		<description>Battle Isle Data Disk 2 - The Moon of Chromos (Euro)</description>
@@ -4554,6 +4799,7 @@ license:CC0
 	</software>
 
 	<!-- Most gameplay SFXs gets cut off [Paula] -->
+	<!-- ATK test: failed -->
 	<software name="battlesq" supported="partial">
 		<!-- SPS (CAPS) release 941 -->
 		<description>Battle Squadron (Euro)</description>
@@ -4568,6 +4814,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="battlesqu" cloneof="battlesq" supported="no">
 		<!-- SPS (CAPS) release 942 -->
 		<description>Battle Squadron (USA)</description>
@@ -4582,6 +4829,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="battletc" supported="no">
 		<!-- SPS (CAPS) release 1536 -->
 		<description>Battle Tec (Euro)</description>
@@ -4596,6 +4844,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bvalley" supported="no">
 		<!-- SPS (CAPS) release 1723 -->
 		<description>Battle Valley (Euro)</description>
@@ -4610,6 +4859,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bvalley1" cloneof="bvalley" supported="no">
 		<!-- SPS (CAPS) release 1724 -->
 		<description>Battle Valley (Euro, v3.0, Budget)</description>
@@ -4624,6 +4874,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bhawk42" supported="no">
 		<!-- SPS (CAPS) release 53 -->
 		<description>Battlehawks 1942 (Euro, Final v1.0 19890222)</description>
@@ -4645,6 +4896,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="battlems" supported="no">
 		<!-- SPS (CAPS) release 635 -->
 		<description>Battlemaster (Euro)</description>
@@ -4659,6 +4911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bships" supported="no">
 		<!-- SPS (CAPS) release 3003 -->
 		<description>Battleships (Euro, Budget)</description>
@@ -4673,6 +4926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: H:U 1 Sector Bad, C:0 H:L 1 Sector Bad -->
 	<software name="battlest" supported="no">
 		<!-- SPS (CAPS) release 2008 -->
 		<description>Battlestorm (USA)</description>
@@ -4687,6 +4941,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="btech" supported="no">
 		<!-- SPS (CAPS) release 1402 -->
 		<description>BattleTech (USA, v2.3)</description>
@@ -4702,6 +4957,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="btoads" supported="no">
 		<!-- SPS (CAPS) release 1816 -->
 		<description>Battletoads (Euro)</description>
@@ -4723,6 +4979,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bckid" supported="no">
 		<!-- SPS (CAPS) release 435 -->
 		<description>B.C. Kid (Euro)</description>
@@ -4739,6 +4996,7 @@ license:CC0
 
 	<!-- intro BGM hiccups [Paula] -->
 	<!-- Has transparent stripes all over the place during intro [copper] -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bchvolly" supported="partial">
 		<!-- SPS (CAPS) release 1249 -->
 		<description>Beach Volley (Euro)</description>
@@ -4753,6 +5011,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="beambend" supported="no">
 		<!-- SPS (CAPS) release 1233 -->
 		<description>Beambender (Euro)</description>
@@ -4782,6 +5041,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bbusters" supported="no">
 		<!-- SPS (CAPS) release 1012 -->
 		<description>Beast Busters (Euro)</description>
@@ -4803,6 +5063,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beastlrd" supported="no">
 		<!-- SPS (CAPS) release 2452 -->
 		<description>Beastlord (Euro)</description>
@@ -4824,6 +5085,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beavers" supported="no">
 		<!-- SPS (CAPS) release 2575 -->
 		<description>Beavers (Euro)</description>
@@ -4851,6 +5113,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="irongate" supported="no">
 		<!-- SPS (CAPS) release 2156 -->
 		<description>Behind the Iron Gate (Euro)</description>
@@ -4872,6 +5135,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steelsky" supported="no">
 		<!-- SPS (CAPS) release 207 -->
 		<description>Beneath a Steel Sky (Euro)</description>
@@ -4971,6 +5235,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steelskyf" cloneof="steelsky" supported="no">
 		<!-- SPS (CAPS) release 2340 -->
 		<description>Beneath a Steel Sky (Fra)</description>
@@ -5070,6 +5335,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steelskyg" cloneof="steelsky" supported="no">
 		<!-- SPS (CAPS) release 461 -->
 		<description>Beneath a Steel Sky (Ger)</description>
@@ -5169,6 +5435,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="benefact" supported="no">
 		<!-- SPS (CAPS) release 636 -->
 		<description>Benefactor (Euro)</description>
@@ -5196,6 +5463,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bermudap" supported="no">
 		<!-- SPS (CAPS) release 436 -->
 		<description>Bermuda Project (Euro)</description>
@@ -5210,6 +5478,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bermudapu" cloneof="bermudap" supported="no">
 		<!-- SPS (CAPS) release 1193 -->
 		<description>Bermuda Project (USA)</description>
@@ -5224,6 +5493,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="bestof" supported="no">
 		<!-- SPS (CAPS) release 2399 -->
 		<description>Best of the Best - Championship Karate (Euro)</description>
@@ -5245,6 +5515,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="betrayal" supported="no">
 		<!-- SPS (CAPS) release 812 -->
 		<description>Betrayal (Euro)</description>
@@ -5266,6 +5537,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="betdead" supported="no">
 		<!-- SPS (CAPS) release 462 -->
 		<description>Better Dead Than Alien! (Euro)</description>
@@ -5281,6 +5553,7 @@ license:CC0
 	</software>
 
 	<!-- crashes in AmigaDOS with DSKDAT R [FDC] dsksync bootblock -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bhcop" supported="no">
 		<!-- SPS (CAPS) release 179 -->
 		<description>Beverly Hills Cop (Euro)</description>
@@ -5302,6 +5575,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="icepalac" supported="no">
 		<!-- SPS (CAPS) release 1541 -->
 		<description>Beyond the Ice Palace (Euro)</description>
@@ -5316,6 +5590,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="icepalac1" cloneof="icepalac" supported="no">
 		<!-- SPS (CAPS) release 1542 -->
 		<description>Beyond the Ice Palace (Euro, Budget)</description>
@@ -5330,6 +5605,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="beyzork" supported="no">
 		<!-- SPS (CAPS) release 1403 -->
 		<description>Beyond Zork - The Coconut of Quendor (USA, r57)</description>
@@ -5344,6 +5620,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bifi2" supported="no">
 		<!-- SPS (CAPS) release 1879 -->
 		<description>Bi-Fi II - Action in Hollywood (Euro, v1.01)</description>
@@ -5358,6 +5635,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bigrun" supported="no">
 		<!-- SPS (CAPS) release 301 -->
 		<description>Big Run (Euro)</description>
@@ -5372,6 +5650,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="biing" supported="no">
 		<!-- SPS (CAPS) release 463 -->
 		<description>Biing! - Sex, Intrigen und Skalpelle (Ger)</description>
@@ -5453,6 +5732,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nascarch" supported="no">
 		<!-- SPS (CAPS) release 1676 -->
 		<description>Bill Elliott's NASCAR Challenge (Euro)</description>
@@ -5474,6 +5754,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="billsim" supported="no">
 		<!-- SPS (CAPS) release 1806 -->
 		<description>Billiards Simulator (Euro)</description>
@@ -5488,6 +5769,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tomato" supported="no">
 		<!-- SPS (CAPS) release 1748 -->
 		<description>Bill's Tomato Game (Euro)</description>
@@ -5502,6 +5784,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tomatod" cloneof="tomato" supported="no">
 		<!-- SPS (CAPS) release 1307 -->
 		<description>Bill's Tomato Game Demo (Euro, bundled with Cytron)</description>
@@ -5516,6 +5799,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="biochall" supported="no">
 		<!-- SPS (CAPS) release 1733 -->
 		<description>Bio Challenge (Euro)</description>
@@ -5530,6 +5814,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="biochall1" cloneof="biochall" supported="no">
 		<!-- SPS (CAPS) release 1734 -->
 		<description>Bio Challenge (Euro, Light Force)</description>
@@ -5544,6 +5829,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bionicc" supported="no">
 		<!-- SPS (CAPS) release 1072 -->
 		<description>Bionic Commando (Euro)</description>
@@ -5558,6 +5844,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bionicca" cloneof="bionicc" supported="no">
 		<!-- SPS (CAPS) release 1074 -->
 		<description>Bionic Commando (USA)</description>
@@ -5572,6 +5859,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="birdprey" supported="no">
 		<!-- SPS (CAPS) release 101 -->
 		<description>Birds of Prey (Euro)</description>
@@ -5593,6 +5881,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bismarck" supported="no">
 		<!-- SPS (CAPS) release 2702 -->
 		<description>Bismarck (Euro)</description>
@@ -5607,6 +5896,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bismarckf" cloneof="bismarck" supported="no">
 		<!-- SPS (CAPS) release 2563 -->
 		<description>Bismarck (Fra)</description>
@@ -5621,6 +5911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bcauldrn" supported="no">
 		<!-- SPS (CAPS) release 2057 -->
 		<description>The Black Cauldron (Euro, v2.00, HLS)</description>
@@ -5635,6 +5926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bcrypt" supported="no">
 		<!-- SPS (CAPS) release 281 -->
 		<description>Black Crypt (Euro)</description>
@@ -5662,6 +5954,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blackgld" supported="no">
 		<!-- SPS (CAPS) release 2830 -->
 		<description>Black Gold (Euro)</description>
@@ -5683,6 +5976,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blackglda" cloneof="blackgld" supported="no">
 		<!-- SPS (CAPS) release 2829 -->
 		<description>Black Gold (Euro, v1.16 19920114, World of Business)</description>
@@ -5704,6 +5998,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bjacadmy" supported="no">
 		<!-- SPS (CAPS) release 668 -->
 		<description>Blackjack Academy (Euro)</description>
@@ -5718,6 +6013,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="blacklmp" supported="no">
 		<!-- SPS (CAPS) release 826 -->
 		<description>Black Lamp (Euro)</description>
@@ -5732,6 +6028,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="blacksec" supported="no">
 		<!-- SPS (CAPS) release 2339 -->
 		<description>Black Sect (Euro)</description>
@@ -5759,6 +6056,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bshadow" supported="no">
 		<!-- SPS (CAPS) release 997 -->
 		<description>Black Shadow (Euro)</description>
@@ -5773,6 +6071,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bshadow1" cloneof="bshadow" supported="no">
 		<!-- SPS (CAPS) release 2283 -->
 		<description>Black Shadow (Euro, Computer Hits Volume Two)</description>
@@ -5787,6 +6086,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:71 onward Bad -->
 	<software name="blktiger" supported="no">
 		<!-- SPS (CAPS) release 1221 -->
 		<description>Black Tiger (Euro)</description>
@@ -5801,6 +6101,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bladewar" supported="no">
 		<!-- SPS (CAPS) release 2201 -->
 		<description>Blade Warrior (Euro)</description>
@@ -5815,6 +6116,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bladewar1" cloneof="bladewar" supported="no">
 		<!-- SPS (CAPS) release 2202 -->
 		<description>Blade Warrior (Euro, Budget)</description>
@@ -5829,6 +6131,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blade" supported="no">
 		<!-- SPS (CAPS) release 1801 -->
 		<description>Blade (Euro)</description>
@@ -5862,6 +6165,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="blastbal" supported="no">
 		<!-- SPS (CAPS) release 1557 -->
 		<description>Blastaball (Euro)</description>
@@ -5876,6 +6180,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad, C:67 H:L 1 Sector Bad -->
 	<software name="blastar" supported="no">
 		<!-- SPS (CAPS) release 2814 -->
 		<description>Blastar (Euro)</description>
@@ -5903,6 +6208,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="blstroid" supported="no">
 		<!-- SPS (CAPS) release 239 -->
 		<description>Blasteroids (Euro)</description>
@@ -5917,6 +6223,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="blzthndr" supported="no">
 		<!-- SPS (CAPS) release 2082 -->
 		<description>Blazing Thunder (Euro)</description>
@@ -5931,6 +6238,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="blinkyss" supported="no">
 		<!-- SPS (CAPS) release 437 -->
 		<description>Blinky's Scary School (Euro)</description>
@@ -5945,6 +6253,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blitzkrg" supported="no">
 		<!-- SPS (CAPS) release 2454 -->
 		<description>Blitzkrieg - Battle at the Ardennes (Euro, v1.10)</description>
@@ -5959,6 +6268,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blitzten" supported="no">
 		<!-- SPS (CAPS) release 2765 -->
 		<description>Blitz Tennis (Euro)</description>
@@ -5980,6 +6290,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="blob" supported="no">
 		<!-- SPS (CAPS) release 1202 -->
 		<description>Blob (Euro, Corkers)</description>
@@ -5994,6 +6305,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="blockbus" supported="no">
 		<!-- SPS (CAPS) release 2058 -->
 		<description>Blockbuster (Euro)</description>
@@ -6008,6 +6320,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blockout" supported="no">
 		<!-- SPS (CAPS) release 208 -->
 		<description>Blockout (Euro)</description>
@@ -6022,6 +6335,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bloodmon" supported="no">
 		<!-- SPS (CAPS) release 302 -->
 		<description>Blood Money (Euro)</description>
@@ -6043,6 +6357,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bloodnet" supported="no">
 		<!-- SPS (CAPS) release 2345 -->
 		<description>BloodNet - A Cyberpunk Gothic (Euro)</description>
@@ -6100,6 +6415,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bloodwyc" supported="no">
 		<!-- SPS (CAPS) release 102 -->
 		<description>Bloodwych (Euro)</description>
@@ -6114,6 +6430,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bloodwyca" cloneof="bloodwyc" supported="no">
 		<!-- SPS (CAPS) release 439 -->
 		<description>Bloodwych (Euro, Alt)</description>
@@ -6128,6 +6445,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bloodwycb" cloneof="bloodwyc" supported="no">
 		<!-- SPS (CAPS) release 1927 -->
 		<description>Bloodwych (Euro, The Power Pack)</description>
@@ -6142,6 +6460,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bloodwycdd" cloneof="bloodwyc" supported="no">
 		<!-- SPS (CAPS) release 43 -->
 		<description>Bloodwych - The Extended Levels (Euro)</description>
@@ -6158,6 +6477,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bluean69" supported="no">
 		<!-- SPS (CAPS) release 1303 -->
 		<description>Blue Angel 69 (Euro)</description>
@@ -6172,6 +6492,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="blueangl" supported="no">
 		<!-- SPS (CAPS) release 1467 -->
 		<description>Blue Angels (USA)</description>
@@ -6187,6 +6508,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bluemax" supported="no">
 		<!-- SPS (CAPS) release 1013 -->
 		<description>Blue Max - Aces of the Great War (Euro)</description>
@@ -6244,6 +6566,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bmx" supported="no">
 		<!-- SPS (CAPS) release 2059 -->
 		<description>BMX Simulator (Euro)</description>
@@ -6258,6 +6581,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bobo" supported="no">
 		<!-- SPS (CAPS) release 1951 -->
 		<description>Bobo (Euro, European Dreams)</description>
@@ -6272,6 +6596,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bobsbadd" supported="no">
 		<!-- SPS (CAPS) release 637 -->
 		<description>Bob's Bad Day (Euro)</description>
@@ -6293,6 +6618,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bblow" supported="no">
 		<!-- SPS (CAPS) release 1147 -->
 		<description>Body Blows (Euro, v2)</description>
@@ -6320,6 +6646,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bblowg" supported="no">
 		<!-- SPS (CAPS) release 1231 -->
 		<description>Body Blows Galactic (Euro)</description>
@@ -6342,6 +6669,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, has GFX pitch issues when the big ship appears on level 1-B -->
+	<!-- ATK test: OK -->
 	<software name="bombrbob" supported="no">
 		<!-- SPS (CAPS) release 1628 -->
 		<description>Bomber Bob (Euro)</description>
@@ -6356,6 +6684,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:even H:L 1 Sector Bad -->
 	<software name="bombjack" supported="no">
 		<!-- SPS (CAPS) release 2797 -->
 		<description>Bomb Jack (Euro)</description>
@@ -6370,6 +6699,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bjtcat" supported="no">
 		<!-- SPS (CAPS) release 1804 -->
 		<description>Bomb Jack + ThunderCats (Euro, Thrill Time Platinum 2)</description>
@@ -6384,6 +6714,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bombuzal" supported="no">
 		<!-- SPS (CAPS) release 1738 -->
 		<description>Bombuzal (Euro)</description>
@@ -6398,6 +6729,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bombuzalc" cloneof="bombuzal" supported="no">
 		<!-- SPS (CAPS) release 2064 -->
 		<description>Bombuzal (Euro, Coverdisk)</description>
@@ -6412,6 +6744,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bnzabros" supported="no">
 		<!-- SPS (CAPS) release 859 -->
 		<description>Bonanza Bros. (Euro)</description>
@@ -6426,6 +6759,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="booly" supported="no">
 		<!-- SPS (CAPS) release 438 -->
 		<description>Booly (Euro)</description>
@@ -6440,6 +6774,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="boot" supported="no">
 		<!-- SPS (CAPS) release 1996 -->
 		<description>Das Boot (USA, v1.0)</description>
@@ -6461,6 +6796,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="borobodr" supported="no">
 		<!-- SPS (CAPS) release 1014 -->
 		<description>Borobodur - The Planet of Doom (Euro)</description>
@@ -6488,6 +6824,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="borodino" supported="no">
 		<!-- SPS (CAPS) release 2642 -->
 		<description>Borodino (Euro)</description>
@@ -6502,6 +6839,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="bortime" supported="no">
 		<!-- SPS (CAPS) release 2933 -->
 		<description>Borrowed Time (Euro)</description>
@@ -6516,6 +6854,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bosmath3" supported="no">
 		<!-- SPS (CAPS) release 2568 -->
 		<description>La Bosse des Maths - 3 ème (Euro)</description>
@@ -6530,6 +6869,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="bostonbc" supported="no">
 		<!-- SPS (CAPS) release 1502 -->
 		<description>Boston Bomb Club (Euro)</description>
@@ -6544,6 +6884,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bdashck" supported="no">
 		<!-- SPS (CAPS) release 464 -->
 		<description>Boulder Dash Construction Kit (Euro)</description>
@@ -6558,6 +6899,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bozuma" supported="no">
 		<!-- SPS (CAPS) release 1234 -->
 		<description>Bozuma (Ger)</description>
@@ -6585,6 +6927,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="brainbls" supported="no">
 		<!-- SPS (CAPS) release 2643 -->
 		<description>Brain Blasters (Euro)</description>
@@ -6599,6 +6942,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bblaster" supported="no">
 		<!-- SPS (CAPS) release 1739, 1762 -->
 		<description>Brainblaster - Bombuzal + Xenon 2 (Euro)</description>
@@ -6626,6 +6970,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dracula" supported="no">
 		<!-- SPS (CAPS) release 55 -->
 		<description>Bram Stoker's Dracula (Euro)</description>
@@ -6647,6 +6992,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bratacca" supported="no">
 		<!-- SPS (CAPS) release 1189 -->
 		<description>Brataccas (USA)</description>
@@ -6661,6 +7007,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="breach" supported="no">
 		<!-- SPS (CAPS) release 1487 -->
 		<description>Breach (USA)</description>
@@ -6675,6 +7022,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="breach2" supported="no">
 		<!-- SPS (CAPS) release 1195 -->
 		<description>Breach 2 (Euro, v2.0)</description>
@@ -6704,6 +7052,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brian" supported="no">
 		<!-- SPS (CAPS) release 240 -->
 		<description>Brian the Lion (Euro)</description>
@@ -6731,6 +7080,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="briand" cloneof="brian" supported="no">
 		<!-- SPS (CAPS) release 1602 -->
 		<description>Brian the Lion Demo (Euro)</description>
@@ -6745,6 +7095,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="briddrac" supported="no">
 		<!-- SPS (CAPS) release 303 -->
 		<description>Brides of Dracula (Euro)</description>
@@ -6759,6 +7110,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bridge5" supported="no">
 		<!-- SPS (CAPS) release 1701 -->
 		<description>Bridge 5.0 (Euro, v5.1)</description>
@@ -6773,6 +7125,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bridge6" supported="no">
 		<!-- SPS (CAPS) release 1702 -->
 		<description>Bridge 6.0 (Euro, r2.49b)</description>
@@ -6787,6 +7140,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bridgepg" supported="no">
 		<!-- SPS (CAPS) release 1922 -->
 		<description>Bridge Player Galactica (Euro)</description>
@@ -6801,6 +7155,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brutal" supported="no">
 		<!-- SPS (CAPS) release 181 -->
 		<description>Brutal - Paws of Fury (Euro)</description>
@@ -6822,6 +7177,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="brutalfb" supported="no">
 		<!-- SPS (CAPS) release 209 -->
 		<description>Brutal Football (Euro)</description>
@@ -6843,6 +7199,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bubba" supported="no">
 		<!-- SPS (CAPS) release 1323 -->
 		<description>Bubba'n'Stix (Euro)</description>
@@ -6864,6 +7221,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bubblep" supported="no">
 		<!-- SPS (CAPS) release 2886 -->
 		<description>Bubble + (Euro)</description>
@@ -6878,6 +7236,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bubblesq" supported="no">
 		<!-- SPS (CAPS) release 2398 -->
 		<description>Bubble and Squeak (Euro)</description>
@@ -6899,6 +7258,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bublbobl" supported="no">
 		<!-- SPS (CAPS) release 2518 -->
 		<description>Bubble Bobble (Euro)</description>
@@ -6913,6 +7273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bublbobljh" cloneof="bublbobl" supported="no">
 		<!-- SPS (CAPS) release 1343 -->
 		<description>Bubble Bobble (Euro, Jatte Hits)</description>
@@ -6927,6 +7288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bublbobl1" cloneof="bublbobl" supported="no">
 		<!-- SPS (CAPS) release 1344 -->
 		<description>Bubble Bobble (Euro, Budget)</description>
@@ -6941,6 +7303,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bublboblu" cloneof="bublbobl" supported="no">
 		<!-- SPS (CAPS) release 1342 -->
 		<description>Bubble Bobble (USA)</description>
@@ -6955,6 +7318,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bubldiz" supported="no">
 		<!-- SPS (CAPS) release 1644 -->
 		<description>Bubble Dizzy (Euro, v1.01)</description>
@@ -6969,6 +7333,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="bubblegh" supported="no">
 		<!-- SPS (CAPS) release 932 -->
 		<description>Bubble Ghost (Euro)</description>
@@ -6983,6 +7348,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bubblegh1" cloneof="bubblegh" supported="no">
 		<!-- SPS (CAPS) release 2280 -->
 		<description>Bubble Ghost (Euro, Super Quintet)</description>
@@ -6997,6 +7363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="buckrog" supported="no">
 		<!-- SPS (CAPS) release 1994 -->
 		<description>Buck Rogers - Countdown to Doomsday (US, v1.0)</description>
@@ -7018,6 +7385,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="buckrogg" cloneof="buckrog" supported="no">
 		<!-- SPS (CAPS) release 445 -->
 		<description>Buck Rogers - Countdown to Doomsday (Ger)</description>
@@ -7040,6 +7408,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="budokan" supported="yes">
 		<!-- SPS (CAPS) release 1215 -->
 		<description>Budokan - The Martial Spirit (Euro)</description>
@@ -7062,6 +7431,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bbashnuc" supported="no">
 		<!-- SPS (CAPS) release 2953, 2954 -->
 		<description>Bug Bash + Nucleus (Euro)</description>
@@ -7083,6 +7453,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bugbombr" supported="no">
 		<!-- SPS (CAPS) release 1579 -->
 		<description>Bug Bomber (Euro)</description>
@@ -7097,6 +7468,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="buggyboy" supported="no">
 		<!-- SPS (CAPS) release 465 -->
 		<description>Buggy Boy (Euro)</description>
@@ -7111,6 +7483,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="buggyboy1" cloneof="buggyboy" supported="no">
 		<!-- SPS (CAPS) release 1242 -->
 		<description>Buggy Boy (Euro, Les Fous du Volant)</description>
@@ -7125,6 +7498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="buggyboy2" cloneof="buggyboy" supported="no">
 		<!-- SPS (CAPS) release 1381 -->
 		<description>Buggy Boy (Euro, Tenstar Pack)</description>
@@ -7139,6 +7513,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="buildlnd" supported="no">
 		<!-- SPS (CAPS) release 1923 -->
 		<description>Builderland (Euro)</description>
@@ -7153,6 +7528,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bullysd" supported="no">
 		<!-- SPS (CAPS) release 2453 -->
 		<description>Bully's Sporting Darts (Euro)</description>
@@ -7167,6 +7543,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bumpburn" supported="no">
 		<!-- SPS (CAPS) release 2920 -->
 		<description>Bump 'n' Burn (Euro)</description>
@@ -7212,6 +7589,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="bumpyarc" supported="no">
 		<!-- SPS (CAPS) release 1604 -->
 		<description>Bumpy's Arcade Fantasy (Euro)</description>
@@ -7226,6 +7604,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bund3000" supported="no">
 		<!-- SPS (CAPS) release 2786 -->
 		<description>Bundesliga 3000 (Euro)</description>
@@ -7247,6 +7626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bmhattrk" supported="no">
 		<!-- SPS (CAPS) release 791 -->
 		<description>Bundesliga Manager Hattrick (Euro)</description>
@@ -7274,6 +7654,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="bunnybrc" supported="no">
 		<!-- SPS (CAPS) release 211 -->
 		<description>Bunny Bricks (Euro)</description>
@@ -7288,6 +7669,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="bureaucr" supported="no">
 		<!-- SPS (CAPS) release 1493 -->
 		<description>Bureaucracy (USA, r86)</description>
@@ -7302,6 +7684,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="burntime" supported="no">
 		<!-- SPS (CAPS) release 2266 -->
 		<description>Burntime (Euro)</description>
@@ -7329,6 +7712,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="burntimeg" cloneof="burntime" supported="no">
 		<!-- SPS (CAPS) release 446 -->
 		<description>Burntime (Ger)</description>
@@ -7356,6 +7740,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cabal" supported="no">
 		<!-- SPS (CAPS) release 638 -->
 		<description>Cabal (Euro)</description>
@@ -7373,6 +7758,7 @@ license:CC0
 	<!-- black screen [FDC] dsksync -->
 	<!-- (Hangs at PC=21050 after failing a copy protection check, D0=0 D1=16 D2=12 D3=0) -->
 	<!-- Doesn't accept [KBD] inputs on language select -->
+	<!-- ATK test: OK -->
 	<software name="cadaver" supported="no">
 		<!-- SPS (CAPS) release 103 -->
 		<description>Cadaver (Euro, v0.01)</description>
@@ -7395,6 +7781,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
+	<!-- ATK test: OK -->
 	<software name="cadavera" cloneof="cadaver" supported="no">
 		<!-- SPS (CAPS) release 2876 -->
 		<description>Cadaver (Euro, v1.03, The Bitmap Brothers Volume 1)</description>
@@ -7417,6 +7804,7 @@ license:CC0
 	</software>
 
 	<!-- "Error validating disk: Key 880 checksum error" -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cadaverpo" cloneof="cadaver" supported="no">
 		<!-- SPS (CAPS) release 820 -->
 		<description>Cadaver - The Pay Off (Euro)</description>
@@ -7432,6 +7820,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cadaverc" supported="no">
 		<!-- SPS (CAPS) release 900 -->
 		<description>Cadaver + Cadaver The Pay Off (Euro, v1.03, Budget)</description>
@@ -7459,6 +7848,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="caesar" supported="no">
 		<!-- SPS (CAPS) release 3085 -->
 		<description>Caesar (Euro)</description>
@@ -7473,6 +7863,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="calculat" supported="no">
 		<!-- SPS (CAPS) release 1892 -->
 		<description>Calculation (Euro, v1.1)</description>
@@ -7487,6 +7878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="calephar" supported="no">
 		<!-- SPS (CAPS) release 2661 -->
 		<description>Calephar (Euro, Prototype)</description>
@@ -7501,6 +7893,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="calgame" supported="no">
 		<!-- SPS (CAPS) release 1445 -->
 		<description>California Games (Euro)</description>
@@ -7521,6 +7914,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="calgamea" cloneof="calgame" supported="no">
 		<!-- SPS (CAPS) release 1447 -->
 		<description>California Games (Euro, Alt)</description>
@@ -7541,6 +7935,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="calgame2" supported="no">
 		<!-- SPS (CAPS) release 1567 -->
 		<description>California Games II (Euro)</description>
@@ -7562,6 +7957,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="campaign" supported="no">
 		<!-- SPS (CAPS) release 1198 -->
 		<description>Campaign (Euro)</description>
@@ -7584,6 +7980,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="campagn2" supported="no">
 		<!-- SPS (CAPS) release 2180 -->
 		<description>Campaign II (Euro)</description>
@@ -7608,6 +8005,7 @@ license:CC0
 
 	<!-- Hangs at a rainbow colored loading screen [FDC] dsksync -->
 	<!-- (checks for string "SOS6" at PC=500be, which is offset because of dsksync) -->
+	<!-- ATK test: failed -->
 	<software name="cfodder" supported="no">
 		<!-- SPS (CAPS) release 860 -->
 		<description>Cannon Fodder (Euro)</description>
@@ -7635,6 +8033,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cfodderf" cloneof="cfodder" supported="no">
 		<!-- SPS (CAPS) release 2332 -->
 		<description>Cannon Fodder (Fra)</description>
@@ -7662,6 +8061,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cfoddpls" supported="no">
 		<!-- SPS (CAPS) release 60 -->
 		<description>Cannon Fodder Plus (Euro)</description>
@@ -7678,6 +8078,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cfodder2" supported="no">
 		<!-- SPS (CAPS) release 104 -->
 		<description>Cannon Fodder 2 (Euro)</description>
@@ -7705,6 +8106,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cfodder2f" cloneof="cfodder2" supported="no">
 		<!-- SPS (CAPS) release 2578 -->
 		<description>Cannon Fodder 2 (Fra)</description>
@@ -7732,6 +8134,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cfodder2g" cloneof="cfodder2" supported="no">
 		<!-- SPS (CAPS) release 241 -->
 		<description>Cannon Fodder 2 (Ger)</description>
@@ -7761,6 +8164,7 @@ license:CC0
 
 	<!-- Hangs at a rainbow colored loading screen [FDC] dsksync -->
 	<!-- (Same as cfodder) -->
+	<!-- ATK test: failed -->
 	<software name="csoccer" supported="no">
 		<!-- SPS (CAPS) release 165 -->
 		<description>Cannon Soccer (Euro)</description>
@@ -7777,6 +8181,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="capncarn" supported="no">
 		<!-- SPS (CAPS) release 2227 -->
 		<description>Cap'n Carnage (Euro)</description>
@@ -7791,6 +8196,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:42 H:L Bad -->
 	<software name="capone" supported="no">
 		<!-- SPS (CAPS) release 2359 -->
 		<description>Capone (Euro, v1.4)</description>
@@ -7805,6 +8211,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="capblood" supported="no">
 		<!-- SPS (CAPS) release 443 -->
 		<description>Captain Blood (Euro)</description>
@@ -7819,6 +8226,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="capbloodu" cloneof="capblood" supported="no">
 		<!-- SPS (CAPS) release 466 -->
 		<description>Captain Blood (USA)</description>
@@ -7833,6 +8241,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="capdynam" supported="no">
 		<!-- SPS (CAPS) release 995 -->
 		<description>Captain Dynamo (Euro, 19921102)</description>
@@ -7847,6 +8256,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="capdynam1" cloneof="capdynam" supported="no">
 		<!-- SPS (CAPS) release 1722 -->
 		<description>Captain Dynamo (Euro, 19920717)</description>
@@ -7861,6 +8271,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="capfizz" supported="no">
 		<!-- SPS (CAPS) release 1777 -->
 		<description>Captain Fizz (Euro)</description>
@@ -7876,6 +8287,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="captplan" supported="no">
 		<!-- SPS (CAPS) release 1448 -->
 		<description>Captain Planet and the Planeteers (Euro)</description>
@@ -7891,6 +8303,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs during gameplay when actually landing on a planet (sometimes it throws DSKDAT access) -->
+	<!-- ATK test: failed -->
 	<software name="captive" supported="no">
 		<!-- SPS (CAPS) release 2164 -->
 		<description>Captive (Euro, v1.2)</description>
@@ -7905,6 +8318,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="captivea" cloneof="captive" supported="no">
 		<!-- SPS (CAPS) release 967 -->
 		<description>Captive (Euro)</description>
@@ -7919,6 +8333,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="captiveb" cloneof="captive" supported="no">
 		<!-- SPS (CAPS) release 105 -->
 		<description>Captive (Euro, 1mb)</description>
@@ -7933,6 +8348,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="carcharo" supported="no">
 		<!-- SPS (CAPS) release 2389 -->
 		<description>Carcharodon - White Sharks (Euro)</description>
@@ -7947,6 +8363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cardiaxx" supported="no">
 		<!-- SPS (CAPS) release 1601 -->
 		<description>Cardiaxx (Euro)</description>
@@ -7961,6 +8378,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cardiaxxa" cloneof="cardiaxx" supported="no">
 		<!-- SPS (CAPS) release 2362 -->
 		<description>Cardiaxx (Euro, Budget?)</description>
@@ -7976,6 +8394,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after loading arcade mode [FDC] copy protection (enables 68k trace mode) -->
+	<!-- ATK test: OK -->
 	<software name="lewisch" supported="no">
 		<!-- SPS (CAPS) release 639 -->
 		<description>The Carl Lewis Challenge (Euro)</description>
@@ -7997,6 +8416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="carlos" supported="no">
 		<!-- SPS (CAPS) release 2299 -->
 		<description>Carlos (Euro)</description>
@@ -8011,6 +8431,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="carrierc" supported="no">
 		<!-- SPS (CAPS) release 1580 -->
 		<description>Carrier Command (Euro, Microprose, 19900813, VR Vol. 1)</description>
@@ -8025,6 +8446,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="carrierca" cloneof="carrierc" supported="no">
 		<!-- SPS (CAPS) release 2268 -->
 		<description>Carrier Command (Euro, Microprose, 19900813, Budget)</description>
@@ -8039,6 +8461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="carrierco" cloneof="carrierc" supported="no">
 		<!-- SPS (CAPS) release 813 -->
 		<description>Carrier Command (Euro, Firebird, vA1.2 19880819)</description>
@@ -8053,6 +8476,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="carthage" supported="no">
 		<!-- SPS (CAPS) release 2328 -->
 		<description>Carthage (Euro)</description>
@@ -8074,6 +8498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="carthageu" cloneof="carthage" supported="no">
 		<!-- SPS (CAPS) release 2329 -->
 		<description>Carthage (USA)</description>
@@ -8095,6 +8520,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="carvup" supported="no">
 		<!-- SPS (CAPS) release 1232 -->
 		<description>CarVup (Euro)</description>
@@ -8109,6 +8535,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="cmaster" supported="no">
 		<!-- SPS (CAPS) release 447 -->
 		<description>Castle Master (Euro)</description>
@@ -8123,6 +8550,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cmaster1" cloneof="cmaster" supported="no">
 		<!-- SPS (CAPS) release 2773 -->
 		<description>Castle Master (Euro, Budget)</description>
@@ -8137,6 +8565,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="cmastr12" supported="no">
 		<!-- SPS (CAPS) release 612 -->
 		<description>Castle Master + Castle Master II - The Crypt (Euro)</description>
@@ -8151,6 +8580,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drbrain" supported="no">
 		<!-- SPS (CAPS) release 304 -->
 		<description>Castle of Dr. Brain (Euro, v1.0)</description>
@@ -8184,6 +8614,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drbrainu" cloneof="drbrain" supported="no">
 		<!-- SPS (CAPS) release 1287 -->
 		<description>Castle of Dr. Brain (USA, v1.0)</description>
@@ -8217,6 +8648,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="castles" supported="no">
 		<!-- SPS (CAPS) release 2381 -->
 		<description>Castles (Euro)</description>
@@ -8238,6 +8670,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="castlesg" cloneof="castles" supported="no">
 		<!-- SPS (CAPS) release 305 -->
 		<description>Castles (Ger)</description>
@@ -8259,6 +8692,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cattivik" supported="no">
 		<!-- SPS (CAPS) release 2752 -->
 		<description>Cattivik - The Videogame (Euro)</description>
@@ -8280,6 +8714,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cavemani" supported="no">
 		<!-- SPS (CAPS) release 2220 -->
 		<description>CaveMania (Euro)</description>
@@ -8294,6 +8729,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cavitas" supported="no">
 		<!-- SPS (CAPS) release 2251 -->
 		<description>Cavitas (Euro)</description>
@@ -8308,6 +8744,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:39 onward Bad -->
 	<software name="celticlg" supported="no">
 		<!-- SPS (CAPS) release 1281 -->
 		<description>Celtic Legends (Euro)</description>
@@ -8329,6 +8766,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="centerbs" supported="no">
 		<!-- SPS (CAPS) release 2785 -->
 		<description>Centerbase - Science-Fiction Simulation (Euro)</description>
@@ -8343,6 +8781,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="centresq" supported="no">
 		<!-- SPS (CAPS) release 467 -->
 		<description>Centrefold Squares (Euro)</description>
@@ -8358,6 +8797,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, defensive battles ends with a "batl:" exception and no actual battle occurs -->
+	<!-- ATK test: OK -->
 	<software name="centur" supported="no">
 		<!-- SPS (CAPS) release 1945 -->
 		<description>Centurion - Defender of Rome (USA)</description>
@@ -8380,6 +8820,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="century" supported="no">
 		<!-- SPS (CAPS) release 640 -->
 		<description>Century (Euro)</description>
@@ -8394,6 +8835,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chalgolf" supported="no">
 		<!-- SPS (CAPS) release 1015 -->
 		<description>Challenge Golf (Euro)</description>
@@ -8408,6 +8850,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="challngr" supported="no">
 		<!-- SPS (CAPS) release 2704 -->
 		<description>Challenger (Euro)</description>
@@ -8422,6 +8865,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shaolin" supported="no">
 		<!-- SPS (CAPS) release 3049 -->
 		<description>Chambers of Shaolin (Euro)</description>
@@ -8436,6 +8880,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shaolin1" cloneof="shaolin" supported="no">
 		<!-- SPS (CAPS) release 3050 -->
 		<description>Chambers of Shaolin (Euro, The First Year)</description>
@@ -8450,6 +8895,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="champ" supported="no">
 		<!-- SPS (CAPS) release 2801 -->
 		<description>The Champ (Euro)</description>
@@ -8467,6 +8913,7 @@ license:CC0
 	<!-- offset flashing on main menu -->
 	<!-- key repeat is too fast on main menu -->
 	<!-- Jumps to lalaland after selecting a competition, [FDC] -->
+	<!-- ATK test: OK -->
 	<software name="champdrv" supported="no">
 		<!-- SPS (CAPS) release 1292 -->
 		<description>Champion Driver (Euro)</description>
@@ -8481,6 +8928,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="champraj" supported="no">
 		<!-- SPS (CAPS) release 2300 -->
 		<description>Champion of the Raj (Euro)</description>
@@ -8502,6 +8950,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ckrynn" supported="no">
 		<!-- SPS (CAPS) release 986 -->
 		<description>Champions of Krynn (Euro, v1.0)</description>
@@ -8529,6 +8978,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:5 H:L Bad -->
 	<software name="champbb" supported="no">
 		<!-- SPS (CAPS) release 2570 -->
 		<description>Championship Baseball (Euro)</description>
@@ -8543,6 +8993,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="champbba" cloneof="champbb" supported="no">
 		<!-- SPS (CAPS) release 2571 -->
 		<description>Championship Baseball (Euro, Budget)</description>
@@ -8558,6 +9009,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="champcrk" supported="no">
 		<!-- SPS (CAPS) release 1632 -->
 		<description>Championship Cricket (Euro)</description>
@@ -8572,6 +9024,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cmang93" supported="no">
 		<!-- SPS (CAPS) release 1662 -->
 		<description>Championship Manager '93 (Euro)</description>
@@ -8599,6 +9052,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cmang94" cloneof="cmang93" supported="no">
 		<!-- SPS (CAPS) release 2742 -->
 		<description>Championship Manager '94 Season Data Disk (Euro)</description>
@@ -8614,6 +9068,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cmang94e" cloneof="cmang93" supported="no">
 		<!-- SPS (CAPS) release 2741 -->
 		<description>Championship Manager End of 1994 Season Data Update Disk (Euro)</description>
@@ -8629,6 +9084,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cmangit" supported="no">
 		<!-- SPS (CAPS) release 1626 -->
 		<description>Championship Manager Italia (Euro)</description>
@@ -8643,6 +9099,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="champrun" supported="no">
 		<!-- SPS (CAPS) release 825 -->
 		<description>Championship Run (Euro)</description>
@@ -8657,6 +9114,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chaoseng" supported="no">
 		<!-- SPS (CAPS) release 106 -->
 		<description>The Chaos Engine (Euro)</description>
@@ -8678,6 +9136,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="chaosen2" supported="no">
 		<!-- SPS (CAPS) release 172 -->
 		<description>The Chaos Engine 2 (Euro)</description>
@@ -8705,6 +9164,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chariots" supported="no">
 		<!-- SPS (CAPS) release 2804 -->
 		<description>Chariots of Wrath (Euro)</description>
@@ -8719,6 +9179,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="charon5" supported="no">
 		<!-- SPS (CAPS) release 2685 -->
 		<description>Charon 5 (Euro)</description>
@@ -8733,6 +9194,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chasehq" supported="no">
 		<!-- SPS (CAPS) release 212 -->
 		<description>Chase H.Q. (Euro)</description>
@@ -8747,6 +9209,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chasehqa" cloneof="chasehq" supported="no">
 		<!-- SPS (CAPS) release 2209 -->
 		<description>Chase H.Q. (Euro, Budget)</description>
@@ -8761,6 +9224,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wof1" supported="no">
 		<!-- SPS (CAPS) release 1443 -->
 		<description>Chase H.Q. + Hard Drivin' (Euro, Wheels of Fire)</description>
@@ -8797,6 +9261,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chsp2150" supported="no">
 		<!-- SPS (CAPS) release 2493 -->
 		<description>Chess Player 2150 (Euro)</description>
@@ -8811,6 +9276,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chsp2150aa" cloneof="chsp2150" supported="no">
 		<!-- SPS (CAPS) release 2313 -->
 		<description>Chess Player 2150 (Euro, Arcade Action)</description>
@@ -8825,6 +9291,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chsp2150g" cloneof="chsp2150" supported="no">
 		<!-- SPS (CAPS) release 669 -->
 		<description>Chess Player 2150 (Ger)</description>
@@ -8839,6 +9306,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chesssim" supported="no">
 		<!-- SPS (CAPS) release 2054 -->
 		<description>Chess Simulator (Euro)</description>
@@ -8853,6 +9321,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cm2000" supported="no">
 		<!-- SPS (CAPS) release 2055 -->
 		<description>The Chessmaster 2000 (Euro)</description>
@@ -8867,6 +9336,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cm2100" supported="no">
 		<!-- SPS (CAPS) release 1988 -->
 		<description>Chessmaster 2100 (USA, v1.2)</description>
@@ -8888,6 +9358,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chicag90" supported="no">
 		<!-- SPS (CAPS) release 2302 -->
 		<description>Chicago 90 (Euro)</description>
@@ -8902,6 +9373,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="chipchal" supported="no">
 		<!-- SPS (CAPS) release 444 -->
 		<description>Chip's Challenge (Euro)</description>
@@ -8916,6 +9388,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chipchalu" cloneof="chipchal" supported="no">
 		<!-- SPS (CAPS) release 2009 -->
 		<description>Chip's Challenge (USA)</description>
@@ -8930,6 +9403,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="columbus" supported="no">
 		<!-- SPS (CAPS) release 306 -->
 		<description>Christoph Kolumbus (Euro, v1.00)</description>
@@ -8963,6 +9437,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cquest" supported="no">
 		<!-- SPS (CAPS) release 1016 -->
 		<description>Chrono Quest (Euro)</description>
@@ -8990,6 +9465,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cquestg" cloneof="cquest" supported="no">
 		<!-- SPS (CAPS) release 792 -->
 		<description>Chrono Quest (Ger)</description>
@@ -9017,6 +9493,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cquest2" supported="no">
 		<!-- SPS (CAPS) release 449 -->
 		<description>Chrono Quest II (Euro)</description>
@@ -9050,6 +9527,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chuckie" supported="no">
 		<!-- SPS (CAPS) release 641 -->
 		<description>Chuckie Egg (Euro)</description>
@@ -9064,6 +9542,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="chuckie2" supported="no">
 		<!-- SPS (CAPS) release 925 -->
 		<description>Chuckie Egg II (Euro)</description>
@@ -9078,6 +9557,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="chuckrck" supported="no">
 		<!-- SPS (CAPS) release 767 -->
 		<description>Chuck Rock (Euro)</description>
@@ -9099,6 +9579,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="chukrck2" supported="no">
 		<!-- SPS (CAPS) release 282 -->
 		<description>Chuck Rock 2 - Son of Chuck (Euro)</description>
@@ -9120,6 +9601,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="aft2" supported="no">
 		<!-- SPS (CAPS) release 670 -->
 		<description>Chuck Yeager's Advanced Flight Trainer 2.0 (Euro)</description>
@@ -9134,6 +9616,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="circusat" supported="no">
 		<!-- SPS (CAPS) release 450 -->
 		<description>Circus Attractions (Euro)</description>
@@ -9155,6 +9638,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="circusatm" cloneof="circusat" supported="no">
 		<!-- SPS (CAPS) release 1689 -->
 		<description>Circus Attractions (Euro, Milestones)</description>
@@ -9169,6 +9653,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="circgame" supported="no">
 		<!-- SPS (CAPS) release 3006 -->
 		<description>Circus Games (Euro, Mega Pack II)</description>
@@ -9190,6 +9675,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cischeat" supported="no">
 		<!-- SPS (CAPS) release 1393 -->
 		<description>Cisco Heat (Euro)</description>
@@ -9204,6 +9690,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="citydef" supported="no">
 		<!-- SPS (CAPS) release 1473 -->
 		<description>City Defence + Karate King (Euro, Sextett)</description>
@@ -9218,6 +9705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="civiliz" supported="no">
 		<!-- SPS (CAPS) release 2090 -->
 		<description>Civilization (Euro, v855.04, Award Winners Platinum Edition)</description>
@@ -9251,6 +9739,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="civiliza" cloneof="civiliz" supported="no">
 		<!-- SPS (CAPS) release 1308 -->
 		<description>Civilization (Euro, v855.01)</description>
@@ -9284,6 +9773,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="civilizg" cloneof="civiliz" supported="no">
 		<!-- SPS (CAPS) release 671 -->
 		<description>Civilization (Ger, v855.04)</description>
@@ -9317,6 +9807,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="civilizga" cloneof="civiliz" supported="no">
 		<!-- SPS (CAPS) release 56 -->
 		<description>Civilization (Ger, v855.01)</description>
@@ -9350,6 +9841,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cjusa" supported="no">
 		<!-- SPS (CAPS) release 1946 -->
 		<description>CJ in the USA (Euro, 19920518)</description>
@@ -9364,6 +9856,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cjantics" supported="no">
 		<!-- SPS (CAPS) release 832 -->
 		<description>CJ's Elephant Antics (Euro)</description>
@@ -9378,6 +9871,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="classarc" supported="no">
 		<!-- SPS (CAPS) release 1017 -->
 		<description>Classic Arcadia (Euro)</description>
@@ -9392,6 +9886,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="classbrd" supported="no">
 		<!-- SPS (CAPS) release 2056 -->
 		<description>Classic Board Games (Euro)</description>
@@ -9406,6 +9901,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cliffh" supported="no">
 		<!-- SPS (CAPS) release 1598 -->
 		<description>Cliffhanger (Euro)</description>
@@ -9420,6 +9916,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="clockwis" supported="no">
 		<!-- SPS (CAPS) release 1420 -->
 		<description>Clockwiser (Euro)</description>
@@ -9441,6 +9938,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cloudkng" supported="no">
 		<!-- SPS (CAPS) release 642 -->
 		<description>Cloud Kingdoms (Euro)</description>
@@ -9456,6 +9954,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="clownman" supported="no">
 		<!-- SPS (CAPS) release 2807 -->
 		<description>Clown-O-Mania (Euro, Budget)</description>
@@ -9470,6 +9969,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="clubfoot" supported="no">
 		<!-- SPS (CAPS) release 2198 -->
 		<description>Club Football - The Manager (Euro)</description>
@@ -9491,6 +9991,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="clue" supported="no">
 		<!-- SPS (CAPS) release 2134 -->
 		<description>The Clue! (Euro)</description>
@@ -9524,6 +10025,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="clueg" cloneof="clue" supported="no">
 		<!-- SPS (CAPS) release 810 -->
 		<description>Der Clou! (Ger)</description>
@@ -9557,6 +10059,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cluemd" supported="no">
 		<!-- SPS (CAPS) release 1122 -->
 		<description>Cluedo - Master Detective (Euro)</description>
@@ -9571,6 +10074,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cluemdu" cloneof="cluemd" supported="no">
 		<!-- SPS (CAPS) release 672 -->
 		<description>Clue - Master Detective (USA)</description>
@@ -9585,6 +10089,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="iceman" supported="no">
 		<!-- SPS (CAPS) release 468 -->
 		<description>Code Name: Iceman (Euro, v1.036)</description>
@@ -9624,6 +10129,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cogans" supported="no">
 		<!-- SPS (CAPS) release 469 -->
 		<description>Cogans Run (Euro)</description>
@@ -9638,6 +10144,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cohort2" supported="no">
 		<!-- SPS (CAPS) release 2941 -->
 		<description>Cohort II - Fighting for Rome (Euro)</description>
@@ -9652,6 +10159,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="colonbeq" supported="no">
 		<!-- SPS (CAPS) release 796 -->
 		<description>The Colonel's Bequest (Euro, v1.000.059)</description>
@@ -9691,6 +10199,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="coloniz" supported="no">
 		<!-- SPS (CAPS) release 452 -->
 		<description>Colonization (Euro, v1.11, 19950531)</description>
@@ -9718,6 +10227,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="colony" supported="no">
 		<!-- SPS (CAPS) release 673 -->
 		<description>The Colony (Euro)</description>
@@ -9739,6 +10249,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="colorado" supported="no">
 		<!-- SPS (CAPS) release 1743 -->
 		<description>Colorado (Euro)</description>
@@ -9753,6 +10264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="coloradoa" cloneof="colorado" supported="no">
 		<!-- SPS (CAPS) release 3088 -->
 		<description>Colorado (Euro, Alt)</description>
@@ -9767,6 +10279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="colosxbr" supported="no">
 		<!-- SPS (CAPS) release 1131 -->
 		<description>Colossus X Bridge (Euro)</description>
@@ -9781,6 +10294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="colosxch" supported="no">
 		<!-- SPS (CAPS) release 1510 -->
 		<description>Colossus Chess X - The Ultimate Chess Program (Euro)</description>
@@ -9795,6 +10309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cairpatr" supported="no">
 		<!-- SPS (CAPS) release 674 -->
 		<description>Combat Air Patrol (Euro)</description>
@@ -9822,6 +10337,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="commando" supported="no">
 		<!-- SPS (CAPS) release 2 -->
 		<description>Commando (Euro)</description>
@@ -9836,6 +10352,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="comp3r" supported="no">
 		<!-- SPS (CAPS) release 1499 -->
 		<description>Computer Third Reich (USA)</description>
@@ -9850,6 +10367,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="conflict" supported="no">
 		<!-- SPS (CAPS) release 307 -->
 		<description>Conflict - Europe (Euro)</description>
@@ -9864,6 +10382,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="conflictf" cloneof="conflict" supported="no">
 		<!-- SPS (CAPS) release 2648 -->
 		<description>Conflict - Europe (Fra)</description>
@@ -9878,6 +10397,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad, C:20-23 Bad, C:40-71 Bad -->
 	<software name="conquer" supported="no">
 		<!-- SPS (CAPS) release 1275 -->
 		<description>Conqueror (Euro)</description>
@@ -9892,6 +10412,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="conquer1" cloneof="conquer" supported="no">
 		<!-- SPS (CAPS) release 1276 -->
 		<description>Conqueror (Euro, Mega Box)</description>
@@ -9906,6 +10427,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="conquer2" cloneof="conquer" supported="no">
 		<!-- SPS (CAPS) release 2260 -->
 		<description>Conqueror (Euro, Budget)</description>
@@ -9920,6 +10442,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="camelot" supported="no">
 		<!-- SPS (CAPS) release 1112 -->
 		<description>Conquests of Camelot (Euro, v1.009)</description>
@@ -9966,6 +10489,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="contcirc" supported="no">
 		<!-- SPS (CAPS) release 1720 -->
 		<description>Continental Circus (Euro)</description>
@@ -9980,6 +10504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="coolcroc" supported="no">
 		<!-- SPS (CAPS) release 920 -->
 		<description>Cool Croc Twins (Euro)</description>
@@ -9994,6 +10519,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="coolspot" supported="no">
 		<!-- SPS (CAPS) release 1345 -->
 		<description>Cool Spot (Euro)</description>
@@ -10021,6 +10547,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="coolwrld" supported="no">
 		<!-- SPS (CAPS) release 1826 -->
 		<description>Cool World (Euro)</description>
@@ -10042,6 +10569,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="corporat" supported="no">
 		<!-- SPS (CAPS) release 107 -->
 		<description>Corporation (Euro)</description>
@@ -10063,6 +10591,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="corporat1" cloneof="corporat" supported="no">
 		<!-- SPS (CAPS) release 2858 -->
 		<description>Corporation (Euro, Alt)</description>
@@ -10084,6 +10613,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="corporatmd" cloneof="corporat" supported="no">
 		<!-- SPS (CAPS) release 266 -->
 		<description>Corporation - Mission Disk (Euro)</description>
@@ -10099,6 +10629,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="corruptn" supported="no">
 		<!-- SPS (CAPS) release 308 -->
 		<description>Corruption (Euro, v1.11)</description>
@@ -10113,6 +10644,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cortex" supported="no">
 		<!-- SPS (CAPS) release 1932 -->
 		<description>Cortex (Euro)</description>
@@ -10127,6 +10659,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="corx" supported="no">
 		<!-- SPS (CAPS) release 930 -->
 		<description>Corx (Euro, Rebel Racer)</description>
@@ -10143,6 +10676,7 @@ license:CC0
 
 	<!-- Gets stuck at the AmigaDOS blue screen [FDC] dsksync bootblock -->
 	<!-- (Sets up a clearly invalid DMA dskpt of 0, enables MFM precomp) -->
+	<!-- ATK test: failed -->
 	<software name="cosmcbnc" supported="no">
 		<!-- SPS (CAPS) release 309 -->
 		<description>Cosmic Bouncer (Euro)</description>
@@ -10157,6 +10691,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cosmcrel" supported="no">
 		<!-- SPS (CAPS) release 1893 -->
 		<description>Cosmic Relief (USA)</description>
@@ -10171,6 +10706,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cosmic" supported="no">
 		<!-- SPS (CAPS) release 213 -->
 		<description>Cosmic Spacehead (Euro)</description>
@@ -10192,6 +10728,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cosmostr" supported="no">
 		<!-- SPS (CAPS) release 1931 -->
 		<description>Cosmostruction (Euro)</description>
@@ -10206,6 +10743,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="duckula" supported="no">
 		<!-- SPS (CAPS) release 828 -->
 		<description>Count Duckula (Euro)</description>
@@ -10220,6 +10758,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="duckula2" supported="no">
 		<!-- SPS (CAPS) release 1712 -->
 		<description>Count Duckula II (Euro)</description>
@@ -10234,6 +10773,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="coveract" supported="no">
 		<!-- SPS (CAPS) release 1834 -->
 		<description>Covert Action (Euro, v447.101)</description>
@@ -10261,6 +10801,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="coveractg" cloneof="coveract" supported="no">
 		<!-- SPS (CAPS) release 310 -->
 		<description>Covert Action (Ger, v447.101)</description>
@@ -10288,6 +10829,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="crack" supported="no">
 		<!-- SPS (CAPS) release 57 -->
 		<description>Crack (Euro)</description>
@@ -10302,6 +10844,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="crkdown" supported="no">
 		<!-- SPS (CAPS) release 1711 -->
 		<description>Crack Down (Euro)</description>
@@ -10316,6 +10859,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="crapsaca" supported="no">
 		<!-- SPS (CAPS) release 675 -->
 		<description>Craps Academy (Euro)</description>
@@ -10330,6 +10874,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="crazycr2" supported="no">
 		<!-- SPS (CAPS) release 311 -->
 		<description>Crazy Cars II (Euro)</description>
@@ -10344,6 +10889,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="crazycr3" supported="no">
 		<!-- SPS (CAPS) release 3068 -->
 		<description>Crazy Cars III (Euro)</description>
@@ -10365,6 +10911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="crazysht" supported="no">
 		<!-- SPS (CAPS) release 2404 -->
 		<description>Crazy Shot (Euro)</description>
@@ -10379,6 +10926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:43 onward Bad -->
 	<software name="crazsue2" supported="no">
 		<!-- SPS (CAPS) release 2195 -->
 		<description>Crazy Sue... Goes On (Euro)</description>
@@ -10395,6 +10943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="creature" supported="no">
 		<!-- SPS (CAPS) release 846 -->
 		<description>Creature (Euro)</description>
@@ -10416,6 +10965,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="creaturs" supported="no">
 		<!-- SPS (CAPS) release 1764 -->
 		<description>Creatures (Euro, 19930208)</description>
@@ -10437,6 +10987,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cribbage" supported="no">
 		<!-- SPS (CAPS) release 1933 -->
 		<description>Cribbage King &amp; Gin King (Euro)</description>
@@ -10451,6 +11002,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cricketc" supported="no">
 		<!-- SPS (CAPS) release 1244 -->
 		<description>Cricket Captain (Euro)</description>
@@ -10465,6 +11017,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="crimenop" supported="no">
 		<!-- SPS (CAPS) release 364 -->
 		<description>Crime Does Not Pay (Euro)</description>
@@ -10479,6 +11032,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="crossout" supported="no">
 		<!-- SPS (CAPS) release 1915 -->
 		<description>Cross Out the Intruder (Euro)</description>
@@ -10493,6 +11047,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="crown" supported="no">
 		<!-- SPS (CAPS) release 1090 -->
 		<description>Crown (Euro)</description>
@@ -10514,6 +11069,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cruisecr" supported="no">
 		<!-- SPS (CAPS) release 108 -->
 		<description>Cruise for a Corpse (Euro)</description>
@@ -10553,6 +11109,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cruisecr1" cloneof="cruisecr" supported="no">
 		<!-- SPS (CAPS) release 1884 -->
 		<description>Cruise for a Corpse (Euro, The Delphine Collection)</description>
@@ -10592,6 +11149,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cruisecrf" cloneof="cruisecr" supported="no">
 		<!-- SPS (CAPS) release 1827 -->
 		<description>Croisiere pour un Cadavre (Fra, v1.04)</description>
@@ -10631,6 +11189,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cruisecrg" cloneof="cruisecr" supported="no">
 		<!-- SPS (CAPS) release 676 -->
 		<description>Cruise for a Corpse (Ger)</description>
@@ -10670,6 +11229,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad, C:1 H:U onward Bad -->
 	<software name="crystdrg" supported="no">
 		<!-- SPS (CAPS) release 1830 -->
 		<description>Crystal Dragon (Euro)</description>
@@ -10697,6 +11257,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ckdizzy" supported="no">
 		<!-- SPS (CAPS) release 109 -->
 		<description>Crystal Kingdom Dizzy (Euro)</description>
@@ -10718,6 +11279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="arborea" supported="no">
 		<!-- SPS (CAPS) release 2386 -->
 		<description>Crystals of Arborea (Euro, Magic Worlds)</description>
@@ -10732,6 +11294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cubulus" supported="no">
 		<!-- SPS (CAPS) release 1857 -->
 		<description>Cubulus (Euro)</description>
@@ -10746,6 +11309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="enchant" supported="no">
 		<!-- SPS (CAPS) release 283 -->
 		<description>Curse of Enchantia (Euro)</description>
@@ -10791,6 +11355,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="azurebnd" supported="no">
 		<!-- SPS (CAPS) release 982 -->
 		<description>Curse of the Azure Bonds (Euro, v1.0)</description>
@@ -10812,6 +11377,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="custodn" supported="no">
 		<!-- SPS (CAPS) release 312 -->
 		<description>Custodian (Euro)</description>
@@ -10826,6 +11392,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cutthr" supported="no">
 		<!-- SPS (CAPS) release 2683 -->
 		<description>Cutthroats (Euro, r23)</description>
@@ -10840,6 +11407,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cyberwrl" supported="no">
 		<!-- SPS (CAPS) release 2603 -->
 		<description>Cyber World (Euro)</description>
@@ -10854,6 +11422,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cyberbal" supported="no">
 		<!-- SPS (CAPS) release 1076 -->
 		<description>Cyberball (Euro)</description>
@@ -10868,6 +11437,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cyberbala" cloneof="cyberbal" supported="no">
 		<!-- SPS (CAPS) release 1446 -->
 		<description>Cyberball (Euro, Winning Team)</description>
@@ -10882,6 +11452,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="cyberbla" supported="no">
 		<!-- SPS (CAPS) release 1383 -->
 		<description>Cyberblast (Euro)</description>
@@ -10896,6 +11467,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cybercn3" supported="no">
 		<!-- SPS (CAPS) release 243 -->
 		<description>Cybercon III (Euro)</description>
@@ -10910,6 +11482,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cybercn3a" cloneof="cybercn3" supported="no">
 		<!-- SPS (CAPS) release 2123 -->
 		<description>Cybercon III (Euro, 19910806, Budget)</description>
@@ -10924,6 +11497,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="cybernod" supported="no">
 		<!-- SPS (CAPS) release 1088 -->
 		<description>Cybernoid - The Fighting Machine (Euro, Action)</description>
@@ -10938,6 +11512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="cybernd2" supported="no">
 		<!-- SPS (CAPS) release 3 -->
 		<description>Cybernoid II - The Revenge (Euro)</description>
@@ -10952,6 +11527,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad, C:1 H:U onward Bad -->
 	<software name="cybpunks" supported="no">
 		<!-- SPS (CAPS) release 365 -->
 		<description>Cyberpunks (Euro)</description>
@@ -10966,6 +11542,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="cycles" supported="no">
 		<!-- SPS (CAPS) release 1018 -->
 		<description>The Cycles - International Grand Prix Racing (Euro)</description>
@@ -10980,6 +11557,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:49 onward Bad -->
 	<software name="cytron" supported="no">
 		<!-- SPS (CAPS) release 110 -->
 		<description>Cytron (Euro)</description>
@@ -11001,6 +11579,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dday" supported="no">
 		<!-- SPS (CAPS) release 455 -->
 		<description>D-Day - The Beginning of the End (Euro)</description>
@@ -11022,6 +11601,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dgen" supported="no">
 		<!-- SPS (CAPS) release 677 -->
 		<description>D/Generation (Euro, v1.05)</description>
@@ -11043,6 +11623,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dailydhh" supported="no">
 		<!-- SPS (CAPS) release 284 -->
 		<description>Daily Double Horse Racing (Euro)</description>
@@ -11057,6 +11638,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dalekat" supported="no">
 		<!-- SPS (CAPS) release 2170 -->
 		<description>Dalek Attack (Euro)</description>
@@ -11078,6 +11660,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dalekat1" cloneof="dalekat" supported="no">
 		<!-- SPS (CAPS) release 1998 -->
 		<description>Dalek Attack (Euro, The Sci-Fi Collecion)</description>
@@ -11099,6 +11682,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="daleyoc" supported="no">
 		<!-- SPS (CAPS) release 313 -->
 		<description>Daley Thompson's Olympic Challenge (Euro)</description>
@@ -11120,6 +11704,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="daleyoca" cloneof="daleyoc" supported="no">
 		<!-- SPS (CAPS) release 957 -->
 		<description>Daley Thompson's Olympic Challenge (Euro, Budget)</description>
@@ -11134,6 +11719,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dandare3" supported="no">
 		<!-- SPS (CAPS) release 2257 -->
 		<description>Dan Dare III - The Escape (Euro)</description>
@@ -11148,6 +11734,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dangerfr" supported="no">
 		<!-- SPS (CAPS) release 975 -->
 		<description>Danger Freak (Euro)</description>
@@ -11162,6 +11749,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dangstrt" supported="no">
 		<!-- SPS (CAPS) release 1019 -->
 		<description>Dangerous Streets (Euro)</description>
@@ -11176,6 +11764,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="darkcstl" supported="no">
 		<!-- SPS (CAPS) release 1459 -->
 		<description>Dark Castle (USA)</description>
@@ -11197,6 +11786,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="darkcent" supported="no">
 		<!-- SPS (CAPS) release 244 -->
 		<description>Dark Century (Euro)</description>
@@ -11211,6 +11801,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tp1" supported="no">
 		<!-- SPS (CAPS) release 2163 -->
 		<description>Dark Fusion + Steel + Turbo Trax (Euro, Turbo Pack)</description>
@@ -11225,6 +11816,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="darkfusn" supported="no">
 		<!-- SPS (CAPS) release 36 -->
 		<description>Dark Fusion (Euro)</description>
@@ -11239,6 +11831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dqkrynn" supported="no">
 		<!-- SPS (CAPS) release 988 -->
 		<description>The Dark Queen of Krynn (Euro, v1.0 19920616)</description>
@@ -11266,6 +11859,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="darkseed" supported="no">
 		<!-- SPS (CAPS) release 2141 -->
 		<description>Darkseed (Euro, v1.0)</description>
@@ -11317,6 +11911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="darkside" supported="no">
 		<!-- SPS (CAPS) release 1099 -->
 		<description>Dark Side (Euro, v1.0)</description>
@@ -11331,6 +11926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="darksideu" cloneof="darkside" supported="no">
 		<!-- SPS (CAPS) release 1424 -->
 		<description>Dark Side (USA, v1.0)</description>
@@ -11345,6 +11941,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="darkman" supported="no">
 		<!-- SPS (CAPS) release 1564 -->
 		<description>Darkman (Euro)</description>
@@ -11359,6 +11956,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="darkmere" supported="no">
 		<!-- SPS (CAPS) release 453 -->
 		<description>Darkmere - The Nightmare's Begun (Euro)</description>
@@ -11392,6 +11990,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="darkspyr" supported="no">
 		<!-- SPS (CAPS) release 111 -->
 		<description>DarkSpyre (Euro)</description>
@@ -11413,6 +12012,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="datastrm" supported="no">
 		<!-- SPS (CAPS) release 1554 -->
 		<description>Datastorm (Euro)</description>
@@ -11427,6 +12027,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="datastrma" cloneof="datastrm" supported="no">
 		<!-- SPS (CAPS) release 1555 -->
 		<description>Datastorm (Euro, Astra Pack)</description>
@@ -11441,6 +12042,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dawnpatr" supported="no">
 		<!-- SPS (CAPS) release 1614 -->
 		<description>Dawn Patrol (Euro)</description>
@@ -11468,6 +12070,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dawnpatrg" cloneof="dawnpatr" supported="no">
 		<!-- SPS (CAPS) release 314 -->
 		<description>Dawn Patrol (Ger)</description>
@@ -11495,6 +12098,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dayphara" supported="no">
 		<!-- SPS (CAPS) release 2052 -->
 		<description>Day of the Pharaoh (Euro)</description>
@@ -11516,6 +12120,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="daypharag" cloneof="dayphara" supported="no">
 		<!-- SPS (CAPS) release 315 -->
 		<description>Day of the Pharaoh (Ger)</description>
@@ -11537,6 +12142,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dayviper" supported="no">
 		<!-- SPS (CAPS) release 454 -->
 		<description>Day of the Viper (Euro)</description>
@@ -11551,6 +12157,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="daysthnd" supported="no">
 		<!-- SPS (CAPS) release 285 -->
 		<description>Days of Thunder (Euro)</description>
@@ -11565,6 +12172,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dbringer" supported="no">
 		<!-- SPS (CAPS) release 2550 -->
 		<description>Deathbringer (Euro)</description>
@@ -11586,6 +12194,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dbringsp" supported="no">
 		<!-- SPS (CAPS) release 316 -->
 		<description>Death Bringer (USA)</description>
@@ -11607,6 +12216,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dkkrynn" supported="no">
 		<!-- SPS (CAPS) release 987 -->
 		<description>Death Knights of Krynn (Euro, v1.0)</description>
@@ -11628,6 +12238,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="deathmsk" supported="no">
 		<!-- SPS (CAPS) release 1326 -->
 		<description>Death Mask (Euro)</description>
@@ -11649,6 +12260,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dogem" supported="no">
 		<!-- SPS (CAPS) release 2139 -->
 		<description>Death or Glory - Das Erbe von Morgan (Ger, Hard Disk Version)</description>
@@ -11676,6 +12288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dogdk" supported="no">
 		<!-- SPS (CAPS) release 2140 -->
 		<description>Death or Glory - Der dunkle Kaiser (Ger, Hard Disk Version)</description>
@@ -11691,6 +12304,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="deathtrp" supported="no">
 		<!-- SPS (CAPS) release 1021 -->
 		<description>Death Trap (Euro)</description>
@@ -11707,6 +12321,7 @@ license:CC0
 
 	<!-- Hangs at a rainbow colored screen [FDC] -->
 	<!-- (fails a CRC check with data uploaded at 0x800, TODO: verify if it's using copper DMA) -->
+	<!-- ATK test: failed -->
 	<software name="deep" supported="no">
 		<!-- SPS (CAPS) release 1218 -->
 		<description>The Deep (Euro)</description>
@@ -11721,6 +12336,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="deepspac" supported="no">
 		<!-- SPS (CAPS) release 1168 -->
 		<description>Deep Space (Euro, v1.00a)</description>
@@ -11735,6 +12351,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="deepspacu" cloneof="deepspac" supported="no">
 		<!-- SPS (CAPS) release 1167 -->
 		<description>Deep Space (USA, v1.00a)</description>
@@ -11749,6 +12366,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="defcon5" supported="no">
 		<!-- SPS (CAPS) release 470 -->
 		<description>Def Con 5 (Euro)</description>
@@ -11764,6 +12382,7 @@ license:CC0
 	</software>
 
 	<!-- "Program failed", clicking on reboot causes Guru Meditation -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="defcrown" supported="no">
 		<!-- SPS (CAPS) release 317 -->
 		<description>Defender of the Crown (Euro)</description>
@@ -11785,6 +12404,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- a500n: wrong GFX pitch on workbench -->
+	<!-- a1200n: hangs when attempting to raid a castle -->
+	<!-- ATK test: OK -->
 	<software name="defcrownu" cloneof="defcrown" supported="no">
 		<!-- SPS (CAPS) release 902 -->
 		<description>Defender of the Crown (USA)</description>
@@ -11806,6 +12428,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="defendr2" supported="no">
 		<!-- SPS (CAPS) release 2258 -->
 		<description>Defender II (Euro)</description>
@@ -11820,6 +12443,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="defearth" supported="no">
 		<!-- SPS (CAPS) release 456 -->
 		<description>Defenders of the Earth (Euro)</description>
@@ -11834,6 +12458,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="deflektr" supported="no">
 		<!-- SPS (CAPS) release 1087 -->
 		<description>Deflektor (Euro, Action)</description>
@@ -11848,6 +12473,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="dejavu" supported="no">
 		<!-- SPS (CAPS) release 1832 -->
 		<description>Deja Vu - A Nightmare Comes True (USA)</description>
@@ -11862,6 +12488,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="deliver" supported="no">
 		<!-- SPS (CAPS) release 1500 -->
 		<description>Deliverance (Euro)</description>
@@ -11883,6 +12510,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="demolitn" supported="no">
 		<!-- SPS (CAPS) release 2712 -->
 		<description>Demolition (Euro)</description>
@@ -11897,6 +12525,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="demonwar" supported="no">
 		<!-- SPS (CAPS) release 1395 -->
 		<description>Demon Wars (Euro)</description>
@@ -11911,6 +12540,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="demnwint" supported="no">
 		<!-- SPS (CAPS) release 1995 -->
 		<description>Demon's Winter (USA, v1.0)</description>
@@ -11925,6 +12555,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="demoniak" supported="no">
 		<!-- SPS (CAPS) release 3071 -->
 		<description>Demoniak (Euro, v1.0)</description>
@@ -11946,6 +12577,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="denaris" supported="no">
 		<!-- SPS (CAPS) release 49 -->
 		<description>Denaris (Euro)</description>
@@ -11967,6 +12599,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="denarisa" cloneof="denaris" supported="no">
 		<!-- SPS (CAPS) release 2166 -->
 		<description>Denaris (Euro, 5th Anniversary)</description>
@@ -11981,6 +12614,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dennis" supported="no">
 		<!-- SPS (CAPS) release 1097 -->
 		<description>Dennis (Euro)</description>
@@ -12004,6 +12638,7 @@ license:CC0
 
 	<!-- Asks to disc swap with disc 1, which is already in, [FDC] dsksync -->
 	<!-- Mouse input doesn't work (TODO: recheck) -->
+	<!-- ATK test: OK -->
 	<software name="dstrike" supported="no">
 		<!-- SPS (CAPS) release 112 -->
 		<description>Desert Strike - Return to the Gulf (Euro)</description>
@@ -12031,6 +12666,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="destroyr" supported="no">
 		<!-- SPS (CAPS) release 318 -->
 		<description>Destroyer (Euro)</description>
@@ -12045,6 +12681,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="detroit" supported="no">
 		<!-- SPS (CAPS) release 1861 -->
 		<description>Detroit (Euro, v1.2)</description>
@@ -12066,6 +12703,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="deuteros" supported="no">
 		<!-- SPS (CAPS) release 958 -->
 		<description>Deuteros (Euro, v2)</description>
@@ -12088,6 +12726,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="deuterosa" cloneof="deuteros" supported="no">
 		<!-- SPS (CAPS) release 319 -->
 		<description>Deuteros (Euro, v1)</description>
@@ -12110,6 +12749,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="deviousd" supported="no">
 		<!-- SPS (CAPS) release 256 -->
 		<description>Devious Designs (Euro)</description>
@@ -12146,6 +12786,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dicktrcs" supported="no">
 		<!-- SPS (CAPS) release 2385 -->
 		<description>Dick Tracy (Euro, Disney Software)</description>
@@ -12174,6 +12815,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="diehard2" supported="no">
 		<!-- SPS (CAPS) release 113 -->
 		<description>Die Hard 2 - Die Harder (Euro)</description>
@@ -12188,6 +12830,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dimoqst" supported="no">
 		<!-- SPS (CAPS) release 1216 -->
 		<description>Dimo's Quest (Euro)</description>
@@ -12202,6 +12845,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dingsda" supported="no">
 		<!-- SPS (CAPS) release 1247 -->
 		<description>Dingsda (Ger)</description>
@@ -12216,6 +12860,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dinodet" supported="no">
 		<!-- SPS (CAPS) release 2617 -->
 		<description>Dinosaur Detective Agency (Euro)</description>
@@ -12230,6 +12875,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="discover" supported="no">
 		<!-- SPS (CAPS) release 2175 -->
 		<description>Discovery - In the Steps of Columbus (Euro)</description>
@@ -12251,6 +12897,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="disc" supported="no">
 		<!-- SPS (CAPS) release 1503 -->
 		<description>Disc (Euro)</description>
@@ -12265,6 +12912,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="disca" cloneof="disc" supported="no">
 		<!-- SPS (CAPS) release 2189 -->
 		<description>Disc (Euro, Budget)</description>
@@ -12279,6 +12927,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="discb" cloneof="disc" supported="no">
 		<!-- SPS (CAPS) release 2440 -->
 		<description>Disc (Euro, Podium)</description>
@@ -12293,6 +12942,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="disphero" supported="no">
 		<!-- SPS (CAPS) release 1367 -->
 		<description>Disposable Hero (Euro)</description>
@@ -12314,6 +12964,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dstntarm" supported="no">
 		<!-- SPS (CAPS) release 2551 -->
 		<description>Distant Armies (Euro)</description>
@@ -12329,6 +12980,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dizzy6" supported="no">
 		<!-- SPS (CAPS) release 1146 -->
 		<description>Prince of the Yolkfolk (Euro)</description>
@@ -12344,6 +12996,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dizzysex" supported="no">
 		<!-- SPS (CAPS) release 2502 -->
 		<description>Dizzy's Excellent Adventures (Euro)</description>
@@ -12365,6 +13018,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dogfight" supported="no">
 		<!-- SPS (CAPS) release 1293 -->
 		<description>Dogfight (Euro, v1.01 19930906)</description>
@@ -12407,6 +13061,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dojodan" supported="no">
 		<!-- SPS (CAPS) release 2503 -->
 		<description>Dojo Dan (Euro)</description>
@@ -12428,6 +13083,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dominatr" supported="no">
 		<!-- SPS (CAPS) release 646 -->
 		<description>Dominator (Euro)</description>
@@ -12442,6 +13098,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dominium" supported="no">
 		<!-- SPS (CAPS) release 2846 -->
 		<description>Dominium (Euro)</description>
@@ -12475,6 +13132,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="donaldac" supported="no">
 		<!-- SPS (CAPS) release 2067 -->
 		<description>Donald's Alphabet Chase (Euro)</description>
@@ -12489,6 +13147,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="donk" supported="no">
 		<!-- SPS (CAPS) release 647 -->
 		<description>Donk! - The Samurai Duck! (Euro)</description>
@@ -12516,6 +13175,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="doodlebg" supported="no">
 		<!-- SPS (CAPS) release 1862 -->
 		<description>Doodle Bug - Bug-Bash 2 (Euro)</description>
@@ -12530,6 +13190,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="doofus" supported="no">
 		<!-- SPS (CAPS) release 648 -->
 		<description>Doofus (Euro)</description>
@@ -12545,6 +13206,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ddragon" supported="yes">
 		<!-- SPS (CAPS) release 2438 -->
 		<description>Double Dragon (Euro, v2.16)</description>
@@ -12559,6 +13221,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ddragona" cloneof="ddragon" supported="no">
 		<!-- SPS (CAPS) release 320 -->
 		<description>Double Dragon (Euro)</description>
@@ -12575,6 +13238,7 @@ license:CC0
 
 	<!-- Guru Meditation [FDC] -->
 	<!-- (Checks data once with adkcon=0x3db0) -->
+	<!-- ATK test: failed -->
 	<software name="ddragon2" supported="no">
 		<!-- SPS (CAPS) release 768 -->
 		<description>Double Dragon II (Euro, v4.01ECS)</description>
@@ -12590,6 +13254,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ddragon2a" cloneof="ddragon2" supported="no">
 		<!-- SPS (CAPS) release 1680 -->
 		<description>Double Dragon II (Euro, v3.84)</description>
@@ -12605,6 +13270,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ddragon2u" cloneof="ddragon2" supported="no">
 		<!-- SPS (CAPS) release 2635 -->
 		<description>Double Dragon II (USA, v4.16ECS)</description>
@@ -12621,6 +13287,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ddragon3" supported="no">
 		<!-- SPS (CAPS) release 321 -->
 		<description>Double Dragon 3 - The Rosetta Stone (Euro)</description>
@@ -12642,6 +13309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="downtrol" supported="no">
 		<!-- SPS (CAPS) release 3009 -->
 		<description>Down at the Trolls (Euro)</description>
@@ -12663,6 +13331,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="doomrev" supported="no">
 		<!-- SPS (CAPS) release 2501 -->
 		<description>Dr. Doom's Revenge! (Euro)</description>
@@ -12677,6 +13346,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="doomrevu" cloneof="doomrev" supported="no">
 		<!-- SPS (CAPS) release 1496 -->
 		<description>Dr. Doom's Revenge! (USA)</description>
@@ -12698,6 +13368,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drplumm" supported="no">
 		<!-- SPS (CAPS) release 2132 -->
 		<description>Dr. Plummet's House of Flux (Euro)</description>
@@ -12712,6 +13383,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dbreed" supported="no">
 		<!-- SPS (CAPS) release 441 -->
 		<description>Dragon Breed (Euro)</description>
@@ -12726,7 +13398,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Throws "system status abnormal" and refuses to boot, [FDC] dsksync bootblock -->
+	<!-- a500p: Throws "system status abnormal" with "FUCK" error code and refuses to boot, supposed to run on ECS? -->
+	<!-- ATK test: OK -->
 	<software name="drgnfght" supported="no">
 		<!-- SPS (CAPS) release 1023 -->
 		<description>Dragon Fighter (Euro)</description>
@@ -12734,6 +13407,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Idea</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049180">
@@ -12748,6 +13423,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dflight" supported="no">
 		<!-- SPS (CAPS) release 2098 -->
 		<description>Dragonflight (Euro)</description>
@@ -12769,6 +13445,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dflightf" cloneof="dflight" supported="no">
 		<!-- SPS (CAPS) release 2755 -->
 		<description>Dragonflight (Fra)</description>
@@ -12790,6 +13467,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dflightg" cloneof="dflight" supported="no">
 		<!-- SPS (CAPS) release 58 -->
 		<description>Dragonflight (Ger)</description>
@@ -12811,6 +13489,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dflightg1" cloneof="dflight" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 58 -->
@@ -12833,6 +13512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="drgnbret" supported="no">
 		<!-- SPS (CAPS) release 72 -->
 		<description>Dragons Breath (Euro)</description>
@@ -12854,6 +13534,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="drgnbretf" cloneof="drgnbret" supported="no">
 		<!-- SPS (CAPS) release 2388 -->
 		<description>Dragons Breath (Fra, Magic Worlds)</description>
@@ -12875,6 +13556,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="drgnbretg" cloneof="drgnbret" supported="no">
 		<!-- SPS (CAPS) release 821 -->
 		<description>Dragons Breath (Ger)</description>
@@ -12896,6 +13578,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drgnbretga" cloneof="drgnbret" supported="no">
 		<!-- SPS (CAPS) release 1272 -->
 		<description>Dragons Breath (Ger, Alt)</description>
@@ -12919,6 +13602,7 @@ license:CC0
 
 	<!-- boot OK, starting a level has background with GFX pitch issue, repeating sample on every correct move -->
 	<!-- Update: hangs when loading a game, regression? -->
+	<!-- ATK test: OK -->
 	<software name="dlairsc" supported="partial">
 		<!-- SPS (CAPS) release 980 -->
 		<description>Dragon's Lair: Escape from Singe's Castle (Euro)</description>
@@ -12959,6 +13643,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dlairsc1" cloneof="dlairsc" supported="no">
 		<!-- SPS (CAPS) release 2495 -->
 		<description>Dragon's Lair: Escape from Singe's Castle (Euro, Alt)</description>
@@ -13001,6 +13686,7 @@ license:CC0
 	<!-- Hangs at VDT logo [FDC] dsksync -->
 	<!-- (Checks specific value in the loaded buffer, offset by 2) -->
 	<!-- Hangs at "Randy Linden production", tries to check [FDC] with dsksync == 0 -->
+	<!-- ATK test: failed -->
 	<software name="dlair" supported="no">
 		<!-- SPS (CAPS) release 1360 -->
 		<description>Dragon's Lair (Euro)</description>
@@ -13048,6 +13734,7 @@ license:CC0
 
 	<!-- locks up at ReadySoft logo [FDC] dsksync -->
 	<!-- In-game it enables [FDC] dsklen == 0 -->
+	<!-- ATK test: failed -->
 	<software name="dlair2" supported="no">
 		<!-- SPS (CAPS) release 59 -->
 		<description>Dragon's Lair II - Time Warp (Euro)</description>
@@ -13096,6 +13783,7 @@ license:CC0
 	<!-- black screen [FDC] dsksync -->
 	<!-- In-game it enables [FDC] dsklen == 0 -->
 	<!-- (same as dlair2) -->
+	<!-- ATK test: failed -->
 	<software name="dlair3" supported="no">
 		<!-- SPS (CAPS) release 649 -->
 		<description>Dragon's Lair III: The Curse of Mordread (Euro)</description>
@@ -13147,6 +13835,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dflame" supported="no">
 		<!-- SPS (CAPS) release 985 -->
 		<description>Dragons of Flame (Euro, v1.0)</description>
@@ -13161,6 +13850,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dspirit" supported="no">
 		<!-- SPS (CAPS) release 1545 -->
 		<description>Dragon Spirit (Euro)</description>
@@ -13175,6 +13865,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="drgstone" supported="no">
 		<!-- SPS (CAPS) release 471 -->
 		<description>Dragonstone (Euro)</description>
@@ -13208,6 +13899,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drgstrik" supported="no">
 		<!-- SPS (CAPS) release 1479 -->
 		<description>DragonStrike (USA, v1.0)</description>
@@ -13229,6 +13921,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dragwars" supported="no">
 		<!-- SPS (CAPS) release 3098 -->
 		<description>Dragon Wars (Euro, v1.2)</description>
@@ -13250,6 +13943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="drakkhen" supported="no">
 		<!-- SPS (CAPS) release 769 -->
 		<description>Drakkhen (Euro, v1.1)</description>
@@ -13271,6 +13965,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="drakkhenu" cloneof="drakkhen" supported="no">
 		<!-- SPS (CAPS) release 1843 -->
 		<description>Drakkhen (USA, v1.1)</description>
@@ -13292,6 +13987,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="drakkhenf" cloneof="drakkhen" supported="no">
 		<!-- SPS (CAPS) release 2558 -->
 		<description>Drakkhen (Fra)</description>
@@ -13313,6 +14009,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="drakkheng" cloneof="drakkhen" supported="no">
 		<!-- SPS (CAPS) release 458 -->
 		<description>Drakkhen (Ger)</description>
@@ -13334,6 +14031,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dreadnog" supported="no">
 		<!-- SPS (CAPS) release 861 -->
 		<description>Dreadnoughts (Euro, v1.11)</description>
@@ -13348,6 +14046,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dreamweb" supported="no">
 		<!-- SPS (CAPS) release 1660 -->
 		<description>DreamWeb (Euro)</description>
@@ -13381,6 +14080,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dreamwebg" cloneof="dreamweb" supported="no">
 		<!-- SPS (CAPS) release 1593 -->
 		<description>DreamWeb (Ger)</description>
@@ -13414,6 +14114,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="driltote" supported="no">
 		<!-- SPS (CAPS) release 2255 -->
 		<description>Driller &amp; Total Eclipse (Euro, Virtual Worlds)</description>
@@ -13428,6 +14129,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="driller" supported="no">
 		<!-- SPS (CAPS) release 2498 -->
 		<description>Driller (Euro, v1.0)</description>
@@ -13442,6 +14144,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="driller1" cloneof="driller" supported="no">
 		<!-- SPS (CAPS) release 2256 -->
 		<description>Driller (Euro, Budget)</description>
@@ -13456,6 +14159,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="drivfrce" supported="no">
 		<!-- SPS (CAPS) release 1504 -->
 		<description>Drivin' Force (Euro)</description>
@@ -13470,6 +14174,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="drivfrcea" cloneof="drivfrce" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 1504 -->
@@ -13485,6 +14190,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="drivfrceb" cloneof="drivfrce" supported="no">
 		<!-- SPS (CAPS) release 1521 -->
 		<description>Drivin' Force (Euro, Budget)</description>
@@ -13499,6 +14205,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="drolecol" supported="no">
 		<!-- SPS (CAPS) release 2443 -->
 		<description>Drôle d'École (5 - 7 Ans) (Fra)</description>
@@ -13521,6 +14228,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, randomly crashes -->
+	<!-- ATK test: OK -->
 	<software name="ducktale" supported="no">
 		<!-- SPS (CAPS) release 299 -->
 		<description>Duck Tales - "The Quest for Gold" (Euro, v1.0)</description>
@@ -13543,6 +14251,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ducktalea" cloneof="ducktale" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 299 -->
@@ -13565,6 +14274,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="dugger" supported="no">
 		<!-- SPS (CAPS) release 322 -->
 		<description>Dugger (Euro)</description>
@@ -13579,6 +14289,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dune" supported="no">
 		<!-- SPS (CAPS) release 1156 -->
 		<description>Dune (Euro)</description>
@@ -13606,6 +14317,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dunef" cloneof="dune" supported="no">
 		<!-- SPS (CAPS) release 2393 -->
 		<description>Dune (Fra)</description>
@@ -13633,6 +14345,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="duneg" cloneof="dune" supported="no">
 		<!-- SPS (CAPS) release 459 -->
 		<description>Dune (Ger)</description>
@@ -13660,6 +14373,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dunei" cloneof="dune" supported="no">
 		<!-- SPS (CAPS) release 2594 -->
 		<description>Dune (Ita)</description>
@@ -13687,6 +14401,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dune2" supported="no">
 		<!-- SPS (CAPS) release 1548 -->
 		<description>Dune II - The Battle for Arrakis (Euro)</description>
@@ -13727,6 +14442,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="dngmster" supported="partial">
 		<!-- SPS (CAPS) release 833 -->
 		<description>Dungeon Master (Euro, v3.6)</description>
@@ -13741,6 +14457,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dngmstr2" supported="no">
 		<!-- SPS (CAPS) release 899 -->
 		<description>Dungeon Master II (Euro, v1.0, sold as A1200 game)</description>
@@ -13786,6 +14503,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dungqst" supported="no">
 		<!-- SPS (CAPS) release 663 -->
 		<description>Dungeon Quest (Euro)</description>
@@ -13807,6 +14525,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dungeons" supported="no">
 		<!-- SPS (CAPS) release 2963 -->
 		<description>Dungeons, Amethysts, Alchemists 'n' Everythin' (Euro, D.A.A.)</description>
@@ -13821,6 +14540,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="avalon" supported="no">
 		<!-- SPS (CAPS) release 1956 -->
 		<description>Dungeons of Avalon (Euro, v1.0)</description>
@@ -13835,6 +14555,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="avalon2" supported="no">
 		<!-- SPS (CAPS) release 1957 -->
 		<description>Dungeons of Avalon II - The Island of Darkness (Euro)</description>
@@ -13850,6 +14571,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="dylandg2" supported="partial">
 		<!-- SPS (CAPS) release 2695 -->
 		<description>Dylan Dog - Ritorno al Crepuscolo (Ita)</description>
@@ -13865,6 +14587,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dylandg3" supported="no">
 		<!-- SPS (CAPS) release 2696 -->
 		<description>Dylan Dog - Storia di Nessuno (Ita)</description>
@@ -13879,6 +14602,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dylandg4" supported="no">
 		<!-- SPS (CAPS) release 2697 -->
 		<description>Dylan Dog - Ombre (Ita)</description>
@@ -13893,6 +14617,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dylandg5" supported="no">
 		<!-- SPS (CAPS) release 2698 -->
 		<description>Dylan Dog - La Mummia (Ita)</description>
@@ -13907,6 +14632,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dylandg6" supported="no">
 		<!-- SPS (CAPS) release 2699 -->
 		<description>Dylan Dog - Maelstrom (Ita)</description>
@@ -13921,6 +14647,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dynablst" supported="no">
 		<!-- SPS (CAPS) release 664 -->
 		<description>Dyna Blaster (Euro)</description>
@@ -13935,6 +14662,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ddux" supported="no">
 		<!-- SPS (CAPS) release 1183 -->
 		<description>Dynamite Dux (Euro)</description>
@@ -13949,6 +14677,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dduxa" cloneof="ddux" supported="no">
 		<!-- SPS (CAPS) release 1719 -->
 		<description>Dynamite Dux (Euro, Sega Master Mix)</description>
@@ -13963,6 +14692,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="dynawars" supported="no">
 		<!-- SPS (CAPS) release 862 -->
 		<description>Dynasty Wars (Euro)</description>
@@ -13977,6 +14707,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dynatech" supported="no">
 		<!-- SPS (CAPS) release 3099 -->
 		<description>Dynatech (Ger, v1.6plus)</description>
@@ -13991,6 +14722,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dyter07" supported="no">
 		<!-- SPS (CAPS) release 678 -->
 		<description>Dyter-07 (Euro)</description>
@@ -14005,6 +14737,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="emotion" supported="no">
 		<!-- SPS (CAPS) release 475 -->
 		<description>E-Motion (Euro)</description>
@@ -14019,6 +14752,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ess" supported="no">
 		<!-- SPS (CAPS) release 1375 -->
 		<description>E.S.S. (Euro)</description>
@@ -14034,6 +14768,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eaglerid" supported="no">
 		<!-- SPS (CAPS) release 2769 -->
 		<description>Eagle's Rider (Euro)</description>
@@ -14055,6 +14790,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="ewbball" supported="no">
 		<!-- SPS (CAPS) release 323 -->
 		<description>Earl Weaver Baseball (Euro)</description>
@@ -14069,6 +14805,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eastwest" supported="no">
 		<!-- SPS (CAPS) release 2241 -->
 		<description>East vs. West Berlin 1948 (Euro)</description>
@@ -14090,6 +14827,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ebonstar" supported="no">
 		<!-- SPS (CAPS) release 915 -->
 		<description>Ebonstar (USA)</description>
@@ -14104,6 +14842,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ecophant" supported="no">
 		<!-- SPS (CAPS) release 2471 -->
 		<description>Eco Phantoms (Euro)</description>
@@ -14125,6 +14864,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eco" supported="no">
 		<!-- SPS (CAPS) release 1139 -->
 		<description>ECO (Euro)</description>
@@ -14139,6 +14879,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="edd" supported="no">
 		<!-- SPS (CAPS) release 650 -->
 		<description>Edd the Duck! (Euro)</description>
@@ -14153,6 +14894,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eishmang" supported="no">
 		<!-- SPS (CAPS) release 2062 -->
 		<description>Eishockey Manager (Ger, v1.00)</description>
@@ -14167,6 +14909,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eishmlim" supported="no">
 		<!-- SPS (CAPS) release 472 -->
 		<description>Eishockey Manager Limited Edition (Ger, v1.02)</description>
@@ -14181,6 +14924,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="elfoc" supported="no">
 		<!-- SPS (CAPS) release 473 -->
 		<description>Elf (Euro, Ocean)</description>
@@ -14202,6 +14946,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="elfmv" supported="no">
 		<!-- SPS (CAPS) release 863 -->
 		<description>Elf (Euro, MicroValue)</description>
@@ -14216,6 +14961,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="elfmania" supported="no">
 		<!-- SPS (CAPS) release 114 -->
 		<description>Elfmania (Euro)</description>
@@ -14237,6 +14983,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="eliminat" supported="no">
 		<!-- SPS (CAPS) release 770 -->
 		<description>Eliminator (Euro)</description>
@@ -14251,6 +14998,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="elite" supported="no">
 		<!-- SPS (CAPS) release 811 -->
 		<description>Elite (Euro, v2.0)</description>
@@ -14265,6 +15013,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="elitea" cloneof="elite" supported="no">
 		<!-- SPS (CAPS) release 1572 -->
 		<description>Elite (Euro, v2.0, Space Legends)</description>
@@ -14279,6 +15028,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="eliteb" cloneof="elite" supported="no">
 		<!-- SPS (CAPS) release 115 -->
 		<description>Elite (Euro)</description>
@@ -14296,6 +15046,7 @@ license:CC0
 	<!-- boot OK -->
 	<!-- sports garbage pitch on intro with a500p, works with a500 only -->
 	<!-- Loading doesn't work on a1200 machine -->
+	<!-- ATK test: OK -->
 	<software name="elvira" supported="partial">
 		<!-- SPS (CAPS) release 267 -->
 		<description>Elvira - Mistress of the Dark (Euro)</description>
@@ -14335,6 +15086,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="elviraf" cloneof="elvira" supported="no">
 		<!-- SPS (CAPS) release 1751 -->
 		<description>Elvira - Mistress of the Dark (Fra)</description>
@@ -14374,6 +15126,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="elvirag" cloneof="elvira" supported="no">
 		<!-- SPS (CAPS) release 474 -->
 		<description>Elvira - Mistress of the Dark (Ger)</description>
@@ -14413,6 +15166,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="elvira2" supported="no">
 		<!-- SPS (CAPS) release 2242 -->
 		<description>Elvira II - The Jaws of Cerberus (Euro)</description>
@@ -14464,6 +15218,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="elvira2f" cloneof="elvira2" supported="no">
 		<!-- SPS (CAPS) release 2663 -->
 		<description>Elvira II - The Jaws of Cerberus (Fra)</description>
@@ -14515,6 +15270,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="elvira2g" cloneof="elvira2" supported="no">
 		<!-- SPS (CAPS) release 2880 -->
 		<description>Elvira II - The Jaws of Cerberus (Ger)</description>
@@ -14566,6 +15322,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="embryo" supported="no">
 		<!-- SPS (CAPS) release 2265 -->
 		<description>Embryo (Euro)</description>
@@ -14605,6 +15362,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="emine" supported="no">
 		<!-- SPS (CAPS) release 1525 -->
 		<description>Emerald Mine (Euro)</description>
@@ -14619,6 +15377,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="emine2" supported="no">
 		<!-- SPS (CAPS) release 1520 -->
 		<description>Emerald Mine II (Euro)</description>
@@ -14633,6 +15392,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="emine3p" supported="no">
 		<!-- SPS (CAPS) release 2185 -->
 		<description>Emerald Mine 3 Professional (Euro)</description>
@@ -14650,6 +15410,7 @@ license:CC0
 	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] dsksync -->
 	<!-- Menu draws a pointer garbage when it's at the bottom of the screen -->
 	<!-- TODO: Understand how to change cpu controlled teams to human -->
+	<!-- ATK test: failed -->
 	<software name="hughesis" supported="no">
 		<!-- SPS (CAPS) release 1077 -->
 		<description>Emlyn Hughes International Soccer (Euro)</description>
@@ -14664,6 +15425,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="emmanuel" supported="no">
 		<!-- SPS (CAPS) release 2693 -->
 		<description>Emmanuelle (Fra)</description>
@@ -14680,6 +15442,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="emmanuelg" cloneof="emmanuel" supported="no">
 		<!-- SPS (CAPS) release 324 -->
 		<description>Emmanuelle (Ger)</description>
@@ -14694,6 +15457,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="empireso" supported="no">
 		<!-- SPS (CAPS) release 844 -->
 		<description>Empire Soccer 94 (Euro)</description>
@@ -14708,6 +15472,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="enchantd" supported="no">
 		<!-- SPS (CAPS) release 3063 -->
 		<description>Enchanted Land (Euro)</description>
@@ -14722,6 +15487,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ancbattl" supported="no">
 		<!-- SPS (CAPS) release 2552 -->
 		<description>Encyclopedia of War - Ancient Battles (Euro)</description>
@@ -14736,6 +15502,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="energie" supported="no">
 		<!-- SPS (CAPS) release 1594 -->
 		<description>Energie-Manager (Ger)</description>
@@ -14750,6 +15517,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="engchamp" supported="no">
 		<!-- SPS (CAPS) release 1671 -->
 		<description>England Championship Special (Euro)</description>
@@ -14764,6 +15532,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="enlighte" supported="no">
 		<!-- SPS (CAPS) release 1948 -->
 		<description>Enlightenment (Euro)</description>
@@ -14779,6 +15548,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="entity" supported="no">
 		<!-- SPS (CAPS) release 1735 -->
 		<description>Entity (Euro)</description>
@@ -14812,6 +15582,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="epic" supported="no">
 		<!-- SPS (CAPS) release 1819 -->
 		<description>Epic (Euro)</description>
@@ -14839,6 +15610,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="erbe" supported="no">
 		<!-- SPS (CAPS) release 1890 -->
 		<description>Das Erbe (Ger)</description>
@@ -14854,6 +15626,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: failed -->
 	<software name="colditz" supported="partial">
 		<!-- SPS (CAPS) release 214 -->
 		<description>Escape from Colditz (Euro)</description>
@@ -14868,6 +15641,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="eprom" supported="no">
 		<!-- SPS (CAPS) release 477 -->
 		<description>Escape from the Planet of the Robot Monsters (Euro)</description>
@@ -14882,6 +15656,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eskgames" supported="no">
 		<!-- SPS (CAPS) release 232 -->
 		<description>Eskimo Games (Euro)</description>
@@ -14896,6 +15671,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="espana92" supported="no">
 		<!-- SPS (CAPS) release 1327 -->
 		<description>España - The Games '92 (Euro)</description>
@@ -14945,6 +15721,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="eswat" supported="no">
 		<!-- SPS (CAPS) release 2577 -->
 		<description>ESWAT (Euro, Super Sega)</description>
@@ -14966,6 +15743,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eurochmp" supported="no">
 		<!-- SPS (CAPS) release 2569 -->
 		<description>European Champions (Euro)</description>
@@ -14987,6 +15765,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="euroch92" supported="no">
 		<!-- SPS (CAPS) release 478 -->
 		<description>European Championship 1992 (Euro)</description>
@@ -15008,6 +15787,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="eurofbc" supported="no">
 		<!-- SPS (CAPS) release 1672 -->
 		<description>European Football Champ (Euro)</description>
@@ -15022,6 +15802,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="euroschl" supported="no">
 		<!-- SPS (CAPS) release 2906 -->
 		<description>European Soccer Challenge (Euro)</description>
@@ -15036,6 +15817,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eurosupl" supported="no">
 		<!-- SPS (CAPS) release 868 -->
 		<description>European Superleague (Euro)</description>
@@ -15050,6 +15832,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="euro88" supported="no">
 		<!-- SPS (CAPS) release 679 -->
 		<description>Euro Soccer '88 (Ger)</description>
@@ -15064,6 +15847,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="eurosocc" supported="no">
 		<!-- SPS (CAPS) release 2905 -->
 		<description>Euro Soccer (Euro)</description>
@@ -15085,6 +15869,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="evilgard" supported="no">
 		<!-- SPS (CAPS) release 2847 -->
 		<description>Evil Garden (Euro)</description>
@@ -15099,6 +15884,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="excalibr" supported="no">
 		<!-- SPS (CAPS) release 2688 -->
 		<description>Excalibur (Euro)</description>
@@ -15113,6 +15899,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="excgames" supported="no">
 		<!-- SPS (CAPS) release 1646 -->
 		<description>Excellent Card Games (Euro)</description>
@@ -15129,6 +15916,7 @@ license:CC0
 
 	<!-- Keeps loading on a green-black screen fade transition [FDC] dsksync -->
 	<!-- Gameplay GFXs are pitch skewed -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="exile" supported="no">
 		<!-- SPS (CAPS) release 32 -->
 		<description>Exile (Euro)</description>
@@ -15143,6 +15931,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="exodus" supported="no">
 		<!-- SPS (CAPS) release 1605 -->
 		<description>Exodus 3010 (Ger)</description>
@@ -15164,6 +15953,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="exolon" supported="no">
 		<!-- SPS (CAPS) release 15 -->
 		<description>Exolon (Euro)</description>
@@ -15178,6 +15968,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="exolona" cloneof="exolon" supported="no">
 		<!-- SPS (CAPS) release 2038 -->
 		<description>Exolon (Euro, Budget)</description>
@@ -15192,6 +15983,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="explora2" supported="no">
 		<!-- SPS (CAPS) release 2662 -->
 		<description>Explora II (Fra)</description>
@@ -15225,6 +16017,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="explora3" supported="no">
 		<!-- SPS (CAPS) release 2676 -->
 		<description>Explora III - Sous le signe du Serpent (Fra)</description>
@@ -15252,6 +16045,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="extase" supported="no">
 		<!-- SPS (CAPS) release 2421 -->
 		<description>Extase (Euro)</description>
@@ -15266,6 +16060,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="extermin" supported="no">
 		<!-- SPS (CAPS) release 1958 -->
 		<description>Exterminator (Euro)</description>
@@ -15280,6 +16075,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="eyehorus" supported="no">
 		<!-- SPS (CAPS) release 1746 -->
 		<description>Eye of Horus (Euro)</description>
@@ -15294,6 +16090,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eyehorusa" cloneof="eyehorus" supported="no">
 		<!-- SPS (CAPS) release 1747 -->
 		<description>Eye of Horus (Euro, Budget, ADOS)</description>
@@ -15308,6 +16105,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eyebehol" supported="no">
 		<!-- SPS (CAPS) release 116 -->
 		<description>Eye of the Beholder (Euro)</description>
@@ -15335,6 +16133,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eyebeholg" cloneof="eyebehol" supported="no">
 		<!-- SPS (CAPS) release 680 -->
 		<description>Eye of the Beholder (Ger)</description>
@@ -15362,6 +16161,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eyebeho2" supported="no">
 		<!-- SPS (CAPS) release 834 -->
 		<description>Eye of the Beholder II - The Legend of Darkmoon (Euro)</description>
@@ -15395,6 +16195,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="eyebeho2g" cloneof="eyebeho2" supported="no">
 		<!-- SPS (CAPS) release 681 -->
 		<description>Eye of the Beholder II - Legende von Darkmoon (Ger)</description>
@@ -15428,6 +16229,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="f15se2" supported="no">
 		<!-- SPS (CAPS) release 479 -->
 		<description>F-15 Strike Eagle II (Euro)</description>
@@ -15449,6 +16251,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="f16comb" supported="no">
 		<!-- SPS (CAPS) release 1024 -->
 		<description>F-16 Combat Pilot (Euro)</description>
@@ -15463,6 +16266,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="f19sf" supported="no">
 		<!-- SPS (CAPS) release 117 -->
 		<description>F-19 Stealth Fighter (Euro, v1.00)</description>
@@ -15484,6 +16288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="f19sfa" cloneof="f19sf" supported="no">
 		<!-- SPS (CAPS) release 2813 -->
 		<description>F-19 Stealth Fighter (Euro, v1.00, Combat Classics 2)</description>
@@ -15498,6 +16303,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="f19sfu" cloneof="f19sf" supported="no">
 		<!-- SPS (CAPS) release 1494 -->
 		<description>F-19 Stealth Fighter (USA, v1.00)</description>
@@ -15525,6 +16331,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="f29ret" supported="no">
 		<!-- SPS (CAPS) release 22 -->
 		<description>F-29 Retaliator (Euro)</description>
@@ -15546,6 +16353,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="f17chal" supported="no">
 		<!-- SPS (CAPS) release 1703 -->
 		<description>F17 Challenge (Euro)</description>
@@ -15568,6 +16376,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="f1gpcirc" supported="partial">
 		<!-- SPS (CAPS) release 118 -->
 		<description>F1 GP Circuits (Euro)</description>
@@ -15582,6 +16391,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="f1" supported="no">
 		<!-- SPS (CAPS) release 2422 -->
 		<description>F1 (Euro)</description>
@@ -15596,6 +16406,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fa18" supported="no">
 		<!-- SPS (CAPS) release 119 -->
 		<description>FA18 Interceptor (Euro)</description>
@@ -15610,6 +16421,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="faceoff" supported="no">
 		<!-- SPS (CAPS) release 1670 -->
 		<description>Face-Off (Euro)</description>
@@ -15625,6 +16437,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="faceoff1" cloneof="faceoff" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 1670 -->
@@ -15641,6 +16454,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="faceoffa" supported="no">
 		<!-- SPS (CAPS) release 2483 -->
 		<description>Face Off (Euro, Budget)</description>
@@ -15656,6 +16470,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="faerytal" supported="no">
 		<!-- SPS (CAPS) release 367 -->
 		<description>The Faery Tale Adventure (Euro)</description>
@@ -15670,6 +16485,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="falcon" supported="no">
 		<!-- SPS (CAPS) release 1754 -->
 		<description>Falcon (Euro, v1.1)</description>
@@ -15691,6 +16507,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="falcon1" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 368 -->
 		<description>Falcon (Euro, v1.00)</description>
@@ -15712,6 +16529,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="falconu" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 1197 -->
 		<description>Falcon (USA, v1.1)</description>
@@ -15733,6 +16551,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="falconu1" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 1271 -->
 		<description>Falcon (USA, v1.00)</description>
@@ -15754,6 +16573,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="falconmd1" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 268 -->
 		<description>Falcon - Operation: Counterstrike - Mission Disk (Euro)</description>
@@ -15769,6 +16589,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="falconmd1u" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 1205 -->
 		<description>Falcon - Operation: Counterstrike - Mission Disk (USA)</description>
@@ -15784,6 +16605,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="falconmd2" cloneof="falcon" supported="no">
 		<!-- SPS (CAPS) release 269 -->
 		<description>Falcon - Operation: Firefight - Mission Disk II (Euro)</description>
@@ -15799,6 +16621,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fantdizz" supported="no">
 		<!-- SPS (CAPS) release 1904 -->
 		<description>Fantastic Dizzy (Euro)</description>
@@ -15820,6 +16643,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fantmang" supported="no">
 		<!-- SPS (CAPS) release 1328 -->
 		<description>Fantasy Manager - The Computer Game (Euro, v1.1)</description>
@@ -15841,6 +16665,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fwdizzy" supported="no">
 		<!-- SPS (CAPS) release 120 -->
 		<description>Fantasy World Dizzy (Euro)</description>
@@ -15855,6 +16680,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fascinat" supported="no">
 		<!-- SPS (CAPS) release 2485 -->
 		<description>Fascination (Fra, Kings of Adventures 1)</description>
@@ -15876,6 +16702,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="fastbrk" supported="no">
 		<!-- SPS (CAPS) release 652 -->
 		<description>Fast Break (Euro)</description>
@@ -15890,6 +16717,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fastfood" supported="no">
 		<!-- SPS (CAPS) release 1947 -->
 		<description>Fast Food (Euro)</description>
@@ -15904,6 +16732,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fatalher" supported="no">
 		<!-- SPS (CAPS) release 52 -->
 		<description>Fatal Heritage (Ger)</description>
@@ -15931,6 +16760,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fate" supported="no">
 		<!-- SPS (CAPS) release 2842 -->
 		<description>Fate - Gates of Dawn (Euro, v1.6)</description>
@@ -15952,6 +16782,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fateg" cloneof="fate" supported="no">
 		<!-- SPS (CAPS) release 544 -->
 		<description>Fate - Gates of Dawn (Ger, v1.7)</description>
@@ -15973,6 +16804,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fateg1" cloneof="fate" supported="no">
 		<!-- SPS (CAPS) release 1261 -->
 		<description>Fate - Gates of Dawn (Ger, v1.4)</description>
@@ -15994,6 +16826,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="foft" supported="no">
 		<!-- SPS (CAPS) release 613 -->
 		<description>FOFT - Federation of Free Traders (Euro)</description>
@@ -16008,6 +16841,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="federatn" cloneof="foft" supported="no">
 		<!-- SPS (CAPS) release 1456 -->
 		<description>Federation (USA)</description>
@@ -16022,6 +16856,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="fedqst1" supported="no">
 		<!-- SPS (CAPS) release 177 -->
 		<description>Federation Quest 1 - B.S.S. Jane Seymour (Euro)</description>
@@ -16043,6 +16878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacewrk" cloneof="fedqst1" supported="no">
 		<!-- SPS (CAPS) release 2017 -->
 		<description>Spacewrecked (USA)</description>
@@ -16071,6 +16907,7 @@ license:CC0
 	</software>
 
 	<!-- Prompts to a CLI 2 (implicitly failing a copy protection?) -->
+	<!-- ATK test: OK -->
 	<software name="fernandz" supported="no">
 		<!-- SPS (CAPS) release 1980 -->
 		<description>Fernandez Must Die (Euro)</description>
@@ -16085,6 +16922,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ferrari" supported="no">
 		<!-- SPS (CAPS) release 481 -->
 		<description>Ferrari Formula One (Euro)</description>
@@ -16100,6 +16938,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="feud" supported="no">
 		<!-- SPS (CAPS) release 762 -->
 		<description>Feud (Euro)</description>
@@ -16114,6 +16953,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fieldglr" supported="no">
 		<!-- SPS (CAPS) release 2286 -->
 		<description>Fields of Glory (Euro)</description>
@@ -16135,6 +16975,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fiendfrd" supported="no">
 		<!-- SPS (CAPS) release 500 -->
 		<description>Fiendish Freddy's Big Top o' Fun (Euro)</description>
@@ -16162,6 +17003,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fifa" supported="no">
 		<!-- SPS (CAPS) release 501 -->
 		<description>FIFA International Soccer (Euro)</description>
@@ -16189,6 +17031,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fightbmb" supported="no">
 		<!-- SPS (CAPS) release 1134 -->
 		<description>Fighter Bomber (Euro)</description>
@@ -16210,6 +17053,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fightbmba" cloneof="fightbmb" supported="no">
 		<!-- SPS (CAPS) release 1135 -->
 		<description>Fighter Bomber (Euro, Power Hits)</description>
@@ -16231,6 +17075,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fduelpro" supported="no">
 		<!-- SPS (CAPS) release 946 -->
 		<description>Fighter Duel Pro (USA, v1.0 19920925)</description>
@@ -16261,6 +17106,7 @@ license:CC0
 	<!-- Cut off title GFX -->
 	<!-- Status bar on the right is offset, cuts off timer (raster effect?) -->
 	<!-- Doesn't recognize double click presses (cfr. attract mode instructions) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fsoccer" supported="no">
 		<!-- SPS (CAPS) release 1532 -->
 		<description>Fighting Soccer (Euro)</description>
@@ -16277,6 +17123,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="finalb" supported="no">
 		<!-- SPS (CAPS) release 2457 -->
 		<description>Final Blow (Euro)</description>
@@ -16291,6 +17138,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="finalcom" supported="no">
 		<!-- SPS (CAPS) release 1964 -->
 		<description>Final Command (Euro)</description>
@@ -16305,6 +17153,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="finalcomf" cloneof="finalcom" supported="no">
 		<!-- SPS (CAPS) release 2668 -->
 		<description>Final Command (Fra)</description>
@@ -16320,6 +17169,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK but bad colors for sprites and layers -->
+	<!-- ATK test: H:U 1 Sector Bad, C:0 H:L 1 Sector Bad -->
 	<software name="ffight" supported="no">
 		<!-- SPS (CAPS) release 1329 -->
 		<description>Final Fight (Euro, Super Fighter)</description>
@@ -16341,6 +17191,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:78 H:L Bad, C:79 Bad -->
 	<software name="finalmis" supported="no">
 		<!-- SPS (CAPS) release 2024 -->
 		<description>The Final Mission (Euro)</description>
@@ -16356,6 +17207,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fmisscry" supported="no">
 		<!-- SPS (CAPS) release 2046 -->
 		<description>Final Mission &amp; Crystal Hammer (Euro, Amiga Star Collection)</description>
@@ -16370,6 +17222,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="firebrig" supported="no">
 		<!-- SPS (CAPS) release 2703 -->
 		<description>Fire-Brigade (Euro)</description>
@@ -16385,6 +17238,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="firebrim" supported="no">
 		<!-- SPS (CAPS) release 3012 -->
 		<description>Fire and Brimstone (Euro)</description>
@@ -16399,6 +17253,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fireforg" supported="no">
 		<!-- SPS (CAPS) release 924 -->
 		<description>Fire and Forget (Euro)</description>
@@ -16413,6 +17268,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:78 H:U 1 Sector Bad -->
 	<software name="firefor2" supported="no">
 		<!-- SPS (CAPS) release 482 -->
 		<description>Fire and Forget II - The Death Convoy (Euro)</description>
@@ -16427,6 +17283,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="firenice" supported="no">
 		<!-- SPS (CAPS) release 502 -->
 		<description>Fire and Ice (Euro)</description>
@@ -16449,6 +17306,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fireball" supported="no">
 		<!-- SPS (CAPS) release 1590 -->
 		<description>Fireball &amp; Balls &amp; Space Bomber 3 (Ger)</description>
@@ -16463,6 +17321,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="firefrce" supported="no">
 		<!-- SPS (CAPS) release 233 -->
 		<description>Fire Force (Euro)</description>
@@ -16484,6 +17343,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fireblst" supported="no">
 		<!-- SPS (CAPS) release 1627 -->
 		<description>Fireblaster (Euro)</description>
@@ -16498,6 +17358,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="firehawk" supported="no">
 		<!-- SPS (CAPS) release 2624 -->
 		<description>Firehawk (Euro, v2)</description>
@@ -16512,6 +17373,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="firepowr" supported="no">
 		<!-- SPS (CAPS) release 61 -->
 		<description>Firepower (Euro)</description>
@@ -16526,6 +17388,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="firezone" supported="no">
 		<!-- SPS (CAPS) release 1478 -->
 		<description>FireZone (USA)</description>
@@ -16540,6 +17403,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="firstcon" supported="no">
 		<!-- SPS (CAPS) release 923 -->
 		<description>First Contact (Euro)</description>
@@ -16554,6 +17418,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="1ppinb" supported="no">
 		<!-- SPS (CAPS) release 418 -->
 		<description>First Person Pinball (Euro)</description>
@@ -16568,6 +17433,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="firstsam" supported="no">
 		<!-- SPS (CAPS) release 1182 -->
 		<description>First Samurai (Euro)</description>
@@ -16589,6 +17455,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fish" supported="no">
 		<!-- SPS (CAPS) release 484 -->
 		<description>Fish! (Euro, v1.03)</description>
@@ -16603,6 +17470,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flashb" supported="no">
 		<!-- SPS (CAPS) release 1163 -->
 		<description>Flashback (Euro, v1.0 19930422)</description>
@@ -16636,6 +17504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flashb1" cloneof="flashb" supported="no">
 		<!-- SPS (CAPS) release 1885 -->
 		<description>Flashback (Euro, The Delphine Collection)</description>
@@ -16669,6 +17538,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flashbf" cloneof="flashb" supported="no">
 		<!-- SPS (CAPS) release 1736 -->
 		<description>Flashback (Fra)</description>
@@ -16702,6 +17572,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flashbg" cloneof="flashb" supported="no">
 		<!-- SPS (CAPS) release 64 -->
 		<description>Flashback (Ger, v1.0 19930426)</description>
@@ -16735,6 +17606,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flamazon" supported="no">
 		<!-- SPS (CAPS) release 971 -->
 		<description>Flight of the Amazon Queen (Euro)</description>
@@ -16810,6 +17682,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="flintrdr" supported="no">
 		<!-- SPS (CAPS) release 245 -->
 		<description>Flight of the Intruder (Euro)</description>
@@ -16831,6 +17704,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fp737" supported="no">
 		<!-- SPS (CAPS) release 2217 -->
 		<description>Flight Path 737 (Euro)</description>
@@ -16845,6 +17719,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fp737a" cloneof="fp737" supported="no">
 		<!-- SPS (CAPS) release 2218 -->
 		<description>Flight Path 737 (Euro, Budget)</description>
@@ -16859,6 +17734,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fsim2" supported="no">
 		<!-- SPS (CAPS) release 329 -->
 		<description>Flight Simulator II (Euro, v1.1)</description>
@@ -16873,6 +17749,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fsim2a" cloneof="fsim2" supported="no">
 		<!-- SPS (CAPS) release 653 -->
 		<description>Flight Simulator II (Euro, v1.01)</description>
@@ -16887,6 +17764,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fsim2u" cloneof="fsim2" supported="no">
 		<!-- SPS (CAPS) release 921 -->
 		<description>Flight Simulator II (USA, v1.0)</description>
@@ -16901,6 +17779,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fsim2sc07" cloneof="fsim2" supported="no">
 		<!-- SPS (CAPS) release 1848 -->
 		<description>Flight Simulator II - Scenery Disk 7 (Euro)</description>
@@ -16916,6 +17795,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fsim2sc11" cloneof="fsim2" supported="no">
 		<!-- SPS (CAPS) release 2776 -->
 		<description>Flight Simulator II - Scenery Disk 11 (Euro)</description>
@@ -16931,6 +17811,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fsim2wet" cloneof="fsim2" supported="no">
 		<!-- SPS (CAPS) release 1847 -->
 		<description>Flight Simulator II - Western European Tour (Euro)</description>
@@ -16946,6 +17827,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="flimboqs" supported="no">
 		<!-- SPS (CAPS) release 121 -->
 		<description>Flimbo's Quest (Euro)</description>
@@ -16960,6 +17842,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flint" supported="no">
 		<!-- SPS (CAPS) release 503 -->
 		<description>The Flintstones (Euro)</description>
@@ -16974,6 +17857,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="flipmag" supported="no">
 		<!-- SPS (CAPS) release 827 -->
 		<description>Flip-it &amp; Magnose - Water Carriers from Mars (Euro)</description>
@@ -16988,6 +17872,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="flood" supported="no">
 		<!-- SPS (CAPS) release 504 -->
 		<description>Flood (Euro)</description>
@@ -17002,6 +17887,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="flyfight" supported="no">
 		<!-- SPS (CAPS) release 1547 -->
 		<description>Fly Fighter (Euro)</description>
@@ -17016,6 +17902,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="foolerr" supported="no">
 		<!-- SPS (CAPS) release 1025 -->
 		<description>The Fool's Errand (Euro)</description>
@@ -17037,6 +17924,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="footdir2" supported="no">
 		<!-- SPS (CAPS) release 1026 -->
 		<description>Football Director II (Euro, v2.06D CDS)</description>
@@ -17051,6 +17939,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="foty2" supported="no">
 		<!-- SPS (CAPS) release 654 -->
 		<description>Footballer of the Year 2 (Euro)</description>
@@ -17065,6 +17954,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fbmang" supported="no">
 		<!-- SPS (CAPS) release 1634 -->
 		<description>Football Manager (Euro)</description>
@@ -17079,6 +17969,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fbmang2" supported="no">
 		<!-- SPS (CAPS) release 246 -->
 		<description>Football Manager 2 (Euro)</description>
@@ -17093,6 +17984,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fbmang2ek" cloneof="fbmang2" supported="no">
 		<!-- SPS (CAPS) release 793 -->
 		<description>Football Manager 2 Expansion Kit (Euro, FM2 &amp; FM2 Expansion Kit)</description>
@@ -17107,6 +17999,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fbmang2eka" cloneof="fbmang2" supported="no">
 		<!-- SPS (CAPS) release 2226 -->
 		<description>Football Manager 2 Expansion Kit (Euro, Amiga Sports Pack)</description>
@@ -17121,6 +18014,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fbmangwc" supported="no">
 		<!-- SPS (CAPS) release 2272 -->
 		<description>Football Manager - World Cup Edition (Euro)</description>
@@ -17135,6 +18029,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fbmangwcg" cloneof="fbmangwc" supported="no">
 		<!-- SPS (CAPS) release 483 -->
 		<description>Football Manager - World Cup Edition (Ger)</description>
@@ -17149,6 +18044,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="fm2wce" supported="no">
 		<!-- SPS (CAPS) release 2367 -->
 		<description>Football Manager 2 &amp; Football Manager - World Cup Edition (Euro, Soccer Mania)</description>
@@ -17163,6 +18059,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="footman" supported="no">
 		<!-- SPS (CAPS) release 655 -->
 		<description>FootMan (Euro)</description>
@@ -17177,6 +18074,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="forgottn" supported="no">
 		<!-- SPS (CAPS) release 1222 -->
 		<description>Forgotten Worlds (Euro)</description>
@@ -17198,6 +18096,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="foundwst" supported="no">
 		<!-- SPS (CAPS) release 2759 -->
 		<description>Foundation's Waste (Euro, Budget)</description>
@@ -17212,6 +18111,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="foundwstc" cloneof="foundwst" supported="no">
 		<!-- SPS (CAPS) release 3155? -->
 		<description>Foundation's Waste (Euro, Coverdisk)</description>
@@ -17228,6 +18128,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="4crystal" supported="no">
 		<!-- SPS (CAPS) release 1959 -->
 		<description>The Four Crystals of Trazere (USA)</description>
@@ -17249,6 +18150,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="baresiko" supported="no">
 		<!-- SPS (CAPS) release 2366 -->
 		<description>Franco Baresi World Cup Kick Off (Ita, v1.1)</description>
@@ -17263,6 +18165,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="frankens" supported="no">
 		<!-- SPS (CAPS) release 2176 -->
 		<description>Frankenstein (Euro)</description>
@@ -17278,6 +18181,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="fred" supported="partial">
 		<!-- SPS (CAPS) release 1652 -->
 		<description>Fred (Euro)</description>
@@ -17293,6 +18197,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="freedom" supported="no">
 		<!-- SPS (CAPS) release 2297 -->
 		<description>Freedom - Les Guerriers de l'Ombre (Fra, Les Enfants du Silence)</description>
@@ -17307,6 +18212,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="frenetic" supported="no">
 		<!-- SPS (CAPS) release 1438 -->
 		<description>Frenetic (Euro)</description>
@@ -17328,6 +18234,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frontier" supported="no">
 		<!-- SPS (CAPS) release 1960 -->
 		<description>Frontier (Euro, 19931006)</description>
@@ -17350,6 +18257,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frontiera" cloneof="frontier" supported="no">
 		<!-- SPS (CAPS) release 2269 -->
 		<description>Frontier (Euro, v1.05r4 19920902)</description>
@@ -17372,6 +18280,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frontierb" cloneof="frontier" supported="no">
 		<!-- SPS (CAPS) release 123 -->
 		<description>Frontier (Euro, 19920902)</description>
@@ -17394,6 +18303,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frontierf" cloneof="frontier" supported="no">
 		<!-- SPS (CAPS) release 2745 -->
 		<description>Frontier (Fra, 19920902)</description>
@@ -17416,6 +18326,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frontierg" cloneof="frontier" supported="no">
 		<!-- SPS (CAPS) release 505 -->
 		<description>Frontier (Ger, 19931011)</description>
@@ -17438,6 +18349,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="frostbyt" supported="no">
 		<!-- SPS (CAPS) release 1529 -->
 		<description>Frost Byte (Euro)</description>
@@ -17452,6 +18364,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fullcont" supported="no">
 		<!-- SPS (CAPS) release 2246 -->
 		<description>Full Contact (Euro)</description>
@@ -17473,6 +18386,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="fullmp" supported="no">
 		<!-- SPS (CAPS) release 656 -->
 		<description>Full Metal Planete (Euro)</description>
@@ -17487,6 +18401,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="fullmpa" cloneof="fullmp" supported="no">
 		<!-- SPS (CAPS) release 2566 -->
 		<description>Full Metal Planete (Euro, Alt)</description>
@@ -17501,6 +18416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="funs2o8" supported="no">
 		<!-- SPS (CAPS) release 2078 -->
 		<description>Fun School 2 - For the Over-8s (Euro)</description>
@@ -17515,6 +18431,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="funs2u6" supported="no">
 		<!-- SPS (CAPS) release 2079 -->
 		<description>Fun School 2 - For the Under-6s (Euro)</description>
@@ -17529,6 +18446,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ffurries" supported="no">
 		<!-- SPS (CAPS) release 1347 -->
 		<description>Fury of the Furries (Euro)</description>
@@ -17568,6 +18486,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="fusion" supported="no">
 		<!-- SPS (CAPS) release 331 -->
 		<description>Fusion (Euro)</description>
@@ -17582,6 +18501,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="futbaskt" supported="no">
 		<!-- SPS (CAPS) release 1253 -->
 		<description>Future Basketball (Euro)</description>
@@ -17596,6 +18516,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="futbike" supported="no">
 		<!-- SPS (CAPS) release 2149 -->
 		<description>Future Bike Simulator (Euro)</description>
@@ -17610,6 +18531,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futclass" supported="no">
 		<!-- SPS (CAPS) release 1744 -->
 		<description>Future Classics Collection (Euro)</description>
@@ -17624,6 +18546,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futshock" supported="no">
 		<!-- SPS (CAPS) release 2783 -->
 		<description>Future Shock (Euro)</description>
@@ -17638,6 +18561,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futspace" supported="no">
 		<!-- SPS (CAPS) release 2820 -->
 		<description>Future Space (Ger)</description>
@@ -17683,6 +18607,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futwars" supported="no">
 		<!-- SPS (CAPS) release 1570 -->
 		<description>Future Wars - Time Travellers (Euro)</description>
@@ -17704,6 +18629,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futwarsa" cloneof="futwars" supported="no">
 		<!-- SPS (CAPS) release 1882 -->
 		<description>Future Wars - Time Travellers (Euro, The Delphine Collection)</description>
@@ -17725,6 +18651,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="voyagtmp" cloneof="futwars" supported="no">
 		<!-- SPS (CAPS) release 2384 -->
 		<description>Les Voyageurs du Temps - La Menace (Fra)</description>
@@ -17746,6 +18673,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futwarsg" cloneof="futwars" supported="no">
 		<!-- SPS (CAPS) release 506 -->
 		<description>Future Wars - Time Travellers (Ger)</description>
@@ -17767,6 +18695,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futwarss" cloneof="futwars" supported="no">
 		<!-- SPS (CAPS) release 2506 -->
 		<description>Future Wars - Time Travellers (Spa)</description>
@@ -17788,6 +18717,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="futwarsu" cloneof="futwars" supported="no">
 		<!-- SPS (CAPS) release 2022 -->
 		<description>Future Wars - Time Travellers (USA)</description>
@@ -17809,6 +18739,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="fuzzball" supported="no">
 		<!-- SPS (CAPS) release 1940 -->
 		<description>Fuzzball (Euro)</description>
@@ -17830,6 +18761,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="fussbtot" supported="no">
 		<!-- SPS (CAPS) release 2135 -->
 		<description>Fußball Total (Ger)</description>
@@ -17851,6 +18783,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="gloc" supported="no">
 		<!-- SPS (CAPS) release 184 -->
 		<description>G-Loc R360 (Euro)</description>
@@ -17865,6 +18798,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gnius" supported="no">
 		<!-- SPS (CAPS) release 895 -->
 		<description>G.nius (Euro)</description>
@@ -17879,6 +18813,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="galactic" supported="no">
 		<!-- SPS (CAPS) release 2012 -->
 		<description>Galactic Empire (Euro)</description>
@@ -17893,6 +18828,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="galactica" cloneof="galactic" supported="no">
 		<!-- SPS (CAPS) release 682 -->
 		<description>Galactic Empire (Euro, Alt)</description>
@@ -17907,6 +18843,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="galinvsn" supported="no">
 		<!-- SPS (CAPS) release 683 -->
 		<description>Galactic Invasion (Euro)</description>
@@ -17921,6 +18858,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="galrats" supported="no">
 		<!-- SPS (CAPS) release 1942 -->
 		<description>Galactic Warrior Rats (Euro, The Sci-Fi Collecion)</description>
@@ -17935,6 +18873,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="galablst" supported="no">
 		<!-- SPS (CAPS) release 2032 -->
 		<description>Galaxy Blast (Euro)</description>
@@ -17951,6 +18890,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="gforce2" supported="no">
 		<!-- SPS (CAPS) release 485 -->
 		<description>Galaxy Force II (Euro)</description>
@@ -17965,6 +18905,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="galdregn" supported="no">
 		<!-- SPS (CAPS) release 802 -->
 		<description>Galdregon's Domain (Euro)</description>
@@ -17986,6 +18927,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="garfield" supported="no">
 		<!-- SPS (CAPS) release 933 -->
 		<description>Garfield - "Big, Fat, Hairy Deal." (Euro)</description>
@@ -18000,6 +18942,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="garrison" supported="no">
 		<!-- SPS (CAPS) release 800 -->
 		<description>Garrison (Euro, v1.02)</description>
@@ -18021,6 +18964,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="garrisn2" supported="no">
 		<!-- SPS (CAPS) release 610 -->
 		<description>Garrison II (Euro, v1.02)</description>
@@ -18042,6 +18986,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lineker" supported="no">
 		<!-- SPS (CAPS) release 883 -->
 		<description>Gary Lineker's Hot-Shot! (Euro)</description>
@@ -18056,6 +19001,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gatewayt" supported="no">
 		<!-- SPS (CAPS) release 2160 -->
 		<description>Gateway to the Savage Frontier (Euro, v1.00)</description>
@@ -18083,6 +19029,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gauntlt2" supported="no">
 		<!-- SPS (CAPS) release 182 -->
 		<description>Gauntlet II (Euro)</description>
@@ -18097,6 +19044,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gauntlt3" supported="no">
 		<!-- SPS (CAPS) release 1550 -->
 		<description>Gauntlet III - The Final Quest (Euro)</description>
@@ -18124,6 +19072,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gazza" supported="no">
 		<!-- SPS (CAPS) release 1027 -->
 		<description>Gazza's Super Soccer (Euro)</description>
@@ -18138,6 +19087,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gbachamp" supported="no">
 		<!-- SPS (CAPS) release 2948 -->
 		<description>GBA Championship Basketball - Two-on-Two (Euro)</description>
@@ -18152,6 +19102,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gearwork" supported="no">
 		<!-- SPS (CAPS) release 1028 -->
 		<description>Gear Works (Euro)</description>
@@ -18166,6 +19117,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="gemiwing" supported="no">
 		<!-- SPS (CAPS) release 486 -->
 		<description>Gemini Wing (Euro)</description>
@@ -18180,6 +19132,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gemx" supported="no">
 		<!-- SPS (CAPS) release 1181 -->
 		<description>Gem'X (Euro)</description>
@@ -18194,6 +19147,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="genesia" supported="no">
 		<!-- SPS (CAPS) release 1808 -->
 		<description>Genesia (Euro)</description>
@@ -18221,6 +19175,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="germcraz" supported="no">
 		<!-- SPS (CAPS) release 507 -->
 		<description>Germ Crazy (Ger)</description>
@@ -18235,6 +19190,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tbirds" supported="no">
 		<!-- SPS (CAPS) release 742 -->
 		<description>Gerry Anderson's Thunderbirds (Euro)</description>
@@ -18256,6 +19212,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="getout" supported="no">
 		<!-- SPS (CAPS) release 1517 -->
 		<description>Get Out (Euro)</description>
@@ -18270,6 +19227,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gettysbg" supported="no">
 		<!-- SPS (CAPS) release 1937 -->
 		<description>Gettysburg (Euro, Turning Points)</description>
@@ -18284,6 +19242,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gflchafb" supported="no">
 		<!-- SPS (CAPS) release 922 -->
 		<description>GFL Championship Football (USA)</description>
@@ -18299,6 +19258,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation [FDC] dsksync bootblock -->
+	<!-- ATK test: OK -->
 	<software name="ghostbs2" supported="no">
 		<!-- SPS (CAPS) release 1029 -->
 		<description>Ghostbusters II (Euro)</description>
@@ -18320,6 +19280,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="ghostbs2u" cloneof="ghostbs2" supported="no">
 		<!-- SPS (CAPS) release 1208 -->
 		<description>Ghostbusters II (USA)</description>
@@ -18341,6 +19302,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gng" supported="no">
 		<!-- SPS (CAPS) release 31 -->
 		<description>Ghosts 'n Goblins (Euro)</description>
@@ -18355,6 +19317,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="ghouls" supported="no">
 		<!-- SPS (CAPS) release 2252 -->
 		<description>Ghouls 'n' Ghosts (Euro)</description>
@@ -18376,6 +19339,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="ghoulsa" cloneof="ghouls" supported="no">
 		<!-- SPS (CAPS) release 1223 -->
 		<description>Ghouls 'n' Ghosts (Euro, Platinum)</description>
@@ -18399,6 +19363,7 @@ license:CC0
 
 	<!-- gng: throws "amiga_fdc_device::live_run - cur_live.bit_counter > 8" then fatalerrors after DSKDAT access -->
 	<!-- venus: asks to swap disk with incorrect pitch GFX then throws DSKDAT R and hangs -->
+	<!-- ATK test: OK -->
 	<software name="ghoulsvf" supported="no">
 		<!-- SPS (CAPS) release 1985 -->
 		<description>Ghouls 'n' Ghosts &amp; Venus the Flytrap (Euro, Chart Attack)</description>
@@ -18420,6 +19385,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="globalfx" supported="no">
 		<!-- SPS (CAPS) release 1030 -->
 		<description>Global Effect (Euro)</description>
@@ -18447,6 +19413,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="globdule" supported="no">
 		<!-- SPS (CAPS) release 183 -->
 		<description>Globdule (Euro)</description>
@@ -18468,6 +19435,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gluecksr" supported="no">
 		<!-- SPS (CAPS) release 1505 -->
 		<description>Glücksrad (Ger)</description>
@@ -18482,6 +19450,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="granger" supported="no">
 		<!-- SPS (CAPS) release 2347 -->
 		<description>Gnome Ranger (Euro)</description>
@@ -18496,6 +19465,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goal" supported="no">
 		<!-- SPS (CAPS) release 1817 -->
 		<description>Goal! (Euro, v1.1)</description>
@@ -18517,6 +19487,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goala" cloneof="goal" supported="no">
 		<!-- SPS (CAPS) release 487 -->
 		<description>Goal! (Euro)</description>
@@ -18538,6 +19509,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins" supported="no">
 		<!-- SPS (CAPS) release 2487 -->
 		<description>Gobliiins (Euro, Kings of Adventures 1)</description>
@@ -18565,6 +19537,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblinsg" cloneof="goblins" supported="no">
 		<!-- SPS (CAPS) release 65 -->
 		<description>Gobliiins (Ger)</description>
@@ -18592,6 +19565,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins2" supported="no">
 		<!-- SPS (CAPS) release 185 -->
 		<description>Gobliins 2 - The Prince Buffoon (Euro)</description>
@@ -18619,6 +19593,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins2f" cloneof="goblins2" supported="no">
 		<!-- SPS (CAPS) release 2866 -->
 		<description>Gobliins 2 - The Prince Buffoon (Fra)</description>
@@ -18646,6 +19621,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins2g" cloneof="goblins2" supported="no">
 		<!-- SPS (CAPS) release 332 -->
 		<description>Gobliins 2 - The Prince Buffoon (Ger)</description>
@@ -18673,6 +19649,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins3" supported="no">
 		<!-- SPS (CAPS) release 2292 -->
 		<description>Goblins 3 (Fra, v1.0)</description>
@@ -18718,6 +19695,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goblins3g" cloneof="goblins3" supported="no">
 		<!-- SPS (CAPS) release 370 -->
 		<description>Goblins 3 (Ger)</description>
@@ -18763,6 +19741,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: H:U 1 Sector Bad, C:0 H:L 1 Sector Bad -->
 	<software name="godfathr" supported="no">
 		<!-- SPS (CAPS) release 1331 -->
 		<description>The Godfather (Euro)</description>
@@ -18811,6 +19790,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- (Hangs at PC=10c after failing a copy protection check, D0=0 D1=295 D2=40 D3=0) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="gods" supported="no">
 		<!-- SPS (CAPS) release 666 -->
 		<description>Gods (Euro, v1.00)</description>
@@ -18832,6 +19812,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="godsa" cloneof="gods" supported="no">
 		<!-- SPS (CAPS) release 2877 -->
 		<description>Gods (Euro, v1.00, Alt)</description>
@@ -18853,6 +19834,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="aztecs" supported="no">
 		<!-- SPS (CAPS) release 1649 -->
 		<description>The Gold of the Aztecs (Euro)</description>
@@ -18874,6 +19856,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goldrush" supported="no">
 		<!-- SPS (CAPS) release 2909 -->
 		<description>Gold Rush! (Euro, v2.05)</description>
@@ -18895,6 +19878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="goldnaxe" supported="no">
 		<!-- SPS (CAPS) release 17 -->
 		<description>Golden Axe (Euro)</description>
@@ -18909,6 +19893,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goldold1" supported="no">
 		<!-- SPS (CAPS) release 1856 -->
 		<description>Golden Oldies Volume 1 (Euro, v2.4)</description>
@@ -18923,6 +19908,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goofyexp" supported="no">
 		<!-- SPS (CAPS) release 2473 -->
 		<description>Goofy's Railway Express (Euro)</description>
@@ -18937,6 +19923,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gotcha" supported="no">
 		<!-- SPS (CAPS) release 2756 -->
 		<description>Gotcha! (Euro)</description>
@@ -18951,6 +19938,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sounessv" supported="no">
 		<!-- SPS (CAPS) release 1700 -->
 		<description>Graeme Souness Vector Soccer (Euro)</description>
@@ -18967,6 +19955,7 @@ license:CC0
 
 	<!-- boot OK, sprites flickers in-game -->
 	<!-- Sports garbage pitch with a500p -->
+	<!-- ATK test: OK -->
 	<software name="graffiti" supported="partial">
 		<!-- SPS (CAPS) release 2168 -->
 		<description>Graffiti Man (Euro, 5th Anniversary)</description>
@@ -18981,6 +19970,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gooch2in" supported="no">
 		<!-- SPS (CAPS) release 1874 -->
 		<description>Graham Gooch's Second Innings (Euro)</description>
@@ -19010,6 +20000,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="taylorsc" supported="no">
 		<!-- SPS (CAPS) release 125 -->
 		<description>Graham Taylor's Soccer Challenge (Euro)</description>
@@ -19031,6 +20022,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="grandmon" supported="no">
 		<!-- SPS (CAPS) release 1917 -->
 		<description>Grand Monster Slam (Euro)</description>
@@ -19052,6 +20044,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="grandmona" cloneof="grandmon" supported="no">
 		<!-- SPS (CAPS) release 1688 -->
 		<description>Grand Monster Slam (Euro, Milestones)</description>
@@ -19066,6 +20059,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="grandnat" supported="no">
 		<!-- SPS (CAPS) release 2361 -->
 		<description>Grand National (Euro)</description>
@@ -19087,6 +20081,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="gpcirc" supported="no">
 		<!-- SPS (CAPS) release 8 -->
 		<description>Grand Prix Circuit (Euro)</description>
@@ -19101,6 +20096,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gpmaster" supported="no">
 		<!-- SPS (CAPS) release 2216 -->
 		<description>Grand Prix Master (Euro, Amiga Sports Pack)</description>
@@ -19115,6 +20111,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gslam" supported="no">
 		<!-- SPS (CAPS) release 1864 -->
 		<description>Grand Slam (Ger)</description>
@@ -19129,6 +20126,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="gravity" supported="no">
 		<!-- SPS (CAPS) release 488 -->
 		<description>Gravity (Euro)</description>
@@ -19143,6 +20141,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gcourts" supported="no">
 		<!-- SPS (CAPS) release 2605 -->
 		<description>Great Courts (Euro)</description>
@@ -19158,6 +20157,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="gcourts2" supported="partial">
 		<!-- SPS (CAPS) release 333 -->
 		<description>Great Courts 2 (Euro)</description>
@@ -19173,6 +20173,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gcourts2a" cloneof="gcourts2" supported="no">
 		<!-- SPS (CAPS) release 1740 -->
 		<description>Great Courts 2 (Euro, Commodore Pack)</description>
@@ -19188,6 +20189,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="ggiana" supported="no">
 		<!-- SPS (CAPS) release 2945 -->
 		<description>The Great Giana Sisters (Euro)</description>
@@ -19203,6 +20205,7 @@ license:CC0
 	</software>
 
 <!-- This is the first release, which features a bug after high score save -->
+	<!-- ATK test: failed -->
 	<software name="ggiana1" cloneof="ggiana" supported="no">
 		<!-- SPS (CAPS) release 2500 -->
 		<description>The Great Giana Sisters (Euro, Older)</description>
@@ -19217,6 +20220,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="greens" supported="no">
 		<!-- SPS (CAPS) release 1661 -->
 		<description>Greens - The Ultimate Golf Simulation (Euro, v2.3)</description>
@@ -19245,6 +20249,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gremlin2" supported="no">
 		<!-- SPS (CAPS) release 489 -->
 		<description>Gremlins 2 - The New Batch (Euro)</description>
@@ -19259,6 +20264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gremlin2a" cloneof="gremlin2" supported="no">
 		<!-- SPS (CAPS) release 2208 -->
 		<description>Gremlins 2 - The New Batch (Euro, Alt)</description>
@@ -19274,6 +20280,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="gridstrt" supported="yes">
 		<!-- SPS (CAPS) release 1470 -->
 		<description>Grid Start (Euro, Sextett)</description>
@@ -19288,6 +20295,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gridiron" supported="no">
 		<!-- SPS (CAPS) release 2124 -->
 		<description>Gridiron! (Euro)</description>
@@ -19309,6 +20317,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="guardang" supported="no">
 		<!-- SPS (CAPS) release 2173 -->
 		<description>The Guardian Angel (Euro)</description>
@@ -19323,6 +20332,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="guildthv" supported="no">
 		<!-- SPS (CAPS) release 334 -->
 		<description>The Guild of Thieves (Euro, v1.01)</description>
@@ -19337,6 +20347,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gulp" supported="no">
 		<!-- SPS (CAPS) release 2632 -->
 		<description>Gulp! (Euro)</description>
@@ -19364,6 +20375,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gunboat" supported="no">
 		<!-- SPS (CAPS) release 2997 -->
 		<description>Gunboat (Euro)</description>
@@ -19385,6 +20397,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="gunship" supported="no">
 		<!-- SPS (CAPS) release 658 -->
 		<description>Gunship (Euro, v832.02)</description>
@@ -19399,6 +20412,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="gunshipu" cloneof="gunship" supported="no">
 		<!-- SPS (CAPS) release 1489 -->
 		<description>Gunship (USA, v832.03)</description>
@@ -19413,6 +20427,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="gship2k" supported="no">
 		<!-- SPS (CAPS) release 808 -->
 		<description>Gunship 2000 (Euro, v3.01)</description>
@@ -19446,6 +20461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="gunshoot" supported="no">
 		<!-- SPS (CAPS) release 2169 -->
 		<description>Gunshoot (Euro)</description>
@@ -19461,6 +20477,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] -->
+	<!-- ATK test: failed -->
 	<software name="guyspy" supported="no">
 		<!-- SPS (CAPS) release 335 -->
 		<description>Guy Spy (Euro)</description>
@@ -19495,6 +20512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hate" supported="no">
 		<!-- SPS (CAPS) release 1930 -->
 		<description>H.A.T.E. - Hostile All Terrain Encounter (Euro)</description>
@@ -19509,6 +20527,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hacker" supported="no">
 		<!-- SPS (CAPS) release 906 -->
 		<description>Hacker (USA)</description>
@@ -19523,6 +20542,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hacker2" supported="no">
 		<!-- SPS (CAPS) release 777 -->
 		<description>Hacker II - The Doomsday Papers (Euro)</description>
@@ -19537,6 +20557,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hacker2a" cloneof="hacker2" supported="no">
 		<!-- SPS (CAPS) release 1262 -->
 		<description>Hacker II - The Doomsday Papers (Euro, Power Hits)</description>
@@ -19551,6 +20572,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hagar" supported="no">
 		<!-- SPS (CAPS) release 1967 -->
 		<description>Hägar (Euro)</description>
@@ -19579,6 +20601,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="halleypr" supported="no">
 		<!-- SPS (CAPS) release 2519 -->
 		<description>The Halley Project: A Mission in Our Solar System (Euro)</description>
@@ -19593,6 +20616,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hammerb" supported="no">
 		<!-- SPS (CAPS) release 1349 -->
 		<description>Hammer Boy (Euro, Budget)</description>
@@ -19607,6 +20631,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hammrfst" supported="no">
 		<!-- SPS (CAPS) release 1358 -->
 		<description>Hammerfist (Euro)</description>
@@ -19621,6 +20646,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hanse" supported="no">
 		<!-- SPS (CAPS) release 1919 -->
 		<description>Hanse - Die Expedition (Ger)</description>
@@ -19642,6 +20668,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="hardball" supported="no">
 		<!-- SPS (CAPS) release 490 -->
 		<description>HardBall! (Euro)</description>
@@ -19656,6 +20683,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="harddriv" supported="no">
 		<!-- SPS (CAPS) release 126 -->
 		<description>Hard Drivin' (Euro)</description>
@@ -19670,6 +20698,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="harddrv2" supported="no">
 		<!-- SPS (CAPS) release 1031 -->
 		<description>Hard Drivin' II - Drive Harder.... (Euro)</description>
@@ -19684,6 +20713,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hardheav" supported="no">
 		<!-- SPS (CAPS) release 1631 -->
 		<description>Hard 'n' Heavy (Euro)</description>
@@ -19698,6 +20728,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="harerh" supported="no">
 		<!-- SPS (CAPS) release 2043 -->
 		<description>Hare Raising Havoc (USA)</description>
@@ -19743,6 +20774,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="harleq" supported="no">
 		<!-- SPS (CAPS) release 2029 -->
 		<description>Harlequin (Euro)</description>
@@ -19764,6 +20796,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="harleqa" cloneof="harleq" supported="no">
 		<!-- SPS (CAPS) release 1596 -->
 		<description>Harlequin (Euro, Special Edition)</description>
@@ -19785,6 +20818,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="harley" supported="no">
 		<!-- SPS (CAPS) release 2011 -->
 		<description>Harley-Davidson - The Road to Sturgis (Euro)</description>
@@ -19799,6 +20833,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="harpoon1" supported="no">
 		<!-- SPS (CAPS) release 1032 -->
 		<description>Harpoon &amp; Battleset 1: Greenland Iceland UK Gap (Euro, v1.0)</description>
@@ -19820,6 +20855,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="harpoon2" supported="no">
 		<!-- SPS (CAPS) release 1033 -->
 		<description>Harpoon Battleset 2: North Atlantic Convoys (Euro)</description>
@@ -19834,6 +20870,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="harpoon3" supported="no">
 		<!-- SPS (CAPS) release 1788 -->
 		<description>Harpoon Battleset 3: The Mediterranean Conflict (Euro)</description>
@@ -19848,6 +20885,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="harrierc" supported="no">
 		<!-- SPS (CAPS) release 919 -->
 		<description>Harrier Combat Simulator (USA)</description>
@@ -19862,6 +20900,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hawkeye" supported="no">
 		<!-- SPS (CAPS) release 1963 -->
 		<description>Hawkeye (Euro)</description>
@@ -19876,6 +20915,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="headover" supported="no">
 		<!-- SPS (CAPS) release 1674 -->
 		<description>Head Over Heels (Euro)</description>
@@ -19890,6 +20930,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="heartchi" supported="no">
 		<!-- SPS (CAPS) release 969 -->
 		<description>Heart of China (Euro, v1.0)</description>
@@ -19953,6 +20994,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="heartchig" cloneof="heartchi" supported="no">
 		<!-- SPS (CAPS) release 1869 -->
 		<description>Heart of China (Ger, v1.0)</description>
@@ -20016,6 +21058,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hvymetal" supported="no">
 		<!-- SPS (CAPS) release 2977 -->
 		<description>Heavy Metal (Euro)</description>
@@ -20030,6 +21073,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="heimdall" supported="no">
 		<!-- SPS (CAPS) release 234 -->
 		<description>Heimdall (Euro)</description>
@@ -20069,6 +21113,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="heimdal2" supported="no">
 		<!-- SPS (CAPS) release 1165 -->
 		<description>Heimdall 2 - Into the Hall of Worlds (Euro)</description>
@@ -20102,6 +21147,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="helicopt" supported="no">
 		<!-- SPS (CAPS) release 491 -->
 		<description>Helicopter Mission (Ger)</description>
@@ -20116,6 +21162,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hellbent" supported="no">
 		<!-- SPS (CAPS) release 1119 -->
 		<description>Hell Bent (Euro)</description>
@@ -20130,6 +21177,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hellraid" supported="no">
 		<!-- SPS (CAPS) release 2855 -->
 		<description>Hellraider (Euro)</description>
@@ -20144,6 +21192,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hellrun" supported="no">
 		<!-- SPS (CAPS) release 2035 -->
 		<description>The Hellrun Machine (Euro)</description>
@@ -20160,6 +21209,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="heltersk" supported="no">
 		<!-- SPS (CAPS) release 2071 -->
 		<description>Helter Skelter (Euro)</description>
@@ -20174,6 +21224,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="henriett" supported="no">
 		<!-- SPS (CAPS) release 1647 -->
 		<description>Henrietta's Book of Spells (Euro)</description>
@@ -20188,6 +21239,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="herolanc" supported="no">
 		<!-- SPS (CAPS) release 778 -->
 		<description>Heroes of the Lance (Euro, v1.0)</description>
@@ -20210,6 +21262,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs at a red and black flashing screen [FDC] dsksync -->
+	<!-- ATK test: C:77-79 Bad -->
 	<software name="heroqst" supported="no">
 		<!-- SPS (CAPS) release 127 -->
 		<description>HeroQuest (Euro)</description>
@@ -20227,6 +21280,7 @@ license:CC0
 	</software>
 
 <!-- This was bundled with HQ -->
+	<!-- ATK test: OK -->
 	<software name="heroqstwl" cloneof="heroqst" supported="no">
 		<!-- SPS (CAPS) release 508 -->
 		<description>HeroQuest - Return of the Witch Lord (Euro)</description>
@@ -20243,6 +21297,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="heroqst2" supported="no">
 		<!-- SPS (CAPS) release 1455 -->
 		<description>HeroQuest II - Legacy of Sorasil (Euro)</description>
@@ -20270,6 +21325,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wannaher" supported="no">
 		<!-- SPS (CAPS) release 795 -->
 		<description>Hero's Quest - So You Want to Be a Hero (Euro, v1.134)</description>
@@ -20309,6 +21365,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hexuma" supported="no">
 		<!-- SPS (CAPS) release 684 -->
 		<description>Hexuma - Das Auge des Kal (Ger)</description>
@@ -20348,6 +21405,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="histeel" supported="no">
 		<!-- SPS (CAPS) release 1397 -->
 		<description>High Steel (Euro)</description>
@@ -20362,6 +21420,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hw42_war" supported="no">
 		<!-- SPS (CAPS) release 1685 -->
 		<description>Highway 42 &amp; Warlords (Ger)</description>
@@ -20376,6 +21435,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hwhawks" supported="no">
 		<!-- SPS (CAPS) release 2538 -->
 		<description>Highway Hawks (Euro)</description>
@@ -20397,6 +21457,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="hwpatrl2" supported="no">
 		<!-- SPS (CAPS) release 2305 -->
 		<description>Highway Patrol 2 (Euro)</description>
@@ -20411,6 +21472,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hillstrt" supported="no">
 		<!-- SPS (CAPS) release 659 -->
 		<description>Hill Street Blues (Euro)</description>
@@ -20425,6 +21487,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hillstrta" cloneof="hillstrt" supported="no">
 		<!-- SPS (CAPS) release 2586 -->
 		<description>Hill Street Blues (Euro, Budget)</description>
@@ -20439,6 +21502,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hillsfar" supported="no">
 		<!-- SPS (CAPS) release 981 -->
 		<description>Hillsfar (Euro, v1.0)</description>
@@ -20453,6 +21517,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hillsfarg" cloneof="hillsfar" supported="no">
 		<!-- SPS (CAPS) release 961 -->
 		<description>Hillsfar (Ger, v1.0)</description>
@@ -20467,6 +21532,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hiredgun" supported="no">
 		<!-- SPS (CAPS) release 1114 -->
 		<description>Hired Guns (Euro, v1.08.39.25)</description>
@@ -20506,6 +21572,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hannabar" supported="no">
 		<!-- SPS (CAPS) release 2516 -->
 		<description>The HiTEC Hanna-Barbera Cartoon Character Collection (Euro)</description>
@@ -20522,6 +21589,7 @@ license:CC0
 
 	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
 	<!-- No sprites on gameplay, BGM is too fast? -->
+	<!-- ATK test: failed -->
 	<software name="hoi" supported="no">
 		<!-- SPS (CAPS) release 962 -->
 		<description>Hoi (Euro)</description>
@@ -20543,6 +21611,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hlem93" supported="no">
 		<!-- SPS (CAPS) release 337 -->
 		<description>Holiday Lemmings 1993 (Euro)</description>
@@ -20557,6 +21626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hlem94" supported="no">
 		<!-- SPS (CAPS) release 492 -->
 		<description>Holiday Lemmings 1994 (Euro)</description>
@@ -20571,6 +21641,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hollyhij" supported="no">
 		<!-- SPS (CAPS) release 1492 -->
 		<description>Hollywood Hijinx (USA, r37)</description>
@@ -20585,6 +21656,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hollypic" supported="no">
 		<!-- SPS (CAPS) release 2833 -->
 		<description>Hollywood Pictures (Ger)</description>
@@ -20613,6 +21685,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hpoker" supported="no">
 		<!-- SPS (CAPS) release 1791 -->
 		<description>Hollywood Poker (Euro)</description>
@@ -20627,6 +21700,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hpokera" cloneof="hpoker" supported="no">
 		<!-- SPS (CAPS) release 1792 -->
 		<description>Hollywood Poker (Euro, Budget)</description>
@@ -20641,6 +21715,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hpokerp" supported="no">
 		<!-- SPS (CAPS) release 2505 -->
 		<description>Hollywood Poker Pro (Euro)</description>
@@ -20662,6 +21737,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hkphooey" supported="no">
 		<!-- SPS (CAPS) release 1559 -->
 		<description>Hong Kong Phooey (Euro)</description>
@@ -20676,6 +21752,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hook" supported="no">
 		<!-- SPS (CAPS) release 887 -->
 		<description>Hook (Euro)</description>
@@ -20709,6 +21786,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="horrorzm" supported="no">
 		<!-- SPS (CAPS) release 286 -->
 		<description>Horror Zombies from the Crypt (Euro)</description>
@@ -20723,6 +21801,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="hostages" supported="no">
 		<!-- SPS (CAPS) release 186 -->
 		<description>Hostages (Euro)</description>
@@ -20737,6 +21816,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hostagesu" cloneof="hostages" supported="no">
 		<!-- SPS (CAPS) release 1173 -->
 		<description>Hostage - Rescue Mission (USA)</description>
@@ -20751,6 +21831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hotrod" supported="no">
 		<!-- SPS (CAPS) release 2437 -->
 		<description>Hot Rod (Euro)</description>
@@ -20765,6 +21846,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: H:U 1 Sector Bad, C:0 H:L 1 Sector Bad -->
 	<software name="hotball" supported="no">
 		<!-- SPS (CAPS) release 2798 -->
 		<description>Hotball (Euro)</description>
@@ -20779,6 +21861,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="hotshot" supported="no">
 		<!-- SPS (CAPS) release 2083 -->
 		<description>Hotshot (Euro)</description>
@@ -20793,6 +21876,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hotshota" cloneof="hotshot" supported="no">
 		<!-- SPS (CAPS) release 2101 -->
 		<description>Hotshot (Euro, Hits for Six Volume Two)</description>
@@ -20807,6 +21891,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="houndshd" supported="no">
 		<!-- SPS (CAPS) release 338 -->
 		<description>The Hound of Shadow (Euro)</description>
@@ -20828,6 +21913,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hoverspr" supported="no">
 		<!-- SPS (CAPS) release 2109 -->
 		<description>Hoversprint (Euro)</description>
@@ -20849,6 +21935,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hoylebg1" supported="no">
 		<!-- SPS (CAPS) release 2084 -->
 		<description>Hoyle's Book of Games Volume 1 (Euro, v1.000.139)</description>
@@ -20870,6 +21957,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hoylebg2" supported="no">
 		<!-- SPS (CAPS) release 2539 -->
 		<description>Hoyle's Book of Games Volume 2 - Solitaire (Euro, v1.001.016 19900717)</description>
@@ -20884,6 +21972,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hoylebg3" supported="no">
 		<!-- SPS (CAPS) release 2085 -->
 		<description>Hoyle's Book of Games Volume III - Great Board Games (Euro, v1.000 19920325)</description>
@@ -20905,6 +21994,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hudsonh" supported="no">
 		<!-- SPS (CAPS) release 1035 -->
 		<description>Hudson Hawk (Euro)</description>
@@ -20919,6 +22009,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="huey" supported="no">
 		<!-- SPS (CAPS) release 2086 -->
 		<description>Huey (Euro)</description>
@@ -20933,6 +22024,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hugo" supported="no">
 		<!-- SPS (CAPS) release 685 -->
 		<description>Hugo (Ger)</description>
@@ -20990,6 +22082,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hugopne" cloneof="hugo" supported="no">
 		<!-- SPS (CAPS) release 2761 -->
 		<description>Hugo: På Nye Eventyr (Den)</description>
@@ -21029,6 +22122,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hugo2" supported="no">
 		<!-- SPS (CAPS) release 2597 -->
 		<description>Hugo 2 (Fin)</description>
@@ -21068,6 +22162,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hugopne2" cloneof="hugo2" supported="no">
 		<!-- SPS (CAPS) release 2762 -->
 		<description>Hugo: På Nye Eventyr 2 (Den)</description>
@@ -21113,6 +22208,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="humans" supported="no">
 		<!-- SPS (CAPS) release 1888 -->
 		<description>The Humans (Euro, Help!)</description>
@@ -21140,6 +22236,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="humansf" cloneof="humans" supported="no">
 		<!-- SPS (CAPS) release 2666 -->
 		<description>The Humans (Fra)</description>
@@ -21167,6 +22264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="humansg" cloneof="humans" supported="no">
 		<!-- SPS (CAPS) release 509 -->
 		<description>The Humans (Ger)</description>
@@ -21194,6 +22292,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="humans2" supported="no">
 		<!-- SPS (CAPS) release 1036 -->
 		<description>Human Race - The Jurassic Levels (Euro)</description>
@@ -21221,6 +22320,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="humans2g" cloneof="humans2" supported="no">
 		<!-- SPS (CAPS) release 510 -->
 		<description>Human Race - The Jurassic Levels (Ger)</description>
@@ -21248,6 +22348,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hungaryf" supported="no">
 		<!-- SPS (CAPS) release 1170 -->
 		<description>Hungary for Fun (Euro)</description>
@@ -21262,6 +22363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="huntredm" supported="no">
 		<!-- SPS (CAPS) release 2232 -->
 		<description>The Hunt for Red October - The Movie (Euro)</description>
@@ -21276,6 +22378,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="huntred" supported="no">
 		<!-- SPS (CAPS) release 128 -->
 		<description>The Hunt for Red October (Euro)</description>
@@ -21290,6 +22393,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="hunter" supported="no">
 		<!-- SPS (CAPS) release 3014 -->
 		<description>Hunter (Euro)</description>
@@ -21304,6 +22408,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="huntkill" supported="no">
 		<!-- SPS (CAPS) release 1423 -->
 		<description>Hunter Killer (Euro, v1.01)</description>
@@ -21321,6 +22426,7 @@ license:CC0
 	<!-- Grey screen [FDC] dsksync -->
 	<!-- Has slight GFX shifted text (attribute color on pilot select, lives counter) -->
 	<!-- GFX garbage strips pops in from time to time during gameplay -->
+	<!-- ATK test: failed -->
 	<software name="hybris" supported="no">
 		<!-- SPS (CAPS) release 1457 -->
 		<description>Hybris (USA, v0.95)</description>
@@ -21335,6 +22441,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hydra" supported="no">
 		<!-- SPS (CAPS) release 2515 -->
 		<description>Hydra (Euro)</description>
@@ -21356,6 +22463,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hyperdom" supported="no">
 		<!-- SPS (CAPS) release 1289 -->
 		<description>Hyperdome (Euro)</description>
@@ -21370,6 +22478,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="hyperion" supported="no">
 		<!-- SPS (CAPS) release 260 -->
 		<description>Hyperion (Euro)</description>
@@ -21384,6 +22493,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="hyperfor" supported="no">
 		<!-- SPS (CAPS) release 493 -->
 		<description>Hyperforce &amp; Artificial Dreams (Euro)</description>
@@ -21399,6 +22509,7 @@ license:CC0
 	</software>
 
 	<!-- Doesn't boot with debugger on, otherwise hangs anytime during the boot phase (spurious irqs or unsafe video code) -->
+	<!-- ATK test: failed -->
 	<software name="ikplus" supported="no">
 		<!-- SPS (CAPS) release 339 -->
 		<description>IK+ (Euro)</description>
@@ -21413,6 +22524,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ikplusa" cloneof="ikplus" supported="no">
 		<!-- SPS (CAPS) release 2063 -->
 		<description>IK+ (Euro, Budget)</description>
@@ -21427,6 +22539,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ikari" supported="no">
 		<!-- SPS (CAPS) release 771 -->
 		<description>Ikari Warriors (Euro)</description>
@@ -21441,6 +22554,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ikaria" cloneof="ikari" supported="no">
 		<!-- SPS (CAPS) release 1782 -->
 		<description>Ikari Warriors (Euro, Tenstar Pack)</description>
@@ -21455,6 +22569,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ilyad" supported="no">
 		<!-- SPS (CAPS) release 1944 -->
 		<description>Ilyad (Euro)</description>
@@ -21471,6 +22586,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="immortal" supported="no">
 		<!-- SPS (CAPS) release 340 -->
 		<description>The Immortal (Euro)</description>
@@ -21492,6 +22608,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="impact" supported="no">
 		<!-- SPS (CAPS) release 2462 -->
 		<description>Impact! (Euro)</description>
@@ -21506,6 +22623,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="imperium" supported="no">
 		<!-- SPS (CAPS) release 341 -->
 		<description>Imperium (Euro)</description>
@@ -21520,6 +22638,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="impossam" supported="no">
 		<!-- SPS (CAPS) release 63 -->
 		<description>Impossamole (Euro)</description>
@@ -21534,6 +22653,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="impm2025" supported="no">
 		<!-- SPS (CAPS) release 1107 -->
 		<description>Impossible Mission 2025 - The Special Edition (Euro)</description>
@@ -21555,6 +22675,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="impmiss2" supported="no">
 		<!-- SPS (CAPS) release 66 -->
 		<description>Impossible Mission II (Euro)</description>
@@ -21569,6 +22690,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="in80days" supported="no">
 		<!-- SPS (CAPS) release 1138 -->
 		<description>In 80 Days Around the World (Euro)</description>
@@ -21590,6 +22712,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="crashdum" supported="no">
 		<!-- SPS (CAPS) release 2771 -->
 		<description>The Incredible Crash Dummies (Euro)</description>
@@ -21611,6 +22734,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indyatad" supported="no">
 		<!-- SPS (CAPS) release 851 -->
 		<description>Indiana Jones and the Fate of Atlantis (Euro, TGA, v1.06 19921012)</description>
@@ -21686,6 +22810,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indyatadf" cloneof="indyatad" supported="no">
 		<!-- SPS (CAPS) release 1639 -->
 		<description>Indiana Jones and the Fate of Atlantis (Fra, TGA, v1.0 19930302)</description>
@@ -21761,6 +22886,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indyatadg" cloneof="indyatad" supported="no">
 		<!-- SPS (CAPS) release 342 -->
 		<description>Indiana Jones and the Fate of Atlantis (Ger, TGA, v1.0 19921028)</description>
@@ -21838,6 +22964,7 @@ license:CC0
 
 	<!-- Hangs at Indy logo on a cyan background [FDC] dsksync -->
 	<!-- Hangs after Lucasarts logo with stuck note (INTREQ=$aaaa) -->
+	<!-- ATK test: failed -->
 	<software name="indycrus" supported="no">
 		<!-- SPS (CAPS) release 1619 -->
 		<description>Indiana Jones and the Last Crusade (Euro, TAG)</description>
@@ -21852,6 +22979,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indycrad" supported="no">
 		<!-- SPS (CAPS) release 1990 -->
 		<description>Indiana Jones and the Last Crusade (USA, TGA, v1.4 19891004)</description>
@@ -21879,6 +23007,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indycradf" cloneof="indycrad" supported="no">
 		<!-- SPS (CAPS) release 1986 -->
 		<description>Indiana Jones and the Last Crusade (Fra, TGA, v1.4 19891006, Fun Radio la Compil Micro 3)</description>
@@ -21906,6 +23035,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indycradg" cloneof="indycrad" supported="no">
 		<!-- SPS (CAPS) release 343 -->
 		<description>Indiana Jones and the Last Crusade (Ger, TGA, v1.4 19891020)</description>
@@ -21933,6 +23063,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indycradi" cloneof="indycrad" supported="no">
 		<!-- SPS (CAPS) release 2323 -->
 		<description>Indiana Jones and the Last Crusade (Ita, TGA, Version Amiga Italian v1.5 19891229)</description>
@@ -21960,6 +23091,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indy" supported="no">
 		<!-- SPS (CAPS) release 660 -->
 		<description>Indiana Jones and the Temple of Doom (Euro, v3.28)</description>
@@ -21974,6 +23106,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="indy500" supported="no">
 		<!-- SPS (CAPS) release 686 -->
 		<description>Indianapolis 500 - The Simulation (Euro)</description>
@@ -21988,6 +23121,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="infestat" supported="no">
 		<!-- SPS (CAPS) release 494 -->
 		<description>Infestation (Euro)</description>
@@ -22002,6 +23136,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="infidel" supported="no">
 		<!-- SPS (CAPS) release 1490 -->
 		<description>Infidel (USA, r22)</description>
@@ -22016,6 +23151,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="innocent" supported="no">
 		<!-- SPS (CAPS) release 1824 -->
 		<description>Innocent Until Caught (Euro)</description>
@@ -22085,6 +23221,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="griffu" supported="no">
 		<!-- SPS (CAPS) release 687 -->
 		<description>Inspektor Griffu - Ein Toter hat Heimweh (Ger)</description>
@@ -22099,6 +23236,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="3dtennis" supported="no">
 		<!-- SPS (CAPS) release 1609 -->
 		<description>International 3D Tennis (Euro, Super Sim Pack)</description>
@@ -22113,6 +23251,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="inticeh" supported="no">
 		<!-- SPS (CAPS) release 665 -->
 		<description>International Ice Hockey (Euro)</description>
@@ -22127,6 +23266,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="int1dayc" supported="no">
 		<!-- SPS (CAPS) release 1368 -->
 		<description>International One Day Cricket (Euro)</description>
@@ -22141,6 +23281,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="intsocch" supported="no">
 		<!-- SPS (CAPS) release 866 -->
 		<description>International Soccer Challenge (Euro)</description>
@@ -22155,6 +23296,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="intsoccha" cloneof="intsocch" supported="no">
 		<!-- SPS (CAPS) release 1581 -->
 		<description>International Soccer Challenge (Euro, VR Vol. 1)</description>
@@ -22169,6 +23311,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="intsocz" supported="no">
 		<!-- SPS (CAPS) release 2429 -->
 		<description>International Soccer (Euro, Zeppelin)</description>
@@ -22183,6 +23326,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="intsport" supported="no">
 		<!-- SPS (CAPS) release 2815 -->
 		<description>International Sports Challenge (Euro)</description>
@@ -22210,6 +23354,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="intphase" supported="no">
 		<!-- SPS (CAPS) release 67 -->
 		<description>Interphase (Euro)</description>
@@ -22224,6 +23369,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="intrigue" supported="no">
 		<!-- SPS (CAPS) release 2448 -->
 		<description>Intrigue a la Renaissance (Fra)</description>
@@ -22238,6 +23384,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="invasion" supported="no">
 		<!-- SPS (CAPS) release 2511 -->
 		<description>Invasion (Euro)</description>
@@ -22252,6 +23399,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="invest" supported="no">
 		<!-- SPS (CAPS) release 2835 -->
 		<description>Inve$t (Ger, World of Business)</description>
@@ -22266,6 +23414,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="investa" cloneof="invest" supported="no">
 		<!-- SPS (CAPS) release 2836 -->
 		<description>Inve$t (Ger, No. 1 Collection)</description>
@@ -22287,6 +23436,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ironlord" supported="no">
 		<!-- SPS (CAPS) release 1650 -->
 		<description>Iron Lord (Euro)</description>
@@ -22308,6 +23458,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ironlordf" cloneof="ironlord" supported="no">
 		<!-- SPS (CAPS) release 2444 -->
 		<description>Iron Lord (Fra)</description>
@@ -22329,6 +23480,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ironlordg" cloneof="ironlord" supported="no">
 		<!-- SPS (CAPS) release 1530 -->
 		<description>Iron Lord (Ger)</description>
@@ -22350,6 +23502,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="irontrck" supported="no">
 		<!-- SPS (CAPS) release 2740 -->
 		<description>Iron Trackers (Euro, Budget)</description>
@@ -22364,6 +23517,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="ishar" supported="no">
 		<!-- SPS (CAPS) release 187 -->
 		<description>Ishar - Legend of the Fortress (Euro)</description>
@@ -22385,6 +23539,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="ishara" cloneof="ishar" supported="no">
 		<!-- SPS (CAPS) release 2750 -->
 		<description>Ishar - Legend of the Fortress (Euro, Ishar Trilogy)</description>
@@ -22406,6 +23561,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="ishar2" supported="no">
 		<!-- SPS (CAPS) release 1435 -->
 		<description>Ishar 2 - Messengers of Doom (Euro)</description>
@@ -22433,6 +23589,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="ishar2a" cloneof="ishar2" supported="no">
 		<!-- SPS (CAPS) release 2747 -->
 		<description>Ishar 2 - Messengers of Doom (Euro, English / French / German)</description>
@@ -22460,6 +23617,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="ishar2g" cloneof="ishar2" supported="no">
 		<!-- SPS (CAPS) release 2748 -->
 		<description>Ishar 2 - Messengers of Doom (Ger)</description>
@@ -22487,6 +23645,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="losthope" supported="no">
 		<!-- SPS (CAPS) release 1318 -->
 		<description>The Island of Lost Hope (Euro, v1.01)</description>
@@ -22508,6 +23667,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="issphere" supported="no">
 		<!-- SPS (CAPS) release 287 -->
 		<description>ISS - Incredible Shrinking Sphere (Euro)</description>
@@ -22522,6 +23682,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="italia90" supported="no">
 		<!-- SPS (CAPS) release 2314 -->
 		<description>Italia 1990 (Euro)</description>
@@ -22536,6 +23697,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ita90wcs" supported="no">
 		<!-- SPS (CAPS) release 2097 -->
 		<description>Italia '90 - World Cup Soccer (Euro)</description>
@@ -22550,6 +23712,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ita90wcsa" cloneof="ita90wcs" supported="no">
 		<!-- SPS (CAPS) release 1717 -->
 		<description>Italia '90 - World Cup Soccer (Euro, Addicted to Fun - Sports Collection)</description>
@@ -22564,6 +23727,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="itanight" supported="no">
 		<!-- SPS (CAPS) release 2324 -->
 		<description>Italian Night 1999 (Ita)</description>
@@ -22585,6 +23749,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="italy90" supported="no">
 		<!-- SPS (CAPS) release 1252 -->
 		<description>Italy 1990 (Euro, U.S. Gold)</description>
@@ -22599,6 +23764,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="italy90a" cloneof="italy90" supported="no">
 		<!-- SPS (CAPS) release 1260 -->
 		<description>Italy 1990 (Euro, U.S. Gold, Budget)</description>
@@ -22613,6 +23779,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="italy90w" supported="no">
 		<!-- SPS (CAPS) release 1610 -->
 		<description>Italy 1990 - Winners Edition (Euro, Super Sim Pack)</description>
@@ -22628,6 +23795,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up on AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="itcame" supported="no">
 		<!-- SPS (CAPS) release 14 -->
 		<description>It Came from the Desert (Euro)</description>
@@ -22655,6 +23823,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="itcame2" cloneof="itcame" supported="no">
 		<!-- SPS (CAPS) release 262 -->
 		<description>Antheads - It Came from the Desert II (Euro)</description>
@@ -22678,6 +23847,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
+	<!-- ATK test: OK -->
 	<software name="ivanhoe" supported="no">
 		<!-- SPS (CAPS) release 1648 -->
 		<description>Ivanhoe (Euro)</description>
@@ -22692,6 +23862,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="offroad" supported="no">
 		<!-- SPS (CAPS) release 387 -->
 		<description>Ivan Ironman Stewart's Super Off Road (Euro)</description>
@@ -22706,6 +23877,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nicklcd2" supported="no">
 		<!-- SPS (CAPS) release 691 -->
 		<description>Jack Nicklaus Course Disk 2 (Euro)</description>
@@ -22721,6 +23893,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nickluso" supported="no">
 		<!-- SPS (CAPS) release 2154 -->
 		<description>Jack Nicklaus Presents The Great Courses of the U.S. Open (Euro)</description>
@@ -22736,6 +23909,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nickl89" supported="no">
 		<!-- SPS (CAPS) release 2125 -->
 		<description>Jack Nicklaus Presents The Major Championship Courses of 1989 (Euro)</description>
@@ -22751,6 +23925,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nicklunl" supported="no">
 		<!-- SPS (CAPS) release 2007 -->
 		<description>Jack Nicklaus' Unlimited Golf &amp; Course Design (USA)</description>
@@ -22772,6 +23947,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="xj220" supported="no">
 		<!-- SPS (CAPS) release 1200 -->
 		<description>Jaguar XJ220 (Euro)</description>
@@ -22793,6 +23969,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="khanwcs" supported="no">
 		<!-- SPS (CAPS) release 129 -->
 		<description>Jahangir Khan's World Championship Squash (Euro)</description>
@@ -22807,6 +23984,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jbond" supported="no">
 		<!-- SPS (CAPS) release 2016 -->
 		<description>James Bond - The Stealth Affair (USA)</description>
@@ -22834,6 +24012,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shogun" supported="no">
 		<!-- SPS (CAPS) release 1257 -->
 		<description>James Clavell's Shōgun (Euro)</description>
@@ -22848,6 +24027,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jpond" supported="no">
 		<!-- SPS (CAPS) release 3015 -->
 		<description>James Pond - Underwater Agent (Euro)</description>
@@ -22862,6 +24042,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jponda" cloneof="jpond" supported="no">
 		<!-- SPS (CAPS) release 3016 -->
 		<description>James Pond - Underwater Agent (Euro, Chart Attack)</description>
@@ -22876,6 +24057,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="robocod" supported="no">
 		<!-- SPS (CAPS) release 1352 -->
 		<description>James Pond II - Codename RoboCod (Euro)</description>
@@ -22890,6 +24072,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robocoda" cloneof="robocod" supported="no">
 		<!-- SPS (CAPS) release 1353 -->
 		<description>James Pond II - Codename RoboCod (Euro, Budget)</description>
@@ -22904,6 +24087,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jaws" supported="no">
 		<!-- SPS (CAPS) release 512 -->
 		<description>Jaws (Euro)</description>
@@ -22918,6 +24102,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jawsa" cloneof="jaws" supported="no">
 		<!-- SPS (CAPS) release 1184 -->
 		<description>Jaws (Euro, Alt)</description>
@@ -22932,6 +24117,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jetsetw2" supported="no">
 		<!-- SPS (CAPS) release 1115 -->
 		<description>Jet Set Willy II (Euro)</description>
@@ -22946,6 +24132,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jetsons" supported="no">
 		<!-- SPS (CAPS) release 2270 -->
 		<description>Jetsons - The Computer Game (Euro)</description>
@@ -22960,6 +24147,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jetstrik" supported="no">
 		<!-- SPS (CAPS) release 130 -->
 		<description>Jetstrike (Euro)</description>
@@ -22981,6 +24169,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jigsawpm" supported="no">
 		<!-- SPS (CAPS) release 2899 -->
 		<description>Jigsaw Puzzlemania (Euro)</description>
@@ -23002,6 +24191,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="jimpower" supported="no">
 		<!-- SPS (CAPS) release 68 -->
 		<description>Jim Power in Mutant Planet (Euro)</description>
@@ -23023,6 +24213,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jimmyfj" supported="no">
 		<!-- SPS (CAPS) release 2157 -->
 		<description>Jimmy's Fantastic Journey (Euro, v1.3)</description>
@@ -23037,6 +24228,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jimmywws" supported="no">
 		<!-- SPS (CAPS) release 2466 -->
 		<description>Jimmy White's Whirlwind Snooker (Euro, v3)</description>
@@ -23051,6 +24243,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jimmywwsa" cloneof="jimmywws" supported="no">
 		<!-- SPS (CAPS) release 513 -->
 		<description>Jimmy White's Whirlwind Snooker (Euro)</description>
@@ -23065,6 +24258,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jimmywwsb" cloneof="jimmywws" supported="no">
 		<!-- SPS (CAPS) release 2467 -->
 		<description>Jimmy White's Whirlwind Snooker (Euro, Award Winners Gold Edition)</description>
@@ -23079,6 +24273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="jinks" supported="no">
 		<!-- SPS (CAPS) release 973 -->
 		<description>Jinks (Euro)</description>
@@ -23100,6 +24295,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jinxter" supported="no">
 		<!-- SPS (CAPS) release 963 -->
 		<description>Jinxter (Euro, v1.2)</description>
@@ -23114,6 +24310,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="joanarc" supported="no">
 		<!-- SPS (CAPS) release 2793 -->
 		<description>Joan of Arc (Euro)</description>
@@ -23135,6 +24332,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="joanarcg" cloneof="joanarc" supported="no">
 		<!-- SPS (CAPS) release 345 -->
 		<description>Jeanne d'Arc (Ger)</description>
@@ -23156,6 +24354,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="joemac" supported="no">
 		<!-- SPS (CAPS) release 2179 -->
 		<description>Joe and Mac - Caveman Ninja (Euro)</description>
@@ -23177,6 +24376,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="joeblade" supported="no">
 		<!-- SPS (CAPS) release 514 -->
 		<description>Joe Blade (Euro)</description>
@@ -23191,6 +24391,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="joeblad2" supported="no">
 		<!-- SPS (CAPS) release 3017 -->
 		<description>Joe Blade 2 (Euro, Budget)</description>
@@ -23205,6 +24406,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="barnesef" supported="no">
 		<!-- SPS (CAPS) release 1925 -->
 		<description>John Barnes European Football (Euro)</description>
@@ -23219,6 +24421,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lowedart" supported="no">
 		<!-- SPS (CAPS) release 2778 -->
 		<description>John Lowe's Ultimate Darts (Euro)</description>
@@ -23234,6 +24437,7 @@ license:CC0
 	</software>
 
 	<!-- crashes on the "You've got it, we've used it" screen if expansion RAM is installed -->
+	<!-- ATK test: OK -->
 	<software name="madden" supported="no">
 		<!-- SPS (CAPS) release 71 -->
 		<description>John Madden Football (Euro)</description>
@@ -23257,6 +24461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jonathan" supported="no">
 		<!-- SPS (CAPS) release 515 -->
 		<description>Jonathan (Ger)</description>
@@ -23326,6 +24531,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="journey" supported="no">
 		<!-- SPS (CAPS) release 499 -->
 		<description>Journey (Euro)</description>
@@ -23341,6 +24547,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="jcearth" supported="partial">
 		<!-- SPS (CAPS) release 1901 -->
 		<description>Journey to the Center of the Earth (Euro)</description>
@@ -23363,6 +24570,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jcearthg" cloneof="jcearth" supported="no">
 		<!-- SPS (CAPS) release 781 -->
 		<description>Reise zum Mittelpunkt der Erde (Ger)</description>
@@ -23384,6 +24592,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jumpjet" supported="no">
 		<!-- SPS (CAPS) release 2528 -->
 		<description>Jump Jet (Euro)</description>
@@ -23398,6 +24607,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="jumpingj" supported="no">
 		<!-- SPS (CAPS) release 1040 -->
 		<description>Jumping Jack'Son (Euro)</description>
@@ -23412,6 +24622,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jungle" supported="no">
 		<!-- SPS (CAPS) release 516 -->
 		<description>The Jungle Book (Ger?)</description>
@@ -23426,6 +24637,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="jstrike" supported="no">
 		<!-- SPS (CAPS) release 188 -->
 		<description>Jungle Strike (Euro)</description>
@@ -23453,6 +24665,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jupiter" supported="no">
 		<!-- SPS (CAPS) release 1280 -->
 		<description>Jupiter's Masterdrive (Euro)</description>
@@ -23467,6 +24680,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="jpark" supported="no">
 		<!-- SPS (CAPS) release 48 -->
 		<description>Jurassic Park (Euro)</description>
@@ -23500,6 +24714,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="k240" supported="no">
 		<!-- SPS (CAPS) release 1565 -->
 		<description>K240 (Euro)</description>
@@ -23527,6 +24742,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kamikaze" supported="no">
 		<!-- SPS (CAPS) release 1573 -->
 		<description>Kamikaze (Euro)</description>
@@ -23541,6 +24757,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kampfgrp" supported="no">
 		<!-- SPS (CAPS) release 2549 -->
 		<description>Kampfgruppe (Euro, v1.4)</description>
@@ -23555,6 +24772,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kartgp" supported="no">
 		<!-- SPS (CAPS) release 517 -->
 		<description>Karting Grand Prix (Euro)</description>
@@ -23569,6 +24787,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kgplas" supported="no">
 		<!-- SPS (CAPS) release 1471 -->
 		<description>Karting Grand Prix &amp; Las Vegas (Euro, Sextett)</description>
@@ -23584,6 +24803,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation on a500p, white screen on a500 -->
+	<!-- ATK test: failed -->
 	<software name="katakis" supported="no">
 		<!-- SPS (CAPS) release 347 -->
 		<description>Katakis (Euro, v1.1)</description>
@@ -23605,6 +24825,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="katakisa" cloneof="katakis" supported="no">
 		<!-- SPS (CAPS) release 1273 -->
 		<description>Katakis (Euro, Highlights)</description>
@@ -23619,6 +24840,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kathedrl" supported="no">
 		<!-- SPS (CAPS) release 518 -->
 		<description>Die Kathedrale (Ger)</description>
@@ -23652,6 +24874,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="keef" supported="no">
 		<!-- SPS (CAPS) release 1460 -->
 		<description>Keef the Thief (USA, v1.0)</description>
@@ -23673,6 +24896,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kellyx" supported="no">
 		<!-- SPS (CAPS) release 1133 -->
 		<description>Kelly X (Euro, Budget)</description>
@@ -23687,6 +24911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kennedy" supported="no">
 		<!-- SPS (CAPS) release 1506 -->
 		<description>Kennedy Approach (Euro)</description>
@@ -23701,6 +24926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dalglish" supported="no">
 		<!-- SPS (CAPS) release 519 -->
 		<description>Kenny Dalglish's Soccer Manager (Euro)</description>
@@ -23715,6 +24941,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="maramon" supported="no">
 		<!-- SPS (CAPS) release 1965 -->
 		<description>The Keys To Maramon (Euro, v1.5)</description>
@@ -23729,6 +24956,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kgb" supported="no">
 		<!-- SPS (CAPS) release 1109 -->
 		<description>KGB (Euro)</description>
@@ -23769,6 +24997,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kgbf" cloneof="kgb" supported="no">
 		<!-- SPS (CAPS) release 2591 -->
 		<description>KGB (Fra)</description>
@@ -23808,6 +25037,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="khalaan" supported="no">
 		<!-- SPS (CAPS) release 2395 -->
 		<description>Khalaan (USA)</description>
@@ -23830,6 +25060,7 @@ license:CC0
 	</software>
 
 	<!-- blue screen, keeps accessing invalid areas, [FDC] dsksync bootblock? -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kickoff" supported="no">
 		<!-- SPS (CAPS) release 189 -->
 		<description>Kick Off (Euro, v1.1)</description>
@@ -23845,6 +25076,7 @@ license:CC0
 	</software>
 
 	<!-- blue screen [FDC] -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kickoffex" cloneof="kickoff" supported="no">
 		<!-- SPS (CAPS) release 73 -->
 		<description>Kick Off - Extra Time (Euro, v2.2)</description>
@@ -23861,6 +25093,7 @@ license:CC0
 	</software>
 
 	<!-- blue screen [FDC] (same as kickoffex) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="koffet" supported="no">
 		<!-- SPS (CAPS) release 881 -->
 		<description>Kick Off + Extra Time (Euro)</description>
@@ -23875,6 +25108,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 2191 -->
 		<description>Kick Off 2 (Euro, v1.6e)</description>
@@ -23889,6 +25123,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2a" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 760 -->
 		<description>Kick Off 2 (Euro, v1.4e)</description>
@@ -23903,6 +25138,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Guru Meditation after prompt to change to game disk (tested with kickoff2a) -->
+	<!-- ATK test: OK -->
 	<software name="kickoff2a1200" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 761 -->
 		<description>Kick Off 2 (Euro, v1.4e,  A1200 Boot Disk)</description>
@@ -23917,6 +25154,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2g" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 1245 -->
 		<description>Kick Off 2 (Ger, v1.4g)</description>
@@ -23931,6 +25169,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2i" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 2574 -->
 		<description>Kick Off 2 (Ita, v1.4i)</description>
@@ -23945,6 +25184,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2s" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 2507 -->
 		<description>Kick Off 2 (Spa, v1.4s)</description>
@@ -23959,6 +25199,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kickoff2ge" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 167 -->
 		<description>Kick Off 2 - Giants of Europe (Euro)</description>
@@ -23974,6 +25215,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2re" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 169 -->
 		<description>Kick Off 2 - Return to Europe (Euro)</description>
@@ -23989,6 +25231,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2fw" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 166 -->
 		<description>Kick Off 2 - The Final Whistle (Euro, v2.1e)</description>
@@ -24004,6 +25247,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2fwa" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 759 -->
 		<description>Kick Off 2 - The Final Whistle (Euro, v1.9e)</description>
@@ -24019,6 +25263,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2fwg" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 2739 -->
 		<description>Kick Off 2 - The Final Whistle (Ger, v1.9g)</description>
@@ -24034,6 +25279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff2wt" cloneof="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 190 -->
 		<description>Kick Off 2 - Winning Tactics (Euro)</description>
@@ -24049,6 +25295,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="koff2wc" supported="no">
 		<!-- SPS (CAPS) release 168 -->
 		<description>Kick Off 2 Plus World Cup '90 (Euro)</description>
@@ -24063,6 +25310,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="koff2wca" cloneof="koff2wc" supported="no">
 		<!-- SPS (CAPS) release 1270 -->
 		<description>Kick Off 2 Plus World Cup '90 (Euro, Alt)</description>
@@ -24077,6 +25325,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="koff2wcg" cloneof="koff2wc" supported="no">
 		<!-- SPS (CAPS) release 689 -->
 		<description>Kick Off 2 Plus World Cup '90 (Ger)</description>
@@ -24091,6 +25340,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="koff2wcg1" cloneof="koff2wc" supported="no">
 		<!-- SPS (CAPS) release 853 -->
 		<description>Kick Off 2 Plus World Cup '90 (Ger, Alt)</description>
@@ -24105,6 +25355,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="koff2wci" cloneof="koff2wc" supported="no">
 		<!-- SPS (CAPS) release 2573 -->
 		<description>Kick Off 2 Plus World Cup '90 (Ita)</description>
@@ -24119,6 +25370,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kickoff3" supported="no">
 		<!-- SPS (CAPS) release 191 -->
 		<description>Kick Off 3 (Euro)</description>
@@ -24140,6 +25392,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="koff3ec" supported="no">
 		<!-- SPS (CAPS) release 170 -->
 		<description>Kick Off 3 - European Challenge (Euro)</description>
@@ -24161,6 +25414,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kidchaos" supported="no">
 		<!-- SPS (CAPS) release 1140 -->
 		<description>Kid Chaos (Euro)</description>
@@ -24194,6 +25448,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kidglove" supported="no">
 		<!-- SPS (CAPS) release 1372 -->
 		<description>Kid Gloves (Euro)</description>
@@ -24208,6 +25463,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kidglov2" supported="no">
 		<!-- SPS (CAPS) release 1543 -->
 		<description>Kid Gloves II (Euro)</description>
@@ -24223,6 +25479,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="killball" supported="no">
 		<!-- SPS (CAPS) release 2565 -->
 		<description>Killerball (Fra, Action Sport)</description>
@@ -24237,6 +25494,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kilcloud" supported="no">
 		<!-- SPS (CAPS) release 3031 -->
 		<description>The Killing Cloud (Euro)</description>
@@ -24258,6 +25516,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="kilcloudu" cloneof="kilcloud" supported="no">
 		<!-- SPS (CAPS) release 3019 -->
 		<description>The Killing Cloud (USA)</description>
@@ -24280,6 +25539,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, stuck note on SFXs when playback ends -->
+	<!-- ATK test: OK -->
 	<software name="killmach" supported="partial">
 		<!-- SPS (CAPS) release 2504 -->
 		<description>Killing Machine (Euro)</description>
@@ -24294,6 +25554,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst1" supported="no">
 		<!-- SPS (CAPS) release 1436 -->
 		<description>King's Quest 1 - Quest for the Crown (Euro, SCI v1.000.054, Enhanced)</description>
@@ -24327,6 +25588,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kingqst" supported="no">
 		<!-- SPS (CAPS) release 1333 -->
 		<description>King's Quest - Quest for the Crown (Euro, v1.0U, HLS)</description>
@@ -24341,6 +25603,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kingqst2" supported="no">
 		<!-- SPS (CAPS) release 2239 -->
 		<description>King's Quest II - Romancing the Throne (Euro, v2.0J, HLS)</description>
@@ -24355,6 +25618,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst2a" cloneof="kingqst2" supported="no">
 		<!-- SPS (CAPS) release 520 -->
 		<description>King's Quest II - Romancing the Throne (Euro, v2.0J)</description>
@@ -24369,6 +25633,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst2b" cloneof="kingqst2" supported="no">
 		<!-- SPS (CAPS) release 2126 -->
 		<description>King's Quest II - Romancing the Throne (Euro, v2.0J, Budget)</description>
@@ -24383,6 +25648,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kingqst3" supported="no">
 		<!-- SPS (CAPS) release 521 -->
 		<description>King's Quest III - To Heir is Human (Euro, v1.01, HLS)</description>
@@ -24397,6 +25663,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst4" supported="no">
 		<!-- SPS (CAPS) release 822 -->
 		<description>King's Quest IV - The Perils of Rosella (Euro, v1.023 19900530)</description>
@@ -24430,6 +25697,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst5" supported="no">
 		<!-- SPS (CAPS) release 348 -->
 		<description>King's Quest V - Absence Makes The Heart Go Yonder (Euro, v1.000.000)</description>
@@ -24487,6 +25755,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingqst6" supported="no">
 		<!-- SPS (CAPS) release 2390 -->
 		<description>King's Quest VI - Heir Today, Gone Tomorrow (Fra)</description>
@@ -24557,6 +25826,7 @@ license:CC0
 	</software>
 
 	<!-- "Software error", clicking on cancel causes Guru Meditation -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kingchic" supported="no">
 		<!-- SPS (CAPS) release 1416 -->
 		<description>The King of Chicago (Euro)</description>
@@ -24578,6 +25848,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="kingchica" cloneof="kingchic" supported="no">
 		<!-- SPS (CAPS) release 1795 -->
 		<description>The King of Chicago (Euro, Alt)</description>
@@ -24599,6 +25870,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingmakr" supported="no">
 		<!-- SPS (CAPS) release 1616 -->
 		<description>Kingmaker (Euro)</description>
@@ -24621,6 +25893,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kingpin" supported="no">
 		<!-- SPS (CAPS) release 2888 -->
 		<description>Kingpin - Arcade Sports Series Bowling (Euro)</description>
@@ -24635,6 +25908,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="klax" supported="no">
 		<!-- SPS (CAPS) release 878 -->
 		<description>Klax (Euro)</description>
@@ -24650,6 +25924,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, DSKDAT W on ranking screen -->
+	<!-- ATK test: failed -->
 	<software name="knigtfrc" supported="partial">
 		<!-- SPS (CAPS) release 1574 -->
 		<description>Knight Force (Euro)</description>
@@ -24664,6 +25939,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="knightmr" supported="no">
 		<!-- SPS (CAPS) release 966 -->
 		<description>Knightmare (Euro)</description>
@@ -24685,6 +25961,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="knigtorc" supported="no">
 		<!-- SPS (CAPS) release 215 -->
 		<description>Knight Orc (Euro)</description>
@@ -24700,6 +25977,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="crystaln" supported="yes">
 		<!-- SPS (CAPS) release 1160 -->
 		<description>Knights of the Crystallion (Euro)</description>
@@ -24721,6 +25999,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="crystalng" cloneof="crystaln" supported="no">
 		<!-- SPS (CAPS) release 1426 -->
 		<description>Knights of the Crystallion (Ger)</description>
@@ -24742,6 +26021,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="knigtsky" supported="no">
 		<!-- SPS (CAPS) release 522 -->
 		<description>Knights of the Sky (Euro, v3.04)</description>
@@ -24763,6 +26043,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="knigtskya" cloneof="knigtsky" supported="no">
 		<!-- SPS (CAPS) release 1309 -->
 		<description>Knights of the Sky (Euro, v3.01)</description>
@@ -24784,6 +26065,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="kristal" supported="no">
 		<!-- SPS (CAPS) release 24 -->
 		<description>The Kristal (Euro)</description>
@@ -24817,6 +26099,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kristalu" cloneof="kristal" supported="no">
 		<!-- SPS (CAPS) release 1194 -->
 		<description>The Kristal (USA)</description>
@@ -24850,6 +26133,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="krustyfh" supported="no">
 		<!-- SPS (CAPS) release 1599 -->
 		<description>Krusty's Fun House (Euro)</description>
@@ -24864,6 +26148,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="kryptegg" supported="no">
 		<!-- SPS (CAPS) release 1578 -->
 		<description>Krypton Egg (Euro, Big Box)</description>
@@ -24878,6 +26163,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="kult" supported="no">
 		<!-- SPS (CAPS) release 661 -->
 		<description>Kult (Euro)</description>
@@ -24892,6 +26178,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kulta" cloneof="kult" supported="no">
 		<!-- SPS (CAPS) release 1512 -->
 		<description>Kult (Euro, Budget)</description>
@@ -24906,6 +26193,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="labangl2" supported="no">
 		<!-- SPS (CAPS) release 2584 -->
 		<description>Labyrinthe d'Anglomania 2 (Fra)</description>
@@ -24920,6 +26208,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="labombre" supported="no">
 		<!-- SPS (CAPS) release 2856 -->
 		<description>Labyrinthe de la Reine des Ombres (Fra)</description>
@@ -24934,6 +26223,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="lablexic" supported="no">
 		<!-- SPS (CAPS) release 2583 -->
 		<description>Le Labyrinthe de Lexicos (Fra)</description>
@@ -24948,6 +26238,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="laberrar" supported="no">
 		<!-- SPS (CAPS) release 2582 -->
 		<description>Le Labyrinthe d'Errare (Fra)</description>
@@ -24962,6 +26253,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lancastr" supported="no">
 		<!-- SPS (CAPS) release 2885 -->
 		<description>Lancaster (Euro, Supreme Challenge - Flight Command)</description>
@@ -24976,6 +26268,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lancelot" supported="no">
 		<!-- SPS (CAPS) release 216 -->
 		<description>Lancelot (Euro)</description>
@@ -24990,6 +26283,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lasersqd" supported="no">
 		<!-- SPS (CAPS) release 1907 -->
 		<description>Laser Squad (Euro)</description>
@@ -25004,6 +26298,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lasersqdu" cloneof="lasersqd" supported="no">
 		<!-- SPS (CAPS) release 1908 -->
 		<description>Laser Squad (USA)</description>
@@ -25020,6 +26315,7 @@ license:CC0
 
 	<!-- Hangs at a rainbow colored screen [FDC] dsksync -->
 	<!-- Has serious GFX pitch corruption when scrolls during gameplay -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lastbtle" supported="no">
 		<!-- SPS (CAPS) release 1044 -->
 		<description>Last Battle (Euro)</description>
@@ -25034,6 +26330,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lastduel" supported="no">
 		<!-- SPS (CAPS) release 2532 -->
 		<description>Last Duel - Inter Planet War 2012 (Euro)</description>
@@ -25049,6 +26346,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up on first stage loading screen, sometimes fatal errors with "amiga_fdc_device::live_run - cur_live.bit_counter > 8" -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lastnin2" supported="no">
 		<!-- SPS (CAPS) release 131 -->
 		<description>Last Ninja 2 - Back With A Vengeance (Euro)</description>
@@ -25064,6 +26362,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, sometimes fatal errors with "amiga_fdc_device::live_run - cur_live.bit_counter > 8" -->
+	<!-- ATK test: OK -->
 	<software name="lastnin2a" cloneof="lastnin2" supported="no">
 		<!-- SPS (CAPS) release 3094 -->
 		<description>Last Ninja 2 - Back With A Vengeance (Euro, Superheroes)</description>
@@ -25078,6 +26377,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lastnin3" supported="no">
 		<!-- SPS (CAPS) release 495 -->
 		<description>Last Ninja 3 (Euro)</description>
@@ -25099,6 +26399,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lasvegas" supported="no">
 		<!-- SPS (CAPS) release 74 -->
 		<description>Las Vegas (Euro)</description>
@@ -25113,6 +26414,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lasvegasa" cloneof="lasvegas" supported="no">
 		<!-- SPS (CAPS) release 2190 -->
 		<description>Las Vegas (Euro, Budget)</description>
@@ -25127,6 +26429,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="leadbg" supported="no">
 		<!-- SPS (CAPS) release 523 -->
 		<description>Leader Board Golf Simulation (Euro)</description>
@@ -25141,6 +26444,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="leadbgt1" cloneof="leadbg" supported="no">
 		<!-- SPS (CAPS) release 1474 -->
 		<description>Leader Board Golf Simulation - Tournament Disk #1 (Euro)</description>
@@ -25156,6 +26460,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="leander" supported="no">
 		<!-- SPS (CAPS) release 496 -->
 		<description>Leander (Euro)</description>
@@ -25183,6 +26488,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="leanderu" cloneof="leander" supported="no">
 		<!-- SPS (CAPS) release 2351 -->
 		<description>Leander (USA)</description>
@@ -25210,6 +26516,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="teramis" supported="no">
 		<!-- SPS (CAPS) release 3061 -->
 		<description>Leavin' Teramis (Euro)</description>
@@ -25224,6 +26531,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ledstorm" supported="no">
 		<!-- SPS (CAPS) release 934 -->
 		<description>LED Storm (Euro)</description>
@@ -25238,6 +26546,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legrobin" supported="no">
 		<!-- SPS (CAPS) release 1968 -->
 		<description>The Legend of Robin Hood - Conquests of the Longbow (Euro, v1.000)</description>
@@ -25295,6 +26604,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legdjel" supported="no">
 		<!-- SPS (CAPS) release 1934 -->
 		<description>Legend of Djel (Euro)</description>
@@ -25309,6 +26619,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legdjelg" cloneof="legdjel" supported="no">
 		<!-- SPS (CAPS) release 1254 -->
 		<description>Legend of Djel (Ger)</description>
@@ -25323,6 +26634,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="faerghal" supported="no">
 		<!-- SPS (CAPS) release 2844 -->
 		<description>Legend of Faerghail (Euro, v2.0e 19901017)</description>
@@ -25378,6 +26690,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="faerghalg" cloneof="faerghal" supported="no">
 		<!-- SPS (CAPS) release 524 -->
 		<description>Legend of Faerghail (Ger, v1.8 19900607)</description>
@@ -25405,6 +26718,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="faerghalu" cloneof="faerghal" supported="no">
 		<!-- SPS (CAPS) release 2843 -->
 		<description>Legend of Faerghail (USA, v2.0e 19901017)</description>
@@ -25432,6 +26746,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kyrandia" supported="no">
 		<!-- SPS (CAPS) release 1575 -->
 		<description>The Legend of Kyrandia (Euro)</description>
@@ -25495,6 +26810,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="kyrandiag" cloneof="kyrandia" supported="no">
 		<!-- SPS (CAPS) release 372 -->
 		<description>The Legend of Kyrandia - Book One (Ger)</description>
@@ -25558,6 +26874,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="leglost" supported="no">
 		<!-- SPS (CAPS) release 2971 -->
 		<description>Legend of the Lost (Euro)</description>
@@ -25572,6 +26889,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legsword" supported="no">
 		<!-- SPS (CAPS) release 797 -->
 		<description>Legend of the Sword (Euro)</description>
@@ -25586,6 +26904,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legvalor" supported="no">
 		<!-- SPS (CAPS) release 837 -->
 		<description>Legends of Valour (Euro)</description>
@@ -25620,6 +26939,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legvalora" cloneof="legvalor" supported="no">
 		<!-- SPS (CAPS) release 838 -->
 		<description>Legends of Valour (Euro, Alt)</description>
@@ -25654,6 +26974,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legvalorf" cloneof="legvalor" supported="no">
 		<!-- SPS (CAPS) release 1768 -->
 		<description>Legends of Valour (Fra)</description>
@@ -25687,6 +27008,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="legvalorg" cloneof="legvalor" supported="no">
 		<!-- SPS (CAPS) release 525 -->
 		<description>Legends of Valour (Ger)</description>
@@ -25720,6 +27042,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="legend" supported="no">
 		<!-- SPS (CAPS) release 1100 -->
 		<description>Legend (Euro, Mindscape)</description>
@@ -25741,6 +27064,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="lslarry" supported="no">
 		<!-- SPS (CAPS) release 349 -->
 		<description>Leisure Suit Larry in The Land of the Lounge Lizards (Euro, v1.05 19870626, HLS)</description>
@@ -25755,6 +27079,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lslarry2" supported="no">
 		<!-- SPS (CAPS) release 193 -->
 		<description>Leisure Suit Larry Goes Looking for Love (in Several Wrong Places) (Euro, v1.003 19891016)</description>
@@ -25789,6 +27114,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lslarry3" supported="no">
 		<!-- SPS (CAPS) release 690 -->
 		<description>Leisure Suit Larry 3: Passionate Patti in Pursuit of the Pulsating Pectorals (Euro, v1.039 19900127)</description>
@@ -25828,6 +27154,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lslarry5" supported="no">
 		<!-- SPS (CAPS) release 2244 -->
 		<description>Leisure Suit Larry 5 - Passionate Patti Does A Little Undercover Work (Euro, v1.000 19911221)</description>
@@ -25881,6 +27208,7 @@ license:CC0
 
 	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
 	<!-- Detects expansion RAM as default -->
+	<!-- ATK test: failed -->
 	<software name="lemmings" supported="no">
 		<!-- SPS (CAPS) release 132 -->
 		<description>Lemmings (Euro)</description>
@@ -25902,6 +27230,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lemmingsa" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 2089 -->
 		<description>Lemmings (Euro, Award Winners Platinum Edition)</description>
@@ -25923,6 +27252,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lemmingsb" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 2238 -->
 		<description>Lemmings (Euro, Book Club)</description>
@@ -25944,6 +27274,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lemmingsc" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 270 -->
 		<description>Lemmings (Euro, Free with Commodore Promotion Pack)</description>
@@ -25958,6 +27289,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lemmingsu" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 901 -->
 		<description>Lemmings (USA)</description>
@@ -25979,6 +27311,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lemmingsua" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 1977 -->
 		<description>Lemmings (USA, Alt)</description>
@@ -26001,6 +27334,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation on a500p, white screen on a500 -->
+	<!-- ATK test: OK -->
 	<software name="lemming2" supported="no">
 		<!-- SPS (CAPS) release 351 -->
 		<description>Lemmings 2 - The Tribes (Euro)</description>
@@ -26028,6 +27362,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lemming2u" cloneof="lemming2" supported="no">
 		<!-- SPS (CAPS) release 1976 -->
 		<description>Lemmings 2 - The Tribes (USA)</description>
@@ -26055,6 +27390,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lemming2d" cloneof="lemming2" supported="no">
 		<!-- SPS (CAPS) release 786 -->
 		<description>Lemmings 2 Demo (Euro, The Future Entertainment Show)</description>
@@ -26094,6 +27430,7 @@ license:CC0
 	<!-- black screen [FDC] dsksync -->
 	<!-- masked Lethal Weapon intro text has raster issue -->
 	<!-- TODO: Needs multiple presses with no video feedback on mission select section? -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lweapon" supported="no">
 		<!-- SPS (CAPS) release 814 -->
 		<description>Lethal Weapon (Euro)</description>
@@ -26108,6 +27445,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lzone" supported="no">
 		<!-- SPS (CAPS) release 2321 -->
 		<description>Lethal Zone (Euro)</description>
@@ -26124,6 +27462,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="liberatn" supported="no">
 		<!-- SPS (CAPS) release 617 -->
 		<description>Liberation - Captive II (Euro)</description>
@@ -26163,6 +27502,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lic2kill" supported="no">
 		<!-- SPS (CAPS) release 772 -->
 		<description>Licence to Kill (Euro)</description>
@@ -26178,6 +27518,7 @@ license:CC0
 	</software>
 
 	<!-- Mouse cursor is uncontrollable -->
+	<!-- ATK test: OK -->
 	<software name="lifendth" supported="no">
 		<!-- SPS (CAPS) release 1126 -->
 		<description>Life and Death (Euro)</description>
@@ -26199,6 +27540,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="lightcor" supported="no">
 		<!-- SPS (CAPS) release 526 -->
 		<description>The Light Corridor (Euro)</description>
@@ -26213,6 +27555,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="loffire" supported="no">
 		<!-- SPS (CAPS) release 1394 -->
 		<description>Line of Fire (Euro)</description>
@@ -26227,6 +27570,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="links" supported="no">
 		<!-- SPS (CAPS) release 2481 -->
 		<description>Links - The Challenge of Golf (Euro, v1.53)</description>
@@ -26254,6 +27598,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="linksu" cloneof="links" supported="no">
 		<!-- SPS (CAPS) release 2010 -->
 		<description>Links - The Challenge of Golf (USA, v1.50)</description>
@@ -26281,6 +27626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="linkscc1" cloneof="links" supported="no">
 		<!-- SPS (CAPS) release 2482 -->
 		<description>Links Championship Course 1 - Firestone Country Club Akron, Ohio (Euro)</description>
@@ -26298,6 +27644,7 @@ license:CC0
 
 	<!-- boot OK in a1200 and a500. a500 doesn't draw any sprite -->
 	<!-- has major raster/alignment issues (stage intro text, in-game), first boss background layer has wrong colors. -->
+	<!-- ATK test: OK -->
 	<software name="lionhart" supported="no">
 		<!-- SPS (CAPS) release 845 -->
 		<description>Lionheart (Euro)</description>
@@ -26332,6 +27679,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="littlecp" supported="partial">
 		<!-- SPS (CAPS) release 913 -->
 		<description>Little Computer People (Euro)</description>
@@ -26346,6 +27694,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="littlecpu" cloneof="littlecp" supported="no">
 		<!-- SPS (CAPS) release 912 -->
 		<description>Little Computer People (USA)</description>
@@ -26360,6 +27709,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="littlepu" supported="no">
 		<!-- SPS (CAPS) release 839 -->
 		<description>Little Puff in Dragonland (Euro)</description>
@@ -26374,6 +27724,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="liveletd" supported="no">
 		<!-- SPS (CAPS) release 2187 -->
 		<description>Live and Let Die (Euro, The James Bond Collection)</description>
@@ -26388,6 +27739,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="liverpol" supported="no">
 		<!-- SPS (CAPS) release 528 -->
 		<description>Liverpool - The Computer Game (Euro)</description>
@@ -26409,6 +27761,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="logical" supported="no">
 		<!-- SPS (CAPS) release 529 -->
 		<description>Logical (Euro)</description>
@@ -26423,6 +27776,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lollypop" supported="no">
 		<!-- SPS (CAPS) release 2864 -->
 		<description>Lollypop (Euro)</description>
@@ -26463,6 +27817,7 @@ license:CC0
 	</software>
 
 	<!-- crashes in AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
+	<!-- ATK test: failed -->
 	<software name="racrally" supported="no">
 		<!-- SPS (CAPS) release 1098 -->
 		<description>Lombard RAC Rally (Euro)</description>
@@ -26484,6 +27839,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="racrallya" cloneof="racrally" supported="no">
 		<!-- SPS (CAPS) release 1144 -->
 		<description>Lombard RAC Rally (Euro, Budget)</description>
@@ -26498,6 +27854,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="racrallyg" cloneof="racrally" supported="no">
 		<!-- SPS (CAPS) release 1928 -->
 		<description>Lombard RAC Rally (Ger, The Power Pack)</description>
@@ -26513,6 +27870,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="loom" supported="partial">
 		<!-- SPS (CAPS) release 618 -->
 		<description>Loom (Euro, v1.2 19900510)</description>
@@ -26541,6 +27899,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="loomg" cloneof="loom" supported="no">
 		<!-- SPS (CAPS) release 75 -->
 		<description>Loom (Ger, v1.2 19900607)</description>
@@ -26568,6 +27927,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="loopz" supported="no">
 		<!-- SPS (CAPS) release 530 -->
 		<description>Loopz (Euro)</description>
@@ -26582,6 +27942,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lotr1" supported="no">
 		<!-- SPS (CAPS) release 1299 -->
 		<description>Lord of the Rings Vol. I (Euro)</description>
@@ -26609,6 +27970,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lotr1f" cloneof="lotr1" supported="no">
 		<!-- SPS (CAPS) release 2373 -->
 		<description>Lord of the Rings Vol. I (Fra)</description>
@@ -26636,6 +27998,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lotr1g" cloneof="lotr1" supported="no">
 		<!-- SPS (CAPS) release 2536 -->
 		<description>Lord of the Rings Vol. I (Ger)</description>
@@ -26663,6 +28026,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lordchao" supported="no">
 		<!-- SPS (CAPS) release 1568 -->
 		<description>Lords of Chaos (Euro)</description>
@@ -26677,6 +28041,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lotrealm" supported="no">
 		<!-- SPS (CAPS) release 1566 -->
 		<description>Lords of the Realm (Euro)</description>
@@ -26705,6 +28070,7 @@ license:CC0
 	</software>
 
 	<!-- crashes in AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="risinsun" supported="no">
 		<!-- SPS (CAPS) release 133 -->
 		<description>Lords of the Rising Sun (Euro)</description>
@@ -26726,6 +28092,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="risinsunu" cloneof="risinsun" supported="no">
 		<!-- SPS (CAPS) release 1779 -->
 		<description>Lords of the Rising Sun (USA)</description>
@@ -26750,6 +28117,7 @@ license:CC0
 	<!-- Garbage on language screen select then black screen [FDC] copy protection check at PC=243AC (enables 68k trace mode) -->
 	<!-- Ocean logo has serious pitch issues -->
 	<!-- [Paula] BGM channels often doesn't playback -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lostpatr" supported="no">
 		<!-- SPS (CAPS) release 773 -->
 		<description>Lost Patrol (Euro)</description>
@@ -26772,6 +28140,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lostpatru" cloneof="lostpatr" supported="no">
 		<!-- SPS (CAPS) release 498 -->
 		<description>Lost Patrol (USA)</description>
@@ -26793,6 +28162,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="infocom" supported="no">
 		<!-- SPS (CAPS) release 928 -->
 		<description>The Lost Treasures of Infocom (USA)</description>
@@ -26840,6 +28210,7 @@ license:CC0
 
 	<!-- Guru Meditation after selecting new game [FDC] dsksync -->
 	<!-- Crashes with wrong GFX colors if player gives up a stage (recheck) -->
+	<!-- ATK test: OK -->
 	<software name="lostvik" supported="no">
 		<!-- SPS (CAPS) release 2235 -->
 		<description>The Lost Vikings (Euro)</description>
@@ -26861,6 +28232,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lostvikf" cloneof="lostvik" supported="no">
 		<!-- SPS (CAPS) release 2236 -->
 		<description>The Lost Vikings (Fra)</description>
@@ -26882,6 +28254,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="matthaus" supported="no">
 		<!-- SPS (CAPS) release 2795 -->
 		<description>Lothar Matthäus (Die Interaktive Fußballsimulation) (Euro)</description>
@@ -26904,6 +28277,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: failed -->
 	<software name="lotus" supported="no">
 		<!-- SPS (CAPS) release 774 -->
 		<description>Lotus Esprit Turbo Challenge (Euro)</description>
@@ -26918,6 +28292,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lotusd" cloneof="lotus" supported="no">
 		<!-- SPS (CAPS) release 2512 -->
 		<description>Lotus Esprit Turbo Challenge Rolling Demo (Euro)</description>
@@ -26932,6 +28307,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="lotusa" cloneof="lotus" supported="no">
 		<!-- SPS (CAPS) release 2848 -->
 		<description>Lotus Esprit Turbo Challenge (Euro, Les Collectors)</description>
@@ -26947,6 +28323,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="lotus3" supported="no">
 		<!-- SPS (CAPS) release 217 -->
 		<description>Lotus III - The Ultimate Challenge (Euro)</description>
@@ -26969,6 +28346,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: failed -->
 	<software name="lotus2" supported="no">
 		<!-- SPS (CAPS) release 497 -->
 		<description>Lotus Turbo Challenge 2 (Euro)</description>
@@ -26983,6 +28361,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="luretemp" supported="no">
 		<!-- SPS (CAPS) release 2031 -->
 		<description>Lure of the Temptress (Euro, 19920617)</description>
@@ -27016,6 +28395,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="luretempa" cloneof="luretemp" supported="no">
 		<!-- SPS (CAPS) release 2030 -->
 		<description>Lure of the Temptress (Euro, 19920806, The Greatest)</description>
@@ -27049,6 +28429,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="luretempf" cloneof="luretemp" supported="no">
 		<!-- SPS (CAPS) release 2040 -->
 		<description>Lure of the Temptress (Fra, 19920618)</description>
@@ -27082,6 +28463,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="luretempi" cloneof="luretemp" supported="no">
 		<!-- SPS (CAPS) release 2028 -->
 		<description>Lure of the Temptress (Ita, 19920707)</description>
@@ -27115,6 +28497,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="lurkinh" supported="no">
 		<!-- SPS (CAPS) release 1404 -->
 		<description>The Lurking Horror (USA, r221)</description>
@@ -27129,6 +28512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="muds" supported="no">
 		<!-- SPS (CAPS) release 703 -->
 		<description>M.U.D.S. - Mean Ugly Dirty Sport (Euro)</description>
@@ -27150,6 +28534,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="m1tank" supported="no">
 		<!-- SPS (CAPS) release 531 -->
 		<description>M1 Tank Platoon (Euro, v849.01)</description>
@@ -27164,6 +28549,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mach3" supported="no">
 		<!-- SPS (CAPS) release 2638 -->
 		<description>Mach 3 (Euro)</description>
@@ -27178,6 +28564,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="madnews" supported="no">
 		<!-- SPS (CAPS) release 532 -->
 		<description>Mad News (Ger)</description>
@@ -27217,6 +28604,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="madprof" supported="no">
 		<!-- SPS (CAPS) release 662 -->
 		<description>Mad Professor Mariarti (Euro)</description>
@@ -27231,6 +28619,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="madshow" supported="no">
 		<!-- SPS (CAPS) release 2861 -->
 		<description>Mad Show (Euro, Budget)</description>
@@ -27245,6 +28634,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="madshowf" cloneof="madshow" supported="no">
 		<!-- SPS (CAPS) release 2860 -->
 		<description>Mad Show (Fra)</description>
@@ -27259,6 +28649,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="madtv" supported="no">
 		<!-- SPS (CAPS) release 533 -->
 		<description>Mad TV (Ger)</description>
@@ -27280,6 +28671,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="magicboy" supported="no">
 		<!-- SPS (CAPS) release 2525 -->
 		<description>Magic Boy (Euro)</description>
@@ -27294,6 +28686,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="maglines" supported="no">
 		<!-- SPS (CAPS) release 1732 -->
 		<description>Magic Lines (Euro)</description>
@@ -27308,6 +28701,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="magicpkt" supported="no">
 		<!-- SPS (CAPS) release 917 -->
 		<description>Magic Pockets (Euro, v1.00)</description>
@@ -27322,6 +28716,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="magician" supported="no">
 		<!-- SPS (CAPS) release 2417 -->
 		<description>The Magician (Euro)</description>
@@ -27336,6 +28731,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="magiclnd" supported="no">
 		<!-- SPS (CAPS) release 1145 -->
 		<description>Magicland Dizzy (Euro)</description>
@@ -27350,6 +28746,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="magscrol" supported="no">
 		<!-- SPS (CAPS) release 271 -->
 		<description>The Magnetic Scrolls Collection Vol. 1 (Euro)</description>
@@ -27384,6 +28781,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, sound whistles -->
+	<!-- ATK test: failed -->
 	<software name="majormtn" supported="partial">
 		<!-- SPS (CAPS) release 1756 -->
 		<description>Major Motion (Euro)</description>
@@ -27398,6 +28796,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mancounc" supported="no">
 		<!-- SPS (CAPS) release 2599 -->
 		<description>The Man from the Council (Euro, Mega Pack II)</description>
@@ -27412,6 +28811,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manager" supported="no">
 		<!-- SPS (CAPS) release 1310 -->
 		<description>The Manager (Euro, v2.0)</description>
@@ -27439,6 +28839,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="manutd" supported="no">
 		<!-- SPS (CAPS) release 1693 -->
 		<description>Manchester United - The Official Computer Game (Euro)</description>
@@ -27460,6 +28861,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manutda" cloneof="manutd" supported="no">
 		<!-- SPS (CAPS) release 1897 -->
 		<description>Manchester United - The Official Computer Game (Euro, Budget)</description>
@@ -27481,6 +28883,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manuteur" supported="no">
 		<!-- SPS (CAPS) release 2206 -->
 		<description>Manchester United Europe (Euro, v2.3, Budget)</description>
@@ -27495,6 +28898,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="manuteura" cloneof="manuteur" supported="no">
 		<!-- SPS (CAPS) release 1120 -->
 		<description>Manchester United Europe (Euro, v2.1)</description>
@@ -27509,6 +28913,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="manuteurb" cloneof="manuteur" supported="no">
 		<!-- SPS (CAPS) release 1104 -->
 		<description>Manchester United Europe (Euro, v2.0)</description>
@@ -27523,6 +28928,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manutplc94" cloneof="manutplc" supported="no">
 		<!-- SPS (CAPS) release 1789 -->
 		<description>Manchester United Premier League Champions - 1994-95 Season Data Disk (Euro)</description>
@@ -27537,6 +28943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manutplc" supported="no">
 		<!-- SPS (CAPS) release 1790 -->
 		<description>Manchester United Premier League Champions (Euro, v1.2 19940330)</description>
@@ -27558,6 +28965,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manhunt" supported="no">
 		<!-- SPS (CAPS) release 354 -->
 		<description>Manhunter - New York (Euro, v1.06)</description>
@@ -27579,6 +28987,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manhunt2" supported="no">
 		<!-- SPS (CAPS) release 1199 -->
 		<description>Manhunter 2 - San Francisco (USA, v3.06 19890817)</description>
@@ -27606,6 +29015,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mmansion" supported="no">
 		<!-- SPS (CAPS) release 1571 -->
 		<description>Maniac Mansion (Euro)</description>
@@ -27627,6 +29037,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mmansionf" cloneof="mmansion" supported="no">
 		<!-- SPS (CAPS) release 2376 -->
 		<description>Maniac Mansion (Fra)</description>
@@ -27648,6 +29059,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mmansiong" cloneof="mmansion" supported="no">
 		<!-- SPS (CAPS) release 355 -->
 		<description>Maniac Mansion (Ger)</description>
@@ -27669,6 +29081,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="manicmin" supported="no">
 		<!-- SPS (CAPS) release 1116 -->
 		<description>Manic Miner (Euro)</description>
@@ -27683,6 +29096,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="manix" supported="no">
 		<!-- SPS (CAPS) release 2533 -->
 		<description>Manix (Euro)</description>
@@ -27697,6 +29111,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="manixa" cloneof="manix" supported="no">
 		<!-- SPS (CAPS) release 2530 -->
 		<description>Manix (Euro, Budget)</description>
@@ -27711,6 +29126,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mortviel" supported="no">
 		<!-- SPS (CAPS) release 2148 -->
 		<description>Le Manoir de Mortvielle (Fra)</description>
@@ -27725,6 +29141,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="marble" supported="no">
 		<!-- SPS (CAPS) release 13 -->
 		<description>Marble Madness (Euro)</description>
@@ -27739,6 +29156,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mastblaz" supported="no">
 		<!-- SPS (CAPS) release 699 -->
 		<description>Masterblazer (Euro)</description>
@@ -27753,6 +29171,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="matchday" supported="no">
 		<!-- SPS (CAPS) release 248 -->
 		<description>Match of the Day (Euro)</description>
@@ -27774,6 +29193,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="matrixmr" supported="no">
 		<!-- SPS (CAPS) release 1705 -->
 		<description>Matrix Marauders (Euro)</description>
@@ -27788,6 +29208,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="maupiti" supported="no">
 		<!-- SPS (CAPS) release 2070 -->
 		<description>Maupiti Island (Euro)</description>
@@ -27809,6 +29230,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="maupitif" cloneof="maupiti" supported="no">
 		<!-- SPS (CAPS) release 2039 -->
 		<description>Maupiti Island (Fra)</description>
@@ -27830,6 +29252,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="maupitig" cloneof="maupiti" supported="no">
 		<!-- SPS (CAPS) release 1362 -->
 		<description>Maupiti Island (Ger)</description>
@@ -27851,6 +29274,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="maya" supported="no">
 		<!-- SPS (CAPS) release 1742 -->
 		<description>Maya (Euro)</description>
@@ -27866,6 +29290,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after selecting a squad -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="maydaysh" supported="no">
 		<!-- SPS (CAPS) release 2219 -->
 		<description>Mayday Squad Heroes (Euro)</description>
@@ -27880,6 +29305,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mcdonald" supported="no">
 		<!-- SPS (CAPS) release 970 -->
 		<description>McDonaldland (Euro)</description>
@@ -27894,6 +29320,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="megalo" supported="no">
 		<!-- SPS (CAPS) release 272 -->
 		<description>Mega Lo Mania (Euro)</description>
@@ -27915,6 +29342,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="megalof" cloneof="megalo" supported="no">
 		<!-- SPS (CAPS) release 1741 -->
 		<description>Mega Lo Mania (Fra)</description>
@@ -27936,6 +29364,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="megalog" cloneof="megalo" supported="no">
 		<!-- SPS (CAPS) release 76 -->
 		<description>Mega Lo Mania (Ger)</description>
@@ -27957,6 +29386,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="megamotn" supported="no">
 		<!-- SPS (CAPS) release 701 -->
 		<description>Mega Motion (Euro)</description>
@@ -27971,6 +29401,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mphoenix" supported="no">
 		<!-- SPS (CAPS) release 1376 -->
 		<description>Mega Phoenix (Euro)</description>
@@ -27985,6 +29416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="megatwin" supported="no">
 		<!-- SPS (CAPS) release 1863 -->
 		<description>Mega Twins (Euro)</description>
@@ -28006,6 +29438,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="megafort" supported="no">
 		<!-- SPS (CAPS) release 1576 -->
 		<description>Megafortress - Flight of the Old Dog (Euro)</description>
@@ -28027,6 +29460,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="megatrv1" supported="no">
 		<!-- SPS (CAPS) release 1498 -->
 		<description>MegaTraveller - Zhodani Conspiracy (Euro)</description>
@@ -28049,6 +29483,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="megatrv2" supported="no">
 		<!-- SPS (CAPS) release 1979 -->
 		<description>MegaTraveller 2 (Euro, v1.05)</description>
@@ -28077,6 +29512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="megatrv2g" cloneof="megatrv2" supported="no">
 		<!-- SPS (CAPS) release 1607 -->
 		<description>MegaTraveller 2 (Ger, v1.04)</description>
@@ -28105,6 +29541,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="menace" supported="no">
 		<!-- SPS (CAPS) release 823 -->
 		<description>Menace (Euro)</description>
@@ -28119,6 +29556,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenry" supported="no">
 		<!-- SPS (CAPS) release 955 -->
 		<description>Mercenary - Escape from Targ &amp; The Second City (Euro)</description>
@@ -28133,6 +29571,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenr2" supported="no">
 		<!-- SPS (CAPS) release 643 -->
 		<description>Damocles - Mercenary II (Euro)</description>
@@ -28147,6 +29586,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenr2u" cloneof="mercenr2" supported="no">
 		<!-- SPS (CAPS) release 1192 -->
 		<description>Damocles - Mercenary II (USA)</description>
@@ -28161,6 +29601,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenr2md1" cloneof="mercenr2" supported="no">
 		<!-- SPS (CAPS) release 644 -->
 		<description>Damocles Mission Disk 1 (Euro)</description>
@@ -28175,6 +29616,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenr2md2" cloneof="mercenr2" supported="no">
 		<!-- SPS (CAPS) release 645 -->
 		<description>Damocles Mission Disk 2 (Euro)</description>
@@ -28189,6 +29631,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mercenr3" supported="no">
 		<!-- SPS (CAPS) release 356 -->
 		<description>Mercenary III - The Dion Crisis (Euro)</description>
@@ -28203,6 +29646,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="mercs" supported="no">
 		<!-- SPS (CAPS) release 1668 -->
 		<description>Mercs (Euro)</description>
@@ -28217,6 +29661,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="metalmst" supported="no">
 		<!-- SPS (CAPS) release 534 -->
 		<description>Metal Masters (Euro)</description>
@@ -28238,6 +29683,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="miamichs" supported="no">
 		<!-- SPS (CAPS) release 2531 -->
 		<description>Miami Chase (Euro)</description>
@@ -28259,6 +29705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mickmack" supported="no">
 		<!-- SPS (CAPS) release 657 -->
 		<description>Mick &amp; Mack as the Global Gladiators (Euro)</description>
@@ -28281,6 +29728,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="micky123" supported="no">
 		<!-- SPS (CAPS) release 2475 -->
 		<description>Mickey 123 - L'Anniversaire Surprise (Fra)</description>
@@ -28302,6 +29750,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mickyabc" supported="no">
 		<!-- SPS (CAPS) release 2477 -->
 		<description>Mickey ABC - Une Journée à la Fête (Fra)</description>
@@ -28329,6 +29778,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mickmotc" supported="no">
 		<!-- SPS (CAPS) release 2474 -->
 		<description>Mickey et la Machine à Mots Croisés (Fra)</description>
@@ -28343,6 +29793,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mickmemr" supported="no">
 		<!-- SPS (CAPS) release 2559 -->
 		<description>Mickey - Jeu de Memoire (Fra)</description>    <!-- Mickey's Memory Challenge -->
@@ -28357,6 +29808,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mickpuzl" supported="no">
 		<!-- SPS (CAPS) release 2476 -->
 		<description>Mickey - Puzzles Animes (Fra)</description>    <!-- Mickey's Jigsaw Puzzles -->
@@ -28378,6 +29830,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mickrunz" supported="no">
 		<!-- SPS (CAPS) release 2845 -->
 		<description>Mickey's Runaway Zoo (Euro)</description>
@@ -28393,6 +29846,7 @@ license:CC0
 	</software>
 
 	<!-- White screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="micromac" supported="no">
 		<!-- SPS (CAPS) release 357 -->
 		<description>Micro Machines (Euro)</description>
@@ -28407,6 +29861,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mpcol" supported="no">
 		<!-- SPS (CAPS) release 852 -->
 		<description>MicroProse Collection for 1991/92 (Euro)</description>
@@ -28422,6 +29877,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs on intro screen -->
+	<!-- ATK test: OK -->
 	<software name="mpf1gp" supported="no">
 		<!-- SPS (CAPS) release 325 -->
 		<description>MicroProse Formula One Grand Prix (Euro)</description>
@@ -28456,6 +29912,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs after selecting a game mode on title screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mpsoccer" supported="no">
 		<!-- SPS (CAPS) release 1078 -->
 		<description>MicroProse Soccer (Euro, Soccer Stars)</description>
@@ -28471,6 +29928,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: failed -->
 	<software name="midres" supported="no">
 		<!-- SPS (CAPS) release 1226 -->
 		<description>Midnight Resistance (Euro)</description>
@@ -28485,6 +29943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="midwint" supported="no">
 		<!-- SPS (CAPS) release 218 -->
 		<description>Midwinter (Euro)</description>
@@ -28499,6 +29958,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="midwinta" cloneof="midwint" supported="no">
 		<!-- SPS (CAPS) release 1582 -->
 		<description>Midwinter (Euro, VR Vol. 1)</description>
@@ -28513,6 +29973,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="midwintf" cloneof="midwint" supported="no">
 		<!-- SPS (CAPS) release 2553 -->
 		<description>Midwinter (Fra)</description>
@@ -28527,6 +29988,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="midwintg" cloneof="midwint" supported="no">
 		<!-- SPS (CAPS) release 358 -->
 		<description>Midwinter (Ger)</description>
@@ -28541,6 +30003,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="midwint2" supported="no">
 		<!-- SPS (CAPS) release 1332 -->
 		<description>Midwinter II (Euro, 1MB 1.7.9.1991)</description>
@@ -28569,6 +30032,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="midwint2g" cloneof="midwint2" supported="no">
 		<!-- SPS (CAPS) release 702 -->
 		<description>Midwinter II (Ger, 1MB 1.7.9.1991)</description>
@@ -28597,6 +30061,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mig29ful" supported="no">
 		<!-- SPS (CAPS) release 1045 -->
 		<description>MiG-29 Fulcrum (Euro)</description>
@@ -28611,6 +30076,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mig29sf" supported="no">
 		<!-- SPS (CAPS) release 535 -->
 		<description>MIG-29 Soviet Fighter (Euro)</description>
@@ -28625,6 +30091,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mightmg2" supported="no">
 		<!-- SPS (CAPS) release 990 -->
 		<description>Might and Magic Book Two - Gates to Another World! (Euro, v1.0 19900507)</description>
@@ -28646,6 +30113,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mightmg3" supported="no">
 		<!-- SPS (CAPS) release 2346 -->
 		<description>Might and Magic III - Isles of Terra (Euro)</description>
@@ -28691,6 +30159,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mightybj" supported="no">
 		<!-- SPS (CAPS) release 536 -->
 		<description>Mighty BombJack (Euro)</description>
@@ -28705,6 +30174,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mikeread" supported="no">
 		<!-- SPS (CAPS) release 867 -->
 		<description>Mike Read's Computer Pop Quiz (Euro)</description>
@@ -28719,6 +30189,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="milkyway" supported="no">
 		<!-- SPS (CAPS) release 2933 -->
 		<description>Milky Way Cafe</description>
@@ -28733,6 +30204,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="millen" supported="no">
 		<!-- SPS (CAPS) release 2027 -->
 		<description>Millenium - Return to Earth (USA)</description>
@@ -28747,6 +30219,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="millen22" supported="no">
 		<!-- SPS (CAPS) release 537 -->
 		<description>Millennium 2.2 (Euro)</description>
@@ -28761,6 +30234,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="millen22a" cloneof="millen22" supported="no">
 		<!-- SPS (CAPS) release 1511 -->
 		<description>Millennium 2.2 (Euro, Budget)</description>
@@ -28775,6 +30249,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="mindbend" supported="no">
 		<!-- SPS (CAPS) release 2034 -->
 		<description>Mindbender (Euro, Budget?)</description>
@@ -28789,6 +30264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mindfrvr" supported="no">
 		<!-- SPS (CAPS) release 1400 -->
 		<description>A Mind Forever Voyaging (USA, r79)</description>
@@ -28803,6 +30279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="mindroll" supported="no">
 		<!-- SPS (CAPS) release 538 -->
 		<description>Mindroll (Euro)</description>
@@ -28817,6 +30294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="mindshdw" supported="no">
 		<!-- SPS (CAPS) release 2546 -->
 		<description>Mindshadow (Euro)</description>
@@ -28831,6 +30309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="minigolf" supported="no">
 		<!-- SPS (CAPS) release 2490 -->
 		<description>Miniature Golf (Euro, Starter Kit)</description>
@@ -28845,6 +30324,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="misselev" supported="no">
 		<!-- SPS (CAPS) release 1282 -->
 		<description>Mission Elevator (Euro)</description>
@@ -28859,6 +30339,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mixedup" supported="no">
 		<!-- SPS (CAPS) release 2680 -->
 		<description>Mixed-Up Mother Goose (Euro, v1.000, Enhanced)</description>
@@ -28881,6 +30362,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="moebius" supported="partial">
 		<!-- SPS (CAPS) release 1385 -->
 		<description>Moebius - The Orb of Celestial Harmony (USA)</description>
@@ -28896,6 +30378,7 @@ license:CC0
 	</software>
 
 	<!-- no mouse pointer, "unable to find monkey2" on disc swap -->
+	<!-- ATK test: OK -->
 	<software name="monkisl2" supported="no">
 		<!-- SPS (CAPS) release 20 -->
 		<description>Monkey Island 2 - LeChuck's Revenge (Euro, v1.0 19920408)</description>
@@ -28971,6 +30454,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monkisl2f" cloneof="monkisl2" supported="no">
 		<!-- SPS (CAPS) release 2596 -->
 		<description>Monkey Island 2 - LeChuck's Revenge (Fra, v1.0 19920423)</description>
@@ -29046,6 +30530,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monkisl2g" cloneof="monkisl2" supported="no">
 		<!-- SPS (CAPS) release 77 -->
 		<description>Monkey Island 2 - LeChuck's Revenge (Ger, v1.0 19920422)</description>
@@ -29121,6 +30606,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monopoly" supported="no">
 		<!-- SPS (CAPS) release 2423 -->
 		<description>Monopoly (Euro)</description>
@@ -29135,6 +30621,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="monopolg" supported="no">
 		<!-- SPS (CAPS) release 1124 -->
 		<description>Monopoly (Euro, Leisure Genius, Board Genius)</description>
@@ -29165,6 +30652,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="montypyt" supported="no">
 		<!-- SPS (CAPS) release 273 -->
 		<description>Monty Python's Flying Circus (Euro)</description>
@@ -29179,6 +30667,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="montypytu" cloneof="montypyt" supported="no">
 		<!-- SPS (CAPS) release 1174 -->
 		<description>Monty Python's Flying Circus (USA)</description>
@@ -29193,6 +30682,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="moochies" supported="no">
 		<!-- SPS (CAPS) release 1425 -->
 		<description>The Moochies (Euro)</description>
@@ -29214,6 +30704,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="moonblst" supported="no">
 		<!-- SPS (CAPS) release 2418 -->
 		<description>Moon Blaster (Fra, Top 3)</description>
@@ -29228,6 +30719,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="moonmist" supported="no">
 		<!-- SPS (CAPS) release 1405 -->
 		<description>Moonmist (USA, r4)</description>
@@ -29242,6 +30734,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="moonshin" supported="no">
 		<!-- SPS (CAPS) release 1540 -->
 		<description>MoonShine Racers (Euro)</description>
@@ -29263,6 +30756,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="moonston" supported="no">
 		<!-- SPS (CAPS) release 360 -->
 		<description>Moonstone - A Hard Days Knight (Euro)</description>
@@ -29290,6 +30784,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="morph" supported="no">
 		<!-- SPS (CAPS) release 1148 -->
 		<description>Morph (Euro)</description>
@@ -29311,6 +30806,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mk" supported="no">
 		<!-- SPS (CAPS) release 288 -->
 		<description>Mortal Kombat (Euro)</description>
@@ -29332,6 +30828,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mkg" cloneof="mk" supported="no">
 		<!-- SPS (CAPS) release 1319 -->
 		<description>Mortal Kombat (Ger)</description>
@@ -29353,6 +30850,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mk2" supported="no">
 		<!-- SPS (CAPS) release 1105 -->
 		<description>Mortal Kombat II (Euro)</description>
@@ -29380,6 +30878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="motormad" supported="no">
 		<!-- SPS (CAPS) release 2350 -->
 		<description>Motorbike Madness (Euro)</description>
@@ -29394,6 +30893,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="motormas" supported="no">
 		<!-- SPS (CAPS) release 1089 -->
 		<description>Motor Massacre (Euro, Action)</description>
@@ -29409,6 +30909,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="motorhed" supported="no">
 		<!-- SPS (CAPS) release 539 -->
 		<description>Motörhead (Euro)</description>
@@ -29423,6 +30924,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mtrap" supported="no">
 		<!-- SPS (CAPS) release 235 -->
 		<description>Mouse Trap (Euro)</description>
@@ -29437,6 +30939,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="movem3dm" supported="no">
 		<!-- SPS (CAPS) release 2194 -->
 		<description>Movem + 3D-Motorrad (Euro)</description>
@@ -29453,6 +30956,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="mrnutz2" supported="no">
 		<!-- SPS (CAPS) release 540 -->
 		<description>Mr. Nutz - Hoppin' Mad (Euro)</description>
@@ -29480,6 +30984,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mrblobby" supported="no">
 		<!-- SPS (CAPS) release 1773 -->
 		<description>Mr Blobby (Euro)</description>
@@ -29501,6 +31006,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dorunrun" supported="no">
 		<!-- SPS (CAPS) release 2178 -->
 		<description>Mr Do! Run Run (Euro)</description>
@@ -29515,6 +31021,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="munsters" supported="no">
 		<!-- SPS (CAPS) release 1265 -->
 		<description>The Munsters (Euro, Kids Pack)</description>
@@ -29529,6 +31036,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="murdrspc" supported="no">
 		<!-- SPS (CAPS) release 2344 -->
 		<description>Murders in Space (Euro)</description>
@@ -29550,6 +31058,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="murder" supported="no">
 		<!-- SPS (CAPS) release 136 -->
 		<description>Murder (Euro)</description>
@@ -29564,6 +31073,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="murdera" cloneof="murder" supported="no">
 		<!-- SPS (CAPS) release 704 -->
 		<description>Murder (Euro, Alt)</description>
@@ -29578,6 +31088,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="myfunmaz" supported="no">
 		<!-- SPS (CAPS) release 2805 -->
 		<description>My Funny Maze (Euro)</description>
@@ -29592,6 +31103,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mystwrld" supported="no">
 		<!-- SPS (CAPS) release 1588 -->
 		<description>Mysterious Worlds (Euro)</description>
@@ -29606,6 +31118,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mystical" supported="no">
 		<!-- SPS (CAPS) release 541 -->
 		<description>Mystical (Euro)</description>
@@ -29620,6 +31133,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="myth" supported="no">
 		<!-- SPS (CAPS) release 2455 -->
 		<description>Myth (Euro, v1.0, Firebird)</description>
@@ -29634,6 +31148,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="myths3" supported="no">
 		<!-- SPS (CAPS) release 700 -->
 		<description>Myth (Euro, System 3)</description>
@@ -29662,6 +31177,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="myths3a" cloneof="myths3" supported="no">
 		<!-- SPS (CAPS) release 1842 -->
 		<description>Myth (Euro, System 3, A600 HD)</description>
@@ -29691,6 +31207,7 @@ license:CC0
 	</software>
 
 	<!-- Stalls at workbench screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nam6575" supported="no">
 		<!-- SPS (CAPS) release 249 -->
 		<description>'Nam 1965-1975 (Euro)</description>
@@ -29712,6 +31229,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="napoleon" supported="no">
 		<!-- SPS (CAPS) release 2564 -->
 		<description>Napoleon I (Euro, v1.0, Internecine)</description>
@@ -29727,6 +31245,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="napolnic" supported="no">
 		<!-- SPS (CAPS) release 2562 -->
 		<description>Napoleonics (Euro)</description>
@@ -29741,6 +31260,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="narc" supported="no">
 		<!-- SPS (CAPS) release 1256 -->
 		<description>NARC (Euro)</description>
@@ -29756,6 +31276,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, intro doesn't move, black screen on game over disc swap, offset layers during gameplay -->
+	<!-- ATK test: OK -->
 	<software name="natnever" supported="no">
 		<!-- SPS (CAPS) release 2667 -->
 		<description>Nathan Never (Euro)</description>
@@ -29783,6 +31304,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="naughty" supported="no">
 		<!-- SPS (CAPS) release 1048 -->
 		<description>Naughty Ones (Euro)</description>
@@ -29797,6 +31319,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="navymove" supported="no">
 		<!-- SPS (CAPS) release 2428 -->
 		<description>Navy Moves (Euro, Top Hits)</description>
@@ -29811,6 +31334,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="navymovea" cloneof="navymove" supported="no">
 		<!-- SPS (CAPS) release 2430 -->
 		<description>Navy Moves (Euro, Hit Squad)</description>
@@ -29826,6 +31350,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation at boot -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="navyseal" supported="no">
 		<!-- SPS (CAPS) release 1251 -->
 		<description>Navy Seals (Euro)</description>
@@ -29840,6 +31365,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nebulus" supported="no">
 		<!-- SPS (CAPS) release 361 -->
 		<description>Nebulus (Euro)</description>
@@ -29854,6 +31380,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nebulusa" cloneof="nebulus" supported="no">
 		<!-- SPS (CAPS) release 1587 -->
 		<description>Nebulus (Euro, Budget)</description>
@@ -29868,6 +31395,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nebuzyna" supported="no">
 		<!-- SPS (CAPS) release 938 -->
 		<description>Nebulus &amp; Zynaps (Euro, Premier Collection)</description>
@@ -29882,6 +31410,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nebulus2" supported="no">
 		<!-- SPS (CAPS) release 1713 -->
 		<description>Nebulus 2 - Pogo a Go Go !!! (Euro)</description>
@@ -29909,6 +31438,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="necronom" supported="no">
 		<!-- SPS (CAPS) release 542 -->
 		<description>Necronom (Euro)</description>
@@ -29923,6 +31453,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="neighbor" supported="no">
 		<!-- SPS (CAPS) release 1798 -->
 		<description>Neighbours (Euro)</description>
@@ -29937,6 +31468,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="netherw" supported="no">
 		<!-- SPS (CAPS) release 2033 -->
 		<description>Netherworld (Euro)</description>
@@ -29951,6 +31483,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="netherwa" cloneof="netherw" supported="no">
 		<!-- SPS (CAPS) release 2037 -->
 		<description>Netherworld (Euro, Premier Collection)</description>
@@ -29965,6 +31498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="neuromnc" supported="no">
 		<!-- SPS (CAPS) release 2604 -->
 		<description>Neuromancer (Euro)</description>
@@ -29981,6 +31515,7 @@ license:CC0
 
 	<!-- black screen with eventually running irq at $ffffff, [FDC] dsksync -->
 	<!-- Hangs on CIA timer A readback while setting mode $99 -->
+	<!-- ATK test: failed -->
 	<software name="nevermnd" supported="no">
 		<!-- SPS (CAPS) release 1507 -->
 		<description>Never Mind (Euro)</description>
@@ -29995,6 +31530,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="neveren2" supported="no">
 		<!-- SPS (CAPS) release 2554 -->
 		<description>The NeverEnding Story II (Euro)</description>
@@ -30010,6 +31546,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nywarr" supported="no">
 		<!-- SPS (CAPS) release 705 -->
 		<description>New York Warriors (Euro)</description>
@@ -30031,6 +31568,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tnzs" supported="no">
 		<!-- SPS (CAPS) release 1180 -->
 		<description>The New Zealand Story (Euro)</description>
@@ -30045,6 +31583,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tnzsa" cloneof="tnzs" supported="no">
 		<!-- SPS (CAPS) release 2875 -->
 		<description>The New Zealand Story (Euro, Alt)</description>
@@ -30059,6 +31598,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="faldoglf" supported="no">
 		<!-- SPS (CAPS) release 1164 -->
 		<description>Nick Faldo's Championship Golf (Euro)</description>
@@ -30080,6 +31620,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nickboom" supported="no">
 		<!-- SPS (CAPS) release 1516 -->
 		<description>Nicky Boom (Euro)</description>
@@ -30094,6 +31635,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="manselgp" supported="no">
 		<!-- SPS (CAPS) release 1102 -->
 		<description>Nigel Mansell's Grand Prix (Euro)</description>
@@ -30108,6 +31650,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mansell" supported="no">
 		<!-- SPS (CAPS) release 137 -->
 		<description>Nigel Mansell's World Championship (Euro)</description>
@@ -30130,6 +31673,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="nighthnt" supported="no">
 		<!-- SPS (CAPS) release 1091 -->
 		<description>Night Hunter (Euro, 10 Great Games)</description>
@@ -30144,6 +31688,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="nshift" supported="no">
 		<!-- SPS (CAPS) release 1508 -->
 		<description>Night Shift (Euro, MAX)</description>
@@ -30158,6 +31703,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nightbrd" supported="no">
 		<!-- SPS (CAPS) release 849 -->
 		<description>Nightbreed - The Action Game (Euro)</description>
@@ -30179,6 +31725,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nightbrda" cloneof="nightbrd" supported="no">
 		<!-- SPS (CAPS) release 1049 -->
 		<description>Nightbreed - The Action Game (Euro, Budget)</description>
@@ -30200,6 +31747,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nightbmv" supported="no">
 		<!-- SPS (CAPS) release 363 -->
 		<description>Nightbreed - The Interactive Movie (Euro)</description>
@@ -30221,6 +31769,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nightdwn" supported="no">
 		<!-- SPS (CAPS) release 1301 -->
 		<description>Nightdawn (Euro)</description>
@@ -30235,6 +31784,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nightdwnu" cloneof="nightdwn" supported="no">
 		<!-- SPS (CAPS) release 2015 -->
 		<description>Nightdawn (USA)</description>
@@ -30249,6 +31799,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="f117asf" supported="no">
 		<!-- SPS (CAPS) release 1209 -->
 		<description>NightHawk F-117A Stealth Fighter 2.0 (Euro, v3.01 19931018)</description>
@@ -30276,6 +31827,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ninjamis" supported="no">
 		<!-- SPS (CAPS) release 2787 -->
 		<description>Ninja Mission (Euro)</description>
@@ -30290,6 +31842,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ninjarab" supported="no">
 		<!-- SPS (CAPS) release 1378 -->
 		<description>Ninja Rabbits (Euro, Mega Collection)</description>
@@ -30305,6 +31858,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="ninjarmx" supported="no">
 		<!-- SPS (CAPS) release 3020 -->
 		<description>Ninja Remix (Euro)</description>
@@ -30332,6 +31886,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="nspirit" supported="no">
 		<!-- SPS (CAPS) release 1669 -->
 		<description>Ninja Spirit (Euro)</description>
@@ -30347,6 +31902,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: failed -->
 	<software name="ninjawar" supported="no">
 		<!-- SPS (CAPS) release 543 -->
 		<description>The Ninja Warriors (Euro)</description>
@@ -30368,6 +31924,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nipponsf" supported="no">
 		<!-- SPS (CAPS) release 1050 -->
 		<description>Nippon Safes Inc. (Euro)</description>
@@ -30407,6 +31964,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="nitrobc" supported="no">
 		<!-- SPS (CAPS) release 18 -->
 		<description>Nitro Boost Challenge (Euro)</description>
@@ -30421,6 +31979,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nobuddie" supported="no">
 		<!-- SPS (CAPS) release 2766 -->
 		<description>No Buddies Land (Euro, Prototype)</description>
@@ -30442,6 +32001,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="noexcuse" supported="no">
 		<!-- SPS (CAPS) release 2456 -->
 		<description>No Excuses (Euro)</description>
@@ -30457,6 +32017,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs when pressing enter on copy-protection screen -->
+	<!-- ATK test: OK -->
 	<software name="noexit" supported="no">
 		<!-- SPS (CAPS) release 2841 -->
 		<description>No Exit (Euro)</description>
@@ -30472,6 +32033,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="no2prize" supported="no">
 		<!-- SPS (CAPS) release 3059 -->
 		<description>No Second Prize (Euro)</description>
@@ -30486,6 +32048,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="no2prizea" cloneof="no2prize" supported="no">
 		<!-- SPS (CAPS) release 3060 -->
 		<description>No Second Prize (Euro, Alt)</description>
@@ -30500,6 +32063,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="noddypt" supported="no">
 		<!-- SPS (CAPS) release 2240 -->
 		<description>Noddy's Playtime (Euro)</description>
@@ -30527,6 +32091,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nordbert" supported="no">
 		<!-- SPS (CAPS) release 1406 -->
 		<description>Nord and Bert Couldn't Make Head or Tail of It (USA, r19)</description>
@@ -30542,6 +32107,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: C:1 Bad -->
 	<software name="northns" supported="partial">
 		<!-- SPS (CAPS) release 194 -->
 		<description>North &amp; South (Euro)</description>
@@ -30556,6 +32122,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="northnsa" cloneof="northns" supported="no">
 		<!-- SPS (CAPS) release 2397 -->
 		<description>North &amp; South (Euro, Le Temps des Héros)</description>
@@ -30570,6 +32137,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="northnsu" cloneof="northns" supported="no">
 		<!-- SPS (CAPS) release 1780 -->
 		<description>North &amp; South (USA)</description>
@@ -30584,6 +32152,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="nova9" supported="no">
 		<!-- SPS (CAPS) release 2253 -->
 		<description>Nova 9 (Euro, v1.0 19920701)</description>
@@ -30612,6 +32181,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="nukewar" supported="no">
 		<!-- SPS (CAPS) release 2014 -->
 		<description>Nuclear War (USA)</description>
@@ -30633,6 +32203,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="obliter" supported="no">
 		<!-- SPS (CAPS) release 706 -->
 		<description>Obliterator (Euro)</description>
@@ -30647,6 +32218,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="obsessn" supported="no">
 		<!-- SPS (CAPS) release 2199 -->
 		<description>Obsession (Euro)</description>
@@ -30734,6 +32306,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="offshore" supported="no">
 		<!-- SPS (CAPS) release 2968 -->
 		<description>Off Shore Warrior (Euro, Titus Action II)</description>
@@ -30748,6 +32321,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ogre" supported="no">
 		<!-- SPS (CAPS) release 1386 -->
 		<description>Ogre (USA)</description>
@@ -30762,6 +32336,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ohnolemm" supported="no">
 		<!-- SPS (CAPS) release 697 -->
 		<description>Oh No! More Lemmings (Euro, Stand Alone)</description>
@@ -30776,6 +32351,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ohnolemdd" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 1898 -->
 		<description>Oh No! More Lemmings (Euro, Data Disk)</description>
@@ -30791,6 +32367,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ohnolemddu" cloneof="lemmings" supported="no">
 		<!-- SPS (CAPS) release 1970 -->
 		<description>Oh No! More Lemmings (USA, Data Disk)</description>
@@ -30806,6 +32383,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oilimper" supported="no">
 		<!-- SPS (CAPS) release 3039 -->
 		<description>Oil Imperium (Euro, v3)</description>
@@ -30827,6 +32405,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oilimperg" cloneof="oilimper" supported="no">
 		<!-- SPS (CAPS) release 545 -->
 		<description>Oil Imperium (Ger)</description>
@@ -30848,6 +32427,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oldtimer" supported="no">
 		<!-- SPS (CAPS) release 1211 -->
 		<description>Oldtimer - Erlebte Geschichte Teil II (Ger)</description>
@@ -30905,6 +32485,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="marseill" supported="no">
 		<!-- SPS (CAPS) release 2431 -->
 		<description>Olympique de Marseille (Euro)</description>
@@ -30927,6 +32508,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="omega" supported="partial">
 		<!-- SPS (CAPS) release 373 -->
 		<description>Omega (Euro)</description>
@@ -30941,6 +32523,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="opbasket" supported="no">
 		<!-- SPS (CAPS) release 2548 -->
 		<description>Omni-Play Basketball (Euro)</description>
@@ -30962,6 +32545,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="omnicron" supported="no">
 		<!-- SPS (CAPS) release 2200 -->
 		<description>Omnicron Conspiracy (Euro, v1.0 19901019)</description>
@@ -30983,6 +32567,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="onestepb" supported="no">
 		<!-- SPS (CAPS) release 2580 -->
 		<description>One Step Beyond (Euro)</description>
@@ -31005,6 +32590,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: OK -->
 	<software name="onslaugh" supported="no">
 		<!-- SPS (CAPS) release 869 -->
 		<description>Onslaught (Euro)</description>
@@ -31019,6 +32605,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="otballea" supported="no">
 		<!-- SPS (CAPS) release 1067 -->
 		<description>On The Ball League Edition (Euro)</description>
@@ -31058,6 +32645,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="otballwc" supported="no">
 		<!-- SPS (CAPS) release 2138 -->
 		<description>On The Ball World Cup Edition (Euro)</description>
@@ -31097,6 +32685,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ooopsup" supported="no">
 		<!-- SPS (CAPS) release 1283 -->
 		<description>Ooops Up (Euro)</description>
@@ -31127,6 +32716,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oozecn" supported="no">
 		<!-- SPS (CAPS) release 2315 -->
 		<description>Ooze - Creepy Nites (Euro, v1.2E)</description>
@@ -31141,6 +32731,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="opcomb2" supported="no">
 		<!-- SPS (CAPS) release 1665 -->
 		<description>Operation Combat II - By Land, Sea and Air (Euro)</description>
@@ -31162,6 +32753,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="opg2d" supported="no">
 		<!-- SPS (CAPS) release 1475 -->
 		<description>Operation GII Demo (Euro)</description>
@@ -31176,6 +32768,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oharrier" supported="no">
 		<!-- SPS (CAPS) release 1051 -->
 		<description>Operation Harrier (Euro)</description>
@@ -31190,6 +32783,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="opjupitr" supported="no">
 		<!-- SPS (CAPS) release 374 -->
 		<description>Operation Jupiter (Fra)</description>
@@ -31204,6 +32798,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="opneptun" supported="no">
 		<!-- SPS (CAPS) release 546 -->
 		<description>Operation Neptune (Euro)</description>
@@ -31218,6 +32813,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ostealth" supported="no">
 		<!-- SPS (CAPS) release 1052 -->
 		<description>Operation Stealth (Euro)</description>
@@ -31245,6 +32841,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ostealtha" cloneof="ostealth" supported="no">
 		<!-- SPS (CAPS) release 1883 -->
 		<description>Operation Stealth (Euro, The Delphine Collection)</description>
@@ -31272,6 +32869,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ostealthf" cloneof="ostealth" supported="no">
 		<!-- SPS (CAPS) release 1654 -->
 		<description>Operation Stealth (Fra, Les Maitres de l'Aventure)</description>
@@ -31299,6 +32897,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ostealthg" cloneof="ostealth" supported="no">
 		<!-- SPS (CAPS) release 375 -->
 		<description>Operation Stealth (Ger)</description>
@@ -31326,6 +32925,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="othunder" supported="no">
 		<!-- SPS (CAPS) release 547 -->
 		<description>Operation Thunderbolt (Euro)</description>
@@ -31347,6 +32947,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="opwolf" supported="no">
 		<!-- SPS (CAPS) release 1128 -->
 		<description>Operation Wolf (Euro)</description>
@@ -31368,6 +32969,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="opwolfa" cloneof="opwolf" supported="no">
 		<!-- SPS (CAPS) release 2491 -->
 		<description>Operation Wolf (Euro, Magnum 4)</description>
@@ -31389,6 +32991,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="orbitald" supported="no">
 		<!-- SPS (CAPS) release 2230 -->
 		<description>Orbital Destroyer (Euro)</description>
@@ -31403,6 +33006,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="orgames" supported="no">
 		<!-- SPS (CAPS) release 2263 -->
 		<description>Oriental Games (Euro)</description>
@@ -31417,6 +33021,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="orgamesa" cloneof="orgames" supported="no">
 		<!-- SPS (CAPS) release 1083 -->
 		<description>Oriental Games (Euro, Magnum)</description>
@@ -31431,6 +33036,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ork" supported="no">
 		<!-- SPS (CAPS) release 219 -->
 		<description>Ork (Euro)</description>
@@ -31452,6 +33058,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="orkd" cloneof="ork" supported="no">
 		<!-- SPS (CAPS) release 1452 -->
 		<description>Ork Demo (Euro)</description>
@@ -31466,6 +33073,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="oscar" supported="no">
 		<!-- SPS (CAPS) release 1228 -->
 		<description>Oscar (Euro)</description>
@@ -31487,6 +33095,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ootw" cloneof="anotherw" supported="no">
 		<!-- SPS (CAPS) release 1556 -->
 		<description>Out of this World (USA)</description>
@@ -31510,6 +33119,7 @@ license:CC0
 
 	<!-- Locks up after Kickstart with DSKDAT W $4000 message (white screen) [FDC] dsksync -->
 	<!-- Uses more [FDC] DSKDAT W $4000 afterwards -->
+	<!-- ATK test: failed -->
 	<software name="outrun" supported="no">
 		<!-- SPS (CAPS) release 1161 -->
 		<description>Out Run (Euro)</description>
@@ -31524,6 +33134,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="outruna" cloneof="outrun" supported="no">
 		<!-- SPS (CAPS) release 2446 -->
 		<description>Out Run (Euro, Giants)</description>
@@ -31538,6 +33149,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="outrunu" cloneof="outrun" supported="no">
 		<!-- SPS (CAPS) release 2355 -->
 		<description>Out Run (USA)</description>
@@ -31553,6 +33165,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs at a red and black flashing screen [FDC] -->
+	<!-- ATK test: C:79 Bad -->
 	<software name="outrneur" supported="no">
 		<!-- SPS (CAPS) release 1597 -->
 		<description>Out Run Europa (Euro)</description>
@@ -31574,6 +33187,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="outzone" supported="no">
 		<!-- SPS (CAPS) release 2333 -->
 		<description>Outzone (Euro)</description>
@@ -31588,6 +33202,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="overdriv" supported="no">
 		<!-- SPS (CAPS) release 1149 -->
 		<description>Overdrive (Euro)</description>
@@ -31609,6 +33224,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="overland" supported="no">
 		<!-- SPS (CAPS) release 1552 -->
 		<description>Overlander (Euro, v1.0 19891127)</description>
@@ -31623,6 +33239,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="overlord" supported="no">
 		<!-- SPS (CAPS) release 1312 -->
 		<description>Overlord (Euro, 19940912)</description>
@@ -31651,6 +33268,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, has a stripe of garbage on bottom (especially noticeable on game end screen) -->
+	<!-- ATK test: OK -->
 	<software name="overnet" supported="partial">
 		<!-- SPS (CAPS) release 2439 -->
 		<description>Over the Net (USA)</description>
@@ -31665,6 +33283,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="goplayer" supported="no">
 		<!-- SPS (CAPS) release 1583 -->
 		<description>The Oxford Softworks Go Player (Euro)</description>
@@ -31679,6 +33298,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="p47thun" supported="no">
 		<!-- SPS (CAPS) release 1227 -->
 		<description>P-47 Thunderbolt (Euro)</description>
@@ -31693,6 +33313,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="p47thuna" cloneof="p47thun" supported="no">
 		<!-- SPS (CAPS) release 1873 -->
 		<description>P-47 Thunderbolt (Euro, Air-Sea Supremacy)</description>
@@ -31707,6 +33328,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pphammer" supported="no">
 		<!-- SPS (CAPS) release 2036 -->
 		<description>P.P. Hammer and His Pneumatic Weapon (Euro, Budget)</description>
@@ -31721,6 +33343,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pacland" supported="no">
 		<!-- SPS (CAPS) release 23 -->
 		<description>Pac-Land (Euro)</description>
@@ -31735,6 +33358,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pacmania" supported="no">
 		<!-- SPS (CAPS) release 1117 -->
 		<description>Pac-Mania (Euro)</description>
@@ -31749,6 +33373,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pacislnd" supported="no">
 		<!-- SPS (CAPS) release 2812 -->
 		<description>Pacific Islands (Euro, Combat Classics 2)</description>
@@ -31770,6 +33395,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="paladin" supported="no">
 		<!-- SPS (CAPS) release 2982 -->
 		<description>Paladin (Euro, v1.0e)</description>
@@ -31784,6 +33410,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="paladin2" supported="no">
 		<!-- SPS (CAPS) release 2113 -->
 		<description>Paladin 2 (Euro)</description>
@@ -31805,6 +33432,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:even H:L 1 Sector Bad -->
 	<software name="pandora" supported="no">
 		<!-- SPS (CAPS) release 2460 -->
 		<description>Pandora (Euro)</description>
@@ -31821,6 +33449,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- Gameplay BGM gets cut off [Paula] -->
+	<!-- ATK test: failed -->
 	<software name="pang" supported="no">
 		<!-- SPS (CAPS) release 929 -->
 		<description>Pang (Euro)</description>
@@ -31836,6 +33465,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up on AmigaDOS, [FDC] uses adkcon=$1100 -->
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="panzakb" supported="no">
 		<!-- SPS (CAPS) release 2400 -->
 		<description>Panza Kick Boxing (Euro)</description>
@@ -31857,6 +33487,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="panzakbf" cloneof="panzakb" supported="no">
 		<!-- SPS (CAPS) release 2488 -->
 		<description>Panza Kick Boxing (Fra, Podium)</description>
@@ -31878,6 +33509,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="paperbo2" supported="no">
 		<!-- SPS (CAPS) release 549 -->
 		<description>Paperboy 2 (Euro)</description>
@@ -31896,6 +33528,7 @@ license:CC0
 	<!-- Hangs on a1200 on boot -->
 	<!-- Expects to read an autoconfig board at $200000, otherwise it straight off refuses to run with a blue screen (should be possible to run with standard  512k RAM?) -->
 	<!-- Bad colors on intro and gameplay -->
+	<!-- ATK test: failed -->
 	<software name="paradr90" supported="no">
 		<!-- SPS (CAPS) release 692 -->
 		<description>Paradroid 90 (Euro)</description>
@@ -31910,6 +33543,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="paradr90a" cloneof="paradr90" supported="no">
 		<!-- SPS (CAPS) release 1462 -->
 		<description>Paradroid 90 (Euro, Challenge)</description>
@@ -31924,6 +33558,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="paraglid" supported="no">
 		<!-- SPS (CAPS) release 2002 -->
 		<description>Paragliding Simulation (Euro)</description>
@@ -31938,6 +33573,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="paramax" supported="no">
 		<!-- SPS (CAPS) release 2184 -->
 		<description>Paramax (Euro)</description>
@@ -31952,6 +33588,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="paranoia" supported="no">
 		<!-- SPS (CAPS) release 3038 -->
 		<description>The Paranoia Complex (Euro)</description>
@@ -31966,6 +33603,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="paranoiag" cloneof="paranoia" supported="no">
 		<!-- SPS (CAPS) release 2162 -->
 		<description>The Paranoia Complex (Ger)</description>
@@ -31981,6 +33619,7 @@ license:CC0
 	</software>
 
 	<!-- Missing text status on top, known to do sprite rasters with [Copper] -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="parasol" supported="partial">
 		<!-- SPS (CAPS) release 139 -->
 		<description>Parasol Stars - The Story of Rainbow Islands II (Euro)</description>
@@ -31995,6 +33634,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="parasola" cloneof="parasol" supported="no">
 		<!-- SPS (CAPS) release 2093 -->
 		<description>Parasol Stars - The Story of Rainbow Islands II (Euro, Alt)</description>
@@ -32009,6 +33649,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="passsht" supported="no">
 		<!-- SPS (CAPS) release 708 -->
 		<description>Passing Shot (Euro)</description>
@@ -32023,6 +33664,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="patricn" supported="no">
 		<!-- SPS (CAPS) release 1802 -->
 		<description>The Patrician (Euro)</description>
@@ -32050,6 +33692,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="patricng" cloneof="patricn" supported="no">
 		<!-- SPS (CAPS) release 376 -->
 		<description>Der Patrizier (Ger)</description>
@@ -32077,6 +33720,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pawn" supported="no">
 		<!-- SPS (CAPS) release 709 -->
 		<description>The Pawn (Euro, v2.2)</description>
@@ -32091,6 +33735,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pegasus" supported="no">
 		<!-- SPS (CAPS) release 1645 -->
 		<description>Pegasus (Euro)</description>
@@ -32112,6 +33757,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="penthous" supported="no">
 		<!-- SPS (CAPS) release 2900 -->
 		<description>Penthouse Hot Numbers Deluxe (Euro)</description>
@@ -32145,6 +33791,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="perfgen" supported="no">
 		<!-- SPS (CAPS) release 2307 -->
 		<description>The Perfect General (Euro, v1.02 19911119)</description>
@@ -32159,6 +33806,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="perfgenf" cloneof="perfgen" supported="no">
 		<!-- SPS (CAPS) release 2383 -->
 		<description>The Perfect General (Fra, v1.02 19911119, Battles of Time)</description>
@@ -32173,6 +33821,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="perfgeng" cloneof="perfgen" supported="no">
 		<!-- SPS (CAPS) release 2309 -->
 		<description>The Perfect General (Ger, v1.02 19911119, The Lords of Power)</description>
@@ -32187,6 +33836,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="perfgenww2" cloneof="perfgen" supported="no">
 		<!-- SPS (CAPS) release 2308 -->
 		<description>The Perfect General - World War II Battle Set (Euro)</description>
@@ -32202,6 +33852,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="periheli" supported="no">
 		<!-- SPS (CAPS) release 799 -->
 		<description>Perihelion (Euro)</description>
@@ -32235,6 +33886,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="persnght" supported="no">
 		<!-- SPS (CAPS) release 2650 -->
 		<description>Personal Nightmare (Euro)</description>
@@ -32262,6 +33914,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="peterpan" supported="no">
 		<!-- SPS (CAPS) release 78 -->
 		<description>Peter Pan (Ger)</description>
@@ -32276,6 +33929,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pgaeuro" supported="no">
 		<!-- SPS (CAPS) release 550 -->
 		<description>PGA European Tour (Euro)</description>
@@ -32297,6 +33951,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pga" supported="no">
 		<!-- SPS (CAPS) release 891 -->
 		<description>PGA Tour Golf (Euro)</description>
@@ -32318,6 +33973,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="phantas" supported="no">
 		<!-- SPS (CAPS) release 1185 -->
 		<description>Phantasie (Euro, v1.0)</description>
@@ -32332,6 +33988,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="phantas3" supported="no">
 		<!-- SPS (CAPS) release 1186 -->
 		<description>Phantasie III - The Wrath of Nikademus (Euro, v1.0 Bonus Ed.)</description>
@@ -32346,6 +34003,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="phantasm" supported="no">
 		<!-- SPS (CAPS) release 2972 -->
 		<description>Phantasm (Euro)</description>
@@ -32360,6 +34018,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="phantasma" cloneof="phantasm" supported="no">
 		<!-- SPS (CAPS) release 2922 -->
 		<description>Phantasm (Euro, Budget)</description>
@@ -32374,6 +34033,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="phobia" supported="no">
 		<!-- SPS (CAPS) release 2225 -->
 		<description>Phobia (Euro)</description>
@@ -32388,6 +34048,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="photonst" supported="no">
 		<!-- SPS (CAPS) release 1427 -->
 		<description>Photon Storm (Euro)</description>
@@ -32402,6 +34063,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="picknpil" supported="no">
 		<!-- SPS (CAPS) release 2782 -->
 		<description>Pick 'n' Pile (Euro)</description>
@@ -32416,6 +34078,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="picknpila" cloneof="picknpil" supported="no">
 		<!-- SPS (CAPS) release 2781 -->
 		<description>Pick 'n' Pile (Euro, Le 2ème sens)</description>
@@ -32430,6 +34093,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="piction" supported="no">
 		<!-- SPS (CAPS) release 1690 -->
 		<description>Pictionary - The Game of Quick Draw (Euro, v3.1a)</description>
@@ -32444,6 +34108,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pbdreams">
 		<!-- SPS (CAPS) release 377 -->
 		<description>Pinball Dreams (Euro)</description>
@@ -32465,6 +34130,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pbfant">
 		<!-- SPS (CAPS) release 25 -->
 		<description>Pinball Fantasies (Euro)</description>
@@ -32498,6 +34164,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="pbmagic" supported="no">
 		<!-- SPS (CAPS) release 2003 -->
 		<description>Pinball Magic (Euro)</description>
@@ -32512,6 +34179,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="pbmagica" cloneof="pbmagic" supported="no">
 		<!-- SPS (CAPS) release 2414 -->
 		<description>Pinball Magic (Euro, Alt)</description>
@@ -32526,6 +34194,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pbprelud" supported="no">
 		<!-- SPS (CAPS) release 2114 -->
 		<description>Pinball Prelude (Euro)</description>
@@ -32559,6 +34228,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pbwizard" supported="no">
 		<!-- SPS (CAPS) release 1300 -->
 		<description>Pinball Wizard (Euro, v1.0)</description>
@@ -32573,6 +34243,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pinkie" supported="no">
 		<!-- SPS (CAPS) release 1774 -->
 		<description>Pinkie (Euro)</description>
@@ -32600,6 +34271,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pink" supported="no">
 		<!-- SPS (CAPS) release 236 -->
 		<description>Pink Panther (Euro)</description>
@@ -32614,6 +34286,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pioneerp" supported="no">
 		<!-- SPS (CAPS) release 2233 -->
 		<description>The Pioneer Plague (Euro)</description>
@@ -32629,6 +34302,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="pipmania" supported="no">
 		<!-- SPS (CAPS) release 220 -->
 		<description>Pipe Mania (Euro)</description>
@@ -32643,6 +34317,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="piracyhs" supported="no">
 		<!-- SPS (CAPS) release 1999 -->
 		<description>Piracy on the High Seas (Euro)</description>
@@ -32670,6 +34345,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pirates" supported="no">
 		<!-- SPS (CAPS) release 552 -->
 		<description>Pirates! (Euro, v832.04)</description>
@@ -32691,6 +34367,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="piratesa" cloneof="pirates" supported="no">
 		<!-- SPS (CAPS) release 551 -->
 		<description>Pirates! (Euro, v832.02)</description>
@@ -32712,6 +34389,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pitfight" supported="no">
 		<!-- SPS (CAPS) release 196 -->
 		<description>Pit-Fighter (Euro)</description>
@@ -32733,6 +34411,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pixiedix" supported="no">
 		<!-- SPS (CAPS) release 2621 -->
 		<description>Pixie and Dixie (Euro)</description>
@@ -32747,6 +34426,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pizzacon" supported="no">
 		<!-- SPS (CAPS) release 553 -->
 		<description>Pizza Connection (Ger)</description>
@@ -32780,6 +34460,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="planetfa" supported="no">
 		<!-- SPS (CAPS) release 2540 -->
 		<description>Planetfall (Euro, r37)</description>
@@ -32795,6 +34476,7 @@ license:CC0
 	</software>
 
 	<!-- "Software error", clicking on cancel causes Guru Meditation -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="platoon" supported="no">
 		<!-- SPS (CAPS) release 1483 -->
 		<description>Platoon (USA)</description>
@@ -32809,6 +34491,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="playdays" supported="no">
 		<!-- SPS (CAPS) release 1577 -->
 		<description>Playdays (Euro)</description>
@@ -32831,6 +34514,7 @@ license:CC0
 	</software>
 
 	<!-- Has slight glitches during gameplay (empty box on startup, sprite overlap drawing, garbage stripe GFX from time to time) -->
+	<!-- ATK test: failed -->
 	<software name="pmanger" supported="partial">
 		<!-- SPS (CAPS) release 171 -->
 		<description>Player Manager (Euro)</description>
@@ -32845,6 +34529,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pmangerg" cloneof="pmanger" supported="no">
 		<!-- SPS (CAPS) release 2772 -->
 		<description>Player Manager (Ger)</description>
@@ -32860,6 +34545,7 @@ license:CC0
 	</software>
 
 	<!-- Has slight glitches during gameplay (empty box on startup, sprite overlap drawing, garbage stripe GFX from time to time) -->
+	<!-- ATK test: failed -->
 	<software name="pmangeri" cloneof="pmanger" supported="partial">
 		<!-- SPS (CAPS) release 2572 -->
 		<description>Player Manager (Ita)</description>
@@ -32874,6 +34560,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="plotting" supported="no">
 		<!-- SPS (CAPS) release 1844 -->
 		<description>Plotting (Euro)</description>
@@ -32888,6 +34575,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="plutos" supported="no">
 		<!-- SPS (CAPS) release 994 -->
 		<description>Plutos (Euro)</description>
@@ -32902,6 +34590,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="plutosu" cloneof="plutos" supported="no">
 		<!-- SPS (CAPS) release 554 -->
 		<description>Plutos (USA)</description>
@@ -32916,6 +34605,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pquest" supported="no">
 		<!-- SPS (CAPS) release 2262 -->
 		<description>Police Quest - In Pursuit of the Death Angel (Euro, v2.0B 19890222, Budget)</description>
@@ -32930,6 +34620,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pquestu" cloneof="pquest" supported="no">
 		<!-- SPS (CAPS) release 1207 -->
 		<description>Police Quest - In Pursuit of the Death Angel (USA, v2.0B 19890222)</description>
@@ -32944,6 +34635,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pquest2" supported="no">
 		<!-- SPS (CAPS) release 1849 -->
 		<description>Police Quest II - The Vengeance (Euro, v1.024)</description>
@@ -32971,6 +34663,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="poolrad" supported="no">
 		<!-- SPS (CAPS) release 555 -->
 		<description>Pool of Radiance (Euro, v1.0)</description>
@@ -32992,6 +34685,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pooldark" supported="no">
 		<!-- SPS (CAPS) release 984 -->
 		<description>Pools of Darkness (Euro, v1.0 19920309)</description>
@@ -33019,6 +34713,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pool" supported="no">
 		<!-- SPS (CAPS) release 2177 -->
 		<description>Pool (Euro)</description>
@@ -33033,6 +34728,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="populous" supported="no">
 		<!-- SPS (CAPS) release 69 -->
 		<description>Populous (Euro, v2.7 19890317)</description>
@@ -33047,6 +34743,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="populousa" cloneof="populous" supported="no">
 		<!-- SPS (CAPS) release 2898 -->
 		<description>Populous (Euro, v2.7 19890317, Budget)</description>
@@ -33061,6 +34758,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="populousu" cloneof="populous" supported="no">
 		<!-- SPS (CAPS) release 70 -->
 		<description>Populous (USA, v2.7 19890330)</description>
@@ -33075,6 +34773,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="populouspl" cloneof="populous" supported="no">
 		<!-- SPS (CAPS) release 3024 -->
 		<description>Populous - The Promised Lands (Euro)</description>
@@ -33090,6 +34789,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="populouspla" cloneof="populous" supported="no">
 		<!-- SPS (CAPS) release 1217 -->
 		<description>Populous - The Promised Lands (Euro, Budget)</description>
@@ -33105,6 +34805,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="populus2" supported="no">
 		<!-- SPS (CAPS) release 79 -->
 		<description>Populous II (Euro)</description>
@@ -33120,6 +34821,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="populus2cg" cloneof="populus2" supported="no">
 		<!-- SPS (CAPS) release 2775 -->
 		<description>Populous II - The Challenge Games (Euro)</description>
@@ -33135,6 +34837,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="populwe" supported="no">
 		<!-- SPS (CAPS) release 711 -->
 		<description>Populous World Editor (Euro, v1.0)</description>
@@ -33149,6 +34852,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="portal" supported="no">
 		<!-- SPS (CAPS) release 1971 -->
 		<description>Portal (USA)</description>
@@ -33177,6 +34881,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="portcall" supported="partial">
 		<!-- SPS (CAPS) release 2489 -->
 		<description>Ports of Call (Euro, v1.1, A600 Smart Start)</description>
@@ -33191,6 +34896,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="postpat" supported="no">
 		<!-- SPS (CAPS) release 1092 -->
 		<description>Postman Pat (Euro, Kids Pack)</description>
@@ -33205,6 +34911,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="power" supported="no">
 		<!-- SPS (CAPS) release 1284 -->
 		<description>The Power (Euro)</description>
@@ -33219,6 +34926,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="pdrift" supported="no">
 		<!-- SPS (CAPS) release 815 -->
 		<description>Power Drift (Euro)</description>
@@ -33240,6 +34948,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pdrifta" cloneof="pdrift" supported="no">
 		<!-- SPS (CAPS) release 1444 -->
 		<description>Power Drift (Euro, Wheels of Fire)</description>
@@ -33254,6 +34963,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pdrive" supported="no">
 		<!-- SPS (CAPS) release 1658 -->
 		<description>Power Drive (Euro)</description>
@@ -33275,6 +34985,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pstruggl" supported="no">
 		<!-- SPS (CAPS) release 556 -->
 		<description>Power Struggle (Fra)</description>
@@ -33289,6 +35000,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pwrdrome" supported="no">
 		<!-- SPS (CAPS) release 140 -->
 		<description>Powerdrome (Euro)</description>
@@ -33303,6 +35015,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pmonger" supported="no">
 		<!-- SPS (CAPS) release 81 -->
 		<description>PowerMonger (Euro)</description>
@@ -33317,6 +35030,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pmongera" cloneof="pmonger" supported="no">
 		<!-- SPS (CAPS) release 1886 -->
 		<description>PowerMonger (Euro, Budget)</description>
@@ -33331,6 +35045,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pmongerww1" cloneof="pmonger" supported="no">
 		<!-- SPS (CAPS) release 614 -->
 		<description>PowerMonger WW1 Edition (Euro)</description>
@@ -33346,6 +35061,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="powrplay" supported="no">
 		<!-- SPS (CAPS) release 856 -->
 		<description>Powerplay - The Game of the Gods (Euro)</description>
@@ -33360,6 +35076,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="powrplaya" cloneof="powrplay" supported="no">
 		<!-- SPS (CAPS) release 1786 -->
 		<description>Powerplay - The Game of the Gods (Euro, Astra Pack)</description>
@@ -33375,6 +35092,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="predatr2" supported="no">
 		<!-- SPS (CAPS) release 274 -->
 		<description>Predator 2 (Euro)</description>
@@ -33396,6 +35114,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="prehist" supported="no">
 		<!-- SPS (CAPS) release 557 -->
 		<description>Prehistorik (Euro)</description>
@@ -33410,6 +35129,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="prehtale" supported="no">
 		<!-- SPS (CAPS) release 3062 -->
 		<description>A Prehistoric Tale (Euro)</description>
@@ -33424,6 +35144,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="premiere" supported="no">
 		<!-- SPS (CAPS) release 1553 -->
 		<description>Premiere (Euro)</description>
@@ -33451,6 +35172,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="prmanger" supported="no">
 		<!-- SPS (CAPS) release 2115 -->
 		<description>Premier Manager (Euro)</description>
@@ -33472,6 +35194,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="prmang2" supported="no">
 		<!-- SPS (CAPS) release 1130 -->
 		<description>Premier Manager II (Euro)</description>
@@ -33499,6 +35222,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="prmang3" supported="no">
 		<!-- SPS (CAPS) release 2127 -->
 		<description>Premier Manager 3 (Euro)</description>
@@ -33520,6 +35244,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="prmanmes" supported="no">
 		<!-- SPS (CAPS) release 1334 -->
 		<description>Premier Multi-Edit System (Euro)</description>
@@ -33534,6 +35259,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="prman3dx" supported="no">
 		<!-- SPS (CAPS) release 2889 -->
 		<description>Premier Manager 3 Deluxe (Euro)</description>
@@ -33576,6 +35302,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="primemov" supported="no">
 		<!-- SPS (CAPS) release 694 -->
 		<description>Prime Mover (Euro)</description>
@@ -33597,6 +35324,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="prince" supported="no">
 		<!-- SPS (CAPS) release 1729 -->
 		<description>Prince (Euro)</description>
@@ -33611,6 +35339,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ppersia" supported="no">
 		<!-- SPS (CAPS) release 1823 -->
 		<description>Prince of Persia (Euro)</description>
@@ -33625,6 +35354,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ppersiaf" cloneof="ppersia" supported="no">
 		<!-- SPS (CAPS) release 2290 -->
 		<description>Prince de Perse (Fra, Super Héros)</description>
@@ -33639,6 +35369,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ppersiag" cloneof="ppersia" supported="no">
 		<!-- SPS (CAPS) release 82 -->
 		<description>Prince of Persia (Ger)</description>
@@ -33653,6 +35384,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ppersiau" cloneof="ppersia" supported="no">
 		<!-- SPS (CAPS) release 1407 -->
 		<description>Prince of Persia (USA)</description>
@@ -33667,6 +35399,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="prison" supported="no">
 		<!-- SPS (CAPS) release 416 -->
 		<description>Prison (Euro)</description>
@@ -33681,6 +35414,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="proboxin" supported="no">
 		<!-- SPS (CAPS) release 1663 -->
 		<description>Pro Boxing Simulator (Euro)</description>
@@ -33695,6 +35429,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="propboat" supported="no">
 		<!-- SPS (CAPS) release 1803 -->
 		<description>Pro PowerBoat Simulator (Euro)</description>
@@ -33709,6 +35444,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pbsnitro" supported="no">
 		<!-- SPS (CAPS) release 2144 -->
 		<description>Pro PowerBoat Simulator + Nitro Boost Challenge (Euro, Quattro Power Machines)</description>
@@ -33723,6 +35459,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="protenns" supported="no">
 		<!-- SPS (CAPS) release 560 -->
 		<description>Pro Tennis Simulator (Euro)</description>
@@ -33737,6 +35474,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="protennt" supported="no">
 		<!-- SPS (CAPS) release 1080 -->
 		<description>Pro Tennis Tour (Euro)</description>
@@ -33751,6 +35489,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="protennta" cloneof="protennt" supported="no">
 		<!-- SPS (CAPS) release 1875 -->
 		<description>Pro Tennis Tour (Euro, Budget)</description>
@@ -33765,6 +35504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="protent2" supported="no">
 		<!-- SPS (CAPS) release 3077 -->
 		<description>Pro Tennis Tour 2 (Euro)</description>
@@ -33779,6 +35519,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="profootb" supported="no">
 		<!-- SPS (CAPS) release 1691 -->
 		<description>Professional Football Simulation (Euro, v3.1b)</description>
@@ -33801,6 +35542,7 @@ license:CC0
 	</software>
 
 	<!-- Has slight GFX color issue when doors opens before starting a game -->
+	<!-- ATK test: OK -->
 	<software name="profezia" supported="partial">
 		<!-- SPS (CAPS) release 2375 -->
 		<description>Profezia (Ita)</description>
@@ -33815,6 +35557,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="profligt" supported="no">
 		<!-- SPS (CAPS) release 1989 -->
 		<description>ProFlight (Euro, v1.51)</description>
@@ -33829,6 +35572,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="projx" supported="no">
 		<!-- SPS (CAPS) release 289 -->
 		<description>Project-X (Euro, v2)</description>
@@ -33862,6 +35606,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="projxa" cloneof="projx" supported="no">
 		<!-- SPS (CAPS) release 886 -->
 		<description>Project-X (Euro)</description>
@@ -33895,6 +35640,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="projxs93" supported="no">
 		<!-- SPS (CAPS) release 927 -->
 		<description>Project-X Special Edition '93 (Euro)</description>
@@ -33922,6 +35668,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="projectl" supported="no">
 		<!-- SPS (CAPS) release 379 -->
 		<description>Projectyle (Euro)</description>
@@ -33936,6 +35683,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="projprom" supported="no">
 		<!-- SPS (CAPS) release 559 -->
 		<description>Projekt Prometheus (Ger)</description>
@@ -33957,6 +35705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="prophecy" supported="no">
 		<!-- SPS (CAPS) release 2557 -->
 		<description>Prophecy I - The Viking Child (Euro)</description>
@@ -33984,6 +35733,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="psoc2190" supported="no">
 		<!-- SPS (CAPS) release 1563 -->
 		<description>ProSoccer 2190 (Euro)</description>
@@ -33998,6 +35748,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="mazexor" supported="no">
 		<!-- SPS (CAPS) release 1465 -->
 		<description>Prospector - In the Mazes of Xor (Euro, v1.0)</description>
@@ -34013,6 +35764,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="protectp" supported="no">
 		<!-- SPS (CAPS) release 1068 -->
 		<description>Protector (Euro, Paradox)</description>
@@ -34027,6 +35779,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="protectv" supported="no">
 		<!-- SPS (CAPS) release 1560 -->
 		<description>Protector (Euro, Virgin Mastertronic)</description>
@@ -34041,6 +35794,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="psyborg" supported="no">
 		<!-- SPS (CAPS) release 561 -->
 		<description>Psyborg (Euro)</description>
@@ -34062,6 +35816,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="pubtriv" supported="no">
 		<!-- SPS (CAPS) release 775 -->
 		<description>Pub Trivia Simulator (Euro)</description>
@@ -34076,6 +35831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="puffysag" supported="no">
 		<!-- SPS (CAPS) release 1651 -->
 		<description>Puffy's Saga (Euro, Winning 5)</description>
@@ -34090,6 +35846,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="puggsy" supported="no">
 		<!-- SPS (CAPS) release 1113 -->
 		<description>Puggsy (Euro)</description>
@@ -34123,6 +35880,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="purplesd" supported="no">
 		<!-- SPS (CAPS) release 562 -->
 		<description>Purple Saturn Day (Euro)</description>
@@ -34137,6 +35895,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="purplesdu" cloneof="purplesd" supported="no">
 		<!-- SPS (CAPS) release 945 -->
 		<description>Purple Saturn Day (USA)</description>
@@ -34151,6 +35910,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pushover" supported="no">
 		<!-- SPS (CAPS) release 1267 -->
 		<description>PushOver (Euro)</description>
@@ -34173,6 +35933,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="pushovera" cloneof="pushover" supported="no">
 		<!-- SPS (CAPS) release 1268 -->
 		<description>PushOver (Euro, Alt)</description>
@@ -34195,6 +35956,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="putty" supported="no">
 		<!-- SPS (CAPS) release 197 -->
 		<description>Putty (Euro)</description>
@@ -34222,6 +35984,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="puzznic" supported="no">
 		<!-- SPS (CAPS) release 41 -->
 		<description>Puzznic (Euro)</description>
@@ -34236,6 +35999,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="pyramax" supported="no">
 		<!-- SPS (CAPS) release 563 -->
 		<description>Pyramax (Euro)</description>
@@ -34250,6 +36014,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="qball" supported="no">
 		<!-- SPS (CAPS) release 713 -->
 		<description>QBall (Euro)</description>
@@ -34264,6 +36029,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="qix" supported="no">
 		<!-- SPS (CAPS) release 3043 -->
 		<description>Qix (USA)</description>
@@ -34278,6 +36044,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="quadrali" supported="no">
 		<!-- SPS (CAPS) release 2469 -->
 		<description>Quadralien (Euro, with StarRay demo)</description>
@@ -34293,6 +36060,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="quadralia" cloneof="quadrali" supported="no">
 		<!-- SPS (CAPS) release 918 -->
 		<description>Quadralien (Euro)</description>
@@ -34307,6 +36075,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="quadrel" supported="no">
 		<!-- SPS (CAPS) release 2407 -->
 		<description>Quadrel (Euro, v1.0, Q.I. 1992)</description>
@@ -34321,6 +36090,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="quadrela" cloneof="quadrel" supported="no">
 		<!-- SPS (CAPS) release 380 -->
 		<description>Quadrel (Euro, v1.0)</description>
@@ -34335,6 +36105,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="quantox" supported="no">
 		<!-- SPS (CAPS) release 2527 -->
 		<description>Quantox (Euro)</description>
@@ -34349,6 +36120,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="quartz" supported="no">
 		<!-- SPS (CAPS) release 2020 -->
 		<description>Quartz (Euro)</description>
@@ -34363,6 +36135,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="qfglory2" supported="no">
 		<!-- SPS (CAPS) release 1868 -->
 		<description>Quest for Glory II - Trial by Fire (Euro, v1.109)</description>
@@ -34420,6 +36193,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="timebird" supported="no">
 		<!-- SPS (CAPS) release 564 -->
 		<description>The Quest for the Time-Bird (Euro)</description>
@@ -34447,6 +36221,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="timebirdf" cloneof="timebird" supported="no">
 		<!-- SPS (CAPS) release 2343 -->
 		<description>La Quête de l'Oiseau du Temps (Fra)</description>
@@ -34468,6 +36243,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="agravain" supported="no">
 		<!-- SPS (CAPS) release 141 -->
 		<description>The Quest of Agravain (Euro)</description>
@@ -34482,6 +36258,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="qos" supported="no">
 		<!-- SPS (CAPS) release 2143 -->
 		<description>A Question of Sport (Euro)</description>
@@ -34496,6 +36273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="questrn2" supported="no">
 		<!-- SPS (CAPS) release 1187 -->
 		<description>Questron II (Euro)</description>
@@ -34510,6 +36288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="quintett" supported="no">
 		<!-- SPS (CAPS) release 714 -->
 		<description>Quintette (Euro)</description>
@@ -34524,6 +36303,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="qwak" supported="no">
 		<!-- SPS (CAPS) release 715 -->
 		<description>Qwak (Euro)</description>
@@ -34538,6 +36318,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rcaeroc" supported="no">
 		<!-- SPS (CAPS) release 944 -->
 		<description>R/C Aerochopper (USA, Issue 1.1)</description>
@@ -34552,6 +36333,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rtype" supported="no">
 		<!-- SPS (CAPS) release 940 -->
 		<description>R-Type (Euro)</description>
@@ -34566,6 +36348,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rtype2" supported="no">
 		<!-- SPS (CAPS) release 2065 -->
 		<description>R-Type II (Euro)</description>
@@ -34580,6 +36363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rbibb2" supported="no">
 		<!-- SPS (CAPS) release 2116 -->
 		<description>R.B.I. Baseball 2 (Euro)</description>
@@ -34594,6 +36378,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rbibb2a" cloneof="rbibb2" supported="no">
 		<!-- SPS (CAPS) release 2155 -->
 		<description>R.B.I. Baseball 2 (Euro, Budget)</description>
@@ -34608,6 +36393,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="raffles" supported="no">
 		<!-- SPS (CAPS) release 21 -->
 		<description>Raffles (Euro)</description>
@@ -34622,6 +36408,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="raider" supported="no">
 		<!-- SPS (CAPS) release 1613 -->
 		<description>Raider (Euro)</description>
@@ -34636,6 +36423,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="railtycn" supported="no">
 		<!-- SPS (CAPS) release 619 -->
 		<description>Railroad Tycoon (Euro, v855.02)</description>
@@ -34657,6 +36445,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="railtycna" cloneof="railtycn" supported="no">
 		<!-- SPS (CAPS) release 854 -->
 		<description>Railroad Tycoon (Euro, v855.01)</description>
@@ -34678,6 +36467,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="railtycng" cloneof="railtycn" supported="no">
 		<!-- SPS (CAPS) release 381 -->
 		<description>Railroad Tycoon (Ger, v855.02)</description>
@@ -34699,6 +36489,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="railtycnga" cloneof="railtycn" supported="no">
 		<!-- SPS (CAPS) release 716 -->
 		<description>Railroad Tycoon (Ger, v855.01)</description>
@@ -34720,6 +36511,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rbisland" supported="no">
 		<!-- SPS (CAPS) release 12 -->
 		<description>Rainbow Islands (Euro)</description>
@@ -34734,6 +36526,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rbislanda" cloneof="rbisland" supported="no">
 		<!-- SPS (CAPS) release 26 -->
 		<description>Rainbow Islands (Euro, Alt)</description>
@@ -34748,6 +36541,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rbislandb" cloneof="rbisland" supported="no">
 		<!-- SPS (CAPS) release 1311 -->
 		<description>Rainbow Islands (Euro, Budget)</description>
@@ -34762,6 +36556,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rambo3" supported="no">
 		<!-- SPS (CAPS) release 2433 -->
 		<description>Rambo III (Euro, Budget)</description>
@@ -34776,6 +36571,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rambo3u" cloneof="rambo3" supported="no">
 		<!-- SPS (CAPS) release 2432 -->
 		<description>Rambo III (USA)</description>
@@ -34790,6 +36586,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rampart" supported="no">
 		<!-- SPS (CAPS) release 2463 -->
 		<description>Rampart (Euro)</description>
@@ -34804,6 +36601,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ranx" supported="no">
 		<!-- SPS (CAPS) release 1637 -->
 		<description>RanX (Fra, 10 Megahits Vol. 3)</description>
@@ -34825,6 +36623,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="reachsky" supported="no">
 		<!-- SPS (CAPS) release 2273 -->
 		<description>Reach for the Skies (Euro, v1.1 19930907)</description>
@@ -34852,6 +36651,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="reachstr" supported="no">
 		<!-- SPS (CAPS) release 1477 -->
 		<description>Reach for the Stars (USA, v3.0)</description>
@@ -34867,6 +36667,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rghostb" supported="no">
 		<!-- SPS (CAPS) release 198 -->
 		<description>The Real Ghostbusters (Euro)</description>
@@ -34881,6 +36682,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="realmtrl" supported="no">
 		<!-- SPS (CAPS) release 3010 -->
 		<description>Realm of the Trolls (Euro, 5th Anniversary)</description>
@@ -34895,6 +36697,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="realms" supported="no">
 		<!-- SPS (CAPS) release 1497 -->
 		<description>Realms (Euro)</description>
@@ -34916,6 +36719,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="arkania" supported="no">
 		<!-- SPS (CAPS) release 616 -->
 		<description>Realms of Arkania - Blade of Destiny (Euro)</description>
@@ -34973,6 +36777,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="schwraug" cloneof="arkania" supported="no">
 		<!-- SPS (CAPS) release 806 -->
 		<description>Das Schwarze Auge - Die Schicksalsklinge (Ger)</description>
@@ -35030,6 +36835,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="recognme" supported="no">
 		<!-- SPS (CAPS) release 1916 -->
 		<description>Recognize Me (Euro)</description>
@@ -35044,6 +36850,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="redbaron" supported="no">
 		<!-- SPS (CAPS) release 1595 -->
 		<description>Red Baron (Euro, v1.0)</description>
@@ -35071,6 +36878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="redbarona" cloneof="redbaron" supported="no">
 		<!-- SPS (CAPS) release 1683 -->
 		<description>Red Baron (Euro, The Lords of Power)</description>
@@ -35092,6 +36900,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="redbarong" cloneof="redbaron" supported="no">
 		<!-- SPS (CAPS) release 2068 -->
 		<description>Red Baron (Ger, v1.0)</description>
@@ -35119,6 +36928,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="redheat" supported="no">
 		<!-- SPS (CAPS) release 565 -->
 		<description>Red Heat (Euro)</description>
@@ -35133,6 +36943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="redheata" cloneof="redheat" supported="no">
 		<!-- SPS (CAPS) release 1154 -->
 		<description>Red Heat (Euro, Budget)</description>
@@ -35147,6 +36958,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="redstorm" supported="no">
 		<!-- SPS (CAPS) release 1603 -->
 		<description>Red Storm Rising (Euro, v843.02)</description>
@@ -35168,6 +36980,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="reeder" supported="no">
 		<!-- SPS (CAPS) release 566 -->
 		<description>Der Reeder (Ger, v1.00 19950823)</description>
@@ -35213,6 +37026,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="reederei" supported="no">
 		<!-- SPS (CAPS) release 567 -->
 		<description>Reederei (Ger)</description>
@@ -35227,6 +37041,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="renaiss" supported="no">
 		<!-- SPS (CAPS) release 2415 -->
 		<description>Renaissance (Euro)</description>
@@ -35241,6 +37056,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="renegade" supported="no">
 		<!-- SPS (CAPS) release 1966 -->
 		<description>Renegade (Euro)</description>
@@ -35255,6 +37071,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="renegadea" cloneof="renegade" supported="no">
 		<!-- SPS (CAPS) release 2183 -->
 		<description>Renegade (Euro, Budget)</description>
@@ -35269,6 +37086,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="intercpt" supported="no">
 		<!-- SPS (CAPS) release 2514 -->
 		<description>Renegade Legion Interceptor (Euro, v1.0 19910513)</description>
@@ -35283,6 +37101,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="resol101" supported="no">
 		<!-- SPS (CAPS) release 221 -->
 		<description>Resolution 101 (Euro)</description>
@@ -35298,6 +37117,7 @@ license:CC0
 	</software>
 
 	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="rete" cloneof="hughesis" supported="no">
 		<!-- SPS (CAPS) release 2751 -->
 		<description>Retee! (Ita)</description>
@@ -35312,6 +37132,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="retmedus" supported="no">
 		<!-- SPS (CAPS) release 2828 -->
 		<description>The Return of Medusa (Ger, v1.07C+ 19910828)</description>
@@ -35326,6 +37147,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="jedi" supported="no">
 		<!-- SPS (CAPS) release 2152 -->
 		<description>Return of the Jedi (Euro)</description>
@@ -35340,6 +37162,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="jedia" cloneof="jedi" supported="no">
 		<!-- SPS (CAPS) release 2153 -->
 		<description>Return of the Jedi (Euro, The Star Wars Trilogy)</description>
@@ -35354,6 +37177,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="retatlnt" supported="no">
 		<!-- SPS (CAPS) release 717 -->
 		<description>Return to Atlantis (Euro)</description>
@@ -35375,6 +37199,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="revelatn" supported="no">
 		<!-- SPS (CAPS) release 1903 -->
 		<description>Revelation! (Euro)</description>
@@ -35390,6 +37215,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="rickdang" supported="no">
 		<!-- SPS (CAPS) release 2294 -->
 		<description>Rick Dangerous (Euro, MicroStyle re-release)</description>
@@ -35405,6 +37231,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart with DSKDAT R (white screen) -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rickdanga" cloneof="rickdang" supported="no">
 		<!-- SPS (CAPS) release 776 -->
 		<description>Rick Dangerous (Euro)</description>
@@ -35420,6 +37247,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: OK -->
 	<software name="rickdangb" cloneof="rickdang" supported="no">
 		<!-- SPS (CAPS) release 2372 -->
 		<description>Rick Dangerous (Euro, Alt, Unlimited Lives?)</description>
@@ -35435,6 +37263,7 @@ license:CC0
 	</software>
 
 	<!-- red screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rickdng2" supported="no">
 		<!-- SPS (CAPS) release 570 -->
 		<description>Rick Dangerous 2 (Euro)</description>
@@ -35450,6 +37279,7 @@ license:CC0
 	</software>
 
 	<!-- red screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rickdng2a" cloneof="rickdng2" supported="no">
 		<!-- SPS (CAPS) release 1877 -->
 		<description>Rick Dangerous 2 (Euro, Budget)</description>
@@ -35464,6 +37294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="daviswts" supported="no">
 		<!-- SPS (CAPS) release 1716 -->
 		<description>Rick Davis's World Trophy Soccer (Euro)</description>
@@ -35478,6 +37309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ringmeds" supported="no">
 		<!-- SPS (CAPS) release 2827 -->
 		<description>Rings of Medusa (Euro, v1.6)</description>
@@ -35492,6 +37324,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ringmedsg" cloneof="ringmeds" supported="no">
 		<!-- SPS (CAPS) release 2824 -->
 		<description>Rings of Medusa (Ger, v1.6)</description>
@@ -35506,6 +37339,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ringmedsga" cloneof="ringmeds" supported="no">
 		<!-- SPS (CAPS) release 2826 -->
 		<description>Rings of Medusa (Ger, v1.04)</description>
@@ -35520,6 +37354,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ringmedsgb" cloneof="ringmeds" supported="no">
 		<!-- SPS (CAPS) release 2825 -->
 		<description>Rings of Medusa (Ger, v1.02)</description>
@@ -35534,6 +37369,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ringside" supported="no">
 		<!-- SPS (CAPS) release 1611 -->
 		<description>Ringside (Euro, Hyperaction)</description>
@@ -35548,6 +37384,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="risedrgn" supported="no">
 		<!-- SPS (CAPS) release 1793 -->
 		<description>Rise of the Dragon (Euro, v1.0)</description>
@@ -35617,6 +37454,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="risk" supported="no">
 		<!-- SPS (CAPS) release 1125 -->
 		<description>Risk (Euro, v1.9, Board Genius)</description>
@@ -35632,6 +37470,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="riskant" supported="no">
 		<!-- SPS (CAPS) release 250 -->
 		<description>Riskant! (Ger)</description>
@@ -35646,6 +37485,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="riskyw" supported="no">
 		<!-- SPS (CAPS) release 571 -->
 		<description>Risky Woods (Euro)</description>
@@ -35667,6 +37507,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="roadblst" supported="no">
 		<!-- SPS (CAPS) release 718 -->
 		<description>Road Blasters (Euro)</description>
@@ -35681,6 +37522,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="roadblsta" cloneof="roadblst" supported="no">
 		<!-- SPS (CAPS) release 2207 -->
 		<description>Road Blasters (Euro, Budget)</description>
@@ -35695,6 +37537,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="roadrash" supported="no">
 		<!-- SPS (CAPS) release 1313 -->
 		<description>Road Rash (Euro)</description>
@@ -35716,6 +37559,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="roadwars" supported="no">
 		<!-- SPS (CAPS) release 142 -->
 		<description>Road Wars (Euro)</description>
@@ -35730,6 +37574,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="roadweur" supported="no">
 		<!-- SPS (CAPS) release 2510 -->
 		<description>Roadwar Europa (Euro, v1.0)</description>
@@ -35744,6 +37589,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="robocop" supported="no">
 		<!-- SPS (CAPS) release 2066 -->
 		<description>RoboCop (Euro)</description>
@@ -35758,6 +37604,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="robocopa" cloneof="robocop" supported="no">
 		<!-- SPS (CAPS) release 1620 -->
 		<description>RoboCop (Euro, Hollywood)</description>
@@ -35772,6 +37619,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robocopb" cloneof="robocop" supported="no">
 		<!-- SPS (CAPS) release 1621 -->
 		<description>RoboCop (Euro, Budget)</description>
@@ -35786,6 +37634,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="robocop2" supported="no">
 		<!-- SPS (CAPS) release 1220 -->
 		<description>RoboCop 2 (Euro)</description>
@@ -35807,6 +37656,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robocop3" supported="no">
 		<!-- SPS (CAPS) release 805 -->
 		<description>RoboCop 3 (Euro, Dongle)</description>
@@ -35834,6 +37684,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robocop3a" cloneof="robocop3" supported="no">
 		<!-- SPS (CAPS) release 979 -->
 		<description>RoboCop 3 (Euro)</description>
@@ -35861,6 +37712,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robocop3u" cloneof="robocop3" supported="no">
 		<!-- SPS (CAPS) release 978 -->
 		<description>RoboCop 3D (USA)</description>
@@ -35888,6 +37740,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="robosprt" supported="no">
 		<!-- SPS (CAPS) release 2592 -->
 		<description>RoboSport (Euro)</description>
@@ -35909,6 +37762,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="robotnic" supported="no">
 		<!-- SPS (CAPS) release 2161 -->
 		<description>Robotnic (Euro)</description>
@@ -35923,6 +37777,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="robozone" supported="no">
 		<!-- SPS (CAPS) release 257 -->
 		<description>Robozone (Euro)</description>
@@ -35944,6 +37799,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rockadod" supported="no">
 		<!-- SPS (CAPS) release 2080 -->
 		<description>Rock-A-Doodle (Euro)</description>
@@ -35960,6 +37816,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, crashes after first take off -->
+	<!-- ATK test: OK -->
 	<software name="rocktrng" supported="no">
 		<!-- SPS (CAPS) release 1641 -->
 		<description>Rocket Ranger (Euro)</description>
@@ -35981,6 +37838,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rocktrnga" cloneof="rocktrng" supported="no">
 		<!-- SPS (CAPS) release 1640 -->
 		<description>Rocket Ranger (Euro, Budget)</description>
@@ -36002,6 +37860,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rocktrngg" cloneof="rocktrng" supported="no">
 		<!-- SPS (CAPS) release 1533 -->
 		<description>Rocket Ranger (Ger)</description>
@@ -36023,6 +37882,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rocktrngga" cloneof="rocktrng" supported="no">
 		<!-- SPS (CAPS) release 1534 -->
 		<description>Rocket Ranger (Ger, Budget)</description>
@@ -36045,6 +37905,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: failed -->
 	<software name="rocknrol" supported="no">
 		<!-- SPS (CAPS) release 801 -->
 		<description>Rock 'n Roll (Euro)</description>
@@ -36066,6 +37927,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rocknrola" cloneof="rocknrol" supported="no">
 		<!-- SPS (CAPS) release 2167 -->
 		<description>Rock 'n Roll (Euro, 5th Anniversary)</description>
@@ -36080,6 +37942,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rodland" supported="no">
 		<!-- SPS (CAPS) release 1509 -->
 		<description>Rod-Land (Euro, v1.32)</description>
@@ -36094,6 +37957,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rodlanda" cloneof="rodland" supported="no">
 		<!-- SPS (CAPS) release 572 -->
 		<description>Rod-Land (Euro, v1.3)</description>
@@ -36108,6 +37972,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="rodymas" supported="no">
 		<!-- SPS (CAPS) release 2424 -->
 		<description>Rody &amp; Mastico (Fra)</description>
@@ -36122,6 +37987,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="rodymasg" cloneof="rodymas" supported="no">
 		<!-- SPS (CAPS) release 2478 -->
 		<description>Rody &amp; Mastico (Ger)</description>
@@ -36136,6 +38002,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rodymas2" supported="no">
 		<!-- SPS (CAPS) release 2336 -->
 		<description>Rody &amp; Mastico II (Fra)</description>
@@ -36150,6 +38017,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rodymas3" supported="no">
 		<!-- SPS (CAPS) release 2337 -->
 		<description>Rody &amp; Mastico III (Fra)</description>
@@ -36164,6 +38032,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rodymas4" supported="no">
 		<!-- SPS (CAPS) release 2334 -->
 		<description>Rody Noël (Fra)</description>
@@ -36178,6 +38047,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rodymas5" supported="no">
 		<!-- SPS (CAPS) release 2335 -->
 		<description>Rody V (Fra)</description>
@@ -36192,6 +38062,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rodymas6" supported="no">
 		<!-- SPS (CAPS) release 2338 -->
 		<description>Rody VI (Fra)</description>
@@ -36206,6 +38077,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rollerbl" supported="no">
 		<!-- SPS (CAPS) release 1513 -->
 		<description>Rollerball (Euro)</description>
@@ -36220,6 +38092,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rolcoast" supported="no">
 		<!-- SPS (CAPS) release 698 -->
 		<description>Roller Coaster Rumbler (Euro)</description>
@@ -36234,6 +38107,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rolronny" supported="no">
 		<!-- SPS (CAPS) release 9 -->
 		<description>Rolling Ronny - The Errand-Boy (Euro)</description>
@@ -36248,6 +38122,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rolronnya" cloneof="rolronny" supported="no">
 		<!-- SPS (CAPS) release 1515 -->
 		<description>Rolling Ronny - The Errand-Boy (Euro, Coverdisk)</description>
@@ -36262,6 +38137,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rthunder" supported="no">
 		<!-- SPS (CAPS) release 2639 -->
 		<description>Rolling Thunder (Euro)</description>
@@ -36276,6 +38152,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rthundera" cloneof="rthunder" supported="no">
 		<!-- SPS (CAPS) release 2640 -->
 		<description>Rolling Thunder (Euro, Budget)</description>
@@ -36290,6 +38167,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="romantic" supported="no">
 		<!-- SPS (CAPS) release 719 -->
 		<description>Romantic Encounters at the Dome (Euro)</description>
@@ -36311,6 +38189,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="romead92" supported="no">
 		<!-- SPS (CAPS) release 780 -->
 		<description>Rome AD 92 - "The Pathway to Power" (Euro)</description>
@@ -36338,6 +38217,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rotox" supported="no">
 		<!-- SPS (CAPS) release 2496 -->
 		<description>Rotox (Euro)</description>
@@ -36359,6 +38239,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="rubicon" supported="no">
 		<!-- SPS (CAPS) release 573 -->
 		<description>Rubicon (Euro)</description>
@@ -36380,6 +38261,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ruffredd" supported="no">
 		<!-- SPS (CAPS) release 27 -->
 		<description>Ruff and Reddy in The "Space Adventure" (Euro)</description>
@@ -36394,6 +38276,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rufftumb" supported="no">
 		<!-- SPS (CAPS) release 199 -->
 		<description>Ruff 'n' Tumble (Euro)</description>
@@ -36415,6 +38298,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ruffian" supported="no">
 		<!-- SPS (CAPS) release 2411 -->
 		<description>Ruffian (Euro)</description>
@@ -36442,6 +38326,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rugbywc" supported="no">
 		<!-- SPS (CAPS) release 258 -->
 		<description>Rugby - The World Cup (Euro)</description>
@@ -36456,6 +38341,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rugbycoa" supported="no">
 		<!-- SPS (CAPS) release 251 -->
 		<description>Rugby Coach (Euro)</description>
@@ -36470,6 +38356,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rugbylco" supported="no">
 		<!-- SPS (CAPS) release 2237 -->
 		<description>Rugby League Coach (Euro)</description>
@@ -36484,6 +38371,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ruleseng" supported="no">
 		<!-- SPS (CAPS) release 1463 -->
 		<description>Rules of Engagement (USA, v1.03 19911014)</description>
@@ -36506,6 +38394,7 @@ license:CC0
 	</software>
 
 	<!-- Vertical scrolling b&w stripes after Kickstart, [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="runninmn" supported="no">
 		<!-- SPS (CAPS) release 382 -->
 		<description>The Running Man (Euro)</description>
@@ -36527,6 +38416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rungaunt" supported="no">
 		<!-- SPS (CAPS) release 1250 -->
 		<description>Run the Gauntlet (Euro, Party Time)</description>
@@ -36548,6 +38438,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rungaunta" cloneof="rungaunt" supported="no">
 		<!-- SPS (CAPS) release 1718 -->
 		<description>Run the Gauntlet (Euro, Addicted to Fun - Sports Collection)</description>
@@ -36569,6 +38460,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="rvfhonda" supported="no">
 		<!-- SPS (CAPS) release 1081 -->
 		<description>RVF Honda (Euro, Magnum)</description>
@@ -36583,6 +38475,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="stunrun" supported="no">
 		<!-- SPS (CAPS) release 2509 -->
 		<description>S.T.U.N. Runner (Euro)</description>
@@ -36598,6 +38491,7 @@ license:CC0
 	</software>
 
 	<!-- crashes randomly either on title screen or in-game -->
+	<!-- ATK test: OK -->
 	<software name="saddam" supported="no">
 		<!-- SPS (CAPS) release 1417 -->
 		<description>The Saddam Hussein Game (USA)</description>
@@ -36612,6 +38506,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sarakon" supported="no">
 		<!-- SPS (CAPS) release 1860 -->
 		<description>Sarakon (Euro, Starbyte)</description>
@@ -36626,6 +38521,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sarakona" cloneof="sarakon" supported="no">
 		<!-- SPS (CAPS) release 2320 -->
 		<description>Sarakon (Euro, Virgin Mastertronic)</description>
@@ -36640,6 +38536,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sarcophs" supported="no">
 		<!-- SPS (CAPS) release 3078 -->
 		<description>Sarcophaser (Euro)</description>
@@ -36654,6 +38551,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sargon3" supported="no">
 		<!-- SPS (CAPS) release 2053 -->
 		<description>Sargon III (Euro)</description>
@@ -36669,6 +38567,7 @@ license:CC0
 	</software>
 
 	<!-- black screen, keeps accessing floppy -->
+	<!-- ATK test: OK -->
 	<software name="sascombs" supported="no">
 		<!-- SPS (CAPS) release 2228 -->
 		<description>SAS Combat Simulator (Euro)</description>
@@ -36683,6 +38582,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sasmig29" supported="no">
 		<!-- SPS (CAPS) release 2205 -->
 		<description>SAS Combat Simulator + MIG-29 Soviet Fighter + Kamikaze (Euro, Quattro Fighters)</description>
@@ -36697,6 +38597,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="satan" supported="no">
 		<!-- SPS (CAPS) release 1082 -->
 		<description>Satan (Euro, Magnum)</description>
@@ -36712,6 +38613,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: failed -->
 	<software name="savage" supported="no">
 		<!-- SPS (CAPS) release 28 -->
 		<description>Savage (Euro)</description>
@@ -36733,6 +38635,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="scarymsa" supported="no">
 		<!-- SPS (CAPS) release 1549 -->
 		<description>Scary Mutant Space Aliens from Mars (Euro)</description>
@@ -36754,6 +38657,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="scooby" supported="no">
 		<!-- SPS (CAPS) release 62 -->
 		<description>Scooby-Doo and Scrappy-Doo (Euro)</description>
@@ -36768,6 +38672,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="scrabble" supported="no">
 		<!-- SPS (CAPS) release 1123 -->
 		<description>Scrabble Deluxe (Euro, Board Genius)</description>
@@ -36782,6 +38687,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="scrabblef" cloneof="scrabble" supported="no">
 		<!-- SPS (CAPS) release 2694 -->
 		<description>Scrabble Deluxe (Fra)</description>
@@ -36796,6 +38702,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sspirits" supported="no">
 		<!-- SPS (CAPS) release 1955 -->
 		<description>Scramble Spirits (Euro)</description>
@@ -36810,6 +38717,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="sdic" supported="no">
 		<!-- SPS (CAPS) release 720 -->
 		<description>SDI (Euro, Cinemaware)</description>
@@ -36824,6 +38732,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="sdicu" cloneof="sdic" supported="no">
 		<!-- SPS (CAPS) release 1266 -->
 		<description>S.D.I. (USA, Cinemaware)</description>
@@ -36838,6 +38747,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="seahaven" supported="no">
 		<!-- SPS (CAPS) release 1929 -->
 		<description>SeaHaven Towers (Euro, v1.2)</description>
@@ -36852,6 +38762,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="seastalk" supported="no">
 		<!-- SPS (CAPS) release 2684 -->
 		<description>Seastalker (Euro, r16)</description>
@@ -36866,6 +38777,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="secndsam" supported="no">
 		<!-- SPS (CAPS) release 721 -->
 		<description>Second Samurai (Euro)</description>
@@ -36894,6 +38806,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="secndout" supported="partial">
 		<!-- SPS (CAPS) release 2760 -->
 		<description>Seconds Out (Euro, Budget)</description>
@@ -36909,6 +38822,7 @@ license:CC0
 	</software>
 
 	<!-- Black screen after first dialogue -->
+	<!-- ATK test: OK -->
 	<software name="monkisl" supported="no">
 		<!-- SPS (CAPS) release 1625 -->
 		<description>The Secret of Monkey Island (Euro, v1.2)</description>
@@ -36943,6 +38857,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monkislf" cloneof="monkisl" supported="no">
 		<!-- SPS (CAPS) release 1750 -->
 		<description>The Secret of Monkey Island (Fra, v1.0 19910426)</description>
@@ -36976,6 +38891,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monkislg" cloneof="monkisl" supported="no">
 		<!-- SPS (CAPS) release 359 -->
 		<description>The Secret of Monkey Island (Ger, D1.2r 19910326)</description>
@@ -37009,6 +38925,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="monkisli" cloneof="monkisl" supported="no">
 		<!-- SPS (CAPS) release 2322 -->
 		<description>The Secret of Monkey Island (Ita, v1.0 19910207)</description>
@@ -37046,6 +38963,7 @@ license:CC0
 	<!-- Does not boot on a500, accesses autoconfig RAM banks at $300000 and $c00000 -->
 	<!-- very offset title GFXs -->
 	<!-- Offset background layer(s) during gameplay -->
+	<!-- ATK test: failed -->
 	<software name="seekdest" supported="no">
 		<!-- SPS (CAPS) release 252 -->
 		<description>Seek and Destroy (Euro)</description>
@@ -37079,6 +38997,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sensgolf" supported="no">
 		<!-- SPS (CAPS) release 200 -->
 		<description>Sensible Golf (Euro)</description>
@@ -37101,6 +39020,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs at a rainbow colored screen -->
+	<!-- ATK test: failed -->
 	<software name="sensible" supported="no">
 		<!-- SPS (CAPS) release 384 -->
 		<description>Sensible Soccer (Euro, v1.0)</description>
@@ -37124,6 +39044,7 @@ license:CC0
 	</software>
 
 
+	<!-- ATK test: failed -->
 	<software name="sensibce" supported="no">
 		<!-- Is this possibly the update version being sent to users sending their 1.0 disks to Renegade?
 		Because according to available sources v1.1 was always boxed as 'European Champions' -->
@@ -37148,6 +39069,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sensibcea" cloneof="sensibce" supported="no">
 		<!-- SPS (CAPS) release 2391 -->
 		<description>Sensible Soccer v1.1 (Euro, Alt)</description>
@@ -37170,6 +39092,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sensibceb" cloneof="sensibce" supported="no">
 		<!-- SPS (CAPS) release 1895 -->
 		<description>Sensible Soccer v1.1 (Euro, Award Winners Gold Edition)</description>
@@ -37192,6 +39115,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sensibie" supported="no">
 		<!-- SPS (CAPS) release 1681 -->
 		<description>Sensible Soccer - International Edition v1.2 (Euro)</description>
@@ -37214,6 +39138,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sensibiea" cloneof="sensibie" supported="no">
 		<!-- SPS (CAPS) release 1840 -->
 		<description>Sensible Soccer - International Edition v1.2 (Euro, Help!)</description>
@@ -37235,6 +39160,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swos" supported="no">
 		<!-- SPS (CAPS) release 201 -->
 		<description>Sensible World of Soccer (Euro, v1.1)</description>
@@ -37256,6 +39182,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swosa" cloneof="swos" supported="no">
 		<!-- SPS (CAPS) release 840 -->
 		<description>Sensible World of Soccer (Euro)</description>
@@ -37277,6 +39204,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="swosup" cloneof="swos" supported="no">
 		<!-- SPS (CAPS) release 841 -->
 		<description>Sensible World of Soccer (Euro, v1.1 Update Disk)</description>
@@ -37291,6 +39219,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swos9596" supported="no">
 		<!-- SPS (CAPS) release 1755 -->
 		<description>Sensible World of Soccer 95-96 (Euro)</description>
@@ -37312,6 +39241,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swosec" supported="no">
 		<!-- SPS (CAPS) release 1825 -->
 		<description>Sensible World of Soccer 95-96 - European Championship Edition (Euro)</description>
@@ -37335,6 +39265,7 @@ license:CC0
 
 	<!-- black screen, [FDC] dsksync -->
 	<!-- Uses [FDC] dskdatr at end of loading cycles, no noticeable effect? -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swos9697" supported="no">
 		<!-- SPS (CAPS) release 842 -->
 		<description>Sensible World of Soccer 96-97 (Euro)</description>
@@ -37356,6 +39287,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sentinel" supported="no">
 		<!-- SPS (CAPS) release 3025 -->
 		<description>The Sentinel (Euro)</description>
@@ -37370,6 +39302,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="settlers" supported="no">
 		<!-- SPS (CAPS) release 143 -->
 		<description>The Settlers (Euro)</description>
@@ -37397,6 +39330,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="settlersf" cloneof="settlers" supported="no">
 		<!-- SPS (CAPS) release 2378 -->
 		<description>The Settlers (Fra)</description>
@@ -37424,6 +39358,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="siedler" cloneof="settlers" supported="no">
 		<!-- SPS (CAPS) release 401 -->
 		<description>Die Siedler (Ger)</description>
@@ -37451,6 +39386,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="7citygld" supported="no">
 		<!-- SPS (CAPS) release 908 -->
 		<description>Seven Cities of Gold (USA)</description>
@@ -37465,6 +39401,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="shdancer" supported="no">
 		<!-- SPS (CAPS) release 202 -->
 		<description>Shadow Dancer (Euro)</description>
@@ -37479,6 +39416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shfightr" supported="no">
 		<!-- SPS (CAPS) release 1630 -->
 		<description>Shadow Fighter (Euro)</description>
@@ -37513,6 +39451,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="beast" supported="no">
 		<!-- SPS (CAPS) release 1357 -->
 		<description>Shadow of the Beast (Euro)</description>
@@ -37534,6 +39473,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beasta" cloneof="beast" supported="no">
 		<!-- SPS (CAPS) release 1414 -->
 		<description>Shadow of the Beast (Euro, Alt)</description>
@@ -37555,6 +39495,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beastbmd" supported="no">
 		<!-- SPS (CAPS) release 1453 -->
 		<description>Shadow of the Beast &amp; Blood Money Demo (Euro)</description>
@@ -37570,6 +39511,7 @@ license:CC0
 	</software>
 
 	<!-- black screen -->
+	<!-- ATK test: failed -->
 	<software name="beast2" supported="no">
 		<!-- SPS (CAPS) release 1359 -->
 		<description>Shadow of the Beast II (Euro)</description>
@@ -37591,6 +39533,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beast2a" cloneof="beast2" supported="no">
 		<!-- SPS (CAPS) release 1481 -->
 		<description>Shadow of the Beast II (Euro, Alt)</description>
@@ -37613,6 +39556,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) -->
+	<!-- ATK test: failed -->
 	<software name="beast3" supported="no">
 		<!-- SPS (CAPS) release 16 -->
 		<description>Shadow of the Beast III (Euro)</description>
@@ -37640,6 +39584,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="beast3u" cloneof="beast3" supported="no">
 		<!-- SPS (CAPS) release 1176 -->
 		<description>Shadow of the Beast III (USA)</description>
@@ -37667,6 +39612,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shadsorc" supported="no">
 		<!-- SPS (CAPS) release 275 -->
 		<description>Shadow Sorcerer (Euro)</description>
@@ -37689,6 +39635,7 @@ license:CC0
 	</software>
 
 	<!-- white/black boxes scattered thru intro -->
+	<!-- ATK test: OK -->
 	<software name="shadwar" supported="partial">
 		<!-- SPS (CAPS) release 830 -->
 		<description>Shadow Warriors (Euro)</description>
@@ -37712,6 +39659,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="shadwara" cloneof="shadwar" supported="no">
 		<!-- SPS (CAPS) release 1679 -->
 		<description>Shadow Warriors (Euro, Alt)</description>
@@ -37733,6 +39681,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="shadgate" supported="no">
 		<!-- SPS (CAPS) release 290 -->
 		<description>Shadowgate (Euro)</description>
@@ -37748,6 +39697,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after showing intro and title -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="shadland" supported="no">
 		<!-- SPS (CAPS) release 574 -->
 		<description>Shadowlands (Euro)</description>
@@ -37769,6 +39719,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shadwrld" supported="no">
 		<!-- SPS (CAPS) release 30 -->
 		<description>Shadoworlds (Euro)</description>
@@ -37790,6 +39741,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shanghai" supported="no">
 		<!-- SPS (CAPS) release 1388 -->
 		<description>Shanghai (Euro, Power Hits)</description>
@@ -37804,6 +39756,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shanghaiu" cloneof="shanghai" supported="no">
 		<!-- SPS (CAPS) release 1387 -->
 		<description>Shanghai (USA)</description>
@@ -37818,6 +39771,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shangh98" supported="no">
 		<!-- SPS (CAPS) release 1538 -->
 		<description>Shanghai '98 (Ger)</description>
@@ -37832,6 +39786,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sharkey" supported="no">
 		<!-- SPS (CAPS) release 2133 -->
 		<description>Sharkey's Moll (Euro)</description>
@@ -37846,6 +39801,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="shinobi" supported="no">
 		<!-- SPS (CAPS) release 1054 -->
 		<description>Shinobi (Euro)</description>
@@ -37860,6 +39816,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shinobiu" cloneof="shinobi" supported="no">
 		<!-- SPS (CAPS) release 2354 -->
 		<description>Shinobi (USA)</description>
@@ -37874,6 +39831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shockwav" supported="no">
 		<!-- SPS (CAPS) release 723 -->
 		<description>ShockWave (Euro)</description>
@@ -37888,6 +39846,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="seuck" supported="no">
 		<!-- SPS (CAPS) release 1335 -->
 		<description>Shoot'Em-Up Construction Kit (Euro)</description>
@@ -37949,6 +39908,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shuffle" supported="no">
 		<!-- SPS (CAPS) release 724 -->
 		<description>Shuffle (Euro)</description>
@@ -37963,6 +39923,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="shflpuck" supported="no">
 		<!-- SPS (CAPS) release 1143 -->
 		<description>Shufflepuck Cafe (Euro, v1.0)</description>
@@ -37977,6 +39938,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="shflpuckf" cloneof="shflpuck" supported="no">
 		<!-- SPS (CAPS) release 2416 -->
 		<description>Shufflepuck Cafe (Fra, v1.0, NRJ Vol. 2)</description>
@@ -37991,6 +39953,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shuttle" supported="no">
 		<!-- SPS (CAPS) release 1906 -->
 		<description>Shuttle - The Space Flight Simulator (Euro, v1.0)</description>
@@ -38012,6 +39975,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="shuttlea" cloneof="shuttle" supported="no">
 		<!-- SPS (CAPS) release 2468 -->
 		<description>Shuttle - The Space Flight Simulator (Euro, v1.0, No Title Screen)</description>
@@ -38033,6 +39997,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sidearms" supported="no">
 		<!-- SPS (CAPS) release 1073 -->
 		<description>Side Arms (Euro)</description>
@@ -38047,6 +40012,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sideshow" supported="no">
 		<!-- SPS (CAPS) release 779 -->
 		<description>SideShow (Euro, v1.0)</description>
@@ -38074,6 +40040,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sidewind" supported="no">
 		<!-- SPS (CAPS) release 51 -->
 		<description>SideWinder (Euro)</description>
@@ -38088,6 +40055,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sidewin2" supported="no">
 		<!-- SPS (CAPS) release 1561 -->
 		<description>SideWinder II (Euro)</description>
@@ -38102,6 +40070,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sierrasc" supported="no">
 		<!-- SPS (CAPS) release 1539 -->
 		<description>Sierra Soccer - World Challenge Edition (Euro)</description>
@@ -38123,6 +40092,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="silentsr" supported="no">
 		<!-- SPS (CAPS) release 402 -->
 		<description>Silent Service - The Submarine Simulation (Euro, v825.03)</description>
@@ -38137,6 +40107,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="silents2" supported="no">
 		<!-- SPS (CAPS) release 949 -->
 		<description>Silent Service II (USA, v1.01 19910708)</description>
@@ -38158,6 +40129,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="silicond" supported="no">
 		<!-- SPS (CAPS) release 1415 -->
 		<description>Silicon Dreams (USA)</description>
@@ -38172,6 +40144,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="silkworm" supported="no">
 		<!-- SPS (CAPS) release 388 -->
 		<description>Silkworm (Euro)</description>
@@ -38186,6 +40159,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="silkworma" cloneof="silkworm" supported="no">
 		<!-- SPS (CAPS) release 2413 -->
 		<description>Silkworm (Euro, Alt)</description>
@@ -38200,6 +40174,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simant" supported="no">
 		<!-- SPS (CAPS) release 2221 -->
 		<description>SimAnt (Euro)</description>
@@ -38227,6 +40202,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simantf" cloneof="simant" supported="no">
 		<!-- SPS (CAPS) release 2665 -->
 		<description>SimAnt (Fra)</description>
@@ -38254,6 +40230,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simantg" cloneof="simant" supported="no">
 		<!-- SPS (CAPS) release 84 -->
 		<description>SimAnt (Ger)</description>
@@ -38282,6 +40259,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="simcity" supported="partial">
 		<!-- SPS (CAPS) release 2193 -->
 		<description>Sim City (Euro, v1.2)</description>
@@ -38297,6 +40275,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcitya" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 888 -->
 		<description>Sim City (Euro, 512k)</description>
@@ -38311,6 +40290,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcityb" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1870 -->
 		<description>Sim City (Euro, 512k, Alt)</description>
@@ -38325,6 +40305,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcityc" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 2192 -->
 		<description>Sim City (Euro, 512k, Alt 2)</description>
@@ -38339,6 +40320,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcityu" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1953 -->
 		<description>Sim City (USA, v1.2)</description>
@@ -38353,6 +40335,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="simcityua" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1992 -->
 		<description>Sim City (USA, v1.0)</description>
@@ -38367,6 +40350,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcitygs1" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1993 -->
 		<description>Sim City Graphics Set 1 - Ancient Cities (USA, v1.00)</description>
@@ -38382,6 +40366,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcitygs2" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1987 -->
 		<description>Sim City Graphics Set 2 - Future Cities (USA, v1.00)</description>
@@ -38397,6 +40382,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simcityte" cloneof="simcity" supported="no">
 		<!-- SPS (CAPS) release 1954 -->
 		<description>Sim City Terrain Editor (USA, v1.0)</description>
@@ -38412,6 +40398,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simearth" supported="no">
 		<!-- SPS (CAPS) release 1066 -->
 		<description>Sim Earth (Euro, v1.0 19920807)</description>
@@ -38433,6 +40420,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simearthf" cloneof="simearth" supported="no">
 		<!-- SPS (CAPS) release 2645 -->
 		<description>Sim Earth (Fra, v1.0 19920807)</description>
@@ -38454,6 +40442,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simlife" supported="no">
 		<!-- SPS (CAPS) release 2585 -->
 		<description>Sim Life (Euro, v1.00 19930718)</description>
@@ -38481,6 +40470,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simlifef" cloneof="simlife" supported="no">
 		<!-- SPS (CAPS) release 2379 -->
 		<description>Sim Life (Fra, v1.00 19930718)</description>
@@ -38508,6 +40498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simlifeg" cloneof="simlife" supported="no">
 		<!-- SPS (CAPS) release 576 -->
 		<description>Sim Life (Ger, v1.00 19930718)</description>
@@ -38535,6 +40526,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simonsor" supported="no">
 		<!-- SPS (CAPS) release 2865 -->
 		<description>Simon the Sorcerer (Euro)</description>
@@ -38598,6 +40590,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simonsorf" cloneof="simonsor" supported="no">
 		<!-- SPS (CAPS) release 2370 -->
 		<description>Simon the Sorcerer (Fra)</description>
@@ -38661,6 +40654,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="simonsorg" cloneof="simonsor" supported="no">
 		<!-- SPS (CAPS) release 1434 -->
 		<description>Simon the Sorcerer (Ger)</description>
@@ -38724,6 +40718,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bartvssm" supported="no">
 		<!-- SPS (CAPS) release 884 -->
 		<description>The Simpsons - Bart vs. The Space Mutants (Euro)</description>
@@ -38745,6 +40740,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bartvssma" cloneof="bartvssm" supported="no">
 		<!-- SPS (CAPS) release 1936 -->
 		<description>The Simpsons - Bart vs. The Space Mutants (Euro, Cartoon Classics)</description>
@@ -38766,6 +40762,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="bartvsw" supported="no">
 		<!-- SPS (CAPS) release 634 -->
 		<description>The Simpsons - Bart vs. The World (Euro)</description>
@@ -38780,6 +40777,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="simulcra" supported="no">
 		<!-- SPS (CAPS) release 2659 -->
 		<description>Simulcra (Euro)</description>
@@ -38794,6 +40792,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="sinbad" supported="no">
 		<!-- SPS (CAPS) release 83 -->
 		<description>Sinbad and the Throne of the Falcon! (USA)</description>
@@ -38815,6 +40814,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sinkswim" supported="no">
 		<!-- SPS (CAPS) release 1065 -->
 		<description>Sink or Swim (Euro)</description>
@@ -38836,6 +40836,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sixiang" supported="no">
 		<!-- SPS (CAPS) release 2757 -->
 		<description>Sixiang (Euro)</description>
@@ -38850,6 +40851,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sketshot" supported="no">
 		<!-- SPS (CAPS) release 2231 -->
 		<description>Skeet Shoot (Euro)</description>
@@ -38864,6 +40866,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="skiordie" supported="no">
 		<!-- SPS (CAPS) release 1258 -->
 		<description>Ski or Die (Euro)</description>
@@ -38878,6 +40881,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="skidmark" supported="no">
 		<!-- SPS (CAPS) release 204 -->
 		<description>Skidmarks (Euro, v1.06)</description>
@@ -38911,6 +40915,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="skidrac1" supported="no">
 		<!-- SPS (CAPS) release 145 -->
 		<description>Skidmarks Racer Issue 1 (Euro)</description>
@@ -38926,6 +40931,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="skrull" supported="partial">
 		<!-- SPS (CAPS) release 1709 -->
 		<description>Skrull the Barbarian (Euro)</description>
@@ -38940,6 +40946,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="skullxbo" supported="no">
 		<!-- SPS (CAPS) release 385 -->
 		<description>Skull and Crossbones (Euro)</description>
@@ -38954,6 +40961,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="skweek" supported="no">
 		<!-- SPS (CAPS) release 2401 -->
 		<description>Skweek (Euro, Les Stars)</description>
@@ -38968,6 +40976,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="skyfight" supported="no">
 		<!-- SPS (CAPS) release 2117 -->
 		<description>Sky Fighter (Euro)</description>
@@ -38982,6 +40991,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="skyhighs" supported="no">
 		<!-- SPS (CAPS) release 2091 -->
 		<description>Sky High Stuntman (Euro)</description>
@@ -38996,6 +41006,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="skyblast" supported="no">
 		<!-- SPS (CAPS) release 2047 -->
 		<description>Skyblaster (Euro, Amiga Star Collection)</description>
@@ -39010,6 +41021,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="skychase" supported="no">
 		<!-- SPS (CAPS) release 2610 -->
 		<description>SkyChase (Euro)</description>
@@ -39024,6 +41036,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="skychasea" cloneof="skychase" supported="no">
 		<!-- SPS (CAPS) release 2612 -->
 		<description>SkyChase (Euro, Supreme Challenge: Flight Command)</description>
@@ -39038,6 +41051,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="skyfox" supported="no">
 		<!-- SPS (CAPS) release 903 -->
 		<description>Skyfox (USA)</description>
@@ -39052,6 +41066,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="skyfoxa" cloneof="skyfox" supported="no">
 		<!-- SPS (CAPS) release 910 -->
 		<description>Skyfox (USA, HLS)</description>
@@ -39066,6 +41081,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="slayer" supported="no">
 		<!-- SPS (CAPS) release 3074 -->
 		<description>Slayer (Euro)</description>
@@ -39080,6 +41096,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="slayerpr" supported="no">
 		<!-- SPS (CAPS) release 3075 -->
 		<description>Slayer (Euro, Budget)</description>
@@ -39094,6 +41111,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="slaygon" supported="no">
 		<!-- SPS (CAPS) release 1775 -->
 		<description>Slaygon (USA, v1.1)</description>
@@ -39108,6 +41126,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sleepgod" supported="no">
 		<!-- SPS (CAPS) release 782 -->
 		<description>Sleeping Gods Lie (Euro)</description>
@@ -39129,6 +41148,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sleepwlk" supported="no">
 		<!-- SPS (CAPS) release 2611 -->
 		<description>Sleepwalker (Euro)</description>
@@ -39156,6 +41176,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sleepwlka" cloneof="sleepwlk" supported="no">
 		<!-- SPS (CAPS) release 291 -->
 		<description>Sleepwalker (Euro, Comic Relief)</description>
@@ -39183,6 +41204,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sliders" supported="no">
 		<!-- SPS (CAPS) release 1855 -->
 		<description>Sliders (Euro)</description>
@@ -39197,6 +41219,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sligtmag" supported="no">
 		<!-- SPS (CAPS) release 2174 -->
 		<description>Slightly Magic (Euro)</description>
@@ -39213,6 +41236,7 @@ license:CC0
 
 	<!-- Locks up after title screen by pressing fire on joystick [FDC] dsksync -->
 	<!-- Player GFX sprite is black filled -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="slipstrm" supported="no">
 		<!-- SPS (CAPS) release 1629 -->
 		<description>Slip Stream (Euro)</description>
@@ -39227,6 +41251,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="slyspy" supported="no">
 		<!-- SPS (CAPS) release 1259 -->
 		<description>Sly Spy - Secret Agent (Euro)</description>
@@ -39248,6 +41273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="smashtv" supported="no">
 		<!-- SPS (CAPS) release 2293 -->
 		<description>Smash T.V. (Euro)</description>
@@ -39263,6 +41289,7 @@ license:CC0
 	</software>
 
 	<!-- "Software error", clicking on cancel causes Guru Meditation -->
+	<!-- ATK test: OK -->
 	<software name="snoopy" supported="no">
 		<!-- SPS (CAPS) release 935 -->
 		<description>Snoopy - The Cool Computer Game (Euro)</description>
@@ -39278,6 +41305,7 @@ license:CC0
 	</software>
 
 	<!-- "Software error", clicking on cancel causes Guru Meditation -->
+	<!-- ATK test: OK -->
 	<software name="snoopya" cloneof="snoopy" supported="no">
 		<!-- SPS (CAPS) release 2929 -->
 		<description>Snoopy - The Cool Computer Game (Euro, Alt)</description>
@@ -39292,6 +41320,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="snowbros" supported="no">
 		<!-- SPS (CAPS) release 2601 -->
 		<description>Snow Bros. (Euro, Prototype)</description>
@@ -39306,6 +41335,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="snowstrk" supported="no">
 		<!-- SPS (CAPS) release 2419 -->
 		<description>SnowStrike (Euro, Super Simpack)</description>
@@ -39320,6 +41350,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="soccerkd" supported="no">
 		<!-- SPS (CAPS) release 1129 -->
 		<description>Soccer Kid (Euro)</description>
@@ -39355,6 +41386,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- Hangs on title screen -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="soccerpb" supported="no">
 		<!-- SPS (CAPS) release 2522 -->
 		<description>Soccer Pinball (Euro)</description>
@@ -39369,6 +41401,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="socstwce" supported="no">
 		<!-- SPS (CAPS) release 2410 -->
 		<description>Soccer Star - World Cup Edition (Euro)</description>
@@ -39383,6 +41416,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="softmang" supported="no">
 		<!-- SPS (CAPS) release 727 -->
 		<description>Software Manager (Ger)</description>
@@ -39410,6 +41444,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="soldlght" supported="no">
 		<!-- SPS (CAPS) release 2001 -->
 		<description>Soldier of Light (Euro)</description>
@@ -39424,6 +41459,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="solitjrn" supported="no">
 		<!-- SPS (CAPS) release 1975 -->
 		<description>Solitaire's Journey (USA)</description>
@@ -39445,6 +41481,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sonempir" supported="no">
 		<!-- SPS (CAPS) release 1974 -->
 		<description>Son of the Empire (Euro)</description>
@@ -39467,6 +41504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sonshush" supported="no">
 		<!-- SPS (CAPS) release 2513 -->
 		<description>Son Shu Shi (Euro, Prototype)</description>
@@ -39488,6 +41526,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sonicbom" supported="no">
 		<!-- SPS (CAPS) release 2561 -->
 		<description>Sonic Boom (Euro)</description>
@@ -39502,6 +41541,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="sophelie" supported="no">
 		<!-- SPS (CAPS) release 2325 -->
 		<description>Sophelie (Euro)</description>
@@ -39516,6 +41556,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sorclord" supported="no">
 		<!-- SPS (CAPS) release 1753 -->
 		<description>Sorcerer Lord (Fra)</description>
@@ -39530,6 +41571,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sorceryp" supported="no">
 		<!-- SPS (CAPS) release 1562 -->
 		<description>Sorcery + (Euro)</description>
@@ -39544,6 +41586,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spc1889" supported="no">
 		<!-- SPS (CAPS) release 2092 -->
 		<description>Space 1889 (Euro)</description>
@@ -39566,6 +41609,7 @@ license:CC0
 	</software>
 
 	<!-- locks up at ReadySoft logo [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="spaceace" supported="no">
 		<!-- SPS (CAPS) release 85 -->
 		<description>Space Ace (Euro)</description>
@@ -39601,6 +41645,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- In-game it enables [FDC] dsklen == $0 and hangs (same as dlair2) -->
+	<!-- ATK test: failed -->
 	<software name="spaceac2" supported="no">
 		<!-- SPS (CAPS) release 931 -->
 		<description>Space Ace II - Borf's Revenge (Euro)</description>
@@ -39640,6 +41685,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="spaceass" supported="no">
 		<!-- SPS (CAPS) release 1696 -->
 		<description>Space Assault (Euro)</description>
@@ -39654,6 +41700,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacebtl" supported="no">
 		<!-- SPS (CAPS) release 2705 -->
 		<description>Space Battle (Euro, v1.1)</description>
@@ -39668,6 +41715,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacecrs" supported="no">
 		<!-- SPS (CAPS) release 1535 -->
 		<description>Space Crusade (Euro)</description>
@@ -39689,6 +41737,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacefgt" supported="no">
 		<!-- SPS (CAPS) release 2304 -->
 		<description>Space Fight (Euro)</description>
@@ -39703,6 +41752,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spacegun" supported="no">
 		<!-- SPS (CAPS) release 2004 -->
 		<description>Space Gun (Euro)</description>
@@ -39724,6 +41774,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sharrier" supported="no">
 		<!-- SPS (CAPS) release 1600 -->
 		<description>Space Harrier (Euro)</description>
@@ -39738,6 +41789,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sharlld" supported="no">
 		<!-- SPS (CAPS) release 2517 -->
 		<description>Space Harrier + Live and Let Die (Euro, The Story so Far Vol. 3)</description>
@@ -39752,6 +41804,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sharrie2" supported="no">
 		<!-- SPS (CAPS) release 1121 -->
 		<description>Space Harrier II (Euro)</description>
@@ -39767,6 +41820,7 @@ license:CC0
 	</software>
 
 	<!-- Fails to disc swap #3 -->
+	<!-- ATK test: OK -->
 	<software name="spchulk" supported="no">
 		<!-- SPS (CAPS) release 1279 -->
 		<description>Space Hulk (Euro)</description>
@@ -39794,6 +41848,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="spacqst" supported="no">
 		<!-- SPS (CAPS) release 1484 -->
 		<description>Space Quest Chapter I - The Sarien Encounter (USA, v1.2, HLS)</description>
@@ -39808,6 +41863,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest1" supported="no">
 		<!-- SPS (CAPS) release 2222 -->
 		<description>Space Quest Chapter I - The Sarien Encounter (Euro, v1.000, Enhanced)</description>
@@ -39854,6 +41910,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest2" supported="no">
 		<!-- SPS (CAPS) release 1053 -->
 		<description>Space Quest Chapter II - Vohaul's Revenge (Euro, v2.0f)</description>
@@ -39868,6 +41925,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest3" supported="no">
 		<!-- SPS (CAPS) release 292 -->
 		<description>Space Quest III: The Pirates of Pestulon (Euro, v1.0V 19890817)</description>
@@ -39901,6 +41959,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest3g" cloneof="spquest3" supported="no">
 		<!-- SPS (CAPS) release 579 -->
 		<description>Space Quest III - Die Piraten von Pestulon (Ger, v1.000)</description>
@@ -39940,6 +41999,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest4" supported="no">
 		<!-- SPS (CAPS) release 1177 -->
 		<description>Space Quest IV - Roger Wilco and the Time Rippers (USA, v1.000)</description>
@@ -39991,6 +42051,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spquest4g" cloneof="spquest4" supported="no">
 		<!-- SPS (CAPS) release 2369 -->
 		<description>Space Quest IV - Roger Wilco und die Zeitspringer (Ger, v1.000)</description>
@@ -40042,6 +42103,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacrace" supported="no">
 		<!-- SPS (CAPS) release 580 -->
 		<description>Space Racer (Euro)</description>
@@ -40056,6 +42118,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacracef" cloneof="spacrace" supported="no">
 		<!-- SPS (CAPS) release 2408 -->
 		<description>Space Racer (Fra)</description>
@@ -40070,6 +42133,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacerng" supported="no">
 		<!-- SPS (CAPS) release 763 -->
 		<description>Space Ranger (Euro)</description>
@@ -40084,6 +42148,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spcrogue" supported="no">
 		<!-- SPS (CAPS) release 2069 -->
 		<description>Space Rogue (Euro)</description>
@@ -40098,6 +42163,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spcstatn" supported="no">
 		<!-- SPS (CAPS) release 1615 -->
 		<description>Space Station - Part I (Euro)</description>
@@ -40112,6 +42178,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="oblivion" supported="no">
 		<!-- SPS (CAPS) release 1428 -->
 		<description>Space Station Oblivion (USA)</description>
@@ -40126,6 +42193,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacebal" supported="no">
 		<!-- SPS (CAPS) release 2675 -->
 		<description>Spaceball (Euro)</description>
@@ -40147,6 +42215,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spacecut" supported="no">
 		<!-- SPS (CAPS) release 1408 -->
 		<description>SpaceCutter (USA)</description>
@@ -40161,6 +42230,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="spacport" supported="no">
 		<!-- SPS (CAPS) release 578 -->
 		<description>Spaceport (Euro)</description>
@@ -40175,6 +42245,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="specfrce" supported="no">
 		<!-- SPS (CAPS) release 728 -->
 		<description>Special Forces (Euro, 1mb, 19921002)</description>
@@ -40202,6 +42273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="speedbl" supported="no">
 		<!-- SPS (CAPS) release 581 -->
 		<description>Speedball (Euro, v1.10)</description>
@@ -40216,6 +42288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="speedblu" cloneof="speedbl" supported="no">
 		<!-- SPS (CAPS) release 86 -->
 		<description>Speedball (USA, v1.05)</description>
@@ -40230,6 +42303,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="speedbl2" supported="no">
 		<!-- SPS (CAPS) release 180 -->
 		<description>Speedball 2 - Brutal Deluxe (Euro, v1.00)</description>
@@ -40244,6 +42318,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="speedbl2a" cloneof="speedbl2" supported="no">
 		<!-- SPS (CAPS) release 2897 -->
 		<description>Speedball 2: Brutal Deluxe (Euro, v1.00, The Bitmap Brothers Volume 1)</description>
@@ -40258,6 +42333,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="speedbl2b" cloneof="speedbl2" supported="no">
 		<!-- SPS (CAPS) release 1876 -->
 		<description>Speedball 2 - Brutal Deluxe (Euro, Budget)</description>
@@ -40272,6 +42348,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="speedbl2u" cloneof="speedbl2" supported="no">
 		<!-- SPS (CAPS) release 2006 -->
 		<description>Speedball 2 - Brutal Deluxe (USA)</description>
@@ -40286,6 +42363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="speedbas" supported="no">
 		<!-- SPS (CAPS) release 1664 -->
 		<description>Speedboat Assassin (Euro)</description>
@@ -40301,6 +42379,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spellbk7" supported="no">
 		<!-- SPS (CAPS) release 2119 -->
 		<description>Spell Book 7 Plus (Euro)</description>
@@ -40315,6 +42394,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="dizzy5" supported="no">
 		<!-- SPS (CAPS) release 2142 -->
 		<description>Spellbound Dizzy (Euro)</description>
@@ -40329,6 +42409,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="spellbnd" supported="no">
 		<!-- SPS (CAPS) release 783 -->
 		<description>SpellBound! (Euro)</description>
@@ -40343,6 +42424,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spellfir" supported="no">
 		<!-- SPS (CAPS) release 231 -->
 		<description>Spellfire the Sorceror (Euro)</description>
@@ -40357,6 +42439,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sphericl" supported="no">
 		<!-- SPS (CAPS) release 977 -->
 		<description>Spherical (Euro)</description>
@@ -40371,6 +42454,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sphrwrld" supported="no">
 		<!-- SPS (CAPS) release 2928 -->
 		<description>Spherical Worlds (Euro)</description>
@@ -40398,6 +42482,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spidertr" supported="no">
 		<!-- SPS (CAPS) release 873 -->
 		<description>Spidertronic (Euro)</description>
@@ -40412,6 +42497,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spindizz" supported="no">
 		<!-- SPS (CAPS) release 1179 -->
 		<description>Spindizzy Worlds (Euro)</description>
@@ -40426,6 +42512,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spinwrld" supported="no">
 		<!-- SPS (CAPS) release 2023 -->
 		<description>Spinworld (Euro)</description>
@@ -40440,6 +42527,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spinwwld" supported="no">
 		<!-- SPS (CAPS) release 2050 -->
 		<description>Spinworld + The Way of the Little Dragon (Euro, Amiga Star Collection)</description>
@@ -40454,6 +42542,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spirexcl" supported="no">
 		<!-- SPS (CAPS) release 1586 -->
 		<description>Spirit of Excalibur (Euro)</description>
@@ -40481,6 +42570,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spirexcla" cloneof="spirexcl" supported="no">
 		<!-- SPS (CAPS) release 2853 -->
 		<description>Spirit of Excalibur (Euro, Strategy Masters)</description>
@@ -40502,6 +42592,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spirexclu" cloneof="spirexcl" supported="no">
 		<!-- SPS (CAPS) release 2852 -->
 		<description>Spirit of Excalibur (USA)</description>
@@ -40523,6 +42614,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spot" supported="no">
 		<!-- SPS (CAPS) release 1558 -->
 		<description>Spot (Euro, v1.6)</description>
@@ -40538,6 +42630,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spyvsspy" supported="no">
 		<!-- SPS (CAPS) release 389 -->
 		<description>Spy vs Spy (Euro)</description>
@@ -40552,6 +42645,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spyvssp2" supported="no">
 		<!-- SPS (CAPS) release 729 -->
 		<description>Spy vs Spy II - The Island Caper (Euro)</description>
@@ -40566,6 +42660,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spyvssp3" supported="no">
 		<!-- SPS (CAPS) release 730 -->
 		<description>Spy vs Spy III - Arctic Antics (Euro)</description>
@@ -40580,6 +42675,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="spywholm" supported="no">
 		<!-- SPS (CAPS) release 3093 -->
 		<description>The Spy Who Loved Me (Euro, Superheroes)</description>
@@ -40594,6 +42690,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spywholma" cloneof="spywholm" supported="no">
 		<!-- SPS (CAPS) release 2186 -->
 		<description>The Spy Who Loved Me (Euro, The James Bond Collection)</description>
@@ -40608,6 +42705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sdragon" supported="no">
 		<!-- SPS (CAPS) release 1079 -->
 		<description>Saint Dragon (Euro)</description>
@@ -40623,6 +42721,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="stackup" supported="no">
 		<!-- SPS (CAPS) release 831 -->
 		<description>Stack Up (Euro)</description>
@@ -40637,6 +42736,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starbrkr" supported="no">
 		<!-- SPS (CAPS) release 2988 -->
 		<description>Star Breaker (Euro)</description>
@@ -40651,6 +42751,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starcomm" supported="no">
 		<!-- SPS (CAPS) release 989 -->
 		<description>Star Command (Euro, v1.0)</description>
@@ -40672,6 +42773,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starctrl" supported="no">
 		<!-- SPS (CAPS) release 2652 -->
 		<description>Star Control (Euro)</description>
@@ -40693,6 +42795,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stargoos" supported="no">
 		<!-- SPS (CAPS) release 1055 -->
 		<description>Star Goose! (Euro)</description>
@@ -40707,6 +42810,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="startrsh" supported="no">
 		<!-- SPS (CAPS) release 695 -->
 		<description>Star Trash (Euro)</description>
@@ -40721,6 +42825,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starwars" supported="no">
 		<!-- SPS (CAPS) release 403 -->
 		<description>Star Wars (Euro)</description>
@@ -40735,6 +42840,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="starwarsa" cloneof="starwars" supported="no">
 		<!-- SPS (CAPS) release 2926 -->
 		<description>Star Wars (Euro, Alt)</description>
@@ -40749,6 +42855,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="swltk" supported="no">
 		<!-- SPS (CAPS) release 939 -->
 		<description>Star Wars + Licence to Kill (Euro, Heroes)</description>
@@ -40763,6 +42870,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="esb" supported="no">
 		<!-- SPS (CAPS) release 1235 -->
 		<description>Star Wars - The Empire Strikes Back (Euro)</description>
@@ -40777,6 +42885,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="esba" cloneof="esb" supported="no">
 		<!-- SPS (CAPS) release 1236 -->
 		<description>Star Wars - The Empire Strikes Back (Euro, The Star Wars Trilogy)</description>
@@ -40791,6 +42900,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starblaz" supported="no">
 		<!-- SPS (CAPS) release 731 -->
 		<description>Starblaze (Euro)</description>
@@ -40805,6 +42915,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starx" supported="no">
 		<!-- SPS (CAPS) release 1409 -->
 		<description>Starcross (USA, r17)</description>
@@ -40819,6 +42930,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stardust" supported="no">
 		<!-- SPS (CAPS) release 2102 -->
 		<description>Stardust (Euro)</description>
@@ -40846,6 +42958,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stardusta" cloneof="stardust" supported="no">
 		<!-- SPS (CAPS) release 2103 -->
 		<description>Stardust (Euro, Alt)</description>
@@ -40873,6 +42986,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starfl" supported="no">
 		<!-- SPS (CAPS) release 855 -->
 		<description>Starflight (Euro)</description>
@@ -40887,6 +43001,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starfl2" supported="no">
 		<!-- SPS (CAPS) release 582 -->
 		<description>StarFlight II (Euro)</description>
@@ -40908,6 +43023,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starglid" supported="no">
 		<!-- SPS (CAPS) release 174 -->
 		<description>Starglider (Euro)</description>
@@ -40922,6 +43038,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stargld2">
 		<!-- SPS (CAPS) release 3000 -->
 		<description>Starglider 2 (Euro)</description>
@@ -40936,6 +43053,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starlord" supported="no">
 		<!-- SPS (CAPS) release 1878 -->
 		<description>Starlord (Euro)</description>
@@ -40963,6 +43081,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starlordg" cloneof="starlord" supported="no">
 		<!-- SPS (CAPS) release 788 -->
 		<description>Starlord (Ger)</description>
@@ -40990,6 +43109,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starray" supported="no">
 		<!-- SPS (CAPS) release 1488 -->
 		<description>StarRay (Euro)</description>
@@ -41033,6 +43153,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starrayb" cloneof="starray" supported="no">
 		<!-- SPS (CAPS) release 1721 -->
 		<description>StarRay (Euro, Budget)</description>
@@ -41047,6 +43168,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="starush" supported="no">
 		<!-- SPS (CAPS) release 2311 -->
 		<description>Starush (Euro)</description>
@@ -41068,6 +43190,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="starways" supported="no">
 		<!-- SPS (CAPS) release 2678 -->
 		<description>Starways (Euro)</description>
@@ -41082,6 +43205,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stationf" supported="no">
 		<!-- SPS (CAPS) release 1491 -->
 		<description>Stationfall (USA, r107)</description>
@@ -41096,6 +43220,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steel" supported="no">
 		<!-- SPS (CAPS) release 1981 -->
 		<description>Steel (Euro)</description>
@@ -41110,6 +43235,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steela" cloneof="steel" supported="no">
 		<!-- SPS (CAPS) release 1982 -->
 		<description>Steel (Euro, Budget)</description>
@@ -41124,6 +43250,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="steelemp" supported="no">
 		<!-- SPS (CAPS) release 1659 -->
 		<description>Steel Empire (Euro)</description>
@@ -41145,6 +43272,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="steg" supported="no">
 		<!-- SPS (CAPS) release 2271 -->
 		<description>Steg the Slug (Euro)</description>
@@ -41159,6 +43287,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stellar7" supported="no">
 		<!-- SPS (CAPS) release 2026 -->
 		<description>Stellar 7 (USA, v1.0)</description>
@@ -41186,6 +43315,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stellar7g" cloneof="stellar7" supported="no">
 		<!-- SPS (CAPS) release 732 -->
 		<description>Stellar 7 (Ger)</description>
@@ -41207,6 +43337,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stellcrs" supported="no">
 		<!-- SPS (CAPS) release 2319 -->
 		<description>Stellar Crusade (USA)</description>
@@ -41228,6 +43359,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="davisws" supported="no">
 		<!-- SPS (CAPS) release 1061 -->
 		<description>Steve Davis World Snooker (Euro)</description>
@@ -41242,6 +43374,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stormeur" supported="no">
 		<!-- SPS (CAPS) release 2279 -->
 		<description>Storm Across Europe - The War in Europe: 1939-45 (Euro, v1.0)</description>
@@ -41256,6 +43389,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="stormstr" supported="no">
 		<!-- SPS (CAPS) release 620 -->
 		<description>Storm Master (Euro)</description>
@@ -41270,6 +43404,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="stormstrf" cloneof="stormstr" supported="no">
 		<!-- SPS (CAPS) release 2387 -->
 		<description>Storm Master (Fra, Magic Worlds)</description>
@@ -41284,6 +43419,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stormbal" supported="no">
 		<!-- SPS (CAPS) release 404 -->
 		<description>Stormball (Euro)</description>
@@ -41299,6 +43435,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: OK -->
 	<software name="stormlrd" supported="no">
 		<!-- SPS (CAPS) release 874 -->
 		<description>Stormlord (Euro)</description>
@@ -41313,6 +43450,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stroysf1" supported="no">
 		<description>The Story So Far Vol. 1 (Euro)</description>
 		<!-- retail, standalone -->
@@ -41335,6 +43473,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sf" supported="no">
 		<!-- SPS (CAPS) release 2784 -->
 		<description>Street Fighter (Euro)</description>
@@ -41349,6 +43488,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sfa" cloneof="sf" supported="no">
 		<!-- SPS (CAPS) release 3041 -->
 		<description>Street Fighter (Euro, Budget)</description>
@@ -41371,6 +43511,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sf2" supported="no">
 		<!-- SPS (CAPS) release 882 -->
 		<description>Street Fighter II - The World Warrior (Euro)</description>
@@ -41404,6 +43545,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="sf2a" cloneof="sf2" supported="no">
 		<!-- SPS (CAPS) release 1371 -->
 		<description>Street Fighter II - The World Warrior (Euro, Alt)</description>
@@ -41438,6 +43580,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs on a cyan background [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="strider" supported="no">
 		<!-- SPS (CAPS) release 1224 -->
 		<description>Strider (Euro)</description>
@@ -41453,6 +43596,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, sports sound whistles from time to time -->
+	<!-- ATK test: C:79 Bad -->
 	<software name="strider2" supported="partial">
 		<!-- SPS (CAPS) release 386 -->
 		<description>Strider II (Euro)</description>
@@ -41467,6 +43611,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="stridij" supported="no">
 		<!-- SPS (CAPS) release 3092 -->
 		<description>Strider II + Indiana Jones and the Last Crusade (Euro, Superheroes)</description>
@@ -41481,6 +43626,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="strikace" supported="no">
 		<!-- SPS (CAPS) release 1485 -->
 		<description>Strike Aces (USA)</description>
@@ -41502,6 +43648,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="strikflt" supported="no">
 		<!-- SPS (CAPS) release 583 -->
 		<description>Strikefleet (Euro)</description>
@@ -41516,6 +43663,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="strikefh" supported="no">
 		<!-- SPS (CAPS) release 2312 -->
 		<description>Strike Force Harrier (Euro)</description>
@@ -41530,6 +43678,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="strikefha" cloneof="strikefh" supported="no">
 		<!-- SPS (CAPS) release 2005 -->
 		<description>Strike Force Harrier (Euro, Budget)</description>
@@ -41544,6 +43693,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="strikmng" supported="no">
 		<!-- SPS (CAPS) release 2121 -->
 		<description>Striker Manager (Euro)</description>
@@ -41558,6 +43708,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="striker" supported="no">
 		<!-- SPS (CAPS) release 1075 -->
 		<description>Striker (Euro, Zool Pack)</description>
@@ -41572,6 +43723,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="spoker2" supported="no">
 		<!-- SPS (CAPS) release 1022 -->
 		<description>Strip Poker II (Euro, 19881124)</description>
@@ -41587,6 +43739,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spoker2p" supported="no">
 		<!-- SPS (CAPS) release 584 -->
 		<description>Strip Poker II+ (Euro)</description>
@@ -41602,6 +43755,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="spoker2pdd1" cloneof="spoker2p" supported="no">
 		<!-- SPS (CAPS) release 784 -->
 		<description>Strip Poker II+ Data Disk 1 (Euro)</description>
@@ -41617,6 +43771,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="stryx" supported="no">
 		<!-- SPS (CAPS) release 733 -->
 		<description>Stryx (Euro)</description>
@@ -41638,6 +43793,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="stuntcar" supported="no">
 		<!-- SPS (CAPS) release 222 -->
 		<description>Stunt Car Racer (Euro)</description>
@@ -41652,6 +43808,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stuntrck" cloneof="stuntcar" supported="no">
 		<!-- SPS (CAPS) release 1142 -->
 		<description>Stunt Track Racer (USA)</description>
@@ -41666,6 +43823,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="subbattl" supported="no">
 		<!-- SPS (CAPS) release 1458 -->
 		<description>Sub Battle Simulator (USA)</description>
@@ -41680,6 +43838,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="subbuteo" supported="no">
 		<!-- SPS (CAPS) release 870 -->
 		<description>Subbuteo - The Computer Game (Euro)</description>
@@ -41694,6 +43853,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suburban" supported="no">
 		<!-- SPS (CAPS) release 959 -->
 		<description>Suburban Commando (Euro)</description>
@@ -41708,6 +43868,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suburbana" cloneof="suburban" supported="no">
 		<!-- SPS (CAPS) release 1943 -->
 		<description>Suburban Commando (Euro, The Sci-Fi Collecion)</description>
@@ -41722,6 +43883,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="subversn" supported="no">
 		<!-- SPS (CAPS) release 223 -->
 		<description>Subversion 1.0 (Euro)</description>
@@ -41736,6 +43898,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suicidem" supported="no">
 		<!-- SPS (CAPS) release 1518 -->
 		<description>Suicide Mission (Euro)</description>
@@ -41750,6 +43913,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="summcamp" supported="no">
 		<!-- SPS (CAPS) release 2276 -->
 		<description>Summer Camp (Euro)</description>
@@ -41764,6 +43928,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sumgames" supported="no">
 		<!-- SPS (CAPS) release 2895 -->
 		<description>Summer Games (Euro, Mega Sports)</description>
@@ -41778,6 +43943,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sumgame2" supported="no">
 		<!-- SPS (CAPS) release 2896 -->
 		<description>Summer Games II (Euro, Mega Sports)</description>
@@ -41792,6 +43958,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="sunxword" supported="no">
 		<!-- SPS (CAPS) release 1692 -->
 		<description>The Sun Crosswords Vol. 1 &amp; 2 (Euro)</description>
@@ -41807,6 +43974,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation (yellow screen on a500) [FDC] -->
+	<!-- ATK test: failed -->
 	<software name="supaplex" supported="no">
 		<!-- SPS (CAPS) release 1902 -->
 		<description>Supaplex (Euro)</description>
@@ -41822,6 +43990,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] -->
+	<!-- ATK test: failed -->
 	<software name="supercar" supported="no">
 		<!-- SPS (CAPS) release 1527 -->
 		<description>Super Cars (Euro)</description>
@@ -41843,6 +44012,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="supercara" cloneof="supercar" supported="no">
 		<!-- SPS (CAPS) release 1528 -->
 		<description>Super Cars (Euro, Budget)</description>
@@ -41858,6 +44028,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="supercr2" supported="no">
 		<!-- SPS (CAPS) release 224 -->
 		<description>Super Cars II (Euro)</description>
@@ -41881,6 +44052,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="supergra" supported="no">
 		<!-- SPS (CAPS) release 2145 -->
 		<description>Super Grand Prix + Violator (Euro, Quattro Power Machines)</description>
@@ -41895,6 +44067,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="shangon" supported="no">
 		<!-- SPS (CAPS) release 816 -->
 		<description>Super Hang-On (Euro)</description>
@@ -41909,6 +44082,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suprhuey" supported="no">
 		<!-- SPS (CAPS) release 2949 -->
 		<description>Super Huey UH-1X (Euro)</description>
@@ -41923,6 +44097,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="slmanger" supported="no">
 		<!-- SPS (CAPS) release 1850 -->
 		<description>Super League Manager (Euro)</description>
@@ -41938,6 +44113,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
+	<!-- ATK test: failed -->
 	<software name="smgp" supported="no">
 		<!-- SPS (CAPS) release 1422 -->
 		<description>Super Monaco GP (Euro)</description>
@@ -41952,6 +44128,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="sscrambl" supported="no">
 		<!-- SPS (CAPS) release 87 -->
 		<description>Super Scramble Simulator (Euro)</description>
@@ -41973,6 +44150,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="sseymour" supported="no">
 		<!-- SPS (CAPS) release 2524 -->
 		<description>Super Seymour (Euro, 19920723)</description>
@@ -41988,6 +44166,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="superski" supported="no">
 		<!-- SPS (CAPS) release 2492 -->
 		<description>Super Ski (Euro, Starter Kit)</description>
@@ -42002,6 +44181,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suprski2" supported="no">
 		<!-- SPS (CAPS) release 734 -->
 		<description>Super Ski II (Euro)</description>
@@ -42024,6 +44204,7 @@ license:CC0
 	</software>
 
 	<!-- Serious GFX pitch issues when boots -->
+	<!-- ATK test: OK -->
 	<software name="sskid" supported="no">
 		<!-- SPS (CAPS) release 1797 -->
 		<description>Super Skidmarks (Euro, v2.2)</description>
@@ -42075,6 +44256,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="supskwek" supported="no">
 		<!-- SPS (CAPS) release 1935 -->
 		<description>Super Skweek (Euro)</description>
@@ -42096,6 +44278,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="supskwekf" cloneof="supskwek" supported="no">
 		<!-- SPS (CAPS) release 2403 -->
 		<description>Super Skweek (Fra, Les Stars)</description>
@@ -42117,6 +44300,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ssinv" supported="no">
 		<!-- SPS (CAPS) release 585 -->
 		<description>Super Space Invaders (Euro)</description>
@@ -42138,6 +44322,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ssinva" cloneof="ssinv" supported="no">
 		<!-- SPS (CAPS) release 2480 -->
 		<description>Super Space Invaders (Euro, Alt)</description>
@@ -42159,6 +44344,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ssportch" supported="no">
 		<!-- SPS (CAPS) release 2547 -->
 		<description>Super Sport Challenge (Euro)</description>
@@ -42186,6 +44372,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ssf2" supported="no">
 		<!-- SPS (CAPS) release 147 -->
 		<description>Super Street Fighter II - The New Challengers (Euro)</description>
@@ -42240,6 +44427,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="stetris" supported="no">
 		<!-- SPS (CAPS) release 2646 -->
 		<description>Super Tetris (Euro)</description>
@@ -42254,6 +44442,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wboymlnd" supported="no">
 		<!-- SPS (CAPS) release 586 -->
 		<description>Wonderboy in Monsterland (Euro)</description>
@@ -42269,6 +44458,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="superzoc" supported="no">
 		<!-- SPS (CAPS) release 1537 -->
 		<description>Super Zocker + Blackjack II (Ger)</description>
@@ -42285,6 +44475,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- Has serious GFX pitch issues on gameplay, no sprites with a500p -->
+	<!-- ATK test: failed -->
 	<software name="suprfrog" supported="no">
 		<!-- SPS (CAPS) release 35 -->
 		<description>Superfrog (Euro)</description>
@@ -42312,6 +44503,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="slsoccer" supported="no">
 		<!-- SPS (CAPS) release 2013 -->
 		<description>Superleague Soccer (Euro)</description>
@@ -42326,6 +44518,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="superman" supported="no">
 		<!-- SPS (CAPS) release 3035 -->
 		<description>Superman - The Man of Steel (Euro)</description>
@@ -42347,6 +44540,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ssicehok" supported="no">
 		<!-- SPS (CAPS) release 88 -->
 		<description>Superstar Ice Hockey (Euro)</description>
@@ -42361,6 +44555,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="suprmacy" supported="no">
 		<!-- SPS (CAPS) release 1384 -->
 		<description>Supremacy - Your Will Be Done (Euro)</description>
@@ -42382,6 +44577,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suspect" supported="no">
 		<!-- SPS (CAPS) release 2868 -->
 		<description>Suspect (USA, r14)</description>
@@ -42396,6 +44592,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="suspend" supported="no">
 		<!-- SPS (CAPS) release 1410 -->
 		<description>Suspended (USA, r8)</description>
@@ -42410,6 +44607,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="suspcarg" supported="no">
 		<!-- SPS (CAPS) release 148 -->
 		<description>Suspicious Cargo (Euro, Special Edition)</description>
@@ -42431,6 +44629,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="swap" supported="no">
 		<!-- SPS (CAPS) release 2146 -->
 		<description>Swap (Fra, NRJ Vol. 4)</description>
@@ -42445,6 +44644,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="switchbl" supported="no">
 		<!-- SPS (CAPS) release 1101 -->
 		<description>Switchblade (Euro)</description>
@@ -42459,6 +44659,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="switchb2" supported="no">
 		<!-- SPS (CAPS) release 1725 -->
 		<description>Switchblade II (Euro)</description>
@@ -42474,6 +44675,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs at kernel "please wait" message -->
+	<!-- ATK test: failed -->
 	<software name="swiv" supported="no">
 		<!-- SPS (CAPS) release 38 -->
 		<description>SWIV (Euro, 19910228)</description>
@@ -42488,6 +44690,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="swooper" supported="no">
 		<!-- SPS (CAPS) release 2165 -->
 		<description>Swooper + Space Baller + Diablo + Zitrax + Championship Othello (Euro, Amiga Stars Collection)</description>
@@ -42502,6 +44705,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="swrdrose" supported="no">
 		<!-- SPS (CAPS) release 2434 -->
 		<description>The Sword and the Rose (Euro)</description>
@@ -42517,6 +44721,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, bird sample keeps repeating -->
+	<!-- ATK test: OK -->
 	<software name="swordhon" supported="partial">
 		<!-- SPS (CAPS) release 149 -->
 		<description>Sword of Honour (Euro)</description>
@@ -42541,6 +44746,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- Hangs at title screen with no BGM -->
+	<!-- ATK test: failed -->
 	<software name="swordsod" supported="no">
 		<!-- SPS (CAPS) release 1103 -->
 		<description>Sword of Sodan (Euro)</description>
@@ -42569,6 +44775,7 @@ license:CC0
 	</software>
 
 	<!-- doesn't recognize data disk when asked to disc swap [FDC] -->
+	<!-- ATK test: OK -->
 	<software name="swrdtwil" supported="no">
 		<!-- SPS (CAPS) release 972 -->
 		<description>Swords of Twilight (Euro)</description>
@@ -42590,6 +44797,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="syndicat" supported="no">
 		<!-- SPS (CAPS) release 739 -->
 		<description>Syndicate (Euro)</description>
@@ -42623,6 +44831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="syndicata" cloneof="syndicat" supported="no">
 		<!-- SPS (CAPS) release 1887 -->
 		<description>Syndicate (Euro, Chaos Pack)</description>
@@ -42656,6 +44865,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="syndicatg" cloneof="syndicat" supported="no">
 		<!-- SPS (CAPS) release 405 -->
 		<description>Syndicate (Ger)</description>
@@ -42689,6 +44899,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="soldner" supported="no">
 		<!-- SPS (CAPS) release 2770 -->
 		<description>Söldner (Ger, v1.0)</description>
@@ -42703,6 +44914,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tableten" supported="no">
 		<!-- SPS (CAPS) release 1912 -->
 		<description>Table Tennis Simulation (Euro)</description>
@@ -42717,6 +44929,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tacmangr" supported="no">
 		<!-- SPS (CAPS) release 2128 -->
 		<description>Tactical Manager (Euro, v2.36)</description>
@@ -42738,6 +44951,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tacman94" supported="no">
 		<!-- SPS (CAPS) release 1338 -->
 		<description>Tactical Manager 94-95 Season (Euro)</description>
@@ -42759,6 +44973,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tacmanit" supported="no">
 		<!-- SPS (CAPS) release 1853 -->
 		<description>Tactical Manager - Italia (Euro)</description>
@@ -42780,6 +44995,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tacmanitg" cloneof="tacmanit" supported="no">
 		<!-- SPS (CAPS) release 1608 -->
 		<description>Der Trainer - Italia (Ger, v2.40)</description>
@@ -42801,6 +45017,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tacmang2" supported="no">
 		<!-- SPS (CAPS) release 2631 -->
 		<description>Tactical Manager 2 (Euro, v2.43)</description>
@@ -42822,6 +45039,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tanglewd" supported="no">
 		<!-- SPS (CAPS) release 1623 -->
 		<description>Tanglewood (Euro, v1.0)</description>
@@ -42836,6 +45054,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tangram" supported="no">
 		<!-- SPS (CAPS) release 2840 -->
 		<description>Tangram (Euro)</description>
@@ -42852,6 +45071,7 @@ license:CC0
 
 	<!-- Black screen after AmigaDOS, [FDC] dsksync -->
 	<!-- Hangs at Targhan title screen [FDC] -->
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="targhan" supported="no">
 		<!-- SPS (CAPS) release 1859 -->
 		<description>Targhan (Euro)</description>
@@ -42866,6 +45086,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="targhana" cloneof="targhan" supported="no">
 		<!-- SPS (CAPS) release 2405 -->
 		<description>Targhan (Fra, Simulation Top)</description>
@@ -42880,6 +45101,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tasstime" supported="no">
 		<!-- SPS (CAPS) release 390 -->
 		<description>Tass Times in Tonetown (Euro)</description>
@@ -42894,6 +45116,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="suzuki" supported="no">
 		<!-- SPS (CAPS) release 1767 -->
 		<description>Team Suzuki (Euro)</description>
@@ -42908,6 +45131,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="teamyank" supported="no">
 		<!-- SPS (CAPS) release 150 -->
 		<description>Team Yankee (Euro)</description>
@@ -42922,6 +45146,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tearaway" supported="no">
 		<!-- SPS (CAPS) release 2690 -->
 		<description>Tearaway Thomas (Euro)</description>
@@ -42936,6 +45161,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tmhtco" supported="no">
 		<!-- SPS (CAPS) release 2301 -->
 		<description>Teenage Mutant Hero Turtles (Euro, The Coin-Op!)</description>
@@ -42951,6 +45177,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tmht" supported="no">
 		<!-- SPS (CAPS) release 587 -->
 		<description>Teenage Mutant Hero Turtles (Euro)</description>
@@ -42966,6 +45193,7 @@ license:CC0
 	</software>
 
 	<!-- bad GFX pitch -->
+	<!-- ATK test: OK -->
 	<software name="tmnt" supported="no">
 		<!-- SPS (CAPS) release 2994 -->
 		<description>Teenage Mutant Ninja Turtles (Euro, Ultra Games)</description>
@@ -42994,6 +45222,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="teeoff" supported="no">
 		<!-- SPS (CAPS) release 1710 -->
 		<description>Tee Off! (Euro)</description>
@@ -43008,6 +45237,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="teenquen" supported="no">
 		<!-- SPS (CAPS) release 225 -->
 		<description>Teenage Queen (Euro)</description>
@@ -43022,6 +45252,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tengenah" supported="no">
 		<description>Tengen Arcade Hits (Euro)</description>
 		<!-- retail, standalone -->
@@ -43058,6 +45289,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U Bad -->
 	<software name="tenniscp" supported="no">
 		<!-- SPS (CAPS) release 737 -->
 		<description>Tennis Cup (Euro)</description>
@@ -43072,6 +45304,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="tenniscpf" cloneof="tenniscp" supported="no">
 		<!-- SPS (CAPS) release 1638 -->
 		<description>Tennis Cup (Fra, NRJ)</description>
@@ -43086,6 +45319,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="tennisc2" supported="no">
 		<!-- SPS (CAPS) release 738 -->
 		<description>Tennis Cup II (Euro)</description>
@@ -43107,6 +45341,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="term2" supported="no">
 		<!-- SPS (CAPS) release 1339 -->
 		<description>Terminator 2 - Judgment Day (Euro)</description>
@@ -43128,6 +45363,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="term2a" cloneof="term2" supported="no">
 		<!-- SPS (CAPS) release 2598 -->
 		<description>Terminator 2 - Judgment Day (Euro, Alt)</description>
@@ -43149,6 +45385,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="t2ag" supported="no">
 		<!-- SPS (CAPS) release 151 -->
 		<description>T2 - The Arcade Game (Euro)</description>
@@ -43171,6 +45408,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, sports repeating samples -->
+	<!-- ATK test: OK -->
 	<software name="terramex" supported="partial">
 		<!-- SPS (CAPS) release 391 -->
 		<description>Terramex (Euro)</description>
@@ -43185,6 +45423,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="terranen" supported="no">
 		<!-- SPS (CAPS) release 1531 -->
 		<description>Terran Envoy (USA)</description>
@@ -43199,6 +45438,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="terrorpd" supported="no">
 		<!-- SPS (CAPS) release 152 -->
 		<description>Terrorpods (Euro)</description>
@@ -43213,6 +45453,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="terry" supported="no">
 		<!-- SPS (CAPS) release 1058 -->
 		<description>Terry's Big Adventure (Euro)</description>
@@ -43227,6 +45468,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="tdriv" supported="no">
 		<!-- SPS (CAPS) release 89 -->
 		<description>Test Drive (Euro)</description>
@@ -43241,6 +45483,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="tdriva" cloneof="tdriv" supported="no">
 		<!-- SPS (CAPS) release 2094 -->
 		<description>Test Drive (Euro, Alt)</description>
@@ -43255,6 +45498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="td2" supported="no">
 		<!-- SPS (CAPS) release 588 -->
 		<description>Test Drive II - The Duel (Euro)</description>
@@ -43269,6 +45513,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="td2cc" cloneof="td2" supported="no">
 		<!-- SPS (CAPS) release 589 -->
 		<description>Test Drive II Scenery Disk - California Challenge (Euro)</description>
@@ -43284,6 +45529,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="td2ec" cloneof="td2" supported="no">
 		<!-- SPS (CAPS) release 818 -->
 		<description>Test Drive II Scenery Disk - European Challenge (Euro)</description>
@@ -43299,6 +45545,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="td2mc" cloneof="td2" supported="no">
 		<!-- SPS (CAPS) release 591 -->
 		<description>Test Drive II Car Disk - The Muscle Cars (Euro)</description>
@@ -43314,6 +45561,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="td2sc" cloneof="td2" supported="no">
 		<!-- SPS (CAPS) release 590 -->
 		<description>Test Drive II Car Disk - The Supercars (Euro)</description>
@@ -43329,6 +45577,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tmcrickt" supported="no">
 		<!-- SPS (CAPS) release 1983 -->
 		<description>Test Match Cricket (Euro)</description>
@@ -43350,6 +45599,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tetris" supported="no">
 		<!-- SPS (CAPS) release 736 -->
 		<description>Tetris (Euro, Mirrorsoft)</description>
@@ -43364,6 +45614,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="thaiboxn" supported="no">
 		<!-- SPS (CAPS) release 2851 -->
 		<description>Thai Boxing (Euro)</description>
@@ -43378,6 +45629,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="thaiboxna" cloneof="thaiboxn" supported="no">
 		<!-- SPS (CAPS) release 2850 -->
 		<description>Thai Boxing (Euro, Budget)</description>
@@ -43392,6 +45644,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="theatdth" supported="no">
 		<!-- SPS (CAPS) release 254 -->
 		<description>Theatre of Death (Euro)</description>
@@ -43413,6 +45666,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="finehour" supported="no">
 		<!-- SPS (CAPS) release 37 -->
 		<description>Their Finest Hour - The Battle of Britain (Euro, Final 1.1 19900630)</description>
@@ -43434,6 +45688,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="finehoura" cloneof="finehour" supported="no">
 		<!-- SPS (CAPS) release 2095 -->
 		<description>Their Finest Hour - The Battle of Britain (Euro, v1.0 19900428)</description>
@@ -43455,6 +45710,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="finemiss" cloneof="finehour" supported="no">
 		<!-- SPS (CAPS) release 1369 -->
 		<description>Their Finest Missions Vol. 1 (Euro)</description>
@@ -43470,6 +45726,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="themeprk" supported="no">
 		<!-- SPS (CAPS) release 90 -->
 		<description>Theme Park (Euro)</description>
@@ -43491,6 +45748,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="tparkmys" supported="no">
 		<!-- SPS (CAPS) release 592 -->
 		<description>Theme Park Mystery - Variations on a Theme (Euro)</description>
@@ -43505,6 +45763,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tparkmysu" cloneof="tparkmys" supported="no">
 		<!-- SPS (CAPS) release 1175 -->
 		<description>Theme Park Mystery - Variations on a Theme (USA)</description>
@@ -43520,6 +45779,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: failed -->
 	<software name="thexder" supported="partial">
 		<!-- SPS (CAPS) release 392 -->
 		<description>Thexder (Euro)</description>
@@ -43534,6 +45794,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="thinktwc" supported="no">
 		<!-- SPS (CAPS) release 1695 -->
 		<description>Think Twice (Euro)</description>
@@ -43548,6 +45809,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="3courier" supported="no">
 		<!-- SPS (CAPS) release 593 -->
 		<description>The Third Courier (Euro)</description>
@@ -43569,6 +45831,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="thomas" supported="no">
 		<!-- SPS (CAPS) release 2203 -->
 		<description>Thomas the Tank Engine (Euro)</description>
@@ -43583,6 +45846,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="thomas2" supported="no">
 		<!-- SPS (CAPS) release 2204 -->
 		<description>Thomas the Tank Engine 2 (Euro)</description>
@@ -43597,6 +45861,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="3stooges" supported="no">
 		<!-- SPS (CAPS) release 741 -->
 		<description>The Three Stooges (Euro)</description>
@@ -43618,6 +45883,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="3stoogesu" cloneof="3stooges" supported="no">
 		<!-- SPS (CAPS) release 740 -->
 		<description>The Three Stooges (USA)</description>
@@ -43639,6 +45905,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tblade" supported="no">
 		<!-- SPS (CAPS) release 393 -->
 		<description>Thunder Blade (Euro)</description>
@@ -43653,6 +45920,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tbladea" cloneof="tblade" supported="no">
 		<!-- SPS (CAPS) release 2630 -->
 		<description>Thunder Blade (Euro, Budget)</description>
@@ -43667,6 +45935,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tbladeu" cloneof="tblade" supported="no">
 		<!-- SPS (CAPS) release 948 -->
 		<description>Thunder Blade (USA)</description>
@@ -43681,6 +45950,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="tburner" supported="no">
 		<!-- SPS (CAPS) release 2412 -->
 		<description>Thunder Burner (Euro)</description>
@@ -43695,6 +45965,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="thdrjaws" supported="no">
 		<!-- SPS (CAPS) release 293 -->
 		<description>Thunder Jaws (Euro)</description>
@@ -43716,6 +45987,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tstrike" supported="no">
 		<!-- SPS (CAPS) release 406 -->
 		<description>Thunder Strike (Euro)</description>
@@ -43730,6 +46002,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="thdrcats" supported="no">
 		<!-- SPS (CAPS) release 2921 -->
 		<description>ThunderCats (Euro)</description>
@@ -43744,6 +46017,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="thdrcatsa" cloneof="thdrcats" supported="no">
 		<!-- SPS (CAPS) release 1783 -->
 		<description>ThunderCats (Euro, Tenstar Pack)</description>
@@ -43758,6 +46032,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="thdrhawk" supported="no">
 		<!-- SPS (CAPS) release 39 -->
 		<description>Thunderhawk AH-73M (Euro)</description>
@@ -43779,6 +46054,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="thdrhawku" cloneof="thdrhawk" supported="no">
 		<!-- SPS (CAPS) release 2019 -->
 		<description>Thunderhawk AH-73M (USA)</description>
@@ -43800,6 +46076,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tigerrod" supported="no">
 		<!-- SPS (CAPS) release 1141 -->
 		<description>Tiger Road (Euro)</description>
@@ -43814,6 +46091,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="time" supported="no">
 		<!-- SPS (CAPS) release 2644 -->
 		<description>Time (Fra)</description>
@@ -43835,6 +46113,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="timeg" cloneof="time" supported="no">
 		<!-- SPS (CAPS) release 1697 -->
 		<description>Time (Ger)</description>
@@ -43856,6 +46135,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="timemag" supported="no">
 		<!-- SPS (CAPS) release 7 -->
 		<description>Time and Magik (Euro)</description>
@@ -43870,6 +46150,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="timemac" supported="no">
 		<!-- SPS (CAPS) release 974 -->
 		<description>Time Machine (Euro)</description>
@@ -43884,6 +46165,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="timerace" supported="no">
 		<!-- SPS (CAPS) release 2420 -->
 		<description>Time Race (Fra, Q.I. 1992)</description>
@@ -43906,6 +46188,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up at language select screen -->
+	<!-- ATK test: OK -->
 	<software name="trun1" supported="no">
 		<!-- SPS (CAPS) release 2593 -->
 		<description>Time Runners 1 - Gateways in Time (Euro)</description>
@@ -43921,6 +46204,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up at language select screen -->
+	<!-- ATK test: OK -->
 	<software name="trun2" supported="no">
 		<!-- SPS (CAPS) release 2713 -->
 		<description>Time Runners 2 - The Space Stone (Euro)</description>
@@ -43935,6 +46219,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun3" supported="no">
 		<!-- SPS (CAPS) release 2714 -->
 		<description>Time Runners 3 - The Big Run (Euro)</description>
@@ -43949,6 +46234,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun4" supported="no">
 		<!-- SPS (CAPS) release 2753 -->
 		<description>Time Runners 4 - The Castle of Fear (Euro)</description>
@@ -43963,6 +46249,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun5" supported="no">
 		<!-- SPS (CAPS) release 2715 -->
 		<description>Time Runners 5 - The Black Knight (Euro)</description>
@@ -43977,6 +46264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun6" supported="no">
 		<!-- SPS (CAPS) release 2716 -->
 		<description>Time Runners 6 - The Bewitched Forest (Euro)</description>
@@ -43991,6 +46279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun7" supported="no">
 		<!-- SPS (CAPS) release 2717 -->
 		<description>Time Runners 7 - In the Land of the Invaders (Euro)</description>
@@ -44005,6 +46294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun8" supported="no">
 		<!-- SPS (CAPS) release 2718 -->
 		<description>Time Runners 8 - The Impregnable Fortress (Euro)</description>
@@ -44019,6 +46309,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun9" supported="no">
 		<!-- SPS (CAPS) release 2719 -->
 		<description>Time Runners 9 - The Time Demon (Euro)</description>
@@ -44033,6 +46324,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun11" supported="no">
 		<!-- SPS (CAPS) release 2720 -->
 		<description>Time Runners 11 - The Steel City (Euro)</description>
@@ -44047,6 +46339,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun12" supported="no">
 		<!-- SPS (CAPS) release 2721 -->
 		<description>Time Runners 12 - A Target for the Cyborg (Euro)</description>
@@ -44061,6 +46354,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun13" supported="no">
 		<!-- SPS (CAPS) release 2722 -->
 		<description>Time Runners 13 - Cyberkiller (Euro)</description>
@@ -44075,6 +46369,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun14" supported="no">
 		<!-- SPS (CAPS) release 2723 -->
 		<description>Time Runners 14 - Toraxid: War Star (Euro)</description>
@@ -44089,6 +46384,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun15" supported="no">
 		<!-- SPS (CAPS) release 2724 -->
 		<description>Time Runners 15 - At the Speed of Light (Euro)</description>
@@ -44103,6 +46399,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun16" supported="no">
 		<!-- SPS (CAPS) release 2725 -->
 		<description>Time Runners 16 - The Galaxy Emperor (Euro)</description>
@@ -44117,6 +46414,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun17" supported="no">
 		<!-- SPS (CAPS) release 2726 -->
 		<description>Time Runners 17 - The Living Labyrinth (Euro)</description>
@@ -44131,6 +46429,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun18" supported="no">
 		<!-- SPS (CAPS) release 2727 -->
 		<description>Time Runners 18 - The Killer Shadow (Euro)</description>
@@ -44145,6 +46444,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun19" supported="no">
 		<!-- SPS (CAPS) release 2728 -->
 		<description>Time Runners 19 - The Nightmare Prince (Euro)</description>
@@ -44159,6 +46459,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun20" supported="no">
 		<!-- SPS (CAPS) release 2729 -->
 		<description>Time Runners 20 - The Mountains of Death (Euro)</description>
@@ -44173,6 +46474,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun21" supported="no">
 		<!-- SPS (CAPS) release 2754 -->
 		<description>Time Runners 21 - The Black Dragon's Course (Euro)</description>
@@ -44187,6 +46489,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun22" supported="no">
 		<!-- SPS (CAPS) release 2730 -->
 		<description>Time Runners 22 - The Eternal Damned (Euro)</description>
@@ -44201,6 +46504,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun23" supported="no">
 		<!-- SPS (CAPS) release 2731 -->
 		<description>Time Runners 23 - The Time Monarch (Euro)</description>
@@ -44215,6 +46519,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun24" supported="no">
 		<!-- SPS (CAPS) release 2732 -->
 		<description>Time Runners 24 - Beyond All Dimensions (Euro)</description>
@@ -44229,6 +46534,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun25" supported="no">
 		<!-- SPS (CAPS) release 2733 -->
 		<description>Time Runners 25 - The Lost Planet Earth (Euro)</description>
@@ -44243,6 +46549,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun26" supported="no">
 		<!-- SPS (CAPS) release 2734 -->
 		<description>Time Runners 26 - The Time Warrior (Euro)</description>
@@ -44257,6 +46564,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun27" supported="no">
 		<!-- SPS (CAPS) release 2735 -->
 		<description>Time Runners 27 - Red Night (Euro)</description>
@@ -44271,6 +46579,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun28" supported="no">
 		<!-- SPS (CAPS) release 2736 -->
 		<description>Time Runners 28 - Beyond the End (Euro)</description>
@@ -44285,6 +46594,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trun29" supported="no">
 		<!-- SPS (CAPS) release 2737 -->
 		<description>Time Runners 29 - The Last Revelation (Euro)</description>
@@ -44300,6 +46610,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up at language select screen -->
+	<!-- ATK test: OK -->
 	<software name="trun30" supported="no">
 		<!-- SPS (CAPS) release 2738 -->
 		<description>Time Runners 30 - The Final Duel (Euro)</description>
@@ -44314,6 +46625,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="timexwrd" supported="no">
 		<!-- SPS (CAPS) release 1132 -->
 		<description>The Times Crosswords Vol. 3 &amp; 4 (Euro)</description>
@@ -44328,6 +46640,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="timelore" supported="no">
 		<!-- SPS (CAPS) release 2777 -->
 		<description>Times of Lore (Euro)</description>
@@ -44342,6 +46655,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tintin" supported="no">
 		<!-- SPS (CAPS) release 1778 -->
 		<description>Tintin on the Moon (Euro)</description>
@@ -44356,6 +46670,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="tinskwek" supported="no">
 		<!-- SPS (CAPS) release 2402 -->
 		<description>Tiny Skweeks (Euro)</description>
@@ -44377,6 +46692,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tipoff" supported="no">
 		<!-- SPS (CAPS) release 1551 -->
 		<description>Tip Off (Euro)</description>
@@ -44398,6 +46714,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tipoffa" cloneof="tipoff" supported="no">
 		<!-- SPS (CAPS) release 1269 -->
 		<description>Tip Off (Euro, French / German / Italian / Spanish)</description>
@@ -44419,6 +46736,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tiptrick" supported="no">
 		<!-- SPS (CAPS) release 2295 -->
 		<description>Tip Trick (Euro)</description>
@@ -44433,6 +46751,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="titanicb" supported="no">
 		<!-- SPS (CAPS) release 394 -->
 		<description>Titanic Blinky (Euro)</description>
@@ -44447,6 +46766,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="titan" supported="no">
 		<!-- SPS (CAPS) release 1913 -->
 		<description>Titan (Euro)</description>
@@ -44461,6 +46781,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="titano" supported="no">
 		<!-- SPS (CAPS) release 1514 -->
 		<description>Titano (Ger)</description>
@@ -44475,6 +46796,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:L 1 Sector Bad -->
 	<software name="titus" supported="no">
 		<!-- SPS (CAPS) release 226 -->
 		<description>Titus the Fox to Marrakech and Back (Euro)</description>
@@ -44489,6 +46811,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tnt" supported="no">
 		<description>TNT (Euro)</description>
 		<!-- retail, standalone -->
@@ -44518,6 +46841,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="toki" supported="no">
 		<!-- SPS (CAPS) release 40 -->
 		<description>Toki (Euro)</description>
@@ -44532,6 +46856,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tomjerh" supported="no">
 		<!-- SPS (CAPS) release 1305 -->
 		<description>Tom &amp; Jerry (Euro, Hunting High and Low)</description>
@@ -44547,6 +46872,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="tomjer2" supported="no">
 		<!-- SPS (CAPS) release 2229 -->
 		<description>Tom &amp; Jerry 2 (Euro)</description>
@@ -44562,6 +46888,7 @@ license:CC0
 	</software>
 
 <!-- According to HOL, Tom &amp; Jerry was the US title of European Tom &amp; Jerry 2 (due to Hunting High and Low not being released there?) -->
+	<!-- ATK test: OK -->
 	<software name="tomjerry" cloneof="tomjer2" supported="no">
 		<!-- SPS (CAPS) release 1306 -->
 		<description>Tom &amp; Jerry (Euro?)</description>
@@ -44576,6 +46903,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tomghost" supported="no">
 		<!-- SPS (CAPS) release 2298 -->
 		<description>Tom and the Ghost (Euro)</description>
@@ -44590,6 +46918,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="landrydx" supported="no">
 		<!-- SPS (CAPS) release 1845 -->
 		<description>Tom Landry Strategy Football - Deluxe Edition (Euro, v1.0)</description>
@@ -44617,6 +46946,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="toobin" supported="no">
 		<!-- SPS (CAPS) release 1219 -->
 		<description>Toobin' (Euro)</description>
@@ -44631,6 +46961,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="topbanan" supported="no">
 		<!-- SPS (CAPS) release 850 -->
 		<description>Top Banana (Euro)</description>
@@ -44652,6 +46983,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="topgear2" supported="no">
 		<!-- SPS (CAPS) release 1737 -->
 		<description>Top Gear 2 (Euro)</description>
@@ -44673,6 +47005,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="torc2081" supported="no">
 		<!-- SPS (CAPS) release 2484 -->
 		<description>Torch 2081 (Euro)</description>
@@ -44687,6 +47020,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tornado" supported="no">
 		<!-- SPS (CAPS) release 807 -->
 		<description>Tornado (Euro)</description>
@@ -44720,6 +47054,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="torvak" supported="no">
 		<!-- SPS (CAPS) release 1796 -->
 		<description>Torvak the Warrior (Euro)</description>
@@ -44741,6 +47076,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="totalcar" supported="no">
 		<!-- SPS (CAPS) release 2172 -->
 		<description>Total Carnage (Euro)</description>
@@ -44762,6 +47098,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="toteclip" supported="no">
 		<!-- SPS (CAPS) release 1973 -->
 		<description>Total Eclipse (USA, v1.0)</description>
@@ -44776,6 +47113,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="totlfoot" supported="no">
 		<!-- SPS (CAPS) release 154 -->
 		<description>Total Football (Euro)</description>
@@ -44803,6 +47141,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="totrecal" supported="no">
 		<!-- SPS (CAPS) release 1769 -->
 		<description>Total Recall (Euro, 2-Hot 2 Handle)</description>
@@ -44824,6 +47163,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="totrecala" cloneof="totrecal" supported="no">
 		<!-- SPS (CAPS) release 1770 -->
 		<description>Total Recall (Euro, Budget)</description>
@@ -44840,6 +47180,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- TODO: verify after copy protection manual -->
+	<!-- ATK test: failed -->
 	<software name="tourgolf" supported="no">
 		<!-- SPS (CAPS) release 1278 -->
 		<description>Tournament Golf (Euro)</description>
@@ -44863,6 +47204,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="towbabel" supported="no">
 		<!-- SPS (CAPS) release 1056 -->
 		<description>Tower of Babel (Euro)</description>
@@ -44877,6 +47219,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="towertop" supported="no">
 		<!-- SPS (CAPS) release 1392 -->
 		<description>Tower Toppler (USA)</description>
@@ -44891,6 +47234,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="celica" supported="no">
 		<!-- SPS (CAPS) release 1766 -->
 		<description>Toyota Celica GT Rally (Euro)</description>
@@ -44905,6 +47249,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="toyottes" supported="no">
 		<!-- SPS (CAPS) release 2623 -->
 		<description>The Toyottes (Euro)</description>
@@ -44919,6 +47264,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tracker" supported="no">
 		<!-- SPS (CAPS) release 743 -->
 		<description>Tracker (Euro)</description>
@@ -44933,6 +47279,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="traders" supported="no">
 		<!-- SPS (CAPS) release 1584 -->
 		<description>Traders (Ger)</description>
@@ -44947,6 +47294,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="trainass" supported="no">
 		<!-- SPS (CAPS) release 2792 -->
 		<description>Trained Assassin (Euro)</description>
@@ -44963,6 +47311,7 @@ license:CC0
 
 	<!-- black screen after AmigaDOS [FDC] dsksync -->
 	<!-- Mouse cursor is uncontrollable -->
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="transarc" supported="no">
 		<!-- SPS (CAPS) release 744 -->
 		<description>Transarctica (Euro)</description>
@@ -44984,6 +47333,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="transarcf" cloneof="transarc" supported="no">
 		<!-- SPS (CAPS) release 2494 -->
 		<description>Transarctica (Fra)</description>
@@ -45005,6 +47355,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="transwrl" supported="no">
 		<!-- SPS (CAPS) release 2837 -->
 		<description>Transworld (Ger, v2.03)</description>
@@ -45019,6 +47370,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="dizzy2" supported="no">
 		<!-- SPS (CAPS) release 594 -->
 		<description>Treasure Island Dizzy (Euro)</description>
@@ -45033,6 +47385,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="savfront" supported="no">
 		<!-- SPS (CAPS) release 992 -->
 		<description>Treasures of the Savage Frontier (USA, v1.00)</description>
@@ -45060,6 +47413,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="treastrp" supported="no">
 		<!-- SPS (CAPS) release 1731 -->
 		<description>Treasure Trap (Euro, v1.08)</description>
@@ -45074,6 +47428,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="triango" supported="no">
 		<!-- SPS (CAPS) release 1909 -->
 		<description>TrianGO (Euro, v1.1)</description>
@@ -45088,6 +47443,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trinity" supported="no">
 		<!-- SPS (CAPS) release 2541 -->
 		<description>Trinity (Euro, r11)</description>
@@ -45102,6 +47458,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="triplex" supported="no">
 		<!-- SPS (CAPS) release 2048 -->
 		<description>Triple X (Euro, Amiga Star Collection)</description>
@@ -45116,6 +47473,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trivtrov" supported="no">
 		<!-- SPS (CAPS) release 2296 -->
 		<description>Trivia Trove (Ger)</description>
@@ -45130,6 +47488,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trivial" supported="no">
 		<!-- SPS (CAPS) release 2147 -->
 		<description>Trivial Pursuit - Amiga Genus Edition (Fra, 10 Megahits Vol. 3)</description>
@@ -45144,6 +47503,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trivialg" cloneof="trivial" supported="no">
 		<!-- SPS (CAPS) release 595 -->
 		<description>Trivial Pursuit - Amiga Genus Edition (Ger)</description>
@@ -45158,6 +47518,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trivianb" supported="no">
 		<!-- SPS (CAPS) release 1785 -->
 		<description>Trivial Pursuit - A New Beginning (Euro, Arcade Action)</description>
@@ -45172,6 +47533,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="trivianbg" cloneof="trivianb" supported="no">
 		<!-- SPS (CAPS) release 91 -->
 		<description>Trivial Pursuit - A New Beginning (Ger)</description>
@@ -45186,6 +47548,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="troddler" supported="no">
 		<!-- SPS (CAPS) release 696 -->
 		<description>Troddlers (Euro)</description>
@@ -45200,6 +47563,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="turbocup" supported="no">
 		<!-- SPS (CAPS) release 2409 -->
 		<description>Turbo Cup (Fra, v2.0, Sports Best)</description>
@@ -45214,6 +47578,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="toutrun" supported="no">
 		<!-- SPS (CAPS) release 1064 -->
 		<description>Turbo Out Run (Euro)</description>
@@ -45235,6 +47600,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="turnburn" supported="no">
 		<!-- SPS (CAPS) release 2523 -->
 		<description>Turn 'n' Burn (Euro)</description>
@@ -45250,6 +47616,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after "Welcome to Turrican" speech -->
+	<!-- ATK test: failed -->
 	<software name="turrican" supported="no">
 		<!-- SPS (CAPS) release 92 -->
 		<description>Turrican (Euro)</description>
@@ -45264,6 +47631,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="turricanu" cloneof="turrican" supported="no">
 		<!-- SPS (CAPS) release 1838 -->
 		<description>Turrican (USA)</description>
@@ -45279,6 +47647,7 @@ license:CC0
 	</software>
 
 	<!-- black screen, keeps trying to access floppy -->
+	<!-- ATK test: failed -->
 	<software name="turricn2" supported="no">
 		<!-- SPS (CAPS) release 29 -->
 		<description>Turrican II (Euro)</description>
@@ -45294,6 +47663,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="turricn2a" cloneof="turricn2" supported="no">
 		<!-- SPS (CAPS) release 2634 -->
 		<description>Turrican II (Euro, Alt)</description>
@@ -45310,6 +47680,7 @@ license:CC0
 	</software>
 
 	<!-- intro has glitches, crashes with wrong GFX pitch on gameplay -->
+	<!-- ATK test: failed -->
 	<software name="turricn3" supported="no">
 		<!-- SPS (CAPS) release 2633 -->
 		<description>Turrican 3 (Euro)</description>
@@ -45324,6 +47695,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="turricn3g" cloneof="turricn3" supported="no">
 		<!-- SPS (CAPS) release 596 -->
 		<description>Turrican 3 (Ger)</description>
@@ -45338,6 +47710,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tusker" supported="no">
 		<!-- SPS (CAPS) release 745 -->
 		<description>Tusker (Euro)</description>
@@ -45359,6 +47732,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tvbasebl" supported="no">
 		<!-- SPS (CAPS) release 754 -->
 		<description>TV Sports Baseball (Euro)</description>
@@ -45380,6 +47754,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tvbasket" supported="no">
 		<!-- SPS (CAPS) release 2122 -->
 		<description>TV Sports Basketball (Euro)</description>
@@ -45401,6 +47776,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="tvboxing" supported="no">
 		<!-- SPS (CAPS) release 755 -->
 		<description>TV Sports Boxing (Euro)</description>
@@ -45422,6 +47798,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tvfootbl" supported="no">
 		<!-- SPS (CAPS) release 407 -->
 		<description>TV Sports Football (Euro)</description>
@@ -45443,6 +47820,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="tvfootbla" cloneof="tvfootbl" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 407 -->
@@ -45465,6 +47843,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="twilight" supported="no">
 		<!-- SPS (CAPS) release 1486 -->
 		<description>The Twilight Zone (USA)</description>
@@ -45486,6 +47865,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="twinwrld" supported="no">
 		<!-- SPS (CAPS) release 1294 -->
 		<description>Twinworld - Land of Vision (Euro)</description>
@@ -45500,6 +47880,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="twylyte" supported="no">
 		<!-- SPS (CAPS) release 746 -->
 		<description>Twylyte (Euro)</description>
@@ -45514,6 +47895,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="typhoon" supported="no">
 		<!-- SPS (CAPS) release 1361 -->
 		<description>Typhoon (Euro, v1.01)</description>
@@ -45528,6 +47910,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="typhoona" cloneof="typhoon" supported="no">
 		<!-- SPS (CAPS) release 1472 -->
 		<description>Typhoon (Euro, v1.01, Alt)</description>
@@ -45542,6 +47925,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="typhthom" supported="no">
 		<!-- SPS (CAPS) release 1389 -->
 		<description>Typhoon Thompson in Search for the Sea Child (USA)</description>
@@ -45556,6 +47940,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="unsquad" supported="no">
 		<!-- SPS (CAPS) release 1606 -->
 		<description>U.N. Squadron (Euro)</description>
@@ -45570,6 +47955,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ufo" supported="no">
 		<!-- SPS (CAPS) release 1677 -->
 		<description>UFO - Enemy Unknown (Euro)</description>
@@ -45609,6 +47995,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ugh" supported="no">
 		<!-- SPS (CAPS) release 396 -->
 		<description>Ugh! (Euro)</description>
@@ -45623,6 +48010,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ultima3" supported="no">
 		<!-- SPS (CAPS) release 2800 -->
 		<description>Ultima III - Exodus (USA)</description>
@@ -45637,6 +48025,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="ultima4" supported="no">
 		<!-- SPS (CAPS) release 1390 -->
 		<description>Ultima IV - Quest of the Avatar (USA)</description>
@@ -45651,6 +48040,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ultima5" supported="no">
 		<!-- SPS (CAPS) release 785 -->
 		<description>Ultima V - Warriors of Destiny (Euro)</description>
@@ -45672,6 +48062,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ultima6" supported="no">
 		<!-- SPS (CAPS) release 294 -->
 		<description>Ultima VI - The False Prophet (Euro)</description>
@@ -45699,6 +48090,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ultgolf" supported="no">
 		<!-- SPS (CAPS) release 2129 -->
 		<description>Ultimate! Golf (Euro)</description>
@@ -45713,6 +48105,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ultride" supported="no">
 		<!-- SPS (CAPS) release 2306 -->
 		<description>The Ultimate Ride (Euro)</description>
@@ -45734,6 +48127,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="usmanger" supported="no">
 		<!-- SPS (CAPS) release 2613 -->
 		<description>Ultimate Soccer Manager (Fra)</description>
@@ -45755,6 +48149,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="usmangerup" cloneof="usmanger" supported="no">
 		<!-- SPS (CAPS) release 1899 -->
 		<description>Ultimate Soccer Manager Update (Euro)</description>
@@ -45777,6 +48172,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ums" supported="no">
 		<!-- SPS (CAPS) release 753 -->
 		<description>UMS - The Universal Military Simulator (Euro, v1.5)</description>
@@ -45798,6 +48194,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="umssd1" cloneof="ums" supported="no">
 		<!-- SPS (CAPS) release 1794 -->
 		<description>UMS Scenario Disk One - The American Civil War (Euro)</description>
@@ -45813,6 +48210,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="umssd2" cloneof="ums" supported="no">
 		<!-- SPS (CAPS) release 1694 -->
 		<description>UMS Scenario Disk Two - Vietnam (Euro)</description>
@@ -45828,6 +48226,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ums2" supported="no">
 		<!-- SPS (CAPS) release 2137 -->
 		<description>UMS II - Nations at War (Euro, v1.2 19910203)</description>
@@ -45861,6 +48260,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="univwar" supported="no">
 		<!-- SPS (CAPS) release 597 -->
 		<description>Universal Warrior (Euro)</description>
@@ -45875,6 +48275,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="universe" supported="no">
 		<!-- SPS (CAPS) release 894 -->
 		<description>Universe (Euro)</description>
@@ -45914,6 +48315,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="univers3" supported="no">
 		<!-- SPS (CAPS) release 1476 -->
 		<description>Universe 3 (USA)</description>
@@ -45935,6 +48337,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="unreal" supported="no">
 		<!-- SPS (CAPS) release 33 -->
 		<description>Unreal (Euro)</description>
@@ -45963,6 +48366,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: failed -->
 	<software name="untouch" supported="no">
 		<!-- SPS (CAPS) release 2392 -->
 		<description>The Untouchables (Euro)</description>
@@ -45984,6 +48388,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="uridium2" supported="no">
 		<!-- SPS (CAPS) release 276 -->
 		<description>Uridium 2 (Euro, Program v1.04, Data v1.03)</description>
@@ -46005,6 +48410,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="uridium2a" cloneof="uridium2" supported="no">
 		<!-- SPS (CAPS) release 2746 -->
 		<description>Uridium 2 (Euro, Program v1.01, Data v1.01)</description>
@@ -46026,6 +48432,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="uridium2b" cloneof="uridium2" supported="no">
 		<!-- SPS (CAPS) release 1526 -->
 		<description>Uridium 2 (Euro)</description>
@@ -46047,6 +48454,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="utopia" supported="no">
 		<!-- SPS (CAPS) release 757 -->
 		<description>Utopia - The Creation of a Nation (Euro, v3.0)</description>
@@ -46068,6 +48476,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="utopiaa" cloneof="utopia" supported="no">
 		<!-- SPS (CAPS) release 758 -->
 		<description>Utopia - The Creation of a Nation (Euro)</description>
@@ -46089,6 +48498,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="utopianw" cloneof="utopia" supported="no">
 		<!-- SPS (CAPS) release 2576 -->
 		<description>Utopia - The New Worlds (Euro)</description>
@@ -46104,6 +48514,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="valhalla" supported="no">
 		<!-- SPS (CAPS) release 756 -->
 		<description>Valhalla - Before the War (Euro)</description>
@@ -46149,6 +48560,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vampempr" supported="no">
 		<!-- SPS (CAPS) release 397 -->
 		<description>Vampire's Empire (Euro)</description>
@@ -46163,6 +48575,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vampclev" supported="no">
 		<!-- SPS (CAPS) release 2049 -->
 		<description>Vampire's Empire + Clever and Smart (Euro, Amiga Star Collection)</description>
@@ -46177,6 +48590,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vaxine" supported="no">
 		<!-- SPS (CAPS) release 747 -->
 		<description>Vaxine (Euro)</description>
@@ -46191,6 +48605,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="vectball" supported="no">
 		<!-- SPS (CAPS) release 2520 -->
 		<description>Vectorball (Euro)</description>
@@ -46206,6 +48621,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after AmigaDOS loading [FDC] -->
+	<!-- ATK test: OK -->
 	<software name="vengexcl" supported="no">
 		<!-- SPS (CAPS) release 2499 -->
 		<description>Vengeance of Excalibur (Euro)</description>
@@ -46239,6 +48655,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vermeer" supported="no">
 		<!-- SPS (CAPS) release 693 -->
 		<description>Vermeer (Ger)</description>
@@ -46253,6 +48670,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vl" supported="no">
 		<!-- SPS (CAPS) release 2214 -->
 		<description>VL - Das Spiel (Ger)</description>
@@ -46268,6 +48686,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="videokid" supported="no">
 		<!-- SPS (CAPS) release 2555 -->
 		<description>VideoKid (Euro)</description>
@@ -46289,6 +48708,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vigilant" supported="no">
 		<!-- SPS (CAPS) release 1188 -->
 		<description>Vigilante (Euro)</description>
@@ -46303,6 +48723,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="vindictr" supported="no">
 		<!-- SPS (CAPS) release 158 -->
 		<description>Vindicators (Euro)</description>
@@ -46317,6 +48738,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="virocop" supported="no">
 		<!-- SPS (CAPS) release 1836 -->
 		<description>Virocop (Euro)</description>
@@ -46344,6 +48766,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="virus" supported="no">
 		<!-- SPS (CAPS) release 4 -->
 		<description>Virus (Euro)</description>
@@ -46358,6 +48781,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vision5d" supported="no">
 		<!-- SPS (CAPS) release 2651 -->
 		<description>Vision - The 5 Dimension Utopia (Ger)</description>
@@ -46412,6 +48836,7 @@ license:CC0
 	<!-- Locks up at AmigaDOS [FDC] dsksync -->
 	<!-- Screen is too dim (tested on a500p) -->
 	<!-- Doesn't accept joy/key inputs on ranking screen (PC=18dcc) -->
+	<!-- ATK test: C:even H:L 1 Sector Bad -->
 	<software name="vixen" supported="no">
 		<!-- SPS (CAPS) release 993 -->
 		<description>Vixen (Euro)</description>
@@ -46426,6 +48851,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:even H:L 1 Sector Bad -->
 	<software name="shefox" cloneof="vixen" supported="no">
 		<!-- SPS (CAPS) release 383 -->
 		<description>She-Fox (Ger)</description>
@@ -46442,6 +48868,7 @@ license:CC0
 
 	<!-- hangs at Kickstart white screen, [FDC] dsksync -->
 	<!-- Runs too fast -->
+	<!-- ATK test: failed -->
 	<software name="viz" supported="no">
 		<!-- SPS (CAPS) release 3030 -->
 		<description>Viz - The Soft Floppy One (Euro)</description>
@@ -46464,6 +48891,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="volfied" supported="no">
 		<!-- SPS (CAPS) release 1418 -->
 		<description>Volfied (Euro)</description>
@@ -46478,6 +48906,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="vballsim" supported="no">
 		<!-- SPS (CAPS) release 1285 -->
 		<description>Volleyball Simulator (Euro, Platinum)</description>
@@ -46492,6 +48921,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="voodoo" supported="no">
 		<!-- SPS (CAPS) release 2556 -->
 		<description>Voodoo Nightmare (Euro)</description>
@@ -46506,6 +48936,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="voodooa" cloneof="voodoo" supported="no">
 		<!-- SPS (CAPS) release 2607 -->
 		<description>Voodoo Nightmare (Euro, Budget)</description>
@@ -46520,6 +48951,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vortex" supported="no">
 		<!-- SPS (CAPS) release 1412 -->
 		<description>Vortex (USA)</description>
@@ -46534,6 +48966,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="voyager" supported="no">
 		<!-- SPS (CAPS) release 228 -->
 		<description>Voyager (Euro)</description>
@@ -46548,6 +48981,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="voyagera" cloneof="voyager" supported="no">
 		<!-- SPS (CAPS) release 1155 -->
 		<description>Voyager (Euro, Budget)</description>
@@ -46562,6 +48996,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vroom" supported="no">
 		<!-- SPS (CAPS) release 1295 -->
 		<description>Vroom (Euro)</description>
@@ -46576,6 +49011,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vroomdd" cloneof="vroom" supported="no">
 		<!-- SPS (CAPS) release 1296 -->
 		<description>Vroom Data Disk (Euro)</description>
@@ -46591,6 +49027,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="vroommp" cloneof="vroom" supported="no">
 		<!-- SPS (CAPS) release 2158 -->
 		<description>Vroom Multi-Player (Euro)</description>
@@ -46609,6 +49046,7 @@ license:CC0
 
 	<!-- black screen [FDC] dsksync -->
 	<!-- Hangs at Vyrus title screen, [FDC] -->
+	<!-- ATK test: OK -->
 	<software name="vyrus" supported="no">
 		<!-- SPS (CAPS) release 1069 -->
 		<description>Vyrus (Euro)</description>
@@ -46623,6 +49061,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wackyrac" supported="no">
 		<!-- SPS (CAPS) release 1941 -->
 		<description>Wacky Races (Euro)</description>
@@ -46637,6 +49076,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="walker" supported="no">
 		<!-- SPS (CAPS) release 159 -->
 		<description>Walker (Euro)</description>
@@ -46664,6 +49104,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wander3d" supported="no">
 		<!-- SPS (CAPS) release 2497 -->
 		<description>Wanderer 3D (Euro)</description>
@@ -46678,6 +49119,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wanted" supported="no">
 		<!-- SPS (CAPS) release 2619 -->
 		<description>Wanted (Euro, Commandos)</description>
@@ -46692,6 +49134,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="warmidle" supported="no">
 		<!-- SPS (CAPS) release 968 -->
 		<description>War in Middle Earth (Euro)</description>
@@ -46713,6 +49156,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wargulf" supported="no">
 		<!-- SPS (CAPS) release 1106 -->
 		<description>War in the Gulf (Euro)</description>
@@ -46734,6 +49178,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="warmachn" supported="no">
 		<!-- SPS (CAPS) release 2074 -->
 		<description>War Machine (Euro)</description>
@@ -46748,6 +49193,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="warzone" supported="no">
 		<!-- SPS (CAPS) release 1212 -->
 		<description>War Zone (Euro, Paradox)</description>
@@ -46762,6 +49208,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="warzonec" supported="no">
 		<!-- SPS (CAPS) release 598 -->
 		<description>War Zone (Euro, Core Design)</description>
@@ -46776,6 +49223,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wargamcs" supported="no">
 		<!-- SPS (CAPS) release 1464 -->
 		<description>Wargame Construction Set (USA, v1.0)</description>
@@ -46790,6 +49238,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="warhead" supported="no">
 		<!-- SPS (CAPS) release 1340 -->
 		<description>Warhead (Euro)</description>
@@ -46804,6 +49253,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="warlock" supported="no">
 		<!-- SPS (CAPS) release 398 -->
 		<description>Warlock's Quest (Euro)</description>
@@ -46818,6 +49268,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="warlocka" cloneof="warlock" supported="no">
 		<!-- SPS (CAPS) release 2282 -->
 		<description>Warlock's Quest (Euro, Super Quintet)</description>
@@ -46832,6 +49283,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="warlocku" cloneof="warlock" supported="no">
 		<!-- SPS (CAPS) release 847 -->
 		<description>Warlock (USA)</description>
@@ -46846,6 +49298,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="warlaven" supported="no">
 		<!-- SPS (CAPS) release 1413 -->
 		<description>Warlock the Avenger (Euro)</description>
@@ -46860,6 +49313,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="warlords" supported="no">
 		<!-- SPS (CAPS) release 789 -->
 		<description>Warlords (Euro, v2.00)</description>
@@ -46881,6 +49335,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wareleyn" supported="no">
 		<!-- SPS (CAPS) release 2924 -->
 		<description>Warriors of Releyne (Euro, v1.00)</description>
@@ -46902,6 +49357,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="waterloo" supported="no">
 		<!-- SPS (CAPS) release 408 -->
 		<description>Waterloo (Euro)</description>
@@ -46916,6 +49372,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="waterlooa" cloneof="waterloo" supported="no">
 		<!-- SPS (CAPS) release 1938 -->
 		<description>Waterloo (Euro, Turning Points)</description>
@@ -46932,6 +49389,7 @@ license:CC0
 
 	<!-- Incorrectly GFX drawn copy protection screen (repeats numpad at bottom) -->
 	<!-- TODO: verify afterwards -->
+	<!-- ATK test: OK -->
 	<software name="waxworks" supported="no">
 		<!-- SPS (CAPS) release 2274 -->
 		<description>Waxworks (Euro)</description>
@@ -47003,6 +49461,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="waxworksf" cloneof="waxworks" supported="no">
 		<!-- SPS (CAPS) release 2394 -->
 		<description>Waxworks (Fra)</description>
@@ -47072,6 +49531,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="waylildr" supported="no">
 		<!-- SPS (CAPS) release 2096 -->
 		<description>The Way of the Little Dragon (Euro)</description>
@@ -47086,6 +49546,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="ween" supported="no">
 		<!-- SPS (CAPS) release 2326 -->
 		<description>Ween - The Prophecy (Fra)</description>
@@ -47113,6 +49574,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="weirddre" supported="no">
 		<!-- SPS (CAPS) release 2100 -->
 		<description>Weird Dreams (Euro)</description>
@@ -47127,6 +49589,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="welltris" supported="no">
 		<!-- SPS (CAPS) release 1622 -->
 		<description>Welltris (Euro)</description>
@@ -47141,6 +49604,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wembleyr" supported="no">
 		<!-- SPS (CAPS) release 1673 -->
 		<description>Wembley Rugby League (Euro)</description>
@@ -47155,6 +49619,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 Bad -->
 	<software name="westgame" supported="no">
 		<!-- SPS (CAPS) release 790 -->
 		<description>Western Games (Euro)</description>
@@ -47176,6 +49641,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="whalevoy" supported="no">
 		<!-- SPS (CAPS) release 2647 -->
 		<description>Whale's Voyage (Euro)</description>
@@ -47227,6 +49693,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="whalevoyg" cloneof="whalevoy" supported="no">
 		<!-- SPS (CAPS) release 1286 -->
 		<description>Whale's Voyage (Ger)</description>
@@ -47278,6 +49745,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="whalevo2" supported="no">
 		<!-- SPS (CAPS) release 600 -->
 		<description>Whale's Voyage 2 (Ger)</description>
@@ -47323,6 +49791,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wtww" supported="no">
 		<!-- SPS (CAPS) release 1771 -->
 		<description>When Two Worlds War (Ger, v1.01)</description>
@@ -47344,6 +49813,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="whirligg" supported="no">
 		<!-- SPS (CAPS) release 2913 -->
 		<description>Whirligig (Euro)</description>
@@ -47358,6 +49828,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="whitedth" supported="no">
 		<!-- SPS (CAPS) release 2461 -->
 		<description>White Death (Euro, v1.3.6)</description>
@@ -47373,6 +49844,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="rogerrab" supported="no">
 		<!-- SPS (CAPS) release 160 -->
 		<description>Who Framed Roger Rabbit (Euro)</description>
@@ -47394,6 +49866,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wicked" supported="no">
 		<!-- SPS (CAPS) release 295 -->
 		<description>Wicked (Euro)</description>
@@ -47408,6 +49881,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wickeda" cloneof="wicked" supported="no">
 		<!-- SPS (CAPS) release 1263 -->
 		<description>Wicked (Euro, Power Hits)</description>
@@ -47422,6 +49896,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wildsocr" supported="no">
 		<!-- SPS (CAPS) release 229 -->
 		<description>Wild Cup Soccer (Euro)</description>
@@ -47444,6 +49919,7 @@ license:CC0
 	</software>
 
 	<!-- Black screen, continous access to [FDC] floppy -->
+	<!-- ATK test: failed -->
 	<software name="wildstrt" supported="no">
 		<!-- SPS (CAPS) release 1678 -->
 		<description>Wild Streets (Euro)</description>
@@ -47458,6 +49934,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wildwest" supported="no">
 		<!-- SPS (CAPS) release 601 -->
 		<description>Wild West World (Ger)</description>
@@ -47479,6 +49956,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wildwhel" supported="no">
 		<!-- SPS (CAPS) release 2654 -->
 		<description>Wild Wheels (Euro)</description>
@@ -47493,6 +49971,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="windwizr" supported="no">
 		<!-- SPS (CAPS) release 2649 -->
 		<description>Window Wizard (Euro)</description>
@@ -47507,6 +49986,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="windwill" supported="no">
 		<!-- SPS (CAPS) release 2879 -->
 		<description>Windsurf Willy (Euro, Hits for Six Volume Seven)</description>
@@ -47521,6 +50001,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="windwillf" cloneof="windwill" supported="no">
 		<!-- SPS (CAPS) release 2878 -->
 		<description>Windsurf Willy (Fra)</description>
@@ -47535,6 +50016,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="windwalk" supported="no">
 		<!-- SPS (CAPS) release 1391 -->
 		<description>Windwalker (USA)</description>
@@ -47549,6 +50031,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wingcomm" supported="no">
 		<!-- SPS (CAPS) release 1657 -->
 		<description>Wing Commander (Euro)</description>
@@ -47576,6 +50059,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wingcommg" cloneof="wingcomm" supported="no">
 		<!-- SPS (CAPS) release 824 -->
 		<description>Wing Commander (Ger)</description>
@@ -47603,6 +50087,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wings" supported="no">
 		<!-- SPS (CAPS) release 410 -->
 		<description>Wings (Euro)</description>
@@ -47625,6 +50110,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wingsdth" supported="no">
 		<!-- SPS (CAPS) release 3022 -->
 		<description>Wings of Death (Euro)</description>
@@ -47647,6 +50133,7 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wingfury" supported="no">
 		<!-- SPS (CAPS) release 599 -->
 		<description>Wings of Fury (Euro)</description>
@@ -47661,6 +50148,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wintcamp" supported="no">
 		<!-- SPS (CAPS) release 1706 -->
 		<description>Winter Camp (Euro)</description>
@@ -47682,6 +50170,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wolympd" supported="no">
 		<!-- SPS (CAPS) release 748 -->
 		<description>Winter Olympiad 88 (Euro)</description>
@@ -47696,6 +50185,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wintol" supported="no">
 		<!-- SPS (CAPS) release 1127 -->
 		<description>Winter Olympics (Euro)</description>
@@ -47723,6 +50213,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="winzer" supported="no">
 		<!-- SPS (CAPS) release 1760 -->
 		<description>Winzer (Ger, v1.14 19970117, World of Business)</description>
@@ -47737,6 +50228,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="winzera" cloneof="winzer" supported="no">
 		<!-- SPS (CAPS) release 1759 -->
 		<description>Winzer (Ger, v1.13 19910929)</description>
@@ -47751,6 +50243,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wipeout" supported="no">
 		<!-- SPS (CAPS) release 161 -->
 		<description>Wipe Out (Euro)</description>
@@ -47765,6 +50258,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wishbrin" supported="no">
 		<!-- SPS (CAPS) release 2543 -->
 		<description>Wishbringer (Euro, r69)</description>
@@ -47779,6 +50273,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="witness" supported="no">
 		<!-- SPS (CAPS) release 2041 -->
 		<description>The Witness (USA, r22)</description>
@@ -47793,6 +50288,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wiznliz" supported="no">
 		<!-- SPS (CAPS) release 749 -->
 		<description>Wiz 'n' Liz (Euro)</description>
@@ -47814,6 +50310,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wizrdwar" supported="no">
 		<!-- SPS (CAPS) release 1 -->
 		<description>Wizard Warz (Euro)</description>
@@ -47828,6 +50325,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wizardr6" supported="no">
 		<!-- SPS (CAPS) release 991 -->
 		<description>Wizardry VI - Bane of the Cosmic Forge (Euro)</description>
@@ -47867,6 +50365,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wizardr6g" cloneof="wizardr6" supported="no">
 		<!-- SPS (CAPS) release 603 -->
 		<description>Wizardry VI - Bane of the Cosmic Forge (Ger)</description>
@@ -47906,6 +50405,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wizball" supported="no">
 		<!-- SPS (CAPS) release 176 -->
 		<description>Wizball (Euro)</description>
@@ -47920,6 +50420,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wizballa" cloneof="wizball" supported="no">
 		<!-- SPS (CAPS) release 1380 -->
 		<description>Wizball (Euro, Tenstar Pack)</description>
@@ -47934,6 +50435,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wizballb" cloneof="wizball" supported="no">
 		<!-- SPS (CAPS) release 1544 -->
 		<description>Wizball (Euro, Budget)</description>
@@ -47948,6 +50450,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wizkid" supported="no">
 		<!-- SPS (CAPS) release 1449 -->
 		<description>Wizkid (Euro)</description>
@@ -47971,6 +50474,7 @@ license:CC0
 
 	<!-- Shows Core Design logo then hangs with red backdrop [FDC] dsksync -->
 	<!-- Has GFX stripe glitch when player dies -->
+	<!-- ATK test: OK -->
 	<software name="wolfchld" supported="no">
 		<!-- SPS (CAPS) release 411 -->
 		<description>Wolfchild (Euro)</description>
@@ -47992,6 +50496,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wolfpack" supported="no">
 		<!-- SPS (CAPS) release 255 -->
 		<description>Wolfpack (Euro)</description>
@@ -48006,6 +50511,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wonderdg" supported="no">
 		<!-- SPS (CAPS) release 1201 -->
 		<description>Wonder Dog (Euro)</description>
@@ -48028,6 +50534,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: OK -->
 	<software name="wondrlnd" supported="partial">
 		<!-- SPS (CAPS) release 277 -->
 		<description>Wonderland (Euro, v1.27i 19910422)</description>
@@ -48062,6 +50569,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="woodywrl" supported="no">
 		<!-- SPS (CAPS) release 2182 -->
 		<description>Woodys World (Euro)</description>
@@ -48089,6 +50597,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wcbox" supported="no">
 		<!-- SPS (CAPS) release 162 -->
 		<description>World Championship Boxing Manager (Euro)</description>
@@ -48103,6 +50612,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wcsoccer" supported="no">
 		<!-- SPS (CAPS) release 1063 -->
 		<description>World Championship Soccer (Euro)</description>
@@ -48117,6 +50627,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wcrugby" supported="no">
 		<!-- SPS (CAPS) release 2131 -->
 		<description>World Class Rugby (Euro)</description>
@@ -48131,6 +50642,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wrldcrkt" supported="no">
 		<!-- SPS (CAPS) release 2130 -->
 		<description>World Cricket (Euro)</description>
@@ -48145,6 +50657,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="worldart" supported="no">
 		<!-- SPS (CAPS) release 871 -->
 		<description>World Darts (Euro)</description>
@@ -48159,6 +50672,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="wldgames" supported="no">
 		<!-- SPS (CAPS) release 604 -->
 		<description>World Games (USA)</description>
@@ -48173,6 +50687,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wldrugby" supported="no">
 		<!-- SPS (CAPS) release 2544 -->
 		<description>World Rugby (Euro, Top 15 Spielesammlung)</description>
@@ -48187,6 +50702,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wldsoccr" supported="no">
 		<!-- SPS (CAPS) release 2150 -->
 		<description>World Soccer (Euro)</description>
@@ -48201,6 +50717,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="wtgolf" supported="no">
 		<!-- SPS (CAPS) release 752 -->
 		<description>World Tour Golf (Euro)</description>
@@ -48216,6 +50733,7 @@ license:CC0
 	</software>
 
 	<!-- Hangs after entering copy-protection value -->
+	<!-- ATK test: OK -->
 	<software name="worms" supported="no">
 		<!-- SPS (CAPS) release 230 -->
 		<description>Worms (Euro)</description>
@@ -48245,6 +50763,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wrathdmn" supported="no">
 		<!-- SPS (CAPS) release 606 -->
 		<description>Wrath of the Demon (Euro)</description>
@@ -48278,6 +50797,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="wreckers" supported="no">
 		<!-- SPS (CAPS) release 751 -->
 		<description>Wreckers (Euro)</description>
@@ -48292,6 +50812,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wwfert" supported="no">
 		<!-- SPS (CAPS) release 1298 -->
 		<description>WWF European Rampage Tour (Euro)</description>
@@ -48313,6 +50834,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wwferta" cloneof="wwfert" supported="no">
 		<!-- SPS (CAPS) release 2449 -->
 		<description>WWF European Rampage Tour (Euro, Alt)</description>
@@ -48334,6 +50856,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wrestlmn" supported="no">
 		<!-- SPS (CAPS) release 205 -->
 		<description>WWF Wrestle Mania (Euro)</description>
@@ -48355,6 +50878,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="wrestlmna" cloneof="wrestlmn" supported="no">
 		<!-- SPS (CAPS) release 2210 -->
 		<description>WWF Wrestle Mania (Euro, Budget)</description>
@@ -48376,6 +50900,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="xit" supported="no">
 		<!-- SPS (CAPS) release 1585 -->
 		<description>X-It (Euro)</description>
@@ -48397,6 +50922,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="xout" supported="no">
 		<!-- SPS (CAPS) release 412 -->
 		<description>X-Out (Euro)</description>
@@ -48418,6 +50944,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="xouta" cloneof="xout" supported="no">
 		<!-- SPS (CAPS) release 1274 -->
 		<description>X-Out (Euro, Budget)</description>
@@ -48432,6 +50959,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="xenomor" supported="no">
 		<!-- SPS (CAPS) release 296 -->
 		<description>Xenomorph (Euro)</description>
@@ -48453,6 +50981,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:1 Bad -->
 	<software name="xenomorg" cloneof="xenomor" supported="no">
 		<!-- SPS (CAPS) release 2939 -->
 		<description>Xenomorph (Ger)</description>
@@ -48475,6 +51004,7 @@ license:CC0
 	</software>
 
 	<!-- Locks up at Xenon logo [FDC] dsksync -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xenon" supported="no">
 		<!-- SPS (CAPS) release 399 -->
 		<description>Xenon (Euro)</description>
@@ -48489,6 +51019,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xenona" cloneof="xenon" supported="no">
 		<!-- SPS (CAPS) release 2873 -->
 		<description>Xenon (Euro, Precious Metal)</description>
@@ -48504,6 +51035,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK -->
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xenon2" supported="yes">
 		<!-- SPS (CAPS) release 297 -->
 		<description>Xenon 2 - Megablast (Euro)</description>
@@ -48526,6 +51058,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xenon2a" cloneof="xenon2" supported="no">
 		<!-- SPS (CAPS) release 2874 -->
 		<description>Xenon 2 - Megablast (Euro, Alt)</description>
@@ -48547,6 +51080,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="xenon2b" cloneof="xenon2" supported="no">
 		<!-- SPS (CAPS) release 2234 -->
 		<description>Xenon 2 - Megablast (Euro, The Power Pack)</description>
@@ -48561,6 +51095,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="xenophob" supported="no">
 		<!-- SPS (CAPS) release 2247 -->
 		<description>Xenophobe (Euro)</description>
@@ -48582,6 +51117,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="xiphos" supported="no">
 		<!-- SPS (CAPS) release 1062 -->
 		<description>Xiphos (Euro)</description>
@@ -48603,6 +51139,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="xp8" supported="no">
 		<!-- SPS (CAPS) release 607 -->
 		<description>XP8 (Euro)</description>
@@ -48630,6 +51167,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xr35" supported="no">
 		<!-- SPS (CAPS) release 34 -->
 		<description>XR-35 Fighter Mission (Euro)</description>
@@ -48644,6 +51182,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="xr35a" cloneof="xr35" supported="no">
 		<!-- SPS (CAPS) release 1110 -->
 		<description>XR-35 Fighter Mission (Euro, Alt)</description>
@@ -48675,6 +51214,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="xtrmrdd" supported="no">
 		<!-- SPS (CAPS) release 1807 -->
 		<description>XTreme Racing Data Disks (Euro, v2.0)</description>
@@ -48697,6 +51237,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="xybots" supported="no">
 		<!-- SPS (CAPS) release 1707 -->
 		<description>Xybots (Euro)</description>
@@ -48711,6 +51252,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="yojoe" supported="no">
 		<!-- SPS (CAPS) release 750 -->
 		<description>Yo! Joe! (Euro)</description>
@@ -48732,6 +51274,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="yogiclnp" supported="no">
 		<!-- SPS (CAPS) release 2171 -->
 		<description>Yogi's Big Clean Up (Euro)</description>
@@ -48746,6 +51289,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="yogiescp" supported="no">
 		<!-- SPS (CAPS) release 1355 -->
 		<description>Yogi's Great Escape (Euro)</description>
@@ -48760,6 +51304,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: C:0 H:U Bad -->
 	<software name="zout" supported="no">
 		<!-- SPS (CAPS) release 609 -->
 		<description>Z-Out (Euro)</description>
@@ -48775,6 +51320,7 @@ license:CC0
 	</software>
 
 	<!-- doesn't boot from stand-alone -->
+	<!-- ATK test: OK -->
 	<software name="zakmk" supported="no">
 		<!-- SPS (CAPS) release 965 -->
 		<description>Zak McKracken and the Alien Mindbenders (Euro)</description>
@@ -48797,6 +51343,7 @@ license:CC0
 	</software>
 
 	<!-- doesn't boot from stand-alone -->
+	<!-- ATK test: OK -->
 	<software name="zakmkf" cloneof="zakmk" supported="no">
 		<!-- SPS (CAPS) release 2365 -->
 		<description>Zak McKracken and the Alien Mindbenders (Fra)</description>
@@ -48819,6 +51366,7 @@ license:CC0
 	</software>
 
 	<!-- doesn't boot from stand-alone -->
+	<!-- ATK test: OK -->
 	<software name="zakmkg" cloneof="zakmk" supported="no">
 		<!-- SPS (CAPS) release 413 -->
 		<description>Zak McKracken and the Alien Mindbenders (Ger)</description>
@@ -48841,6 +51389,7 @@ license:CC0
 	</software>
 
 	<!-- Guru Meditation -->
+	<!-- ATK test: C:0 H:U 1 Sector Bad -->
 	<software name="zanygolf" supported="no">
 		<!-- SPS (CAPS) release 1482 -->
 		<description>Zany Golf (USA)</description>
@@ -48855,6 +51404,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zarathru" supported="no">
 		<!-- SPS (CAPS) release 1501 -->
 		<description>Zarathrusta (Euro)</description>
@@ -48869,6 +51419,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zargon" supported="no">
 		<!-- SPS (CAPS) release 1684 -->
 		<description>Zargon (Ger)</description>
@@ -48884,6 +51435,7 @@ license:CC0
 	</software>
 
 	<!-- Pressing enter on title sequence is ignored on a500, causes Guru Meditation on a1200 -->
+	<!-- ATK test: OK -->
 	<software name="zeewolf" supported="no">
 		<!-- SPS (CAPS) release 414 -->
 		<description>Zeewolf (Euro, v1.02)</description>
@@ -48898,6 +51450,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zeewolf2" supported="no">
 		<!-- SPS (CAPS) release 608 -->
 		<description>Zeewolf 2 - Wild Justice (Euro)</description>
@@ -48912,6 +51465,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="ziriax" supported="no">
 		<!-- SPS (CAPS) release 3001 -->
 		<description>Ziriax (Euro)</description>
@@ -48941,6 +51495,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zonewarr" supported="no">
 		<!-- SPS (CAPS) release 1618 -->
 		<description>Zone Warrior (Euro)</description>
@@ -48962,6 +51517,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zool" supported="no">
 		<!-- SPS (CAPS) release 893 -->
 		<description>Zool (Euro)</description>
@@ -48984,6 +51540,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zoola" cloneof="zool" supported="no">
 		<!-- SPS (CAPS) release 2426 -->
 		<description>Zool (Euro, Award Winners Gold Edition)</description>
@@ -49006,6 +51563,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zool2" supported="no">
 		<!-- SPS (CAPS) release 1111 -->
 		<description>Zool 2 (Euro)</description>
@@ -49027,6 +51585,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zoom" supported="no">
 		<!-- SPS (CAPS) release 1910 -->
 		<description>Zoom! (Euro)</description>
@@ -49041,6 +51600,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zork" supported="no">
 		<!-- SPS (CAPS) release 2681 -->
 		<description>Zork I - The Great Underground Empire (Euro, r88)</description>
@@ -49055,6 +51615,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zork2" supported="no">
 		<!-- SPS (CAPS) release 2542 -->
 		<description>Zork II - The Wizard Of Frobozz (Euro, v48)</description>
@@ -49069,6 +51630,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zorktril" supported="no">
 		<!-- SPS (CAPS) release 2042 -->
 		<description>Zork Trilogy - Zork I (r88) + Zork II (v48) + Zork III (r17) (USA)</description>
@@ -49083,6 +51645,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: OK -->
 	<software name="zork0" supported="no">
 		<!-- SPS (CAPS) release 1411 -->
 		<description>Zork Zero (USA, r366)</description>
@@ -49097,6 +51660,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zyconix" supported="no">
 		<!-- SPS (CAPS) release 1057 -->
 		<description>Zyconix (Euro)</description>
@@ -49111,6 +51675,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- ATK test: failed -->
 	<software name="zynaps" supported="no">
 		<!-- SPS (CAPS) release 879 -->
 		<description>Zynaps (Euro)</description>
@@ -49124,7 +51689,4 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
-
-
 </softwarelist>
-

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -21685,14 +21685,16 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Doesn't load on a500p (with wrong GFX pitch too, btanb?) -->
 	<!-- ATK test: OK -->
-	<software name="hpoker" supported="no">
+	<software name="hpoker" supported="partial">
 		<!-- SPS (CAPS) release 1791 -->
 		<description>Hollywood Poker (Euro)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1987</year>
 		<publisher>Diamond</publisher>
+		<!-- Up + fire to change cards after selection -->
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps1791)hollywoodpoker.ipf" size="1049612" crc="d3828066" sha1="9bd25d93a94aa2a91c5267cdc53dae9e4a394c62"/>
@@ -21701,7 +21703,7 @@ license:CC0
 	</software>
 
 	<!-- ATK test: OK -->
-	<software name="hpokera" cloneof="hpoker" supported="no">
+	<software name="hpokera" cloneof="hpoker" supported="partial">
 		<!-- SPS (CAPS) release 1792 -->
 		<description>Hollywood Poker (Euro, Budget)</description>
 		<!-- budget, standalone -->
@@ -25108,6 +25110,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Has slight glitches during gameplay (empty box on startup, sprite overlap drawing, garbage stripe GFX from time to time) -->
 	<!-- ATK test: failed -->
 	<software name="kickoff2" supported="no">
 		<!-- SPS (CAPS) release 2191 -->
@@ -27517,7 +27520,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Mouse cursor is uncontrollable -->
+	<!-- Mouse cursor is uncontrollable, [joytest] reset counter -->
 	<!-- ATK test: OK -->
 	<software name="lifendth" supported="no">
 		<!-- SPS (CAPS) release 1126 -->
@@ -32588,7 +32591,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation -->
+	<!-- Guru Meditation, [FDC] copy protection (enables 68k trace mode, corrupt A2 at PC=3e4) -->
 	<!-- ATK test: OK -->
 	<software name="onslaugh" supported="no">
 		<!-- SPS (CAPS) release 869 -->
@@ -33267,6 +33270,8 @@ license:CC0
 	</software>
 
 	<!-- boot OK, has a stripe of garbage on bottom (especially noticeable on game end screen) -->
+	<!-- Has GFX pitch issues on PAL machines (btanb?) -->
+	<!-- Has optional Genias or Standard 4-players interface (unsupported) -->
 	<!-- ATK test: OK -->
 	<software name="overnet" supported="partial">
 		<!-- SPS (CAPS) release 2439 -->
@@ -33275,6 +33280,7 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Merit</publisher>
+		<!-- Developer: Genias -->
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2439)overthenet.ipf" size="1049180" crc="7fcbc438" sha1="ee82d07d9d32270075313f86726bb32e615cd835"/>
@@ -36926,6 +36932,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Guru Meditation, [Blitter] transfer at PC=00DBD6 that pitfalls existing code -->
+	<!-- [FDC] dsksync afterward -->
 	<!-- ATK test: failed -->
 	<software name="redheat" supported="no">
 		<!-- SPS (CAPS) release 565 -->
@@ -37483,6 +37491,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- No background GFXs, known to abuse of the [Copper] sprites -->
 	<!-- ATK test: OK -->
 	<software name="riskyw" supported="no">
 		<!-- SPS (CAPS) release 571 -->
@@ -37491,6 +37500,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1992</year>
 		<publisher>Electronic Arts</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">
@@ -43851,6 +43862,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- black screen, [FDC] dsksync -->
+	<!-- Has GFX pitch issues on gameplay -->
 	<!-- ATK test: OK -->
 	<software name="suburban" supported="no">
 		<!-- SPS (CAPS) release 959 -->
@@ -44370,6 +44383,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Has GFX pitch issues on intro -->
+	<!-- Guru Meditation after intro -->
 	<!-- ATK test: OK -->
 	<software name="ssf2" supported="no">
 		<!-- SPS (CAPS) release 147 -->
@@ -44718,9 +44733,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, bird sample keeps repeating -->
+	<!-- boot OK -->
 	<!-- ATK test: OK -->
-	<software name="swordhon" supported="partial">
+	<software name="swordhon" supported="yes">
 		<!-- SPS (CAPS) release 149 -->
 		<description>Sword of Honour (Euro)</description>
 		<!-- retail, standalone -->
@@ -44728,6 +44743,7 @@ license:CC0
 		<year>1992</year>
 		<publisher>Prestige</publisher>
 		<info name="usage" value="Sports manual copy-protection (Kodeord)" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049180">
@@ -44912,8 +44928,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Has GFX wrong colors on initial training setup screen, "fixed" by blitter ball layer copies -->
 	<!-- ATK test: OK -->
-	<software name="tableten" supported="no">
+	<software name="tableten" supported="partial">
 		<!-- SPS (CAPS) release 1912 -->
 		<description>Table Tennis Simulation (Euro)</description>
 		<!-- retail, standalone -->
@@ -44971,6 +44988,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Crashes almost always after entering correct copy protection word, "FT I,FLAGS.DAT" printed on screen -->
+	<!-- If loading works (with -debug only?) no player data is loaded correctly -->
+	<!-- TODO: word is always "CLUB"? Is RNG working right? -->
 	<!-- ATK test: OK -->
 	<software name="tacmanit" supported="no">
 		<!-- SPS (CAPS) release 1853 -->
@@ -44979,6 +44999,9 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1994</year>
 		<publisher>Black Legend</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+		<!-- Disks are referred in-game by Disk A or B, those diverges from the floppy markings tho -->
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">
@@ -45405,7 +45428,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, sports repeating samples -->
+	<!-- boot OK on a500 -->
+	<!-- a500p: black screen, caused by PORTS irq2 never cleared -->
 	<!-- ATK test: OK -->
 	<software name="terramex" supported="partial">
 		<!-- SPS (CAPS) release 391 -->
@@ -46001,7 +46025,7 @@ license:CC0
 	</software>
 
 	<!-- ATK test: OK -->
-	<software name="thdrcats" supported="no">
+	<software name="thdrcats" supported="yes">
 		<!-- SPS (CAPS) release 2921 -->
 		<description>ThunderCats (Euro)</description>
 		<!-- retail, standalone -->
@@ -46185,9 +46209,10 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up at language select screen -->
+	<!-- boot OK -->
+	<!-- TODO: verify character drawing GFX in point and click sections -->
 	<!-- ATK test: OK -->
-	<software name="trun1" supported="no">
+	<software name="trun1" supported="partial">
 		<!-- SPS (CAPS) release 2593 -->
 		<description>Time Runners 1 - Gateways in Time (Euro)</description>
 		<!-- retail, standalone -->
@@ -46201,9 +46226,10 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up at language select screen -->
+	<!-- boot OK -->
+	<!-- TODO: verify character drawing GFX in point and click sections -->
 	<!-- ATK test: OK -->
-	<software name="trun2" supported="no">
+	<software name="trun2" supported="partial">
 		<!-- SPS (CAPS) release 2713 -->
 		<description>Time Runners 2 - The Space Stone (Euro)</description>
 		<!-- retail, standalone -->
@@ -46623,8 +46649,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- boot OK -->
 	<!-- ATK test: OK -->
-	<software name="timexwrd" supported="no">
+	<software name="timexwrd" supported="yes">
 		<!-- SPS (CAPS) release 1132 -->
 		<description>The Times Crosswords Vol. 3 &amp; 4 (Euro)</description>
 		<!-- retail, standalone -->
@@ -46712,14 +46739,19 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- boot OK, has slight garbage GFX stripe on bottom of screen -->
+	<!-- Accesses [FDC] dskdatr during loading, no noticeable effect? -->
+	<!-- TODO: how to create data disk? -->
 	<!-- ATK test: OK -->
-	<software name="tipoffa" cloneof="tipoff" supported="no">
+	<software name="tipoffa" cloneof="tipoff" supported="partial">
 		<!-- SPS (CAPS) release 1269 -->
 		<description>Tip Off (Euro, French / German / Italian / Spanish)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1992</year>
 		<publisher>Anco</publisher>
+		<info name="usage" value="Does not support external floppy drives"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049874">
@@ -47111,8 +47143,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Transparency sprite issue when ball goes near the goal lines (i.e. top or bottom of field) -->
 	<!-- ATK test: OK -->
-	<software name="totlfoot" supported="no">
+	<software name="totlfoot" supported="partial">
 		<!-- SPS (CAPS) release 154 -->
 		<description>Total Football (Euro)</description>
 		<!-- retail, standalone -->
@@ -47161,8 +47194,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- boot OK -->
 	<!-- ATK test: OK -->
-	<software name="totrecala" cloneof="totrecal" supported="no">
+	<software name="totrecala" cloneof="totrecal" supported="yes">
 		<!-- SPS (CAPS) release 1770 -->
 		<description>Total Recall (Euro, Budget)</description>
 		<!-- budget, standalone -->
@@ -47308,7 +47342,7 @@ license:CC0
 	</software>
 
 	<!-- black screen after AmigaDOS [FDC] dsksync -->
-	<!-- Mouse cursor is uncontrollable -->
+	<!-- Mouse cursor is uncontrollable, [joytest] reset counters -->
 	<!-- ATK test: C:79 H:U 1 Sector Bad -->
 	<software name="transarc" supported="no">
 		<!-- SPS (CAPS) release 744 -->
@@ -47441,14 +47475,17 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- boot OK -->
 	<!-- ATK test: OK -->
-	<software name="trinity" supported="no">
+	<software name="trinity" supported="yes">
 		<!-- SPS (CAPS) release 2541 -->
 		<description>Trinity (Euro, r11)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1986</year>
 		<publisher>Infocom</publisher>
+		<info name="usage" value="Launch Trinity file from Workbench"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2541)trinity.ipf" size="1049612" crc="fe8c6853" sha1="f7ff68729bd963521b2e89e80441cdf7d945458f"/>
@@ -47456,6 +47493,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- bad GFX pitch -->
 	<!-- ATK test: OK -->
 	<software name="triplex" supported="no">
 		<!-- SPS (CAPS) release 2048 -->
@@ -47464,6 +47502,9 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Axxiom</publisher>
+		<!-- As in title screen -->
+		<info name="alt_title" value="Tripple-X" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps2048)triplex.ipf" size="1049612" crc="a6d1bb80" sha1="e33d788eb8ee97cb0b2f4e85d599d7acd802f1c5"/>
@@ -49385,8 +49426,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Incorrectly GFX drawn copy protection screen (repeats numpad at bottom) -->
-	<!-- TODO: verify afterwards -->
+	<!-- GFX garbage spawns on bottom (repeats bitplane layers from above) -->
 	<!-- ATK test: OK -->
 	<software name="waxworks" supported="no">
 		<!-- SPS (CAPS) release 2274 -->
@@ -49395,7 +49435,7 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1993</year>
 		<publisher>Accolade</publisher>
-		<info name="usage" value="Sports manual copy-protection" />
+		<info name="usage" value="Sports code wheel copy-protection" />
 
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -79,7 +79,7 @@ license:CC0
     any non-write protected discs you insert as long as they're memory resident.
  -->
 
-<softwarelist name="amigaocs_flop" description="Amiga OCS disk images">
+<softwarelist name="amigaocs_flop" description="Commodore Amiga OCS disk images">
 
 	<!-- Not listed in SPS? -->
 
@@ -2832,7 +2832,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen with continous floppy access [FDC] -->
+	<!-- black screen with continous floppy access [FDC] dsksync -->
 	<!-- (keeps jumping to empty area at PC=4d000 after failing a copy protection check at PC=70032, D0=0 D1=5d5 D2=67 D3=0) -->
 	<software name="arnie2" supported="no">
 		<!-- SPS (CAPS) release 1924 -->
@@ -3607,9 +3607,10 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1987</year>
 		<publisher>King Size</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps206)backgammon.ipf" size="1049180" crc="b7e159cb" sha1="64a12d9db73c704195ce0d6733fb3c52cc5fba7b"/>
+				<rom name="(sps206)backgammon.ipf" size="1049180" crc="b7e159cb" sha1="64a12d9db73c704195ce0d6733fb3c52cc5fba7b" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -3894,7 +3895,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="bangkokk" supported="no">
+	<!-- boot OK -->
+	<software name="bangkokk" supported="yes">
 		<!-- SPS (CAPS) release 1137 -->
 		<description>Bangkok Knights (Euro)</description>
 		<!-- retail, standalone -->
@@ -3943,7 +3945,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation during "The game is loading" phase -->
+	<!-- Guru Meditation during "The game is loading" phase [FDC] with adkcon=1100 -->
 	<software name="barbpal" supported="no">
 		<!-- SPS (CAPS) release 1784 -->
 		<description>Barbarian (Euro, v16.3.88, Palace)</description>
@@ -3959,6 +3961,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Hangs at kickstart white screen [FDC] dsksync -->
 	<software name="barb2psy" supported="no">
 		<!-- SPS (CAPS) release 611 -->
 		<description>Barbarian II (Euro, Psygnosis)</description>
@@ -4290,7 +4293,6 @@ license:CC0
 	</software>
 
 	<!-- Black screen, [CIAB] fails on comparing a TOD 9 > 0x115 at PC=de4 -->
-	<!-- BGMs and SFXs whistles [Paula] -->
 	<software name="batman1" cloneof="batman" supported="no">
 		<!-- SPS (CAPS) release 19 -->
 		<description>Batman (Euro, Single Disk)</description>
@@ -4734,7 +4736,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- BGMs/SFXs channels whistles [Paula] -->
+	<!-- intro BGM hiccups [Paula] -->
 	<!-- Has transparent stripes all over the place during intro [copper] -->
 	<software name="bchvolly" supported="partial">
 		<!-- SPS (CAPS) release 1249 -->
@@ -4771,9 +4773,10 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Magic Bytes</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1043202">
-				<rom name="(sps1304)beam.ipf" size="1043202" crc="7b894a65" sha1="d88c483405e7b3cb3c1ab2e4fb374036f342e032"/>
+				<rom name="(sps1304)beam.ipf" size="1043202" crc="7b894a65" sha1="d88c483405e7b3cb3c1ab2e4fb374036f342e032" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -5276,7 +5279,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- crashes in AmigaOS with DSKDAT R [FDC] -->
+	<!-- crashes in AmigaDOS with DSKDAT R [FDC] dsksync bootblock -->
 	<software name="bhcop" supported="no">
 		<!-- SPS (CAPS) release 179 -->
 		<description>Beverly Hills Cop (Euro)</description>
@@ -6210,6 +6213,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="bluesb" supported="no">
 		<!-- SPS (CAPS) release 3081 -->
 		<description>The Blues Brothers (Euro)</description>
@@ -6224,6 +6228,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="bluesb1" cloneof="bluesb" supported="no">
 		<!-- SPS (CAPS) release 3082 -->
 		<description>The Blues Brothers (Euro, Alt)</description>
@@ -7363,8 +7368,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
 	<!-- (Hangs at PC=21050 after failing a copy protection check, D0=0 D1=16 D2=12 D3=0) -->
+	<!-- Doesn't accept [KBD] inputs on language select -->
 	<software name="cadaver" supported="no">
 		<!-- SPS (CAPS) release 103 -->
 		<description>Cadaver (Euro, v0.01)</description>
@@ -7386,7 +7392,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
 	<software name="cadavera" cloneof="cadaver" supported="no">
 		<!-- SPS (CAPS) release 2876 -->
 		<description>Cadaver (Euro, v1.03, The Bitmap Brothers Volume 1)</description>
@@ -7598,9 +7604,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a rainbow colored loading screen [FDC] -->
-	<!-- (checks for string "SOS6" at PC=500be, which is offset because precompensation is enabled) -->
-	<!-- (eventually disables precompensation when starting a level, tries to sync with MFM instead of GCR) -->
+	<!-- Hangs at a rainbow colored loading screen [FDC] dsksync -->
+	<!-- (checks for string "SOS6" at PC=500be, which is offset because of dsksync) -->
 	<software name="cfodder" supported="no">
 		<!-- SPS (CAPS) release 860 -->
 		<description>Cannon Fodder (Euro)</description>
@@ -7752,6 +7757,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Hangs at a rainbow colored loading screen [FDC] dsksync -->
+	<!-- (Same as cfodder) -->
 	<software name="csoccer" supported="no">
 		<!-- SPS (CAPS) release 165 -->
 		<description>Cannon Soccer (Euro)</description>
@@ -7966,7 +7973,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- no BGM, black screen after loading arcade mode (spurious irq?) -->
+	<!-- black screen after loading arcade mode (spurious irq?) -->
 	<software name="lewisch" supported="no">
 		<!-- SPS (CAPS) release 639 -->
 		<description>The Carl Lewis Challenge (Euro)</description>
@@ -8455,6 +8462,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- offset flashing on main menu -->
+	<!-- key repeat is too fast on main menu -->
+	<!-- Jumps to lalaland after selecting a competition, [FDC] -->
 	<software name="champdrv" supported="no">
 		<!-- SPS (CAPS) release 1292 -->
 		<description>Champion Driver (Euro)</description>
@@ -8770,6 +8780,7 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Ocean</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049304">
@@ -8779,7 +8790,7 @@ license:CC0
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps1246)chasehqii-specialcriminalinvestigation_disk2.ipf" size="1049612" crc="950fe6b4" sha1="471e0b0535db4121f1a4c37f5b70ba2611f5d005"/>
+				<rom name="(sps1246)chasehqii-specialcriminalinvestigation_disk2.ipf" size="1049612" crc="950fe6b4" sha1="471e0b0535db4121f1a4c37f5b70ba2611f5d005"status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -10128,7 +10139,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Gets stuck at the AmigaOS blue screen [FDC] -->
+	<!-- Gets stuck at the AmigaDOS blue screen [FDC] dsksync bootblock -->
 	<!-- (Sets up a clearly invalid DMA dskpt of 0, enables MFM precomp) -->
 	<software name="cosmcbnc" supported="no">
 		<!-- SPS (CAPS) release 309 -->
@@ -11989,8 +12000,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Asks to disc swap with disc 1, which is already in [FDC] -->
-	<!-- (copy protection) -->
+	<!-- Asks to disc swap with disc 1, which is already in, [FDC] dsksync -->
+	<!-- Mouse input doesn't work (TODO: recheck) -->
 	<software name="dstrike" supported="no">
 		<!-- SPS (CAPS) release 112 -->
 		<description>Desert Strike - Return to the Gulf (Euro)</description>
@@ -12606,7 +12617,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
 	<software name="ddragon3" supported="no">
 		<!-- SPS (CAPS) release 321 -->
 		<description>Double Dragon 3 - The Rosetta Stone (Euro)</description>
@@ -12712,6 +12723,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Throws "system status abnormal" and refuses to boot, [FDC] dsksync bootblock -->
 	<software name="drgnfght" supported="no">
 		<!-- SPS (CAPS) release 1023 -->
 		<description>Dragon Fighter (Euro)</description>
@@ -12983,8 +12995,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at VDT logo [FDC] -->
-	<!-- (Checks specific value in the loaded buffer, offset by 2. Enables MFM precomp) -->
+	<!-- Hangs at VDT logo [FDC] dsksync -->
+	<!-- (Checks specific value in the loaded buffer, offset by 2) -->
+	<!-- Hangs at "Randy Linden production", tries to check [FDC] with dsksync == 0 -->
 	<software name="dlair" supported="no">
 		<!-- SPS (CAPS) release 1360 -->
 		<description>Dragon's Lair (Euro)</description>
@@ -13030,7 +13043,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up at ReadySoft logo [FDC] -->
+	<!-- locks up at ReadySoft logo [FDC] dsksync -->
+	<!-- In-game it enables [FDC] dsklen == 0 -->
 	<software name="dlair2" supported="no">
 		<!-- SPS (CAPS) release 59 -->
 		<description>Dragon's Lair II - Time Warp (Euro)</description>
@@ -13076,8 +13090,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
-	<!-- (same copy protection as dlair2) -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- In-game it enables [FDC] dsklen == 0 -->
+	<!-- (same as dlair2) -->
 	<software name="dlair3" supported="no">
 		<!-- SPS (CAPS) release 649 -->
 		<description>Dragon's Lair III: The Curse of Mordread (Euro)</description>
@@ -14629,7 +14644,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] -->
+	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] dsksync -->
+	<!-- Menu draws a pointer garbage when it's at the bottom of the screen -->
+	<!-- TODO: Understand how to change cpu controlled teams to human -->
 	<software name="hughesis" supported="no">
 		<!-- SPS (CAPS) release 1077 -->
 		<description>Emlyn Hughes International Soccer (Euro)</description>
@@ -14916,10 +14933,11 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Grandslam</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<info name="alt_title" value="Espionage - The Computer Game (Box)" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps11)espionage.ipf" size="1049612" crc="258a0c8e" sha1="604fbea189f9f2a1dc252bb9dc952f4af2f3b051"/>
+				<rom name="(sps11)espionage.ipf" size="1049612" crc="258a0c8e" sha1="604fbea189f9f2a1dc252bb9dc952f4af2f3b051" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -15106,8 +15124,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Keeps loading on a green-black screen fade transition [FDC] -->
-	<!-- TODO: verify if it's using copper DMA for transfers -->
+	<!-- Keeps loading on a green-black screen fade transition [FDC] dsksync -->
+	<!-- Gameplay GFXs are pitch skewed -->
 	<software name="exile" supported="no">
 		<!-- SPS (CAPS) release 32 -->
 		<description>Exile (Euro)</description>
@@ -16049,6 +16067,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Prompts to a CLI 2 (implicitly failing a copy protection?) -->
 	<software name="fernandz" supported="no">
 		<!-- SPS (CAPS) release 1980 -->
 		<description>Fernandez Must Die (Euro)</description>
@@ -16236,6 +16255,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Cut off title GFX -->
+	<!-- Status bar on the right is offset, cuts off timer (raster effect?) -->
+	<!-- Doesn't recognize double click presses (cfr. attract mode instructions) -->
 	<software name="fsoccer" supported="no">
 		<!-- SPS (CAPS) release 1532 -->
 		<description>Fighting Soccer (Euro)</description>
@@ -16243,6 +16265,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Activision</publisher>
+		<info name="usage" value="Requires Joystick on port 1"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049304">
 				<rom name="(sps1532)fightingsoccer.ipf" size="1049304" crc="f8825b02" sha1="89db1d0c75d817fdd46d286b682b8a12e6183eb4"/>
@@ -18271,7 +18295,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation [FDC] -->
+	<!-- Guru Meditation [FDC] dsksync bootblock -->
 	<software name="ghostbs2" supported="no">
 		<!-- SPS (CAPS) release 1029 -->
 		<description>Ghostbusters II (Euro)</description>
@@ -18782,7 +18806,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
 	<!-- (Hangs at PC=10c after failing a copy protection check, D0=0 D1=295 D2=40 D3=0) -->
 	<software name="gods" supported="no">
 		<!-- SPS (CAPS) release 666 -->
@@ -19159,7 +19183,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) [FDC] -->
+	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
 	<software name="ggiana" supported="no">
 		<!-- SPS (CAPS) release 2945 -->
 		<description>The Great Giana Sisters (Euro)</description>
@@ -20181,7 +20205,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a red and black flashing screen [FDC] -->
+	<!-- Hangs at a red and black flashing screen [FDC] dsksync -->
 	<software name="heroqst" supported="no">
 		<!-- SPS (CAPS) release 127 -->
 		<description>HeroQuest (Euro)</description>
@@ -20189,6 +20213,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Gremlin Graphics</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+		
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1010622">
 				<rom name="(sps127)heroquest.ipf" size="1010622" crc="910577eb" sha1="a40aaba4de04248e5fcc5443c818da7790ef910c"/>
@@ -20205,6 +20231,7 @@ license:CC0
 		<year>1991</year>
 		<publisher>Gremlin Graphics</publisher>
 		<info name="usage" value="Requires &quot;Hero Quest&quot; to work" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps508)heroquestreturnofthewitchlord.ipf" size="1049612" crc="7e3e0955" sha1="72817f62c3a0de5defa39e9ca3d56c2ff1de06f4"/>
@@ -20489,7 +20516,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) [FDC] -->
+	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
+	<!-- No sprites on gameplay, BGM is too fast? -->
 	<software name="hoi" supported="no">
 		<!-- SPS (CAPS) release 962 -->
 		<description>Hoi (Euro)</description>
@@ -21286,7 +21314,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Grey screen [FDC] -->
+	<!-- Grey screen [FDC] dsksync -->
+	<!-- Has slight GFX shifted text (attribute color on pilot select, lives counter) -->
+	<!-- GFX garbage strips pops in from time to time during gameplay -->
 	<software name="hybris" supported="no">
 		<!-- SPS (CAPS) release 1457 -->
 		<description>Hybris (USA, v0.95)</description>
@@ -21364,6 +21394,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Doesn't boot with debugger on, otherwise hangs anytime during the boot phase (spurious irqs or unsafe video code) -->
 	<software name="ikplus" supported="no">
 		<!-- SPS (CAPS) release 339 -->
 		<description>IK+ (Euro)</description>
@@ -21801,7 +21832,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at Indy logo on a cyan background [FDC] -->
+	<!-- Hangs at Indy logo on a cyan background [FDC] dsksync -->
+	<!-- Hangs after Lucasarts logo with stuck note (INTREQ=$aaaa) -->
 	<software name="indycrus" supported="no">
 		<!-- SPS (CAPS) release 1619 -->
 		<description>Indiana Jones and the Last Crusade (Euro, TAG)</description>
@@ -22591,8 +22623,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up on AmigaOS with DSKDAT R [FDC] -->
-	<!-- (actually a side effect of failing earlier than that) -->
+	<!-- Locks up on AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
 	<software name="itcame" supported="no">
 		<!-- SPS (CAPS) release 14 -->
 		<description>It Came from the Desert (Euro)</description>
@@ -22642,7 +22673,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
 	<software name="ivanhoe" supported="no">
 		<!-- SPS (CAPS) release 1648 -->
 		<description>Ivanhoe (Euro)</description>
@@ -23794,7 +23825,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- blue screen (keeps accessing invalid areas, [FDC]?) -->
+	<!-- blue screen, keeps accessing invalid areas, [FDC] dsksync bootblock? -->
 	<software name="kickoff" supported="no">
 		<!-- SPS (CAPS) release 189 -->
 		<description>Kick Off (Euro, v1.1)</description>
@@ -24983,7 +25014,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a rainbow colored screen [FDC] -->
+	<!-- Hangs at a rainbow colored screen [FDC] dsksync -->
+	<!-- Has serious GFX pitch corruption when scrolls during gameplay -->
 	<software name="lastbtle" supported="no">
 		<!-- SPS (CAPS) release 1044 -->
 		<description>Last Battle (Euro)</description>
@@ -25321,6 +25353,7 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Rainbow Arts</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049180">
@@ -25336,7 +25369,7 @@ license:CC0
 		<part name="flop3" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 3" />
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps1589)legendoffaerghail_disk3.ipf" size="1049180" crc="235c8d31" sha1="45b63cc92bc499405474049ba774adef0baeccb4"/>
+				<rom name="(sps1589)legendoffaerghail_disk3.ipf" size="1049180" crc="235c8d31" sha1="45b63cc92bc499405474049ba774adef0baeccb4" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -25842,7 +25875,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) -->
+	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
+	<!-- Detects expansion RAM as default -->
 	<software name="lemmings" supported="no">
 		<!-- SPS (CAPS) release 132 -->
 		<description>Lemmings (Euro)</description>
@@ -26052,7 +26086,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen [FDC] -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- masked Lethal Weapon intro text has raster issue -->
+	<!-- TODO: Needs multiple presses with no video feedback on mission select section? -->
 	<software name="lweapon" supported="no">
 		<!-- SPS (CAPS) release 814 -->
 		<description>Lethal Weapon (Euro)</description>
@@ -26255,7 +26291,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK in a1200, has major raster/alignment issues, first boss background layer has wrong colors. Doesn't boot in a500 -->
+	<!-- boot OK in a1200 and a500. a500 doesn't draw any sprite -->
+	<!-- has major raster/alignment issues (stage intro text, in-game), first boss background layer has wrong colors. -->
 	<software name="lionhart" supported="no">
 		<!-- SPS (CAPS) release 845 -->
 		<description>Lionheart (Euro)</description>
@@ -26420,8 +26457,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- crashes in AmigaOS with DSKDAT R [FDC] -->
-	<!-- (False positive, thrashing memory) -->
+	<!-- crashes in AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
 	<software name="racrally" supported="no">
 		<!-- SPS (CAPS) release 1098 -->
 		<description>Lombard RAC Rally (Euro)</description>
@@ -26663,7 +26699,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- crashes in AmigaOS with DSKDAT R -->
+	<!-- crashes in AmigaDOS with DSKDAT R, side effect of [FDC] dsksync bootblock -->
 	<software name="risinsun" supported="no">
 		<!-- SPS (CAPS) release 133 -->
 		<description>Lords of the Rising Sun (Euro)</description>
@@ -26795,6 +26831,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Guru Meditation after selecting new game [FDC] dsksync -->
+	<!-- Crashes with wrong GFX colors if player gives up a stage (recheck) -->
 	<software name="lostvik" supported="no">
 		<!-- SPS (CAPS) release 2235 -->
 		<description>The Lost Vikings (Euro)</description>
@@ -29933,6 +29971,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- black screen with eventually running irq at $ffffff, [FDC] dsksync -->
+	<!-- Hangs on CIA timer A readback while setting mode $99 -->
 	<software name="nevermnd" supported="no">
 		<!-- SPS (CAPS) release 1507 -->
 		<description>Never Mind (Euro)</description>
@@ -31071,9 +31111,10 @@ license:CC0
 		<year>1988</year>
 		<publisher>Ariolasoft</publisher>
 		<info name="alt_title" value="Ooze - Als die Geister mürbe wurden (Box)" />
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps1255)ooze.ipf" size="1049612" crc="40d448b7" sha1="66c53d7a931bae8c5436db777c19e40893fd0c9d"/>
+				<rom name="(sps1255)ooze.ipf" size="1049612" crc="40d448b7" sha1="66c53d7a931bae8c5436db777c19e40893fd0c9d" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -31459,7 +31500,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart with DSKDAT W 4000 message (white screen) -->
+	<!-- Locks up after Kickstart with DSKDAT W $4000 message (white screen) [FDC] dsksync -->
+	<!-- Uses more [FDC] DSKDAT W $4000 afterwards -->
 	<software name="outrun" supported="no">
 		<!-- SPS (CAPS) release 1161 -->
 		<description>Out Run (Euro)</description>
@@ -31502,7 +31544,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a red and black flashing screen -->
+	<!-- Hangs at a red and black flashing screen [FDC] -->
 	<software name="outrneur" supported="no">
 		<!-- SPS (CAPS) release 1597 -->
 		<description>Out Run Europa (Euro)</description>
@@ -31769,7 +31811,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- Gameplay BGM gets cut off [Paula] -->
 	<software name="pang" supported="no">
 		<!-- SPS (CAPS) release 929 -->
 		<description>Pang (Euro)</description>
@@ -31784,7 +31827,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up on AmigaOS -->
+	<!-- Locks up on AmigaDOS, [FDC] uses adkcon=$1100 -->
 	<software name="panzakb" supported="no">
 		<!-- SPS (CAPS) release 2400 -->
 		<description>Panza Kick Boxing (Euro)</description>
@@ -31841,6 +31884,10 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Hangs at Kickstart white screen, [FDC] dsksync -->
+	<!-- Hangs on a1200 on boot -->
+	<!-- Expects to read an autoconfig board at $200000, otherwise it straight off refuses to run with a blue screen (should be possible to run with standard  512k RAM?) -->
+	<!-- Bad colors on intro and gameplay -->
 	<software name="paradr90" supported="no">
 		<!-- SPS (CAPS) release 692 -->
 		<description>Paradroid 90 (Euro)</description>
@@ -31925,7 +31972,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="parasol" supported="no">
+	<!-- Missing text status on top, known to do sprite rasters with [Copper] -->
+	<software name="parasol" supported="partial">
 		<!-- SPS (CAPS) release 139 -->
 		<description>Parasol Stars - The Story of Rainbow Islands II (Euro)</description>
 		<!-- retail, standalone -->
@@ -32774,8 +32822,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Crashes on title screen -->
-	<software name="pmanger" supported="no">
+	<!-- Has slight glitches during gameplay (empty box on startup, sprite overlap drawing, garbage stripe GFX from time to time) -->
+	<software name="pmanger" supported="partial">
 		<!-- SPS (CAPS) release 171 -->
 		<description>Player Manager (Euro)</description>
 		<!-- retail, standalone -->
@@ -32803,8 +32851,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Crashes on title screen -->
-	<software name="pmangeri" cloneof="pmanger" supported="no">
+	<!-- Has slight glitches during gameplay (empty box on startup, sprite overlap drawing, garbage stripe GFX from time to time) -->
+	<software name="pmangeri" cloneof="pmanger" supported="partial">
 		<!-- SPS (CAPS) release 2572 -->
 		<description>Player Manager (Ita)</description>
 		<!-- retail, standalone -->
@@ -33512,9 +33560,10 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>MicroProse</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps712)presidentismissing,the.ipf" size="1049612" crc="03a617da" sha1="d5d5028f8b834567ee9b5a55264a9b860f00b6f8"/>
+				<rom name="(sps712)presidentismissing,the.ipf" size="1049612" crc="03a617da" sha1="d5d5028f8b834567ee9b5a55264a9b860f00b6f8" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -33743,7 +33792,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="profezia" supported="no">
+	<!-- Has slight GFX color issue when doors opens before starting a game -->
+	<software name="profezia" supported="partial">
 		<!-- SPS (CAPS) release 2375 -->
 		<description>Profezia (Ita)</description>
 		<!-- retail, standalone -->
@@ -35239,7 +35289,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up on AmigaDOS with "Now Loading" msg -->
+	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] dsksync -->
 	<software name="rete" cloneof="hughesis" supported="no">
 		<!-- SPS (CAPS) release 2751 -->
 		<description>Retee! (Ita)</description>
@@ -36447,6 +36497,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Vertical scrolling b&w stripes after Kickstart, [FDC] dsksync -->
 	<software name="runninmn" supported="no">
 		<!-- SPS (CAPS) release 382 -->
 		<description>The Running Man (Euro)</description>
@@ -36983,6 +37034,10 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- black screen, [FDC] dsksync -->
+	<!-- Does not boot on a500, accesses autoconfig RAM banks at $300000 and $c00000 -->
+	<!-- very offset title GFXs -->
+	<!-- Offset background layer(s) during gameplay -->
 	<software name="seekdest" supported="no">
 		<!-- SPS (CAPS) release 252 -->
 		<description>Seek and Destroy (Euro)</description>
@@ -37270,7 +37325,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen with continous floppy access after AmigaOS loading -->
+	<!-- black screen, [FDC] dsksync -->
+	<!-- Uses [FDC] dskdatr at end of loading cycles, no noticeable effect? -->
 	<software name="swos9697" supported="no">
 		<!-- SPS (CAPS) release 842 -->
 		<description>Sensible World of Soccer 96-97 (Euro)</description>
@@ -37856,7 +37912,7 @@ license:CC0
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disquette 0" />
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps2669)shortgrey,the_disquette0.ipf" size="1049180" crc="75229841" sha1="5ebf2dd7c0b5c2cd7a3b5cf32bfe75aced00490d"/>
+				<rom name="(sps2669)shortgrey,the_disquette0.ipf" size="1049180" crc="75229841" sha1="5ebf2dd7c0b5c2cd7a3b5cf32bfe75aced00490d" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
@@ -37868,19 +37924,19 @@ license:CC0
 		<part name="flop3" interface="floppy_3_5">
 			<feature name="part_id" value="Disquette 2" />
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps2669)shortgrey,the_disquette2.ipf" size="1049180" crc="5d98644d" sha1="e71d1fd635af5d8676f23d94a9e843880efe579c"/>
+				<rom name="(sps2669)shortgrey,the_disquette2.ipf" size="1049180" crc="5d98644d" sha1="e71d1fd635af5d8676f23d94a9e843880efe579c" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop4" interface="floppy_3_5">
 			<feature name="part_id" value="Disquette 3" />
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps2669)shortgrey,the_disquette3.ipf" size="1049180" crc="8554cdcc" sha1="d8cf8560e3e5ffbad7f18f6d6754ead0b9171e7b"/>
+				<rom name="(sps2669)shortgrey,the_disquette3.ipf" size="1049180" crc="8554cdcc" sha1="d8cf8560e3e5ffbad7f18f6d6754ead0b9171e7b" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop5" interface="floppy_3_5">
 			<feature name="part_id" value="Disquette 4" />
 			<dataarea name="flop" size="1049180">
-				<rom name="(sps2669)shortgrey,the_disquette4.ipf" size="1049180" crc="ba114b74" sha1="1fc3ff80b3b61a191337fb30e03c1cebae032b31"/>
+				<rom name="(sps2669)shortgrey,the_disquette4.ipf" size="1049180" crc="ba114b74" sha1="1fc3ff80b3b61a191337fb30e03c1cebae032b31" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -39147,7 +39203,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after title screen by pressing fire on joystick -->
+	<!-- Locks up after title screen by pressing fire on joystick [FDC] dsksync -->
+	<!-- Player GFX sprite is black filled -->
 	<software name="slipstrm" supported="no">
 		<!-- SPS (CAPS) release 1629 -->
 		<description>Slip Stream (Euro)</description>
@@ -39288,7 +39345,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- Hangs on title screen -->
 	<software name="soccerpb" supported="no">
 		<!-- SPS (CAPS) release 2522 -->
 		<description>Soccer Pinball (Euro)</description>
@@ -39499,7 +39557,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up at ReadySoft logo -->
+	<!-- locks up at ReadySoft logo [FDC] dsksync -->
 	<software name="spaceace" supported="no">
 		<!-- SPS (CAPS) release 85 -->
 		<description>Space Ace (Euro)</description>
@@ -39533,7 +39591,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- In-game it enables [FDC] dsklen == $0 and hangs (same as dlair2) -->
 	<software name="spaceac2" supported="no">
 		<!-- SPS (CAPS) release 931 -->
 		<description>Space Ace II - Borf's Revenge (Euro)</description>
@@ -40951,10 +41010,11 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Logotron</publisher>
+		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Boot Disk" />
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps1612)starray_bootdisk.ipf" size="1049612" crc="a2c003ee" sha1="a217fb846733230ea739616065aa1f9c98bb39b1"/>
+				<rom name="(sps1612)starray_bootdisk.ipf" size="1049612" crc="a2c003ee" sha1="a217fb846733230ea739616065aa1f9c98bb39b1" status="baddump"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
@@ -41369,7 +41429,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs on a cyan background (cfr. indycrus) -->
+	<!-- Hangs on a cyan background [FDC] dsksync -->
 	<software name="strider" supported="no">
 		<!-- SPS (CAPS) release 1224 -->
 		<description>Strider (Euro)</description>
@@ -41738,7 +41798,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation (yellow screen on a500) -->
+	<!-- Guru Meditation (yellow screen on a500) [FDC] -->
 	<software name="supaplex" supported="no">
 		<!-- SPS (CAPS) release 1902 -->
 		<description>Supaplex (Euro)</description>
@@ -41753,7 +41813,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
 	<software name="supercar" supported="no">
 		<!-- SPS (CAPS) release 1527 -->
 		<description>Super Cars (Euro)</description>
@@ -41789,7 +41849,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) -->
+	<!-- Locks up after Kickstart (white screen) [FDC] dsksync -->
 	<software name="supercr2" supported="no">
 		<!-- SPS (CAPS) release 224 -->
 		<description>Super Cars II (Euro)</description>
@@ -41797,6 +41857,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Gremlin Graphics</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="996938">
@@ -41867,7 +41929,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
 	<software name="smgp" supported="no">
 		<!-- SPS (CAPS) release 1422 -->
 		<description>Super Monaco GP (Euro)</description>
@@ -42212,7 +42274,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- Has serious GFX pitch issues on gameplay, no sprites with a500p -->
 	<software name="suprfrog" supported="no">
 		<!-- SPS (CAPS) release 35 -->
 		<description>Superfrog (Euro)</description>
@@ -42467,7 +42530,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- Hangs at title screen with no BGM -->
 	<software name="swordsod" supported="no">
 		<!-- SPS (CAPS) release 1103 -->
 		<description>Sword of Sodan (Euro)</description>
@@ -42495,7 +42559,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- doesn't recognize data disk when asked to disc swap (compiled with different Workbench?) -->
+	<!-- doesn't recognize data disk when asked to disc swap [FDC] -->
 	<software name="swrdtwil" supported="no">
 		<!-- SPS (CAPS) release 972 -->
 		<description>Swords of Twilight (Euro)</description>
@@ -42777,7 +42841,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Black screen after AmigaOS -->
+	<!-- Black screen after AmigaDOS, [FDC] dsksync -->
+	<!-- Hangs at Targhan title screen [FDC] -->
 	<software name="targhan" supported="no">
 		<!-- SPS (CAPS) release 1859 -->
 		<description>Targhan (Euro)</description>
@@ -44764,7 +44829,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- TODO: verify after copy protection manual -->
 	<software name="tourgolf" supported="no">
 		<!-- SPS (CAPS) release 1278 -->
 		<description>Tournament Golf (Euro)</description>
@@ -44772,6 +44838,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Elite</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1 - Program Disk" />
 			<dataarea name="flop" size="1009544">
@@ -44884,7 +44952,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen after AmigaOS -->
+	<!-- black screen after AmigaDOS [FDC] dsksync -->
+	<!-- Mouse cursor is uncontrollable -->
 	<software name="transarc" supported="no">
 		<!-- SPS (CAPS) release 744 -->
 		<description>Transarctica (Euro)</description>
@@ -46127,7 +46196,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen after AmigaOS loading -->
+	<!-- black screen after AmigaDOS loading [FDC] -->
 	<software name="vengexcl" supported="no">
 		<!-- SPS (CAPS) release 2499 -->
 		<description>Vengeance of Excalibur (Euro)</description>
@@ -46331,7 +46400,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up at AmigaOS -->
+	<!-- Locks up at AmigaDOS [FDC] dsksync -->
+	<!-- Screen is too dim (tested on a500p) -->
+	<!-- Doesn't accept joy/key inputs on ranking screen (PC=18dcc) -->
 	<software name="vixen" supported="no">
 		<!-- SPS (CAPS) release 993 -->
 		<description>Vixen (Euro)</description>
@@ -46360,8 +46431,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- hangs at Kickstart white screen, [FDC] wants dsksync to not write on RAM after bootblock load -->
-	<!-- Runs too fast, and button isn't recognized during gameplay -->
+	<!-- hangs at Kickstart white screen, [FDC] dsksync -->
+	<!-- Runs too fast -->
 	<software name="viz" supported="no">
 		<!-- SPS (CAPS) release 3030 -->
 		<description>Viz - The Soft Floppy One (Euro)</description>
@@ -46527,7 +46598,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
+	<!-- Hangs at Vyrus title screen, [FDC] -->
 	<software name="vyrus" supported="no">
 		<!-- SPS (CAPS) release 1069 -->
 		<description>Vyrus (Euro)</description>
@@ -46849,7 +46921,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Incorrectly drawn copy protection screen (repeats numpad at bottom) -->
+	<!-- Incorrectly GFX drawn copy protection screen (repeats numpad at bottom) -->
 	<!-- TODO: verify afterwards -->
 	<software name="waxworks" supported="no">
 		<!-- SPS (CAPS) release 2274 -->
@@ -47362,7 +47434,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Black screen, continous access to floppy -->
+	<!-- Black screen, continous access to [FDC] floppy -->
 	<software name="wildstrt" supported="no">
 		<!-- SPS (CAPS) release 1678 -->
 		<description>Wild Streets (Euro)</description>
@@ -47565,7 +47637,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] dsksync -->
 	<software name="wingfury" supported="no">
 		<!-- SPS (CAPS) release 599 -->
 		<description>Wings of Fury (Euro)</description>
@@ -47888,7 +47960,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Shows Core Design logo then hangs with red backdrop -->
+	<!-- Shows Core Design logo then hangs with red backdrop [FDC] dsksync -->
+	<!-- Has GFX stripe glitch when player dies -->
 	<software name="wolfchld" supported="no">
 		<!-- SPS (CAPS) release 411 -->
 		<description>Wolfchild (Euro)</description>
@@ -48142,6 +48215,7 @@ license:CC0
 		<year>1995</year>
 		<publisher>Ocean</publisher>
 		<info name="usage" value="Sports manual copy-protection (Worms codes)" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049180">
@@ -48391,7 +48465,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up at Xenon logo -->
+	<!-- Locks up at Xenon logo [FDC] dsksync -->
 	<software name="xenon" supported="no">
 		<!-- SPS (CAPS) release 399 -->
 		<description>Xenon (Euro)</description>
@@ -48420,8 +48494,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
-	<software name="xenon2" supported="no">
+	<!-- boot OK -->
+	<software name="xenon2" supported="yes">
 		<!-- SPS (CAPS) release 297 -->
 		<description>Xenon 2 - Megablast (Euro)</description>
 		<!-- retail, standalone -->
@@ -48434,6 +48508,7 @@ license:CC0
 				<rom name="(sps297)xenon2_disk1.ipf" size="1049304" crc="41441b95" sha1="72cf591760e014b53e946bf9603ae71b3d21d0d8"/>
 			</dataarea>
 		</part>
+		<!-- "Game Disk" -->
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1049612">
@@ -48851,7 +48926,7 @@ license:CC0
 		<info name="additional" value="Mastered with virus" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1055523">
-				<rom name="(sps2768)zombi.ipf" size="1055523" crc="97261026" sha1="922fdade85ab40968c3c4d028ab841151573d572"/>
+				<rom name="(sps2768)zombi.ipf" size="1055523" crc="97261026" sha1="922fdade85ab40968c3c4d028ab841151573d572" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -4447,6 +4447,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="batashes" supported="no">
 		<!-- SPS (CAPS) release 2526 -->
 		<description>Battle for the Ashes (Euro)</description>
@@ -6688,6 +6689,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="brianlar" supported="no">
 		<!-- SPS (CAPS) release 1225 -->
 		<description>Brian Lara's Cricket (Euro)</description>
@@ -7973,7 +7975,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen after loading arcade mode (spurious irq?) -->
+	<!-- black screen after loading arcade mode [FDC] copy protection (enables 68k trace mode) -->
 	<software name="lewisch" supported="no">
 		<!-- SPS (CAPS) release 639 -->
 		<description>The Carl Lewis Challenge (Euro)</description>
@@ -12129,6 +12131,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="dicktr" supported="no">
 		<!-- SPS (CAPS) release 3083 -->
 		<description>Dick Tracy (Euro, Titus)</description>
@@ -18992,6 +18995,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="goochwcc" supported="no">
 		<!-- SPS (CAPS) release 1248 -->
 		<description>Graham Gooch World Class Cricket (Euro)</description>
@@ -26065,6 +26069,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="lxcess">
 		<!-- SPS (CAPS) release 3058 -->
 		<description>Lethal Xcess (Euro)</description>
@@ -26742,7 +26747,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Garbage on language screen select then black screen -->
+	<!-- Garbage on language screen select then black screen [FDC] copy protection check at PC=243AC (enables 68k trace mode) -->
+	<!-- Ocean logo has serious pitch issues -->
+	<!-- [Paula] BGM channels often doesn't playback -->
 	<software name="lostpatr" supported="no">
 		<!-- SPS (CAPS) release 773 -->
 		<description>Lost Patrol (Euro)</description>
@@ -29143,6 +29150,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="monstbus">
 		<!-- SPS (CAPS) release 3032 -->
 		<description>Monster Business (Euro)</description>
@@ -30660,7 +30668,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Fatal errors on mount without any meaningful message (!?) -->
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="odyssey" supported="no">
 		<!-- SPS (CAPS) release 2854 -->
 		<description>Odyssey (Euro, aud304312c 19970206)</description>
@@ -30682,7 +30690,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Fatal errors on mount without any meaningful message (!?) -->
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="odysseya" cloneof="odyssey" supported="no">
 		<!-- SPS (CAPS) release 195 -->
 		<description>Odyssey (Euro, aud304312b 19960201)</description>
@@ -30704,7 +30712,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Fatal errors on mount without any meaningful message (!?) -->
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="odysseyb" cloneof="odyssey" supported="no">
 		<!-- SPS (CAPS) release 897 -->
 		<description>Odyssey (Euro, aud304312a 19950523)</description>
@@ -42217,6 +42225,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Fatal errors in ipf_decode::generate_timings type 4 -->
 	<software name="tennisch" supported="no">
 		<!-- SPS (CAPS) release 1153 -->
 		<description>Super Tennis Champs (Euro)</description>
@@ -48649,6 +48658,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- fatalerrors when trying to mount "Incompatible image format or corrupted data" -->
 	<software name="xr35b" cloneof="xr35" supported="no">
 		<!-- invalid - this was marked as SPS but these checksums don't appear in the list -->
 		<!-- SPS (CAPS) release 34 -->

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -4153,6 +4153,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Sport wrong pitch on Workbench loading for a500p -->
 	<software name="bargames" supported="no">
 		<!-- SPS (CAPS) release 2947 -->
 		<description>Bar Games (Euro)</description>
@@ -4160,6 +4161,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Accolade</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">
@@ -4249,12 +4252,14 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="basejump" supported="no">
+	<software name="basejump" supported="yes">
 		<!-- SPS (CAPS) release 1799 -->
 		<description>Base Jumpers (Euro)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1995</year>
+		<!-- Omake: Will give two hidden messages if player press b2 during gameplay -->
+
 		<publisher>Grandslam</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
@@ -4284,6 +4289,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Black screen, [CIAB] fails on comparing a TOD 9 > 0x115 at PC=de4 -->
+	<!-- BGMs and SFXs whistles [Paula] -->
 	<software name="batman1" cloneof="batman" supported="no">
 		<!-- SPS (CAPS) release 19 -->
 		<description>Batman (Euro, Single Disk)</description>
@@ -22584,7 +22591,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up on AmigaOS with DSKDAT R -->
+	<!-- Locks up on AmigaOS with DSKDAT R [FDC] -->
+	<!-- (actually a side effect of failing earlier than that) -->
 	<software name="itcame" supported="no">
 		<!-- SPS (CAPS) release 14 -->
 		<description>It Came from the Desert (Euro)</description>
@@ -26412,7 +26420,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- crashes in AmigaOS with DSKDAT R -->
+	<!-- crashes in AmigaOS with DSKDAT R [FDC] -->
+	<!-- (False positive, thrashing memory) -->
 	<software name="racrally" supported="no">
 		<!-- SPS (CAPS) release 1098 -->
 		<description>Lombard RAC Rally (Euro)</description>
@@ -46351,6 +46360,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- hangs at Kickstart white screen, [FDC] wants dsksync to not write on RAM after bootblock load -->
+	<!-- Runs too fast, and button isn't recognized during gameplay -->
 	<software name="viz" supported="no">
 		<!-- SPS (CAPS) release 3030 -->
 		<description>Viz - The Soft Floppy One (Euro)</description>

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -2138,6 +2138,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Gameplay screen blacks out randomly -->
 	<!-- ATK test: OK -->
 	<software name="amigakar" supported="no">
 		<!-- SPS (CAPS) release 45 -->
@@ -4798,7 +4799,6 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Most gameplay SFXs gets cut off [Paula] -->
 	<!-- ATK test: failed -->
 	<software name="battlesq" supported="partial">
 		<!-- SPS (CAPS) release 941 -->
@@ -4994,7 +4994,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- intro BGM hiccups [Paula] -->
+	<!-- boots in a500p only, [FDC]? -->
 	<!-- Has transparent stripes all over the place during intro [copper] -->
 	<!-- ATK test: C:0 H:U Bad -->
 	<software name="bchvolly" supported="partial">
@@ -28116,7 +28116,6 @@ license:CC0
 
 	<!-- Garbage on language screen select then black screen [FDC] copy protection check at PC=243AC (enables 68k trace mode) -->
 	<!-- Ocean logo has serious pitch issues -->
-	<!-- [Paula] BGM channels often doesn't playback -->
 	<!-- ATK test: C:0 H:U Bad -->
 	<software name="lostpatr" supported="no">
 		<!-- SPS (CAPS) release 773 -->
@@ -33448,7 +33447,6 @@ license:CC0
 	</software>
 
 	<!-- black screen [FDC] dsksync -->
-	<!-- Gameplay BGM gets cut off [Paula] -->
 	<!-- ATK test: failed -->
 	<software name="pang" supported="no">
 		<!-- SPS (CAPS) release 929 -->
@@ -49531,8 +49529,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- AI does not work on a500p (btanb?) -->
 	<!-- ATK test: OK -->
-	<software name="waylildr" supported="no">
+	<software name="waylildr" supported="partial">
 		<!-- SPS (CAPS) release 2096 -->
 		<description>The Way of the Little Dragon (Euro)</description>
 		<!-- retail, standalone -->
@@ -49964,6 +49963,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1991</year>
 		<publisher>Ocean</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2654)wildwheels.ipf" size="1049180" crc="274020f5" sha1="9a2fdada1af9b804ca4f0bc8499a023fb04259c1"/>
@@ -50725,6 +50726,7 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1988</year>
 		<publisher>Electronic Arts</publisher>
+		<info name="usage" value="Sports manual copy-protection (Course Names)"/>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049612">
 				<rom name="(sps752)worldtourgolf.ipf" size="1049612" crc="f48fabed" sha1="3b4c4a5e1e7be30521fa00cbc7a4ed7564ae8c85"/>
@@ -50900,8 +50902,9 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- boot OK -->
 	<!-- ATK test: OK -->
-	<software name="xit" supported="no">
+	<software name="xit" supported="yes">
 		<!-- SPS (CAPS) release 1585 -->
 		<description>X-It (Euro)</description>
 		<!-- retail, standalone -->

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -11,14 +11,14 @@ license:CC0
 
     Most images for the initial import are from SPS / CAPS collections
 
-	ATK test notes refers to Amiga Test Kit v1.18:
-	https://github.com/keirf/Amiga-Stuff
-	Specifically the Floppy Drive Test Read Item, the test note refers 
-	to the flop1 been tested from DF1 up with a -bench 90:
-	- OK means that all tracks have been reported good;
-	- a generic "failed" means that most if not all tracks reports as bad (test didn't complete);
-	- C refers to the Track number(s), H is the (U)pper, (L)ower head (if not omitted),
-	  "1 Sector Bad" reports as one sector being bad, otherwise "Bad" [Track];
+    ATK test notes refers to Amiga Test Kit v1.18:
+    https://github.com/keirf/Amiga-Stuff
+    Specifically the Floppy Drive Test Read Item, the test note refers
+    to the flop1 been tested from DF1 up with a -bench 90:
+    - OK means that all tracks have been reported good;
+    - a generic "failed" means that most if not all tracks reports as bad (test didn't complete);
+    - C refers to the Track number(s), H is the (U)pper, (L)ower head (if not omitted),
+      "1 Sector Bad" reports as one sector being bad, otherwise "Bad" [Track];
 
     todo (SPS):
     - see if it's possible to better verify these images, the SPS dat only lists the (highly insecure) CRC32s so we're relying on trust here
@@ -21271,7 +21271,7 @@ license:CC0
 		<year>1991</year>
 		<publisher>Gremlin Graphics</publisher>
 		<info name="usage" value="Sports manual copy-protection"/>
-		
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1010622">
 				<rom name="(sps127)heroquest.ipf" size="1010622" crc="910577eb" sha1="a40aaba4de04248e5fcc5443c818da7790ef910c"/>

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -8790,7 +8790,7 @@ license:CC0
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 2" />
 			<dataarea name="flop" size="1049612">
-				<rom name="(sps1246)chasehqii-specialcriminalinvestigation_disk2.ipf" size="1049612" crc="950fe6b4" sha1="471e0b0535db4121f1a4c37f5b70ba2611f5d005"status="baddump" />
+				<rom name="(sps1246)chasehqii-specialcriminalinvestigation_disk2.ipf" size="1049612" crc="950fe6b4" sha1="471e0b0535db4121f1a4c37f5b70ba2611f5d005" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>

--- a/hash/amigaocs_flop.xml
+++ b/hash/amigaocs_flop.xml
@@ -459,7 +459,8 @@ license:CC0
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1992</year>
-		<publisher>Ocean</publisher>    <!-- Actually published by Maxis outside Europe -->
+		<!-- Actually published by Maxis outside Europe -->
+		<publisher>Ocean</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1 (HiRes)" />
 			<dataarea name="flop" size="1049612">
@@ -1437,6 +1438,8 @@ license:CC0
 	</software>
 
 	<!-- Throws "amiga_fdc_device::live_run - cur_live.bit_counter > 8" after credits display -->
+	<!-- Motor keeps spinning badly on disk swap screen(s) (verify) -->
+	<!-- No player sprite, red dots incorrectly drawn on several elements during gameplay (namely alien enemies) -->
 	<software name="abreed" supported="no">
 		<!-- SPS (CAPS) release 998 -->
 		<description>Alien Breed (Euro)</description>
@@ -1760,8 +1763,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Black screen after pressing fire on title screen -->
-	<software name="altbeast" supported="no">
+	<!-- Seldomly throw Guru Meditation (TODO: btanb? verify) -->
+	<software name="altbeast" supported="partial">
 		<!-- SPS (CAPS) release 819 -->
 		<description>Altered Beast (Euro)</description>
 		<!-- retail, standalone -->
@@ -1827,8 +1830,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK in English, crashes after copy-protection otherwise -->
-	<software name="spidermn" supported="no">
+	<!-- boot OK (tested English and Italian) -->
+	<software name="spidermn" supported="yes">
 		<!-- SPS (CAPS) release 1006 -->
 		<description>The Amazing Spider-Man (Euro)</description>
 		<!-- retail, standalone -->
@@ -2508,14 +2511,15 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
-	<software name="archipel" supported="no">
+	<software name="archipel" supported="yes">
 		<!-- SPS (CAPS) release 627 -->
 		<description>Archipelagos (Euro)</description>
 		<!-- retail, standalone -->
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Logotron</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="376986">
 				<rom name="(sps627)archipelagos.ipf" size="376986" crc="5bb45d86" sha1="8f044750f718ba200ae73a5de3756cbfabe4520a"/>
@@ -2812,7 +2816,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, can randomly lock up during gameplay, has continous whistle after every sample -->
+	<!-- boot OK, verify clicking at the end of samples playbacks -->
+	<!-- can randomly lock up during gameplay -->
 	<software name="arnie" supported="no">
 		<!-- SPS (CAPS) release 1007 -->
 		<description>Arnie (Euro)</description>
@@ -2827,7 +2832,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen with continous floppy access -->
+	<!-- black screen with continous floppy access [FDC] -->
+	<!-- (keeps jumping to empty area at PC=4d000 after failing a copy protection check at PC=70032, D0=0 D1=5d5 D2=67 D3=0) -->
 	<software name="arnie2" supported="no">
 		<!-- SPS (CAPS) release 1924 -->
 		<description>Arnie 2 (Euro)</description>
@@ -2932,8 +2938,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, first chunk of BGM keeps repeating -->
-	<software name="asparmgp" cloneof="gpmaster" supported="no">
+	<!-- boot OK -->
+	<software name="asparmgp" cloneof="gpmaster" supported="yes">
 		<!-- SPS (CAPS) release 1241 -->
 		<description>Aspar Master Grand Prix (Euro, Les Fous du Volant)</description>
 		<!-- retail, standalone -->
@@ -3937,7 +3943,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Gets stuck at "The game is loading" -->
+	<!-- Guru Meditation during "The game is loading" phase -->
 	<software name="barbpal" supported="no">
 		<!-- SPS (CAPS) release 1784 -->
 		<description>Barbarian (Euro, v16.3.88, Palace)</description>
@@ -3994,7 +4000,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- blue screen -->
+	<!-- Prompts to a CLI 2 (implicitly failing a copy protection?) -->
 	<software name="barb2pal" supported="no">
 		<!-- SPS (CAPS) release 2264 -->
 		<description>Barbarian II (Euro, Palace, v4.8.89)</description>
@@ -4017,7 +4023,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="barb2paln4" cloneof="barb2pal" supported="no">
+	<!-- boot OK -->
+	<software name="barb2paln4" cloneof="barb2pal" supported="yes">
 		<!-- SPS (CAPS) release 1828 -->
 		<description>Barbarian II (Euro, Palace, NRJ Vol. 4)</description>
 		<!-- retail, standalone -->
@@ -4536,8 +4543,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) -->
-	<software name="battlesq" supported="no">
+	<!-- Most gameplay SFXs gets cut off [Paula] -->
+	<software name="battlesq" supported="partial">
 		<!-- SPS (CAPS) release 941 -->
 		<description>Battle Squadron (Euro)</description>
 		<!-- retail, standalone -->
@@ -4720,8 +4727,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- blue screen -->
-	<software name="bchvolly" supported="no">
+	<!-- BGMs/SFXs channels whistles [Paula] -->
+	<!-- Has transparent stripes all over the place during intro [copper] -->
+	<software name="bchvolly" supported="partial">
 		<!-- SPS (CAPS) release 1249 -->
 		<description>Beach Volley (Euro)</description>
 		<!-- retail, standalone -->
@@ -5261,7 +5269,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- crashes in AmigaOS with DSKDAT R -->
+	<!-- crashes in AmigaOS with DSKDAT R [FDC] -->
 	<software name="bhcop" supported="no">
 		<!-- SPS (CAPS) release 179 -->
 		<description>Beverly Hills Cop (Euro)</description>
@@ -7017,8 +7025,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, samples may keep repeating -->
-	<software name="budokan" supported="partial">
+	<!-- boot OK -->
+	<software name="budokan" supported="yes">
 		<!-- SPS (CAPS) release 1215 -->
 		<description>Budokan - The Martial Spirit (Euro)</description>
 		<!-- retail, standalone -->
@@ -7348,7 +7356,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
+	<!-- (Hangs at PC=21050 after failing a copy protection check, D0=0 D1=16 D2=12 D3=0) -->
 	<software name="cadaver" supported="no">
 		<!-- SPS (CAPS) release 103 -->
 		<description>Cadaver (Euro, v0.01)</description>
@@ -7370,6 +7379,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- black screen [FDC] -->
 	<software name="cadavera" cloneof="cadaver" supported="no">
 		<!-- SPS (CAPS) release 2876 -->
 		<description>Cadaver (Euro, v1.03, The Bitmap Brothers Volume 1)</description>
@@ -7581,7 +7591,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a rainbow colored loading screen -->
+	<!-- Hangs at a rainbow colored loading screen [FDC] -->
+	<!-- (checks for string "SOS6" at PC=500be, which is offset because precompensation is enabled) -->
+	<!-- (eventually disables precompensation when starting a level, tries to sync with MFM instead of GCR) -->
 	<software name="cfodder" supported="no">
 		<!-- SPS (CAPS) release 860 -->
 		<description>Cannon Fodder (Euro)</description>
@@ -7862,7 +7874,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a green-black-green striped screen -->
+	<!-- Hangs during gameplay when actually landing on a planet (sometimes it throws DSKDAT access) -->
 	<software name="captive" supported="no">
 		<!-- SPS (CAPS) release 2164 -->
 		<description>Captive (Euro, v1.2)</description>
@@ -7947,6 +7959,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- no BGM, black screen after loading arcade mode (spurious irq?) -->
 	<software name="lewisch" supported="no">
 		<!-- SPS (CAPS) release 639 -->
 		<description>The Carl Lewis Challenge (Euro)</description>
@@ -10108,7 +10121,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Gets stuck at the AmigaOS blue screen -->
+	<!-- Gets stuck at the AmigaOS blue screen [FDC] -->
+	<!-- (Sets up a clearly invalid DMA dskpt of 0, enables MFM precomp) -->
 	<software name="cosmcbnc" supported="no">
 		<!-- SPS (CAPS) release 309 -->
 		<description>Cosmic Bouncer (Euro)</description>
@@ -11671,7 +11685,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a rainbow colored screen -->
+	<!-- Hangs at a rainbow colored screen [FDC] -->
+	<!-- (fails a CRC check with data uploaded at 0x800, TODO: verify if it's using copper DMA) -->
 	<software name="deep" supported="no">
 		<!-- SPS (CAPS) release 1218 -->
 		<description>The Deep (Euro)</description>
@@ -11728,7 +11743,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- "Software error", clicking on cancel causes Guru Meditation -->
+	<!-- "Program failed", clicking on reboot causes Guru Meditation -->
 	<software name="defcrown" supported="no">
 		<!-- SPS (CAPS) release 317 -->
 		<description>Defender of the Crown (Euro)</description>
@@ -11967,7 +11982,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Asks to disc swap with disc 1 (which is already in) -->
+	<!-- Asks to disc swap with disc 1, which is already in [FDC] -->
+	<!-- (copy protection) -->
 	<software name="dstrike" supported="no">
 		<!-- SPS (CAPS) release 112 -->
 		<description>Desert Strike - Return to the Gulf (Euro)</description>
@@ -12365,7 +12381,7 @@ license:CC0
 		<publisher>Elite</publisher>
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1016901">
-				<rom name="dogsofwar.ipf" size="1016901" crc="e738511f" sha1="5581ab144292d0e1283beaa6188addd111bb4099"/>
+				<rom name="dogsofwar.ipf" size="1016901" crc="e738511f" sha1="5581ab144292d0e1283beaa6188addd111bb4099" status="baddump"/>
 			</dataarea>
 		</part>
 	</software>
@@ -12507,8 +12523,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Black screen after pressing fire on title -->
-	<software name="ddragon" supported="no">
+	<!-- boot OK -->
+	<software name="ddragon" supported="yes">
 		<!-- SPS (CAPS) release 2438 -->
 		<description>Double Dragon (Euro, v2.16)</description>
 		<!-- retail, standalone -->
@@ -12536,7 +12552,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation -->
+	<!-- Guru Meditation [FDC] -->
+	<!-- (Checks data once with adkcon=0x3db0) -->
 	<software name="ddragon2" supported="no">
 		<!-- SPS (CAPS) release 768 -->
 		<description>Double Dragon II (Euro, v4.01ECS)</description>
@@ -12582,7 +12599,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
 	<software name="ddragon3" supported="no">
 		<!-- SPS (CAPS) release 321 -->
 		<description>Double Dragon 3 - The Rosetta Stone (Euro)</description>
@@ -12879,6 +12896,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, starting a level has background with GFX pitch issue, repeating sample on every correct move -->
+	<!-- Update: hangs when loading a game, regression? -->
 	<software name="dlairsc" supported="partial">
 		<!-- SPS (CAPS) release 980 -->
 		<description>Dragon's Lair: Escape from Singe's Castle (Euro)</description>
@@ -12958,7 +12976,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at VDT logo -->
+	<!-- Hangs at VDT logo [FDC] -->
+	<!-- (Checks specific value in the loaded buffer, offset by 2. Enables MFM precomp) -->
 	<software name="dlair" supported="no">
 		<!-- SPS (CAPS) release 1360 -->
 		<description>Dragon's Lair (Euro)</description>
@@ -13004,7 +13023,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up at ReadySoft logo -->
+	<!-- locks up at ReadySoft logo [FDC] -->
 	<software name="dlair2" supported="no">
 		<!-- SPS (CAPS) release 59 -->
 		<description>Dragon's Lair II - Time Warp (Euro)</description>
@@ -13050,7 +13069,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
+	<!-- (same copy protection as dlair2) -->
 	<software name="dlair3" supported="no">
 		<!-- SPS (CAPS) release 649 -->
 		<description>Dragon's Lair III: The Curse of Mordread (Euro)</description>
@@ -14248,7 +14268,9 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, voice speech keeps repeating -->
+	<!-- boot OK -->
+	<!-- sports garbage pitch on intro with a500p, works with a500 only -->
+	<!-- Loading doesn't work on a1200 machine -->
 	<software name="elvira" supported="partial">
 		<!-- SPS (CAPS) release 267 -->
 		<description>Elvira - Mistress of the Dark (Euro)</description>
@@ -14600,7 +14622,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up on AmigaDOS with "Now Loading" msg -->
+	<!-- locks up on AmigaDOS with "Now Loading" msg [FDC] -->
 	<software name="hughesis" supported="no">
 		<!-- SPS (CAPS) release 1077 -->
 		<description>Emlyn Hughes International Soccer (Euro)</description>
@@ -14622,6 +14644,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1989</year>
 		<publisher>Tomahawk</publisher>
+		<info name="usage" value="Sports manual copy-protection"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1049180">
 				<rom name="(sps2693)emmanuelle.ipf" size="1049180" crc="1836371c" sha1="3ede574ec023320c47a952d2264e74aa30de9dfd"/>
@@ -15075,7 +15099,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Keeps loading on a green-black screen fade transition -->
+	<!-- Keeps loading on a green-black screen fade transition [FDC] -->
+	<!-- TODO: verify if it's using copper DMA for transfers -->
 	<software name="exile" supported="no">
 		<!-- SPS (CAPS) release 32 -->
 		<description>Exile (Euro)</description>
@@ -18239,7 +18264,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- locks up at "please wait, loading" screen -->
+	<!-- Guru Meditation [FDC] -->
 	<software name="ghostbs2" supported="no">
 		<!-- SPS (CAPS) release 1029 -->
 		<description>Ghostbusters II (Euro)</description>
@@ -18338,8 +18363,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- gng: fatalerrors with amiga_fdc_device::live_run - cur_live.bit_counter > 8 -->
-	<!-- venus: black screen -->
+	<!-- gng: throws "amiga_fdc_device::live_run - cur_live.bit_counter > 8" then fatalerrors after DSKDAT access -->
+	<!-- venus: asks to swap disk with incorrect pitch GFX then throws DSKDAT R and hangs -->
 	<software name="ghoulsvf" supported="no">
 		<!-- SPS (CAPS) release 1985 -->
 		<description>Ghouls 'n' Ghosts &amp; Venus the Flytrap (Euro, Chart Attack)</description>
@@ -18750,7 +18775,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
+	<!-- (Hangs at PC=10c after failing a copy protection check, D0=0 D1=295 D2=40 D3=0) -->
 	<software name="gods" supported="no">
 		<!-- SPS (CAPS) release 666 -->
 		<description>Gods (Euro, v1.00)</description>
@@ -18906,6 +18932,7 @@ license:CC0
 	</software>
 
 	<!-- boot OK, sprites flickers in-game -->
+	<!-- Sports garbage pitch with a500p -->
 	<software name="graffiti" supported="partial">
 		<!-- SPS (CAPS) release 2168 -->
 		<description>Graffiti Man (Euro, 5th Anniversary)</description>
@@ -19095,7 +19122,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, SFXs repeats -->
+	<!-- boot OK -->
 	<software name="gcourts2" supported="partial">
 		<!-- SPS (CAPS) release 333 -->
 		<description>Great Courts 2 (Euro)</description>
@@ -19125,7 +19152,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) -->
+	<!-- Locks up after Kickstart (white screen) [FDC] -->
 	<software name="ggiana" supported="no">
 		<!-- SPS (CAPS) release 2945 -->
 		<description>The Great Giana Sisters (Euro)</description>
@@ -19211,8 +19238,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs after pressing fire on ranking screen -->
-	<software name="gridstrt" supported="no">
+	<!-- boot OK -->
+	<software name="gridstrt" supported="yes">
 		<!-- SPS (CAPS) release 1470 -->
 		<description>Grid Start (Euro, Sextett)</description>
 		<!-- retail, standalone -->
@@ -19398,7 +19425,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
 	<software name="guyspy" supported="no">
 		<!-- SPS (CAPS) release 335 -->
 		<description>Guy Spy (Euro)</description>
@@ -20147,7 +20174,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a red and black flashing screen -->
+	<!-- Hangs at a red and black flashing screen [FDC] -->
 	<software name="heroqst" supported="no">
 		<!-- SPS (CAPS) release 127 -->
 		<description>HeroQuest (Euro)</description>
@@ -20455,7 +20482,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Locks up after Kickstart (white screen) -->
+	<!-- Locks up after Kickstart (white screen) [FDC] -->
 	<software name="hoi" supported="no">
 		<!-- SPS (CAPS) release 962 -->
 		<description>Hoi (Euro)</description>
@@ -21252,7 +21279,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Grey screen -->
+	<!-- Grey screen [FDC] -->
 	<software name="hybris" supported="no">
 		<!-- SPS (CAPS) release 1457 -->
 		<description>Hybris (USA, v0.95)</description>
@@ -21767,7 +21794,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at Indy logo on a cyan background -->
+	<!-- Hangs at Indy logo on a cyan background [FDC] -->
 	<software name="indycrus" supported="no">
 		<!-- SPS (CAPS) release 1619 -->
 		<description>Indiana Jones and the Last Crusade (Euro, TAG)</description>
@@ -22607,7 +22634,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
 	<software name="ivanhoe" supported="no">
 		<!-- SPS (CAPS) release 1648 -->
 		<description>Ivanhoe (Euro)</description>
@@ -23163,7 +23190,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- keeps repeating samples, crashes on the "You've got it, we've used it" screen if expansion RAM is installed -->
+	<!-- crashes on the "You've got it, we've used it" screen if expansion RAM is installed -->
 	<software name="madden" supported="no">
 		<!-- SPS (CAPS) release 71 -->
 		<description>John Madden Football (Euro)</description>
@@ -23172,6 +23199,7 @@ license:CC0
 		<year>1992</year>
 		<publisher>Electronic Arts</publisher>
 		<info name="usage" value="Sports manual copy-protection (Player Ratings)" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Program Disk" />
 			<dataarea name="flop" size="1049180">
@@ -23512,7 +23540,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation (white screen on a500) -->
+	<!-- Guru Meditation on a500p, white screen on a500 -->
 	<software name="katakis" supported="no">
 		<!-- SPS (CAPS) release 347 -->
 		<description>Katakis (Euro, v1.1)</description>
@@ -23758,7 +23786,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- blue screen -->
+	<!-- blue screen (keeps accessing invalid areas, [FDC]?) -->
 	<software name="kickoff" supported="no">
 		<!-- SPS (CAPS) release 189 -->
 		<description>Kick Off (Euro, v1.1)</description>
@@ -23773,6 +23801,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- blue screen [FDC] -->
 	<software name="kickoffex" cloneof="kickoff" supported="no">
 		<!-- SPS (CAPS) release 73 -->
 		<description>Kick Off - Extra Time (Euro, v2.2)</description>
@@ -23788,6 +23817,7 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- blue screen [FDC] (same as kickoffex) -->
 	<software name="koffet" supported="no">
 		<!-- SPS (CAPS) release 881 -->
 		<description>Kick Off + Extra Time (Euro)</description>
@@ -24206,8 +24236,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
-	<software name="killmach" supported="no">
+	<!-- boot OK, stuck note on SFXs when playback ends -->
+	<software name="killmach" supported="partial">
 		<!-- SPS (CAPS) release 2504 -->
 		<description>Killing Machine (Euro)</description>
 		<!-- retail, standalone -->
@@ -24576,7 +24606,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- boot OK, no sound (clicks), DSKDAT W on ranking screen -->
+	<!-- boot OK, DSKDAT W on ranking screen -->
 	<software name="knigtfrc" supported="partial">
 		<!-- SPS (CAPS) release 1574 -->
 		<description>Knight Force (Euro)</description>
@@ -24626,8 +24656,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Gets to main menu, repeating speech and actual menu never appears -->
-	<software name="crystaln" supported="no">
+	<!-- boot OK -->
+	<software name="crystaln" supported="yes">
 		<!-- SPS (CAPS) release 1160 -->
 		<description>Knights of the Crystallion (Euro)</description>
 		<!-- retail, standalone -->
@@ -24945,7 +24975,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Hangs at a rainbow colored screen -->
+	<!-- Hangs at a rainbow colored screen [FDC] -->
 	<software name="lastbtle" supported="no">
 		<!-- SPS (CAPS) release 1044 -->
 		<description>Last Battle (Euro)</description>
@@ -25924,7 +25954,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Guru Meditation (white screen on a500) -->
+	<!-- Guru Meditation on a500p, white screen on a500 -->
 	<software name="lemming2" supported="no">
 		<!-- SPS (CAPS) release 351 -->
 		<description>Lemmings 2 - The Tribes (Euro)</description>
@@ -26014,7 +26044,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- black screen -->
+	<!-- black screen [FDC] -->
 	<software name="lweapon" supported="no">
 		<!-- SPS (CAPS) release 814 -->
 		<description>Lethal Weapon (Euro)</description>
@@ -37585,7 +37615,7 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- white/black boxes scattered thru intro, gameplay sports repeating samples -->
+	<!-- white/black boxes scattered thru intro -->
 	<software name="shadwar" supported="partial">
 		<!-- SPS (CAPS) release 830 -->
 		<description>Shadow Warriors (Euro)</description>
@@ -37593,6 +37623,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1990</year>
 		<publisher>Ocean</publisher>
+		<info name="usage" value="Press 1 or 2 to start a game. Press S during intro to switch between Music or SFX"/>
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">
@@ -46806,6 +46838,8 @@ license:CC0
 		</part>
 	</software>
 
+	<!-- Incorrectly drawn copy protection screen (repeats numpad at bottom) -->
+	<!-- TODO: verify afterwards -->
 	<software name="waxworks" supported="no">
 		<!-- SPS (CAPS) release 2274 -->
 		<description>Waxworks (Euro)</description>
@@ -46813,6 +46847,8 @@ license:CC0
 		<!-- (Amiga, OCS, PAL) -->
 		<year>1993</year>
 		<publisher>Accolade</publisher>
+		<info name="usage" value="Sports manual copy-protection" />
+
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk 1" />
 			<dataarea name="flop" size="1049612">

--- a/src/devices/machine/8364_paula.cpp
+++ b/src/devices/machine/8364_paula.cpp
@@ -2,22 +2,36 @@
 // copyright-holders: Aaron Giles, Dirk Best
 /***************************************************************************
 
-    Commodore 8364 "Paula"
+    MOS Technology 8364 "Paula"
+
+	TODO:
+	- Inherit FDC, serial and irq controller to here;
+	- Move Agnus "location" logic from here;
+	- low-pass filter;
+	- convert volume values to non-linear dB scale (cfr. )
+	- Verify ADKCON modulation;
+	- Verify manual mode;
+	- When a DMA stop occurs, is the correlated channel playback stopped
+	  at the end of the current cycle or as soon as possible like current
+	  implementation?
 
 ***************************************************************************/
 
 #include "emu.h"
 #include "8364_paula.h"
 
+#define LIVE_AUDIO_VIEW 0
+
 //#define VERBOSE 1
 #include "logmacro.h"
+#include <cstring>
 
 
 //**************************************************************************
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(PAULA_8364, paula_8364_device, "paula_8364", "8364 Paula")
+DEFINE_DEVICE_TYPE(PAULA_8364, paula_8364_device, "paula_8364", "MOS 8364 \"Paula\"")
 
 
 //*************************************************************************
@@ -51,14 +65,29 @@ void paula_8364_device::device_start()
 	for (int i = 0; i < 4; i++)
 	{
 		m_channel[i].index = i;
-		m_channel[i].curticks = 0;
-		m_channel[i].manualmode = false;
-		m_channel[i].curlocation = 0;
 		m_channel[i].irq_timer = machine().scheduler().timer_alloc(timer_expired_delegate(FUNC(paula_8364_device::signal_irq), this));
 	}
 
 	// create the stream
 	m_stream = stream_alloc(0, 4, clock() / CLOCK_DIVIDER);
+}
+
+void paula_8364_device::device_reset()
+{
+	m_dmacon = 0;
+	m_adkcon = 0;
+	for (auto &chan : m_channel)
+	{
+		chan.loc = 0;
+		chan.len = 0;
+		chan.per = 0;
+		chan.vol = 0;
+		chan.curticks = 0;
+		chan.manualmode = false;
+		chan.curlocation = 0;
+		chan.curlength = 0;
+		chan.dma_enabled = false;
+	}
 }
 
 //-------------------------------------------------
@@ -99,6 +128,18 @@ void paula_8364_device::reg_w(offs_t offset, uint16_t data)
 	case REG_DMACON:
 		m_stream->update();
 		m_dmacon = (data & 0x8000) ? (m_dmacon | (data & 0x021f)) : (m_dmacon & ~(data & 0x021f));  // only bits 15, 9 and 5 to 0
+		// update the DMA latches on each channel and reload if fresh
+		// This holds true particularly for Ocean games (bchvolly, lostpatr, pang) and waylildr:
+		// they sets a DMA length for a channel then enable DMA then resets that length to 1
+		// after a short delay loop.
+		for (int channum = 0; channum < 4; channum++)
+		{
+			audio_channel *chan = &m_channel[channum];
+			if (!chan->dma_enabled && ((m_dmacon >> channum) & 1))
+				dma_reload(chan, true);
+
+			chan->dma_enabled = BIT(m_dmacon, channum);
+		}
 		break;
 
 	case REG_ADKCON:
@@ -106,7 +147,7 @@ void paula_8364_device::reg_w(offs_t offset, uint16_t data)
 		m_adkcon = (data & 0x8000) ? (m_adkcon | (data & 0x7fff)) : (m_adkcon & ~(data & 0x7fff));
 		break;
 
-	// to be moved
+	// FIXME: location belongs to Agnus
 	case REG_AUD0LCL: m_channel[CHAN_0].loc = (m_channel[CHAN_0].loc & 0xffff0000) | ((data & 0xfffe) <<  0); break; // 15-bit
 	case REG_AUD0LCH: m_channel[CHAN_0].loc = (m_channel[CHAN_0].loc & 0x0000ffff) | ((data & 0x001f) << 16); break; // 3-bit on ocs, 5-bit ecs
 	case REG_AUD1LCL: m_channel[CHAN_1].loc = (m_channel[CHAN_1].loc & 0xffff0000) | ((data & 0xfffe) <<  0); break; // 15-bit
@@ -119,19 +160,19 @@ void paula_8364_device::reg_w(offs_t offset, uint16_t data)
 	// audio data
 	case REG_AUD0LEN: m_channel[CHAN_0].len = data; break;
 	case REG_AUD0PER: m_channel[CHAN_0].per = data; break;
-	case REG_AUD0VOL: m_channel[CHAN_0].vol = data; break;
+	case REG_AUD0VOL: m_channel[CHAN_0].vol = data & 0x7f; break;
 	case REG_AUD0DAT: m_channel[CHAN_0].dat = data; m_channel[CHAN_0].manualmode = true; break;
 	case REG_AUD1LEN: m_channel[CHAN_1].len = data; break;
 	case REG_AUD1PER: m_channel[CHAN_1].per = data; break;
-	case REG_AUD1VOL: m_channel[CHAN_1].vol = data; break;
+	case REG_AUD1VOL: m_channel[CHAN_1].vol = data & 0x7f; break;
 	case REG_AUD1DAT: m_channel[CHAN_1].dat = data; m_channel[CHAN_1].manualmode = true; break;
 	case REG_AUD2LEN: m_channel[CHAN_2].len = data; break;
 	case REG_AUD2PER: m_channel[CHAN_2].per = data; break;
-	case REG_AUD2VOL: m_channel[CHAN_2].vol = data; break;
+	case REG_AUD2VOL: m_channel[CHAN_2].vol = data & 0x7f; break;
 	case REG_AUD2DAT: m_channel[CHAN_2].dat = data; m_channel[CHAN_2].manualmode = true; break;
 	case REG_AUD3LEN: m_channel[CHAN_3].len = data; break;
 	case REG_AUD3PER: m_channel[CHAN_3].per = data; break;
-	case REG_AUD3VOL: m_channel[CHAN_3].vol = data; break;
+	case REG_AUD3VOL: m_channel[CHAN_3].vol = data & 0x7f; break;
 	case REG_AUD3DAT: m_channel[CHAN_3].dat = data; m_channel[CHAN_3].manualmode = true; break;
 	}
 }
@@ -160,7 +201,33 @@ void paula_8364_device::dma_reload(audio_channel *chan, bool startup)
 	else
 		signal_irq(nullptr, chan->index);
 
-	LOG("dma_reload(%d): offs=%05X len=%04X\n", chan->index, chan->curlocation, chan->curlength);
+	LOG("dma_reload(%d): offs=%06X len=%04X\n", chan->index, chan->curlocation, chan->curlength);
+}
+
+std::string paula_8364_device::print_audio_state()
+{
+	std::ostringstream outbuffer;
+
+	util::stream_format(outbuffer, "DMACON: %04x (%d) ADKCON %04x\n", m_dmacon, BIT(m_dmacon, 9), m_adkcon);
+	for (auto &chan : m_channel)
+	{
+		util::stream_format(outbuffer, "%d (%d) (%d%d) REGS: %06x %04x %03x %02x %d LIVE: %06x %04x %d\n"
+			, chan.index
+			, BIT(m_dmacon, chan.index)
+			, BIT(m_adkcon, chan.index+4)
+			, BIT(m_adkcon, chan.index)
+			, chan.loc
+			, chan.len
+			, chan.per
+			, chan.vol
+			, chan.manualmode
+			, chan.curlocation
+			, chan.curlength
+			, chan.dma_enabled
+		);
+	}
+
+	return outbuffer.str();
 }
 
 //-------------------------------------------------
@@ -186,16 +253,9 @@ void paula_8364_device::sound_stream_update(sound_stream &stream, std::vector<re
 	}
 
 	int samples = outputs[0].samples() * CLOCK_DIVIDER;
-
-	// update the DMA states on each channel and reload if fresh
-	for (channum = 0; channum < 4; channum++)
-	{
-		audio_channel *chan = &m_channel[channum];
-		if (!chan->dma_enabled && ((m_dmacon >> channum) & 1))
-			dma_reload(chan, true);
-
-		chan->dma_enabled = BIT(m_dmacon, channum);
-	}
+	
+	if (LIVE_AUDIO_VIEW)
+		popmessage(print_audio_state());
 
 	// loop until done
 	while (samples > 0)

--- a/src/devices/machine/8364_paula.cpp
+++ b/src/devices/machine/8364_paula.cpp
@@ -4,16 +4,16 @@
 
     MOS Technology 8364 "Paula"
 
-	TODO:
-	- Inherit FDC, serial and irq controller to here;
-	- Move Agnus "location" logic from here;
-	- low-pass filter;
-	- convert volume values to non-linear dB scale (cfr. )
-	- Verify ADKCON modulation;
-	- Verify manual mode;
-	- When a DMA stop occurs, is the correlated channel playback stopped
-	  at the end of the current cycle or as soon as possible like current
-	  implementation?
+    TODO:
+    - Inherit FDC, serial and irq controller to here;
+    - Move Agnus "location" logic from here;
+    - low-pass filter;
+    - convert volume values to non-linear dB scale (cfr. )
+    - Verify ADKCON modulation;
+    - Verify manual mode;
+    - When a DMA stop occurs, is the correlated channel playback stopped
+      at the end of the current cycle or as soon as possible like current
+      implementation?
 
 ***************************************************************************/
 
@@ -253,7 +253,7 @@ void paula_8364_device::sound_stream_update(sound_stream &stream, std::vector<re
 	}
 
 	int samples = outputs[0].samples() * CLOCK_DIVIDER;
-	
+
 	if (LIVE_AUDIO_VIEW)
 		popmessage(print_audio_state());
 
@@ -341,7 +341,7 @@ void paula_8364_device::sound_stream_update(sound_stream &stream, std::vector<re
 					{
 						dma_reload(chan, false);
 						// reload the data pointer, otherwise aliasing / buzzing outside the given buffer will be heard
-						// For example: Xenon 2 sets up location=0x63298 length=0x20 
+						// For example: Xenon 2 sets up location=0x63298 length=0x20
 						// for silencing channels on-the-fly without relying on irqs.
 						// Without this the location will read at 0x632d8 (data=0x7a7d), causing annoying buzzing.
 						chan->dat = m_mem_r(chan->curlocation);

--- a/src/devices/machine/8364_paula.h
+++ b/src/devices/machine/8364_paula.h
@@ -148,7 +148,7 @@ private:
 	sound_stream *m_stream;
 
 	TIMER_CALLBACK_MEMBER( signal_irq );
-	
+
 	std::string print_audio_state();
 };
 

--- a/src/devices/machine/8364_paula.h
+++ b/src/devices/machine/8364_paula.h
@@ -137,7 +137,7 @@ private:
 
 	// callbacks
 	devcb_read16 m_mem_r;
-	devcb_write_line m_int_w;
+	devcb_write8 m_int_w;
 
 	// internal state
 	uint16_t m_dmacon;

--- a/src/devices/machine/8364_paula.h
+++ b/src/devices/machine/8364_paula.h
@@ -133,7 +133,7 @@ private:
 		uint16_t dat;
 	};
 
-	void dma_reload(audio_channel *chan);
+	void dma_reload(audio_channel *chan, bool startup);
 
 	// callbacks
 	devcb_read16 m_mem_r;

--- a/src/devices/machine/8364_paula.h
+++ b/src/devices/machine/8364_paula.h
@@ -66,6 +66,7 @@ public:
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_reset() override;
 
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, std::vector<read_stream_view> const &inputs, std::vector<write_stream_view> &outputs) override;
@@ -147,6 +148,8 @@ private:
 	sound_stream *m_stream;
 
 	TIMER_CALLBACK_MEMBER( signal_irq );
+	
+	std::string print_audio_state();
 };
 
 // device type definition

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -210,7 +210,12 @@ void amiga_fdc_device::live_run(const attotime &limit)
 				}
 
 				if(cur_live.bit_counter > 8)
-					fatalerror("amiga_fdc_device::live_run - cur_live.bit_counter > 8\n");
+				{
+					// CHECKME: abreed, ghoulsvf Ghouls'n Goblins and lastnin2 at very least throws this
+					// is it a side effect of something else not happening at the right time or the assumption is right?
+					cur_live.bit_counter = 0;
+					logerror("amiga_fdc_device::live_run - cur_live.bit_counter > 8\n")
+				}
 
 				if(cur_live.bit_counter == 8) {
 					live_delay(RUNNING_SYNCPOINT);
@@ -233,7 +238,10 @@ void amiga_fdc_device::live_run(const attotime &limit)
 					return;
 				cur_live.bit_counter++;
 				if(cur_live.bit_counter > 8)
-					fatalerror("amiga_fdc_device::live_run - cur_live.bit_counter > 8\n");
+				{
+					cur_live.bit_counter = 0;
+					logerror("amiga_fdc_device::live_run - cur_live.bit_counter > 8\n")
+				}
 
 				if(cur_live.bit_counter == 8) {
 					live_delay(RUNNING_SYNCPOINT);
@@ -454,6 +462,7 @@ void amiga_fdc_device::ciaaprb_w(uint8_t data)
 
 	live_sync();
 
+	// FIXME: several sources claims that multiple drive selects is really possible
 	if(!(data & 0x08))
 		floppy = floppy_devices[0];
 	else if(!(data & 0x10))

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -358,7 +358,10 @@ void amiga_fdc_device::dma_check()
 	bool was_writing = dskbyt & 0x2000;
 	dskbyt &= 0x9fff;
 	if(dma_enabled()) {
-		LOGDMA("%s: DMA start dskpt=%08x dsklen=%04x adkcon=%04x dsksync=%04x\n", machine().describe_context(), dskpt, dsklen & 0x3fff, adkcon, dsksync);
+		LOGDMA("%s: DMA start dskpt=%08x dsklen=%04x dir=%s adkcon=%04x dsksync=%04x\n",
+			machine().describe_context(), 
+			dskpt, dsklen & 0x3fff, BIT(dsklen, 14) ? "RAM->disk" : "disk->RAM", adkcon, dsksync
+		);
 
 		if(dma_state == IDLE) {
 			dma_state = adkcon & 0x0400 ? DMA_WAIT_START : DMA_RUNNING_BYTE_0;

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -14,7 +14,7 @@
 
 #define LOG_WARN    (1U << 1)   // Show warnings
 #define LOG_DMA     (1U << 2)   // Show DMA setups
-#define LOG_SYNC    (1U << 3)	// Show sync block setups
+#define LOG_SYNC    (1U << 3)   // Show sync block setups
 
 #define VERBOSE (LOG_WARN | LOG_DMA | LOG_SYNC)
 
@@ -268,12 +268,12 @@ void amiga_fdc_device::live_run(const attotime &limit)
 				if(cur_live.shift_reg == dsksync) {
 					if(adkcon & 0x0400) {
 						// FIXME: exact dsksync behaviour
-						// - Some games currently writes two dsksync to the buffer (marked as "[FDC] dsksync"), 
+						// - Some games currently writes two dsksync to the buffer (marked as "[FDC] dsksync"),
 						//   removing one will make most of them happy.
 						//   This is reported as 0-lower cylinder good and everything else as bad in the ATK suite;
 						// - Some games trashes memory, mostly the ones with "[FDC] dsksync bootblock":
 						//   they attempt to load the tracks in AmigaDOS in the same way that's done by the
-						//   Kickstart to check if the disk is bootable. 
+						//   Kickstart to check if the disk is bootable.
 						//   This is reported as 0-upper cylinder bad in the ATK suite;
 						if(dma_state == DMA_WAIT_START) {
 							cur_live.bit_counter = 0;
@@ -299,7 +299,7 @@ void amiga_fdc_device::live_run(const attotime &limit)
 							cur_live.bit_counter = 0;
 					}
 					//else
-					//	LOGSYNC("%s: no DSKSYNC\n", this->tag());
+					//  LOGSYNC("%s: no DSKSYNC\n", this->tag());
 
 					dskbyt |= 0x1000;
 					m_write_dsksyn(1);
@@ -367,7 +367,7 @@ void amiga_fdc_device::dma_check()
 	dskbyt &= 0x9fff;
 	if(dma_enabled()) {
 		LOGDMA("%s: DMA start dskpt=%08x dsklen=%04x dir=%s adkcon=%04x dsksync=%04x\n",
-			machine().describe_context(), 
+			machine().describe_context(),
 			dskpt, dsklen & 0x3fff, BIT(dsklen, 14) ? "RAM->disk" : "disk->RAM", adkcon, dsksync
 		);
 

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -298,8 +298,8 @@ void amiga_fdc_device::live_run(const attotime &limit)
 						} else if(cur_live.bit_counter != 8)
 							cur_live.bit_counter = 0;
 					}
-					else
-						LOGSYNC("%s: no DSKSYNC\n", this->tag());
+					//else
+					//	LOGSYNC("%s: no DSKSYNC\n", this->tag());
 
 					dskbyt |= 0x1000;
 					m_write_dsksyn(1);

--- a/src/devices/machine/amigafdc.cpp
+++ b/src/devices/machine/amigafdc.cpp
@@ -267,6 +267,14 @@ void amiga_fdc_device::live_run(const attotime &limit)
 			if(!(dskbyt & 0x2000)) {
 				if(cur_live.shift_reg == dsksync) {
 					if(adkcon & 0x0400) {
+						// FIXME: exact dsksync behaviour
+						// - Some games currently writes two dsksync to the buffer (marked as "[FDC] dsksync"), 
+						//   removing one will make most of them happy.
+						//   This is reported as 0-lower cylinder good and everything else as bad in the ATK suite;
+						// - Some games trashes memory, mostly the ones with "[FDC] dsksync bootblock":
+						//   they attempt to load the tracks in AmigaDOS in the same way that's done by the
+						//   Kickstart to check if the disk is bootable. 
+						//   This is reported as 0-upper cylinder bad in the ATK suite;
 						if(dma_state == DMA_WAIT_START) {
 							cur_live.bit_counter = 0;
 

--- a/src/devices/machine/mos6526.cpp
+++ b/src/devices/machine/mos6526.cpp
@@ -902,7 +902,10 @@ uint8_t mos6526_device::read(offs_t offset)
 	case ICR:
 		data = (m_ir1 << 7) | m_icr;
 
-		if (machine().side_effects_disabled())
+		// Do not reset irqs unless one is effectively issued.
+		// cfr. amigaocs_flop.xml barb2paln4 that polls for Timer B status 
+		//      until it expires at PC=7821c and other places.
+		if (machine().side_effects_disabled() || !m_icr)
 			return data;
 
 		m_icr_read = true;

--- a/src/mame/drivers/alg.cpp
+++ b/src/mame/drivers/alg.cpp
@@ -7,6 +7,13 @@
     Amiga 500 + Sony laserdisc player LDP-1450
     (LDP-3300P for Zorton Brothers, LDP-1500 for Marbella Vice)
 
+	TODO:
+	- Implement LD comms (thru Amiga SERDAT / SERDATR ports);
+	- Why it enables FDC DMA like at all?
+	  Is the board really capable of reading floppies for some reason?
+	- Picmatic games may really belong to a different driver, 
+	  just sharing the Amiga base state;
+
     Games Supported:
 
         Mad Dog McCree [3 versions]
@@ -913,49 +920,52 @@ GAME( 199?, alg_bios,     0,        alg_r1,   alg,    alg_state, init_ntsc,     
 
 // Rev. A board
 // PAL R1
-GAME( 1990, maddoga,      maddog,   alg_r1,   alg,    alg_state, init_palr1,    ROT0,  "American Laser Games", "Mad Dog McCree v1C board rev.A", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1990, maddoga,      maddog,   alg_r1,   alg,    alg_state, init_palr1,    ROT0,  "American Laser Games", "Mad Dog McCree (v1C board rev.A)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // PAL R3
-GAME( 1991, wsjr,         alg_bios, alg_r1,   alg,    alg_state, init_palr3,    ROT0,  "American Laser Games", "Who Shot Johnny Rock? v1.6", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1991, wsjr_15,      wsjr,     alg_r1,   alg,    alg_state, init_palr3,    ROT0,  "American Laser Games", "Who Shot Johnny Rock? v1.5", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1991, wsjr,         alg_bios, alg_r1,   alg,    alg_state, init_palr3,    ROT0,  "American Laser Games", "Who Shot Johnny Rock? (v1.6)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1991, wsjr_15,      wsjr,     alg_r1,   alg,    alg_state, init_palr3,    ROT0,  "American Laser Games", "Who Shot Johnny Rock? (v1.5)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // Rev. B board
 // PAL R6
 
-GAME( 1990, maddog,       alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog McCree v2.03 board rev.B", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1990, maddog_202,   maddog,   alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog McCree v2.02 board rev.B", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1990, maddog,       alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog McCree (v2.03 board rev.B)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1990, maddog_202,   maddog,   alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog McCree (v2.02 board rev.B)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 	// Works OK but uses right player (2) controls only for trigger and holster
-GAME( 1992, maddog2,      alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold v2.04", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1992, maddog2_202,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold v2.02", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1992, maddog2_110,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold v1.10", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1992, maddog2_100,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold v1.00", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, maddog2,      alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold (v2.04)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, maddog2_202,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold (v2.02)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, maddog2_110,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold (v1.10)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, maddog2_100,  maddog2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Mad Dog II: The Lost Gold (v1.00)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 	// Works ok but uses right player (2) controls only for trigger and holster
-GAME( 1992, spacepir,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Space Pirates v2.2", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1992, spacepir_14,  spacepir, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Space Pirates v1.4", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, spacepir,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Space Pirates (v2.2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, spacepir_14,  spacepir, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Space Pirates (v1.4)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
-GAME( 1992, gallgall,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Gallagher's Gallery v2.2", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1992, gallgall_21,  gallgall, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Gallagher's Gallery v2.1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, gallgall,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Gallagher's Gallery (v2.2)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1992, gallgall_21,  gallgall, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Gallagher's Gallery (v2.1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 	// All good, but no holster
-GAME( 1993, crimepat,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol v1.51", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1993, crimepat_14,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol v1.4",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1993, crimepat_12,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol v1.2",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1993, crimepat_10,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol v1.0",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimepat,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol (v1.51)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimepat_14,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol (v1.4)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimepat_12,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol (v1.2)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimepat_10,  crimepat, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol (v1.0)",  MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
-GAME( 1993, crimep2,      alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol 2: Drug Wars v1.3", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1993, crimep2_11,   crimep2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol 2: Drug Wars v1.1", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1994, lastbh,       alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "The Last Bounty Hunter v1.01",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1994, lastbh_006,   lastbh,   alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "The Last Bounty Hunter v0.06",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, fastdraw,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT90, "American Laser Games", "Fast Draw Showdown v1.31",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1995, fastdraw_130, fastdraw, alg_r2,   alg_2p, alg_state, init_palr6,    ROT90, "American Laser Games", "Fast Draw Showdown v1.30",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimep2,      alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol 2: Drug Wars (v1.3)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1993, crimep2_11,   crimep2,  alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "Crime Patrol 2: Drug Wars (v1.1)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1994, lastbh,       alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "The Last Bounty Hunter (v1.01)",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1994, lastbh_006,   lastbh,   alg_r2,   alg_2p, alg_state, init_palr6,    ROT0,  "American Laser Games", "The Last Bounty Hunter (v0.06)",   MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, fastdraw,     alg_bios, alg_r2,   alg_2p, alg_state, init_palr6,    ROT90, "American Laser Games", "Fast Draw Showdown (v1.31)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, fastdraw_130, fastdraw, alg_r2,   alg_2p, alg_state, init_palr6,    ROT90, "American Laser Games", "Fast Draw Showdown (v1.30)",       MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 	// Works OK but uses right player (2) controls only for trigger and holster
 
 // NOVA games on ALG hardware with own address scramble
-GAME( 1995, aplatoon,     alg_bios, alg_r2,   alg,    alg_state, init_aplatoon, ROT0,  "Nova?", "Platoon V.3.1 US", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1995, aplatoon,     alg_bios, alg_r2,   alg,    alg_state, init_aplatoon, ROT0,  "Nova?", "Platoon (V.3.1 US)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 
 // Picmatic games NTSC or PAL (50 or 100Hz) TV standard, own ROM board
-GAME( 1993, zortonbr_100, zortonbr, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Zorton Brothers v1.00 (Los Justicieros)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
-GAME( 1994, zortonbr,     alg_bios, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Zorton Brothers v1.01 (Los Justicieros)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+// CHECKME: Zorton Brothers is the English title while Los Justicieros is the Spanish one?
+// Eventually confirm if they shares same roms with different LD side depending on language,
+// or perhaps the title "Zorton Brothers" is the only one for Arcade LD, while "Los Justicieros" is the later PC release?
+GAME( 1993, zortonbr_100, zortonbr, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Zorton Brothers / Los Justicieros (v1.00)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
+GAME( 1994, zortonbr,     alg_bios, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Zorton Brothers / Los Justicieros (v1.01)", MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1994, marvice,      alg_bios, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Marbella Vice",                           MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1994, marvice100hz, alg_bios, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Marbella Vice (100Hz display)",           MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )
 GAME( 1995, tierras100hz, alg_bios, picmatic, alg,    alg_state, init_pal,      ROT0,  "Picmatic", "Tierras Salvajes (100Hz display)",        MACHINE_NOT_WORKING | MACHINE_NO_SOUND | MACHINE_IMPERFECT_GRAPHICS )

--- a/src/mame/drivers/amiga.cpp
+++ b/src/mame/drivers/amiga.cpp
@@ -1865,7 +1865,7 @@ void a3000_state::a3000(machine_config &config)
 	// real-time clock
 	RP5C01(config, "rtc", XTAL(32'768));
 
-	// todo: zorro3 slots, super dmac, scsi
+	// TODO: zorro3 slots, super dmac, scsi
 
 	// software
 	SOFTWARE_LIST(config, "a3000_list").set_original("amiga_a3000");
@@ -1950,7 +1950,7 @@ void a600_state::a600(machine_config &config)
 	ata_interface_device &ata(ATA_INTERFACE(config, "ata").options(ata_devices, "hdd", nullptr, false));
 	ata.irq_handler().set("gayle", FUNC(gayle_device::ide_interrupt_w));
 
-	// todo: pcmcia
+	// TODO: pcmcia
 
 	// software
 	SOFTWARE_LIST(config, "ecs_list").set_original("amigaecs_flop");
@@ -2009,7 +2009,7 @@ void a1200_state::a1200(machine_config &config)
 	subdevice<amiga_keyboard_bus_device>("kbd").set_default_option("a1200_us");
 #endif
 
-	// todo: pcmcia
+	// TODO: pcmcia
 
 	// software
 	SOFTWARE_LIST(config, "aga_list").set_original("amigaaga_flop");
@@ -2060,7 +2060,7 @@ void a4000_state::a4000(machine_config &config)
 	ata_interface_device &ata(ATA_INTERFACE(config, "ata").options(ata_devices, "hdd", nullptr, false));
 	ata.irq_handler().set(FUNC(a4000_state::ide_interrupt_w));
 
-	// todo: zorro3
+	// TODO: zorro3
 
 	// software
 	SOFTWARE_LIST(config, "aga_list").set_original("amigaaga_flop");
@@ -2089,7 +2089,7 @@ void a4000_state::a400030(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &a4000_state::a400030_mem);
 	m_maincpu->set_cpu_space(AS_PROGRAM);
 
-	// todo: ide
+	// TODO: ide
 }
 
 void a4000_state::a400030n(machine_config &config)
@@ -2164,7 +2164,7 @@ void a4000_state::a4000t(machine_config &config)
 	m_maincpu->set_addrmap(AS_PROGRAM, &a4000_state::a4000t_mem);
 	m_maincpu->set_cpu_space(AS_PROGRAM);
 
-	// todo: ide, zorro3, scsi, super dmac
+	// TODO: ide, zorro3, scsi, super dmac
 }
 
 void a4000_state::a4000tn(machine_config &config)
@@ -2423,7 +2423,8 @@ ROM_END
 
 ROM_START( cd32 )
 	ROM_REGION32_BE(0x100000, "kickstart", 0)
-//  ROM_LOAD16_WORD("391640-03.u6a", 0x000000, 0x100000, CRC(a4fbc94a) SHA1(816ce6c5077875850c7d43452230a9ba3a2902db)) // todo: this is the real dump
+	// TODO: this is the real dump
+//  ROM_LOAD16_WORD("391640-03.u6a", 0x000000, 0x100000, CRC(a4fbc94a) SHA1(816ce6c5077875850c7d43452230a9ba3a2902db))
 	ROM_LOAD16_WORD("391640-03.u6a", 0x000000, 0x100000, CRC(d3837ae4) SHA1(06807db3181637455f4d46582d9972afec8956d9))
 ROM_END
 

--- a/src/mame/drivers/amiga.cpp
+++ b/src/mame/drivers/amiga.cpp
@@ -1607,6 +1607,7 @@ void amiga_state::amiga_base(machine_config &config)
 
 	// floppy drives
 	AMIGA_FDC(config, m_fdc, amiga_state::CLK_7M_PAL);
+	m_fdc->index_callback().set(m_cia_1, FUNC(mos8520_device::flag_w));
 	m_fdc->read_dma_callback().set(FUNC(amiga_state::chip_ram_r));
 	m_fdc->write_dma_callback().set(FUNC(amiga_state::chip_ram_w));
 	m_fdc->dskblk_callback().set(FUNC(amiga_state::fdc_dskblk_w));

--- a/src/mame/includes/amiga.h
+++ b/src/mame/includes/amiga.h
@@ -458,7 +458,7 @@ public:
 	uint16_t custom_chip_r(offs_t offset);
 	void custom_chip_w(offs_t offset, uint16_t data);
 
-	DECLARE_WRITE_LINE_MEMBER( paula_int_w );
+	void paula_int_w(offs_t channel, u8 state);
 
 	uint16_t rom_mirror_r(offs_t offset, uint16_t mem_mask = ~0);
 	uint32_t rom_mirror32_r(offs_t offset, uint32_t mem_mask = ~0);

--- a/src/mame/machine/amiga.cpp
+++ b/src/mame/machine/amiga.cpp
@@ -202,7 +202,7 @@ WRITE_LINE_MEMBER(amiga_state::fdc_dskblk_w)
 
 WRITE_LINE_MEMBER(amiga_state::fdc_dsksyn_w)
 {
-	set_interrupt(INTENA_SETCLR | INTENA_DSKSYN);
+	set_interrupt((state ? INTENA_SETCLR : 0) | INTENA_DSKSYN);
 }
 
 WRITE_LINE_MEMBER( amiga_state::kbreset_w )
@@ -922,7 +922,7 @@ TIMER_CALLBACK_MEMBER( amiga_state::amiga_blitter_proc )
 	CUSTOM_REG(REG_DMACON) &= ~0x4000;
 
 	// signal an interrupt
-	set_interrupt(0x8000 | INTENA_BLIT);
+	set_interrupt(INTENA_SETCLR | INTENA_BLIT);
 
 	/* reset the blitter timer */
 	m_blitter_timer->reset();

--- a/src/mame/machine/amiga.cpp
+++ b/src/mame/machine/amiga.cpp
@@ -1496,6 +1496,13 @@ void amiga_state::custom_chip_w(offs_t offset, uint16_t data)
 			CUSTOM_REG(offset) = data;
 			break;
 
+		case REG_BPL1MOD:   case REG_BPL2MOD:
+			// bit 0 is implicitly ignored on writes,
+			// and wouldn't otherwise make sense with 68k inability of word reading with odd addresses.
+			// hpoker/hpokera would otherwise draw misaligned bottom GFX area without this (writes 0x27)
+			data &= ~1;
+			break;
+
 		case REG_COLOR00:   case REG_COLOR01:   case REG_COLOR02:   case REG_COLOR03:
 		case REG_COLOR04:   case REG_COLOR05:   case REG_COLOR06:   case REG_COLOR07:
 		case REG_COLOR08:   case REG_COLOR09:   case REG_COLOR10:   case REG_COLOR11:

--- a/src/mame/machine/amiga.cpp
+++ b/src/mame/machine/amiga.cpp
@@ -387,9 +387,9 @@ TIMER_CALLBACK_MEMBER( amiga_state::amiga_irq_proc )
 	m_irq_timer->reset();
 }
 
-WRITE_LINE_MEMBER( amiga_state::paula_int_w )
+void amiga_state::paula_int_w (offs_t channel, u8 state)
 {
-	set_interrupt(INTENA_SETCLR | (0x80 << state));
+	set_interrupt(INTENA_SETCLR | (0x80 << channel));
 }
 
 
@@ -1443,7 +1443,6 @@ void amiga_state::custom_chip_w(offs_t offset, uint16_t data)
 
 			data = (data & INTENA_SETCLR) ? (CUSTOM_REG(offset) | (data & 0x7fff)) : (CUSTOM_REG(offset) & ~(data & 0x7fff));
 			CUSTOM_REG(offset) = data;
-
 			if (temp & INTENA_SETCLR)
 				// if we're enabling irq's, delay a bit
 				m_irq_timer->adjust(m_maincpu->cycles_to_attotime(AMIGA_IRQ_DELAY_CYCLES));


### PR DESCRIPTION
- amiga.cpp: connect missing DSKINDEX signal from FDC to CIA-B ICR bit 4 
- amigafdc.cpp: workaround live_counter > 8 to reset, makes abreed to boot to gameplay;
- amigafdc.cpp: fix DMAON readback, giving logica2 diag BIOS the chance to print extensive floppy test info;
- mos6526.cpp: guard against resetting IRQs when none is chained, makes timer B polling reads to actually work in barb2paln4 which fixes booting;
- 8364_paula.cpp: fix output channel of irq delegation, and throw one when a DMA reaches the end of a stream. Fixes asparmgp/gpmaster BGMs;
- 8364_paula.cpp: avoid reading audio DMA buffers outside the allocated ranges, fixes sound buzzing/aliasing bug (xenon2);
- 8364_paula.cpp: fix DMA reload behaviour (fixes BGMs in Ocean games) add live logging;
- amiga.cpp: ignore bit 0 with BPLxMOD writes, fixes hpoker/hpokera bottom GFX area display;
- amigaocs_flop.xml: Major QA updates, most notably AmigaTestKit floppy read test notes for almost every single item in the SW list;
- alg.cpp: standardize title metadatas;





