### PR TITLE
bus/nes: Updated all Konami VRC boards.

### DIFF
--- a/hash/nes.hsi
+++ b/hash/nes.hsi
@@ -33904,11 +33904,11 @@ license:CC0
 	</hash>
 	<hash crc32="743387ff" sha1="2dc2c795421a5db2427c460f35828a23beba9274" name="Lagrange Point (J)">
 		<status>Known Bad Image</status>
-		<extrainfo>85 2 32 0</extrainfo>
+		<extrainfo>85 130 32 0</extrainfo>
 
 	</hash>
 	<hash crc32="33ce3ff0" sha1="c87e7e6a68dd9c7e24652cd2c7d390a14e8adf04" name="Lagrange Point (J)">
-		<extrainfo>85 2 32 0</extrainfo>
+		<extrainfo>85 130 32 0</extrainfo>
 
 	</hash>
 	<hash crc32="0865e77a" sha1="78b063838b95c28801812fb8dfb08e4aabefb24e" name="Lam by darkdata (Milk &amp; Nuts Hack)">

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -21508,7 +21508,7 @@ license:CC0
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="vrc7" />
 			<feature name="pcb" value="KONAMI-VRC-7" />
-			<feature name="vrc7-pin17" value="PRG A4" />
+			<feature name="vrc7-pin19" value="PRG A4" />
 			<dataarea name="prg" size="524288">
 				<rom name="rc851j00p" size="524288" crc="743387ff" sha1="2dc2c795421a5db2427c460f35828a23beba9274" offset="00000" />
 			</dataarea>
@@ -39732,7 +39732,7 @@ license:CC0
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="vrc7" />
 			<feature name="pcb" value="KONAMI-VRC-7" />
-			<feature name="vrc7-pin17" value="PRG A3" />
+			<feature name="vrc7-pin19" value="PRG A3" />
 			<dataarea name="prg" size="131072">
 				<rom name="rv051j00p" size="131072" crc="1aa0479c" sha1="8ab54a69f551d954179109fb5ae33df42ba2eb30" offset="00000" />
 			</dataarea>
@@ -75823,7 +75823,7 @@ Other
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="vrc7" />
 			<feature name="pcb" value="KONAMI-VRC-7" />
-			<feature name="vrc7-pin17" value="PRG A3" /> <!-- unconfirmed, based on Tiny Toon 2 -->
+			<feature name="vrc7-pin19" value="PRG A3" />
 			<dataarea name="chr" size="131072">
 				<rom name="super mario bros 14 (unl).chr" size="131072" crc="24e491ea" sha1="324f922f8f7cdecb948a5348d79e37428654c1bc" offset="00000" status="baddump" />
 			</dataarea>
@@ -78054,6 +78054,7 @@ be better to redump them properly. -->
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="vrc7" />
 			<feature name="pcb" value="UNL-VRC7" />
+			<feature name="vrc7-pin19" value="PRG A3" />
 			<dataarea name="chr" size="262144">
 				<rom name="mortal kombat v pro [p1][u].chr" size="262144" crc="879fadf1" sha1="9f38b8fa75d70b518ac5cb5886718bba51c43846" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes/kaiser.cpp
+++ b/src/devices/bus/nes/kaiser.cpp
@@ -526,7 +526,7 @@ void nes_ks7032_device::write_h(offs_t offset, u8 data)
 		case 0x2000:
 		case 0x3000:
 		{
-			int shift = (offset >> 10);
+			int shift = 4 * BIT(offset, 12, 2);
 			m_irq_count_latch &= ~(0x000f << shift);
 			m_irq_count_latch |= (data & 0x0f) << shift;
 			break;

--- a/src/devices/bus/nes/konami.cpp
+++ b/src/devices/bus/nes/konami.cpp
@@ -16,11 +16,6 @@
  * Konami VRC-6 [mapper 24,26]
  * Konami VRC-7 [mapper 85]
 
-
- TODO:
- - improve IRQ (CPU mode not currently emulated)
- - add VRC-6 sound features
-
  ***********************************************************************************************************/
 
 
@@ -50,28 +45,28 @@ DEFINE_DEVICE_TYPE(NES_VRC6, nes_konami_vrc6_device, "nes_vrc6", "NES Cart Konam
 DEFINE_DEVICE_TYPE(NES_VRC7, nes_konami_vrc7_device, "nes_vrc7", "NES Cart Konami VRC-7 PCB")
 
 
-nes_konami_vrc1_device::nes_konami_vrc1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc1_device::nes_konami_vrc1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_VRC1, tag, owner, clock)
 {
 }
 
-nes_konami_vrc2_device::nes_konami_vrc2_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc2_device::nes_konami_vrc2_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, type, tag, owner, clock), m_latch(0)
 {
 }
 
-nes_konami_vrc2_device::nes_konami_vrc2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc2_device::nes_konami_vrc2_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_konami_vrc2_device(mconfig, NES_VRC2, tag, owner, clock)
 {
 }
 
-nes_konami_vrc3_device::nes_konami_vrc3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc3_device::nes_konami_vrc3_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_VRC3, tag, owner, clock), m_irq_count(0), m_irq_count_latch(0), m_irq_enable(0), m_irq_enable_latch(0), m_irq_mode(0), irq_timer(nullptr)
 {
 }
 
 nes_konami_vrc4_device::nes_konami_vrc4_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
-	: nes_nrom_device(mconfig, type, tag, owner, clock), m_prg_flip(0), m_irq_count(0), m_irq_count_latch(0), m_irq_enable(0), m_irq_enable_latch(0), m_irq_mode(0), m_irq_prescale(0), irq_timer(nullptr)
+	: nes_nrom_device(mconfig, type, tag, owner, clock), m_prg_flip(0), m_wram_enable(0), m_irq_count(0), m_irq_count_latch(0), m_irq_enable(0), m_irq_enable_latch(0), m_irq_mode(0), m_irq_prescale(0), irq_timer(nullptr)
 {
 }
 
@@ -80,12 +75,12 @@ nes_konami_vrc4_device::nes_konami_vrc4_device(const machine_config &mconfig, co
 {
 }
 
-nes_konami_vrc6_device::nes_konami_vrc6_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc6_device::nes_konami_vrc6_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_konami_vrc4_device(mconfig, NES_VRC6, tag, owner, clock), m_vrc6snd(*this, "vrc6snd")
 {
 }
 
-nes_konami_vrc7_device::nes_konami_vrc7_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_konami_vrc7_device::nes_konami_vrc7_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_konami_vrc4_device(mconfig, NES_VRC7, tag, owner, clock), m_vrc7snd(*this, "vrc7snd")
 {
 }
@@ -105,7 +100,7 @@ void nes_konami_vrc1_device::pcb_reset()
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
 
-	memset(m_mmc_vrom_bank, 0, sizeof(m_mmc_vrom_bank));
+	m_mmc_vrom_bank[0] = m_mmc_vrom_bank[1] = 0;
 }
 
 void nes_konami_vrc2_device::device_start()
@@ -123,7 +118,7 @@ void nes_konami_vrc2_device::pcb_reset()
 	chr8(0, m_chr_source);
 
 	m_latch = 0;
-	memset(m_mmc_vrom_bank, 0, sizeof(m_mmc_vrom_bank));
+	std::fill(std::begin(m_mmc_vrom_bank), std::end(m_mmc_vrom_bank), 0x00);
 }
 
 void nes_konami_vrc3_device::device_start()
@@ -153,7 +148,6 @@ void nes_konami_vrc3_device::pcb_reset()
 	m_irq_count_latch = 0;
 }
 
-
 void nes_konami_vrc4_device::device_start()
 {
 	common_start();
@@ -167,6 +161,7 @@ void nes_konami_vrc4_device::device_start()
 	save_item(NAME(m_irq_count));
 	save_item(NAME(m_irq_count_latch));
 	save_item(NAME(m_prg_flip));
+	save_item(NAME(m_wram_enable));
 	save_item(NAME(m_mmc_prg_bank));
 	save_item(NAME(m_mmc_vrom_bank));
 }
@@ -184,46 +179,17 @@ void nes_konami_vrc4_device::pcb_reset()
 	m_irq_count_latch = 0;
 
 	m_prg_flip = 0;
+	m_wram_enable = 0;
 	m_mmc_prg_bank[0] = 0;
 	m_mmc_prg_bank[1] = 0;
 	set_prg();
 	std::fill(std::begin(m_mmc_vrom_bank), std::end(m_mmc_vrom_bank), 0x00);
 }
 
-void nes_konami_vrc6_device::device_start()
-{
-	nes_konami_vrc4_device::device_start();
-}
-
-void nes_konami_vrc7_device::device_start()
-{
-	common_start();
-	irq_timer = timer_alloc(TIMER_IRQ);
-	irq_timer->adjust(attotime::zero, 0, clocks_to_attotime(1));
-
-	save_item(NAME(m_irq_mode));
-	save_item(NAME(m_irq_prescale));
-	save_item(NAME(m_irq_enable));
-	save_item(NAME(m_irq_enable_latch));
-	save_item(NAME(m_irq_count));
-	save_item(NAME(m_irq_count_latch));
-}
-
 void nes_konami_vrc7_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg8_89(0);
-	prg8_ab(0);
-	prg8_cd(0);
-	prg8_ef(0xff);
-	chr8(0, m_chr_source);
-
-	m_irq_mode = 0;
-	m_irq_prescale = 0;
-	m_irq_enable = 0;
-	m_irq_enable_latch = 0;
-	m_irq_count = 0;
-	m_irq_count_latch = 0;
+	nes_konami_vrc4_device::pcb_reset();
+	prg32((m_prg_chunks >> 1) - 1);
 }
 
 
@@ -240,29 +206,25 @@ void nes_konami_vrc7_device::pcb_reset()
 
  iNES: mapper 75
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_konami_vrc1_device::write_h(offs_t offset, uint8_t data)
+void nes_konami_vrc1_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("VRC-1 write_h, offset: %04x, data: %02x\n", offset, data));
 
 	switch (offset & 0x7000)
 	{
 		case 0x0000:
-			prg8_89(data);
-			break;
 		case 0x2000:
-			prg8_ab(data);
-			break;
 		case 0x4000:
-			prg8_cd(data);
+			prg8_x(BIT(offset, 13, 2), data & 0x0f);
 			break;
 		case 0x1000:
-			set_nt_mirroring((data & 0x01) ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
-			m_mmc_vrom_bank[0] = (m_mmc_vrom_bank[0] & 0x0f) | ((data & 0x02) << 3);
-			m_mmc_vrom_bank[1] = (m_mmc_vrom_bank[1] & 0x0f) | ((data & 0x04) << 2);
+			set_nt_mirroring(data & 1 ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
+			m_mmc_vrom_bank[0] = (m_mmc_vrom_bank[0] & 0x0f) | BIT(data, 1) << 4;
+			m_mmc_vrom_bank[1] = (m_mmc_vrom_bank[1] & 0x0f) | BIT(data, 2) << 4;
 			chr4_0(m_mmc_vrom_bank[0], CHRROM);
 			chr4_4(m_mmc_vrom_bank[1], CHRROM);
 			break;
@@ -281,11 +243,11 @@ void nes_konami_vrc1_device::write_h(offs_t offset, uint8_t data)
 
  Konami VRC-2
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-uint8_t nes_konami_vrc2_device::read_m(offs_t offset)
+u8 nes_konami_vrc2_device::read_m(offs_t offset)
 {
 	LOG_MMC(("VRC-2 read_m, offset: %04x\n", offset));
 
@@ -293,11 +255,11 @@ uint8_t nes_konami_vrc2_device::read_m(offs_t offset)
 		return m_battery[offset & (m_battery.size() - 1)];
 	else if (!m_prgram.empty())
 		return m_prgram[offset & (m_prgram.size() - 1)];
-	else    // sort of protection? it returns open bus in $7000-$7fff and (open bus & 0xfe) | m_latch in $6000-$6fff
-		return (offset < 0x1000) ? ((get_open_bus() & 0xfe) | (m_latch & 1)) : get_open_bus();
+	else    // VRC2 was planned with EEPROM support; the non-working feature behaves as a vestigial 1-bit latch in $6000-$6fff on certain boards (contraj, ggoemon2 depend on this)
+		return (offset < 0x1000) ? (get_open_bus() & 0xfe) | (m_latch & 1) : get_open_bus();
 }
 
-void nes_konami_vrc2_device::write_m(offs_t offset, uint8_t data)
+void nes_konami_vrc2_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("VRC-2 write_m, offset: %04x, data: %02x\n", offset, data));
 
@@ -309,19 +271,17 @@ void nes_konami_vrc2_device::write_m(offs_t offset, uint8_t data)
 		m_latch = data;
 }
 
-void nes_konami_vrc2_device::write_h(offs_t offset, uint8_t data)
+void nes_konami_vrc2_device::write_h(offs_t offset, u8 data)
 {
-	uint8_t bank, shift, mask;
-	uint16_t add_lines = ((offset << (9 - m_vrc_ls_prg_a)) & 0x200) | ((offset << (8 - m_vrc_ls_prg_b)) & 0x100);
 	LOG_MMC(("VRC-2 write_h, offset: %04x, data: %02x\n", offset, data));
+
+	u8 addr_lines = bitswap<2>(offset, m_vrc_ls_prg_a, m_vrc_ls_prg_b);
 
 	switch (offset & 0x7000)
 	{
 		case 0x0000:
-			prg8_89(data);
-			break;
 		case 0x2000:
-			prg8_ab(data);
+			prg8_x(BIT(offset, 13), data);
 			break;
 		case 0x1000:
 			set_nt_mirroring(data & 1 ? PPU_MIRROR_HORZ : PPU_MIRROR_VERT);
@@ -330,12 +290,14 @@ void nes_konami_vrc2_device::write_h(offs_t offset, uint8_t data)
 		case 0x4000:
 		case 0x5000:
 		case 0x6000:
-			bank = ((offset & 0x7000) - 0x3000) / 0x0800 + BIT(add_lines, 9);
-			shift = BIT(add_lines, 8) * 4;
-			mask = (0xf0 >> shift);
-			m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & mask) | (((data >> m_vrc_ls_chr) & 0x0f) << shift);
-			chr1_x(bank, m_mmc_vrom_bank[bank], CHRROM);
+		{
+			int bank = 2 * (BIT(offset, 12, 3) - 3) + BIT(addr_lines, 1);
+			int shift = BIT(addr_lines, 0) * 4;
+			int mask = 0x0f << shift;
+			m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & ~mask) | (((data >> m_vrc_ls_chr) << shift) & mask);
+			chr1_x(bank, m_mmc_vrom_bank[bank], m_chr_source);
 			break;
+		}
 		default:
 			logerror("VRC-2 write_h uncaught write, addr: %04x value: %02x\n", offset + 0x8000, data);
 			break;
@@ -350,7 +312,7 @@ void nes_konami_vrc2_device::write_h(offs_t offset, uint8_t data)
 
  iNES: mapper 73
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
@@ -360,53 +322,40 @@ void nes_konami_vrc3_device::device_timer(emu_timer &timer, device_timer_id id, 
 	{
 		if (m_irq_enable)
 		{
-			if (m_irq_mode) // 8bits mode
+			u16 mask = m_irq_mode ? 0x00ff : 0xffff; // 8 or 16 bit mode?
+
+			// upper byte only incremented and reloaded in 16-bit mode
+			m_irq_count = (m_irq_count & ~mask) | ((m_irq_count + 1) & mask);
+			if (!(m_irq_count & mask))
 			{
-				if ((m_irq_count & 0x00ff) == 0xff)
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = m_irq_count_latch;
-				}
-				else
-					m_irq_count = (m_irq_count & 0xff00) | ((m_irq_count & 0x00ff) + 1);
-			}
-			else    // 16bits mode
-			{
-				if (m_irq_count == 0xffff)
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = m_irq_count_latch;
-				}
-				else
-					m_irq_count++;
+				set_irq_line(ASSERT_LINE);
+				m_irq_count = (m_irq_count & ~mask) | (m_irq_count_latch & mask);
 			}
 		}
 	}
 }
 
-void nes_konami_vrc3_device::write_h(offs_t offset, uint8_t data)
+void nes_konami_vrc3_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("VRC-3 write_h, offset: %04x, data: %02x\n", offset, data));
 
 	switch (offset & 0x7000)
 	{
 		case 0x0000:
-			m_irq_count_latch = (m_irq_count_latch & 0xfff0) | ((data & 0x0f) << 0);
-			break;
 		case 0x1000:
-			m_irq_count_latch = (m_irq_count_latch & 0xff0f) | ((data & 0x0f) << 4);
-			break;
 		case 0x2000:
-			m_irq_count_latch = (m_irq_count_latch & 0xf0ff) | ((data & 0x0f) << 8);
-			break;
 		case 0x3000:
-			m_irq_count_latch = (m_irq_count_latch & 0x0fff) | ((data & 0x0f) << 12);
+		{
+			int shift = 4 * BIT(offset, 12, 2);
+			m_irq_count_latch &= ~(0x000f << shift);
+			m_irq_count_latch |= (data & 0x0f) << shift;
 			break;
+		}
 		case 0x4000:
 			m_irq_mode = data & 0x04;
 			m_irq_enable = data & 0x02;
 			m_irq_enable_latch = data & 0x01;
-			if (data & 0x02)
+			if (m_irq_enable)
 				m_irq_count = m_irq_count_latch;
 			set_irq_line(CLEAR_LINE);
 			break;
@@ -415,7 +364,7 @@ void nes_konami_vrc3_device::write_h(offs_t offset, uint8_t data)
 			set_irq_line(CLEAR_LINE);
 			break;
 		case 0x7000:
-			prg16_89ab(data);
+			prg16_89ab(data & 0x07);
 			break;
 		default:
 			logerror("VRC-3 write_h uncaught write, offset %04x, data: %02x\n", offset, data);
@@ -505,11 +454,29 @@ void nes_konami_vrc4_device::set_prg(int prg_base, int prg_mask)
 	prg8_x(3, prg_base | prg_mask);
 }
 
+u8 nes_konami_vrc4_device::read_m(offs_t offset)
+{
+	LOG_MMC(("VRC-4 read_m, offset: %04x\n", offset));
+
+	if (m_wram_enable)
+		return device_nes_cart_interface::read_m(offset);
+	else
+		return get_open_bus();
+}
+
+void nes_konami_vrc4_device::write_m(offs_t offset, u8 data)
+{
+	LOG_MMC(("VRC-4 write_m, offset: %04x, data: %02x\n", offset, data));
+
+	if (m_wram_enable)
+		device_nes_cart_interface::write_m(offset, data);
+}
+
 void nes_konami_vrc4_device::write_h(offs_t offset, u8 data)
 {
-	int bank, shift, mask;
-	u16 add_lines = ((offset << (9 - m_vrc_ls_prg_a)) & 0x200) | ((offset << (8 - m_vrc_ls_prg_b)) & 0x100);
 	LOG_MMC(("VRC-4 write_h, offset: %04x, data: %02x\n", offset, data));
+
+	u8 addr_lines = bitswap<2>(offset, m_vrc_ls_prg_a, m_vrc_ls_prg_b);
 
 	switch (offset & 0x7000)
 	{
@@ -519,8 +486,9 @@ void nes_konami_vrc4_device::write_h(offs_t offset, u8 data)
 			set_prg();
 			break;
 		case 0x1000:
-			if (add_lines & 0x200)
+			if (BIT(addr_lines, 1))
 			{
+				m_wram_enable = data & 0x01;
 				m_prg_flip = data & 0x02;
 				set_prg();
 			}
@@ -531,31 +499,30 @@ void nes_konami_vrc4_device::write_h(offs_t offset, u8 data)
 		case 0x4000:
 		case 0x5000:
 		case 0x6000:
-			bank = ((offset & 0x7000) - 0x3000) / 0x0800 + BIT(add_lines, 9);
-			shift = BIT(add_lines, 8) * 4;
-			mask = shift ? 0x1f0 : 0x0f;
+		{
+			int bank = 2 * (BIT(offset, 12, 3) - 3) + BIT(addr_lines, 1);
+			int shift = BIT(addr_lines, 0) * 4;
+			int mask = shift ? 0x1f0 : 0x0f;
 			m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & ~mask) | ((data << shift) & mask);
 			chr1_x(bank, m_mmc_vrom_bank[bank], m_chr_source);
 			break;
+		}
 		case 0x7000:
-			switch (add_lines)
+			switch (addr_lines)
 			{
-				case 0x000:
+				case 0:
 					m_irq_count_latch = (m_irq_count_latch & 0xf0) | (data & 0x0f);
 					break;
-				case 0x100:
-					m_irq_count_latch = (m_irq_count_latch & 0x0f) | ((data & 0x0f) << 4);
+				case 1:
+					m_irq_count_latch = (m_irq_count_latch & 0x0f) | (data & 0x0f) << 4;
 					break;
-				case 0x200:
+				case 2:
 					irq_ctrl_w(data);
 					break;
-				case 0x300:
+				case 3:
 					irq_ack_w();
 					break;
 			}
-			break;
-		default:
-			logerror("VRC-4 write_h uncaught write, addr: %04x value: %02x\n", ((offset & 0x7000) | add_lines) + 0x8000, data);
 			break;
 	}
 }
@@ -564,61 +531,63 @@ void nes_konami_vrc4_device::write_h(offs_t offset, u8 data)
 
  Konami VRC-6
 
- In MESS: Supported. It also uses konami_irq (there are IRQ
+ In MAME: Supported. It also uses konami_irq (there are IRQ
  issues though: see Akumajou Densetsu intro).
+
+ TODO: Implement other CHR modes not used by any of
+ the three released VRC6 games?
 
  -------------------------------------------------*/
 
-void nes_konami_vrc6_device::write_h(offs_t offset, uint8_t data)
+void nes_konami_vrc6_device::write_h(offs_t offset, u8 data)
 {
-	uint8_t bank;
-	uint16_t add_lines = ((offset << (9 - m_vrc_ls_prg_a)) & 0x200) | ((offset << (8 - m_vrc_ls_prg_b)) & 0x100);
 	LOG_MMC(("VRC-6 write_h, offset: %04x, data: %02x\n", offset, data));
+
+	u8 addr_lines = bitswap<2>(offset, m_vrc_ls_prg_a, m_vrc_ls_prg_b);
 
 	switch (offset & 0x7000)
 	{
 		case 0x0000:
-			prg16_89ab(data);
+			prg16_89ab(data & 0x0f);
 			break;
 		case 0x4000:
-			prg8_cd(data);
+			prg8_cd(data & 0x1f);
 			break;
 		case 0x1000:    // pulse 1 & global control
-			m_vrc6snd->write(add_lines>>8, data);
+			m_vrc6snd->write(addr_lines, data);
 			break;
 		case 0x2000:    // pulse 2
-			m_vrc6snd->write((add_lines>>8) | 0x100, data);
+			m_vrc6snd->write(addr_lines | 0x100, data);
 			break;
 		case 0x3000:
-			if (add_lines == 0x300)
+			if (addr_lines == 3)
+			{
 				set_mirror(data >> 2);
+				m_wram_enable = BIT(data, 7);
+			}
 			else    // saw
-				m_vrc6snd->write((add_lines>>8) | 0x200, data);
+				m_vrc6snd->write(addr_lines | 0x200, data);
 			break;
 		case 0x5000:
 		case 0x6000:
-			bank = ((offset & 0x7000) - 0x5000) / 0x0400 + ((add_lines & 0x0300) >> 8);
-			chr1_x(bank, data, CHRROM);
+			chr1_x(4 * BIT(offset, 13) + addr_lines, data, CHRROM);
 			break;
 		case 0x7000:
-			switch (add_lines)
+			switch (addr_lines)
 			{
-				case 0x000:
+				case 0:
 					m_irq_count_latch = data;
 					break;
-				case 0x100:
+				case 1:
 					irq_ctrl_w(data);
 					break;
-				case 0x200:
+				case 2:
 					irq_ack_w();
 					break;
 				default:
-					logerror("VRC-6 write_h uncaught write, addr: %04x value: %02x\n", ((offset & 0x7000) | add_lines) + 0x8000, data);
+					logerror("VRC-6 write_h uncaught write, addr: %04x value: %02x\n", ((offset & 0x7000) | addr_lines) + 0x8000, data);
 					break;
 			}
-			break;
-		default:
-			logerror("VRC-6 write_h uncaught write, addr: %04x value: %02x\n", ((offset & 0x7000) | add_lines) + 0x8000, data);
 			break;
 	}
 }
@@ -646,74 +615,51 @@ void nes_konami_vrc6_device::device_add_mconfig(machine_config &config)
 
  iNES: mapper 85
 
- In MESS: Supported. It also uses konami_irq.
+ In MAME: Supported. It also uses konami_irq.
 
  -------------------------------------------------*/
 
-void nes_konami_vrc7_device::write_h(offs_t offset, uint8_t data)
+void nes_konami_vrc7_device::write_h(offs_t offset, u8 data)
 {
-	uint8_t bank;
 	LOG_MMC(("VRC-7 write_h, offset: %04x, data: %02x\n", offset, data));
 
-	switch (offset & 0x7038)
+	u8 reg = bitswap<4>(offset, 14, 13, 12, m_vrc_ls_prg_a);
+
+	switch (reg)
 	{
-		case 0x0000:
-			prg8_89(data);
+		case 0x0:
+		case 0x1:
+		case 0x2:
+			prg8_x(reg, data & 0x3f);
 			break;
-		case 0x0008:
-		case 0x0010:
-		case 0x0018:
-			prg8_ab(data);
+		case 0x3:
+			if (BIT(offset, 5))
+				m_vrc7snd->data_w(data);
+			else
+				m_vrc7snd->address_w(data);
 			break;
-
-		case 0x1000:
-			prg8_cd(data);
+		case 0x4:
+		case 0x5:
+		case 0x6:
+		case 0x7:
+		case 0x8:
+		case 0x9:
+		case 0xa:
+		case 0xb:
+			chr1_x(reg - 4, data, m_chr_source);
 			break;
-
-		case 0x1010:
-		case 0x1018:
-			m_vrc7snd->address_w(data);
-			break;
-		case 0x1030:
-		case 0x1038:
-			m_vrc7snd->data_w(data);
-			break;
-
-		case 0x2000:
-		case 0x2008:
-		case 0x2010:
-		case 0x2018:
-		case 0x3000:
-		case 0x3008:
-		case 0x3010:
-		case 0x3018:
-		case 0x4000:
-		case 0x4008:
-		case 0x4010:
-		case 0x4018:
-		case 0x5000:
-		case 0x5008:
-		case 0x5010:
-		case 0x5018:
-			bank = ((offset & 0x7000) - 0x2000) / 0x0800 + ((offset & 0x0018) ? 1 : 0);
-			chr1_x(bank, data, m_chr_source);
-			break;
-
-		case 0x6000:
+		case 0xc:
 			set_mirror(data);
+			m_wram_enable = BIT(data, 7);
 			break;
-		case 0x6008: case 0x6010: case 0x6018:
+		case 0xd:
 			m_irq_count_latch = data;
 			break;
-		case 0x7000:
+		case 0xe:
 			irq_ctrl_w(data);
 			break;
-		case 0x7008: case 0x7010: case 0x7018:
+		case 0xf:
 			irq_ack_w();
-			break;
-
-		default:
-			logerror("VRC-7 write_h uncaught write, addr: %04x value: %02x\n", offset + 0x8000, data);
 			break;
 	}
 }

--- a/src/devices/bus/nes/konami.h
+++ b/src/devices/bus/nes/konami.h
@@ -16,9 +16,9 @@ class nes_konami_vrc1_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_konami_vrc1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc1_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -27,7 +27,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	uint8_t m_mmc_vrom_bank[2];
+	u8 m_mmc_vrom_bank[2];
 };
 
 
@@ -37,24 +37,24 @@ class nes_konami_vrc2_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_konami_vrc2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc2_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_m(offs_t offset, uint8_t data) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
 	// construction/destruction
-	nes_konami_vrc2_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc2_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
 
 private:
-	uint8_t m_mmc_vrom_bank[8];
-	uint8_t m_latch;
+	u8 m_mmc_vrom_bank[8];
+	u8 m_latch;
 };
 
 
@@ -64,9 +64,9 @@ class nes_konami_vrc3_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_konami_vrc3_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc3_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -76,12 +76,11 @@ protected:
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param) override;
 
 private:
-	static constexpr device_timer_id TIMER_IRQ = 0;
-
-	uint16_t m_irq_count, m_irq_count_latch;
+	u16 m_irq_count, m_irq_count_latch;
 	int m_irq_enable, m_irq_enable_latch;
 	int m_irq_mode;
 
+	static constexpr device_timer_id TIMER_IRQ = 0;
 	emu_timer *irq_timer;
 };
 
@@ -94,25 +93,27 @@ public:
 	// construction/destruction
 	nes_konami_vrc4_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
-	static constexpr device_timer_id TIMER_IRQ = 0;
-
+	// construction/destruction
 	nes_konami_vrc4_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
-
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param) override;
+
 	void set_mirror(u8 data);
 	void set_prg(int prg_base, int prg_mask);
 	virtual void set_prg() { set_prg(0x00, 0x1f); }
 	u16 m_mmc_vrom_bank[8];
 	u8 m_mmc_prg_bank[2];
 	u8 m_prg_flip;
+	u8 m_wram_enable;
 
 	void irq_tick();
 	virtual void irq_ack_w();
@@ -122,6 +123,7 @@ protected:
 	int m_irq_mode;
 	int m_irq_prescale;
 
+	static constexpr device_timer_id TIMER_IRQ = 0;
 	emu_timer *irq_timer;
 };
 
@@ -132,16 +134,15 @@ class nes_konami_vrc6_device : public nes_konami_vrc4_device
 {
 public:
 	// construction/destruction
-	nes_konami_vrc6_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc6_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 protected:
 	// device-level overrides
-	virtual void device_start() override;
-
 	virtual void device_add_mconfig(machine_config &config) override;
 
+private:
 	required_device<vrc6snd_device> m_vrc6snd;
 };
 
@@ -152,16 +153,14 @@ class nes_konami_vrc7_device : public nes_konami_vrc4_device
 {
 public:
 	// construction/destruction
-	nes_konami_vrc7_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_konami_vrc7_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
 	// device-level overrides
-	virtual void device_start() override;
-
 	virtual void device_add_mconfig(machine_config &config) override;
 
 private:

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -940,6 +940,10 @@ void nes_cart_slot_device::call_load_ines()
 				m_cart->set_vrc_lines(0, 1, 0);
 			break;
 
+		case KONAMI_VRC7:
+			m_cart->set_vrc_lines((crc_hack || submapper == 2) ? 4 : 3, 0, 0);
+			break;
+
 		case IREM_G101:
 			if (crc_hack && !submapper)
 				m_cart->set_mirroring(PPU_MIRROR_HIGH); // Major League has hardwired mirroring

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -654,6 +654,9 @@ void nes_cart_slot_device::call_load_pcb()
 //      osd_printf_error("VRC-6, pin9: A%d, pin10: A%d\n", nes_cart_get_line(get_feature("vrc6-pin9"), nes_cart_get_line(get_feature("vrc6-pin10"));
 	}
 
+	if (m_pcb_id == KONAMI_VRC7)
+		m_cart->set_vrc_lines(nes_cart_get_line(get_feature("vrc7-pin19")), 0, 0);
+
 	if (m_pcb_id == STD_SXROM || m_pcb_id == STD_SOROM)
 	{
 		if (get_feature("mmc1_type") != nullptr)


### PR DESCRIPTION
- Added missing WRAM enable bit (VRC4/6/7).
- Simplified handling of pins that connect to variable address lines (VRC2/4/6/7). VRC7's pin 19 now is configured dynamically like the others.
- For each VRC chip, masked bank numbers to reflect actual ROM size supported by pinout.
- Removed unreachable logging statements, other assorted cleanups and simplifications.