### PR TITLE
n64: fix several RDP regressions

### DIFF
--- a/src/mame/video/n64.cpp
+++ b/src/mame/video/n64.cpp
@@ -2290,7 +2290,7 @@ void n64_rdp::cmd_tex_rect(uint64_t *cmd_buf)
 	ewdata[16] = ((dtdy >> 5) & 0xffff) << 32;                  // dsde, dtde, dwde (0)
 	ewdata[17] = ((dtdy >> 5) & 0xffff) << 32;                  // dsdy, dtdy, dwdy (0)
 	ewdata[18] = ((dtdy & 0x1f) << 11) << 32;                   // dsde frac, dtde frac, dwde frac (0)
-	ewdata[38] = ((dtdy & 0x1f) << 11) << 32;                   // dsdy frac, dtdy frac, dwdy frac (0)
+	ewdata[19] = ((dtdy & 0x1f) << 11) << 32;                   // dsdy frac, dtdy frac, dwdy frac (0)
 	// ewdata[40-43] = 0;                                       // depth
 
 	draw_triangle(cmd_buf, true, true, false, true);
@@ -2301,7 +2301,7 @@ void n64_rdp::cmd_tex_rect_flip(uint64_t *cmd_buf)
 	const uint64_t w1 = cmd_buf[0];
 	const uint64_t w2 = cmd_buf[1];
 
-	const uint64_t tilenum  = (w1 >> 56) & 0x7;
+	const uint64_t tilenum  = (w1 >> 24) & 0x7;
 	const uint64_t xh = (w1 >> 12) & 0xfff;
 	const uint64_t xl = (w1 >> 44) & 0xfff;
 	const uint64_t yh = (w1 >>  0) & 0xfff;
@@ -2393,7 +2393,7 @@ void n64_rdp::cmd_set_convert(uint64_t *cmd_buf)
 	k2 = (SIGN9(k2) << 1) + 1;
 	k3 = (SIGN9(k3) << 1) + 1;
 
-	set_yuv_factors(rgbaint_t(0, k0, k2, k3), rgbaint_t(0, 0, k1, 0), rgbaint_t(k4, k4, k4, k4), rgbaint_t(k5, k5, k5, k5));
+	set_yuv_factors(rgbaint_t(0, k0, k2, 0), rgbaint_t(0, 0, k1, k3), rgbaint_t(k4, k4, k4, k4), rgbaint_t(k5, k5, k5, k5));
 }
 
 void n64_rdp::cmd_set_scissor(uint64_t *cmd_buf)
@@ -2411,7 +2411,7 @@ void n64_rdp::cmd_set_scissor(uint64_t *cmd_buf)
 void n64_rdp::cmd_set_prim_depth(uint64_t *cmd_buf)
 {
 	const uint64_t w1 = cmd_buf[0];
-	m_misc_state.m_primitive_z = (uint32_t)(w1 & 0x7fff0000);
+	m_misc_state.m_primitive_z = (uint16_t)(w1 >> 16) & 0x7fff;
 	m_misc_state.m_primitive_dz = (uint16_t)(w1 >> 32);
 }
 
@@ -3718,7 +3718,7 @@ void n64_rdp::span_draw_1cycle(int32_t scanline, const extent_t &extent, const r
 
 	if(object.m_other_modes.z_source_sel)
 	{
-		z.w = object.m_misc_state.m_primitive_z;
+		z.w = (uint32_t)object.m_misc_state.m_primitive_z << 16;
 		dzpix = object.m_misc_state.m_primitive_dz;
 		dzinc = 0;
 	}
@@ -4045,7 +4045,7 @@ void n64_rdp::span_draw_2cycle(int32_t scanline, const extent_t &extent, const r
 
 	if(object.m_other_modes.z_source_sel)
 	{
-		z.w = object.m_misc_state.m_primitive_z;
+		z.w = (uint32_t)object.m_misc_state.m_primitive_z << 16;
 		dzpix = object.m_misc_state.m_primitive_dz;
 		dzinc = 0;
 	}

--- a/src/mame/video/n64.h
+++ b/src/mame/video/n64.h
@@ -196,9 +196,9 @@ public:
 	uint16_t*     get_tmem16() { return (uint16_t*)m_tmem.get(); }
 
 	// YUV Factors
-	void        set_yuv_factors(color_t k023, color_t k1, color_t k4, color_t k5) { m_k023 = k023; m_k1 = k1; m_k4 = k4; m_k5 = k5; }
-	color_t&    get_k023() { return m_k023; }
-	color_t&    get_k1() { return m_k1; }
+	void        set_yuv_factors(color_t k02, color_t k13, color_t k4, color_t k5) { m_k02 = k02; m_k13 = k13; m_k4 = k4; m_k5 = k5; }
+	color_t&    get_k02() { return m_k02; }
+	color_t&    get_k13() { return m_k13; }
 
 	// Blender-related (move into RDP::Blender)
 	void        set_blender_input(int32_t cycle, int32_t which, color_t** input_rgb, color_t** input_a, int32_t a, int32_t b, rdp_span_aux* userdata);
@@ -371,8 +371,8 @@ private:
 	std::unique_ptr<uint8_t[]>  m_tmem;
 
 	// YUV factors
-	color_t m_k023;
-	color_t m_k1;
+	color_t m_k02;
+	color_t m_k13;
 	color_t m_k4;
 	color_t m_k5;
 

--- a/src/mame/video/rdptpipe.cpp
+++ b/src/mame/video/rdptpipe.cpp
@@ -199,12 +199,12 @@ void n64_texture_pipe_t::cycle_nearest(color_t* TEX, color_t* prev, int32_t SSS,
 
 	t0.sign_extend(0x00000100, 0xffffff00);
 
-	rgbaint_t k1r(m_rdp->get_k1());
-	k1r.mul_imm(t0.get_r32());
+	rgbaint_t k13r(m_rdp->get_k13());
+	k13r.mul_imm(t0.get_r32());
 
-	TEX->set(m_rdp->get_k023());
+	TEX->set(m_rdp->get_k02());
 	TEX->mul_imm(t0.get_g32());
-	TEX->add(k1r);
+	TEX->add(k13r);
 	TEX->add_imm(0x80);
 	TEX->shr_imm(8);
 	TEX->add_imm(t0.get_b32());
@@ -249,12 +249,12 @@ void n64_texture_pipe_t::cycle_linear(color_t* TEX, color_t* prev, int32_t SSS, 
 
 	t0.sign_extend(0x00000100, 0xffffff00);
 
-	rgbaint_t k1r(m_rdp->get_k1());
-	k1r.mul_imm(t0.get_r32());
+	rgbaint_t k13r(m_rdp->get_k13());
+	k13r.mul_imm(t0.get_r32());
 
-	TEX->set(m_rdp->get_k023());
+	TEX->set(m_rdp->get_k02());
 	TEX->mul_imm(t0.get_g32());
-	TEX->add(k1r);
+	TEX->add(k13r);
 	TEX->add_imm(0x80);
 	TEX->shr_imm(8);
 	TEX->add_imm(t0.get_b32());
@@ -738,12 +738,13 @@ void n64_texture_pipe_t::fetch_yuv(rgbaint_t& out, int32_t s, int32_t t, int32_t
 {
 	const uint16_t *tc = ((uint16_t*)userdata->m_tmem);
 
-	const int32_t taddr = (((tbase << 3) + s) ^ sTexAddrSwap8[t & 1]) & 0x7ff;
+	const int32_t taddr = (tbase << 3) + s;
+	const int32_t taddrhi = (taddr ^ sTexAddrSwap8[t & 1]) & 0x7ff;
 	const int32_t taddrlow = ((taddr >> 1) ^ sTexAddrSwap16[t & 1]) & 0x3ff;
 
 	const uint16_t c = tc[taddrlow];
 
-	int32_t y = userdata->m_tmem[taddr | 0x800];
+	int32_t y = userdata->m_tmem[taddrhi | 0x800];
 	int32_t u = c >> 8;
 	int32_t v = c & 0xff;
 
@@ -751,7 +752,7 @@ void n64_texture_pipe_t::fetch_yuv(rgbaint_t& out, int32_t s, int32_t t, int32_t
 	u |= ((u & 0x80) << 1);
 	v |= ((v & 0x80) << 1);
 
-	out.set(y & 0xff, y & 0xff, u & 0xff, v & 0xff);
+	out.set(y, u, v, y);
 }
 
 void n64_texture_pipe_t::fetch_ci4_tlut0(rgbaint_t& out, int32_t s, int32_t t, int32_t tbase, int32_t tpal, rdp_span_aux* userdata)


### PR DESCRIPTION
- YUV texture fetch and color space conversion
- textured rectangle command parsing
- set primitive depth command parsing

The following test ROMs illustrate these issues:
https://github.com/PeterLemon/N64/blob/master/RDP/16BPP/Rectangle/FillZBufferRectangle320x240/Cycle1FillZBufferRectangle16BPP320X240.N64
https://github.com/PeterLemon/N64/blob/master/RDP/16BPP/Rectangle/TextureRectangle/Cycle1TextureRectangleYUV16B320x240/Cycle1TextureRectangle16BPPYUV16B320X240.N64
