### PR TITLE
h8_sci_device: don't set TDRE when receiving

### DIFF
--- a/src/devices/cpu/h8/h8_sci.cpp
+++ b/src/devices/cpu/h8/h8_sci.cpp
@@ -623,7 +623,6 @@ void h8_sci_device::tx_dropped_edge()
 
 void h8_sci_device::rx_start()
 {
-	ssr |= SSR_TDRE;
 	rx_parity = smr & SMR_OE ? 0 : 1;
 	rsr = 0x00;
 	if(V>=2) logerror("start receive\n");


### PR DESCRIPTION
This seems to fix an issue with ctk551 where transmitting and receiving MIDI at the same time could cause TX interrupts to not occur properly, which could cause the firmware's outgoing MIDI buffer to become full, at which point it locks up waiting for the buffer to be processed by an interrupt that never occurs.

The new behavior was verified against the H8/3397 manual from Renesas.