### PR TITLE
machine/playch10.cpp: Properly clear IRQs for MMC3 boards.

### DIFF
--- a/src/mame/includes/playch10.h
+++ b/src/mame/includes/playch10.h
@@ -94,8 +94,8 @@ private:
 	void cboard_vrom_switch_w(uint8_t data);
 	void eboard_rom_switch_w(offs_t offset, uint8_t data);
 	void gboard_rom_switch_w(offs_t offset, uint8_t data);
-	void iboard_rom_switch_w(uint8_t data);
 	void hboard_rom_switch_w(offs_t offset, uint8_t data);
+	void iboard_rom_switch_w(uint8_t data);
 	void playch10_videoram_w(offs_t offset, uint8_t data);
 
 	TILE_GET_INFO_MEMBER(get_bg_tile_info);
@@ -180,8 +180,6 @@ private:
 	int m_mmc1_shiftreg;
 	int m_mmc1_shiftcount;
 	int m_mmc1_rom_mask;
-	int m_gboard_scanline_counter;
-	int m_gboard_scanline_latch;
 	int m_gboard_banks[2];
 	int m_gboard_4screen;
 	int m_gboard_last_bank;

--- a/src/mame/machine/playch10.cpp
+++ b/src/mame/machine/playch10.cpp
@@ -823,7 +823,7 @@ void playch10_state::gboard_scanline_cb( int scanline, int vblank, int blanked )
 
 		if (m_IRQ_enable && !blanked && (m_IRQ_count == 0) && priorCount) // according to blargg the latter should be present as well, but it breaks Rampart and Joe & Mac US: they probably use the alt irq!
 		{
-			m_cartcpu->set_input_line(0, HOLD_LINE);
+			m_cartcpu->set_input_line(0, ASSERT_LINE);
 		}
 	}
 }
@@ -953,6 +953,7 @@ void playch10_state::gboard_rom_switch_w(offs_t offset, uint8_t data)
 
 		case 0x6000: /* disable irqs */
 			m_IRQ_enable = 0;
+			m_cartcpu->set_input_line(0, CLEAR_LINE);
 		break;
 
 		case 0x6001: /* enable irqs */
@@ -981,8 +982,6 @@ void playch10_state::init_pcgboard()
 
 	m_gboard_banks[0] = 0x1e;
 	m_gboard_banks[1] = 0x1f;
-	m_gboard_scanline_counter = 0;
-	m_gboard_scanline_latch = 0;
 	m_gboard_4screen = 0;
 	m_IRQ_enable = 0;
 	m_IRQ_count = m_IRQ_count_latch = 0;
@@ -1098,17 +1097,12 @@ void playch10_state::init_pchboard()
 	/* Roms are banked at $8000 to $bfff */
 	m_cartcpu->space(AS_PROGRAM).install_write_handler(0x8000, 0xffff, write8sm_delegate(*this, FUNC(playch10_state::hboard_rom_switch_w)));
 
-	/* extra ram at $6000-$7fff */
-	m_extra_ram = std::make_unique<uint8_t[]>(0x2000);
-	save_pointer(NAME(m_extra_ram), 0x2000);
-	m_cartcpu->space(AS_PROGRAM).install_ram(0x6000, 0x7fff, m_extra_ram.get());
-
 	m_gboard_banks[0] = 0x1e;
 	m_gboard_banks[1] = 0x1f;
-	m_gboard_scanline_counter = 0;
-	m_gboard_scanline_latch = 0;
 	m_gboard_last_bank = 0xff;
 	m_gboard_command = 0;
+	m_IRQ_enable = 0;
+	m_IRQ_count = m_IRQ_count_latch = 0;
 
 	/* common init */
 	init_playch10();


### PR DESCRIPTION
- Removed WRAM from PinBot, there's none on its PCB.