### PR TITLE
bus/nes_ctrl: Work on Famicom joypads + more separation of EXP port.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -28230,6 +28230,7 @@ license:CC0
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="HVC-SLRROM" />
 			<feature name="mmc1_type" value="MMC1B2" />
+			<feature name="peripheral" value="pachinko" />
 			<dataarea name="prg" size="131072">
 				<rom name="cds-81-0 prg" size="131072" crc="41f87a9b" sha1="bd6709f785e9c8e96fc7b0b55f2c26c76fe3f17e" offset="00000" />
 			</dataarea>
@@ -28250,6 +28251,7 @@ license:CC0
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="HVC-SLROM" />
 			<feature name="mmc1_type" value="MMC1B2" />
+			<feature name="peripheral" value="pachinko" />
 			<dataarea name="prg" size="131072">
 				<rom name="cds-82-0 prg" size="131072" crc="1644c162" sha1="17f1a1ec7456291122aaeb5431cd4c1c11fe29e3" offset="00000" />
 			</dataarea>
@@ -28314,6 +28316,7 @@ license:CC0
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="HVC-TNROM" />
 			<feature name="mmc3_type" value="MMC3C" />
+			<feature name="peripheral" value="pachinko" />
 			<dataarea name="prg" size="524288">
 				<rom name="cds-84-0 prg" size="524288" crc="e08c8a60" sha1="baf3a4e0423a86e53234e806843149ef7d0974a9" offset="00000" />
 			</dataarea>
@@ -28338,11 +28341,16 @@ license:CC0
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="HVC-TKROM" />
 			<feature name="mmc3_type" value="MMC3C" />
+			<feature name="peripheral" value="pachinko" />
 			<dataarea name="prg" size="262144">
 				<rom name="cds-pe-0 prg" size="262144" crc="9525fa38" sha1="20b5b83fac09a42bbc7e2b5f3deb9835fa14b650" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="131072">
 				<rom name="cds-pe-0 chr" size="131072" crc="45fd2145" sha1="a1fbb3f96e68ab4d98f2737d63204aee91612ccb" offset="00000" />
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -42749,6 +42757,7 @@ license:CC0
 			<feature name="slot" value="uxrom" />
 			<feature name="pcb" value="HVC-UNROM" />
 			<feature name="mirroring" value="vertical" />
+			<feature name="peripheral" value="4p_adapter" />
 			<dataarea name="prg" size="131072">
 				<rom name="ath-xw-0 prg" size="131072" crc="b1b16b8a" sha1="bb40175966f18efad8d82bebea3d4d8444a133e6" offset="00000" />
 			</dataarea>
@@ -50158,6 +50167,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SNROM" />
+			<feature name="peripheral" value="4p_adapter" />
 			<dataarea name="prg" size="131072">
 				<rom name="spot - the video game (japan).prg" size="131072" crc="0abdd5ca" sha1="8b62b3fc95957f52d146e7bc3c90ab33c4005aec" offset="00000" status="baddump" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -32067,8 +32067,9 @@ license:CC0
 			<dataarea name="chr" size="262144">
 				<rom name="koe-iu-0 chr" size="262144" crc="44b22b3d" sha1="bfdb1a89f403b7deea2e29addf1d18e745442771" offset="00000" />
 			</dataarea>
-			<!-- 8k WRAM on cartridge -->
-			<dataarea name="wram" size="8192">
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 			<!-- 1k Internal RAM in the MMC5 chip (ExRAM) -->
 			<dataarea name="mapper_ram" size="1024">
@@ -41540,6 +41541,10 @@ license:CC0
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/nes_ctrl/ctrl.cpp
+++ b/src/devices/bus/nes_ctrl/ctrl.cpp
@@ -78,8 +78,9 @@ DEFINE_DEVICE_TYPE(NES_CONTROL_PORT, nes_control_port_device, "nes_control_port"
 //  device_nes_control_port_interface - constructor
 //-------------------------------------------------
 
-device_nes_control_port_interface::device_nes_control_port_interface(const machine_config &mconfig, device_t &device) :
-	device_interface(device, "nesctrl")
+device_nes_control_port_interface::device_nes_control_port_interface(const machine_config &mconfig, device_t &device)
+	: device_interface(device, "nesctrl")
+	, m_strobe(0)
 {
 	m_port = dynamic_cast<nes_control_port_device *>(device.owner());
 }
@@ -207,7 +208,7 @@ void fc_control_port2_devices(device_slot_interface &device)
 
 void fc_expansion_devices(device_slot_interface &device)
 {
-	device.option_add("joypad", NES_JOYPAD);
+	device.option_add("joypad", NES_FCPAD_EXP);
 	device.option_add("arcstick", NES_ARCSTICK);
 	device.option_add("fc_keyboard", NES_FCKEYBOARD);
 	device.option_add("zapper", NES_ZAPPER);

--- a/src/devices/bus/nes_ctrl/ctrl.h
+++ b/src/devices/bus/nes_ctrl/ctrl.h
@@ -43,7 +43,11 @@ public:
 protected:
 	device_nes_control_port_interface(const machine_config &mconfig, device_t &device);
 
+	// helper to keep track of strobe bit, returns true on 1 to 0 transitions
+	bool write_strobe(u8 data) { u8 prev = m_strobe; m_strobe = data & 1; return prev && !m_strobe; }
+
 	nes_control_port_device *m_port;
+	u8 m_strobe;
 };
 
 

--- a/src/devices/bus/nes_ctrl/hori.cpp
+++ b/src/devices/bus/nes_ctrl/hori.cpp
@@ -2,20 +2,25 @@
 // copyright-holders:Fabio Priuli
 /**********************************************************************
 
-    Nintendo Family Computer Hori Twin (and 4P?) adapters
+    Nintendo Family Computer Hori Twin and 4 Players adapters
 
-    Emulation of the 4Players adapter is quite pointless: if 2P mode
-    (default mode) it behaves like a Hori Twin adapter, in 4P mode
-    it has P1 and P2 inputs overwriting the inputs coming from the
-    main controllers (possibly creating a bit of confusion, since
-    you get 6 sets of inputs with only 4 acknowledged by the running
-    system).
-    For the moment we keep it available for documentation purposes.
+    In general these adapters work by reading pin 13 (the Famicom sees
+    this in memory location $4016, bit 1) of their subports. It is not
+    clear if other lines are pass-thru. For the moment we only emulate
+    joypads connected to these ports, which only use pin 13 when read.
 
-    TODO: find out confirmation whether in 2P mode, inputs from joypads
-    connected to the 4players adapter are really seen as P3 and P4 inputs.
-    it seems the most reasonable setup (so that users with only 2
-    external pads can use the adapter in 4P games), but one never knows...
+    The Hori Twin passes subport 1's input directly through to $4016
+    bit 1. It reroutes subport 2's to $4017 bit 1. Incidentally, HAL
+    released a device, Joypair, that should be functionally equivalent
+    to the Hori Twin.
+
+    The Hori 4 Players adapter has a 2/4 switch. In 2P mode it works
+    just like the Hori Twin. In 4P mode it still passes through joypad
+    reads to bit 1 of $4016 and $4017, but it operates like the NES Four
+    Score (which in fact uses a Hori PCB). Subport 1 then subport 3
+    inputs are passed serially to $4016 bit 1. Likewise subport 2 and 4
+    go to $4017 bit 1. A signature byte can be read from both locations
+    following this.
 
 **********************************************************************/
 
@@ -28,7 +33,7 @@
 //**************************************************************************
 
 DEFINE_DEVICE_TYPE(NES_HORITWIN, nes_horitwin_device, "nes_horitwin", "FC Hori Twin Adapter")
-DEFINE_DEVICE_TYPE(NES_HORI4P,   nes_hori4p_device,   "nes_hori4p",   "FC Hori 4P Adapter")
+DEFINE_DEVICE_TYPE(NES_HORI4P,   nes_hori4p_device,   "nes_hori4p",   "FC Hori 4 Players Adaptor")
 
 
 static INPUT_PORTS_START( nes_hori4p )
@@ -51,7 +56,7 @@ ioport_constructor nes_hori4p_device::device_input_ports() const
 
 static void hori_adapter(device_slot_interface &device)
 {
-	device.option_add("joypad", NES_JOYPAD);
+	device.option_add("joypad", NES_FCPAD_EXP);
 }
 
 
@@ -61,27 +66,21 @@ static void hori_adapter(device_slot_interface &device)
 
 void nes_horitwin_device::device_add_mconfig(machine_config &config)
 {
-	NES_CONTROL_PORT(config, m_port1, hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, m_port2, hori_adapter, "joypad");
-	if (m_port != nullptr)
+	for (int i = 0; i < 2; i++)
 	{
-		m_port1->set_screen_tag(m_port->m_screen);
-		m_port2->set_screen_tag(m_port->m_screen);
+		NES_CONTROL_PORT(config, m_subexp[i], hori_adapter, "joypad");
+		if (m_port != nullptr)
+			m_subexp[i]->set_screen_tag(m_port->m_screen);
 	}
 }
 
 void nes_hori4p_device::device_add_mconfig(machine_config &config)
 {
-	NES_CONTROL_PORT(config, m_port1, hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, m_port2, hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, m_port3, hori_adapter, "joypad");
-	NES_CONTROL_PORT(config, m_port4, hori_adapter, "joypad");
-	if (m_port != nullptr)
+	for (int i = 0; i < 4; i++)
 	{
-		m_port1->set_screen_tag(m_port->m_screen);
-		m_port2->set_screen_tag(m_port->m_screen);
-		m_port3->set_screen_tag(m_port->m_screen);
-		m_port4->set_screen_tag(m_port->m_screen);
+		NES_CONTROL_PORT(config, m_subexp[i], hori_adapter, "joypad");
+		if (m_port != nullptr)
+			m_subexp[i]->set_screen_tag(m_port->m_screen);
 	}
 }
 
@@ -94,23 +93,33 @@ void nes_hori4p_device::device_add_mconfig(machine_config &config)
 //  nes_horitwin_device - constructor
 //-------------------------------------------------
 
-nes_horitwin_device::nes_horitwin_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, NES_HORITWIN, tag, owner, clock),
-	device_nes_control_port_interface(mconfig, *this),
-	m_port1(*this, "port1"),
-	m_port2(*this, "port2")
+nes_horitwin_device::nes_horitwin_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, NES_HORITWIN, tag, owner, clock)
+	, device_nes_control_port_interface(mconfig, *this)
+	, m_subexp(*this, "subexp%u", 0)
 {
 }
 
-nes_hori4p_device::nes_hori4p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, NES_HORI4P, tag, owner, clock),
-	device_nes_control_port_interface(mconfig, *this),
-	m_port1(*this, "port1"),
-	m_port2(*this, "port2"),
-	m_port3(*this, "port3"),
-	m_port4(*this, "port4"),
-	m_cfg(*this, "CONFIG")
+nes_hori4p_device::nes_hori4p_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, NES_HORI4P, tag, owner, clock)
+	, device_nes_control_port_interface(mconfig, *this)
+	, m_subexp(*this, "subexp%u", 0)
+	, m_cfg(*this, "CONFIG")
 {
+}
+
+
+//-------------------------------------------------
+//  device_start
+//-------------------------------------------------
+
+void nes_hori4p_device::device_start()
+{
+	save_item(NAME(m_count));
+	save_item(NAME(m_sig));
+	save_item(NAME(m_strobe));
+
+	reset_regs();
 }
 
 
@@ -118,39 +127,28 @@ nes_hori4p_device::nes_hori4p_device(const machine_config &mconfig, const char *
 //  read
 //-------------------------------------------------
 
-uint8_t nes_horitwin_device::read_exp(offs_t offset)
+u8 nes_horitwin_device::read_exp(offs_t offset)
 {
-	uint8_t ret = 0;
-	if (offset == 0)    //$4016
-		ret |= (m_port1->read_bit0() << 1);
-	else    //$4017
-		ret |= (m_port2->read_bit0() << 1);
-	return ret;
+	return m_subexp[offset]->read_exp(0);
 }
 
-uint8_t nes_hori4p_device::read_exp(offs_t offset)
+u8 nes_hori4p_device::read_exp(offs_t offset)
 {
-	uint8_t ret = 0;
-	if (m_cfg->read() == 0) // 2P
+	u8 ret = 0;
+	int mode4p = m_cfg->read();
+
+	if (m_count[offset] < 16 || !mode4p)  // read from P1/P2 for first byte, P3/P4 for second byte if in 4P mode
 	{
-		if (offset == 0)    //$4016
-			ret |= (m_port1->read_bit0() << 1);
-		else    //$4017
-			ret |= (m_port2->read_bit0() << 1);
+		int port = 2 * (BIT(m_count[offset], 3) & mode4p) + offset;
+		ret = m_subexp[port]->read_exp(0);
 	}
-	else    // 4P
+	else    // excess reads return a distinct signature byte on both $4016 and $4017
 	{
-		if (offset == 0)    //$4016
-		{
-			ret |= (m_port1->read_bit0() << 0);
-			ret |= (m_port3->read_bit0() << 1);
-		}
-		else    //$4017
-		{
-			ret |= (m_port2->read_bit0() << 0);
-			ret |= (m_port4->read_bit0() << 1);
-		}
+		ret = (m_sig[offset] & 1) << 1;
+		m_sig[offset] >>= 1;
 	}
+	m_count[offset]++;
+
 	return ret;
 }
 
@@ -158,16 +156,27 @@ uint8_t nes_hori4p_device::read_exp(offs_t offset)
 //  write
 //-------------------------------------------------
 
-void nes_horitwin_device::write(uint8_t data)
+void nes_horitwin_device::write(u8 data)
 {
-	m_port1->write(data);
-	m_port2->write(data);
+	m_subexp[0]->write(data);
+	m_subexp[1]->write(data);
 }
 
-void nes_hori4p_device::write(uint8_t data)
+void nes_hori4p_device::write(u8 data)
 {
-	m_port1->write(data);
-	m_port2->write(data);
-	m_port3->write(data);
-	m_port4->write(data);
+	for (int i = 0; i < 4; i++)
+		m_subexp[i]->write(data);
+
+	if (write_strobe(data))
+		reset_regs();
+}
+
+void nes_hori4p_device::reset_regs()
+{
+	m_count[0] = 0;
+	m_count[1] = 0;
+
+	// signature third bytes returned in 4P mode, pair is flipped from what Four Score returns
+	m_sig[0] = 0x04;
+	m_sig[1] = 0x08;
 }

--- a/src/devices/bus/nes_ctrl/hori.h
+++ b/src/devices/bus/nes_ctrl/hori.h
@@ -2,7 +2,7 @@
 // copyright-holders:Fabio Priuli
 /**********************************************************************
 
-    Nintendo Family Computer Hori Twin (and 4P?) adapters
+    Nintendo Family Computer Hori Twin and 4 Players adapters
 
 **********************************************************************/
 
@@ -25,20 +25,20 @@ class nes_horitwin_device : public device_t,
 {
 public:
 	// construction/destruction
-	nes_horitwin_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_horitwin_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	// device-level overrides
 	virtual void device_start() override { }
 	virtual void device_add_mconfig(machine_config &config) override;
 
-	virtual uint8_t read_exp(offs_t offset) override;
-	virtual void write(uint8_t data) override;
+	virtual u8 read_exp(offs_t offset) override;
+	virtual void write(u8 data) override;
 
 private:
-	required_device<nes_control_port_device> m_port1;
-	required_device<nes_control_port_device> m_port2;
+	required_device_array<nes_control_port_device, 2> m_subexp;
 };
+
 
 // ======================> nes_hori4p_device
 
@@ -47,29 +47,29 @@ class nes_hori4p_device : public device_t,
 {
 public:
 	// construction/destruction
-	nes_hori4p_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_hori4p_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	// device-level overrides
-	virtual void device_start() override { }
+	virtual void device_start() override;
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual ioport_constructor device_input_ports() const override;
 
-	virtual uint8_t read_exp(offs_t offset) override;
-	virtual void write(uint8_t data) override;
+	virtual u8 read_exp(offs_t offset) override;
+	virtual void write(u8 data) override;
 
 private:
-	required_device<nes_control_port_device> m_port1;
-	required_device<nes_control_port_device> m_port2;
-	required_device<nes_control_port_device> m_port3;
-	required_device<nes_control_port_device> m_port4;
+	void reset_regs();
+
+	required_device_array<nes_control_port_device, 4> m_subexp;
 	required_ioport m_cfg;
+	u8 m_count[2];
+	u8 m_sig[2];
 };
 
 
 // device type definition
 DECLARE_DEVICE_TYPE(NES_HORITWIN, nes_horitwin_device)
 DECLARE_DEVICE_TYPE(NES_HORI4P,   nes_hori4p_device)
-
 
 #endif // MAME_BUS_NES_CTRL_HORI_H

--- a/src/devices/bus/nes_ctrl/joypad.cpp
+++ b/src/devices/bus/nes_ctrl/joypad.cpp
@@ -25,6 +25,14 @@
     game (an image of such connection is shown e.g. in Nekketsu Koukou
     Dodgeball Bu manual)
 
+    FIXME: The official Nintendo stick mentioned above by Hori has the
+    P1/P2 and 4/8-way switches but it DOESN'T have a daisy chain port.
+    ASCII made at least two sticks, AS-2088-FC and AS-3399-FC, that may
+    be the only two that exist with a daisy chain port. The former has
+    no additional switches at all, so its port may be a pass-thru. The
+    latter has many features: P1/P2 and 4/8-way switches, turbo, jacks
+    for data recorder, etc.
+
 **********************************************************************/
 
 #include "emu.h"
@@ -35,12 +43,13 @@
 //**************************************************************************
 
 DEFINE_DEVICE_TYPE(NES_JOYPAD,      nes_joypad_device,   "nes_joypad",   "Nintendo NES / FC Control Pad")
+DEFINE_DEVICE_TYPE(NES_FCPAD_EXP,   nes_fcpadexp_device, "nes_fcpadexp", "Nintendo Family Computer Expansion Port Pad")
 DEFINE_DEVICE_TYPE(NES_FCPAD_P2,    nes_fcpad2_device,   "nes_fcpad2",   "Nintendo Family Computer P2 Pad")
 DEFINE_DEVICE_TYPE(NES_CCPAD_LEFT,  nes_ccpadl_device,   "nes_ccpadl",   "FC Crazy Climber Left Pad")
 DEFINE_DEVICE_TYPE(NES_CCPAD_RIGHT, nes_ccpadr_device,   "nes_ccpadr",   "FC Crazy Climber Right Pad")
 DEFINE_DEVICE_TYPE(NES_ARCSTICK,    nes_arcstick_device, "nes_arcstick", "Nintendo Family Computer Arcade Stick")
 
-static INPUT_PORTS_START( nes_joypad )
+INPUT_PORTS_START( nes_joypad )
 	PORT_START("JOYPAD")
 	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_NAME("%p A")
 	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_NAME("%p B")
@@ -168,15 +177,26 @@ void nes_arcstick_device::device_add_mconfig(machine_config &config)
 //  nes_joypad_device - constructor
 //-------------------------------------------------
 
-nes_joypad_device::nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, type, tag, owner, clock),
-	device_nes_control_port_interface(mconfig, *this),
-	m_joypad(*this, "JOYPAD"), m_latch(0)
+nes_joypad_device::nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: device_t(mconfig, type, tag, owner, clock)
+	, device_nes_control_port_interface(mconfig, *this)
+	, m_joypad(*this, "JOYPAD")
+	, m_latch(0)
 {
 }
 
-nes_joypad_device::nes_joypad_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nes_joypad_device(mconfig, NES_JOYPAD, tag, owner, clock)
+nes_joypad_device::nes_joypad_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_joypad_device(mconfig, NES_JOYPAD, tag, owner, clock)
+{
+}
+
+nes_fcpadexp_device::nes_fcpadexp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: nes_joypad_device(mconfig, type, tag, owner, clock)
+{
+}
+
+nes_fcpadexp_device::nes_fcpadexp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_fcpadexp_device(mconfig, NES_FCPAD_EXP, tag, owner, clock)
 {
 }
 
@@ -186,20 +206,20 @@ nes_fcpad2_device::nes_fcpad2_device(const machine_config &mconfig, const char *
 {
 }
 
-nes_ccpadl_device::nes_ccpadl_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nes_joypad_device(mconfig, NES_CCPAD_LEFT, tag, owner, clock)
+nes_ccpadl_device::nes_ccpadl_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_joypad_device(mconfig, NES_CCPAD_LEFT, tag, owner, clock)
 {
 }
 
-nes_ccpadr_device::nes_ccpadr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nes_joypad_device(mconfig, NES_CCPAD_RIGHT, tag, owner, clock)
+nes_ccpadr_device::nes_ccpadr_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_joypad_device(mconfig, NES_CCPAD_RIGHT, tag, owner, clock)
 {
 }
 
-nes_arcstick_device::nes_arcstick_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	nes_joypad_device(mconfig, NES_ARCSTICK, tag, owner, clock),
-	m_daisychain(*this, "subexp"),
-	m_cfg(*this, "CONFIG")
+nes_arcstick_device::nes_arcstick_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_fcpadexp_device(mconfig, NES_ARCSTICK, tag, owner, clock)
+	, m_daisychain(*this, "subexp")
+	, m_cfg(*this, "CONFIG")
 {
 }
 
@@ -211,16 +231,7 @@ nes_arcstick_device::nes_arcstick_device(const machine_config &mconfig, const ch
 void nes_joypad_device::device_start()
 {
 	save_item(NAME(m_latch));
-}
-
-
-//-------------------------------------------------
-//  device_reset
-//-------------------------------------------------
-
-void nes_joypad_device::device_reset()
-{
-	m_latch = 0;
+	save_item(NAME(m_strobe));
 }
 
 
@@ -228,11 +239,20 @@ void nes_joypad_device::device_reset()
 //  read
 //-------------------------------------------------
 
-uint8_t nes_joypad_device::read_bit0()
+u8 nes_joypad_device::read_bit0()
 {
-	uint8_t ret = m_latch & 1;
-	m_latch >>= 1;
+	if (m_strobe)
+		m_latch = m_joypad->read();
+
+	u8 ret = m_latch & 1;
+	m_latch = (m_latch >> 1) | 0x80;  // fill shift reg with 1s, since excess reads on official pads return 1
+
 	return ret;
+}
+
+u8 nes_fcpadexp_device::read_exp(offs_t offset)
+{
+	return offset ? 0 : nes_joypad_device::read_bit0() << 1;
 }
 
 u8 nes_fcpad2_device::read_bit2()
@@ -246,29 +266,14 @@ u8 nes_fcpad2_device::read_bit2()
 // with each other? currently, we only support the following setup:
 // if the first pad is set as P1, the daisy chained pad is checked
 // for P2 only, and vice versa.
-uint8_t nes_arcstick_device::read_exp(offs_t offset)
+u8 nes_arcstick_device::read_exp(offs_t offset)
 {
-	uint8_t ret = 0;
-	if (offset == 0)    //$4016
-	{
-		if ((m_cfg->read() & 2) == 0)   // we are P1 input
-		{
-			ret |= (m_latch & 1) << 1;
-			m_latch >>= 1;
-		}
-		else
-			ret |= m_daisychain->read_exp(0);
-	}
-	else    //$4017
-	{
-		if ((m_cfg->read() & 2) == 2)   // we are P2 input
-		{
-			ret |= (m_latch & 1) << 1;
-			m_latch >>= 1;
-		}
-		else
-			ret |= m_daisychain->read_exp(1);
-	}
+	u8 ret = 0;
+
+	if (BIT(m_cfg->read(), 1) == offset)    // P# matches the port? That's us!
+		ret = nes_fcpadexp_device::read_exp(0);
+	else                                    // otherwise it's possibly the other controller
+		ret = m_daisychain->read_exp(offset);
 
 	return ret;
 }
@@ -277,20 +282,14 @@ uint8_t nes_arcstick_device::read_exp(offs_t offset)
 //  write
 //-------------------------------------------------
 
-void nes_joypad_device::write(uint8_t data)
+void nes_joypad_device::write(u8 data)
 {
-	if (data & 0x01)
-		return;
-
-	m_latch = m_joypad->read();
+	if (write_strobe(data))
+		m_latch = m_joypad->read();
 }
 
-void nes_arcstick_device::write(uint8_t data)
+void nes_arcstick_device::write(u8 data)
 {
 	m_daisychain->write(data);
-
-	if (data & 0x01)
-		return;
-
-	m_latch = m_joypad->read();
+	nes_fcpadexp_device::write(data);
 }

--- a/src/devices/bus/nes_ctrl/joypad.h
+++ b/src/devices/bus/nes_ctrl/joypad.h
@@ -13,6 +13,7 @@
 
 #include "ctrl.h"
 
+INPUT_PORTS_EXTERN( nes_joypad );
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -25,23 +26,39 @@ class nes_joypad_device : public device_t,
 {
 public:
 	// construction/destruction
-	nes_joypad_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_joypad_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual ioport_constructor device_input_ports() const override;
 
 protected:
-	nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
-	virtual void device_reset() override;
 
-	virtual uint8_t read_bit0() override;
-	virtual void write(uint8_t data) override;
+	virtual u8 read_bit0() override;
+	virtual void write(u8 data) override;
 
 	required_ioport m_joypad;
-	uint32_t m_latch;
+	u32 m_latch;  // wider than standard joypad's 8-bit latch to accomodate subclass devices
 };
+
+
+// ======================> nes_fcpadexp_device
+
+class nes_fcpadexp_device : public nes_joypad_device
+{
+public:
+	// construction/destruction
+	nes_fcpadexp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+protected:
+	nes_fcpadexp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+
+	virtual u8 read_bit0() override { return 0; }
+	virtual u8 read_exp(offs_t offset) override;
+};
+
 
 // ======================> nes_fcpad2_device
 
@@ -60,16 +77,18 @@ private:
 	required_ioport m_mic;
 };
 
+
 // ======================> nes_ccpadl_device
 
 class nes_ccpadl_device : public nes_joypad_device
 {
 public:
 	// construction/destruction
-	nes_ccpadl_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ccpadl_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual ioport_constructor device_input_ports() const override;
 };
+
 
 // ======================> nes_ccpadr_device
 
@@ -77,26 +96,26 @@ class nes_ccpadr_device : public nes_joypad_device
 {
 public:
 	// construction/destruction
-	nes_ccpadr_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ccpadr_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual ioport_constructor device_input_ports() const override;
 };
 
+
 // ======================> nes_arcstick_device
 
-class nes_arcstick_device : public nes_joypad_device
+class nes_arcstick_device : public nes_fcpadexp_device
 {
 public:
 	// construction/destruction
-	nes_arcstick_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_arcstick_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual ioport_constructor device_input_ports() const override;
 	virtual void device_add_mconfig(machine_config &config) override;
 
-	virtual uint8_t read_bit0() override { return 0; }
-	virtual uint8_t read_exp(offs_t offset) override;
-	virtual void write(uint8_t data) override;
+	virtual u8 read_exp(offs_t offset) override;
+	virtual void write(u8 data) override;
 
 	required_device<nes_control_port_device> m_daisychain;
 	required_ioport m_cfg;
@@ -105,6 +124,7 @@ protected:
 
 // device type definition
 DECLARE_DEVICE_TYPE(NES_JOYPAD,         nes_joypad_device)
+DECLARE_DEVICE_TYPE(NES_FCPAD_EXP,      nes_fcpadexp_device)
 DECLARE_DEVICE_TYPE(NES_FCPAD_P2,       nes_fcpad2_device)
 DECLARE_DEVICE_TYPE(NES_CCPAD_LEFT,     nes_ccpadl_device)
 DECLARE_DEVICE_TYPE(NES_CCPAD_RIGHT,    nes_ccpadr_device)

--- a/src/devices/bus/nes_ctrl/pachinko.cpp
+++ b/src/devices/bus/nes_ctrl/pachinko.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Fabio Priuli
 /**********************************************************************
 
-    Nintendo Family Computer Pachinko Controller
+    Nintendo Family Computer Coconuts Japan CJPC-102 Pachinko Controller
 
 **********************************************************************/
 
@@ -13,19 +13,11 @@
 //  DEVICE DEFINITIONS
 //**************************************************************************
 
-DEFINE_DEVICE_TYPE(NES_PACHINKO, nes_pachinko_device, "nes_pachinko", "Famicom Pachinko Controller")
+DEFINE_DEVICE_TYPE(NES_PACHINKO, nes_pachinko_device, "nes_pachinko", "Coconuts Japan Pachinko Controller")
 
 
 static INPUT_PORTS_START( nes_pachinko )
-	PORT_START("JOYPAD")
-	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON2 ) PORT_NAME("A")
-	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON1 ) PORT_NAME("B")
-	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_SELECT )
-	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_START )
-	PORT_BIT( 0x10, IP_ACTIVE_HIGH, IPT_JOYSTICK_UP ) PORT_8WAY
-	PORT_BIT( 0x20, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN ) PORT_8WAY
-	PORT_BIT( 0x40, IP_ACTIVE_HIGH, IPT_JOYSTICK_LEFT ) PORT_8WAY
-	PORT_BIT( 0x80, IP_ACTIVE_HIGH, IPT_JOYSTICK_RIGHT ) PORT_8WAY
+	PORT_INCLUDE( nes_joypad )
 
 	PORT_START("TRIGGER")
 	PORT_BIT( 0xff, 0, IPT_PEDAL ) PORT_MINMAX(0, 0x63) PORT_SENSITIVITY(25) PORT_KEYDELTA(20)
@@ -48,33 +40,10 @@ ioport_constructor nes_pachinko_device::device_input_ports() const
 //  nes_pachinko_device - constructor
 //-------------------------------------------------
 
-nes_pachinko_device::nes_pachinko_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, NES_PACHINKO, tag, owner, clock),
-	device_nes_control_port_interface(mconfig, *this),
-	m_joypad(*this, "JOYPAD"),
-	m_trigger(*this, "TRIGGER"),
-	m_latch(0)
+nes_pachinko_device::nes_pachinko_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_fcpadexp_device(mconfig, NES_PACHINKO, tag, owner, clock)
+	, m_trigger(*this, "TRIGGER")
 {
-}
-
-
-//-------------------------------------------------
-//  device_start
-//-------------------------------------------------
-
-void nes_pachinko_device::device_start()
-{
-	save_item(NAME(m_latch));
-}
-
-
-//-------------------------------------------------
-//  device_reset
-//-------------------------------------------------
-
-void nes_pachinko_device::device_reset()
-{
-	m_latch = 0;
 }
 
 
@@ -82,13 +51,15 @@ void nes_pachinko_device::device_reset()
 //  read
 //-------------------------------------------------
 
-uint8_t nes_pachinko_device::read_exp(offs_t offset)
+u8 nes_pachinko_device::read_exp(offs_t offset)
 {
-	uint8_t ret = 0;
+	u8 ret = 0;
 	// this controller behaves like a standard P3 joypad, with longer stream of inputs
 	if (offset == 0)    //$4016
 	{
-		ret |= (m_latch & 1) << 1;
+		if (m_strobe)
+			set_latch();
+		ret = (m_latch & 1) << 1;
 		m_latch >>= 1;
 	}
 	return ret;
@@ -98,12 +69,14 @@ uint8_t nes_pachinko_device::read_exp(offs_t offset)
 //  write
 //-------------------------------------------------
 
-void nes_pachinko_device::write(uint8_t data)
+void nes_pachinko_device::write(u8 data)
 {
-	if (data & 0x01)
-		return;
+	if (write_strobe(data))
+		set_latch();
+}
 
+void nes_pachinko_device::set_latch()
+{
 	m_latch = m_joypad->read();
-	m_latch |= ((m_trigger->read() ^ 0xff) & 0xff) << 8;
-	m_latch |= 0xff0000;
+	m_latch |= ~bitswap<8>(m_trigger->read(), 0, 1, 2, 3, 4, 5, 6, 7) << 8;
 }

--- a/src/devices/bus/nes_ctrl/pachinko.h
+++ b/src/devices/bus/nes_ctrl/pachinko.h
@@ -2,7 +2,7 @@
 // copyright-holders:Fabio Priuli
 /**********************************************************************
 
-    Nintendo Family Computer Pachinko Controller
+    Nintendo Family Computer Coconuts Japan CJPC-102 Pachinko Controller
 
 **********************************************************************/
 
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "ctrl.h"
+#include "joypad.h"
 
 
 //**************************************************************************
@@ -20,27 +20,24 @@
 
 // ======================> nes_pachinko_device
 
-class nes_pachinko_device : public device_t,
-							public device_nes_control_port_interface
+class nes_pachinko_device : public nes_fcpadexp_device
 {
 public:
 	// construction/destruction
-	nes_pachinko_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_pachinko_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual ioport_constructor device_input_ports() const override;
 
 protected:
-	// device-level overrides
-	virtual void device_start() override;
-	virtual void device_reset() override;
+	virtual u8 read_exp(offs_t offset) override;
+	virtual void write(u8 data) override;
 
-	virtual uint8_t read_exp(offs_t offset) override;
-	virtual void write(uint8_t data) override;
+private:
+	void set_latch();
 
-	required_ioport m_joypad;
 	required_ioport m_trigger;
-	uint32_t m_latch;
 };
+
 
 // device type definition
 DECLARE_DEVICE_TYPE(NES_PACHINKO, nes_pachinko_device)

--- a/src/devices/bus/nes_ctrl/powerpad.cpp
+++ b/src/devices/bus/nes_ctrl/powerpad.cpp
@@ -82,7 +82,6 @@ nes_powerpad_device::nes_powerpad_device(const machine_config &mconfig, const ch
 	: device_t(mconfig, NES_POWERPAD, tag, owner, clock)
 	, device_nes_control_port_interface(mconfig, *this)
 	, m_ipt(*this, "POWERPAD.%u", 0)
-	, m_strobe(0)
 {
 }
 
@@ -123,10 +122,7 @@ u8 nes_powerpad_device::read_bit34()
 
 void nes_powerpad_device::write(u8 data)
 {
-	u8 prev_strobe = m_strobe;
-	m_strobe = data & 1;
-
-	if (prev_strobe && !m_strobe)
+	if (write_strobe(data))
 		for (int i = 0; i < 2; i++)
 			m_latch[i] = m_ipt[i]->read();
 }

--- a/src/devices/bus/nes_ctrl/powerpad.h
+++ b/src/devices/bus/nes_ctrl/powerpad.h
@@ -39,7 +39,6 @@ protected:
 private:
 	required_ioport_array<2> m_ipt;
 	u8 m_latch[2];
-	u8 m_strobe;
 };
 
 

--- a/src/mame/machine/nes.cpp
+++ b/src/mame/machine/nes.cpp
@@ -191,11 +191,7 @@ uint8_t nes_state::fc_in0_r()
 	// bit 2 from P2 controller microphone
 	ret |= m_ctrl2->read_bit2();
 
-	// at the same time, we might have a standard joypad connected to the expansion port which
-	// shall be read as P3 (this is needed here to avoid implementing the expansion port as a
-	// different device compared to the standard control port... it might be changed later)
-	ret |= (m_exp->read_bit0() << 1);
-	// finally, read the expansion port as expected
+	// and bit 1 comes from expansion port
 	ret |= m_exp->read_exp(0);
 	return ret;
 }
@@ -206,8 +202,7 @@ uint8_t nes_state::fc_in1_r()
 	// bit 0 from controller port
 	ret |= m_ctrl2->read_bit0();
 
-	// finally, read the expansion port as expected (standard pad cannot be hooked as P4, so
-	// no read_bit0 here)
+	// bits 1-4 from expansion port (in theory bit 0 also can be read on AV Famicom when controller is unplugged)
 	ret |= m_exp->read_exp(1);
 	return ret;
 }


### PR DESCRIPTION
- Enforced proper strobe behavior on joypads. Added helper function to controller interface for common pattern.
- Added proper expansion port version of joypad.
- Streamlined pachinko controller by making it an expansion joypad subclass. Moreover, ball launch lever now works correctly!
- Added missing battery-backed WRAM to Pachio-kun 5, game runs now.
- Simplified arcade stick a bit, now also a subclass of the expansion joypad.
- Rewrote Hori Twin and 4 Players adapters. The latter's 4P mode protocol now works. In theory this supports six players simultaneously, though all known games using it have duplicate controls for P1 and P2.

machine/nes.cpp: Removed hack that shifted bit 0 reads to support controller port joypads on expansion port. There shouldn't be any expansion port devices left that write to bit 0.