### PR TITLE
fixed errors/warnings under vs2022

### DIFF
--- a/src/frontend/mame/infoxml.cpp
+++ b/src/frontend/mame/infoxml.cpp
@@ -434,9 +434,6 @@ void info_xml_creator::output(std::ostream &out, const std::function<bool(const 
 	struct prepared_info
 	{
 		prepared_info() = default;
-		prepared_info(const prepared_info &) = delete;
-		prepared_info(prepared_info &&) = default;
-		prepared_info &operator=(const prepared_info &) = delete;
 
 		std::string     m_xml_snippet;
 		device_type_set m_dev_set;

--- a/src/frontend/mame/ui/icorender.cpp
+++ b/src/frontend/mame/ui/icorender.cpp
@@ -179,7 +179,7 @@ bool load_ico_image(util::core_file &fp, unsigned count, unsigned index, bitmap_
 {
 	// read the directory entry
 	std::error_condition err;
-	size_t actual;
+	size_t actual = 0;
 	icon_dir_entry_t dir;
 	err = fp.seek(sizeof(icon_dir_t) + (sizeof(icon_dir_entry_t) * index), SEEK_SET);
 	if (!err)
@@ -212,8 +212,8 @@ int images_in_ico(util::core_file &fp)
 {
 	// read and check the icon file header
 	std::error_condition err;
-	size_t actual;
-	icon_dir_t header;
+	size_t actual = 0;
+	icon_dir_t header = { };
 	err = fp.seek(0, SEEK_SET);
 	if (!err)
 		err = fp.read(&header, sizeof(header), actual);


### PR DESCRIPTION
infoxml - removed deleted ctors causing 'attempting to reference a deleted function' errors due to using std::future<>
icorender - fixed warnings 'potentially uninitialized local variable used'.  warnings treated as errors and prevents successful build.