### PR TITLE
Build fix on mac: 10 ^ 7 hits the -Wxor-used-as-pow check

### DIFF
--- a/src/mame/drivers/cmi.cpp
+++ b/src/mame/drivers/cmi.cpp
@@ -160,7 +160,7 @@
 
 static const int ch_int_levels[8] =
 {
-	12 ^ 7, 8 ^ 7, 13 ^ 7, 9 ^ 7, 14 ^ 7, 10 ^ 7, 15 ^ 7, 11  ^ 7
+	12 xor 7, 8 xor 7, 13 xor 7, 9 xor 7, 14 xor 7, 10 xor 7, 15 xor 7, 11  xor 7
 };
 
 #define IRQ_PERRINT_LEVEL       (0 ^ 7)


### PR DESCRIPTION
On building with recent clang on mac, 10 ^ N hits -Wxor-used-as-pow
check. This happens only when a left value is 10, and we can explicitly
say xor to express an exclusive OR operation.

This simple patch replace existing '^'s with 'xor's so that we can
compile it on recent mac, and the code looks consistent in the file.