### PR TITLE
ampro.cpp: Added quad density 5.25" floppy drive option

### DIFF
--- a/src/mame/drivers/ampro.cpp
+++ b/src/mame/drivers/ampro.cpp
@@ -168,6 +168,7 @@ static const z80_daisy_config daisy_chain_intf[] =
 static void ampro_floppies(device_slot_interface &device)
 {
 	device.option_add("525dd", FLOPPY_525_DD);
+	device.option_add("525qd", FLOPPY_525_QD);
 }
 
 /* Input ports */


### PR DESCRIPTION
Added a second call to the "ampro_floppies" function to add support DSQD drives as an option for a given floppy device. 