### PR TITLE
bus/nes: Simplified NES-EVENT board.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -27196,6 +27196,7 @@ license:CC0
 		<description>Nintendo World Championships 1990 (USA)</description>
 		<year>1990</year>
 		<publisher>Nintendo</publisher>
+		<info name="usage" value="To play, press start on controller 2."/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="nes_event" />
 			<feature name="pcb" value="NES-EVENT" />

--- a/src/devices/bus/nes/event.h
+++ b/src/devices/bus/nes/event.h
@@ -14,20 +14,16 @@ class nes_event_device : public nes_sxrom_device
 {
 public:
 	// construction/destruction
-	nes_event_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual ioport_constructor device_input_ports() const override;
+	nes_event_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual void pcb_reset() override;
 
 protected:
-	static constexpr device_timer_id TIMER_EVENT = 0;
-
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param, void *ptr) override;
+	virtual ioport_constructor device_input_ports() const override;
 
-	virtual void update_regs(int reg) override;
 	virtual void set_prg() override;
 	virtual void set_chr() override;
 
@@ -35,10 +31,10 @@ protected:
 
 	int m_nwc_init;
 
+	static constexpr device_timer_id TIMER_EVENT = 0;
 	emu_timer *event_timer;
-	attotime timer_freq;
 
-	uint32_t m_timer_count;
+	u32 m_timer_count;
 	int m_timer_on, m_timer_enabled;
 };
 

--- a/src/devices/bus/nes/mmc1.cpp
+++ b/src/devices/bus/nes/mmc1.cpp
@@ -184,7 +184,7 @@ void nes_sxrom_device::set_chr(int chr_base, int chr_mask)
 		chr8((chr_base | (m_reg[1] & chr_mask)) >> 1, m_chr_source);
 }
 
-// this allows for easier implementation of the NES-EVENT board used for Nintento World Championships
+// this allows for easier implementation of MMC1 subclasses
 void nes_sxrom_device::update_regs(int reg)
 {
 	switch (reg)


### PR DESCRIPTION
- IRQ timer now counts up and no longer latches DIP setting when initialized, i.e. DIP switches are always live.
- Removed deprecated hold_irq_line().