### PR TITLE
bus/nes_ctrl: Added NES support for Virtual Boy controllers.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -79263,6 +79263,22 @@ be better to redump them properly. -->
 		</part>
 	</software>
 
+	<software name="candesto" supported="partial"> <!-- Restore/Options not yet supported -->
+		<description>Candelabra - Estoscerro</description>
+		<year>2020</year> <!-- cartridge release year -->
+		<publisher>&lt;homebrew&gt;</publisher>
+		<part name="cart" interface="nes_cart">
+			<feature name="slot" value="unrom512" />
+			<feature name="mirroring" value="vertical" />
+			<dataarea name="prg" size="524288">
+				<rom name="candelabra - estoscerro.prg" size="524288" crc="acc3e3df" sha1="6b929e2aaaf31b6bcddf530f608612aa5826632f" status="baddump" /> <!-- this is from the .nes file distributed by the author, Sly Dog Studios -->
+			</dataarea>
+			<!-- 8k VRAM on cartridge? -->
+			<dataarea name="vram" size="8192">
+			</dataarea>
+		</part>
+	</software>
+
 <!-- Author self-published through mail order, carts made by RetroZone -->
 	<software name="et">
 		<description>E.T.</description>

--- a/src/devices/bus/nes_ctrl/ctrl.cpp
+++ b/src/devices/bus/nes_ctrl/ctrl.cpp
@@ -185,6 +185,7 @@ void nes_control_port1_devices(device_slot_interface &device)
 	device.option_add("4score_p1p3", NES_4SCORE_P1P3);
 	device.option_add("miracle_piano", NES_MIRACLE);
 	device.option_add("snes_adapter", NES_SNESADAPTER);
+	device.option_add("vboy", NES_VBOYCTRL);
 }
 
 void nes_control_port2_devices(device_slot_interface &device)
@@ -195,6 +196,7 @@ void nes_control_port2_devices(device_slot_interface &device)
 	device.option_add("powerpad", NES_POWERPAD);
 	device.option_add("4score_p2p4", NES_4SCORE_P2P4);
 	device.option_add("snes_adapter", NES_SNESADAPTER);
+	device.option_add("vboy", NES_VBOYCTRL);
 }
 
 void fc_control_port1_devices(device_slot_interface &device)

--- a/src/devices/bus/nes_ctrl/joypad.h
+++ b/src/devices/bus/nes_ctrl/joypad.h
@@ -31,16 +31,18 @@ public:
 	virtual ioport_constructor device_input_ports() const override;
 
 protected:
-	nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+	nes_joypad_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 latch_fill = 0x80);
 
 	// device-level overrides
 	virtual void device_start() override;
 
 	virtual u8 read_bit0() override;
 	virtual void write(u8 data) override;
+	virtual void set_latch() { m_latch = m_joypad->read(); }
 
 	required_ioport m_joypad;
 	u32 m_latch;  // wider than standard joypad's 8-bit latch to accomodate subclass devices
+	u32 m_latch_fill;  // the new MSB as a joypad's shift register shifts
 };
 
 
@@ -53,7 +55,7 @@ public:
 	nes_fcpadexp_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
-	nes_fcpadexp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
+	nes_fcpadexp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, u32 latch_fill = 0x80);
 
 	virtual u8 read_bit0() override { return 0; }
 	virtual u8 read_exp(offs_t offset) override;
@@ -122,6 +124,19 @@ protected:
 };
 
 
+// ======================> nes_vboyctrl_device
+
+class nes_vboyctrl_device : public nes_joypad_device
+{
+public:
+	// construction/destruction
+	nes_vboyctrl_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
+
+protected:
+	virtual ioport_constructor device_input_ports() const override;
+};
+
+
 // device type definition
 DECLARE_DEVICE_TYPE(NES_JOYPAD,         nes_joypad_device)
 DECLARE_DEVICE_TYPE(NES_FCPAD_EXP,      nes_fcpadexp_device)
@@ -129,5 +144,6 @@ DECLARE_DEVICE_TYPE(NES_FCPAD_P2,       nes_fcpad2_device)
 DECLARE_DEVICE_TYPE(NES_CCPAD_LEFT,     nes_ccpadl_device)
 DECLARE_DEVICE_TYPE(NES_CCPAD_RIGHT,    nes_ccpadr_device)
 DECLARE_DEVICE_TYPE(NES_ARCSTICK,       nes_arcstick_device)
+DECLARE_DEVICE_TYPE(NES_VBOYCTRL,       nes_vboyctrl_device)
 
 #endif // MAME_BUS_NES_CTRL_JOYPAD_H

--- a/src/devices/bus/nes_ctrl/pachinko.cpp
+++ b/src/devices/bus/nes_ctrl/pachinko.cpp
@@ -41,39 +41,11 @@ ioport_constructor nes_pachinko_device::device_input_ports() const
 //-------------------------------------------------
 
 nes_pachinko_device::nes_pachinko_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-	: nes_fcpadexp_device(mconfig, NES_PACHINKO, tag, owner, clock)
+	: nes_fcpadexp_device(mconfig, NES_PACHINKO, tag, owner, clock, 0)
 	, m_trigger(*this, "TRIGGER")
 {
 }
 
-
-//-------------------------------------------------
-//  read
-//-------------------------------------------------
-
-u8 nes_pachinko_device::read_exp(offs_t offset)
-{
-	u8 ret = 0;
-	// this controller behaves like a standard P3 joypad, with longer stream of inputs
-	if (offset == 0)    //$4016
-	{
-		if (m_strobe)
-			set_latch();
-		ret = (m_latch & 1) << 1;
-		m_latch >>= 1;
-	}
-	return ret;
-}
-
-//-------------------------------------------------
-//  write
-//-------------------------------------------------
-
-void nes_pachinko_device::write(u8 data)
-{
-	if (write_strobe(data))
-		set_latch();
-}
 
 void nes_pachinko_device::set_latch()
 {

--- a/src/devices/bus/nes_ctrl/pachinko.h
+++ b/src/devices/bus/nes_ctrl/pachinko.h
@@ -29,12 +29,9 @@ public:
 	virtual ioport_constructor device_input_ports() const override;
 
 protected:
-	virtual u8 read_exp(offs_t offset) override;
-	virtual void write(u8 data) override;
+	virtual void set_latch() override;
 
 private:
-	void set_latch();
-
 	required_ioport m_trigger;
 };
 


### PR DESCRIPTION
- Generalized the read/write pattern for joypads a bit more and placed it in the base NES joypad class.
- Using that, added Virtual Boy controller and simplified Pachinko controller some more.

New working software list additions (nes.xml)
-----------------------------------
Candelabra - Estoscerro [SlyDogStudios]