### PR TITLE
Fixing issue with locale sensitivity in the -listxml command

### DIFF
--- a/src/frontend/mame/infoxml.cpp
+++ b/src/frontend/mame/infoxml.cpp
@@ -30,6 +30,7 @@
 #include <cctype>
 #include <cstring>
 #include <future>
+#include <locale>
 #include <queue>
 #include <type_traits>
 #include <unordered_set>
@@ -491,6 +492,9 @@ void info_xml_creator::output(std::ostream &out, const std::function<bool(const 
 			{
 				prepared_info result;
 				std::ostringstream stream;
+
+				// make this locale neutral
+				stream.imbue(std::locale(""));
 
 				// output each of the drivers
 				for (const game_driver &driver : drivers)


### PR DESCRIPTION
This was a regression introduced in 0.237 and part the MT#8118 bug report