### PR TITLE
k573dio: Document new registers and update PCB schematic

### DIFF
--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -89,6 +89,8 @@ void k573dio_device::amap(address_map &map)
 	map(0x0a, 0x0b).r(FUNC(k573dio_device::a0a_r));
 	map(0x10, 0x11).w(FUNC(k573dio_device::a10_w));
 	map(0x80, 0x81).r(FUNC(k573dio_device::a80_r));
+	map(0x90, 0x91).w(FUNC(k573dio_device::network_id_w));
+	//map(0x92, 0x93).w(FUNC(k573dio_device::network_unk_w));
 	map(0xa0, 0xa1).w(FUNC(k573dio_device::mpeg_start_adr_high_w));
 	map(0xa2, 0xa3).w(FUNC(k573dio_device::mpeg_start_adr_low_w));
 	map(0xa4, 0xa5).w(FUNC(k573dio_device::mpeg_end_adr_high_w));
@@ -102,6 +104,10 @@ void k573dio_device::amap(address_map &map)
 	map(0xb4, 0xb5).rw(FUNC(k573dio_device::ram_r), FUNC(k573dio_device::ram_w));
 	map(0xb6, 0xb7).w(FUNC(k573dio_device::ram_read_adr_high_w));
 	map(0xb8, 0xb9).w(FUNC(k573dio_device::ram_read_adr_low_w));
+	map(0xc0, 0xc1).rw(FUNC(k573dio_device::network_r), FUNC(k573dio_device::network_w));
+	map(0xc2, 0xc3).r(FUNC(k573dio_device::network_output_buf_size_r));
+	map(0xc4, 0xc5).r(FUNC(k573dio_device::network_input_buf_size_r));
+	//map(0xc8, 0xc9).w(FUNC(k573dio_device::network_unk2_w));
 	map(0xca, 0xcb).r(FUNC(k573dio_device::mp3_counter_high_r));
 	map(0xcc, 0xcd).rw(FUNC(k573dio_device::mp3_counter_low_r), FUNC(k573dio_device::mp3_counter_low_w));
 	map(0xce, 0xcf).r(FUNC(k573dio_device::mp3_counter_diff_r));
@@ -138,6 +144,7 @@ void k573dio_device::device_start()
 	save_item(NAME(output_data));
 	save_item(NAME(is_ddrsbm_fpga));
 	save_item(NAME(crypto_key1));
+	save_item(NAME(network_id));
 
 	k573fpga->set_ddrsbm_fpga(is_ddrsbm_fpga);
 }
@@ -147,6 +154,7 @@ void k573dio_device::device_reset()
 	ram_adr = 0;
 	ram_read_adr = 0;
 	crypto_key1 = 0;
+	network_id = 0;
 
 	std::fill(std::begin(output_data), std::end(output_data), 0);
 }
@@ -208,12 +216,6 @@ uint16_t k573dio_device::a0a_r()
 void k573dio_device::a10_w(uint16_t data)
 {
 	LOGUNKNOWNREG("%s: a10_w: %04x (%s)\n", tag(), data, machine().describe_context());
-}
-
-uint16_t k573dio_device::ac4_r()
-{
-	LOGUNKNOWNREG("%s: ac4_r (%s)\n", tag(), machine().describe_context());
-	return 0;
 }
 
 uint16_t k573dio_device::a80_r()
@@ -434,4 +436,33 @@ void k573dio_device::output(int offset, uint16_t data)
 			output_cb(4*offset + i, newbit, 0xff);
 	}
 	output_data[offset] = data;
+}
+
+uint16_t k573dio_device::network_r()
+{
+	// Return a byte from the input buffer
+	return 0;
+}
+
+void k573dio_device::network_w(uint16_t data)
+{
+	// Write a byte to the output buffer
+}
+
+uint16_t k573dio_device::network_output_buf_size_r()
+{
+	// Number of bytes in the output buffer waiting to be sent
+	return 0;
+}
+
+uint16_t k573dio_device::network_input_buf_size_r()
+{
+	// Number of bytes in the input buffer waiting to be read
+	return 0;
+}
+
+void k573dio_device::network_id_w(uint16_t data)
+{
+	// The network ID configured in the operator menu
+	network_id = data;
 }

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -49,7 +49,7 @@
   | AK4309B   CN18         29.450MHz  MAS3507D    |
   |                                               |
   |                           CN3                 |
-  | HYC24855  RCA-L/R                             |
+  | HYC2485S  RCA-1/2                             |
   |-----------------------------------------------|
 
   Notes:
@@ -73,8 +73,8 @@
   CN18        - 6 pin connector
   MAS3507D    - IM MAS3507D D8 9173 51 HM U 072953.000 ES  MPEG 1/2 Layer 2/3 Audio Decoder
   CN3         - Connector joining this PCB to the MAIN PCB
-  HYC24855    - ?
-  RCA-L/R     - RCA connectors for left/right audio output
+  HYC2485S    - RS485 transceiver
+  RCA-1/2     - RCA connectors for network communication
 
 */
 
@@ -89,7 +89,6 @@ void k573dio_device::amap(address_map &map)
 	map(0x0a, 0x0b).r(FUNC(k573dio_device::a0a_r));
 	map(0x10, 0x11).w(FUNC(k573dio_device::a10_w));
 	map(0x80, 0x81).r(FUNC(k573dio_device::a80_r));
-	map(0xc4, 0xc5).r(FUNC(k573dio_device::ac4_r));
 	map(0xa0, 0xa1).w(FUNC(k573dio_device::mpeg_start_adr_high_w));
 	map(0xa2, 0xa3).w(FUNC(k573dio_device::mpeg_start_adr_low_w));
 	map(0xa4, 0xa5).w(FUNC(k573dio_device::mpeg_end_adr_high_w));

--- a/src/mame/machine/k573dio.cpp
+++ b/src/mame/machine/k573dio.cpp
@@ -91,10 +91,10 @@ void k573dio_device::amap(address_map &map)
 	map(0x80, 0x81).r(FUNC(k573dio_device::a80_r));
 	map(0x90, 0x91).w(FUNC(k573dio_device::network_id_w));
 	//map(0x92, 0x93).w(FUNC(k573dio_device::network_unk_w));
-	map(0xa0, 0xa1).w(FUNC(k573dio_device::mpeg_start_adr_high_w));
-	map(0xa2, 0xa3).w(FUNC(k573dio_device::mpeg_start_adr_low_w));
-	map(0xa4, 0xa5).w(FUNC(k573dio_device::mpeg_end_adr_high_w));
-	map(0xa6, 0xa7).w(FUNC(k573dio_device::mpeg_end_adr_low_w));
+	map(0xa0, 0xa1).rw(FUNC(k573dio_device::mpeg_start_adr_high_r), FUNC(k573dio_device::mpeg_start_adr_high_w));
+	map(0xa2, 0xa3).rw(FUNC(k573dio_device::mpeg_start_adr_low_r), FUNC(k573dio_device::mpeg_start_adr_low_w));
+	map(0xa4, 0xa5).rw(FUNC(k573dio_device::mpeg_end_adr_high_r), FUNC(k573dio_device::mpeg_end_adr_high_w));
+	map(0xa6, 0xa7).rw(FUNC(k573dio_device::mpeg_end_adr_low_r), FUNC(k573dio_device::mpeg_end_adr_low_w));
 	map(0xa8, 0xa9).rw(FUNC(k573dio_device::mpeg_key_1_r), FUNC(k573dio_device::mpeg_key_1_w));
 	map(0xaa, 0xab).r(FUNC(k573dio_device::mpeg_ctrl_r));
 	map(0xac, 0xad).rw(FUNC(k573dio_device::mas_i2c_r), FUNC(k573dio_device::mas_i2c_w));
@@ -224,10 +224,20 @@ uint16_t k573dio_device::a80_r()
 	return 0x1234;
 }
 
+uint16_t k573dio_device::mpeg_start_adr_high_r()
+{
+	return k573fpga->get_mp3_start_addr() >> 16;
+}
+
 void k573dio_device::mpeg_start_adr_high_w(uint16_t data)
 {
 	LOGMP3("FPGA MPEG start address high %04x\n", data);
 	k573fpga->set_mp3_start_addr((k573fpga->get_mp3_start_addr() & 0x0000ffff) | (data << 16)); // high
+}
+
+uint16_t k573dio_device::mpeg_start_adr_low_r()
+{
+	return k573fpga->get_mp3_start_addr() & 0xffff;
 }
 
 void k573dio_device::mpeg_start_adr_low_w(uint16_t data)
@@ -239,10 +249,20 @@ void k573dio_device::mpeg_start_adr_low_w(uint16_t data)
 		k573fpga->set_crypto_key3(0);
 }
 
+uint16_t k573dio_device::mpeg_end_adr_high_r()
+{
+	return k573fpga->get_mp3_end_addr() >> 16;
+}
+
 void k573dio_device::mpeg_end_adr_high_w(uint16_t data)
 {
 	LOGMP3("FPGA MPEG end address high %04x\n", data);
 	k573fpga->set_mp3_end_addr((k573fpga->get_mp3_end_addr() & 0x0000ffff) | (data << 16)); // high
+}
+
+uint16_t k573dio_device::mpeg_end_adr_low_r()
+{
+	return k573fpga->get_mp3_end_addr() & 0xffff;
 }
 
 void k573dio_device::mpeg_end_adr_low_w(uint16_t data)

--- a/src/mame/machine/k573dio.h
+++ b/src/mame/machine/k573dio.h
@@ -26,9 +26,13 @@ public:
 	void a10_w(uint16_t data);
 	uint16_t a80_r();
 
+	uint16_t mpeg_start_adr_high_r();
 	void mpeg_start_adr_high_w(uint16_t data);
+	uint16_t mpeg_start_adr_low_r();
 	void mpeg_start_adr_low_w(uint16_t data);
+	uint16_t mpeg_end_adr_high_r();
 	void mpeg_end_adr_high_w(uint16_t data);
+	uint16_t mpeg_end_adr_low_r();
 	void mpeg_end_adr_low_w(uint16_t data);
 	uint16_t mpeg_key_1_r();
 	void mpeg_key_1_w(uint16_t data);

--- a/src/mame/machine/k573dio.h
+++ b/src/mame/machine/k573dio.h
@@ -25,7 +25,6 @@ public:
 	uint16_t a0a_r();
 	void a10_w(uint16_t data);
 	uint16_t a80_r();
-	uint16_t ac4_r();
 
 	void mpeg_start_adr_high_w(uint16_t data);
 	void mpeg_start_adr_low_w(uint16_t data);
@@ -61,6 +60,11 @@ public:
 	void output_4_w(uint16_t data);
 	void output_2_w(uint16_t data);
 	void output_5_w(uint16_t data);
+	uint16_t network_r();
+	void network_w(uint16_t data);
+	uint16_t network_output_buf_size_r();
+	uint16_t network_input_buf_size_r();
+	void network_id_w(uint16_t data);
 
 protected:
 	virtual void device_start() override;
@@ -82,6 +86,8 @@ private:
 
 	bool is_ddrsbm_fpga;
 	u16 crypto_key1;
+
+	uint16_t network_id;
 };
 
 DECLARE_DEVICE_TYPE(KONAMI_573_DIGITAL_IO_BOARD, k573dio_device)


### PR DESCRIPTION
- Network communication registers have been documented. I don't know the proper way to implement RS485 to connect multiple instances of MAME together so the registers are stubbed for now. See https://github.com/mamedev/mame/issues/9090 and https://github.com/mamedev/mame/issues/9101 for discussion.
- MP3 start/end addresses are read in some cases so I've added the appropriate readers.