### PR TITLE
hiscore.dat: Add "Mega Man 2: The Power Fighters (Hispanic 960712)" (megaman2h), fix "1000 Miglia: Great 1000 Miles Rally" (gtmr/gtmra/gtmro/gtmrusa) and add clones (gtmrb/gtmro)

### DIFF
--- a/plugins/hiscore/hiscore.dat
+++ b/plugins/hiscore/hiscore.dat
@@ -3527,6 +3527,7 @@ mshvsfu1d:
 ;megamn2d:******Mega Man 2: The Power Fighters (USA 960708 Phoenix Edition) (bootleg)
 megaman2:
 megaman2a:
+megaman2h:
 megamn2d:
 rockman2j:
 @:maincpu,program,ffefc0,118,00,02

--- a/plugins/hiscore/hiscore.dat
+++ b/plugins/hiscore/hiscore.dat
@@ -7592,12 +7592,18 @@ gtmr2u:
 ;gtmra:******1000 Miglia: Great 1000 Miles Rally (94/06/13)
 gtmr:
 gtmra:
-@:maincpu,program,102df2,19e,59,80
+@:maincpu,program,102df2,1a0,59,01
+
+
+;******1000 Miglia: Great 1000 Miles Rally (94/05/..)
+gtmrb:
+gtmro:
+@:maincpu,program,102dee,1a0,59,01
 
 
 gtmre:
 gtmrusa:
-@:maincpu,program,1035fa,19e,59,80
+@:maincpu,program,1035fa,1a0,59,01
 
 
 ;@s:kangaroo.cpp


### PR DESCRIPTION
hiscore.dat: new clone of megaman supported. Tested and working with mame.
hiscore.dat: new clones of gtmr supported in hiscore.dat, using a specific memory location for them. Tested and working with mame.
hiscore.dat: fixed gtmr/gtmra/gtmre/gtmrusa to save also the last car of the last track. Tested and working with mame.
