### PR TITLE
New scaling algorithm. Fixes aspect related issues, undesired overscan, etc.

### DIFF
--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1199,61 +1199,101 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 			if (target_orientation & ORIENTATION_SWAP_XY)
 				src_aspect = 1.0 / src_aspect;
 
-			// get target aspect
-			float target_aspect = (float)target_width / (float)target_height * target_pixel_aspect;
+			// we need the ratio of target to source aspect
+			float aspect_ratio = m_keepaspect ? (float)target_width / (float)target_height * target_pixel_aspect / src_aspect : 1.0;
+
+			// first compute (a, b) scale factors to fit the screen
+			float a = (float)target_width / src_width;
+			float b = (float)target_height / src_height;
 
 			// apply automatic axial stretching if required
 			int scale_mode = m_scale_mode;
-			if (m_scale_mode == SCALE_FRACTIONAL_AUTO)
+			if (scale_mode == SCALE_FRACTIONAL_AUTO)
+				scale_mode = (m_manager.machine().system().flags & ORIENTATION_SWAP_XY) ^ (target_orientation & ORIENTATION_SWAP_XY) ?
+							SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
+
+			// determine the scaling method for each axis
+			bool a_is_fract = (scale_mode == SCALE_FRACTIONAL_X || scale_mode == SCALE_FRACTIONAL);
+			bool b_is_fract = (scale_mode == SCALE_FRACTIONAL_Y || scale_mode == SCALE_FRACTIONAL);
+
+			// check if we have user defined scale factors, if so use them instead, but only on integer axes
+			int a_user = a_is_fract ? 0 : m_int_scale_x;
+			int b_user = b_is_fract ? 0 : m_int_scale_y;
+
+			// we allow overscan either explicitely or if integer scale factors are forced by user
+			bool int_overscan = m_int_overscan || (m_keepaspect && (a_user != 0 || b_user != 0));
+			float a_max = std::max(a, (float)a_user);
+			float b_max = std::max(b, (float)b_user);
+
+
+			// get the usable bounding box considering the type of scaling for each axis
+			float usable_aspect = (a_is_fract ? a : (float)std::max(1.0, floor(a))) * src_width /
+								 ((b_is_fract ? b : (float)std::max(1.0, floor(b))) * src_height) * target_pixel_aspect;
+
+			// depending on the relative shape between target and source, let's define 'a' and 'b' so that:
+			// * a is the leader axis (first to hit a boundary)
+			// * b is the follower axis
+			if (usable_aspect > src_aspect)
 			{
-				bool is_rotated = (m_manager.machine().system().flags & ORIENTATION_SWAP_XY) ^ (target_orientation & ORIENTATION_SWAP_XY);
-				scale_mode = is_rotated ? SCALE_FRACTIONAL_Y : SCALE_FRACTIONAL_X;
+				std::swap(a, b);
+				std::swap(a_user, b_user);
+				std::swap(a_is_fract, b_is_fract);
+				std::swap(a_max, b_max);
+				aspect_ratio = 1.0 / aspect_ratio;
 			}
 
-			// first compute scale factors to fit the screen
-			float xscale = (float)target_width / src_width;
-			float yscale = (float)target_height / src_height;
+			// now find an (a, b) pair that best fits our boundaries and scale options
+			float a_best = 1.0, b_best = 1.0;
+			float diff = 1000;
 
-			// apply aspect correction
-			if (m_keepaspect)
+			// fill (a0, a1) range
+			float u = a_user == 0 ? a : (float)a_user;
+			float a_range[] = {a_is_fract ? u : (float)std::max(1.0, floor(u)), a_is_fract ? u : (float)std::max(1.0, round(u))};
+
+			for (float aa : a_range)
 			{
-				if (target_aspect > src_aspect)
-					xscale *= src_aspect / target_aspect;
-				else
-					yscale *= target_aspect / src_aspect;
-			}
+				// apply aspect correction to 'b' axis if needed, considering resulting 'a' borders
+				float ba = b * (m_keepaspect ? aspect_ratio * (aa / a) : 1.0);
 
-			bool x_fits = render_round_nearest(xscale) * src_width <= target_width;
-			bool y_fits = render_round_nearest(yscale) * src_height <= target_height;
+				// fill (b0, b1) range
+				float v = b_user == 0 ? ba : (float)b_user;
+				float b_range[] = {b_is_fract ? v : (float)std::max(1.0, floor(v)), b_is_fract ? v : (float)std::max(1.0, round(v))};
 
-			// compute integer scale factors
-			float integer_x = std::max(1.0f, float(m_int_overscan || x_fits ? render_round_nearest(xscale) : floor(xscale)));
-			float integer_y = std::max(1.0f, float(m_int_overscan || y_fits ? render_round_nearest(yscale) : floor(yscale)));
+				for (float bb : b_range)
+				{
+					// we may need to propagate proportions back to 'a' axis
+					float ab = aa;
+					if (m_keepaspect && a_user == 0)
+					{
+						if (a_is_fract) ab *= (bb / ba);
+						else if (b_user != 0) ab = (float)std::max(1.0, round(ab * (bb / ba)));
+					}
 
-			// check if we have user defined scale factors, if so use them instead
-			integer_x = m_int_scale_x > 0 ? m_int_scale_x : integer_x;
-			integer_y = m_int_scale_y > 0 ? m_int_scale_y : integer_y;
+					// if overscan isn't allowed, discard values that exceed the usable bounding box, except a minimum of 1.0
+					if (!int_overscan && ((ab > a_max && bb > 1.0) || (bb > b_max && ab > 1.0)))
+						continue;
 
-			// now apply desired scale mode
-			if (scale_mode == SCALE_FRACTIONAL_X)
-			{
-				if (m_keepaspect) xscale *= integer_y / yscale;
-				yscale = integer_y;
+					// score the result
+					float new_diff = fabs(aspect_ratio * (a / b) - (ab / bb));
+
+					if (new_diff <= diff)
+					{
+						diff = new_diff;
+						a_best = ab;
+						b_best = bb;
+					}
+				}
 			}
-			else if (scale_mode == SCALE_FRACTIONAL_Y)
-			{
-				if (m_keepaspect) yscale *= integer_x / xscale;
-				xscale = integer_x;
-			}
-			else
-			{
-				xscale = integer_x;
-				yscale = integer_y;
-			}
+			a = a_best;
+			b = b_best;
+
+			// restore orientation
+			if (usable_aspect > src_aspect)
+				std::swap(a, b);
 
 			// set the final width/height
-			visible_width = render_round_nearest(src_width * xscale);
-			visible_height = render_round_nearest(src_height * yscale);
+			visible_width = render_round_nearest(src_width * a);
+			visible_height = render_round_nearest(src_height * b);
 			break;
 		}
 	}

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1197,10 +1197,10 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 
 			// apply orientation if required
 			if (target_orientation & ORIENTATION_SWAP_XY)
-				src_aspect = 1.0 / src_aspect;
+				src_aspect = 1.0f / src_aspect;
 
 			// we need the ratio of target to source aspect
-			float aspect_ratio = m_keepaspect ? (float)target_width / (float)target_height * target_pixel_aspect / src_aspect : 1.0;
+			float aspect_ratio = m_keepaspect ? (float)target_width / (float)target_height * target_pixel_aspect / src_aspect : 1.0f;
 
 			// first compute (a, b) scale factors to fit the screen
 			float a = (float)target_width / src_width;
@@ -1227,8 +1227,8 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 
 
 			// get the usable bounding box considering the type of scaling for each axis
-			float usable_aspect = (a_is_fract ? a : (float)std::max(1.0, floor(a))) * src_width /
-								 ((b_is_fract ? b : (float)std::max(1.0, floor(b))) * src_height) * target_pixel_aspect;
+			float usable_aspect = (a_is_fract ? a : std::max(1.0f, floorf(a))) * src_width /
+								 ((b_is_fract ? b : std::max(1.0f, floorf(b))) * src_height) * target_pixel_aspect;
 
 			// depending on the relative shape between target and source, let's define 'a' and 'b' so that:
 			// * a is the leader axis (first to hit a boundary)
@@ -1239,25 +1239,25 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 				std::swap(a_user, b_user);
 				std::swap(a_is_fract, b_is_fract);
 				std::swap(a_max, b_max);
-				aspect_ratio = 1.0 / aspect_ratio;
+				aspect_ratio = 1.0f / aspect_ratio;
 			}
 
 			// now find an (a, b) pair that best fits our boundaries and scale options
-			float a_best = 1.0, b_best = 1.0;
+			float a_best = 1.0f, b_best = 1.0f;
 			float diff = 1000;
 
 			// fill (a0, a1) range
 			float u = a_user == 0 ? a : (float)a_user;
-			float a_range[] = {a_is_fract ? u : (float)std::max(1.0, floor(u)), a_is_fract ? u : (float)std::max(1.0, round(u))};
+			float a_range[] = {a_is_fract ? u : std::max(1.0f, floorf(u)), a_is_fract ? u : std::max(1.0f, roundf(u))};
 
 			for (float aa : a_range)
 			{
 				// apply aspect correction to 'b' axis if needed, considering resulting 'a' borders
-				float ba = b * (m_keepaspect ? aspect_ratio * (aa / a) : 1.0);
+				float ba = b * (m_keepaspect ? aspect_ratio * (aa / a) : 1.0f);
 
 				// fill (b0, b1) range
 				float v = b_user == 0 ? ba : (float)b_user;
-				float b_range[] = {b_is_fract ? v : (float)std::max(1.0, floor(v)), b_is_fract ? v : (float)std::max(1.0, round(v))};
+				float b_range[] = {b_is_fract ? v : std::max(1.0f, floorf(v)), b_is_fract ? v : std::max(1.0f, roundf(v))};
 
 				for (float bb : b_range)
 				{
@@ -1266,11 +1266,11 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 					if (m_keepaspect && a_user == 0)
 					{
 						if (a_is_fract) ab *= (bb / ba);
-						else if (b_user != 0) ab = (float)std::max(1.0, round(ab * (bb / ba)));
+						else if (b_user != 0) ab = std::max(1.0f, roundf(ab * (bb / ba)));
 					}
 
-					// if overscan isn't allowed, discard values that exceed the usable bounding box, except a minimum of 1.0
-					if (!int_overscan && ((ab > a_max && bb > 1.0) || (bb > b_max && ab > 1.0)))
+					// if overscan isn't allowed, discard values that exceed the usable bounding box, except a minimum of 1.0f
+					if (!int_overscan && ((ab > a_max && bb > 1.0f) || (bb > b_max && ab > 1.0f)))
 						continue;
 
 					// score the result

--- a/src/emu/render.cpp
+++ b/src/emu/render.cpp
@@ -1274,7 +1274,7 @@ void render_target::compute_visible_area(s32 target_width, s32 target_height, fl
 						continue;
 
 					// score the result
-					float new_diff = fabs(aspect_ratio * (a / b) - (ab / bb));
+					float new_diff = fabsf(aspect_ratio * (a / b) - (ab / bb));
 
 					if (new_diff <= diff)
 					{

--- a/src/osd/windows/window.cpp
+++ b/src/osd/windows/window.cpp
@@ -304,6 +304,7 @@ win_window_info::win_window_info(
 	, m_targetview(0)
 	, m_targetorient(0)
 	, m_targetvismask(0)
+	, m_targetscalemode(0)
 	, m_lastclicktime(std::chrono::steady_clock::time_point::min())
 	, m_lastclickx(0)
 	, m_lastclicky(0)
@@ -783,12 +784,14 @@ void win_window_info::update()
 	int const targetorient = target()->orientation();
 	render_layer_config const targetlayerconfig = target()->layer_config();
 	u32 const targetvismask = target()->visibility_mask();
-	if (targetview != m_targetview || targetorient != m_targetorient || targetlayerconfig != m_targetlayerconfig || targetvismask != m_targetvismask)
+	int const targetscalemode = target()->scale_mode();
+	if (targetview != m_targetview || targetorient != m_targetorient || targetlayerconfig != m_targetlayerconfig || targetvismask != m_targetvismask || targetscalemode != m_targetscalemode)
 	{
 		m_targetview = targetview;
 		m_targetorient = targetorient;
 		m_targetlayerconfig = targetlayerconfig;
 		m_targetvismask = targetvismask;
+		m_targetscalemode = targetscalemode;
 
 		// in window mode, reminimize/maximize
 		if (!fullscreen())

--- a/src/osd/windows/window.h
+++ b/src/osd/windows/window.h
@@ -107,6 +107,7 @@ public:
 	int                 m_targetorient;
 	render_layer_config m_targetlayerconfig;
 	u32                 m_targetvismask;
+	int                 m_targetscalemode;
 
 	// input info
 	std::chrono::steady_clock::time_point  m_lastclicktime;


### PR DESCRIPTION
Solves issues related to: https://github.com/mamedev/mame/pull/8209
Fixes: https://github.com/mamedev/mame/issues/8387
Fixes: https://mametesters.org/view.php?id=8110

This is a general case algorithm for all scale modes. Now, the SCALE_FRACTIONAL case wouldn't need a separate implementation anymore, however I'd rather keep it by now since it's much simpler than the general case.

I would have preferred a "single run" algorithm like the previous ones, but the way these features are expected to work seems to require a "find-best-fit" type of implementation, that correctly accounts for the effects of rounding scale values to integers over respective axes.

