### PR TITLE
ms32.cpp: Documenting Shutokou Red Zone as undumped

### DIFF
--- a/src/mame/drivers/ms32.cpp
+++ b/src/mame/drivers/ms32.cpp
@@ -169,6 +169,7 @@ Hayaoshi Quiz Grand Champion Taikai (hayaosi2)
 Not Dumped:
 
 Super Strong Warriors
+Shutokou Red Zone / Super Circuit Red Zone
 
 NOTE: Several games use the ROM cart board number for the EPROM numbers.  Though several
       use MB93166 for the MB-94166 cart


### PR DESCRIPTION
[Footage of the game](https://www.youtube.com/watch?v=OuR6TjPbg3A) - [attract](https://www.youtube.com/watch?v=OL30cIwp28M)

[Hardware info per Hydregion's comments here.](https://mametesters.org/view.php?id=3523)