### PR TITLE
[naomi.cpp] Fix the BG Offset 

### DIFF
--- a/src/mame/video/powervr2.cpp
+++ b/src/mame/video/powervr2.cpp
@@ -2861,7 +2861,10 @@ void powervr2_device::render_to_accumulation_buffer(bitmap_rgb32 &bitmap, const 
 
 	dc_state *state = machine().driver_data<dc_state>();
 	address_space &space = state->m_maincpu->space(AS_PROGRAM);
-	uint32_t c=space.read_dword(0x05000000+((isp_backgnd_t & 0xfffff8)>>1)+(3+3)*4);
+
+	// TODO: read ISP/TSP command from isp_background_t instead of assuming Gourad-shaded
+	// full-screen polygon.
+	uint32_t c=space.read_dword(0x05000000+(param_base&0xf00000)+((isp_backgnd_t&0xfffff8)>>1)+(3+3)*4);
 	bitmap.fill(c, cliprect);
 
 	// TODO: modifier volumes


### PR DESCRIPTION
The background offset register is calculated not only against the base of texture RAM, but also against the `param_base` register. MAME was only calculating against the base of texture RAM. This appeared to work because the Naomi BIOS and most games use double-buffering with one of the two buffers based at 0x0 in the texture RAM (`param_base` set to 0) and they write the background polygon as their first draw command. However, for code not using the official SEGA libraries the current code can calculate the background offset wrong resulting in an incorrectly drawn background. This is tested against a homebrew program that was run in MAME, Demul and on actual hardware (Rev. H-based multibios, net dimm) with identical results in all three.

I also added a TODO into the section as the `isp_backgnd_t` offset pointer points at a full command word and the current index hack to pull out an RGB value is only valid for non-textured, gourad shaded backgrounds that don't change color per-vertex with a stride parameter set to "1". If I get around to implementing support for textured backgrounds in libnaomi (https://github.com/DragonMinded/netboot/tree/trunk/homebrew) I will probably take a stab at supporting other background modes here as well.