### PR TITLE
icorender: appease msvc

### DIFF
--- a/src/frontend/mame/ui/icorender.cpp
+++ b/src/frontend/mame/ui/icorender.cpp
@@ -44,6 +44,13 @@ namespace {
 // ICO file header
 struct icon_dir_t
 {
+	void byteswap()
+	{
+		reserved = little_endianize_int16(reserved);
+		type = little_endianize_int16(type);
+		count = little_endianize_int16(count);
+	}
+
 	uint16_t    reserved;   // must be 0
 	uint16_t    type;       // 1 for icon or 2 for cursor
 	uint16_t    count;      // number of images in the file
@@ -179,7 +186,7 @@ bool load_ico_image(util::core_file &fp, unsigned count, unsigned index, bitmap_
 {
 	// read the directory entry
 	std::error_condition err;
-	size_t actual;
+	size_t actual = 0;
 	icon_dir_entry_t dir;
 	err = fp.seek(sizeof(icon_dir_t) + (sizeof(icon_dir_entry_t) * index), SEEK_SET);
 	if (!err)
@@ -212,7 +219,7 @@ int images_in_ico(util::core_file &fp)
 {
 	// read and check the icon file header
 	std::error_condition err;
-	size_t actual;
+	size_t actual = 0;
 	icon_dir_t header;
 	err = fp.seek(0, SEEK_SET);
 	if (!err)
@@ -222,9 +229,7 @@ int images_in_ico(util::core_file &fp)
 		LOG("Failed to read ICO file header\n");
 		return -1;
 	}
-	header.reserved = little_endianize_int16(header.reserved);
-	header.type = little_endianize_int16(header.type);
-	header.count = little_endianize_int16(header.count);
+	header.byteswap();
 	if (0U != header.reserved)
 	{
 		LOG("Invalid ICO file header reserved field %u (expected 0)\n", header.reserved);


### PR DESCRIPTION
MSVC warns about potentially uninitialized variables in this code, probably because it can't properly follow the short-circuit evaluation of `err`. Initializing `size_t` variables to 0 seems relatively harmless/lightweight and using a helper function to byte swap the `icon_dir_t` struct values at least follows the pattern from the `icon_dir_entry_t` struct in the same code.

Disabling the MSVC warning globally just to permit this particular file to compile seems like as poor a choice as adding an explicit `#pragma` to disable it in this file, but any other suggestions would be welcome.