### PR TITLE
mark blockcar (Visco's Block Carnival / Thunder & Lightning 2 in seta.cpp) X1 sample ROM as BAD_DUMP + other small improvements

### DIFF
--- a/src/mame/drivers/cps1.cpp
+++ b/src/mame/drivers/cps1.cpp
@@ -14070,7 +14070,7 @@ GAME( 1988, forgottnue,  forgottn, forgottn,   forgottn, cps_state, init_cps1,  
 GAME( 1988, forgottnuc,  forgottn, forgottn,   forgottn, cps_state, init_cps1,     ROT0,   "Capcom", "Forgotten Worlds (USA, B-Board 88618B-2, Rev. C)", MACHINE_SUPPORTS_SAVE )
 GAME( 1988, forgottnua,  forgottn, forgottn,   forgottn, cps_state, init_cps1,     ROT0,   "Capcom", "Forgotten Worlds (USA, B-Board 88618B-2, Rev. A)", MACHINE_SUPPORTS_SAVE )
 GAME( 1988, forgottnuaa, forgottn, forgottn,   forgottn, cps_state, init_cps1,     ROT0,   "Capcom", "Forgotten Worlds (USA, B-Board 88618B-2, Rev. AA)", MACHINE_SUPPORTS_SAVE )
-GAME( 1988, forgottnj,   forgottn, forgottn,   forgottnj,cps_state, init_cps1,     ROT0,   "Capcom", "Forgotten Worlds (Japan)", MACHINE_SUPPORTS_SAVE )
+GAME( 1988, forgottnj,   forgottn, forgottn,   forgottnj,cps_state, init_cps1,     ROT0,   "Capcom", "Forgotten Worlds (Japan) (English prototype)", MACHINE_SUPPORTS_SAVE ) // shows a Japan warning but runs an English localized version of the game, many changes, unfinished levels, ends abruptly.
 GAME( 1988, lostwrld,    forgottn, forgottn,   forgottn, cps_state, init_cps1,     ROT0,   "Capcom", "Lost Worlds (Japan)", MACHINE_SUPPORTS_SAVE )
 GAME( 1988, lostwrldo,   forgottn, forgottn,   forgottn, cps_state, init_cps1,     ROT0,   "Capcom", "Lost Worlds (Japan Old Ver.)", MACHINE_SUPPORTS_SAVE )
 GAME( 1988, ghouls,      0,        cps1_10MHz, ghouls,   cps_state, init_cps1,     ROT0,   "Capcom", "Ghouls'n Ghosts (World)", MACHINE_SUPPORTS_SAVE )   // "EXPORT" // Wed.26.10.1988 in the ROMs

--- a/src/mame/drivers/gaelco.cpp
+++ b/src/mame/drivers/gaelco.cpp
@@ -16,6 +16,19 @@ Year   Game                PCB            NOTES
 1995   Biomechanical Toy   REF 922804/2   Unprotected
 1996   Maniac Square       REF 922804/2   Prototype
 
+TODO: Figure out why Thunder Hoop crashes if you die on Level 4
+      This can be bypassed by killing yourself at the same time as
+	  the Level 3 boss dies, suggesting the end stage animation is
+	  somehow corrupting the game state. Could this be a bug in
+	  the supported revision of the game?  It doesn't depend on
+	  CPU clock, vblank timing, there are no unmapped reads or
+	  writes of significance.  Could it be related to a dipswitch
+	  setting?
+
+	  Priorities for all games - the games don't make extensive
+	  enough use of the priority scheme to properly draw any
+	  conclusions.
+
 ***************************************************************************/
 
 #include "emu.h"
@@ -64,6 +77,12 @@ void gaelco_state::oki_bankswitch_w(uint8_t data)
 	m_okibank->set_entry(data & 0x0f);
 }
 
+void gaelco_state::irqack_w(uint16_t data)
+{
+	// INT 6 ACK or Watchdog timer - written at the end of an IRQ
+	m_maincpu->set_input_line(6, CLEAR_LINE);
+}
+
 /*********** Squash Encryption Related Code ******************/
 
 void gaelco_state::vram_encrypted_w(offs_t offset, uint16_t data, uint16_t mem_mask)
@@ -109,7 +128,7 @@ void gaelco_state::bigkarnk_map(address_map &map)
 	map(0x100000, 0x101fff).ram().w(FUNC(gaelco_state::vram_w)).share("videoram");              // Video RAM
 	map(0x102000, 0x103fff).ram();                                                              // Screen RAM
 	map(0x108000, 0x108007).writeonly().share("vregs");                                         // Video Registers
-//  map(0x10800c, 0x10800d).w("watchdog", FUNC(watchdog_timer_device::reset16_w));                  // INT 6 ACK/Watchdog timer
+	map(0x10800c, 0x10800d).w(FUNC(gaelco_state::irqack_w));                                    // INT 6 ACK/Watchdog timer
 	map(0x200000, 0x2007ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette"); // Palette
 	map(0x440000, 0x440fff).ram().share("spriteram");                                           // Sprite RAM
 	map(0x700000, 0x700001).portr("DSW1");
@@ -138,7 +157,7 @@ void gaelco_state::maniacsq_map(address_map &map)
 	map(0x100000, 0x101fff).ram().w(FUNC(gaelco_state::vram_w)).share("videoram");                // Video RAM
 	map(0x102000, 0x103fff).ram();                                                                // Screen RAM
 	map(0x108000, 0x108007).writeonly().share("vregs");                                           // Video Registers
-//  map(0x10800c, 0x10800d).w("watchdog", FUNC(watchdog_timer_device::reset16_w));                    // INT 6 ACK/Watchdog timer
+	map(0x10800c, 0x10800d).w(FUNC(gaelco_state::irqack_w));                                      // INT 6 ACK/Watchdog timer
 	map(0x200000, 0x2007ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");   // Palette
 	map(0x440000, 0x440fff).ram().share("spriteram");                                             // Sprite RAM
 	map(0x700000, 0x700001).portr("DSW2");
@@ -156,7 +175,7 @@ void gaelco_state::squash_map(address_map &map)
 	map(0x100000, 0x101fff).ram().w(FUNC(gaelco_state::vram_encrypted_w)).share("videoram");     // Video RAM
 	map(0x102000, 0x103fff).ram().w(FUNC(gaelco_state::encrypted_w)).share("screenram");         // Screen RAM
 	map(0x108000, 0x108007).writeonly().share("vregs");                                          // Video Registers
-//  map(0x10800c, 0x10800d).w("watchdog", FUNC(watchdog_timer_device::reset16_w));                   // INT 6 ACK/Watchdog timer
+	map(0x10800c, 0x10800d).w(FUNC(gaelco_state::irqack_w));                                     // INT 6 ACK/Watchdog timer
 	map(0x200000, 0x2007ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");  // Palette
 	map(0x440000, 0x440fff).ram().share("spriteram");                                            // Sprite RAM
 	map(0x700000, 0x700001).portr("DSW2");
@@ -175,7 +194,7 @@ void gaelco_state::thoop_map(address_map &map)
 	map(0x100000, 0x101fff).ram().w(FUNC(gaelco_state::thoop_vram_encrypted_w)).share("videoram"); // Video RAM
 	map(0x102000, 0x103fff).ram().w(FUNC(gaelco_state::thoop_encrypted_w)).share("screenram");     // Screen RAM
 	map(0x108000, 0x108007).writeonly().share("vregs");                                            // Video Registers
-//  map(0x10800c, 0x10800d).w("watchdog", FUNC(watchdog_timer_device::reset16_w));                     // INT 6 ACK/Watchdog timer
+	map(0x10800c, 0x10800d).w(FUNC(gaelco_state::irqack_w));                                      // INT 6 ACK/Watchdog timer
 	map(0x200000, 0x2007ff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");    // Palette
 	map(0x440000, 0x440fff).ram().share("spriteram");                                              // Sprite RAM
 	map(0x700000, 0x700001).portr("DSW2");
@@ -641,7 +660,7 @@ void gaelco_state::bigkarnk(machine_config &config)
 	// Basic machine hardware
 	M68000(config, m_maincpu, XTAL(24'000'000)/2);   // MC68000P10, 12 MHz?
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaelco_state::bigkarnk_map);
-	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_hold));
+	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_assert));
 
 	MC6809E(config, m_audiocpu, XTAL(8'000'000)/4);  // 68B09EP, 2 MHz?
 	m_audiocpu->set_addrmap(AS_PROGRAM, &gaelco_state::bigkarnk_snd_map);
@@ -684,7 +703,7 @@ void gaelco_state::maniacsq(machine_config &config)
 	// Basic machine hardware
 	M68000(config, m_maincpu, XTAL(24'000'000)/2); /* verified on pcb */
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaelco_state::maniacsq_map);
-	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_hold));
+	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_assert));
 
 	// Video hardware
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
@@ -713,7 +732,7 @@ void gaelco_state::squash(machine_config &config)
 	// Basic machine hardware
 	M68000(config, m_maincpu, XTAL(20'000'000)/2); // Verified on PCB
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaelco_state::squash_map);
-	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_hold));
+	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_assert));
 
 	config.set_maximum_quantum(attotime::from_hz(600));
 
@@ -730,13 +749,13 @@ void gaelco_state::squash(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500) /* not accurate */);
 	screen.set_size(32*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco_state::screen_update_maniacsq));
+	screen.set_screen_update(FUNC(gaelco_state::screen_update_thoop));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_gaelco);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 1024);
 
-	MCFG_VIDEO_START_OVERRIDE(gaelco_state,maniacsq)
+	MCFG_VIDEO_START_OVERRIDE(gaelco_state,squash)
 
 	// Sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -751,7 +770,7 @@ void gaelco_state::thoop(machine_config &config)
 	// Basic machine hardware
 	M68000(config, m_maincpu, XTAL(24'000'000)/2); // Verified on PCB
 	m_maincpu->set_addrmap(AS_PROGRAM, &gaelco_state::thoop_map);
-	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_hold));
+	m_maincpu->set_vblank_int("screen", FUNC(gaelco_state::irq6_line_assert));
 
 	config.set_maximum_quantum(attotime::from_hz(600));
 
@@ -768,13 +787,13 @@ void gaelco_state::thoop(machine_config &config)
 	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500) /* not accurate */);
 	screen.set_size(32*16, 32*16);
 	screen.set_visarea(0, 320-1, 16, 256-1);
-	screen.set_screen_update(FUNC(gaelco_state::screen_update_maniacsq));
+	screen.set_screen_update(FUNC(gaelco_state::screen_update_thoop));
 	screen.set_palette(m_palette);
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_gaelco);
 	PALETTE(config, m_palette).set_format(palette_device::xBGR_555, 1024);
 
-	MCFG_VIDEO_START_OVERRIDE(gaelco_state,maniacsq)
+	MCFG_VIDEO_START_OVERRIDE(gaelco_state,bigkarnk)
 
 	// Sound hardware
 	SPEAKER(config, "mono").front_center();

--- a/src/mame/drivers/seta.cpp
+++ b/src/mame/drivers/seta.cpp
@@ -10730,7 +10730,11 @@ ROM_START( blockcar )
 	ROM_LOAD( "bl-chr-1.l3",  0x080000, 0x080000, CRC(563de808) SHA1(40b2f9f4a4cb1a019f6419572ee21d66dda7d4af) )
 
 	ROM_REGION( 0x100000, "x1snd", 0 )  /* Samples */
-	ROM_LOAD( "bl-snd-0.a13",  0x000000, 0x080000, CRC(a92dabaf) SHA1(610c1dc0467753dfddaa4b27bc40cb118b0bc7a3) )
+	/* The game plays music from 0x000000 to 0x0bffff and sfx from 0x0c0000 to 0x0fffff
+	   Loading the ROM mirrored like this causes sfx to play instead of music in some levels.
+	   the most logical conclusion is that the ROM below was dumped at half size and should
+	   be 1MByte, hence BAD_DUMP */
+	ROM_LOAD( "bl-snd-0.a13",  0x000000, 0x080000, BAD_DUMP CRC(a92dabaf) SHA1(610c1dc0467753dfddaa4b27bc40cb118b0bc7a3) )
 	ROM_RELOAD(                0x080000, 0x080000  )
 ROM_END
 
@@ -11881,9 +11885,8 @@ ROM_START( pairlove )
 	ROM_LOAD( "ut2-001-004.5j",  0x000000, 0x080000, CRC(fdc47b26) SHA1(0de51bcf67b909ac9578f0d1b14af8a4c758aacf) )
 	ROM_LOAD( "ut2-001-005.5l",  0x080000, 0x080000, CRC(076f94a2) SHA1(94b4b41a497dea1b6db5396bd7cd81ebcb217735) )
 
-	ROM_REGION( 0x100000, "x1snd", 0 )  /* Samples */
+	ROM_REGION( 0x80000, "x1snd", 0 )  /* Samples */
 	ROM_LOAD( "ut2-001-003.12a",  0x000000, 0x080000, CRC(900219a9) SHA1(3260a900df25beba597bf947a9fbb6f7392827d7) )
-	ROM_RELOAD(                   0x080000, 0x080000 )
 ROM_END
 
 ROM_START( crazyfgt )

--- a/src/mame/includes/gaelco.h
+++ b/src/mame/includes/gaelco.h
@@ -26,7 +26,10 @@ public:
 		m_videoram(*this, "videoram"),
 		m_vregs(*this, "vregs"),
 		m_spriteram(*this, "spriteram"),
-		m_screenram(*this, "screenram") { }
+		m_screenram(*this, "screenram"),
+		m_use_squash_sprite_disable(false),
+		m_sprite_palette_force_high(0x38)
+	{ }
 
 	void bigkarnk(machine_config &config);
 	void thoop(machine_config &config);
@@ -62,15 +65,18 @@ private:
 	void thoop_vram_encrypted_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void thoop_encrypted_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
 	void vram_w(offs_t offset, u16 data, u16 mem_mask);
+	void irqack_w(uint16_t data);
 
 	template<int Layer> TILE_GET_INFO_MEMBER(get_tile_info);
 
 	virtual void machine_start() override;
 	DECLARE_VIDEO_START(bigkarnk);
 	DECLARE_VIDEO_START(maniacsq);
+	DECLARE_VIDEO_START(squash);
 
 	uint32_t screen_update_bigkarnk(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_maniacsq(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	uint32_t screen_update_thoop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	void draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect );
 
 	void bigkarnk_map(address_map &map);
@@ -79,4 +85,8 @@ private:
 	void oki_map(address_map &map);
 	void squash_map(address_map &map);
 	void thoop_map(address_map &map);
+
+	/* per-game configuration */
+	bool m_use_squash_sprite_disable;
+	uint8_t m_sprite_palette_force_high;
 };

--- a/src/mame/video/gaelco.cpp
+++ b/src/mame/video/gaelco.cpp
@@ -75,11 +75,24 @@ VIDEO_START_MEMBER(gaelco_state,bigkarnk)
 	m_tilemap[1]->set_transmask(0, 0xff01, 0x00ff); // pens 1-7 opaque, pens 0, 8-15 transparent
 }
 
+VIDEO_START_MEMBER(gaelco_state,squash)
+{
+	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaelco_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaelco_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
+
+	m_tilemap[0]->set_transmask(0, 0xff01, 0x00ff); // pens 1-7 opaque, pens 0, 8-15 transparent
+	m_tilemap[1]->set_transmask(0, 0xff01, 0x00ff); // pens 1-7 opaque, pens 0, 8-15 transparent
+
+	m_sprite_palette_force_high = 0x3c;
+	m_use_squash_sprite_disable = true;
+}
+
 VIDEO_START_MEMBER(gaelco_state,maniacsq)
 {
 	m_tilemap[0] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaelco_state::get_tile_info<0>)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 	m_tilemap[1] = &machine().tilemap().create(*m_gfxdecode, tilemap_get_info_delegate(*this, FUNC(gaelco_state::get_tile_info<1>)), TILEMAP_SCAN_ROWS, 16, 16, 32, 32);
 
+	// it is possible Maniac Square hardware also has more complex priority handling, but does not use it
 	m_tilemap[0]->set_transparent_pen(0);
 	m_tilemap[1]->set_transparent_pen(0);
 }
@@ -121,6 +134,22 @@ void gaelco_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 	for (i = 0x800 - 4 - 1; i >= 3; i -= 4)
 	{
 		int sx = m_spriteram[i + 2] & 0x01ff;
+
+		/* Hide bad sprites that appear after Squash continue screen (unwanted
+		   Insert Coin and Press 1P/2P start message in bad colouds)
+
+		   The PCB doesn't render these, but the exact disable condition is not
+		   understood, the sprites in question have highest priority, there
+		   does not appear to be any kind of list end marker, or 'number of
+		   sprites' register, nor would they be over any sprite limit.
+
+		   The most logical conclusion is if this specific value in the first
+		   word acts as a disable, but that would stop you putting 8x8 sprites
+		   on the lowest line in other cases */
+		if (m_use_squash_sprite_disable)
+			if (m_spriteram[i] == 0x0800)
+				continue;
+
 		int sy = (240 - (m_spriteram[i] & 0x00ff)) & 0x00ff;
 		int number = m_spriteram[i + 3];
 		int color = (m_spriteram[i + 2] & 0x7e00) >> 9;
@@ -131,13 +160,18 @@ void gaelco_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 		int yflip = attr & 0x40;
 		int spr_size, pri_mask;
 
-		/* palettes 0x38-0x3f are used for high priority sprites in Big Karnak */
-		if (color >= 0x38)
+		/* palettes 0x38-0x3f are used for high priority sprites in Big Karnak
+		   the same logic in Squash causes player sprites to be drawn over the
+		   pixels that form the glass play area.
+
+		   Is this accurate, or just exposing a different flaw in the priority
+		   handling? */
+		if (color >= m_sprite_palette_force_high)
 			priority = 4;
 
 		switch (priority)
 		{
-			case 0: pri_mask = 0xff00; break;
+			case 0: pri_mask = 0xff00; break;  // above everything?
 			case 1: pri_mask = 0xff00 | 0xf0f0; break;
 			case 2: pri_mask = 0xff00 | 0xf0f0 | 0xcccc; break;
 			case 3: pri_mask = 0xff00 | 0xf0f0 | 0xcccc | 0xaaaa; break;
@@ -197,6 +231,50 @@ uint32_t gaelco_state::screen_update_maniacsq(screen_device &screen, bitmap_ind1
 
 	m_tilemap[1]->draw(screen, bitmap, cliprect, 0, 4);
 	m_tilemap[0]->draw(screen, bitmap, cliprect, 0, 4);
+
+	draw_sprites(screen, bitmap, cliprect);
+	return 0;
+}
+
+uint32_t gaelco_state::screen_update_thoop(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect)
+{
+	/* set scroll registers */
+	m_tilemap[0]->set_scrolly(0, m_vregs[0]);
+	m_tilemap[0]->set_scrollx(0, m_vregs[1] + 4);
+	m_tilemap[1]->set_scrolly(0, m_vregs[2]);
+	m_tilemap[1]->set_scrollx(0, m_vregs[3]);
+
+	screen.priority().fill(0, cliprect);
+	bitmap.fill(0, cliprect);
+
+	// the priority handling differs from Big Karnak (or the Big Karnak implementation isn't correct)
+	// the games only make minimal use of the priority features.
+
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 3, 0);
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 3, 0);
+
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 3, 0);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 3, 0);
+
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 2, 1);
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 2, 1);
+
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 2, 1);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 2, 1);
+
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 1, 2);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 1, 2);
+
+	// sprites are sandwiched in here
+
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 1, 4);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 1, 4);
+
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 0, 8);
+	m_tilemap[1]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 0, 8);
+
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER1 | 0, 8);
+	m_tilemap[0]->draw(screen, bitmap, cliprect, TILEMAP_DRAW_LAYER0 | 0, 8);
 
 	draw_sprites(screen, bitmap, cliprect);
 	return 0;

--- a/src/mame/video/gaelco.cpp
+++ b/src/mame/video/gaelco.cpp
@@ -145,7 +145,10 @@ void gaelco_state::draw_sprites( screen_device &screen, bitmap_ind16 &bitmap, co
 
 		   The most logical conclusion is if this specific value in the first
 		   word acts as a disable, but that would stop you putting 8x8 sprites
-		   on the lowest line in other cases */
+		   on the lowest line in other cases.  This does cause the 'X'
+		   co-ordinate display to vanish in one of the test mode features, but
+		   that feature does not appear to be functional anyway so also needs
+		   to be verified on hardware. */
 		if (m_use_squash_sprite_disable)
 			if (m_spriteram[i] == 0x0800)
 				continue;


### PR DESCRIPTION
- marked blockcar (Visco's Block Carnival / Thunder & Lightning 2 in seta.cpp) X1 sample ROM as BAD_DUMP as it appears to be half size
- marked forgottnj as a prototype, it's an unfinished version of the game
- misc research into gaelco.cpp priorities (thoop) + irq acks + sprite disable (squash)
