### PR TITLE
spectrum: move gfx to screen_device

### DIFF
--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -211,7 +211,7 @@ protected:
 	optional_ioport m_io_joy1;
 	optional_ioport m_io_joy2;
 
-	void spectrum_UpdateBorderBitmap();
+	virtual void spectrum_UpdateBorderBitmap();
 	virtual u16 get_border_color();
 	virtual void spectrum_UpdateScreenBitmap(bool eof = false);
 	inline unsigned char get_display_color(unsigned char color, int invert);


### PR DESCRIPTION
POC for modernization of screen_device usage.

This implementation is done on self-contained Pentagon driver with intention to be moved to parent spectrum.
Improvements:
* gfx rendered directly on screen_device without intermediate bitmaps (m_border_bitmap, m_screen_bitmap)
* INT raised on beginning of vblank instead of manually adjusted position
* position of the gfx can be moved to arbitrary position (see: PENTAGON_SCREEN), not customly hardcoded at (0,0). That respects vblank/hblank positions "before" real screen, not wrongly "after" previously.