### PR TITLE
hp_taco: added support for writing hp9825-format tapes

### DIFF
--- a/src/devices/machine/hp_taco.h
+++ b/src/devices/machine/hp_taco.h
@@ -110,6 +110,7 @@ private:
 	bool is_at_slow_speed() const;
 	void start_rd();
 	void start_wr();
+	bool adv_bit_idx();
 	void update_checksum(uint16_t data);
 	void cmd_fsm();
 	static uint8_t get_cmd(uint16_t cmd_reg);


### PR DESCRIPTION
Hi,
this commit adds the capability to write hp9825-format tapes to HP TACO driver (it could already read this format).
Thanks.
--F.Ulivi