### PR TITLE
swim1/swim2 - initialize m_floppy and m_timer

### DIFF
--- a/src/devices/machine/swim1.cpp
+++ b/src/devices/machine/swim1.cpp
@@ -12,7 +12,9 @@
 DEFINE_DEVICE_TYPE(SWIM1, swim1_device, "swim1", "Apple SWIM1 (Sander/Wozniak Integrated Machine) version 1 floppy controller")
 
 swim1_device::swim1_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	applefdintf_device(mconfig, SWIM1, tag, owner, clock)
+	applefdintf_device(mconfig, SWIM1, tag, owner, clock),
+	m_floppy(nullptr),
+	m_timer(nullptr)
 {
 }
 
@@ -20,6 +22,7 @@ void swim1_device::device_start()
 {
 	applefdintf_device::device_start();
 
+	m_timer = timer_alloc();
 	save_item(NAME(m_last_sync));
 	save_item(NAME(m_flux_write_start));
 	save_item(NAME(m_flux_write));

--- a/src/devices/machine/swim2.cpp
+++ b/src/devices/machine/swim2.cpp
@@ -20,7 +20,8 @@
 DEFINE_DEVICE_TYPE(SWIM2, swim2_device, "swim2", "Apple SWIM2 (Sander/Wozniak Integrated Machine) version 2 floppy controller")
 
 swim2_device::swim2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	applefdintf_device(mconfig, SWIM2, tag, owner, clock)
+	applefdintf_device(mconfig, SWIM2, tag, owner, clock),
+	m_floppy(nullptr)
 {
 }
 


### PR DESCRIPTION
I encountered some odd crashes testing the a2superdrive slot options (eg, `mame apple2ee -sl7 superdrive -sl7:superdrive:fdc:0 35sd` ). Poking further, swim1 had an invalid `m_floppy` since it is never initialized.  swim2 would also have the same issue.  There's also a timer in swim1 that isn't initialized.