### PR TITLE
create 68010 bus error stack frame / fix for 68010 RTE stack frame unwinding

### DIFF
--- a/src/devices/cpu/m68000/m68k_in.lst
+++ b/src/devices/cpu/m68000/m68k_in.lst
@@ -6886,16 +6886,12 @@ e5c0 ffc0 roxl     w A+-DXWL    01:8 7:14 234fc:5
 			m_instr_mode = INSTRUCTION_YES;
 			m_run_mode = RUN_MODE_NORMAL;
 		} else {
-			if (format_word == 0x8) /* type 1000 stack frame */
+			if (format_word == 0x8) /* 68010 - type 1000 stack frame */
 			{
 				new_sr = m68ki_pull_16();
 				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();   /* format word */
-				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
-				m_instr_mode = INSTRUCTION_YES;
-				m_run_mode = RUN_MODE_NORMAL;
-				m68ki_fake_pull_16();  /* special status */
+				m68ki_fake_pull_16();  /* format word */
+				m68ki_fake_pull_16();  /* special status word */
 				m68ki_fake_pull_32();  /* fault address */
 				m68ki_fake_pull_32();  /* reserved and data output buffer */
 				m68ki_fake_pull_32();  /* reserved and data input buffer */
@@ -6908,6 +6904,10 @@ e5c0 ffc0 roxl     w A+-DXWL    01:8 7:14 234fc:5
 				m68ki_fake_pull_32();
 				m68ki_fake_pull_32();
 				m68ki_fake_pull_32();
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				m_instr_mode = INSTRUCTION_YES;
+				m_run_mode = RUN_MODE_NORMAL;
 			}
 			else
 			{

--- a/src/devices/cpu/m68000/m68kcpu.cpp
+++ b/src/devices/cpu/m68000/m68kcpu.cpp
@@ -957,8 +957,15 @@ void m68000_base_device::execute_run()
 
 					if (!CPU_TYPE_IS_020_PLUS())
 					{
-						/* Note: This is implemented for 68000 only! */
-						m68ki_stack_frame_buserr(sr);
+						if (CPU_TYPE_IS_010())
+						{
+							m68ki_stack_frame_1000(m_ppc, sr, EXCEPTION_BUS_ERROR);
+						}
+						else
+						{
+							/* Note: This is implemented for 68000 only! */
+							m68ki_stack_frame_buserr(sr);
+						}
 					}
 					else if(!CPU_TYPE_IS_040_PLUS()) {
 						if (m_mmu_tmp_buserror_address == m_ppc)

--- a/src/devices/cpu/m68000/m68kops.cpp
+++ b/src/devices/cpu/m68000/m68kops.cpp
@@ -26542,16 +26542,12 @@ void m68000_base_device::x4e73_rte_l_71()
 			m_instr_mode = INSTRUCTION_YES;
 			m_run_mode = RUN_MODE_NORMAL;
 		} else {
-			if (format_word == 0x8) /* type 1000 stack frame */
+			if (format_word == 0x8) /* 68010 - type 1000 stack frame */
 			{
 				new_sr = m68ki_pull_16();
 				new_pc = m68ki_pull_32();
-				m68ki_fake_pull_16();   /* format word */
-				m68ki_jump(new_pc);
-				m68ki_set_sr(new_sr);
-				m_instr_mode = INSTRUCTION_YES;
-				m_run_mode = RUN_MODE_NORMAL;
-				m68ki_fake_pull_16();  /* special status */
+				m68ki_fake_pull_16();  /* format word */
+				m68ki_fake_pull_16();  /* special status word */
 				m68ki_fake_pull_32();  /* fault address */
 				m68ki_fake_pull_32();  /* reserved and data output buffer */
 				m68ki_fake_pull_32();  /* reserved and data input buffer */
@@ -26564,6 +26560,10 @@ void m68000_base_device::x4e73_rte_l_71()
 				m68ki_fake_pull_32();
 				m68ki_fake_pull_32();
 				m68ki_fake_pull_32();
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				m_instr_mode = INSTRUCTION_YES;
+				m_run_mode = RUN_MODE_NORMAL;
 			}
 			else
 			{


### PR DESCRIPTION
I have been working on the AT&T UNIX PC driver (68010) and ran into an issue with page fault handling. I tracked this back to the RTE instruction for 68010 wherein the SP can potentially be changed mid-unwind of the bus error exception stack frame (format = 8), when transitioning from supervisor mode back to user mode (A7 being set to USP).

I also added 68010 format 8 stack frame setup in the bus error handling code.  This code is presently inaccessible to 68010, due to the `pmmu_enabled` conditional. But that is a separate topic being discussed in issue #9170 