### PR TITLE
bus/nes_ctrl: Fixed Family Trainer button reads.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -46607,6 +46607,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="cnrom" />
 			<feature name="pcb" value="NES-CNROM" />
 			<feature name="mirroring" value="horizontal" />
+			<feature name="peripheral" value="ftrainer" />
 			<dataarea name="chr" size="32768">
 				<rom name="family trainer 10 - rairai kyonsees (japan) (beta).chr" size="32768" crc="c688741a" sha1="ab747dc1d1007f46de07d2c44a7cacdacd691fb9" offset="00000" status="baddump" />
 			</dataarea>
@@ -46627,6 +46628,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="cnrom" />
 			<feature name="pcb" value="NES-CNROM" />
 			<feature name="mirroring" value="horizontal" />
+			<feature name="peripheral" value="ftrainer" />
 			<dataarea name="chr" size="32768">
 				<rom name="family trainer 10 - rairai kyonsees (japan).chr" size="32768" crc="ecb80045" sha1="6ef04bcc4fd32949a6f7460b3ab7f5d00f55218d" offset="00000" status="baddump" />
 			</dataarea>
@@ -46647,6 +46649,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="discrete_74x161" />
 			<feature name="pcb" value="BANDAI-74*161/161/32" />
 			<feature name="mirroring" value="vertical" />
+			<feature name="peripheral" value="ftrainer" />
 			<dataarea name="chr" size="131072">
 				<rom name="family trainer 6 - manhattan police (japan).chr" size="131072" crc="b40d4a42" sha1="595f4f58ce13686a872299225232bd360752e25f" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes_ctrl/ftrainer.cpp
+++ b/src/devices/bus/nes_ctrl/ftrainer.cpp
@@ -16,7 +16,7 @@
 DEFINE_DEVICE_TYPE(NES_FTRAINER, nes_ftrainer_device, "nes_famtrain", "Bandai Family Trainer")
 
 
-static INPUT_PORTS_START( nes_joypad )
+static INPUT_PORTS_START( nes_ftrainer )
 	PORT_START("LAYOUT")
 	PORT_CONFNAME( 0x01, 0x00, "Family Trainer Button Layout")
 	PORT_CONFSETTING(  0x00, "Side A" )
@@ -26,7 +26,7 @@ static INPUT_PORTS_START( nes_joypad )
 	PORT_START("FT_COL.0")
 	// side A layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_UNUSED )                                                        PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid1")  PORT_CODE(KEYCODE_J) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid1")  PORT_CODE(KEYCODE_F) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_UNUSED )                                                        PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	// side B layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 12")    PORT_CODE(KEYCODE_M) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
@@ -35,9 +35,9 @@ static INPUT_PORTS_START( nes_joypad )
 
 	PORT_START("FT_COL.1")
 	// side A layout
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Low1")  PORT_CODE(KEYCODE_N) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid2")  PORT_CODE(KEYCODE_H) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Top1")  PORT_CODE(KEYCODE_Y) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Low1")  PORT_CODE(KEYCODE_B) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid2")  PORT_CODE(KEYCODE_G) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Top1")  PORT_CODE(KEYCODE_T) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	// side B layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 11")    PORT_CODE(KEYCODE_N) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
 	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 7")     PORT_CODE(KEYCODE_H) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
@@ -45,9 +45,9 @@ static INPUT_PORTS_START( nes_joypad )
 
 	PORT_START("FT_COL.2")
 	// side A layout
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Low2")  PORT_CODE(KEYCODE_B) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid3")  PORT_CODE(KEYCODE_G) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Top2")  PORT_CODE(KEYCODE_T) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Low2")  PORT_CODE(KEYCODE_N) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid3")  PORT_CODE(KEYCODE_H) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Top2")  PORT_CODE(KEYCODE_Y) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	// side B layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 10")    PORT_CODE(KEYCODE_B) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
 	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 6")     PORT_CODE(KEYCODE_G) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
@@ -56,7 +56,7 @@ static INPUT_PORTS_START( nes_joypad )
 	PORT_START("FT_COL.3")
 	// side A layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_UNUSED )                                                        PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid4")  PORT_CODE(KEYCODE_F) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer Mid4")  PORT_CODE(KEYCODE_J) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_UNUSED )                                                        PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x00)
 	// side B layout
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_KEYPAD ) PORT_NAME("Family Trainer 9")     PORT_CODE(KEYCODE_V) PORT_CONDITION("LAYOUT", 0x01, EQUALS, 0x01)
@@ -71,7 +71,7 @@ INPUT_PORTS_END
 
 ioport_constructor nes_ftrainer_device::device_input_ports() const
 {
-	return INPUT_PORTS_NAME( nes_joypad );
+	return INPUT_PORTS_NAME( nes_ftrainer );
 }
 
 
@@ -120,27 +120,16 @@ void nes_ftrainer_device::device_reset()
 uint8_t nes_ftrainer_device::read_exp(offs_t offset)
 {
 	uint8_t ret = 0;
-	if (offset == 1)    //$4017
+
+	if (offset == 1)    // $4017
 	{
-		if (!BIT(m_row_scan, 0))
-		{
-			// read low line: buttons 9,10,11,12
-			for (int i = 0; i < 4; i++)
-				ret |= ((m_trainer[i]->read() & 0x01) << (1 + i));
-		}
-		else if (!BIT(m_row_scan, 1))
-		{
-			// read mid line: buttons 5,6,7,8
-			for (int i = 0; i < 4; i++)
-				ret |= ((m_trainer[i]->read() & 0x02) << (1 + i));
-		}
-		else if (!BIT(m_row_scan, 2))
-		{
-			// read high line: buttons 1,2,3,4
-			for (int i = 0; i < 4; i++)
-				ret |= ((m_trainer[i]->read() & 0x04) << (1 + i));
-		}
+		for (int row = 0; row < 3; row++)  // bottom row first (buttons 9,10,11,12)
+			if (!BIT(m_row_scan, row))
+				for (int col = 0; col < 4; col++)  // side B right column first (buttons 4,8,12)
+					ret |= BIT(m_trainer[col]->read(), row) << (col + 1);
+		return ~ret & 0x1e;  // 0: pressed, 1: not pressed
 	}
+
 	return ret;
 }
 


### PR DESCRIPTION
- Column input reads now shifted to correct bit, fixing reads for top two rows.
- Button presses are correctly 0 bits.
- Multiple rows can be scanned per read.
- Flipped key bindings on mat side A. Now left/right on keyboard actually corresponds to left/right on mat.