### PR TITLE
segag80v.cpp: Corrected speech ROM labels for zektor and startrek

### DIFF
--- a/src/mame/drivers/segag80v.cpp
+++ b/src/mame/drivers/segag80v.cpp
@@ -1252,7 +1252,7 @@ ROM_START( zektor )
 	ROM_LOAD( "1606.prom-u21",   0xa800, 0x0800, CRC(7965f636) SHA1(5c8720beedab4979a813ce7f0e8961c863973ff7) )
 
 	ROM_REGION( 0x0800, "speech:cpu", 0 )
-	ROM_LOAD( "1670.speech-u7",  0x0000, 0x0800, CRC(b779884b) SHA1(ac07e99717a1f51b79f3e43a5d873ebfa0559320) )
+	ROM_LOAD( "1607.speech-u7",  0x0000, 0x0800, CRC(b779884b) SHA1(ac07e99717a1f51b79f3e43a5d873ebfa0559320) )
 
 	ROM_REGION( 0x0020, "speech:proms", 0 )
 	ROM_LOAD( "6331.speech-u30", 0x0000, 0x0020, CRC(adcb81d0) SHA1(74b0efc7e8362b0c98e54a6107981cff656d87e1) ) // speech board addressing
@@ -1327,7 +1327,7 @@ ROM_START( startrek )
 	ROM_LOAD( "1870.prom-u23",   0xb800, 0x0800, CRC(4340616d) SHA1(e93686a29377933332523425532d102e30211111) )
 
 	ROM_REGION( 0x0800, "speech:cpu", 0 )
-	ROM_LOAD( "1670.speech-u7",  0x0000, 0x0800, CRC(b779884b) SHA1(ac07e99717a1f51b79f3e43a5d873ebfa0559320) )
+	ROM_LOAD( "1607.speech-u7",  0x0000, 0x0800, CRC(b779884b) SHA1(ac07e99717a1f51b79f3e43a5d873ebfa0559320) )
 
 	ROM_REGION( 0x0020, "speech:proms", 0 )
 	ROM_LOAD( "6331.speech-u30", 0x0000, 0x0020, CRC(adcb81d0) SHA1(74b0efc7e8362b0c98e54a6107981cff656d87e1) ) // speech board addressing


### PR DESCRIPTION
I recently ran mame and saw I could no longer run zektor due to this commit:

Fix a typo in a ROM filename (1607->1670) commit d26b99931c00c2ec5d097bfc82d443dad4d44469

The 1607 was not a typo; I was there 25 years ago when the ROMS for Zektor were
originally read from the speech PCB.

In addition, I noticed that startrek had, all this time, also been using the incorrect
ROM labeling.  A quick online search of "star trek speech pcb" will bring up a visual of the original
PCB with the EPROM clearly labeled "1607". 

Besides, EPROM number 1670 is reserved for Tac/Scan; Sega/Gremlin didn't reuse EPROM numbers, though they
did reuse the eproms themselves across games (for example, Space Fury and Astro Blaster also share speech EPROM 808).

Unfortunately, this will effect people playing zektor and startrek. Perhaps mame needs either a more
stringent review for EPROM labeling changes or a fuzzy match/renaming based on matching crc so changes like
this will be less impactful
![star_trek_speech](https://user-images.githubusercontent.com/10748638/150002778-2ec03421-c0cc-474f-b438-da7f5902d9f3.jpg)
.