### PR TITLE
tms32031.cpp: Add TMS320VC33 emulation support, Add notes

### DIFF
--- a/src/mame/audio/cage.cpp
+++ b/src/mame/audio/cage.cpp
@@ -200,7 +200,7 @@ TIMER_DEVICE_CALLBACK_MEMBER( atari_cage_device::dma_timer_callback )
 	m_tms32031_io_regs[DMA_SOURCE_ADDR] = param;
 
 	/* set the interrupt */
-	m_cpu->set_input_line(TMS3203X_DINT, ASSERT_LINE);
+	m_cpu->set_input_line(TMS3203X_DINT0, ASSERT_LINE);
 	m_dma_enabled = 0;
 }
 


### PR DESCRIPTION
Implement instruction fetch cycle differences between TMS320C3x family DSPs, Add support for low power operation mode
Add infos for RAM block configuration, Not implemented operations
Fix spacing, Reduce duplicates
reference: TMS320VC33 datasheet, User's Guide from Texas Instruments