### PR TITLE
Fix building with gcc-12

### DIFF
--- a/src/lib/netlist/plib/pstream.h
+++ b/src/lib/netlist/plib/pstream.h
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <ios>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
Fedora rawhide has updated gcc to version 12. Minimal changes are required to get mame to build.