### PR TITLE
[naomi.cpp] Add support for render mode 5.

### DIFF
--- a/src/mame/video/powervr2.cpp
+++ b/src/mame/video/powervr2.cpp
@@ -3360,9 +3360,17 @@ void powervr2_device::pvr_accumulationbuffer_to_framebuffer(address_space &space
 		}
 		break;
 
-		case 0x05:
-			printf("pvr_accumulationbuffer_to_framebuffer buffer to tile at %d,%d - unsupported pack mode %02x (0888 KGB 32-bit)\n",x,y,packmode);
-			break;
+		case 0x05: // 0888 KRGB 32 bit
+		{
+			switch(unpackmode)
+			{
+				case 0x00: fb_convert_8888argb_to_555rgb(space,x,y); break;
+				case 0x01: fb_convert_8888argb_to_565rgb(space,x,y); break;
+				case 0x02: fb_convert_8888argb_to_888rgb24(space,x,y); break;
+				case 0x03: fb_convert_8888argb_to_888rgb32(space,x,y); break;
+			}
+		}
+		break;
 
 		case 0x06: // 8888 ARGB 32 bit
 		{


### PR DESCRIPTION
This is a super simple "fix" that adds support for render mode 5 (ARGB0888). I tied the functionality to render mode 6 (ARGB8888) in order to get it to work instead of printing the error message per-pixel. Technically this is incorrect: ARGB0888 fills in the alpha value based on a preset value in a configuration register 0xA05F8048 (which is not implemented in MAME), while ARGB8888 takes the alpha value from the written pixel itself. However, the implementation in MAME for all render modes does not set the alpha value in the resulting framebuffer meaning that ARGB0888 and ARGB8888 are functionally identical according to the current implementation. This doesn't matter in practice because of two reasons: 1) The alpha value is only useful when rendering if you compare against the chroma threshold in 0xA05F8044 (this defaults to 0 and MAME does not appear to implement support for it anyway), and 2) alpha writeback seems most useful when using the PowerVR to render to a texture, and 32-bit ARGB textures are not supported.

Either way, after this fix the render output from MAME matches hardware when I tested it (https://dragonminded.com/images/mamehw.jpg).