### PR TITLE
fmtowns_flop_orig.xml: 7 new dumps, 2 replacements

### DIFF
--- a/hash/fmtowns_flop_orig.xml
+++ b/hash/fmtowns_flop_orig.xml
@@ -31,7 +31,7 @@ ADPCM Kaihatsu Shien Library V2.1                                   Fujitsu     
 AgentNet V1.0 (V1.1)                                                CSK Research Institute (CRI)      1990/12    FD
 ASM-386 Tool Kit V2.2                                               Fujitsu                           1995/3     FD
 Bruce Wilcox no AI Igo 3 [FMR]                                      Alfa System                       ?          FD
-Cannon Sight                                                        Nikkonren Kikaku                  1993/?     FD×02
+Cannon Sight                                                        Nichikonren Kikaku                1993/?     FD×02
 CB Trainer Jikkou System V1.1                                       Fujitsu                           1993/5     FD
 CD-ROM XA Kyoutsuu Library V1.1                                     Fujitsu                           1991/7     FD
 Chuugakkou Ongaku: Ongakushi                                        Musical Plan                      1991/6     FD
@@ -41,9 +41,9 @@ Chuugakkou Suugaku New Simulation Zukei-hen 2-nen                   Tokyo Shosek
 Chuugakkou Suugaku New Simulation Zukei-hen 3-nen                   Tokyo Shoseki                     1994/3     FD
 Crescent                                                            Silky's                           1993/11    FD×04
 CRI Postman (Full Color)                                            CSK Research Institute (CRI)      1990/10    FD
-Cross Eitan Chinchin Hametaoshi                                     Nikkonren Kikaku                  1995/12    FD×02
-Cross Eitan Hametaoshi                                              Nikkonren Kikaku                  1993/?     FD
-Cross Eitan Junior Hametaoshi                                       Nikkonren Kikaku                  1993/?     FD
+Cross Eitan Chinchin Hametaoshi                                     Nichikonren Kikaku                1995/12    FD×02
+Cross Eitan Hametaoshi                                              Nichikonren Kikaku                1993/?     FD
+Cross Eitan Junior Hametaoshi                                       Nichikonren Kikaku                1993/?     FD
 CS-1 Towns                                                          Unitek Japan                      1991/1     FD
 Cyber Animater                                                      Fujitsu                           1992/7     FD
 CyberMotion                                                         Fujitsu                           1993/3     FD
@@ -51,11 +51,11 @@ D.O. Kaizokuban                                                     Brother Koug
 Daifugou Gakuen                                                     Brother Kougyou (Takeru)          ?          FDx??
 Daisenryaku 3 '90 Map Collection Vol. 2                             Pegasus Japan                     1992/7     FD
 Data Townsman                                                       Log                               1991/7     FD
-Dennou Kyoushi (Cyber Teacher)                                      Nikkonren Kikaku                  1993/?     FD
-Dennou Sakka DX                                                     Nikkonren Kikaku                  1993/?     FD×02
-Dennou Sakka DX (Cyber Writer Deluxe)                               Nikkonren Kikaku                  1993/?     FD
-Dennou Seito (Cyber Pupil)                                          Nikkonren Kikaku                  1993/?     FD
-D-Return                                                            Nikkonren Kikaku                  1990/11    FD×02
+Dennou Kyoushi (Cyber Teacher)                                      Nichikonren Kikaku                1993/?     FD
+Dennou Sakka DX                                                     Nichikonren Kikaku                1993/?     FD×02
+Dennou Sakka DX (Cyber Writer Deluxe)                               Nichikonren Kikaku                1993/?     FD
+Dennou Seito (Cyber Pupil)                                          Nichikonren Kikaku                1993/?     FD
+D-Return                                                            Nichikonren Kikaku                1990/11    FD×02
 Euphony V1.1                                                        Fujitsu                           1989/7     FD
 F-ISAM386 V1.1                                                      Fujitsu                           1991/3     FD
 F-ISAM386 V3.1                                                      Fujitsu                           1992/11    FD
@@ -85,11 +85,9 @@ Gear Video                                                          Inter Limite
 Geitassha Towns (Data Shuu)                                         Shoubi Gakuen                     1990/6     FD×63
 Gokanshi                                                            Tensui Software                   1995/7     FD
 Grapharmony V1.0                                                    Fujitsu                           1992/3     FD
-Hametaoshi Tool                                                     Nikkonren Kikaku                  1995/12    FD×02
+Hametaoshi Tool                                                     Nichikonren Kikaku                1995/12    FD×02
 Hana yori Dango                                                     Active                            1992/4     FD×03
 Healthy Life 2 Ryouri Data                                          Top Business System               1993/7     FD
-Hometown, U.S.A.                                                    Fujitsu                           1990/3     FD×02
-Hon'yaku Helper Zurukamashi                                         Nikkonren Kikaku                  1991/1     FD×02
 Hunting Roulette                                                    JAST                              1994/9     FD×03
 Hyper Album Omoide-kun                                              Computer System                   1991/2     FD×02
 Igo Taishou                                                         Shoudai Sangyou                   ?          FD×02
@@ -97,23 +95,23 @@ Igo Taishou V2                                                      Shoudai Sang
 Image II                                                            Software House Parsley            1994/6     FD×04
 Image Color System Pro                                              Raison                            1989/11    FD
 Jiman Grand Prix                                                    Map Japan                         1992/3     FD
-Joou-sama ga Oshiete Ageru: Eigo no Bunpou                          Nikkonren Kikaku                  1994/11    FD
-Joou-sama ga Oshiete Ageru: Kagaku no Busshitsu                     Nikkonren Kikaku                  1993/?     FD
-Joou-sama ga Oshiete Ageru: Kanji no Gakushuu                       Nikkonren Kikaku                  1994/11    FD
-Joou-sama ga Oshiete Ageru: Rekishi Nengou: Eitango 600             Nikkonren Kikaku                  1994/7     FD
+Joou-sama ga Oshiete Ageru: Eigo no Bunpou                          Nichikonren Kikaku                1994/11    FD
+Joou-sama ga Oshiete Ageru: Kagaku no Busshitsu                     Nichikonren Kikaku                1993/?     FD
+Joou-sama ga Oshiete Ageru: Kanji no Gakushuu                       Nichikonren Kikaku                1994/11    FD
+Joou-sama ga Oshiete Ageru: Rekishi Nengou: Eitango 600             Nichikonren Kikaku                1994/7     FD
 Jouhou Kiso Lunch Box                                               Uchida Youkou                     1994/3     FD×04
 JPEG Support Library V2.1                                           Fujitsu                           1993/1     FD
 Kakikomi Jiyuu na Gakushuu Note                                     Nihon Kyouiku Shinbunsha          1992/5     FD
-Kakitaoshi Ver 2.0                                                  Nikkonren Kikaku                  1993/?     FD
+Kakitaoshi Ver 2.0                                                  Nichikonren Kikaku                1993/?     FD
 Kanji Match                                                         Tokyo Shoseki                     1993/4     FD
-Kanji-ru Teacher Junior Kokitaoshi                                  Nikkonren Kikaku                  1993/?     FD×02
-Kanji-ru Teacher Kokitaoshi                                         Nikkonren Kikaku                  1993/?     FD×02
+Kanji-ru Teacher Junior Kokitaoshi                                  Nichikonren Kikaku                1993/?     FD×02
+Kanji-ru Teacher Kokitaoshi                                         Nichikonren Kikaku                1993/?     FD×02
 Keyword Eiwa Jiten (Kenkyuusha-hen)                                 Camp                              1989/12    FD×02
 Keyword Waei Jiten (Kenkyuusha-hen)                                 Camp                              1989/12    FD×02
 Kimi Toshitai You-jan Part 1                                        System Pro                        1989/9     FD
 Kiwame Jouseki Shuu                                                 Log                               1992/11    FD
 LiveMotion Support Library                                          Fujitsu                           1993/1     FD
-Loop Eraser                                                         Nikkonren Kikaku                  1994/9     FD×02
+Loop Eraser                                                         Nichikonren Kikaku                1994/9     FD×02
 Loop: Izanahi no Kaikiten                                           Grocer                            1995/10    FD×05
 LPACK                                                               Kansai Denki                      1991/10    FD
 Lucid ASM & Debugger Ver. 1.1                                       Kansai Denki                      1990/4     FD
@@ -153,7 +151,7 @@ Nihongo MS-Windows V3.0                                             Fujitsu     
 Orihime V1.0                                                        Yoshikawa Systec                  1993/8     FD
 Otoko to Onna no Aishou Shindan                                     System House Space                1993/6     FD
 PC Globe 5.0                                                        Hiro                              1995/3     FD×04
-Planetary Campaign                                                  Nikkonren Kikaku                  1993/?     FD
+Planetary Campaign                                                  Nichikonren Kikaku                1993/?     FD
 Pleria                                                              Orange House                      1992/7     FD×05
 Present 2                                                           Orange House                      1992/10    FD×05
 Purple Cat Vol. 1                                                   Palm Tree                         1993/3     FD×02
@@ -185,9 +183,9 @@ SimCity Terrain Editor                                              Fujitsu     
 Sokudoku-kun                                                        OBIC Office Automation            1990/12    FD×02
 Sougen Towns: Nihongo Expert Shell                                  AI Soft                           1990/4     FD×03
 Soukou Towns: Idea Processor                                        AI Soft                           1990/9     FD×29
-Spell Master Junior Kakitaoshi                                      Nikkonren Kikaku                  1991/8     FD×02
-Spell Master Kakitaoshi                                             Nikkonren Kikaku                  1991/8     FD×02
-Super Itekomashi Perfect                                            Nikkonren Kikaku                  1994/12    FD
+Spell Master Junior Kakitaoshi                                      Nichikonren Kikaku                1991/8     FD×02
+Spell Master Kakitaoshi                                             Nichikonren Kikaku                1991/8     FD×02
+Super Itekomashi Perfect                                            Nichikonren Kikaku                1994/12    FD
 Super Paso-rika Keisuke                                             Fujitsu Ooita Software Laboratory 1993/7     FD×02
 Symmetry 17                                                         Jouhou Suuri Kenkyuusho           1992/2     FD
 Tablet Keyboard Driver V1.1                                         Fujitsu                           1993/7     FD
@@ -212,7 +210,6 @@ Totsugeki! Bakkon Street                                            JAST        
 Totsugeki! Bakkon Street 2: Hunting Roulette                        JAST                              1994/9     FDx03
 Towns Butsuri Newton-kun                                            Fujitsu Ooita Software Laboratory 1991/4     FD
 Towns Drill Sansuu 1-nen Gear V1.1.L20                              Kyouiku Soft Kenkyuusho           1989/9     FD
-Towns Drill Sansuu 1-nen Gear V2.1                                  Kyouiku Soft Kenkyuusho           1992/3     FD
 Towns Drill Shougaku Sansuu 1-nen~3-nen                             Kyouiku Soft Kenkyuusho           1994/3     FD×03
 Towns Drill Shougaku Sansuu 1-nen~6-nen (Gakkou-you Set 500)        Kyouiku Soft Kenkyuusho           1992/4     FD×07
 Towns Drill Shougaku Sansuu 1-nen~6-nen (Gakkou-you)                Kyouiku Soft Kenkyuusho           1992/4     FD×07
@@ -231,16 +228,15 @@ Towns Jouhou Kiso Select-F                                          Tokyo Shosek
 TownsGEAR de Obenkyou Dai-1-kan: Seigo Mondai                       Kyouiku Soft Kenkyuusho           1992/3     FD×02
 TownsGEAR de Obenkyou Dai-2-kan: Sentaku Mondai                     Kyouiku Soft Kenkyuusho           1992/3     FD×02
 TownsGEAR de Obenkyou Dai-3-kan: Suuchi Mondai                      Kyouiku Soft Kenkyuusho           1992/3     FD×02
-Type Master Oshitaoshi                                              Nikkonren Kikaku                  1992/7     FD
+Type Master Oshitaoshi                                              Nichikonren Kikaku                1992/7     FD
 Video Library V1.1                                                  Fujitsu                           1991/10    FD
 Video Library V2.1                                                  Fujitsu                           1992/12    FD
 VideoCD Saisei Kit V1.1 L10                                         Fujitsu                           1995/1     FD
 VIP Karaoke                                                         CSK Research Institute (CRI)      1992/4     FD
 WordLook                                                            CSK Research Institute (CRI)      1991/4     FD
 Youjuu Club Custom                                                  D.O.                              1992/3     FD×03
-Zurukamashi Adult Jisho                                             Nikkonren Kikaku                  1992/2     FD
-Zurukamashi Junior Jisho                                            Nikkonren Kikaku                  1991/5     FD
-Zurukamashi Ver 2.0                                                 Nikkonren Kikaku                  1993/?     FD×02
+Zurukamashi Adult Jisho                                             Nichikonren Kikaku                1992/2     FD
+Zurukamashi Ver 2.0                                                 Nichikonren Kikaku                1993/?     FD×02
 
 -->
 
@@ -682,10 +678,25 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<software name="drill1">
+		<description>Towns Drill - Shougaku Sansuu Series - Sansuu 1-nen (TownsGEAR V2.1 version)</description>
+		<year>1992</year>
+		<publisher>教育ソフト研究所 (Kyouiku Soft Kenkyuusho)</publisher>
+		<info name="release" value="199203xx" />
+		<info name="alt_title" value="ＴＯＷＮＳドリル　小学算数シリーズ　算数１年" />
+		<info name="usage" value="Requires 2 MB RAM. Run TownsGEAR V2.1 and switch the active drive to A: to start the software" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<rom name="towns_drill_shougaku_sansuu_1-nen_gear_v2.1.hdm" size="1261568" crc="e2c3585a" sha1="172b8b6b124bc250f090514aed8a9be8e3b635d8"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="drill4">
 		<description>Towns Drill - Shougaku Sansuu Series - Sansuu 4-nen (TownsGEAR V2.1 version)</description>
 		<year>1992</year>
 		<publisher>教育ソフト研究所 (Kyouiku Soft Kenkyuusho)</publisher>
+		<info name="release" value="199203xx" />
 		<info name="alt_title" value="ＴＯＷＮＳドリル　小学算数シリーズ　算数４年" />
 		<info name="usage" value="Requires 2 MB RAM. Run TownsGEAR V2.1 and switch the active drive to A: to start the software" />
 		<part name="flop1" interface="floppy_3_5">
@@ -699,6 +710,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		<description>Towns Drill - Shougaku Sansuu Series - Sansuu 5-nen (TownsGEAR V2.1 version)</description>
 		<year>1992</year>
 		<publisher>教育ソフト研究所 (Kyouiku Soft Kenkyuusho)</publisher>
+		<info name="release" value="199203xx" />
 		<info name="alt_title" value="ＴＯＷＮＳドリル　小学算数シリーズ　算数５年" />
 		<info name="usage" value="Requires 2 MB RAM. Run TownsGEAR V2.1 and switch the active drive to A: to start the software" />
 		<part name="flop1" interface="floppy_3_5">
@@ -845,11 +857,31 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<!-- Bundled with the book of the same title. Compatible with FMR, FM Towns, Panacom M and OASYS computers. -->
+	<software name="fmtools">
+		<description>FMR/Towns Kihon DOS Tools</description>
+		<year>1993</year>
+		<publisher>ソフトバンク (SoftBank)</publisher>
+		<info name="alt_title" value="ＦＭＲ／ＴＯＷＮＳ　基本ＤＯＳツールズ" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="#1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="fmr-towns_kihon_dos_tools_disk1.hdm" size="1261568" crc="dd098356" sha1="09bbbd60a702961e76262617079819c6056c5829"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="#2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="fmr-towns_kihon_dos_tools_disk2.hdm" size="1261568" crc="838c4e97" sha1="8d2119cc743bbae422fc426b3b04d3ffd2591910"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<!-- Bundled with "Oh! FM Towns Shinsoukan No.1" magazine -->
 	<software name="futoph01">
 		<description>Futoppara FD Heisei 1-gou</description>
 		<year>1991</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成1号" />
 		<info name="release" value="199110xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -863,7 +895,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph02">
 		<description>Futoppara FD Heisei 2-gou</description>
 		<year>1992</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成2号" />
 		<info name="release" value="199204xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -877,7 +909,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph03">
 		<description>Futoppara FD Heisei 3-gou</description>
 		<year>1992</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成3号" />
 		<info name="release" value="199208xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -891,7 +923,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph04">
 		<description>Futoppara FD Heisei 4-gou</description>
 		<year>1992</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成4号" />
 		<info name="release" value="199212xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -905,7 +937,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph05">
 		<description>Futoppara FD Heisei 5-gou</description>
 		<year>1993</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成5号" />
 		<info name="release" value="199303xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -919,7 +951,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph06">
 		<description>Futoppara FD Heisei 6-gou</description>
 		<year>1993</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成6号" />
 		<info name="release" value="199308xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -933,12 +965,12 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph07">
 		<description>Futoppara FD Heisei 7-gou</description>
 		<year>1993</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成7号" />
 		<info name="release" value="199311xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
-				<rom name="futoppara fd heisei #07.hdm" size="1261568" crc="91d8bc3f" sha1="54eef9754dec15b4ede6a4f16fe2c15eb101255c"/>
+				<rom name="futoppara fd heisei #07.hdm" size="1261568" crc="d1f36112" sha1="cda16bc77ae8d4846adbb9c03bf50616c56de747"/>
 			</dataarea>
 		</part>
 	</software>
@@ -947,7 +979,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph08">
 		<description>Futoppara FD Heisei 8-gou</description>
 		<year>1994</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成8号" />
 		<info name="release" value="199403xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -961,7 +993,7 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph09">
 		<description>Futoppara FD Heisei 9-gou</description>
 		<year>1994</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成9号" />
 		<info name="release" value="199406xx" />
 		<part name="flop1" interface="floppy_3_5">
@@ -975,12 +1007,12 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 	<software name="futoph10">
 		<description>Futoppara FD Heisei 10-gou</description>
 		<year>1995</year>
-		<publisher>SoftBank</publisher>
+		<publisher>ソフトバンク (SoftBank)</publisher>
 		<info name="alt_title" value="太っ腹FD平成10号" />
 		<info name="release" value="199503xx" />
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
-				<rom name="futoppara fd heisei #10.hdm" size="1261568" crc="ae02ab66" sha1="39a2921484d1f6b141fe43af046003593b07cf0d"/>
+				<rom name="futoppara fd heisei #10.hdm" size="1261568" crc="86458c41" sha1="70b54f8c4017eb2c0fa2b64928b179aa5a11acbe"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1088,6 +1120,25 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 			<feature name="part_id" value="Data Disk" />
 			<dataarea name="flop" size="1261568">
 				<rom name="houma_hunter_lime_vol_3_data_disk.hdm" size="1261568" crc="18719a36" sha1="200fdc928c15ae0d04ec8a41e7929ece01026e6f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="htownusa">
+		<description>Hometown, U.S.A.</description>
+		<year>1990</year>
+		<publisher>富士通 (Fujitsu)</publisher>
+		<info name="release" value="199003xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="Program Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="hometown_usa_program_disk.hdm" size="1261568" crc="e0ff7da3" sha1="da00e38412950cd84c2bcc3c3595aaa4957ff811"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Data Disk" />
+			<dataarea name="flop" size="1261568">
+				<rom name="hometown_usa_data_disk.hdm" size="1261568" crc="3e57ab67" sha1="c8434f9162db045c8221d2c09cf4726335296197"/>
 			</dataarea>
 		</part>
 	</software>
@@ -2351,6 +2402,61 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		</part>
 	</software>
 
+	<software name="ywsansu2">
+		<description>Yoku Wakaru Sansuu - Shougaku 2-nen</description>
+		<year>1993</year>
+		<publisher>パル教育システム (Pal Kyouiku System)</publisher>
+		<info name="alt_title" value="よくわかる算数　小学２年" />
+		<info name="usage" value="Requires 2 MB RAM. Boot TownsOS V2.1L10 or later, then run the icon on floppy drive A:"/>
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="No. 1" />
+			<dataarea name="flop" size="1261568">
+				<rom name="yoku_wakaru_sansuu_shougaku_2-nen_disk_1.hdm" size="1261568" crc="5b298c15" sha1="9c20bedddf326b9ab5e291802fe852cd7b950bf5"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="No. 2" />
+			<dataarea name="flop" size="1261568">
+				<rom name="yoku_wakaru_sansuu_shougaku_2-nen_disk_2.hdm" size="1261568" crc="4b868fc8" sha1="a50e465ed3a1f4f2398ecad84180d2fe86f6c553"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zurujr">
+		<description>Hon'yaku Helper Zurukamashi - Jisho Disk Junior</description>
+		<year>1991</year>
+		<publisher>日コン連企画 (Nichikonren Kikaku)</publisher>
+		<info name="alt_title" value="翻訳ヘルパーずるかまし　辞書ディスクジュニア" />
+		<info name="release" value="199105xx" />
+		<info name="usage" value="Additional dictionary disk for Zurukamashi. Use it in place of the included one."/>
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="1261568">
+				<!-- The original disk had a single-byte CRC error on an empty sector. It has been manually fixed. -->
+				<rom name="zurukamashi_jisho_disk_junior.hdm" size="1261568" crc="e21a1ceb" sha1="f37c4d3f2d4c82761dce9b0a162eb3e25da856ba" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="zurukama">
+		<description>Hon'yaku Helper Zurukamashi</description>
+		<year>1991</year>
+		<publisher>日コン連企画 (Nichikonren Kikaku)</publisher>
+		<info name="alt_title" value="翻訳ヘルパーずるかまし" />
+		<info name="release" value="199101xx" />
+		<part name="flop1" interface="floppy_3_5">
+			<feature name="part_id" value="System Disk" />
+			<dataarea name="flop" size="3444720">
+				<rom name="zurukamashi_system_disk.mfm" size="3444720" crc="0e371991" sha1="b0e4adce99796fdc598d8499da73b021fadfc5c1"/>
+			</dataarea>
+		</part>
+		<part name="flop2" interface="floppy_3_5">
+			<feature name="part_id" value="Jisho Disk" />
+			<dataarea name="flop" size="3446264">
+				<!-- This image has several sectors with bad CRCs, but it's probably not intentional -->
+				<rom name="zurukamashi_jisho_disk.mfm" size="3446264" crc="aa64f699" sha1="89411f74f5666e917e45447f0d0e225137f3a184" status="baddump"/>
+			</dataarea>
+		</part>
+	</software>
 
 
 <!-- DOUJIN / HOMEBREW DISCS -->
@@ -2395,6 +2501,22 @@ Zurukamashi Ver 2.0                                                 Nikkonren Ki
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="1261568">
 				<rom name="sadistic_gamers_part-5.hdm" size="1261568" crc="a783f0a9" sha1="33d609c14afa750daa1eca3020586db14b14c7ac"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- PC-9801 / X68000 / FM Towns hybrid -->
+	<software name="sgamerss1">
+		<description>Sadistic Gamers Syndrome - Episode I</description>
+		<year>1992</year>
+		<publisher>&lt;doujin&gt;</publisher>
+		<info name="alt_title" value="サディスティック・ゲーマーズ・シンドローム　エピソードI" />
+		<info name="developer" value="シクスティーンズ (16s)" />
+		<info name="usage" value="Requires 2 MB RAM. Boot TownsOS V2.1L10 or later, then run the icon on floppy drive A:" />
+		<part name="flop1" interface="floppy_3_5">
+			<dataarea name="flop" size="3445257">
+				<!-- The disk is missing side 1 of track 0, but the game still works. It's unknown if this is intentional or a damaged disk. -->
+				<rom name="sadistic_gamers_syndrome_episode_1.mfm" size="3445257" crc="bdfb0c79" sha1="c1778e6d06630fe00dedcf3228486ca90269bfd1"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Changed the romanization of 日コン連企画 to "Nichikonren Kikaku" as seen in the official website (http://www.nichikon.co.jp/)
- Replaced the Futoppara FD Heisei disks 7 and 10 with unmodified images

New working software list additions (fmtowns_flop_orig.xml)
-----------------------------------------------------------
FMR/Towns Kihon DOS Tools [cyo.the.vile]
Hometown, U.S.A. [cyo.the.vile]
Hon'yaku Helper Zurukamashi [cyo.the.vile]
Hon'yaku Helper Zurukamashi - Jisho Disk Junior [cyo.the.vile]
Sadistic Gamers Syndrome - Episode I [cyo.the.vile]
Towns Drill - Shougaku Sansuu Series - Sansuu 1-nen (TownsGEAR V2.1 version) [cyo.the.vile]
Yoku Wakaru Sansuu - Shougaku 2-nen [cyo.the.vile]

Replaced software list items
----------------------------
Futoppara FD Heisei 7-gou [fuzzball]
Futoppara FD Heisei 10-gou [fuzzball]