### PR TITLE
expand buffer size from 15 to 16 for %t time in video_manager::open_next

### DIFF
--- a/src/emu/video.cpp
+++ b/src/emu/video.cpp
@@ -1129,7 +1129,7 @@ std::error_condition video_manager::open_next(emu_file &file, const char *extens
 
 	if (pos_time != -1)
 	{
-		char t_str[15];
+		char t_str[16];
 		const std::time_t cur_time = std::time(nullptr);
 		strftime(t_str, sizeof(t_str), "%Y%m%d_%H%M%S", std::localtime(&cur_time));
 		strreplace(snapstr, "%t", t_str);


### PR DESCRIPTION
One thing I just noticed:

the %t time format code from video_manager::open_next
it needs to be "char t_str[16];"  to accommodate the format string since it's 4+2+2+1+2+2+2+1 (terminating zero) for 16 chars.

If it doesn't have enough room for the zero it will drop the last specifier:

char t_str[15]; and a -snapname "%g/%t" will give filenames like: 
20211225_0406.png

char t_str[16]; and a -snapname "%g/%t" will give filenames like: 
20211225_042939.png

```
      if (pos_time != -1)
        {
                char t_str[16];
                const std::time_t cur_time = std::time(nullptr);
                strftime(t_str, sizeof(t_str), "%Y%m%d_%H%M%S", std::localtime(&cur_time));
                strreplace(snapstr, "%t", t_str);
        }

```
