### PR TITLE
Fix chdman threading on cpus with many cores

### DIFF
--- a/src/osd/osdsync.cpp
+++ b/src/osd/osdsync.cpp
@@ -85,14 +85,15 @@ static void spin_while_not(const volatile _AtomType * volatile atom, const _Main
 //  osd_num_processors
 //============================================================
 
-int osd_get_num_processors()
+int osd_get_num_processors(bool heavy_mt)
 {
 #if defined(SDLMAME_EMSCRIPTEN)
 	// multithreading is not supported at this time
 	return 1;
 #else
+	unsigned int threads = std::thread::hardware_concurrency();
 	// max out at 4 for now since scaling above that seems to do poorly
-	return std::min(std::thread::hardware_concurrency(), 4U);
+	return heavy_mt ? threads : std::min(std::thread::hardware_concurrency(), 4U);
 #endif
 }
 
@@ -211,7 +212,7 @@ int osd_num_processors = 0;
 //  FUNCTION PROTOTYPES
 //============================================================
 
-static int effective_num_processors();
+static int effective_num_processors(bool heavy_mt);
 static void * worker_thread_entry(void *param);
 static void worker_thread_process(osd_work_queue *queue, work_thread_info *thread);
 static bool queue_has_list_items(osd_work_queue *queue);
@@ -251,7 +252,7 @@ int thread_adjust_priority(std::thread *thread, int adjust)
 osd_work_queue *osd_work_queue_alloc(int flags)
 {
 	int threadnum;
-	int numprocs = effective_num_processors();
+	int numprocs = effective_num_processors(!(flags & WORK_QUEUE_FLAG_HIGH_FREQ));
 	osd_work_queue *queue;
 	int osdthreadnum = 0;
 	int allocthreadnum;
@@ -639,9 +640,9 @@ void osd_work_item_release(osd_work_item *item)
 //  effective_num_processors
 //============================================================
 
-static int effective_num_processors()
+static int effective_num_processors(bool heavy_mt)
 {
-	int physprocs = osd_get_num_processors();
+	int physprocs = osd_get_num_processors(heavy_mt);
 
 	// osd_num_processors == 0 for 'auto'
 	if (osd_num_processors > 0)

--- a/src/osd/osdsync.h
+++ b/src/osd/osdsync.h
@@ -159,8 +159,8 @@ public:
 private:
 	std::mutex               m_mutex;
 	std::condition_variable  m_cond;
-	std::atomic<int32_t>       m_autoreset;
-	std::atomic<int32_t>       m_signalled;
+	int32_t                  m_autoreset;
+	int32_t                  m_signalled;
 
 };
 

--- a/src/osd/osdsync.h
+++ b/src/osd/osdsync.h
@@ -136,16 +136,17 @@ public:
 
 	    Return value:
 
-	        None
+	        Whether or not the event was actually signalled (false if the event had already been signalled)
 
 	    Notes:
 
 	        All threads waiting for the event will be signalled.
 	-----------------------------------------------------------------------------*/
-	void set()
+	bool set()
 	{
 		m_mutex.lock();
-		if (m_signalled == false)
+		bool needs_signal = !m_signalled;
+		if (needs_signal)
 		{
 			m_signalled = true;
 			if (m_autoreset)
@@ -154,6 +155,7 @@ public:
 				m_cond.notify_all();
 		}
 		m_mutex.unlock();
+		return needs_signal;
 	}
 
 private:


### PR DESCRIPTION
- Defaults chdman to all threads on the system (previously used a maximum of 4 threads)
- Fixes a race condition that made chdman's rapid task allocation not properly wake up all threads (a thread wouldn't mark itself as active until it started running, so if two tasks were scheduled in quick succession, the first would notify a thread, and the second would see that that thread wasn't active yet (since it was notified but not yet running) and notify the *same* thread instead of a new one).

Side note: `osd_event` feels very easy to misuse.  In particular, the way it prevents inclusion of other checks under its lock makes me worry about anything that attempts to combine it with other flags to conditionally call `set()`.  In addition to the old wake code, `osd_work_queue::doneevent` does this with `osd_work_queue::waiting`.  I would recommend considering using a `std::unique_lock` like `std::condition_variable`, which makes it easy to extend the locking period to cover other flags, or maybe drop `osd_event` entirely in favor of directly using `std::mutex` and `std::condition_variable`