### PR TITLE
bus/nes: Fixed 4-screen mirroring when loading loose .nes files.

### DIFF
--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -792,7 +792,13 @@ void nes_cart_slot_device::call_load_ines()
 	if (BIT(local_options, 1))
 		battery_size = NES_BATTERY_SIZE; // with original iNES format we can only support 8K WRAM battery
 	m_cart->set_trainer(BIT(local_options, 2) ? true : false);
-	m_cart->set_four_screen_vram(BIT(local_options, 3) ? true : false);
+
+	// A select few boards or their variants have on-cart RAM to support 4-screen mirroring
+	if ((BIT(local_options, 3) && (m_pcb_id == STD_TXROM || m_pcb_id == NAMCOT_34X3)) || m_pcb_id == IREM_LROG017 || m_pcb_id == SACHEN_SHERO)
+	{
+		m_cart->set_four_screen_vram(true);
+		m_cart->set_mirroring(PPU_MIRROR_4SCREEN);
+	}
 
 	if (ines20)
 	{
@@ -1041,36 +1047,32 @@ void nes_cart_slot_device::call_load_ines()
 	m_cart->set_bus_conflict(bus_conflict);
 
 	// SETUP step 4: logging what we have found
-	if (!ines20)
+	logerror("Loaded game in %s format:\n", ines20 ? "NES 2.0" : "iNES");
+	logerror("-- Mapper: %u\n", mapper);
+	if (ines20)
+		logerror("-- Submapper: %u\n", header[8] >> 4);
+	logerror("-- PRG 0x%x (%d x 16k chunks)\n", prg_size, prg_size / 0x4000);
+	logerror("-- VROM 0x%x (%d x 8k chunks)\n", vrom_size, vrom_size / 0x2000);
+	logerror("-- VRAM 0x%x (%d x 8k chunks)\n", vram_size, vram_size / 0x2000);
+	logerror("-- Mirroring: %s\n", BIT(header[6], 0) ? "Vertical" : "Horizontal");
+	if (battery_size)
+		logerror("-- Battery found\n");
+	if (m_cart->get_trainer())
+		logerror("-- Trainer found\n");
+	if (m_cart->get_four_screen_vram())
+		logerror("-- 4-screen VRAM\n");
+	if (ines20)
 	{
-		logerror("Loaded game in iNES format:\n");
-		logerror("-- Mapper %u\n", mapper);
-		logerror("-- PRG 0x%x (%d x 16k chunks)\n", prg_size, prg_size / 0x4000);
-		logerror("-- VROM 0x%x (%d x 8k chunks)\n", vrom_size, vrom_size / 0x2000);
-		logerror("-- VRAM 0x%x (%d x 8k chunks)\n", vram_size, vram_size / 0x2000);
-		logerror("-- Mirroring %s\n", BIT(header[6], 0) ? "Vertical" : "Horizontal");
-		if (battery_size)
-			logerror("-- Battery found\n");
-		if (m_cart->get_trainer())
-			logerror("-- Trainer found\n");
-		if (m_cart->get_four_screen_vram())
-			logerror("-- 4-screen VRAM\n");
-		logerror("-- TV System: %s\n", ((header[10] & 3) == 0) ? "NTSC" : (header[10] & 1) ? "Both NTSC and PAL" : "PAL");
+		logerror("-- PRG NVWRAM: %d\n", header[10] >> 4);
+		logerror("-- PRG WRAM: %d\n", header[10] & 0x0f);
+		logerror("-- CHR NVWRAM: %d\n", header[11] >> 4);
+		logerror("-- CHR WRAM: %d\n", header[11] & 0x0f);
+
+		static const char *timing[] = { "NTSC", "PAL", "Multi-region", "Dendy" };
+		logerror("-- CPU/PPU Timing: %s\n", timing[header[12] & 3]);
 	}
 	else
-	{
-		logerror("Loaded game in Extended iNES format:\n");
-		logerror("-- Mapper: %u\n", mapper);
-		logerror("-- Submapper: %u\n", (header[8] & 0xf0) >> 4);
-		logerror("-- PRG 0x%x (%d x 16k chunks)\n", prg_size, prg_size / 0x4000);
-		logerror("-- VROM 0x%x (%d x 8k chunks)\n", vrom_size, vrom_size / 0x2000);
-		logerror("-- VRAM 0x%x (%d x 8k chunks)\n", vram_size, vram_size / 0x2000);
-		logerror("-- PRG NVWRAM: %d\n", (header[10] & 0xf0) >> 4);
-		logerror("-- PRG WRAM: %d\n", header[10] & 0x0f);
-		logerror("-- CHR NVWRAM: %d\n", (header[11] & 0xf0) >> 4);
-		logerror("-- CHR WRAM: %d\n", header[11] & 0x0f);
-		logerror("-- TV System: %s\n", (header[12] & 2) ? "Both NTSC and PAL" : (header[12] & 1) ? "PAL" : "NTSC");
-	}
+		logerror("-- TV System: %s\n", ((header[10] & 3) == 0) ? "NTSC" : (header[10] & 1) ? "Both NTSC and PAL" : "PAL");
 
 	// SETUP step 5: allocate pointers for PRG/VROM
 	if (prg_size)


### PR DESCRIPTION
- Also, tweaked logging so newer .nes files show backwards compatible fields.