### PR TITLE
nes_apu.cpp: Added noise channel period table for PAL systems.

### DIFF
--- a/src/devices/sound/nes_apu.cpp
+++ b/src/devices/sound/nes_apu.cpp
@@ -49,36 +49,23 @@
 #include "emu.h"
 #include "nes_apu.h"
 
-/* INTERNAL FUNCTIONS */
+// INTERNAL FUNCTIONS
 
-/* INITIALIZE WAVE TIMES RELATIVE TO SAMPLE RATE */
-static void create_vbltimes(u32 * table,const u8 *vbl,unsigned int rate)
+// INITIALIZE WAVE TIMES RELATIVE TO SAMPLE RATE
+static void create_vbltimes(u32 *table, const u8 *vbl, unsigned int rate)
 {
-	int i;
-
-	for (i = 0; i < 0x20; i++)
+	for (int i = 0; i < 0x20; i++)
 		table[i] = vbl[i] * rate;
 }
 
-/* INITIALIZE SAMPLE TIMES IN TERMS OF VSYNCS */
+// INITIALIZE SAMPLE TIMES IN TERMS OF VSYNCS
 void nesapu_device::create_syncs(unsigned long sps)
 {
-	int i;
-	unsigned long val = sps;
+	for (int i = 0; i < SYNCS_MAX1; i++)
+		m_sync_times1[i] = sps * (i + 1);
 
-	for (i = 0; i < SYNCS_MAX1; i++)
-	{
-		m_sync_times1[i] = val;
-		val += sps;
-	}
-
-	val = 0;
-	for (i = 0; i < SYNCS_MAX2; i++)
-	{
-		m_sync_times2[i] = val;
-		m_sync_times2[i] >>= 2;
-		val += sps;
-	}
+	for (int i = 0; i < SYNCS_MAX2; i++)
+		m_sync_times2[i] = (sps * i) >> 2;
 }
 
 DEFINE_DEVICE_TYPE(NES_APU, nesapu_device, "nesapu", "N2A03 APU")
@@ -387,7 +374,7 @@ s8 nesapu_device::apu_noise(apu_t::noise_t *chan)
 	if (0 == chan->vbl_length)
 		return 0;
 
-	freq = noise_freq[chan->regs[2] & 0x0F];
+	freq = noise_freq[m_is_pal][chan->regs[2] & 0x0F];
 	chan->phaseacc -= 4;
 	while (chan->phaseacc < 0)
 	{

--- a/src/devices/sound/nes_defs.h
+++ b/src/devices/sound/nes_defs.h
@@ -195,7 +195,7 @@ struct apu_t
 /* vblank length table used for squares, triangle, noise */
 static const apu_t::uint8 vbl_length[32] =
 {
-	5, 127, 10, 1, 19,  2, 40,  3, 80,  4, 30,  5, 7,  6, 13,  7,
+	5, 127, 10, 1, 20,  2, 40,  3, 80,  4, 30,  5, 7,  6, 13,  7,
 	6,   8, 12, 9, 24, 10, 48, 11, 96, 12, 36, 13, 8, 14, 16, 15
 };
 
@@ -205,10 +205,12 @@ static const int freq_limit[8] =
 	0x3FF, 0x555, 0x666, 0x71C, 0x787, 0x7C1, 0x7E0, 0x7F0,
 };
 
-/* table of noise frequencies */
-static const int noise_freq[16] =
+// table of noise period
+// each fundamental is determined as: freq = master / period / 93
+static const int noise_freq[2][16] =
 {
-	4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 2046
+	{ 4, 8, 16, 32, 64, 96, 128, 160, 202, 254, 380, 508, 762, 1016, 2034, 4068 }, // NTSC
+	{ 4, 8, 14, 30, 60, 88, 118, 148, 188, 236, 354, 472, 708,  944, 1890, 3778 }  // PAL
 };
 
 // dpcm (cpu) cycle period
@@ -216,7 +218,7 @@ static const int noise_freq[16] =
 static const int dpcm_clocks[2][16] =
 {
 	{ 428, 380, 340, 320, 286, 254, 226, 214, 190, 160, 142, 128, 106, 85, 72, 54 }, // NTSC
-	{ 398, 354, 316, 298, 276, 236, 210, 198, 176, 148, 132, 118, 98, 78, 66, 50 } // PAL
+	{ 398, 354, 316, 298, 276, 236, 210, 198, 176, 148, 132, 118,  98, 78, 66, 50 }  // PAL
 };
 
 /* ratios of pos/neg pulse for square waves */


### PR DESCRIPTION
- Fixed a value in the parallel NTSC table for the largest period (lowest freq).
- Fixed a value in the counter length table (for all channels but DMC).