### PR TITLE
cage.cpp: Add partially support of variable sound output channels

### DIFF
--- a/src/mame/audio/cage.h
+++ b/src/mame/audio/cage.h
@@ -17,7 +17,7 @@
 #include "sound/dmadac.h"
 
 
-class atari_cage_device : public device_t
+class atari_cage_device : public device_t, public device_mixer_interface
 {
 public:
 	enum

--- a/src/mame/drivers/atarigt.cpp
+++ b/src/mame/drivers/atarigt.cpp
@@ -58,6 +58,7 @@
 
 #include "cpu/m68000/m68000.h"
 #include "machine/eeprompar.h"
+#include "speaker.h"
 
 
 #define LOG_PROTECTION      (0)
@@ -866,6 +867,26 @@ void atarigt_state::atarigt(machine_config &config)
 	m_cage->irq_handler().set(FUNC(atarigt_state::cage_irq_callback));
 }
 
+// for stereo + subwoofer output configuration
+void atarigt_state::atarigt_stereo(machine_config &config)
+{
+	atarigt(config);
+
+	// 3 Channel output directly from CAGE or through motherboard JAMMA output
+	// based on dedicated cabinet configuration;
+	// 'universal' kit supports mono and stereo, with/without subwoofer.
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+	SPEAKER(config, "subwoofer").front_floor(); // Next to the coin door at dedicated cabinet, just silence for now (not implemented)
+
+	// TODO: correct? sound board has only 1 DAC populated.
+	m_cage->add_route(0, "rspeaker", 1.0);
+	m_cage->add_route(1, "lspeaker", 1.0);
+	m_cage->add_route(2, "lspeaker", 1.0);
+	m_cage->add_route(3, "rspeaker", 1.0);
+	m_cage->add_route(4, "subwoofer", 1.0);
+}
+
 void atarigt_state::tmek(machine_config &config)
 {
 	atarigt(config);
@@ -876,19 +897,30 @@ void atarigt_state::tmek(machine_config &config)
 	m_adc->in_callback<6>().set_ioport("AN2");
 	m_adc->in_callback<7>().set_ioport("AN3");
 
+	// 5 Channel output (4 Channel input connected to Quad Amp PCB)
+	SPEAKER(config, "flspeaker").front_left();
+	SPEAKER(config, "frspeaker").front_right();
+	SPEAKER(config, "rlspeaker").headrest_left();
+	SPEAKER(config, "rrspeaker").headrest_right();
+	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
+
 	m_cage->set_speedup(0x4fad);
+	m_cage->add_route(0, "frspeaker", 1.0); // Foward Right
+	m_cage->add_route(1, "rlspeaker", 1.0); // Back Left
+	m_cage->add_route(2, "flspeaker", 1.0); // Foward Left
+	m_cage->add_route(3, "rrspeaker", 1.0); // Back Right
 }
 
 void atarigt_state::primrage(machine_config &config)
 {
-	atarigt(config);
+	atarigt_stereo(config);
 
 	m_cage->set_speedup(0x42f2);
 }
 
 void atarigt_state::primrage20(machine_config &config)
 {
-	atarigt(config);
+	atarigt_stereo(config);
 
 	m_cage->set_speedup(0x48a4);
 }

--- a/src/mame/drivers/metalmx.cpp
+++ b/src/mame/drivers/metalmx.cpp
@@ -690,9 +690,21 @@ void metalmx_state::metalmx(machine_config &config)
 
 	PALETTE(config, "palette", palette_device::RGB_565);
 
+	// TODO: copied from atarigt.cpp; Same configurations as T-Mek?
+	// 5 Channel output (4 Channel input connected to Quad Amp PCB)
+	SPEAKER(config, "flspeaker").front_left();
+	SPEAKER(config, "frspeaker").front_right();
+	SPEAKER(config, "rlspeaker").headrest_left();
+	SPEAKER(config, "rrspeaker").headrest_right();
+	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
+
 	ATARI_CAGE(config, m_cage, 0);
 	m_cage->set_speedup(0); // TODO: speedup address
 	m_cage->irq_handler().set(FUNC(metalmx_state::cage_irq_callback));
+	m_cage->add_route(0, "frspeaker", 1.0); // Foward Right
+	m_cage->add_route(1, "rlspeaker", 1.0); // Back Left
+	m_cage->add_route(2, "flspeaker", 1.0); // Foward Left
+	m_cage->add_route(3, "rrspeaker", 1.0); // Back Right
 }
 
 

--- a/src/mame/drivers/seattle.cpp
+++ b/src/mame/drivers/seattle.cpp
@@ -199,6 +199,7 @@
 #include "machine/pci-ide.h"
 #include "video/voodoo_pci.h"
 #include "screen.h"
+#include "speaker.h"
 
 #include "calspeed.lh"
 #include "vaportrx.lh"
@@ -2131,9 +2132,21 @@ void seattle_state::mace(machine_config &config)
 void seattle_state::sfrush(machine_config &config)
 {
 	flagstaff(config);
+	// 5 Channel output (4 Channel input connected to Quad Amp PCB)
+	SPEAKER(config, "flspeaker").front_left();
+	SPEAKER(config, "frspeaker").front_right();
+	SPEAKER(config, "rlspeaker").headrest_left();
+	SPEAKER(config, "rrspeaker").headrest_right();
+	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
+
 	atari_cage_seattle_device &cage(ATARI_CAGE_SEATTLE(config, "cage", 0));
 	cage.set_speedup(0x5236);
 	cage.irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
+	// TODO: copied from atarigt.cpp; Same configurations as T-Mek?
+	cage.add_route(0, "frspeaker", 1.0); // Foward Right
+	cage.add_route(1, "rlspeaker", 1.0); // Back Left
+	cage.add_route(2, "flspeaker", 1.0); // Foward Left
+	cage.add_route(3, "rrspeaker", 1.0); // Back Right
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_STANDARD);
@@ -2146,9 +2159,22 @@ void seattle_state::sfrush(machine_config &config)
 void seattle_state::sfrushrk(machine_config &config)
 {
 	flagstaff(config);
+	// 5 Channel output (4 Channel input connected to Quad Amp PCB)
+	SPEAKER(config, "flspeaker").front_left();
+	SPEAKER(config, "frspeaker").front_right();
+	SPEAKER(config, "rlspeaker").headrest_left();
+	SPEAKER(config, "rrspeaker").headrest_right();
+	//SPEAKER(config, "subwoofer").seat(); Not implemented, Quad Amp PCB output;
+
 	atari_cage_seattle_device &cage(ATARI_CAGE_SEATTLE(config, "cage", 0));
 	cage.set_speedup(0x5329);
 	cage.irq_handler().set(m_ioasic, FUNC(midway_ioasic_device::cage_irq_handler));
+	// TODO: copied from atarigt.cpp; Same configurations as T-Mek?
+	cage.add_route(0, "frspeaker", 1.0); // Foward Right
+	cage.add_route(1, "rlspeaker", 1.0); // Back Left
+	cage.add_route(2, "flspeaker", 1.0); // Foward Left
+	cage.add_route(3, "rrspeaker", 1.0); // Back Right
+
 
 	MIDWAY_IOASIC(config, m_ioasic, 0);
 	m_ioasic->set_shuffle(MIDWAY_IOASIC_SFRUSHRK);

--- a/src/mame/includes/atarigt.h
+++ b/src/mame/includes/atarigt.h
@@ -39,6 +39,7 @@ public:
 	{ }
 
 	void atarigt(machine_config &config);
+	void atarigt_stereo(machine_config &config);
 	void tmek(machine_config &config);
 	void primrage20(machine_config &config);
 	void primrage(machine_config &config);


### PR DESCRIPTION
Add device_mixer_interface for sound output routines, Add PCB layouts, Add notes
atarigt.cpp,seattle.cpp: Add/Fix sound channel configurations based on operator's manuals, Schematics, Add notes
metalmx.cpp: Move sound channel configurations from cage.cpp, Add notes