### PR TITLE
bus/nes: Overhauled SOMARI board emulation.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -62625,11 +62625,12 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		</part>
 	</software>
 
-	<software name="avmsnzs1" cloneof="avmsnzs" supported="partial">
-		<description>AV Mei Shao Nv Zhan Shi (Asia, Alt)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="AV Pretty Girl Fight"/>
+	<software name="avmsnzs">
+		<description>AV Měi Shàonǚ Zhànshì Girl Fighting (Asia)</description>
+		<year>1994</year>
+		<publisher>Ge De Industry</publisher>
+		<info name="alt_title" value="AV美少女戰士"/>
+		<info name="alt_title" value="AV Bishoujo Senshi"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="somari" />
 			<feature name="pcb" value="SOMERITEAM-SL-12" />
@@ -62638,23 +62639,6 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			</dataarea>
 			<dataarea name="prg" size="131072">
 				<rom name="av pretty girl fight (unl) (as) [a1].prg" size="131072" crc="8a34d37c" sha1="893c9dd94677fe5b88a4d65adfd4245da14aa9f5" offset="00000" status="baddump" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="avmsnzs" supported="partial">
-		<description>AV Mei Shao Nv Zhan Shi (Asia)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="AV Pretty Girl Fight"/>
-		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="somari" />
-			<feature name="pcb" value="SOMERITEAM-SL-12" />
-			<dataarea name="chr" size="524288">
-				<rom name="av mei shao nv zhan shi (unl).chr" size="524288" crc="cbeeaa5d" sha1="71d401f3b8de595b49269ddf240e50650ad6bc37" offset="00000" status="baddump" />
-			</dataarea>
-			<dataarea name="prg" size="131072">
-				<rom name="av mei shao nv zhan shi (unl).prg" size="131072" crc="64130ad8" sha1="84a3afb5f556a8f14ec2a6dcaf4ff219992bb90a" offset="00000" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -66414,10 +66398,10 @@ All musics were removed in this game.
 		</part>
 	</software>
 
-	<software name="kartfght" supported="no">
+	<software name="kartfght">
 		<description>Kart Fighter (Asia, SOMARI-W)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1994?</year>
+		<publisher>Ge De Industry</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="somari" />
 			<feature name="pcb" value="SOMERITEAM-SL-12" />
@@ -67060,10 +67044,10 @@ All musics were removed in this game.
 		</part>
 	</software>
 
-	<software name="somari" supported="no">
+	<software name="somari">
 		<description>Somari (Asia, SOMARI-W)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1994</year>
+		<publisher>Ge De Industry</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="somari" />
 			<feature name="pcb" value="SOMERITEAM-SL-12" />
@@ -67076,10 +67060,10 @@ All musics were removed in this game.
 		</part>
 	</software>
 
-	<software name="somari1" cloneof="somari" supported="no">
+	<software name="somari1" cloneof="somari">
 		<description>Somari (Asia, SOMARI-P)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1994</year>
+		<publisher>Ge De Industry</publisher>
 		<info name="serial" value="NT-616"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="somari" />
@@ -76840,6 +76824,7 @@ be better to redump them properly. -->
 		<description>Garou Densetsu Special (Asia, Alt 2)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
+		<info name="alt_title" value="餓狼伝説 Special"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
@@ -76854,8 +76839,9 @@ be better to redump them properly. -->
 
 	<software name="garousp">
 		<description>Garou Densetsu Special (Asia, SOMARI-W)</description>
-		<year>19??</year>
-		<publisher>&lt;unknown&gt;</publisher>
+		<year>1995</year>
+		<publisher>Ge De Industry</publisher>
+		<info name="alt_title" value="餓狼伝説 Special"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="somari" />
 			<feature name="pcb" value="SOMERITEAM-SL-12" />
@@ -76872,6 +76858,7 @@ be better to redump them properly. -->
 		<description>Garou Densetsu Special (Asia, alt)</description>
 		<year>1995</year>
 		<publisher>Kasheng</publisher>
+		<info name="alt_title" value="餓狼伝説 Special"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="kasing" />
 			<dataarea name="chr" size="262144">

--- a/src/devices/bus/nes/batlab.h
+++ b/src/devices/bus/nes/batlab.h
@@ -48,7 +48,7 @@ private:
 	u32 m_dpcm_addr;
 	u8 m_dpcm_ctrl;
 
-	uint16_t m_irq_count, m_irq_count_latch;
+	u16 m_irq_count, m_irq_count_latch;
 	int m_irq_enable;
 };
 

--- a/src/devices/bus/nes/mmc3.h
+++ b/src/devices/bus/nes/mmc3.h
@@ -40,6 +40,7 @@ protected:
 	// are there MMC3 clones which need more regs?
 	uint16_t m_mmc_prg_bank[4];
 	uint16_t m_mmc_vrom_bank[8];  // a few clones need more than the 6 banks used by base MMC3 (e.g. waixing_g)
+	uint8_t m_mmc_mirror;
 
 	int m_prg_base, m_prg_mask; // MMC3 based multigame carts select a block of banks by using these (and then act like normal MMC3),
 	int m_chr_base, m_chr_mask; // while MMC3 and clones (mapper 118 & 119) simply set them as 0 and 0xff resp.

--- a/src/devices/bus/nes/somari.h
+++ b/src/devices/bus/nes/somari.h
@@ -14,14 +14,11 @@ class nes_somari_device : public nes_txrom_device
 {
 public:
 	// construction/destruction
-	nes_somari_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_somari_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_l(offs_t offset, uint8_t data) override { write_m(offset + 0x100, data); }
-	virtual void write_m(offs_t offset, uint8_t data) override;
-	void mmc1_w(offs_t offset, uint8_t data);
-	void mmc3_w(offs_t offset, uint8_t data);
-	void vrc2_w(offs_t offset, uint8_t data);
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_l(offs_t offset, u8 data) override { write_m(offset + 0x100, data); }
+	virtual void write_m(offs_t offset, u8 data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -30,25 +27,25 @@ protected:
 	virtual void device_start() override;
 
 private:
+	void mmc1_reset_latch();
+	void mmc1_w(offs_t offset, u8 data);
+	void vrc2_w(offs_t offset, u8 data);
 	void update_prg();
 	void update_chr();
 	void update_mirror();
-	void bank_update_switchmode();
+	void update_all_banks();
 
-	uint8_t m_board_mode;
-
-	// MMC3 - inherited from txrom
-	uint8_t m_mmc3_mirror_reg;
+	u8 m_board_mode;
 
 	// MMC1
-	uint8_t m_count;
-	uint8_t m_mmc1_latch;
-	uint8_t m_mmc1_reg[4];
+	u8 m_mmc1_count;
+	u8 m_mmc1_latch;
+	u8 m_mmc1_reg[4];
 
 	// VRC2
-	uint8_t m_vrc_prg_bank[2];
-	uint8_t m_vrc_vrom_bank[8];
-	uint8_t m_vrc_mirror_reg;
+	u8 m_vrc_prg_bank[2];
+	u8 m_vrc_vrom_bank[8];
+	u8 m_vrc_mirror;
 };
 
 


### PR DESCRIPTION
- Fixed non-booting games.
- Garou Densetsu Special no longer crashes on black screen between rounds.
- Fixed graphics corruption in AV Bishoujo Senshi. Yes, those graphics too.
- Removed bad alt dump of AV Bishoujo Senshi.
- Also save mirroring state in MMC3 (TxROM) base class as it's useful for subclasses.

Software list items promoted to working (nes.xml)
---------------------------------------
Kart Fighter (Asia, SOMARI-W)
Somari (Asia, SOMARI-W)
Somari (Asia, SOMARI-P)