### PR TITLE
raiden.cpp: Use prio_* for single pass sprite draw routine, Minor cleanups, Add notes for country/game mode byte

### DIFF
--- a/src/mame/drivers/raiden.cpp
+++ b/src/mame/drivers/raiden.cpp
@@ -93,26 +93,26 @@ void raiden_state::main_map(address_map &map)
 	map(0x07000, 0x07fff).ram().share("spriteram");
 	map(0x08000, 0x08fff).ram().share("shared_ram");
 	map(0x0a000, 0x0a00d).rw(m_seibu_sound, FUNC(seibu_sound_device::main_r), FUNC(seibu_sound_device::main_w)).umask16(0x00ff);
-	map(0x0c000, 0x0c7ff).w(FUNC(raiden_state::raiden_text_w)).share("videoram");
+	map(0x0c000, 0x0c7ff).w(FUNC(raiden_state::textram_w)).share("textram");
 	map(0x0e000, 0x0e001).portr("P1_P2");
 	map(0x0e002, 0x0e003).portr("DSW");
 	map(0x0e004, 0x0e005).nopw(); // watchdog?
 	map(0x0e006, 0x0e006).w(FUNC(raiden_state::raiden_control_w));
 	map(0x0f000, 0x0f03f).writeonly().share("scroll_ram");
-	map(0xa0000, 0xfffff).rom();
+	map(0xa0000, 0xfffff).rom().region("maincpu", 0);
 }
 
 void raiden_state::sub_map(address_map &map)
 {
 	map(0x00000, 0x01fff).ram();
-	map(0x02000, 0x027ff).ram().w(FUNC(raiden_state::raiden_background_w)).share("back_data");
-	map(0x02800, 0x02fff).ram().w(FUNC(raiden_state::raiden_foreground_w)).share("fore_data");
+	map(0x02000, 0x027ff).ram().w(FUNC(raiden_state::bgram_w)).share("bgram");
+	map(0x02800, 0x02fff).ram().w(FUNC(raiden_state::fgram_w)).share("fgram");
 	map(0x03000, 0x03fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x04000, 0x04fff).ram().share("shared_ram");
 	map(0x07ffe, 0x07fff).nopw(); // ?
 	map(0x08000, 0x08001).nopw(); // watchdog?
 	map(0x0a000, 0x0a001).nopw(); // ?
-	map(0xc0000, 0xfffff).rom();
+	map(0xc0000, 0xfffff).rom().region("sub", 0);
 }
 
 
@@ -128,21 +128,21 @@ void raiden_state::raidenu_main_map(address_map &map)
 	map(0x0b002, 0x0b003).portr("DSW");
 	map(0x0b004, 0x0b005).nopw(); // watchdog?
 	map(0x0b006, 0x0b006).w(FUNC(raiden_state::raiden_control_w));
-	map(0x0c000, 0x0c7ff).w(FUNC(raiden_state::raiden_text_w)).share("videoram");
+	map(0x0c000, 0x0c7ff).w(FUNC(raiden_state::textram_w)).share("textram");
 	map(0x0d000, 0x0d00d).rw(m_seibu_sound, FUNC(seibu_sound_device::main_r), FUNC(seibu_sound_device::main_w)).umask16(0x00ff);
-	map(0xa0000, 0xfffff).rom();
+	map(0xa0000, 0xfffff).rom().region("maincpu", 0);
 }
 
 void raiden_state::raidenu_sub_map(address_map &map)
 {
 	map(0x00000, 0x05fff).ram();
-	map(0x06000, 0x067ff).ram().w(FUNC(raiden_state::raiden_background_w)).share("back_data");
-	map(0x06800, 0x06fff).ram().w(FUNC(raiden_state::raiden_foreground_w)).share("fore_data");
+	map(0x06000, 0x067ff).ram().w(FUNC(raiden_state::bgram_w)).share("bgram");
+	map(0x06800, 0x06fff).ram().w(FUNC(raiden_state::fgram_w)).share("fgram");
 	map(0x07000, 0x07fff).ram().w(m_palette, FUNC(palette_device::write16)).share("palette");
 	map(0x08000, 0x08fff).ram().share("shared_ram");
 	map(0x0a000, 0x0a001).nopw(); // ?
 	map(0x0c000, 0x0c001).nopw(); // watchdog?
-	map(0xc0000, 0xfffff).rom();
+	map(0xc0000, 0xfffff).rom().region("sub", 0);
 }
 
 
@@ -157,10 +157,10 @@ void raidenb_state::raidenb_main_map(address_map &map)
 	map(0x0b002, 0x0b003).portr("DSW");
 	map(0x0b004, 0x0b005).nopw(); // watchdog?
 	map(0x0b006, 0x0b006).w(FUNC(raidenb_state::raidenb_control_w));
-	map(0x0c000, 0x0c7ff).w(FUNC(raidenb_state::raiden_text_w)).share("videoram");
+	map(0x0c000, 0x0c7ff).w(FUNC(raidenb_state::textram_w)).share("textram");
 	map(0x0d000, 0x0d00d).rw(m_seibu_sound, FUNC(seibu_sound_device::main_r), FUNC(seibu_sound_device::main_w)).umask16(0x00ff);
 	map(0x0d040, 0x0d08f).rw("crtc", FUNC(seibu_crtc_device::read), FUNC(seibu_crtc_device::write));
-	map(0xa0000, 0xfffff).rom();
+	map(0xa0000, 0xfffff).rom().region("maincpu", 0);
 }
 
 
@@ -286,40 +286,33 @@ INPUT_PORTS_END
 
 /******************************************************************************/
 
-static const gfx_layout raiden_charlayout =
+static const gfx_layout charlayout =
 {
-	8,8,        /* 8*8 characters */
-	2048,       /* 512 characters */
-	4,          /* 4 bits per pixel */
-	{ 4,0,(0x08000*8)+4,0x08000*8  },
-	{ 0,1,2,3,8,9,10,11 },
-	{ 0*16, 1*16, 2*16, 3*16, 4*16, 5*16, 6*16, 7*16 },
-	128
+	8,8,           /* 8*8 characters */
+	RGN_FRAC(1,1), /* 1024 characters */
+	4,             /* 4 bits per pixel */
+	{ STEP4(12,-4) },
+	{ STEP4(0,1), STEP4(16,1) },
+	{ STEP8(0,16*2) },
+	8*8*4
 };
 
-static const gfx_layout raiden_spritelayout =
+static const gfx_layout tilelayout =
 {
-	16,16,      /* 16*16 tiles */
-	4096,       /* 2048*4 tiles */
-	4,          /* 4 bits per pixel */
-	{ 12, 8, 4, 0 },
-	{
-	0,1,2,3, 16,17,18,19,
-	512+0,512+1,512+2,512+3,
-	512+8+8,512+9+8,512+10+8,512+11+8,
-	},
-	{
-	0*32, 1*32, 2*32, 3*32, 4*32, 5*32, 6*32, 7*32,
-	8*32, 9*32, 10*32, 11*32, 12*32, 13*32, 14*32, 15*32,
-	},
-	1024
+	16,16,         /* 16*16 tiles */
+	RGN_FRAC(1,1), /* 4096 tiles */
+	4,             /* 4 bits per pixel */
+	{ STEP4(12,-4) },
+	{ STEP4(0,1), STEP4(16,1), STEP4(16*16*2,1), STEP4(16*16*2+16,1) },
+	{ STEP16(0,16*2) },
+	16*16*4
 };
 
 static GFXDECODE_START( gfx_raiden )
-	GFXDECODE_ENTRY( "gfx1", 0, raiden_charlayout,   768, 16 )
-	GFXDECODE_ENTRY( "gfx2", 0, raiden_spritelayout,   0, 16 )
-	GFXDECODE_ENTRY( "gfx3", 0, raiden_spritelayout, 256, 16 )
-	GFXDECODE_ENTRY( "gfx4", 0, raiden_spritelayout, 512, 16 )
+	GFXDECODE_ENTRY( "text",    0, charlayout, 768, 16 )
+	GFXDECODE_ENTRY( "bgtiles", 0, tilelayout,   0, 16 )
+	GFXDECODE_ENTRY( "fgtiles", 0, tilelayout, 256, 16 )
+	GFXDECODE_ENTRY( "sprites", 0, tilelayout, 512, 16 )
 GFXDECODE_END
 
 
@@ -400,7 +393,7 @@ void raiden_state::raidenu(machine_config &config)
 	m_subcpu->set_addrmap(AS_PROGRAM, &raiden_state::raidenu_sub_map);
 }
 
-void raidenb_state::raidenb_layer_scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask)
+void raidenb_state::raidenb_layer_scroll_w(offs_t offset, u16 data, u16 mem_mask)
 {
 	COMBINE_DATA(&m_raidenb_scroll_ram[offset]);
 }
@@ -440,32 +433,32 @@ Note: Seibu labeled the roms simply as 1 through 10 and didn't generally
 /* These versions use the same board and make use of the region byte at 0x1fffe (0x1fffd also may differ and is used for unknown purpose) */
 
 ROM_START( raiden ) /* from a board with 2 daughter cards, no official board #s? */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3.u022",  0x0c0000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) ) /* both 3 & 4 had a red "dot" on label, 4 also had printed "J" */
-	ROM_LOAD16_BYTE( "4j.u023", 0x0c0001, 0x20000, CRC(505c4c5d) SHA1(07f61fd1ff24f482a1ae2f86c4c0f32850cbd539) ) /* 0x1fffd == 0x00, 0x1fffe == 0x04 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3.u022",  0x020000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) ) /* both 3 & 4 had a red "dot" on label, 4 also had printed "J" */
+	ROM_LOAD16_BYTE( "4j.u023", 0x020001, 0x20000, CRC(505c4c5d) SHA1(07f61fd1ff24f482a1ae2f86c4c0f32850cbd539) ) /* 0x1fffd == 0x00, 0x1fffe == 0x04 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8.u212",      0x000000, 0x08000, CRC(cbe055c7) SHA1(34a06a541d059c621d87fdf41546c9d052a61963) )
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* tiles @ U105 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* tiles @ U115 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) )
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -481,32 +474,32 @@ ROM_START( raiden ) /* from a board with 2 daughter cards, no official board #s?
 ROM_END
 
 ROM_START( raidena )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3.u022",  0x0c0000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
-	ROM_LOAD16_BYTE( "4.u023",  0x0c0001, 0x20000, CRC(6bdfd416) SHA1(7c3692d0c46c0fd360b9b2b5a8dc55d9217be357) ) /* 0x1fffd == 0x00, 0x1fffe == 0x84 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3.u022",  0x020000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
+	ROM_LOAD16_BYTE( "4.u023",  0x020001, 0x20000, CRC(6bdfd416) SHA1(7c3692d0c46c0fd360b9b2b5a8dc55d9217be357) ) /* 0x1fffd == 0x00, 0x1fffe == 0x84 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8.u212",      0x000000, 0x08000, CRC(cbe055c7) SHA1(34a06a541d059c621d87fdf41546c9d052a61963) )
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* tiles @ U105 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* tiles @ U115 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) )
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -522,32 +515,32 @@ ROM_START( raidena )
 ROM_END
 
 ROM_START( raident )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3.u022",  0x0c0000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
-	ROM_LOAD16_BYTE( "4t.u023", 0x0c0001, 0x20000, CRC(61eefab1) SHA1(a886ce1eb1c6451b1cf9eb8dbdc2d484d9881ced) ) /* 0x1fffd == 0x02, 0x1fffe == 0x06 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3.u022",  0x020000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
+	ROM_LOAD16_BYTE( "4t.u023", 0x020001, 0x20000, CRC(61eefab1) SHA1(a886ce1eb1c6451b1cf9eb8dbdc2d484d9881ced) ) /* 0x1fffd == 0x02, 0x1fffe == 0x06 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8.u212",      0x000000, 0x08000, CRC(cbe055c7) SHA1(34a06a541d059c621d87fdf41546c9d052a61963) )
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* tiles @ U105 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* tiles @ U115 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) )
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -563,32 +556,32 @@ ROM_START( raident )
 ROM_END
 
 ROM_START( raidenu )
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3a.u022", 0x0c0000, 0x20000, CRC(a8fadbdd) SHA1(a23729a51c45c1dba4e625503a37d111ae72ced0) ) /* Both 3A & 4A different for the US version */
-	ROM_LOAD16_BYTE( "4a.u023", 0x0c0001, 0x20000, CRC(bafb268d) SHA1(132d3ebf9d9d5fffa3040338106fad428c54dbaa) ) /* 0x1fffd == 0x01, 0x1fffe == 0x85 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3a.u022", 0x020000, 0x20000, CRC(a8fadbdd) SHA1(a23729a51c45c1dba4e625503a37d111ae72ced0) ) /* Both 3A & 4A different for the US version */
+	ROM_LOAD16_BYTE( "4a.u023", 0x020001, 0x20000, CRC(bafb268d) SHA1(132d3ebf9d9d5fffa3040338106fad428c54dbaa) ) /* 0x1fffd == 0x01, 0x1fffe == 0x85 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8.u212",      0x000000, 0x08000, CRC(cbe055c7) SHA1(34a06a541d059c621d87fdf41546c9d052a61963) )
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* tiles @ U105 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* tiles @ U115 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) )
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -604,32 +597,32 @@ ROM_START( raidenu )
 ROM_END
 
 ROM_START( raidenk ) /* Same board as above. Not sure why the sound CPU would be decrypted */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3.u022",  0x0c0000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
-	ROM_LOAD16_BYTE( "4k.u023", 0x0c0001, 0x20000, CRC(fddf24da) SHA1(ececed0b0b96d070d85bfb6174029142bc96d5f0) ) /* 0x1fffd == 0x02, 0x1fffe == 0xA4 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3.u022",  0x020000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
+	ROM_LOAD16_BYTE( "4k.u023", 0x020001, 0x20000, CRC(fddf24da) SHA1(ececed0b0b96d070d85bfb6174029142bc96d5f0) ) /* 0x1fffd == 0x02, 0x1fffe == 0xA4 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8b.u212",     0x000000, 0x08000, CRC(99ee7505) SHA1(b97c8ee5e26e8554b5de506fba3b32cc2fde53c9) ) /* Not encrypted */
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* tiles @ U105 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* tiles @ U115 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) )
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -645,39 +638,38 @@ ROM_START( raidenk ) /* Same board as above. Not sure why the sound CPU would be
 ROM_END
 
 ROM_START( raidenkb ) /* Korean bootleg board. ROMs for main, sub, audiocpu, chars and oki match raidenk, while object and tile ROMs are differently split */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3.u022",  0x0c0000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
-	ROM_LOAD16_BYTE( "4k.u023", 0x0c0001, 0x20000, CRC(fddf24da) SHA1(ececed0b0b96d070d85bfb6174029142bc96d5f0) ) /* 0x1fffd == 0x02, 0x1fffe == 0xA4 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3.u022",  0x020000, 0x20000, CRC(f6af09d0) SHA1(ecd49f3351359ea2d5cbd140c9962d45c5544ecd) )
+	ROM_LOAD16_BYTE( "4k.u023", 0x020001, 0x20000, CRC(fddf24da) SHA1(ececed0b0b96d070d85bfb6174029142bc96d5f0) ) /* 0x1fffd == 0x02, 0x1fffe == 0xA4 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.u042", 0x0c0000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
-	ROM_LOAD16_BYTE( "6.u043", 0x0c0001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.u042", 0x000000, 0x20000, CRC(ed03562e) SHA1(bf6b44fb53fa2321cd52c00fcb43b8ceb6ceffff) )
+	ROM_LOAD16_BYTE( "6.u043", 0x000001, 0x20000, CRC(a19d5b5d) SHA1(aa5e5be60b737913e5677f88ebc218302245e5af) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8b.u212",     0x000000, 0x08000, CRC(99ee7505) SHA1(b97c8ee5e26e8554b5de506fba3b32cc2fde53c9) ) /* Not encrypted */
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD16_BYTE( "rkb15bg.bin", 0x00000, 0x20000, CRC(13a69064) SHA1(a9fcd785e3bac7c0d39be532b3755e6dd45fc314) )
 	ROM_LOAD16_BYTE( "rkb17bg.bin", 0x00001, 0x20000, CRC(d7a6c649) SHA1(01d6f18af0385466e3956c3f3afc82393acee6bc) )
 	ROM_LOAD16_BYTE( "rkb16bg.bin", 0x40000, 0x20000, CRC(66ea8484) SHA1(f4452e1b0991bf81a60b580ba822fc43b1a443e6) )
 	ROM_LOAD16_BYTE( "rkb18bg.bin", 0x40001, 0x20000, CRC(42362d56) SHA1(1cad19fa3f66e34865383d9a94e9058114910365) )
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD16_BYTE( "rkb7bg.bin",  0x00000, 0x20000, CRC(25239711) SHA1(978cfc6487ed711cc1b513824741c347ec92889d) )
 	ROM_LOAD16_BYTE( "rkb9bg.bin",  0x00001, 0x20000, CRC(6ca0d7b3) SHA1(ef63657a01b07aaa0ded7b0d405b872b4d3a56a8) )
 	ROM_LOAD16_BYTE( "rkb8bg.bin",  0x40000, 0x20000, CRC(3cad38fc) SHA1(de2257f70c3e71905bc959f80be183c6d95fd06d) )
 	ROM_LOAD16_BYTE( "rkb10bg.bin", 0x40001, 0x20000, CRC(6fce95a3) SHA1(1d3beda3a4dd0a2a3afbb7b5b16d87bf3257bcb4) )
 
-
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* sprites */
 	ROM_LOAD16_BYTE( "rkb19obj.bin", 0x00000, 0x20000, CRC(34fa4485) SHA1(d9893c484ee4f80e364824500c6c048f58f49752) )
 	ROM_LOAD16_BYTE( "rkb21obj.bin", 0x00001, 0x20000, CRC(d806395b) SHA1(7c6fc848aa40a49590e00d0b02ce21ad5414e387) )
 	ROM_LOAD16_BYTE( "rkb20obj.bin", 0x40000, 0x20000, CRC(8b7ca3c6) SHA1(81c3e98cbd81a39e04b5e7fb3683aba50545f774) )
@@ -691,32 +683,32 @@ ROM_START( raidenkb ) /* Korean bootleg board. ROMs for main, sub, audiocpu, cha
 ROM_END
 
 ROM_START( raidenb )/* Different hardware, Main & Sub CPU code not encrypted. */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3__,raidenb.u022", 0x0c0000, 0x20000, CRC(9d735bf5) SHA1(531981eac2ef0c0635f067a649899f98738d5c67) ) /* Simply labeled as 3 */
-	ROM_LOAD16_BYTE( "4__,raidenb.u023", 0x0c0001, 0x20000, CRC(8d184b99) SHA1(71cd4179aa2341d2ceecbb6a9c26f5919d46ca4c) ) /* Simply labeled as 4 */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3__,raidenb.u022", 0x020000, 0x20000, CRC(9d735bf5) SHA1(531981eac2ef0c0635f067a649899f98738d5c67) ) /* Simply labeled as 3 */
+	ROM_LOAD16_BYTE( "4__,raidenb.u023", 0x020001, 0x20000, CRC(8d184b99) SHA1(71cd4179aa2341d2ceecbb6a9c26f5919d46ca4c) ) /* Simply labeled as 4 */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5__,raidenb.u042", 0x0c0000, 0x20000, CRC(7aca6d61) SHA1(4d80ec87e54d7495b9bdf819b9985b1c8183c80d) ) /* Simply labeled as 5 */
-	ROM_LOAD16_BYTE( "6__,raidenb.u043", 0x0c0001, 0x20000, CRC(e3d35cc2) SHA1(4329865985aaf3fb524618e2e958563c8fa6ead5) ) /* Simply labeled as 6 */
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5__,raidenb.u042", 0x000000, 0x20000, CRC(7aca6d61) SHA1(4d80ec87e54d7495b9bdf819b9985b1c8183c80d) ) /* Simply labeled as 5 */
+	ROM_LOAD16_BYTE( "6__,raidenb.u043", 0x000001, 0x20000, CRC(e3d35cc2) SHA1(4329865985aaf3fb524618e2e958563c8fa6ead5) ) /* Simply labeled as 6 */
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "rai6.u212",   0x000000, 0x08000, CRC(723a483b) SHA1(50e67945e83ea1748fb748de3287d26446d4e0a0) ) /* Should be labeled "8" ??? */
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* U919 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* U920 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* Sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD( "sei440", 0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) ) /* U165 on this PCB */
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -727,32 +719,32 @@ ROM_START( raidenb )/* Different hardware, Main & Sub CPU code not encrypted. */
 ROM_END
 
 ROM_START( raidenub ) // only region bits differ from raidenb
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.u0253", 0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.u0252", 0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3u.u022", 0x0c0000, 0x20000, CRC(9d735bf5) SHA1(531981eac2ef0c0635f067a649899f98738d5c67) ) /* Simply labeled as 3u */
-	ROM_LOAD16_BYTE( "4u.u023", 0x0c0001, 0x20000, CRC(95c110ef) SHA1(e6aea374ca63cdd851af66240e51461882d170e8) ) /* Simply labeled as 4u */
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.u0253", 0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.u0252", 0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3u.u022", 0x020000, 0x20000, CRC(9d735bf5) SHA1(531981eac2ef0c0635f067a649899f98738d5c67) ) /* Simply labeled as 3u */
+	ROM_LOAD16_BYTE( "4u.u023", 0x020001, 0x20000, CRC(95c110ef) SHA1(e6aea374ca63cdd851af66240e51461882d170e8) ) /* Simply labeled as 4u */
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5__,raidenb.u042", 0x0c0000, 0x20000, CRC(7aca6d61) SHA1(4d80ec87e54d7495b9bdf819b9985b1c8183c80d) ) /* Simply labeled as 5 */
-	ROM_LOAD16_BYTE( "6__,raidenb.u043", 0x0c0001, 0x20000, CRC(e3d35cc2) SHA1(4329865985aaf3fb524618e2e958563c8fa6ead5) ) /* Simply labeled as 6 */
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5__,raidenb.u042", 0x000000, 0x20000, CRC(7aca6d61) SHA1(4d80ec87e54d7495b9bdf819b9985b1c8183c80d) ) /* Simply labeled as 5 */
+	ROM_LOAD16_BYTE( "6__,raidenb.u043", 0x000001, 0x20000, CRC(e3d35cc2) SHA1(4329865985aaf3fb524618e2e958563c8fa6ead5) ) /* Simply labeled as 6 */
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "rai6.u212",   0x000000, 0x08000, CRC(723a483b) SHA1(50e67945e83ea1748fb748de3287d26446d4e0a0) ) /* Should be labeled "8" ??? */
 	ROM_CONTINUE(            0x010000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x018000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* On some PCBs there is no explicit */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U location for these two roms     */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* U919 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* U920 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* Sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD( "sei440", 0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) ) /* U165 on this PCB */
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -763,32 +755,32 @@ ROM_START( raidenub ) // only region bits differ from raidenb
 ROM_END
 
 ROM_START( raidenua )/* Different hardware, Main, Sub & sound CPU code not encrypted. */
-	ROM_REGION( 0x100000, "maincpu", 0 ) /* v30 main cpu */
-	ROM_LOAD16_BYTE( "1.c8",   0x0a0000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
-	ROM_LOAD16_BYTE( "2.c7",   0x0a0001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
-	ROM_LOAD16_BYTE( "3dd.e8", 0x0c0000, 0x20000, CRC(b6f3bad2) SHA1(214474ab9fa65e2716155b77d7825951cc98148a) )
-	ROM_LOAD16_BYTE( "4dd.e7", 0x0c0001, 0x20000, CRC(d294dfc1) SHA1(03606ddfa35d5cb34c447fa370495e1fbb0cad0e) )
+	ROM_REGION( 0x060000, "maincpu", 0 ) /* v30 main cpu */
+	ROM_LOAD16_BYTE( "1.c8",   0x000000, 0x10000, CRC(a4b12785) SHA1(446314e82ce01315cb3e3d1f323eaa2ad6fb48dd) )
+	ROM_LOAD16_BYTE( "2.c7",   0x000001, 0x10000, CRC(17640bd5) SHA1(5bbc99900426b1a072b52537ae9a50220c378a0d) )
+	ROM_LOAD16_BYTE( "3dd.e8", 0x020000, 0x20000, CRC(b6f3bad2) SHA1(214474ab9fa65e2716155b77d7825951cc98148a) )
+	ROM_LOAD16_BYTE( "4dd.e7", 0x020001, 0x20000, CRC(d294dfc1) SHA1(03606ddfa35d5cb34c447fa370495e1fbb0cad0e) )
 
-	ROM_REGION( 0x100000, "sub", 0 ) /* v30 sub cpu */
-	ROM_LOAD16_BYTE( "5.p8", 0x0c0000, 0x20000, CRC(15c1cf45) SHA1(daac732a1d3e8f36fa665f984e05651cbca74fef) )
-	ROM_LOAD16_BYTE( "6.p7", 0x0c0001, 0x20000, CRC(261c381b) SHA1(64a9e0ea9abcba6287829cf4abb806362b62c806) )
+	ROM_REGION( 0x040000, "sub", 0 ) /* v30 sub cpu */
+	ROM_LOAD16_BYTE( "5.p8", 0x000000, 0x20000, CRC(15c1cf45) SHA1(daac732a1d3e8f36fa665f984e05651cbca74fef) )
+	ROM_LOAD16_BYTE( "6.p7", 0x000001, 0x20000, CRC(261c381b) SHA1(64a9e0ea9abcba6287829cf4abb806362b62c806) )
 
 	ROM_REGION( 0x20000, "audiocpu", 0 ) /* 64k code for sound Z80 */
 	ROM_LOAD( "8.w8",        0x00000, 0x08000, CRC(105b9c11) SHA1(eb142806f8410d584d914b91207361a15ab18e6f) )
 	ROM_CONTINUE(            0x10000, 0x08000 )
 	ROM_COPY( "audiocpu", 0x000000, 0x18000, 0x08000 )
 
-	ROM_REGION( 0x010000, "gfx1", 0 ) /* Chars */
-	ROM_LOAD( "9",  0x00000, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* U016 on this PCB */
-	ROM_LOAD( "10", 0x08000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U017 on this PCB */
+	ROM_REGION( 0x010000, "text", 0 ) /* Chars */
+	ROM_LOAD16_BYTE( "9",  0x00001, 0x08000, CRC(1922b25e) SHA1(da27122dd1c43770e7385ad602ef397c64d2f754) ) /* U016 on this PCB */
+	ROM_LOAD16_BYTE( "10", 0x00000, 0x08000, CRC(5f90786a) SHA1(4f63b07c6afbcf5196a433f3356bef984fe303ef) ) /* U017 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx2", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "bgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei420", 0x00000, 0x80000, CRC(da151f0b) SHA1(02682497caf5f058331f18c652471829fa08d54f) ) /* U011 on this PCB */
 
-	ROM_REGION( 0x080000, "gfx3", 0 ) /* tiles */
+	ROM_REGION( 0x080000, "fgtiles", 0 ) /* tiles */
 	ROM_LOAD( "sei430", 0x00000, 0x80000, CRC(ac1f57ac) SHA1(1de926a0db73b99904ef119ac816c53d1551156a) ) /* U013 on this PCB */
 
-	ROM_REGION( 0x090000, "gfx4", 0 ) /* Sprites */
+	ROM_REGION( 0x090000, "sprites", 0 ) /* Sprites */
 	ROM_LOAD( "sei440",  0x00000, 0x80000, CRC(946d7bde) SHA1(30e8755c2b1ca8bff6278710b8422b51f75eec10) ) /* U012 on this PCB */
 
 	ROM_REGION( 0x40000, "oki", 0 )  /* ADPCM samples */
@@ -807,27 +799,27 @@ encryption method! The technique is a combination of a XOR table plus
 bit-swapping */
 void raiden_state::common_decrypt()
 {
-	uint16_t *RAM = (uint16_t *)memregion("maincpu")->base();
+	u16 *RAM = (u16 *)memregion("maincpu")->base();
 	int i;
 
 	for (i = 0; i < 0x20000; i++)
 	{
-		static const uint16_t xor_table[] = { 0x200e,0x0006,0x000a,0x0002,0x240e,0x000e,0x04c2,0x00c2,0x008c,0x0004,0x0088,0x0000,0x048c,0x000c,0x04c0,0x00c0 };
-		uint16_t data = RAM[0xc0000/2 + i];
+		static const u16 xor_table[] = { 0x200e,0x0006,0x000a,0x0002,0x240e,0x000e,0x04c2,0x00c2,0x008c,0x0004,0x0088,0x0000,0x048c,0x000c,0x04c0,0x00c0 };
+		u16 data = RAM[0x20000/2 + i];
 		data ^= xor_table[i & 0x0f];
 		data = bitswap<16>(data, 15,14,10,12,11,13,9,8,3,2,5,4,7,1,6,0);
-		RAM[0xc0000/2 + i] = data;
+		RAM[0x20000/2 + i] = data;
 	}
 
-	RAM = (uint16_t *)memregion("sub")->base();
+	RAM = (u16 *)memregion("sub")->base();
 
 	for (i = 0; i < 0x20000; i++)
 	{
-		static const uint16_t xor_table[] = { 0x0080,0x0080,0x0244,0x0288,0x0288,0x0288,0x1041,0x1009 };
-		uint16_t data = RAM[0xc0000/2 + i];
+		static const u16 xor_table[] = { 0x0080,0x0080,0x0244,0x0288,0x0288,0x0288,0x1041,0x1009 };
+		u16 data = RAM[0x00000/2 + i];
 		data ^= xor_table[i & 0x07];
 		data = bitswap<16>(data, 15,14,13,9,11,10,12,8,2,0,5,4,7,3,1,6);
-		RAM[0xc0000/2 + i] = data;
+		RAM[0x00000/2 + i] = data;
 	}
 }
 

--- a/src/mame/drivers/raiden.cpp
+++ b/src/mame/drivers/raiden.cpp
@@ -12,14 +12,19 @@
 
     To access test mode, reset with both start buttons held.
 
-    The country byte is stored at 0xffffd in the main cpu region,
+    The country/game mode byte is stored at 0xffffd in the main cpu region,
     (that's 0x1fffe in program rom 4).
 
-        0x80  = World/Japan version? (Seibu Kaihatsu) (distributed by Tecmo?)
-        0x81  = USA version (Fabtek license)
-        0x82  = Taiwan version (Liang HWA Electronics license)
-        0x83  = Hong Kong version (Wah Yan Electronics license)
-        0x84  = Korean version (IBL Corporation license)
+    High nibble: Player respawn behavior when single playing
+	    0x0*  = If single playing, Restart at checkpoint when every miss
+	    0x8*  = Respawn instantly when every miss
+
+    Low nibble: country/region code
+        0x*0  = World/Japan version? (Seibu Kaihatsu) (distributed by Tecmo?)
+        0x*1  = USA version (Fabtek license)
+        0x*2  = Taiwan version (Liang HWA Electronics license)
+        0x*3  = Hong Kong version (Wah Yan Electronics license)
+        0x*4  = Korean version (IBL Corporation license)
 
         There are also strings for Spanish, Greece, Mexico, Middle &
         South America though it's not clear if they are used.

--- a/src/mame/drivers/raiden.cpp
+++ b/src/mame/drivers/raiden.cpp
@@ -16,8 +16,8 @@
     (that's 0x1fffe in program rom 4).
 
     High nibble: Player respawn behavior when single playing
-	    0x0*  = If single playing, Restart at checkpoint when every miss
-	    0x8*  = Respawn instantly when every miss
+        0x0*  = If single playing, Restart at checkpoint when every miss
+        0x8*  = Respawn instantly when every miss
 
     Low nibble: country/region code
         0x*0  = World/Japan version? (Seibu Kaihatsu) (distributed by Tecmo?)

--- a/src/mame/includes/raiden.h
+++ b/src/mame/includes/raiden.h
@@ -27,10 +27,10 @@ public:
 		m_palette(*this, "palette"),
 		m_spriteram(*this, "spriteram"),
 		m_shared_ram(*this, "shared_ram"),
-		m_videoram(*this, "videoram"),
+		m_textram(*this, "textram"),
 		m_scroll_ram(*this, "scroll_ram"),
-		m_back_data(*this, "back_data"),
-		m_fore_data(*this, "fore_data")
+		m_bgram(*this, "bgram"),
+		m_fgram(*this, "fgram")
 	{ }
 
 	void raidene(machine_config &config);
@@ -44,17 +44,17 @@ protected:
 	required_device<cpu_device> m_maincpu;
 	required_device<seibu_sound_device> m_seibu_sound;
 
-	uint8_t m_bg_layer_enabled;
-	uint8_t m_fg_layer_enabled;
-	uint8_t m_tx_layer_enabled;
-	uint8_t m_sp_layer_enabled;
-	uint8_t m_flipscreen;
+	bool m_bg_layer_enabled;
+	bool m_fg_layer_enabled;
+	bool m_tx_layer_enabled;
+	bool m_sp_layer_enabled;
+	bool m_flipscreen;
 
 	virtual void video_start() override;
 
-	uint32_t screen_update_common(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, uint16_t *scrollregs);
+	u32 screen_update_common(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect, u16 *scrollregs);
 
-	void raiden_text_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void textram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	void common_video_start();
 
@@ -63,29 +63,29 @@ protected:
 	required_device<palette_device> m_palette;
 	required_device<buffered_spriteram16_device> m_spriteram;
 
-	required_shared_ptr<uint16_t> m_shared_ram;
-	required_shared_ptr<uint16_t> m_videoram;
-	optional_shared_ptr<uint16_t> m_scroll_ram;
-	required_shared_ptr<uint16_t> m_back_data;
-	required_shared_ptr<uint16_t> m_fore_data;
+	required_shared_ptr<u16> m_shared_ram;
+	required_shared_ptr<u16> m_textram;
+	optional_shared_ptr<u16> m_scroll_ram;
+	required_shared_ptr<u16> m_bgram;
+	required_shared_ptr<u16> m_fgram;
 
 	tilemap_t *m_bg_layer;
 	tilemap_t *m_fg_layer;
 	tilemap_t *m_tx_layer;
 
-	void raiden_background_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void raiden_foreground_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
-	void raiden_control_w(uint8_t data);
+	void bgram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void fgram_w(offs_t offset, u16 data, u16 mem_mask = ~0);
+	void raiden_control_w(u8 data);
 
 	TILE_GET_INFO_MEMBER(get_back_tile_info);
 	TILE_GET_INFO_MEMBER(get_fore_tile_info);
 	TILE_GET_INFO_MEMBER(get_text_tile_info);
 
-	uint32_t screen_update_raiden(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_raiden(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
 	DECLARE_WRITE_LINE_MEMBER(vblank_irq);
 
-	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, int pri_mask);
+	void draw_sprites(bitmap_ind16 &bitmap, const rectangle &cliprect, bitmap_ind8 &primap);
 	void common_decrypt();
 
 	void main_map(address_map &map);
@@ -109,13 +109,13 @@ protected:
 	virtual void video_start() override;
 
 private:
-	uint16_t m_raidenb_scroll_ram[6];
+	u16 m_raidenb_scroll_ram[6];
 
-	uint32_t screen_update_raidenb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
+	u32 screen_update_raidenb(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 
-	void raidenb_control_w(uint8_t data);
-	void raidenb_layer_enable_w(uint16_t data);
-	void raidenb_layer_scroll_w(offs_t offset, uint16_t data, uint16_t mem_mask = ~0);
+	void raidenb_control_w(u8 data);
+	void raidenb_layer_enable_w(u16 data);
+	void raidenb_layer_scroll_w(offs_t offset, u16 data, u16 mem_mask = ~0);
 
 	void raidenb_main_map(address_map &map);
 };


### PR DESCRIPTION
Reduce unnecessary memory region size, Simplify gfxdecode layouts, Fix namings, Use shorter/correct type values