### PR TITLE
yuvomz80.cpp: Correct machine name

### DIFF
--- a/src/mame/drivers/yuvomz80.cpp
+++ b/src/mame/drivers/yuvomz80.cpp
@@ -18,7 +18,7 @@ Golden Hexa: http://www.youtube.com/watch?v=3u1ccTo3SGI
 */
 
 /*
-Golden Hexa by Yubis
+Hexa President by Yubis
 
 PCBs:
 
@@ -48,13 +48,13 @@ public:
 		m_maincpu(*this, "maincpu")
 	{ }
 
-	void goldhexa(machine_config &config);
 	void hexapres(machine_config &config);
+	void hexaprez(machine_config &config);
 
 private:
-	void audio_io_map(address_map &map);
 	void audio_mem_map(address_map &map);
-	void hexapres_audio_io_map(address_map &map);
+	void audio_io_map(address_map &map);
+	void hexaprez_audio_io_map(address_map &map);
 	void io_map(address_map &map);
 	void mem_map(address_map &map);
 
@@ -85,19 +85,36 @@ void yuvomz80_state::audio_mem_map(address_map &map)
 void yuvomz80_state::audio_io_map(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x00, 0x01).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write));
-}
-
-void yuvomz80_state::hexapres_audio_io_map(address_map &map)
-{
-	map.global_mask(0xff);
 	map(0x00, 0x03).rw("ymsnd", FUNC(ym2610_device::read), FUNC(ym2610_device::write));
 }
 
-static INPUT_PORTS_START( goldhexa )
+void yuvomz80_state::hexaprez_audio_io_map(address_map &map)
+{
+	map.global_mask(0xff);
+	map(0x00, 0x01).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write));
+}
+
+static INPUT_PORTS_START( hexapres )
 INPUT_PORTS_END
 
-void yuvomz80_state::goldhexa(machine_config &config)
+void yuvomz80_state::hexapres(machine_config &config)
+{
+	Z80(config, m_maincpu, XTAL(8'000'000));
+	m_maincpu->set_disable();
+
+	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(8'000'000)));
+	audiocpu.set_addrmap(AS_PROGRAM, &yuvomz80_state::audio_mem_map);
+	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::audio_io_map);
+
+	SPEAKER(config, "mono").front_center();
+	ym2610_device &ymsnd(YM2610(config, "ymsnd", 8000000)); // type guessed
+	ymsnd.irq_handler().set_inputline("audiocpu", 0);
+	ymsnd.add_route(0, "mono", 0.25);
+	ymsnd.add_route(1, "mono", 1.0);
+	ymsnd.add_route(2, "mono", 1.0);
+}
+
+void yuvomz80_state::hexaprez(machine_config &config)
 {
 	Z80(config, m_maincpu, XTAL(8'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &yuvomz80_state::mem_map);
@@ -105,7 +122,7 @@ void yuvomz80_state::goldhexa(machine_config &config)
 
 	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(8'000'000)));
 	audiocpu.set_addrmap(AS_PROGRAM, &yuvomz80_state::audio_mem_map);
-	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::audio_io_map);
+	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::hexaprez_audio_io_map);
 
 	I8255A(config, "ppi0", 0);
 	I8255A(config, "ppi1", 0);
@@ -119,36 +136,6 @@ void yuvomz80_state::goldhexa(machine_config &config)
 	ymz.add_route(0, "lspeaker", 1.00);
 	ymz.add_route(1, "rspeaker", 1.00);
 }
-
-void yuvomz80_state::hexapres(machine_config &config)
-{
-	Z80(config, m_maincpu, XTAL(8'000'000));
-	m_maincpu->set_disable();
-
-	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(8'000'000)));
-	audiocpu.set_addrmap(AS_PROGRAM, &yuvomz80_state::audio_mem_map);
-	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::hexapres_audio_io_map);
-
-	SPEAKER(config, "mono").front_center();
-	ym2610_device &ymsnd(YM2610(config, "ymsnd", 8000000)); // type guessed
-	ymsnd.irq_handler().set_inputline("audiocpu", 0);
-	ymsnd.add_route(0, "mono", 0.25);
-	ymsnd.add_route(1, "mono", 1.0);
-	ymsnd.add_route(2, "mono", 1.0);
-}
-
-
-ROM_START( goldhexa )
-	ROM_REGION(0x10000, "maincpu", 0)
-	ROM_LOAD( "ghp_program_ver.1.02.ic8",  0x0000, 0x10000, CRC(a21a8cfd) SHA1(324f54ca6e17373138df2854f8c5e77cf78e9434) ) // 1111xxxxxxxxxxxx = 0xFF
-
-	ROM_REGION(0x10000, "audiocpu", 0)
-	ROM_LOAD( "hp-sp_ver.1.01.ic7",  0x0000, 0x2000, CRC(05133b91) SHA1(2fe931e55c503f15aedfb1c1ea14c257f57c564b) ) // 1xxxxxxxxxxxx = 0xFF
-
-	ROM_REGION(0x100000, "ymz", 0)
-	ROM_LOAD( "ghp_pcm-a_ver.1.01.ic12",  0x00000, 0x80000, CRC(08de888b) SHA1(a6b68accb136481f45b65eab33e0bab5212a1daf) )
-	ROM_LOAD( "ghp_pcm-b_ver.1.01.ic13",  0x80000, 0x80000, CRC(161838c9) SHA1(52b9c324b01702c1164a462af371d82e8c2eea43) )
-ROM_END
 
 ROM_START( hexapres )
 	ROM_REGION(0x10000, "maincpu", 0)
@@ -164,5 +151,17 @@ ROM_START( hexapres )
 	ROM_LOAD( "ghp_voib.bin",  0x00000, 0x80000, CRC(8be745fe) SHA1(840bbb212c8c519f2e4633f8db731fcf3f55635a) )
 ROM_END
 
-GAME( 200?, goldhexa, 0, goldhexa, goldhexa, yuvomz80_state, empty_init, ROT0, "Yubis", "Golden Hexa", MACHINE_IS_SKELETON_MECHANICAL )
-GAME( 200?, hexapres, 0, hexapres, goldhexa, yuvomz80_state, empty_init, ROT0, "Yubis", "Hexa President", MACHINE_IS_SKELETON_MECHANICAL )
+ROM_START( hexaprez )
+	ROM_REGION(0x10000, "maincpu", 0)
+	ROM_LOAD( "ghp_program_ver.1.02.ic8",  0x0000, 0x10000, CRC(a21a8cfd) SHA1(324f54ca6e17373138df2854f8c5e77cf78e9434) ) // 1111xxxxxxxxxxxx = 0xFF
+
+	ROM_REGION(0x10000, "audiocpu", 0)
+	ROM_LOAD( "hp-sp_ver.1.01.ic7",  0x0000, 0x2000, CRC(05133b91) SHA1(2fe931e55c503f15aedfb1c1ea14c257f57c564b) ) // 1xxxxxxxxxxxx = 0xFF
+
+	ROM_REGION(0x100000, "ymz", 0)
+	ROM_LOAD( "ghp_pcm-a_ver.1.01.ic12",  0x00000, 0x80000, CRC(08de888b) SHA1(a6b68accb136481f45b65eab33e0bab5212a1daf) )
+	ROM_LOAD( "ghp_pcm-b_ver.1.01.ic13",  0x80000, 0x80000, CRC(161838c9) SHA1(52b9c324b01702c1164a462af371d82e8c2eea43) )
+ROM_END
+
+GAME( 1995, hexapres, 0, hexapres, hexapres, yuvomz80_state, empty_init, ROT0, "Yubis", "Hexa President (YM2610 set)", MACHINE_IS_SKELETON_MECHANICAL )
+GAME( 1995, hexaprez, 0, hexaprez, hexapres, yuvomz80_state, empty_init, ROT0, "Yubis", "Hexa President (YMZ280B set)", MACHINE_IS_SKELETON_MECHANICAL )

--- a/src/mame/drivers/yuvomz80.cpp
+++ b/src/mame/drivers/yuvomz80.cpp
@@ -18,7 +18,7 @@ Golden Hexa: http://www.youtube.com/watch?v=3u1ccTo3SGI
 */
 
 /*
-Hexa President by Yubis
+Hexa President by Yuvo / Yubis
 
 PCBs:
 
@@ -48,13 +48,13 @@ public:
 		m_maincpu(*this, "maincpu")
 	{ }
 
-	void hexapres(machine_config &config);
-	void hexaprez(machine_config &config);
+	void hexaprs(machine_config &config);
+	void hexaprsz(machine_config &config);
 
 private:
 	void audio_mem_map(address_map &map);
 	void audio_io_map(address_map &map);
-	void hexaprez_audio_io_map(address_map &map);
+	void hexaprsz_audio_io_map(address_map &map);
 	void io_map(address_map &map);
 	void mem_map(address_map &map);
 
@@ -88,16 +88,16 @@ void yuvomz80_state::audio_io_map(address_map &map)
 	map(0x00, 0x03).rw("ymsnd", FUNC(ym2610_device::read), FUNC(ym2610_device::write));
 }
 
-void yuvomz80_state::hexaprez_audio_io_map(address_map &map)
+void yuvomz80_state::hexaprsz_audio_io_map(address_map &map)
 {
 	map.global_mask(0xff);
 	map(0x00, 0x01).rw("ymz", FUNC(ymz280b_device::read), FUNC(ymz280b_device::write));
 }
 
-static INPUT_PORTS_START( hexapres )
+static INPUT_PORTS_START( hexaprs )
 INPUT_PORTS_END
 
-void yuvomz80_state::hexapres(machine_config &config)
+void yuvomz80_state::hexaprs(machine_config &config)
 {
 	Z80(config, m_maincpu, XTAL(8'000'000));
 	m_maincpu->set_disable();
@@ -114,7 +114,7 @@ void yuvomz80_state::hexapres(machine_config &config)
 	ymsnd.add_route(2, "mono", 1.0);
 }
 
-void yuvomz80_state::hexaprez(machine_config &config)
+void yuvomz80_state::hexaprsz(machine_config &config)
 {
 	Z80(config, m_maincpu, XTAL(8'000'000));
 	m_maincpu->set_addrmap(AS_PROGRAM, &yuvomz80_state::mem_map);
@@ -122,7 +122,7 @@ void yuvomz80_state::hexaprez(machine_config &config)
 
 	z80_device &audiocpu(Z80(config, "audiocpu", XTAL(8'000'000)));
 	audiocpu.set_addrmap(AS_PROGRAM, &yuvomz80_state::audio_mem_map);
-	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::hexaprez_audio_io_map);
+	audiocpu.set_addrmap(AS_IO, &yuvomz80_state::hexaprsz_audio_io_map);
 
 	I8255A(config, "ppi0", 0);
 	I8255A(config, "ppi1", 0);
@@ -137,9 +137,9 @@ void yuvomz80_state::hexaprez(machine_config &config)
 	ymz.add_route(1, "rspeaker", 1.00);
 }
 
-ROM_START( hexapres )
+ROM_START( hexaprs )
 	ROM_REGION(0x10000, "maincpu", 0)
-	ROM_LOAD( "hexapres.bin",  0x0000, 0x10000, NO_DUMP )
+	ROM_LOAD( "hexaprs.bin",  0x0000, 0x10000, NO_DUMP )
 
 	ROM_REGION(0x10000, "audiocpu", 0)
 	ROM_LOAD( "ghp_snd.bin",  0x0000, 0x10000, CRC(8933b6ea) SHA1(a66157f2b7407ab374db07bcda34f066740f14dc) )
@@ -151,7 +151,7 @@ ROM_START( hexapres )
 	ROM_LOAD( "ghp_voib.bin",  0x00000, 0x80000, CRC(8be745fe) SHA1(840bbb212c8c519f2e4633f8db731fcf3f55635a) )
 ROM_END
 
-ROM_START( hexaprez )
+ROM_START( hexaprsz )
 	ROM_REGION(0x10000, "maincpu", 0)
 	ROM_LOAD( "ghp_program_ver.1.02.ic8",  0x0000, 0x10000, CRC(a21a8cfd) SHA1(324f54ca6e17373138df2854f8c5e77cf78e9434) ) // 1111xxxxxxxxxxxx = 0xFF
 
@@ -163,5 +163,5 @@ ROM_START( hexaprez )
 	ROM_LOAD( "ghp_pcm-b_ver.1.01.ic13",  0x80000, 0x80000, CRC(161838c9) SHA1(52b9c324b01702c1164a462af371d82e8c2eea43) )
 ROM_END
 
-GAME( 1995, hexapres, 0, hexapres, hexapres, yuvomz80_state, empty_init, ROT0, "Yubis", "Hexa President (YM2610 set)", MACHINE_IS_SKELETON_MECHANICAL )
-GAME( 1995, hexaprez, 0, hexaprez, hexapres, yuvomz80_state, empty_init, ROT0, "Yubis", "Hexa President (YMZ280B set)", MACHINE_IS_SKELETON_MECHANICAL )
+GAME( 1995, hexaprs,  0,       hexaprs,  hexaprs, yuvomz80_state, empty_init, ROT0, "Yuvo / Yubis", "Hexa President (YM2610 set)", MACHINE_IS_SKELETON_MECHANICAL )
+GAME( 1995, hexaprsz, hexaprs, hexaprsz, hexaprs, yuvomz80_state, empty_init, ROT0, "Yuvo / Yubis", "Hexa President (YMZ280B set)", MACHINE_IS_SKELETON_MECHANICAL )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43823,7 +43823,7 @@ rocktris                        // (c) 1994? Yun Sung
 
 @source:yuvomz80.cpp
 hexaprs                         // 1995 Yuvo / Yubis - Hexa President (YM2610 set)
-hexaprz                         // 1995 Yuvo / Yubis - Hexa President (YMZ280B set)
+hexaprsz                        // 1995 Yuvo / Yubis - Hexa President (YMZ280B set)
 
 @source:z100.cpp
 z100                            //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43822,8 +43822,8 @@ magixb                          // bootleg
 rocktris                        // (c) 1994? Yun Sung
 
 @source:yuvomz80.cpp
-hexapres                        // 1995 Yuvo / Yubis - Hexa President (YM2610 set)
-hexaprez                        // 1995 Yuvo / Yubis - Hexa President (YMZ280B set)
+hexaprs                         // 1995 Yuvo / Yubis - Hexa President (YM2610 set)
+hexaprz                         // 1995 Yuvo / Yubis - Hexa President (YMZ280B set)
 
 @source:z100.cpp
 z100                            //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43822,8 +43822,8 @@ magixb                          // bootleg
 rocktris                        // (c) 1994? Yun Sung
 
 @source:yuvomz80.cpp
-hexapres                        // 1995 Yubis
-hexaprez                        // 1995 Yubis
+goldhexa                        // Yuvo / Yubis
+hexapres                        //
 
 @source:z100.cpp
 z100                            //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43822,8 +43822,8 @@ magixb                          // bootleg
 rocktris                        // (c) 1994? Yun Sung
 
 @source:yuvomz80.cpp
-goldhexa                        // Yuvo / Yubis
-hexapres                        //
+hexapres                        // 1995 Yubis
+hexaprez                        // 1995 Yubis
 
 @source:z100.cpp
 z100                            //

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -43822,8 +43822,8 @@ magixb                          // bootleg
 rocktris                        // (c) 1994? Yun Sung
 
 @source:yuvomz80.cpp
-goldhexa                        // Yuvo / Yubis
-hexapres                        //
+hexapres                        // 1995 Yuvo / Yubis - Hexa President (YM2610 set)
+hexaprez                        // 1995 Yuvo / Yubis - Hexa President (YMZ280B set)
 
 @source:z100.cpp
 z100                            //


### PR DESCRIPTION
From YouTube video references and ROM analyzing, ymz ICs of conventional goldhexa set have sounds of Hexa President and doesn't have songs of Golden Hexa.
goldhexa set should be renamed as "Hexa President (YMZ280B set)".

Release month of Hexa President is described as early June of 1995 in Game Machine no.499 (https://onitama.tv/gamemachine/pdf/19950715p.pdf) P.19.
(Golden Hexa is posted its advertise in Game Machine no.457 (https://onitama.tv/gamemachine/pdf/19930915p.pdf) p.11, published in 1993.)