### PR TITLE
i8255: always latch input data when strobe is asserted

### DIFF
--- a/src/devices/machine/i8255.cpp
+++ b/src/devices/machine/i8255.cpp
@@ -895,7 +895,7 @@ WRITE_LINE_MEMBER( i8255_device::pc2_w )
 		else
 		{
 			// port B strobe
-			if (!m_ibf[PORT_B] && !state)
+			if (!state)
 			{
 				LOG("I8255 Port B Strobe\n");
 
@@ -915,7 +915,7 @@ WRITE_LINE_MEMBER( i8255_device::pc4_w )
 	if ((group_mode(GROUP_A) == 2) || ((group_mode(GROUP_A) == 1) && (port_mode(PORT_A) == MODE_INPUT)))
 	{
 		// port A strobe
-		if (!m_ibf[PORT_A] && !state)
+		if (!state)
 		{
 			LOG("I8255 Port A Strobe\n");
 


### PR DESCRIPTION
This behaviour is expected by ibm6580 self-tests.   Datasheet (page 1058 of components/intel/_dataBooks/1982_Intel_Component_Data_Catalog.pdf) seems to confirm this:

> ~STB (Strobe Input).  A "low" on this input loads data into the input latch.