### PR TITLE
c64_cass.xml: Added twenty entries

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -4845,6 +4845,33 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="ferrari">
+		<description>Ferrari Formula One</description>
+		<year>1990</year>
+		<publisher>Activision</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Tape 1 Side 1: Boot"/>
+			<dataarea name="cass" size="262666">
+				<rom name="Ferrari_Formula_One_Tape_1_Side_1.tap" size="262666" crc="5af5f5b7" sha1="20afc4a8f3fad1ce3cd5024c3c04b291dcbb3d02"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side 1: Fiorano Set-up and Practice"/>
+			<dataarea name="cass" size="551020">
+				<rom name="Ferrari_Formula_One_Tape_2_Side_1.tap" size="551020" crc="d6fa9877" sha1="ca1e5a1c8b599d14ebd932c4ddd50b183648ee30"/>
+			</dataarea>
+		</part>
+
+		<part name="cass3" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side 2: Grand Prix Circuits"/>
+			<dataarea name="cass" size="1057500">
+				<rom name="Ferrari_Formula_One_Tape_2_Side_2.tap" size="1057500" crc="3dd58955" sha1="9a917617bd5f37edf16417bf1a1ad136cead919f"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="feud">
 		<description>Feud</description>
 		<year>1987</year>
@@ -4862,6 +4889,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 			<feature name="part_id" value="Side B"/>
 			<dataarea name="cass" size="611910">
 				<rom name="feudb.tap" size="611910" crc="0cbe87c1" sha1="b06e65952e8d2c8ee0b8cb227134136ba53b62b3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fightn">
+		<description>Fight Night</description>
+		<year>1985</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="421960">
+				<rom name="Fight_Night_Side_1.tap" size="421960" crc="3ac7ad28" sha1="b13af54a028280c139b72ce0e8be7e61e0898805"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="629356">
+				<rom name="Fight_Night_Side_2.tap" size="629356" crc="7adb74c6" sha1="17895eed3074e7a353cd5fac754ca303fd9632d5"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4885,6 +4932,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="ffight" supported="no"> <!-- game loads and runs, but once past the player select screen, graphics are completely garbled so game is unplayable -->
+		<description>Final Fight</description>
+		<year>1991</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="671950">
+				<rom name="Final_Fight_Side_1.tap" size="671950" crc="0825dc9a" sha1="5866658a8cdfcd4339f4d30c7e1cfcaa5a6ce55a"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="1311108">
+				<rom name="Final_Fight_Side_2.tap" size="1311108" crc="c5511e5e" sha1="b2466265993813b918f48a6d060a813a44086d05"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="findkeep">
 		<description>Finders Keepers</description>
 		<year>1985</year>
@@ -4903,6 +4970,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="fireant">
+		<description>Fire Ant</description>
+		<year>1983</year>
+		<publisher>Mogul</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="720103">
+				<rom name="Fire_Ant.tap" size="720103" crc="94e6a521" sha1="50e0480d749c455cb01657441014fc3fd722dec8"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="firelord">
 		<description>Firelord</description>
 		<year>1990</year>
@@ -4911,6 +4990,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="532122">
 				<rom name="Firelord.tap" size="532122" crc="3bafc24e" sha1="ccfad147bbbb48ef0e2d2cd6bd614a578ec02605"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="firelordh" cloneof="firelord">
+		<description>Firelord (Hewson Consultants)</description>
+		<year>1986</year>
+		<publisher>Hewson Consultants</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="532122">
+				<rom name="Firelord.tap" size="532122" crc="80c4a7a9" sha1="f3fa271de452cb12f1a773a9dacf6f9631274c3f"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4951,7 +5042,19 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
-	<software name="fist2">
+	<software name="fstrikee" cloneof="fstrike">
+		<description>First Strike (Elite Systems)</description>
+		<year>1989</year>
+		<publisher>Elite Systems</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="675937">
+				<rom name="First_Strike.tap" size="675937" crc="a24edc7e" sha1="6376af476c81e96a395850cab6e3163b04247275"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fist2" supported="no"> <!-- game loads but doesn't run (just displays a light blue screen) -->
 		<description>Fist II: La Leyenda Continua</description>
 		<year>1986</year>
 		<publisher>Erbe</publisher>
@@ -4971,6 +5074,60 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="fist2m" cloneof="fist2" supported="no"> <!-- game loads but doesn't run (just displays a light blue screen) -->
+		<description>Fist II: The Legend Continues</description>
+		<year>1986</year>
+		<publisher>Melbourne House</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="597436">
+				<rom name="Fist_II-_The_Legend_Continues_Side_1.tap" size="597436" crc="7233b95d" sha1="1d0c979c97b48f07a97c198abb9535dfa42304f9"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="523846">
+				<rom name="Fist_II-_The_Legend_Continues_Side_2.tap" size="523846" crc="6989fe06" sha1="86883ab655cc9cbff21f221908139b3578d2929f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fistsnth">
+		<description>Fists 'n' Throttles</description>
+		<year>1988</year>
+		<publisher>Elite Systems</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Tape 1 Side A: Dragons Lair"/>
+			<dataarea name="cass" size="1222090">
+				<rom name="Fists_'N'_Throttles_Tape_1_Side_A.tap" size="1222090" crc="95df659e" sha1="3f92f7b7161e18a664c71f3dad0cb222acc8871b"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Tape 1 Side B: Dragons Lair"/>
+			<dataarea name="cass" size="1222090">
+				<rom name="Fists_'N'_Throttles_Tape_1_Side_B.tap" size="1222090" crc="2210ea51" sha1="c04afd8a7f04e2b4996efac8bca67fed7a7ad2c0"/>
+			</dataarea>
+		</part>
+
+		<part name="cass3" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side A: Enduro Racer / Ikari Warriors"/>
+			<dataarea name="cass" size="1214682">
+				<rom name="Fists_'N'_Throttles_Tape_2_Side_A.tap" size="1214682" crc="cdcdb248" sha1="8f04429e4a52d0f0e82681952578c7852896229d"/>
+			</dataarea>
+		</part>
+
+		<part name="cass4" interface="cbm_cass">
+			<feature name="part_id" value="Tape 2 Side B: Buggy Boy / Thundercats"/>
+			<dataarea name="cass" size="1360150">
+				<rom name="Fists_'N'_Throttles_Tape_2_Side_B.tap" size="1360150" crc="e8fe6f73" sha1="bd65bf898fe669509bfcad6493d6638c4f42b0b3"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="flak">
 		<description>Flak</description>
 		<year>1984</year>
@@ -4983,6 +5140,36 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="flightpa">
+		<description>Flight Path 737</description>
+		<year>1984</year>
+		<publisher>Anirog</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="610450">
+				<rom name="Flight_Path_737-_Advanced_Pilot_Trainer.tap" size="610450" crc="97f34bcf" sha1="b8888c5b9855e8492d39f3ecc23eabf357a83a98"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="flintstn" supported="no"> <!-- game loads but doesn't run (just displays a light blue screen) -->
+		<description>The Flintstones</description>
+		<year>1989</year>
+		<publisher>Grandslam</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="614404">
+				<rom name="Flintstones,_The.tap" size="614404" crc="e4a2b051" sha1="b6490b868ce4c76addec347cdc0b8ecf2a325ac3"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="614404">
+				<rom name="Flintstones,_The_a1.tap" size="614404" crc="ea60184b" sha1="c82606fd67a85b210faef3ac05fe4837002e5662"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="flyfther">
 		<description>Flying Feathers</description>
 		<year>1984</year>
@@ -4991,6 +5178,48 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="491822">
 				<rom name="Flying_Feathers.tap" size="491822" crc="ff6b2ba0" sha1="e336ead87fa377f01ac6ff8ccbbb9382da588542"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="flyfthera" cloneof="flyfther">
+		<description>Flying Feathers (alt)</description>
+		<year>1984</year>
+		<publisher>Bubble Bus Software</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="472747">
+				<rom name="Flying_Feathers.tap" size="472747" crc="6cfdf56b" sha1="13b90e55d57aed325709f7672147c491645204c1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fshark">
+		<description>Flying Shark</description>
+		<year>1987</year>
+		<publisher>Firebird</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="1399905">
+				<rom name="Flying_Shark.tap" size="1399905" crc="73cf4228" sha1="7bf18c573584305255c9a8a1c68b6166729528ef"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="1400017">
+				<rom name="Flying_Shark_a1.tap" size="1400017" crc="4ab4e5eb" sha1="ded24bfdc10b3c2d108a10b56c6de34eba48847e"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fbmngr2">
+		<description>Football Manager 2</description>
+		<year>1988</year>
+		<publisher>Addictive Games</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="477077">
+				<rom name="Football_Manager_2.tap" size="477077" crc="743e80d6" sha1="cf72514b8bc7e3d18a5475a13cc19169a254387e"/>
 			</dataarea>
 		</part>
 	</software>
@@ -5025,6 +5254,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="forgottn">
+		<description>Forgotten Worlds</description>
+		<year>1989</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="512014">
+				<rom name="Forgotten_Worlds_Side_1.tap" size="512014" crc="8086cadf" sha1="41b58795a98f026be651e03d3ad8e2adfc87683b"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="1652512">
+				<rom name="Forgotten_Worlds_Side_2.tap" size="1652512" crc="d3e4c76a" sha1="e8f850d63f0ee8d62a848e4ac7784cc7b806a95e"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="f1sim">
 		<description>Formula 1 Simulator</description>
 		<year>1985</year>
@@ -5039,6 +5288,36 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass2" interface="cbm_cass">
 			<dataarea name="cass" size="448397">
 				<rom name="Formula_1_Simulator_a1.tap" size="448397" crc="827409bc" sha1="361d1223ef22b62637a6ed18c543f8010517d622"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="fortapoc">
+		<description>Fort Apocalypse</description>
+		<year>1984</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="225834">
+				<rom name="Fort_Apocalypse.tap" size="225834" crc="ca5e88d4" sha1="6596e883e3150574a9626799b32227da022350e8"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="foxxfb">
+		<description>Foxx Fights Back</description>
+		<year>1988</year>
+		<publisher>Image Works</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="577959">
+				<rom name="Foxx_Fights_Back.tap" size="577959" crc="5ef1ebf1" sha1="4b1f093ea4d86bbff4b9573c198897e591918894"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="577959">
+				<rom name="Foxx_Fights_Back_a1.tap" size="577959" crc="50b7a537" sha1="f6a2867ea420ee3ba6a025a5cb20b342c78d7f41"/>
 			</dataarea>
 		</part>
 	</software>
@@ -5115,6 +5394,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="freddy" supported="partial"> <!-- game loads load and runs but when starting game, player character keeps dropping through floor and dies -->
+		<description>Freddy Hardest</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="738562">
+				<rom name="Freddy_Hardest_Side_1.tap" size="738562" crc="88b7655a" sha1="1c2bdb47e49039deb0433799b567274b470c66dd"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="738562">
+				<rom name="Freddy_Hardest_Side_2.tap" size="738562" crc="7c2073d5" sha1="b6793c73daa2f77a1e512a14e4f974b5956c1a11"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="frightmare">
 		<description>Frightmare</description>
 		<year>1989</year>
@@ -5123,6 +5422,30 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="643137">
 				<rom name="Frightmare.tap" size="643137" crc="0760196b" sha1="985f185d710ef67956a184339343d9218ffb4e29"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="frogger64">
+		<description>Frogger 64</description>
+		<year>1983</year>
+		<publisher>Interceptor Software</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="1162592">
+				<rom name="Frogger_64.tap" size="1162592" crc="de32ab16" sha1="7b033612916c6994098884313c95e5de78c72ee4"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="frontlin">
+		<description>Front Line</description>
+		<year>1984</year>
+		<publisher>Interceptor Software</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="538666">
+				<rom name="Front_Line.tap" size="538666" crc="191105e7" sha1="337bcd321d0bb6b860c0df861d3e9821d0e3b304"/>
 			</dataarea>
 		</part>
 	</software>
@@ -5185,6 +5508,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="594389">
 				<rom name="Fungus.tap" size="594389" crc="e0129b8b" sha1="bbaf13a6bf7cc5ea44c11be25cdd1cbe51d0fca0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="futurekn">
+		<description>Future Knight</description>
+		<year>1986</year>
+		<publisher>Gremlin Graphics</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="555234">
+				<rom name="Future_Knight.tap" size="555234" crc="01f48865" sha1="244a93ef3b84241115e4234524efecad28765e80"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
---------------------------------------
Ferrari Formula One (Activision) [C64 Ultimate Tape Archive V2.0]
Fight Night (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Fire Ant (Mogul) [C64 Ultimate Tape Archive V2.0]
Firelord (Hewson Consultants) [C64 Ultimate Tape Archive V2.0]
First Strike (Elite Systems) [C64 Ultimate Tape Archive V2.0]
Fists 'n' Throttles (Elite Systems) [C64 Ultimate Tape Archive V2.0]
Flight Path 737 (Anirog) [C64 Ultimate Tape Archive V2.0]
Flying Feathers (Bubble Bus Software, alt) [C64 Ultimate Tape Archive V2.0]
Flying Shark (Firebird) [C64 Ultimate Tape Archive V2.0]
Football Manager 2 (Addictive Games) [C64 Ultimate Tape Archive V2.0]
Forgotten Worlds (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Fort Apocalypse (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Foxx Fights Back (Image Works) [C64 Ultimate Tape Archive V2.0]
Freddy Hardest (Imagine) [C64 Ultimate Tape Archive V2.0]
Frogger 64 (Interceptor Software) [C64 Ultimate Tape Archive V2.0]
Front Line (Interceptor Software) [C64 Ultimate Tape Archive V2.0]
Future Knight (Gremlin Graphics) [C64 Ultimate Tape Archive V2.0]

New NOT_WORKING software list additions
---------------------------------------
Final Fight (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Fist II: The Legend Continues (Melbourne House) [C64 Ultimate Tape Archive V2.0]
The Flintstones (Grandslam) [C64 Ultimate Tape Archive V2.0]

Note that I have demoted the existing Fist II (Erbe) entry as this also fails to load correctly.