### PR TITLE
New working clone

### DIFF
--- a/src/mame/drivers/hh_sm510.cpp
+++ b/src/mame/drivers/hh_sm510.cpp
@@ -1402,6 +1402,7 @@ ROM_END
   ИМ-49  Ночные воришки      Nochnye vorishki     Night Burglars      -
   ИМ-50  Космический полёт   Kosmicheskij poljot  Space Flight        The Model ID is the same as Amusing Arithmetic (not emulated in MAME)
   ИМ-51  Морская атака       Morskaja ataka       -                   -
+  ИМ-53  Атака астероидов    Ataka asteroidov     -                   -
 
 ***************************************************************************/
 
@@ -1423,6 +1424,7 @@ public:
 	void nburglar(machine_config &config);
 	void spaceflt(machine_config &config);
 	void morataka(machine_config &config);
+	void atakaast(machine_config &config);
 };
 
 // config
@@ -1514,6 +1516,11 @@ void gnw_mmouse_state::morataka(machine_config &config)
 	kb1013vk12_common(config, 1648, 1080); // R mask option ?
 }
 
+void gnw_mmouse_state::atakaast(machine_config &config)
+{
+	kb1013vk12_common(config, 1620, 1080); // R mask option ?
+}
+
 // roms
 
 ROM_START( gnw_mmouse )
@@ -1602,6 +1609,14 @@ ROM_START( morataka )
 
 	ROM_REGION( 105057, "screen", 0)
 	ROM_LOAD( "morataka.svg", 0, 105057, CRC(c235c56c) SHA1(b6ef74ba7826221683243e23513270d0f0f2cfda) )
+ROM_END
+
+ROM_START( atakaast )
+	ROM_REGION( 0x1000, "maincpu", 0 )
+	ROM_LOAD( "im-53.bin", 0x0000, 0x0740, CRC(cb820c32) SHA1(7e94fc255f32db725d5aa9e196088e490c1a1443) )
+
+	ROM_REGION( 105570, "screen", 0)
+	ROM_LOAD( "atakaast.svg", 0, 105570, CRC(3d79aacc) SHA1(bc25969f4d6fa75b320130c920ac0bdc8fb44cbd) )
 ROM_END
 
 
@@ -9659,6 +9674,7 @@ CONS( 1989, frogling,     gnw_mmouse,  0, frogling,     gnw_mmouse,   gnw_mmouse
 CONS( 19??, nburglar,     gnw_mmouse,  0, nburglar,     gnw_mmouse,   gnw_mmouse_state,   empty_init, "bootleg (Elektronika)", "Night Burglars", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
 CONS( 19??, spaceflt,     gnw_mmouse,  0, spaceflt,     gnw_mmouse,   gnw_mmouse_state,   empty_init, "bootleg (Elektronika)", "Space Flight", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
 CONS( 19??, morataka,     gnw_mmouse,  0, morataka,     gnw_mmouse,   gnw_mmouse_state,   empty_init, "bootleg (Elektronika)", "Morskaja ataka", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
+CONS( 1992, atakaast,     gnw_mmouse,  0, atakaast,     gnw_mmouse,   gnw_mmouse_state,   empty_init, "bootleg (Elektronika)", "Ataka asteroidov", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
 CONS( 1981, gnw_fire,     0,           0, gnw_fire,     gnw_fire,     gnw_fire_state,     empty_init, "Nintendo", "Game & Watch: Fire (Wide Screen)", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
 CONS( 1989, spacebridge,  gnw_fire,    0, spacebridge,  gnw_fire,     gnw_fire_state,     empty_init, "bootleg (Elektronika)", "Space Bridge", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )
 CONS( 1982, gnw_tbridge,  0,           0, gnw_tbridge,  gnw_tbridge,  gnw_tbridge_state,  empty_init, "Nintendo", "Game & Watch: Turtle Bridge", MACHINE_SUPPORTS_SAVE | MACHINE_REQUIRES_ARTWORK )

--- a/src/mame/drivers/hh_sm510.cpp
+++ b/src/mame/drivers/hh_sm510.cpp
@@ -1402,7 +1402,7 @@ ROM_END
   ИМ-49  Ночные воришки      Nochnye vorishki     Night Burglars      -
   ИМ-50  Космический полёт   Kosmicheskij poljot  Space Flight        The Model ID is the same as Amusing Arithmetic (not emulated in MAME)
   ИМ-51  Морская атака       Morskaja ataka       -                   -
-  ИМ-53  Атака астероидов    Ataka asteroidov     -                   Graphics is very similar to ИМ-50
+  ИМ-53  Атака астероидов    Ataka asteroidov     -                   Graphics are very similar to ИМ-50
 
 ***************************************************************************/
 

--- a/src/mame/drivers/hh_sm510.cpp
+++ b/src/mame/drivers/hh_sm510.cpp
@@ -1402,7 +1402,7 @@ ROM_END
   ИМ-49  Ночные воришки      Nochnye vorishki     Night Burglars      -
   ИМ-50  Космический полёт   Kosmicheskij poljot  Space Flight        The Model ID is the same as Amusing Arithmetic (not emulated in MAME)
   ИМ-51  Морская атака       Morskaja ataka       -                   -
-  ИМ-53  Атака астероидов    Ataka asteroidov     -                   -
+  ИМ-53  Атака астероидов    Ataka asteroidov     -                   Graphics is very similar to ИМ-50
 
 ***************************************************************************/
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -16398,6 +16398,7 @@ scrabsen                        // Selchow & Righter
 smastmind                       // Invicta
 
 @source:hh_sm510.cpp
+atakaast                        // Elektronika
 auslalom                        // Elektronika
 bassmate                        // Telko
 exospace                        // Elektronika


### PR DESCRIPTION
-----------------
Ataka asteroidov [algestam, Milan Galcik]

No export version name has been found for this game. The release year has been verified from the game manual (https://skopil.ru/images/elektronika/instructions/ataka_asteroidov.pdf - states 1992 on last page).

This is the last game from the current batch of clones provided by Milan.