### PR TITLE
coco3: fix crash in some AGI games

### DIFF
--- a/src/devices/bus/coco/coco_fdc.cpp
+++ b/src/devices/bus/coco/coco_fdc.cpp
@@ -84,11 +84,13 @@
 
 //#define LOG_GENERAL   (1U << 0) //defined in logmacro.h already
 #define LOG_WDFDC   (1U << 1) // Shows register setup
+#define LOG_WDIO    (1U << 2) // Shows Data read and write
 
-//#define VERBOSE (LOG_GENERAL )
+//#define VERBOSE (LOG_GENERAL | LOG_WDFDC)
 #include "logmacro.h"
 
 #define LOGWDFDC(...)   LOGMASKED(LOG_WDFDC,  __VA_ARGS__)
+#define LOGWDIO(...)   LOGMASKED(LOG_WDIO,  __VA_ARGS__)
 
 /***************************************************************************
     PARAMETERS
@@ -185,6 +187,8 @@ void coco_fdc_device_base::device_add_mconfig(machine_config &config)
 	WD1773(config, m_wd17xx, 8_MHz_XTAL);
 	m_wd17xx->intrq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_intrq_w));
 	m_wd17xx->drq_wr_callback().set(FUNC(coco_fdc_device_base::fdc_drq_w));
+	m_wd17xx->set_disable_motor_control(true);
+	m_wd17xx->set_force_ready(true);
 
 	FLOPPY_CONNECTOR(config, m_floppies[0], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
 	FLOPPY_CONNECTOR(config, m_floppies[1], coco_fdc_floppies, "525dd", coco_fdc_device_base::floppy_formats).enable_sound(true);
@@ -418,7 +422,7 @@ void coco_fdc_device_base::update_lines()
 			else if( (m_cache_controler & 0x07) == 0x06 ) /* Copy Write cache to controller */
 			{
 				u8 data = m_cache_buffer->read(m_cache_pointer++);
-				LOG("Cached drq write: %2.2x\n", data );
+				LOG("Cached copy drq write: %2.2x\n", data );
 				m_wd17xx->data_w(data);
 			}
 			else
@@ -537,7 +541,7 @@ u8 coco_fdc_device_base::scs_read(offs_t offset)
 			break;
 		case 11:
 			result = m_wd17xx->data_r();
-			LOGWDFDC("m_wd17xx->data_r: %2.2x\n", result );
+			LOGWDIO("m_wd17xx->data_r: %2.2x\n", result );
 			break;
 	}
 
@@ -594,7 +598,7 @@ void coco_fdc_device_base::scs_write(offs_t offset, u8 data)
 			m_wd17xx->sector_w(data);
 			break;
 		case 11:
-			LOGWDFDC("m_wd17xx->data_w: %2.2x\n", data );
+			LOGWDIO("m_wd17xx->data_w: %2.2x\n", data );
 			m_wd17xx->data_w(data);
 			break;
 	};

--- a/src/lib/formats/jvc_dsk.cpp
+++ b/src/lib/formats/jvc_dsk.cpp
@@ -105,10 +105,8 @@
 ***************************************************************************/
 
 #include "jvc_dsk.h"
-
 #include "ioprocs.h"
-
-#include "osdcore.h" // osd_printf_*
+#include "imageutl.h"
 
 
 jvc_format::jvc_format()
@@ -156,7 +154,7 @@ bool jvc_format::parse_header(util::random_read &io, int &header_size, int &trac
 	switch (header_size)
 	{
 	case 5:
-		osd_printf_info("jvc_format: sector attribute flag unsupported\n");
+		LOG_FORMATS("jvc_format: sector attribute flag unsupported\n");
 		return false;
 	case 4: base_sector_id = header[3];
 		[[fallthrough]];
@@ -170,7 +168,7 @@ bool jvc_format::parse_header(util::random_read &io, int &header_size, int &trac
 		break;
 	}
 
-	osd_printf_verbose("Floppy disk image geometry: %d tracks, %d head(s), %d sectors with %d bytes.\n", tracks, heads, sectors, sector_size);
+	LOG_FORMATS("jvc_format: Floppy disk image geometry: %d tracks, %d head(s), %d sectors with %d bytes.\n", tracks, heads, sectors, sector_size);
 
 	return tracks * heads * sectors * sector_size == (size - header_size);
 }
@@ -184,6 +182,7 @@ int jvc_format::identify(util::random_read &io, uint32_t form_factor, const std:
 bool jvc_format::load(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants, floppy_image *image)
 {
 	int header_size, track_count, head_count, sector_count, sector_size, sector_base_id;
+	int max_tracks, max_heads;
 
 	if (!parse_header(io, header_size, track_count, head_count, sector_count, sector_size, sector_base_id))
 		return false;
@@ -191,7 +190,21 @@ bool jvc_format::load(util::random_read &io, uint32_t form_factor, const std::ve
 	// safety check
 	if (sector_count * sector_size > 10000)
 	{
-		osd_printf_error("jvc_format: incorrect track layout\n");
+		LOG_FORMATS("jvc_format: incorrect track layout\n");
+		return false;
+	}
+
+	image->get_maximal_geometry(max_tracks, max_heads);
+
+	if (track_count > max_tracks)
+	{
+		LOG_FORMATS("jvc_format: Floppy disk has too many tracks for this drive (floppy tracks=%d, drive tracks=%d).\n", track_count, max_tracks);
+		return false;
+	}
+
+	if (head_count > max_heads)
+	{
+		LOG_FORMATS("jvc_format: Floppy disk has too many sides for this drive (floppy sides=%d, drive sides=%d).\n", head_count, max_heads);
 		return false;
 	}
 
@@ -261,7 +274,7 @@ bool jvc_format::save(util::random_read_write &io, const std::vector<uint32_t> &
 			{
 				if (sectors[1 + i].size() != 256)
 				{
-					osd_printf_error("jvc_format: invalid sector size: %d\n", sectors[1 + i].size());
+					LOG_FORMATS("jvc_format: invalid sector size: %d\n", sectors[1 + i].size());
 					return false;
 				}
 

--- a/src/lib/formats/os9_dsk.cpp
+++ b/src/lib/formats/os9_dsk.cpp
@@ -67,7 +67,7 @@ const char *os9_format::description() const
 
 const char *os9_format::extensions() const
 {
-	return "dsk,os9";
+	return "os9,dsk";
 }
 
 int os9_format::identify(util::random_read &io, uint32_t form_factor, const std::vector<uint32_t> &variants)
@@ -218,7 +218,7 @@ int os9_format::find_size(util::random_read &io, uint32_t form_factor, const std
 				continue;
 		}
 
-		LOG_FORMATS("OS9 matching format index %d\n", i);
+		LOG_FORMATS("os9_dsk: matching format index %d: tracks %d, sectors %d, sides: %d\n", i, f.track_count, f.sector_count, f.head_count);
 		return i;
 	}
 	return -1;
@@ -236,17 +236,17 @@ const wd177x_format::format &os9_format::get_track_format(const format &f, int h
 	}
 
 	if (n < 0) {
-		LOG_FORMATS("Error format not found\n");
+		LOG_FORMATS("os9_dsk: Error format not found\n");
 		return f;
 	}
 
 	if (head >= f.head_count) {
-		LOG_FORMATS("Error invalid head %d\n", head);
+		LOG_FORMATS("os9_dsk: Error invalid head %d\n", head);
 		return f;
 	}
 
 	if (track >= f.track_count) {
-		LOG_FORMATS("Error invalid track %d\n", track);
+		LOG_FORMATS("os9_dsk: Error invalid track %d\n", track);
 		return f;
 	}
 


### PR DESCRIPTION
formats/jvc_disk: Change osd_printf_info() to LOG_FORMATS(). Changed code to verify image geometry against floppy drive geometry.
formats/os9_dsk: Improved logging
bus/coco/coco_fdc: Improved logging. Turned on disable_motor_control and force_read in wd1773. This fixed some new games that use the AGI Engine