### PR TITLE
Move Touchdown Football to ibmpcjr_flop

### DIFF
--- a/hash/ibm5150.xml
+++ b/hash/ibm5150.xml
@@ -2291,18 +2291,6 @@ Known PC Booter Games Not Dumped, Or Dumped and Lost when Demonlord's Site went 
 		</part>
 	</software>
 
-	<software name="tdown">
-		<description>Touchdown Football</description>
-		<year>1984</year>
-		<publisher>Imagic</publisher>
-		<info name="usage" value="PC Booter" />
-		<part name="flop1" interface="floppy_5_25">
-			<dataarea name="flop" size="327680">
-				<rom name="touchdown football.img" size="327680" crc="0fbaedb6" sha1="c42650559b2b4eb4b789fd2fa22bc5c8c0589e45"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="tracer">
 		<description>The Tracer Sanction</description>
 		<year>1984</year>

--- a/hash/ibmpcjr_flop.xml
+++ b/hash/ibmpcjr_flop.xml
@@ -120,4 +120,15 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
+
+	<software name="tdown">
+		<description>Touchdown Football</description>
+		<year>1984</year>
+		<publisher>Imagic</publisher>
+		<part name="flop1" interface="floppy_5_25">
+			<dataarea name="flop" size="327680">
+				<rom name="touchdown football.img" size="327680" crc="0fbaedb6" sha1="c42650559b2b4eb4b789fd2fa22bc5c8c0589e45"/>
+			</dataarea>
+		</part>
+	</software>
 </softwarelist>


### PR DESCRIPTION
Fixes #8838. [Back cover](https://www.mobygames.com/images/covers/l/31083-touchdown-football-pc-booter-back-cover.jpg) says it requires a PCjr, and apparently won't boot using the ibm5150 driver