### PR TITLE
src/mame/etc/gen_device_defs.py: major overhaul of device file generation:

### DIFF
--- a/src/mame/etc/gen_device_defs.py
+++ b/src/mame/etc/gen_device_defs.py
@@ -1,27 +1,84 @@
-# license: BSD-3-Clause
+#!/usr/bin/python
+##
+## license:BSD-3-Clause
+## copyright-holders:Angelo Salese
 """Simple Python script to generate a new definition from the template_* files
+It will create a new device .cpp/.h definition, using template_device.* as a base.
+Most arguments are sanitized and validated to match a Jinja2-like {{ foo }} pattern.
+
+This should be run from the root of your mame tree, i.e.
+python ./src/mame/etc/gen_device_defs.py <params>
 """
 import argparse
 import os
 
+# Derived license options over a source grep done on November 2021 source code
+# TODO: consider using SPDX patterns instead, derive externally
+# https://spdx.org/licenses/
+LICENSE_OPTIONS = [
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "GPL-2.0+",
+    "GPL2+",
+    "LGPL-2.1+",
+    "MIT",
+]
+
+CPP_EXTENSIONS = [".cpp", ".h"]
+
+def generate_device_header(value: str) -> str:
+    """Generate the C++ macro variable key, deriving from the given path
+
+    MAME design prefixes MAME_ and suffixes an _H for each include guard.
+    This is left by design in the file itself, it also pleases IDEs better
+    (e.g. vscode would otherwise believe that everything in the include guard shouldn't be linted)
+
+    Args:
+        value (str): FQDN file that needs to be translated
+
+    Raises:
+        AssertionError:
+            if attempting to generate a device header out of the scope of this.
+
+    Returns:
+        str:
+            device header sanitized.
+            Treats bus type file as a special option, so that it will parse as:
+            bus/<bus_family>/<bus_devicefile> -> BUS_<BUS_FAMILY>_<BUS_DEVICE>
+            ditto for CPU:
+            cpu/<cpu_family>/<cpu_devicefile> -> CPU_<CPU_FAMILY>_<CPU_DEVICE>
+            It otherwise treat everything else as:
+            <device_type>/<devicefile> -> <DEVICE_TYPE>_<DEVICEFILE>
+    """
+    _is_bus_file = "bus" + os.path.sep in value or "cpu" + os.path.sep in value
+    _fh = value.split(os.path.sep)
+    main_category_idx = -3 if _is_bus_file else -2
+    file_category = _fh[main_category_idx]
+    assert file_category in ["bus", "cpu", "machine", "video", "sound", "imagedev"], (
+        f"{generate_device_header.__name__} -> {file_category} invalid for device_handler"
+    )
+    return "_".join(_fh[main_category_idx:]).upper()
+
 def get_args():
-    parser = argparse.ArgumentParser(description="""
-        Create a new device .cpp/.h definition, using template_device.* as a base.
-        All arguments are sanitized to match the given patterns
-        """
+    parser = argparse.ArgumentParser(
+        description=__doc__
     )
     parser.add_argument(
         "-device_file",
         required=True,
         type=str,
-        help="The device .cpp/.h base file name, also the header macro directive \"acorn_vidc20.cpp\" -> \"MAME_MACHINE_ACORN_VIDC20_H\""
+        help=" ".join([
+            "The device .cpp/.h base file path, also derives the header macro directive by",
+            "deriving from the path \"src/devices/machine/acorn_vidc20.cpp\"",
+            "-> \"MAME_MACHINE_ACORN_VIDC20_H\""
+        ])
     )
-    # TODO: directory option, honor with os.getcwd() as default
+    # TODO: number of parameters can go out of hand, consider using a data source instead
     parser.add_argument(
         "-license_opt",
-        default="BSD-3-Clause",
+        default=LICENSE_OPTIONS[0],
         type=str,
-        help="License option"
+        help=f"License option, valid field options are: {repr(LICENSE_OPTIONS)}"
     )
     parser.add_argument(
         "-device_longname",
@@ -33,13 +90,17 @@ def get_args():
         "-device_classname",
         required=True,
         type=str,
-        help="Class declaration \"acorn_vidc20\", this will also be the filename output"
+        help=" ".join([
+            "Class declaration i.e. \"acorn_vidc20\",",
+            "this usually matches device filename except for structures that needs",
+            "to be further break down into sub-classes.",
+        ])
     )
     parser.add_argument(
         "-device_typename",
         required=True,
         type=str,
-        help='Type handle declaration \"ACORN_VIDC20\"'
+        help="Type handle declaration i.e. \"ACORN_VIDC20\""
     )
     parser.add_argument(
         "-author_name",
@@ -48,29 +109,54 @@ def get_args():
         help="Your author handle name in copyright header"
     )
     # TODO: add optional structures like device_memory_interface
+    # TODO: dry-run option
+    # TODO: interactive mode
+    # TODO: bus width
 
     user_input = vars(parser.parse_args())
     return {
         **user_input,
-        "device_header": user_input["device_file"].upper()
+        "device_header": generate_device_header(user_input["device_file"])
     }
 
-def sanitize(k, v):
+def sanitize(key: str, value: str) -> str:
     rules_fn = {
         "device_typename": lambda v: v.upper().strip(),
-        "device_classname": lambda v: v.lower().strip()
-        # TODO: validate license_opt with an enum
+        "device_classname": lambda v: v.lower().strip(),
     }
-    return rules_fn.get(k, lambda v: v.strip())(v)
+    return rules_fn.get(key, lambda v: v.strip())(value)
+
+def validate(key: str, value: str) -> bool:
+    assert_fn = {
+        "license_opt": lambda v: v in LICENSE_OPTIONS,
+    }
+    return assert_fn.get(key, lambda _: True)(value)
 
 if __name__ == '__main__':
+    # default place where template_device files lies, given as convenience for future extensions
+    DEFAULT_TEMPLATE_PATH = os.path.sep.join(["src", "mame", "etc"])
+    SRC_TEMPLATE_PATH = f"{os.getcwd()}{os.path.sep}{DEFAULT_TEMPLATE_PATH}"
+
     args = get_args()
-    for file_type in [".cpp", ".h"]:
-        with open(".{0}template_device{1}".format(os.path.sep, file_type), "r", encoding="utf-8", newline="\n") as template_fh:
+    DEVICE_FILEPATH = args["device_file"]
+    DST_BASE_PATH = f"{os.getcwd()}{os.path.sep}{DEVICE_FILEPATH}"
+    assert not any(item in DST_BASE_PATH for item in CPP_EXTENSIONS), (
+        f"device_file -> {DST_BASE_PATH} must not have C++ extension"
+    )
+    del args["device_file"]
+
+    for file_type in CPP_EXTENSIONS:
+        SRC_TEMPLATE_FILE = os.path.sep.join([SRC_TEMPLATE_PATH, f"template_device{file_type}"])
+        with open(SRC_TEMPLATE_FILE, "r", encoding="utf-8") as template_fh:
             buf_string = template_fh.read()
         for k, v in args.items():
-            if k == "device_file":
-                continue
-            buf_string = buf_string.replace("<" + k + ">", sanitize(k, v))
-        with open(".{0}{1}{2}".format(os.path.sep, args["device_file"], file_type), "w", encoding="utf-8", newline="\n") as result_fh:
+            # TODO: consider fully translating this to a Jinja2 or equivalent library
+            buf_string = buf_string.replace("{{ " + k + " }}", sanitize(k, v))
+            assert validate(k, v), f"{v} does not honor {k} ruleset"
+
+        DST_DEVICE_FILE = f"{DEVICE_FILEPATH}{file_type}"
+
+        with open(DST_DEVICE_FILE, "w", encoding="utf-8", newline=os.linesep) as result_fh:
             result_fh.write(buf_string)
+
+    # TODO: auto-inject in LUA scripts

--- a/src/mame/etc/template_device.cpp
+++ b/src/mame/etc/template_device.cpp
@@ -1,13 +1,13 @@
-// license:<license_opt>
-// copyright-holders:<author_name>
-/***************************************************************************
+// license:{{ license_opt }}
+// copyright-holders:{{ author_name }}
+/**************************************************************************************************
 
-<device_longname>
+	{{ device_longname }}
 
-***************************************************************************/
+**************************************************************************************************/
 
 #include "emu.h"
-#include "<device_classname>.h"
+#include "{{ device_classname }}.h"
 
 
 //**************************************************************************
@@ -16,7 +16,7 @@
 
 
 // device type definition
-DEFINE_DEVICE_TYPE(<device_typename>, <device_classname>_device, "<device_classname>", "<device_longname>")
+DEFINE_DEVICE_TYPE({{ device_typename }}, {{ device_classname }}_device, "{{ device_classname }}", "{{ device_longname }}")
 
 
 //**************************************************************************
@@ -25,12 +25,12 @@ DEFINE_DEVICE_TYPE(<device_typename>, <device_classname>_device, "<device_classn
 
 
 //-------------------------------------------------
-//  <device_classname>_device - constructor
+//  {{ device_classname }}_device - constructor
 //-------------------------------------------------
 
 
-<device_classname>_device::<device_classname>_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, <device_typename>, tag, owner, clock)
+{{ device_classname }}_device::{{ device_classname }}_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, {{ device_typename }}, tag, owner, clock)
 {
 }
 
@@ -41,7 +41,7 @@ DEFINE_DEVICE_TYPE(<device_typename>, <device_classname>_device, "<device_classn
 //-------------------------------------------------
 
 
-void <device_classname>_device::device_add_mconfig(machine_config &config)
+void {{ device_classname }}_device::device_add_mconfig(machine_config &config)
 {
 	//DEVICE(config, ...);
 }
@@ -52,7 +52,7 @@ void <device_classname>_device::device_add_mconfig(machine_config &config)
 //-------------------------------------------------
 
 
-void <device_classname>_device::device_start()
+void {{ device_classname }}_device::device_start()
 {
 }
 
@@ -62,7 +62,7 @@ void <device_classname>_device::device_start()
 //-------------------------------------------------
 
 
-void <device_classname>_device::device_reset()
+void {{ device_classname }}_device::device_reset()
 {
 }
 
@@ -72,12 +72,12 @@ void <device_classname>_device::device_reset()
 //**************************************************************************
 
 
-uint8_t <device_classname>_device::read(address_space &space, offs_t offset, uint8_t mem_mask = ~0)
+uint8_t {{ device_classname }}_device::read(address_space &space, offs_t offset, uint8_t mem_mask = ~0)
 {
 	return 0;
 }
 
 
-void <device_classname>_device::write(address_space &space, offs_t offset, uint8_t data, uint8_t mem_mask = ~0)
+void {{ device_classname }}_device::write(address_space &space, offs_t offset, uint8_t data, uint8_t mem_mask = ~0)
 {
 }

--- a/src/mame/etc/template_device.h
+++ b/src/mame/etc/template_device.h
@@ -1,13 +1,13 @@
-// license:<license_opt>
-// copyright-holders:<author_name>
-/***************************************************************************
+// license:{{ license_opt }}
+// copyright-holders:{{ author_name }}
+/**************************************************************************************************
 
-<device_longname>
+	{{ device_longname }}
 
-***************************************************************************/
+**************************************************************************************************/
 
-#ifndef MAME_MACHINE_<device_header>_H
-#define MAME_MACHINE_<device_header>_H
+#ifndef MAME_{{ device_header }}_H
+#define MAME_{{ device_header }}_H
 
 #pragma once
 
@@ -15,15 +15,15 @@
 //  TYPE DEFINITIONS
 //**************************************************************************
 
-class <device_classname>_device : public device_t
+class {{ device_classname }}_device : public device_t
 {
 public:
 	// construction/destruction
-	<device_classname>_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	{{ device_classname }}_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// I/O operations
-	void write(address_space &space, offs_t offset, uint8_t data, uint8_t mem_mask = ~0);
-	uint8_t read(address_space &space, offs_t offset, uint8_t mem_mask = ~0);
+	void write(address_space &space, offs_t offset, u8 data, u32 mem_mask = ~0);
+	u8 read(address_space &space, offs_t offset, u32 mem_mask = ~0);
 
 protected:
 	// device-level overrides
@@ -35,6 +35,6 @@ protected:
 
 
 // device type definition
-DECLARE_DEVICE_TYPE(<device_typename>, <device_classname>_device)
+DECLARE_DEVICE_TYPE({{ device_typename }}, {{ device_classname }}_device)
 
-#endif // MAME_MACHINE_<device_header>_H
+#endif // MAME_{{ device_header }}_H


### PR DESCRIPTION
* Converted template_device.* to use basic Jinja2-like patterns;
* Add support for creating device defs in the known MAME folders where a device file is expected;
* Add license field validation;
* Improve documentation;