### PR TITLE
Refactor docs build process to use new template and env variable

### DIFF
--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,14 @@
+{% if mamedev_site %}
+    <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Downloads') }}">
+        <span class="rst-current-version" data-toggle="rst-current-version">
+            <span class="fa fa-book">Downloads</span>
+            <span class="fa fa-caret-down"></span>
+        </span>
+        <div class="rst-other-versions">
+            <dl>
+                <dd><a href="https://docs.mamedev.org/_files/MAME.pdf">PDF</a></dd>
+                <dd><a href="https://docs.mamedev.org/_files/MAME.epub">EPUB</a></dd>
+            </dl>
+        </div>
+    </div>
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -262,3 +262,12 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+# Add download links at bottom left when the MAMEDEV environment
+# varaible is set. See versions.html in the _template folder.
+try:
+    html_context
+except NameError:
+    html_context = dict()
+if os.getenv("MAMEDEV") != None:
+    html_context['mamedev_site'] = True

--- a/docs/themes/sphinx_rtd_theme/theme.conf
+++ b/docs/themes/sphinx_rtd_theme/theme.conf
@@ -18,4 +18,3 @@ prev_next_buttons_location = bottom
 style_external_links = False
 style_nav_header_background =
 vcs_pageview_mode =
-mamedevorg = True

--- a/docs/themes/sphinx_rtd_theme/versions.html
+++ b/docs/themes/sphinx_rtd_theme/versions.html
@@ -1,49 +1,34 @@
 {% if READTHEDOCS %}
 {# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Read the Docs</span>
-      v: {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dt>{{ _('Versions') }}</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        <dt>{{ _('Downloads') }}</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        {# Translators: The phrase "Read the Docs" is not translated #}
-        <dt>{{ _('On Read the Docs') }}</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-          </dd>
-      </dl>
-    </div>
-  </div>
-{% endif %}
-{# This section only gets used when mamedevorg is set to anything in theme.conf #}
-{% if theme_mamedevorg %}
-  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Downloads') }}">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book">Downloads</span>
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dd><a href="https://docs.mamedev.org/_files/MAME.pdf">PDF</a></dd>
-        <dd><a href="https://docs.mamedev.org/_files/MAME.epub">EPUB</a></dd>
-      </dl>
-    </div>
-  </div>
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
+	<span class="rst-current-version" data-toggle="rst-current-version">
+		<span class="fa fa-book"> Read the Docs</span>
+		v: {{ current_version }}
+		<span class="fa fa-caret-down"></span>
+	</span>
+	<div class="rst-other-versions">
+		<dl>
+			<dt>{{ _('Versions') }}</dt>
+			{% for slug, url in versions %}
+			<dd><a href="{{ url }}">{{ slug }}</a></dd>
+			{% endfor %}
+		</dl>
+		<dl>
+			<dt>{{ _('Downloads') }}</dt>
+			{% for type, url in downloads %}
+			<dd><a href="{{ url }}">{{ type }}</a></dd>
+			{% endfor %}
+		</dl>
+		<dl>
+			{# Translators: The phrase "Read the Docs" is not translated #}
+			<dt>{{ _('On Read the Docs') }}</dt>
+			<dd>
+				<a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
+			</dd>
+			<dd>
+				<a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
+			</dd>
+		</dl>
+	</div>
+</div>
 {% endif %}

--- a/docs/update.sh
+++ b/docs/update.sh
@@ -12,7 +12,8 @@ elif [ $LOCAL = $BASE ]; then
     echo "Need to pull"
     git pull
     make clean
-    make site
+    # The environment variable added here adds bottom left download pane.
+    MAMEDEV=1 make site
 elif [ $REMOTE = $BASE ]; then
     echo "Need to push"
 else


### PR DESCRIPTION
This refactor will prevent updates to the theme from blowing away our changes by using the _template.
The bottom left download links panel will appear when "make html" is run with the environment variable "MAMEDEV" set to anything, and it will not build it into the HTML otherwise.