### PR TITLE
nes_apu.cpp: Added missing DPCM period table for PAL. (MT8183)

### DIFF
--- a/src/devices/sound/nes_apu.cpp
+++ b/src/devices/sound/nes_apu.cpp
@@ -86,6 +86,7 @@ DEFINE_DEVICE_TYPE(NES_APU, nesapu_device, "nesapu", "N2A03 APU")
 nesapu_device::nesapu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, type, tag, owner, clock)
 	, device_sound_interface(mconfig, *this)
+	, m_is_pal(0)
 	, m_samps_per_sync(0)
 	, m_buffer_size(0)
 	, m_stream(nullptr)
@@ -121,6 +122,7 @@ void nesapu_device::device_reset()
 void nesapu_device::device_clock_changed()
 {
 	calculate_rates();
+	m_is_pal = m_clock == PAL_APU_CLOCK;
 }
 
 void nesapu_device::calculate_rates()
@@ -207,8 +209,8 @@ void nesapu_device::device_start()
 	save_item(NAME(m_APU.tail));
 	#else
 	save_item(NAME(m_APU.buf_pos));
-	save_item(NAME(m_APU.step_mode));
 	#endif
+	save_item(NAME(m_APU.step_mode));
 }
 
 /* TODO: sound channels should *ALL* have DC volume decay */
@@ -433,7 +435,7 @@ s8 nesapu_device::apu_dpcm(apu_t::dpcm_t *chan)
 
 	if (chan->enabled)
 	{
-		freq = dpcm_clocks[chan->regs[0] & 0x0F];
+		freq = dpcm_clocks[m_is_pal][chan->regs[0] & 0x0F];
 		chan->phaseacc -= 4;
 
 		while (chan->phaseacc < 0)

--- a/src/devices/sound/nes_apu.h
+++ b/src/devices/sound/nes_apu.h
@@ -68,9 +68,12 @@ private:
 	/* GLOBAL CONSTANTS */
 	static constexpr unsigned  SYNCS_MAX1     = 0x20;
 	static constexpr unsigned  SYNCS_MAX2     = 0x80;
+	static constexpr u32       NTSC_APU_CLOCK = 21477272 / 12;
+	static constexpr u32       PAL_APU_CLOCK  = 26601712 / 16;
 
 	// internal state
 	apu_t   m_APU;                   /* Actual APUs */
+	int     m_is_pal;
 	u32     m_samps_per_sync;        /* Number of samples per vsync */
 	u32     m_buffer_size;           /* Actual buffer size in bytes */
 	u32     m_vbl_times[0x20];       /* VBL durations in samples */

--- a/src/devices/sound/nes_defs.h
+++ b/src/devices/sound/nes_defs.h
@@ -211,10 +211,12 @@ static const int noise_freq[16] =
 	4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 2046
 };
 
-/* dpcm transfer freqs */
-static const int dpcm_clocks[16] =
+// dpcm (cpu) cycle period
+// each frequency is determined as: freq = master / period
+static const int dpcm_clocks[2][16] =
 {
-	428, 380, 340, 320, 286, 254, 226, 214, 190, 160, 142, 128, 106, 85, 72, 54
+	{ 428, 380, 340, 320, 286, 254, 226, 214, 190, 160, 142, 128, 106, 85, 72, 54 }, // NTSC
+	{ 398, 354, 316, 298, 276, 236, 210, 198, 176, 148, 132, 118, 98, 78, 66, 50 } // PAL
 };
 
 /* ratios of pos/neg pulse for square waves */


### PR DESCRIPTION
Fixes pitch being flat for DPCM sounds for nespal (and m82p). This is most apparent in Mr. Gimmick, though it affects all software that use the DPCM channel.