### PR TITLE
genie: Set _FILE_OFFSET_BITS=64

### DIFF
--- a/3rdparty/genie/build/gmake.linux/genie.make
+++ b/3rdparty/genie/build/gmake.linux/genie.make
@@ -46,7 +46,7 @@ ifeq ($(config),release)
   OBJDIR              = obj/Release
   TARGETDIR           = ../../bin/linux
   override TARGET              = $(TARGETDIR)/genie
-  DEFINES            += -DNDEBUG -DLUA_COMPAT_MODULE -DLUA_USE_POSIX -DLUA_USE_DLOPEN
+  DEFINES            += -DNDEBUG -DLUA_COMPAT_MODULE -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_FILE_OFFSET_BITS=64
   INCLUDES           += -I"../../src/host/lua-5.3.0/src"
   ALL_CPPFLAGS       += $(CPPFLAGS) -MMD -MP -MP $(DEFINES) $(INCLUDES)
   ALL_ASMFLAGS       += $(ASMFLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -Os $(MPARAM) -Wno-implicit-fallthrough
@@ -133,7 +133,7 @@ ifeq ($(config),debug)
   OBJDIR              = obj/Debug
   TARGETDIR           = ../../bin/linux
   override TARGET              = $(TARGETDIR)/genie
-  DEFINES            += -D_DEBUG -DLUA_COMPAT_MODULE -DLUA_USE_POSIX -DLUA_USE_DLOPEN
+  DEFINES            += -D_DEBUG -DLUA_COMPAT_MODULE -DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_FILE_OFFSET_BITS=64
   INCLUDES           += -I"../../src/host/lua-5.3.0/src"
   ALL_CPPFLAGS       += $(CPPFLAGS) -MMD -MP -MP $(DEFINES) $(INCLUDES)
   ALL_ASMFLAGS       += $(ASMFLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(ARCH) -Wall -Wextra -g $(MPARAM) -Wno-implicit-fallthrough

--- a/3rdparty/genie/scripts/genie.lua
+++ b/3rdparty/genie/scripts/genie.lua
@@ -77,6 +77,9 @@
 			links        { "m" }
 			linkoptions  { "-rdynamic" }
 
+		configuration "linux"
+			define       { "_FILE_OFFSET_BITS=64" }
+
 		configuration "macosx"
 			targetdir   "../bin/darwin"
 			defines     { "LUA_USE_MACOSX" }


### PR DESCRIPTION
Compiles GENie with `off_t` defined as a 64-bit integer to assist with building MAME on a 32-bit operating system like Raspberry Pi OS and a storage volume larger than 2 GB.

Without this, the build can fail with a misleading error:

```
[string "premake.fields = {}..."]:82: Can't find matching files for pattern :.../mame/scripts/resources/uwp/assets/*.png
stack traceback:
        [C]: in function 'error'
        [string "premake.fields = {}..."]:82: in function 'makeabsolute'
        [string "premake.fields = {}..."]:76: in function 'makeabsolute'
        [string "premake.fields = {}..."]:92: in function <[string "premake.fields = {}..."]:71>
        (...tail calls...)
        .../mame/scripts/src/main.lua:79: in function 'mainProject'
        .../mame/scripts/genie.lua:1566: in main chunk
        [C]: in upvalue 'builtin_dofile'
        [string "premake = { }..."]:109: in function 'dofile'
        [string "_WORKING_DIR        = os.getcwd()..."]:46: in function '_premake_main'
make: *** [makefile:1391: build/projects/sdl/mame/gmake-linux/Makefile] Error 1
```

The "**Can't find matching files for pattern**" error message is misleading because GENie's [`os.matchnext()` function](https://github.com/mamedev/mame/blob/6f2242561da182ab92b04a5f424740c2942b74ad/3rdparty/genie/src/host/os_match.c#L162-L181) doesn't check its `readdir()` calls for error.  But here it's actually failing with `EOVERFLOW` because the type `off_t` is only 32-bits.