### PR TITLE
hh_sm510: Remove uncertain Fowling IDs

### DIFF
--- a/src/mame/drivers/hh_sm510.cpp
+++ b/src/mame/drivers/hh_sm510.cpp
@@ -1392,7 +1392,7 @@ ROM_END
   The following Mickey Mouse Elektronika clones are emulated in MAME:
   * IM-02: Nu, pogodi! (Ну, погоди!)
   * IM-13: Explorers of Space (Разведчики космоса)
-  * IM-16: Fowling (Охота) (also listed as IM-18 and I-08 by some sources)
+  * IM-16: Fowling (Охота)
   * IM-22: Monkey Goalkeeper (Весёлые футболисты)
 
 ***************************************************************************/


### PR DESCRIPTION
Removing additional IDs listed for Elektronika Fowling. Images found of the instruction booklet states `IM-16` and haven't found any images of the other IDs on the product or manual.