### PR TITLE
Address some Lua scripting pitfalls

### DIFF
--- a/docs/source/techspecs/luareference.rst
+++ b/docs/source/techspecs/luareference.rst
@@ -3148,15 +3148,22 @@ debugger is not enabled.
 Instantiation
 ^^^^^^^^^^^^^
 
-emu.symbol_table(machine, [parent], [device])
+emu.symbol_table(machine)
     Creates a new symbol table in the context of the specified machine,
-    optionally supplying a parent symbol table.  If a parent symbol table is
-    supplied, it must not be destroyed before the new symbol table.  If a device
-    is specified and it implements ``device_memory_interface``, it is used as
-    the base for looking up address spaces and memory regions.  Note that if a
-    device that does not implement ``device_memory_interface`` is supplied, it
-    will not be used (address spaces and memory regions will be looked up
-    relative to the root device).
+emu.symbol_table(parent, [device])
+    Creates a new symbol table with the specified parent symbol table.  If a
+    device is specified and it implements ``device_memory_interface``, it will
+    be used as the base for looking up address spaces and memory regions.  Note
+    that if a device that does not implement ``device_memory_interface`` is
+    supplied, it will not be used (address spaces and memory regions will be
+    looked up relative to the root device).
+emu.symbol_table(device)
+    Creates a new symbol table in the context of the specified device.  If the
+    device implements ``device_memory_interface``, it will be used as the base
+    for looking up address spaces and memory regions.  Note that if a device
+    that does not implement ``device_memory_interface`` is supplied, it will
+    only be used to determine the machine context (address spaces and memory
+    regions will be looked up relative to the root device).
 
 Methods
 ^^^^^^^
@@ -3171,6 +3178,8 @@ symbols:add(name, [value])
     is added with the supplied value.  If no value is supplied, a read/write
     symbol is created with and initial value of zero.  If a symbol entry with
     the specified name already exists in the symbol table, it will be replaced.
+
+    Returns the new :ref:`symbol entry <luareference-debug-symentry>`.
 symbols:add(name, getter, [setter], [format])
     Adds a named integer symbol using getter and optional setter callbacks.  The
     name must be a string.  The getter must be a function returning an integer
@@ -3179,10 +3188,14 @@ symbols:add(name, getter, [setter], [format])
     string for displaying the symbol value may optionally be supplied.  If a
     symbol entry with the specified name already exists in the symbol table, it
     will be replaced.
+
+    Returns the new :ref:`symbol entry <luareference-debug-symentry>`.
 symbols:add(name, minparams, maxparams, execute)
     Adds a named function symbol.  The name must be a string.  The minimum and
     maximum numbers of parameters must be integers.  If a symbol entry with the
     specified name already exists in the symbol table, it will be replaced.
+
+    Returns the new :ref:`symbol entry <luareference-debug-symentry>`.
 symbols:find(name)
     Returns the :ref:`symbol entry <luareference-debug-symentry>` with the
     specified name, or ``nil`` if there is no symbol with the specified name in
@@ -3251,8 +3264,6 @@ emu.parsed_expression(symbols, string, [default_base])
     default base for interpreting integer literals is not supplied, 16 is used
     (hexadecimal).  Raises an error if the string contains syntax errors or uses
     undefined symbols.
-emu.parsed_expression(expression)
-    Creates a copy of an existing parsed expression.
 
 Methods
 ^^^^^^^
@@ -3267,7 +3278,7 @@ expression:parse(string)
     expression is not preserved when attempting to parse an invalid expression
     string.
 expression:execute()
-    Evaluates the expression, returning an unsigned integer result.  Raises an 
+    Evaluates the expression, returning an unsigned integer result.  Raises an
     error if the expression cannot be evaluated (e.g. calling a function with an
     invalid number of arguments).
 
@@ -3288,19 +3299,24 @@ Symbol entry
 ~~~~~~~~~~~~
 
 Wraps MAME’s ``symbol_entry`` class, which represents an entry in a
-:ref:`symbol table <luareference-debug-symtable>`.
+:ref:`symbol table <luareference-debug-symtable>`.  Note that symbol entries
+must not be used after the symbol table they belong to is destroyed.
 
 Instantiation
 ^^^^^^^^^^^^^
 
-symbols:find(name)
-    Obtains the symbol entry with the specified name from a
-    :ref:`symbol table <luareference-debug-symtable>`, but does not search
-    parent symbol tables.
-symbols:deep_find(name)
-    Obtains the symbol entry with the specified name from a
-    :ref:`symbol table <luareference-debug-symtable>`, recursively searching
-    parent symbol tables.
+symbols:add(name, [value])
+    Adds an integer symbol to a
+    :ref:`symbol table <luareference-debug-symtable>`, returning the new symbol
+    entry.
+symbols:add(name, getter, [setter], [format])
+    Adds an integer symbol to a
+    :ref:`symbol table <luareference-debug-symtable>`, returning the new symbol
+    entry.
+symbols:add(name, minparams, maxparams, execute)
+    Adds function symbol to a
+    :ref:`symbol table <luareference-debug-symtable>`, returning the new symbol
+    entry.
 
 Properties
 ^^^^^^^^^^

--- a/docs/source/techspecs/luareference.rst
+++ b/docs/source/techspecs/luareference.rst
@@ -1383,9 +1383,6 @@ space:install_read_tap(start, end, name, callback)
     and the memory access mask.  To modify the data being read, return the
     modified value from the callback function as an integer.  If the callback
     does not return an integer, the data will not be modified.
-
-    Note that pass-through handlers must be explicitly removed before the
-    emulation session ends.
 space:install_write_tap(start, end, name, callback)
     Installs a :ref:`pass-through handler <luareference-mem-tap>` that will
     receive notifications on write to the specified range of addresses in the
@@ -1396,9 +1393,6 @@ space:install_write_tap(start, end, name, callback)
     written, and the memory access mask.  To modify the data being written,
     return the modified value from the callback function as an integer.  If the
     callback does not return an integer, the data will not be modified.
-
-    Note that pass-through handlers must be explicitly removed before the
-    emulation session ends.
 
 Properties
 ^^^^^^^^^^
@@ -1454,8 +1448,7 @@ Pass-through handler
 Tracks a pass-through handler installed in an
 :ref:`address space <luareference-mem-space>`.  A memory pass-through handler
 receives notifications on accesses to a specified range of addresses, and can
-modify the data that is read or written if desired.  Note that you must remove
-pass-through handlers before the emulation session ends.
+modify the data that is read or written if desired.
 
 Instantiation
 ^^^^^^^^^^^^^

--- a/docs/source/techspecs/luareference.rst
+++ b/docs/source/techspecs/luareference.rst
@@ -63,6 +63,29 @@ Core classes
 Many of MAME’s core classes used to implement an emulation session are available
 to Lua scripts.
 
+.. _luareference-core-notifiersub:
+
+Notifier subscription
+~~~~~~~~~~~~~~~~~~~~~
+
+Wraps MAME’s ``util::notifier_subscription`` class, which manages a subscription
+to a broadcast notification.
+
+Methods
+^^^^^^^
+
+subscription:unsubscribe()
+    Unsubscribes from notifications.  The subscription will become inactive and
+    no future notifications will be received.
+
+Properties
+^^^^^^^^^^
+
+subscription.is_active (read-only)
+    A Boolean indicating whether the subscription is active.  A subscription
+    becomes inactive after explicitly unsubscribing or if the underlying
+    notifier is destroyed.
+
 .. _luareference-core-attotime:
 
 Attotime
@@ -1364,15 +1387,13 @@ space:read_range(start, end, width, [step])
     greater than or equal to the start address.  The width must be 8, 16, 30 or
     64.  If the step is provided, it must be a positive number of elements.
 space:add_change_notifier(callback)
-    Adds a
-    :ref:`handler change subscription <luareference-mem-spacechangenotif>` to
-    the address space.  The callback function is passed a single string as an
-    argument, either ``r`` if read handlers have potentially changed, ``w`` if
-    write handlers have potentially changed, or ``rw`` if both read and write
-    handlers have potentially changed.
+    Add a callback to receive notifications for handler changes in address
+    space.  The callback function is passed a single string as an argument,
+    either ``r`` if read handlers have potentially changed, ``w`` if write
+    handlers have potentially changed, or ``rw`` if both read and write handlers
+    have potentially changed.
 
-    Note that handler change subscriptions must be explicitly removed before the
-    emulation session ends.
+    Returns a :ref:`notifier subscription <luareference-core-notifiersub>`.
 space:install_read_tap(start, end, name, callback)
     Installs a :ref:`pass-through handler <luareference-mem-tap>` that will
     receive notifications on reads from the specified range of addresses in the
@@ -1416,29 +1437,6 @@ space.endianness (read-only)
 space.map (read-only)
     The configured :ref:`address map <luareference-mem-map>` for the space or
     ``nil``.
-
-.. _luareference-mem-spacechangenotif:
-
-Address space change notifier
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Tracks a subscription to :ref:`address space <luareference-mem-space>` handler
-changes.  Note that you must remove subscriptions before the emulation session
-ends.
-
-Instantiation
-^^^^^^^^^^^^^
-
-manager.machine.devices[tag].spaces[name]:add_change_notifier(callback)
-    Adds a handler change subscriptions to an
-    :ref:`address space <luareference-mem-space>`.
-
-Methods
-^^^^^^^
-
-notifier:remove()
-    Removes the notification subscription.  The associated callback will not be
-    called on future handler changes for the address space.
 
 .. _luareference-mem-tap:
 
@@ -3386,7 +3384,7 @@ emulated CPU device.
 Instantiation
 ^^^^^^^^^^^^^
 
-manager.machine.devices[tag]:debug()
+manager.machine.devices[tag].debug
     Returns the debugger interface for an emulated CPU device, or ``nil`` if the
     device is not a CPU.
 
@@ -3471,7 +3469,7 @@ emulated CPU device.
 Instantiation
 ^^^^^^^^^^^^^
 
-manager.machine.devices[tag]:debug():bplist()[bp]
+manager.machine.devices[tag].debug:bplist()[bp]
     Gets the specified breakpoint for an emulated CPU device, or ``nil`` if no
     breakpoint corresponds to the specified index.
 
@@ -3482,7 +3480,7 @@ breakpoint.index (read-only)
     The breakpoint’s index.  The can be used to enable, disable or clear the
     breakpoint via the
     :ref:`CPU debugger interface <luareference-debug-devdebug>`.
-breakpoint.enabled (read-only)
+breakpoint.enabled (read/write)
     A Boolean indicating whether the breakpoint is currently enabled.
 breakpoint.address (read-only)
     The breakpoint’s address.
@@ -3505,7 +3503,7 @@ emulated CPU device.
 Instantiation
 ^^^^^^^^^^^^^
 
-manager.machine.devices[tag]:debug():wplist(space)[wp]
+manager.machine.devices[tag].debug:wplist(space)[wp]
     Gets the specified watchpoint for an address space of an emulated CPU
     device, or ``nil`` if no watchpoint in the address space corresponds to the
     specified index.
@@ -3517,7 +3515,7 @@ watchpoint.index (read-only)
     The watchpoint’s index.  The can be used to enable, disable or clear the
     watchpoint via the
     :ref:`CPU debugger interface <luareference-debug-devdebug>`.
-watchpoint.enabled (read-only)
+watchpoint.enabled (read/write)
     A Boolean indicating whether the watchpoint is currently enabled.
 watchpoint.type (read-only)
     Either ``"r"``, ``"w"`` or ``"rw"`` for a read, write or read/write

--- a/scripts/src/lib.lua
+++ b/scripts/src/lib.lua
@@ -98,6 +98,7 @@ end
 		MAME_DIR .. "src/lib/util/msdib.h",
 		MAME_DIR .. "src/lib/util/nanosvg.cpp",
 		MAME_DIR .. "src/lib/util/nanosvg.h",
+		MAME_DIR .. "src/lib/util/notifier.h",
 		MAME_DIR .. "src/lib/util/opresolv.cpp",
 		MAME_DIR .. "src/lib/util/opresolv.h",
 		MAME_DIR .. "src/lib/util/options.cpp",

--- a/src/devices/bus/bbc/tube/tube_32016.h
+++ b/src/devices/bus/bbc/tube/tube_32016.h
@@ -57,7 +57,7 @@ protected:
 	required_device<ram_device> m_ram;
 	required_memory_region m_rom;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 
 	void tube_32016_mem(address_map &map);
 };

--- a/src/devices/bus/bbc/tube/tube_arm.cpp
+++ b/src/devices/bus/bbc/tube/tube_arm.cpp
@@ -113,14 +113,19 @@ void bbc_tube_arm_device::device_reset()
 	/* enable the reset vector to be fetched from ROM */
 	m_maincpu->space(AS_PROGRAM).install_rom(0x000000, 0x003fff, 0x3fc000, m_bootstrap->base());
 
-	m_rom_shadow_tap = program.install_write_tap(0x0000000, 0x03fffff, "rom_shadow_w",[this](offs_t offset, u32 &data, u32 mem_mask)
-	{
-		/* delete this tap */
-		m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_write_tap(
+			0x0000000, 0x03fffff,
+			"rom_shadow_w",
+			[this] (offs_t offset, u32 &data, u32 mem_mask)
+			{
+				/* delete this tap */
+				m_rom_shadow_tap.remove();
 
-		/* install ram */
-		m_maincpu->space(AS_PROGRAM).install_ram(0x0000000, 0x03fffff, m_ram->pointer());
-	});
+				/* install ram */
+				m_maincpu->space(AS_PROGRAM).install_ram(0x0000000, 0x03fffff, m_ram->pointer());
+			},
+			&m_rom_shadow_tap);
 }
 
 

--- a/src/devices/bus/bbc/tube/tube_arm.h
+++ b/src/devices/bus/bbc/tube/tube_arm.h
@@ -47,7 +47,7 @@ private:
 	required_device<ram_device> m_ram;
 	required_memory_region m_bootstrap;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 
 	void tube_arm_mem(address_map &map);
 };

--- a/src/devices/bus/electron/mc68k.h
+++ b/src/devices/bus/electron/mc68k.h
@@ -48,7 +48,7 @@ private:
 	required_memory_region m_boot_rom;
 	required_memory_region m_exp_rom;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 
 	void mem_map(address_map &map);
 

--- a/src/devices/bus/vme/vme_cp31.h
+++ b/src/devices/bus/vme/vme_cp31.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
+#include "vme.h"
+
 #include "bus/rs232/rs232.h"
-#include "bus/vme/vme.h"
 #include "cpu/m68000/m68000.h"
 #include "machine/68153bim.h"
 #include "machine/68230pit.h"
@@ -44,7 +45,7 @@ private:
 	required_region_ptr<uint32_t> m_sysrom;
 
 	// Pointer to System ROMs needed by bootvect_r and masking RAM buffer for post reset accesses
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	bool m_bus_error;
 	emu_timer *m_bus_error_timer;
 

--- a/src/devices/bus/vme/vme_hcpu30.cpp
+++ b/src/devices/bus/vme/vme_hcpu30.cpp
@@ -582,20 +582,22 @@ void vme_hcpu30_card_device::device_reset()
 	m_fdc->ready_w(false);
 
 	program.install_rom(0x00000000, 0x00000007, m_sysrom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xff000000, 0xff007fff, "rom_shadow_r", [this](offs_t offset, u32 &data, u32 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xff000000, 0xff007fff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u32 &data, u32 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x00000000, 0x00000007, m_p_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x00000000, 0x00000007, m_p_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void vme_hcpu30_card_device::device_timer(emu_timer &timer, device_timer_id id, int param)

--- a/src/devices/bus/vme/vme_hcpu30.h
+++ b/src/devices/bus/vme/vme_hcpu30.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
+#include "vme.h"
+
 #include "bus/centronics/ctronics.h"
 #include "bus/nscsi/hd.h"
 #include "bus/rs232/rs232.h"
-#include "bus/vme/vme.h"
 #include "cpu/m68000/m68000.h"
 #include "imagedev/floppy.h"
 #include "machine/clock.h"
@@ -60,7 +61,7 @@ private:
 	DECLARE_WRITE_LINE_MEMBER(fdcdrq_callback);
 
 	// Pointer to System ROMs needed by bootvect_r and masking RAM buffer for post reset accesses
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	uint16_t    m_irq_state;
 	uint16_t    m_irq_mask;
 	uint8_t     m_rtc_reg[16];

--- a/src/devices/bus/vme/vme_mvme120.h
+++ b/src/devices/bus/vme/vme_mvme120.h
@@ -61,8 +61,7 @@ protected:
 
 	required_ioport m_input_s3;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
-	memory_passthrough_handler *m_ram_wwp_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 
 	required_region_ptr<uint16_t> m_sysrom;
 	required_shared_ptr<uint16_t> m_localram;
@@ -80,7 +79,7 @@ protected:
 	uint16_t vme_a16_r();
 	void vme_a16_w(uint16_t data);
 
-	uint16_t rom_shadow_tap(offs_t address, u16 data, u16 mem_mask);
+	void rom_shadow_tap(offs_t address, u16 data, u16 mem_mask);
 
 	DECLARE_WRITE_LINE_MEMBER(watchdog_reset);
 	DECLARE_WRITE_LINE_MEMBER(mfp_interrupt);

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -56,7 +56,6 @@ i386_device::i386_device(const machine_config &mconfig, device_type type, const 
 	, device_vtlb_interface(mconfig, *this, AS_PROGRAM)
 	, m_program_config("program", ENDIANNESS_LITTLE, program_data_width, program_addr_width, 0, 32, 12)
 	, m_io_config("io", ENDIANNESS_LITTLE, io_data_width, 16, 0)
-	, m_dr_breakpoints{nullptr, nullptr, nullptr, nullptr}
 	, m_smiact(*this)
 	, m_ferr_handler(*this)
 {

--- a/src/devices/cpu/i386/i386.cpp
+++ b/src/devices/cpu/i386/i386.cpp
@@ -2025,10 +2025,7 @@ void i386_device::i386_common_init()
 	m_ferr_handler(0);
 
 	set_icountptr(m_cycles);
-	m_notifier = m_program->add_change_notifier([this](read_or_write mode)
-	{
-		dri_changed();
-	});
+	m_notifier = m_program->add_change_notifier([this] (read_or_write mode) { dri_changed(); });
 }
 
 void i386_device::device_start()

--- a/src/devices/cpu/i386/i386.h
+++ b/src/devices/cpu/i386/i386.h
@@ -274,7 +274,7 @@ protected:
 	uint32_t m_dr[8];       // Debug registers
 	uint32_t m_tr[8];       // Test registers
 
-	memory_passthrough_handler* m_dr_breakpoints[4];
+	memory_passthrough_handler m_dr_breakpoints[4];
 	int m_notifier;
 
 	//386 Debug Register change handlers.

--- a/src/devices/cpu/i386/i386.h
+++ b/src/devices/cpu/i386/i386.h
@@ -275,7 +275,7 @@ protected:
 	uint32_t m_tr[8];       // Test registers
 
 	memory_passthrough_handler m_dr_breakpoints[4];
-	int m_notifier;
+	util::notifier_subscription m_notifier;
 
 	//386 Debug Register change handlers.
 	inline void dri_changed();

--- a/src/devices/cpu/i386/i386segs.hxx
+++ b/src/devices/cpu/i386/i386segs.hxx
@@ -2482,7 +2482,7 @@ inline void i386_device::dri_changed()
 	if(!(m_dr[7] & 0xff)) return;
 	for(dr = 0; dr < 4; dr++)
 	{
-		if(m_dr_breakpoints[dr]) m_dr_breakpoints[dr]->remove();
+		m_dr_breakpoints[dr].remove();
 		int dr_enabled = (m_dr[7] & (1 << (dr << 1))) || (m_dr[7] & (1 << ((dr << 1) + 1))); // Check both local enable AND global enable bits for this breakpoint.
 		if(dr_enabled)
 		{
@@ -2512,9 +2512,9 @@ inline void i386_device::dri_changed()
 					m_dr[6] |= 1 << dr;
 					i386_trap(1,0,0);
 				}
-			}, m_dr_breakpoints[dr]);
+			}, &m_dr_breakpoints[dr]);
 			else if(breakpoint_type == 3) m_dr_breakpoints[dr] = m_program->install_readwrite_tap(phys_addr, phys_addr + 3, "i386_debug_readwrite_breakpoint",
-			[&, dr, true_mask](offs_t offset, u32& data, u32 mem_mask)
+			[this, dr, true_mask](offs_t offset, u32& data, u32 mem_mask)
 			{
 				if(true_mask & mem_mask)
 				{
@@ -2522,14 +2522,14 @@ inline void i386_device::dri_changed()
 					i386_trap(1,0,0);
 				}
 			},
-			[&, dr, true_mask](offs_t offset, u32& data, u32 mem_mask)
+			[this, dr, true_mask](offs_t offset, u32& data, u32 mem_mask)
 			{
 				if(true_mask & mem_mask)
 				{
 					m_dr[6] |= 1 << dr;
 					i386_trap(1,0,0);
 				}
-			}, m_dr_breakpoints[dr]);
+			}, &m_dr_breakpoints[dr]);
 		}
 	}
 }

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -462,10 +462,10 @@ device_debug::device_debug(device_t &device)
 		for (int i=0; i != count; i++)
 			if (m_memory->has_space(i)) {
 				address_space &space = m_memory->space(i);
-				m_notifiers.push_back(space.add_change_notifier([this, &space](read_or_write mode) { reinstall(space, mode); }));
+				m_notifiers.emplace_back(space.add_change_notifier([this, &space] (read_or_write mode) { reinstall(space, mode); }));
 			}
 			else
-				m_notifiers.push_back(-1);
+				m_notifiers.emplace_back();
 	}
 
 	// set up state-related stuff

--- a/src/emu/debug/debugcpu.cpp
+++ b/src/emu/debug/debugcpu.cpp
@@ -458,7 +458,7 @@ device_debug::device_debug(device_t &device)
 	// set up notifiers and clear the passthrough handlers
 	if (m_memory) {
 		int count = m_memory->max_space_count();
-		m_phw.resize(count, nullptr);
+		m_phw.resize(count);
 		for (int i=0; i != count; i++)
 			if (m_memory->has_space(i)) {
 				address_space &space = m_memory->space(i);
@@ -562,15 +562,14 @@ void device_debug::reinstall(address_space &space, read_or_write mode)
 	int id = space.spacenum();
 	if (u32(mode) & u32(read_or_write::WRITE))
 	{
-		if (m_phw[id])
-			m_phw[id]->remove();
+		m_phw[id].remove();
 		if (m_track_mem)
 			switch (space.data_width())
 			{
-			case  8: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space](offs_t address, u8  &data, u8 ) { write_tracking(space, address, data); }, m_phw[id]); break;
-			case 16: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space](offs_t address, u16 &data, u16) { write_tracking(space, address, data); }, m_phw[id]); break;
-			case 32: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space](offs_t address, u32 &data, u32) { write_tracking(space, address, data); }, m_phw[id]); break;
-			case 64: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space](offs_t address, u64 &data, u64) { write_tracking(space, address, data); }, m_phw[id]); break;
+			case  8: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space] (offs_t address, u8  &data, u8 ) { write_tracking(space, address, data); }, &m_phw[id]); break;
+			case 16: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space] (offs_t address, u16 &data, u16) { write_tracking(space, address, data); }, &m_phw[id]); break;
+			case 32: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space] (offs_t address, u32 &data, u32) { write_tracking(space, address, data); }, &m_phw[id]); break;
+			case 64: m_phw[id] = space.install_write_tap(0, space.addrmask(), "track_mem", [this, &space] (offs_t address, u64 &data, u64) { write_tracking(space, address, data); }, &m_phw[id]); break;
 			}
 	}
 }

--- a/src/emu/debug/debugcpu.h
+++ b/src/emu/debug/debugcpu.h
@@ -239,9 +239,9 @@ private:
 														//    (0 = not tracing over,
 														//    ~0 = not currently tracing over)
 	};
-	std::unique_ptr<tracer>                m_trace;                    // tracer state
+	std::unique_ptr<tracer>                m_trace;     // tracer state
 
-	std::vector<memory_passthrough_handler *> m_phw;    // passthrough handler reference for each space, write mode
+	std::vector<memory_passthrough_handler> m_phw;      // passthrough handler reference for each space, write mode
 	std::vector<int>        m_notifiers;                // notifiers for each space
 
 	// pc tracking

--- a/src/emu/debug/debugcpu.h
+++ b/src/emu/debug/debugcpu.h
@@ -242,7 +242,7 @@ private:
 	std::unique_ptr<tracer>                m_trace;     // tracer state
 
 	std::vector<memory_passthrough_handler> m_phw;      // passthrough handler reference for each space, write mode
-	std::vector<int>        m_notifiers;                // notifiers for each space
+	std::vector<util::notifier_subscription> m_notifiers; // notifiers for each space
 
 	// pc tracking
 	class dasm_pc_tag

--- a/src/emu/debug/express.cpp
+++ b/src/emu/debug/express.cpp
@@ -387,10 +387,10 @@ void symbol_table::set_memory_modified_func(memory_modified_func modified)
 //  add - add a new u64 pointer symbol
 //-------------------------------------------------
 
-void symbol_table::add(const char *name, read_write rw, u64 *ptr)
+symbol_entry &symbol_table::add(const char *name, read_write rw, u64 *ptr)
 {
 	m_symlist.erase(name);
-	m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, rw, ptr));
+	return *m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, rw, ptr)).first->second;
 }
 
 
@@ -398,10 +398,10 @@ void symbol_table::add(const char *name, read_write rw, u64 *ptr)
 //  add - add a new value symbol
 //-------------------------------------------------
 
-void symbol_table::add(const char *name, u64 value)
+symbol_entry &symbol_table::add(const char *name, u64 value)
 {
 	m_symlist.erase(name);
-	m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, value));
+	return *m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, value)).first->second;
 }
 
 
@@ -409,10 +409,10 @@ void symbol_table::add(const char *name, u64 value)
 //  add - add a new register symbol
 //-------------------------------------------------
 
-void symbol_table::add(const char *name, getter_func getter, setter_func setter, const std::string &format_string)
+symbol_entry &symbol_table::add(const char *name, getter_func getter, setter_func setter, const std::string &format_string)
 {
 	m_symlist.erase(name);
-	m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, getter, setter, format_string));
+	return *m_symlist.emplace(name, std::make_unique<integer_symbol_entry>(*this, name, getter, setter, format_string)).first->second;
 }
 
 
@@ -420,10 +420,10 @@ void symbol_table::add(const char *name, getter_func getter, setter_func setter,
 //  add - add a new function symbol
 //-------------------------------------------------
 
-void symbol_table::add(const char *name, int minparams, int maxparams, execute_func execute)
+symbol_entry &symbol_table::add(const char *name, int minparams, int maxparams, execute_func execute)
 {
 	m_symlist.erase(name);
-	m_symlist.emplace(name, std::make_unique<function_symbol_entry>(*this, name, minparams, maxparams, execute));
+	return *m_symlist.emplace(name, std::make_unique<function_symbol_entry>(*this, name, minparams, maxparams, execute)).first->second;
 }
 
 

--- a/src/emu/debug/express.h
+++ b/src/emu/debug/express.h
@@ -175,15 +175,16 @@ public:
 	// getters
 	const std::unordered_map<std::string, std::unique_ptr<symbol_entry>> &entries() const { return m_symlist; }
 	symbol_table *parent() const { return m_parent; }
+	running_machine &machine() { return m_machine; }
 
 	// setters
 	void set_memory_modified_func(memory_modified_func modified);
 
 	// symbol access
-	void add(const char *name, read_write rw, u64 *ptr = nullptr);
-	void add(const char *name, u64 constvalue);
-	void add(const char *name, getter_func getter, setter_func setter = nullptr, const std::string &format_string = "");
-	void add(const char *name, int minparams, int maxparams, execute_func execute);
+	symbol_entry &add(const char *name, read_write rw, u64 *ptr = nullptr);
+	symbol_entry &add(const char *name, u64 constvalue);
+	symbol_entry &add(const char *name, getter_func getter, setter_func setter = nullptr, const std::string &format_string = "");
+	symbol_entry &add(const char *name, int minparams, int maxparams, execute_func execute);
 	symbol_entry *find(const char *name) const { if (name) { auto search = m_symlist.find(name); if (search != m_symlist.end()) return search->second.get(); else return nullptr; } else return nullptr; }
 	symbol_entry *find_deep(const char *name);
 

--- a/src/emu/debug/points.cpp
+++ b/src/emu/debug/points.cpp
@@ -184,7 +184,7 @@ debug_watchpoint::debug_watchpoint(
 
 debug_watchpoint::~debug_watchpoint()
 {
-	m_space.remove_change_notifier(m_notifier);
+	m_notifier.reset();
 	m_phr.remove();
 	m_phw.remove();
 }

--- a/src/emu/debug/points.cpp
+++ b/src/emu/debug/points.cpp
@@ -185,10 +185,8 @@ debug_watchpoint::debug_watchpoint(
 debug_watchpoint::~debug_watchpoint()
 {
 	m_space.remove_change_notifier(m_notifier);
-	if (m_phr)
-		m_phr->remove();
-	if (m_phw)
-		m_phw->remove();
+	m_phr.remove();
+	m_phw.remove();
 }
 
 void debug_watchpoint::setEnabled(bool value)
@@ -201,10 +199,8 @@ void debug_watchpoint::setEnabled(bool value)
 		else
 		{
 			m_installing = true;
-			if(m_phr)
-				m_phr->remove();
-			if(m_phw)
-				m_phw->remove();
+			m_phr.remove();
+			m_phw.remove();
 			m_installing = false;
 		}
 	}
@@ -215,24 +211,28 @@ void debug_watchpoint::install(read_or_write mode)
 	if (m_installing)
 		return;
 	m_installing = true;
-	if ((u32(mode) & u32(read_or_write::READ)) && m_phr)
-		m_phr->remove();
-	if ((u32(mode) & u32(read_or_write::WRITE)) && m_phw)
-		m_phw->remove();
+	if (u32(mode) & u32(read_or_write::READ))
+		m_phr.remove();
+	if (u32(mode) & u32(read_or_write::WRITE))
+		m_phw.remove();
 	std::string name = util::string_format("wp@%x", m_address);
 	switch (m_space.data_width())
 	{
 	case  8:
 		if (u32(m_type) & u32(mode) & u32(read_or_write::READ))
-			m_phr = m_space.install_read_tap(m_start_address[0], m_end_address[0], name,
-											 [this](offs_t offset, u8 &data, u8 mem_mask) {
-												 triggered(read_or_write::READ, offset, data, mem_mask);
-											 }, m_phr);
+			m_phr = m_space.install_read_tap(
+					m_start_address[0], m_end_address[0], name,
+					[this](offs_t offset, u8 &data, u8 mem_mask) {
+						triggered(read_or_write::READ, offset, data, mem_mask);
+					},
+					&m_phr);
 		if (u32(m_type) & u32(mode) & u32(read_or_write::WRITE))
-			m_phw = m_space.install_write_tap(m_start_address[0], m_end_address[0], name,
-											  [this](offs_t offset, u8 &data, u8 mem_mask) {
-												  triggered(read_or_write::WRITE, offset, data, mem_mask);
-											  }, m_phw);
+			m_phw = m_space.install_write_tap(
+					m_start_address[0], m_end_address[0], name,
+					[this](offs_t offset, u8 &data, u8 mem_mask) {
+						triggered(read_or_write::WRITE, offset, data, mem_mask);
+					},
+					&m_phw);
 		break;
 
 	case 16:
@@ -241,17 +241,21 @@ void debug_watchpoint::install(read_or_write mode)
 			{
 				u16 mask = m_masks[i];
 				if (u32(m_type) & u32(mode) & u32(read_or_write::READ))
-					m_phr = m_space.install_read_tap(m_start_address[i], m_end_address[i], name,
-													 [this, mask](offs_t offset, u16 &data, u16 mem_mask) {
-														 if (mem_mask & mask)
-															 triggered(read_or_write::READ, offset, data, mem_mask);
-													 }, m_phr);
+					m_phr = m_space.install_read_tap(
+							m_start_address[i], m_end_address[i], name,
+							[this, mask](offs_t offset, u16 &data, u16 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::READ, offset, data, mem_mask);
+							},
+							&m_phr);
 				if (u32(m_type) & u32(mode) & u32(read_or_write::WRITE))
-					m_phw = m_space.install_write_tap(m_start_address[i], m_end_address[i], name,
-													  [this, mask](offs_t offset, u16 &data, u16 mem_mask) {
-														  if (mem_mask & mask)
-															  triggered(read_or_write::WRITE, offset, data, mem_mask);
-													  }, m_phw);
+					m_phw = m_space.install_write_tap(
+							m_start_address[i], m_end_address[i], name,
+							[this, mask](offs_t offset, u16 &data, u16 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::WRITE, offset, data, mem_mask);
+							 },
+							 &m_phw);
 			}
 		break;
 
@@ -261,17 +265,21 @@ void debug_watchpoint::install(read_or_write mode)
 			{
 				u32 mask = m_masks[i];
 				if (u32(m_type) & u32(mode) & u32(read_or_write::READ))
-					m_phr = m_space.install_read_tap(m_start_address[i], m_end_address[i], name,
-													 [this, mask](offs_t offset, u32 &data, u32 mem_mask) {
-														 if (mem_mask & mask)
-															 triggered(read_or_write::READ, offset, data, mem_mask);
-													 }, m_phr);
+					m_phr = m_space.install_read_tap(
+							m_start_address[i], m_end_address[i], name,
+							[this, mask](offs_t offset, u32 &data, u32 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::READ, offset, data, mem_mask);
+							},
+							&m_phr);
 				if (u32(m_type) & u32(mode) & u32(read_or_write::WRITE))
-					m_phw = m_space.install_write_tap(m_start_address[i], m_end_address[i], name,
-													  [this, mask](offs_t offset, u32 &data, u32 mem_mask) {
-														  if (mem_mask & mask)
-															  triggered(read_or_write::WRITE, offset, data, mem_mask);
-													  }, m_phw);
+					m_phw = m_space.install_write_tap(
+							m_start_address[i], m_end_address[i], name,
+							[this, mask](offs_t offset, u32 &data, u32 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::WRITE, offset, data, mem_mask);
+								},
+								&m_phw);
 			}
 		break;
 
@@ -281,17 +289,20 @@ void debug_watchpoint::install(read_or_write mode)
 			{
 				u64 mask = m_masks[i];
 				if (u32(m_type) & u32(mode) & u32(read_or_write::READ))
-					m_phr = m_space.install_read_tap(m_start_address[i], m_end_address[i], name,
-													 [this, mask](offs_t offset, u64 &data, u64 mem_mask) {
-														 if (mem_mask & mask)
-															 triggered(read_or_write::READ, offset, data, mem_mask);
-													 }, m_phr);
+					m_phr = m_space.install_read_tap(
+							m_start_address[i], m_end_address[i], name,
+							[this, mask](offs_t offset, u64 &data, u64 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::READ, offset, data, mem_mask);
+							},
+							&m_phr);
 				if (u32(m_type) & u32(mode) & u32(read_or_write::WRITE))
 					m_phw = m_space.install_write_tap(m_start_address[i], m_end_address[i], name,
-													  [this, mask](offs_t offset, u64 &data, u64 mem_mask) {
-														  if (mem_mask & mask)
-															  triggered(read_or_write::WRITE, offset, data, mem_mask);
-													  }, m_phw);
+							[this, mask](offs_t offset, u64 &data, u64 mem_mask) {
+								if (mem_mask & mask)
+									triggered(read_or_write::WRITE, offset, data, mem_mask);
+							},
+							&m_phw);
 			}
 		break;
 	}

--- a/src/emu/debug/points.h
+++ b/src/emu/debug/points.h
@@ -102,8 +102,8 @@ private:
 	void triggered(read_or_write type, offs_t address, u64 data, u64 mem_mask);
 
 	device_debug * m_debugInterface;                 // the interface we were created from
-	memory_passthrough_handler *m_phr;               // passthrough handler reference, read access
-	memory_passthrough_handler *m_phw;               // passthrough handler reference, write access
+	memory_passthrough_handler m_phr;                // passthrough handler reference, read access
+	memory_passthrough_handler m_phw;                // passthrough handler reference, write access
 	address_space &      m_space;                    // address space
 	int                  m_index;                    // user reported index
 	bool                 m_enabled;                  // enabled?

--- a/src/emu/debug/points.h
+++ b/src/emu/debug/points.h
@@ -112,7 +112,7 @@ private:
 	offs_t               m_length;                   // length of watch area
 	parsed_expression    m_condition;                // condition
 	std::string          m_action;                   // action
-	int                  m_notifier;                 // address map change notifier id
+	util::notifier_subscription m_notifier;          // address map change notifier ID
 
 	offs_t               m_start_address[3];         // the start addresses of the checks to install
 	offs_t               m_end_address[3];           // the end addresses

--- a/src/emu/emu.h
+++ b/src/emu/emu.h
@@ -18,6 +18,9 @@
 #ifndef __EMU_H__
 #define __EMU_H__
 
+// get forward declarations before anything else
+#include "emufwd.h"
+
 #include <list>
 #include <forward_list>
 #include <vector>

--- a/src/emu/emumem.cpp
+++ b/src/emu/emumem.cpp
@@ -865,62 +865,62 @@ void address_space_installer::populate_map_entry(const address_map_entry &entry,
 
 
 
-memory_passthrough_handler *address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 8-bits wide bus read tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 16-bits wide bus read tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 32-bits wide bus read tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 64-bits wide bus read tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 8-bits wide bus write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 16-bits wide bus write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 32-bits wide bus write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 64-bits wide bus write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 8-bits wide bus read/write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 16-bits wide bus read/write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	fatalerror("Tryingw to install a 32-bits wide bus read/write tap in a %d-bits wide bus\n", data_width());
 }
 
-memory_passthrough_handler *address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph)
+memory_passthrough_handler address_space_installer::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph)
 {
 	fatalerror("Trying to install a 64-bits wide bus read/write tap in a %d-bits wide bus\n", data_width());
 }

--- a/src/emu/emumem.h
+++ b/src/emu/emumem.h
@@ -50,6 +50,14 @@ enum class read_or_write
 };
 
 
+//**************************************************************************
+//  FORWARD DECLARATIONS
+//**************************************************************************
+
+class handler_entry;
+template<int Width, int AddrShift> class handler_entry_read_passthrough;
+template<int Width, int AddrShift> class handler_entry_write_passthrough;
+
 
 //**************************************************************************
 //  TYPE DEFINITIONS
@@ -90,7 +98,7 @@ struct memory_entry_context {
 
 struct memory_entry {
 	offs_t start, end;
-	class handler_entry *entry;
+	handler_entry *entry;
 	std::vector<memory_entry_context> context;
 };
 
@@ -465,6 +473,29 @@ constexpr int handler_entry_dispatch_lowbits(int highbits, int width, int ashift
 		width + ashift;
 }
 
+
+// =====================-> Passthrough handler management structure
+
+class memory_passthrough_handler_impl
+{
+public:
+	memory_passthrough_handler_impl(address_space &space) : m_space(space) {}
+	memory_passthrough_handler_impl(memory_passthrough_handler_impl const &) = delete;
+
+	void remove();
+
+private:
+	address_space &m_space;
+	std::unordered_set<handler_entry *> m_handlers;
+
+	void add_handler(handler_entry *handler) { m_handlers.insert(handler); }
+	void remove_handler(handler_entry *handler) { m_handlers.erase(m_handlers.find(handler)); }
+
+	friend address_space;
+	template<int Width, int AddrShift> friend class ::handler_entry_read_passthrough;
+	template<int Width, int AddrShift> friend class ::handler_entry_write_passthrough;
+};
+
 } // namespace emu::detail
 
 
@@ -561,8 +592,6 @@ protected:
 
 // Provides the populate/read/get_ptr/lookup API
 
-template<int Width, int AddrShift> class handler_entry_read_passthrough;
-
 template<int Width, int AddrShift> class handler_entry_read : public handler_entry
 {
 public:
@@ -596,7 +625,7 @@ public:
 	virtual void populate_nomirror(offs_t start, offs_t end, offs_t ostart, offs_t oend, handler_entry_read<Width, AddrShift> *handler);
 	virtual void populate_mirror(offs_t start, offs_t end, offs_t ostart, offs_t oend, offs_t mirror, handler_entry_read<Width, AddrShift> *handler);
 
-	inline void populate_mismatched(offs_t start, offs_t end, offs_t mirror, const memory_units_descriptor<Width, AddrShift> &descriptor) {
+	void populate_mismatched(offs_t start, offs_t end, offs_t mirror, const memory_units_descriptor<Width, AddrShift> &descriptor) {
 		start &= ~NATIVE_MASK;
 		end |= NATIVE_MASK;
 		std::vector<mapping> mappings;
@@ -609,7 +638,7 @@ public:
 	virtual void populate_mismatched_nomirror(offs_t start, offs_t end, offs_t ostart, offs_t oend, const memory_units_descriptor<Width, AddrShift> &descriptor, u8 rkey, std::vector<mapping> &mappings);
 	virtual void populate_mismatched_mirror(offs_t start, offs_t end, offs_t ostart, offs_t oend, offs_t mirror, const memory_units_descriptor<Width, AddrShift> &descriptor, std::vector<mapping> &mappings);
 
-	inline void populate_passthrough(offs_t start, offs_t end, offs_t mirror, handler_entry_read_passthrough<Width, AddrShift> *handler) {
+	void populate_passthrough(offs_t start, offs_t end, offs_t mirror, handler_entry_read_passthrough<Width, AddrShift> *handler) {
 		start &= ~NATIVE_MASK;
 		end |= NATIVE_MASK;
 		std::vector<mapping> mappings;
@@ -635,8 +664,6 @@ public:
 // =====================-> The parent class of all write handlers
 
 // Provides the populate/write/get_ptr/lookup API
-
-template<int Width, int AddrShift> class handler_entry_write_passthrough;
 
 template<int Width, int AddrShift> class handler_entry_write : public handler_entry
 {
@@ -711,20 +738,21 @@ public:
 // =====================-> Passthrough handler management structure
 class memory_passthrough_handler
 {
-	template<int Width, int AddrShift> friend class handler_entry_read_passthrough;
-	template<int Width, int AddrShift> friend class handler_entry_write_passthrough;
-
 public:
-	memory_passthrough_handler(address_space &space) : m_space(space) {}
+	memory_passthrough_handler() : m_impl() {}
+	memory_passthrough_handler(std::shared_ptr<emu::detail::memory_passthrough_handler_impl> const &impl) : m_impl(impl) {}
 
-	inline void remove();
+	void remove()
+	{
+		auto impl(m_impl.lock());
+		if (impl)
+			impl->remove();
+	}
 
 private:
-	address_space &m_space;
-	std::unordered_set<handler_entry *> m_handlers;
+	std::weak_ptr<emu::detail::memory_passthrough_handler_impl> m_impl;
 
-	void add_handler(handler_entry *handler) { m_handlers.insert(handler); }
-	void remove_handler(handler_entry *handler) { m_handlers.erase(m_handlers.find(handler)); }
+	friend class address_space;
 };
 
 // =====================-> Forward declaration for address_space
@@ -1687,32 +1715,32 @@ public:
 	virtual void install_device_delegate(offs_t addrstart, offs_t addrend, device_t &device, address_map_constructor &map, u64 unitmask = 0, int cswidth = 0, u16 flags = 0) = 0;
 
 	// install taps without mirroring
-	memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
-	memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
-	memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
-	memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
-	memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
+	memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_read_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr) { return install_write_tap(addrstart, addrend, 0, name, tap, mph); }
+	memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
+	memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
+	memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
+	memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr) { return install_readwrite_tap(addrstart, addrend, 0, name, tapr, tapw, mph); }
 
 	// install taps with mirroring
-	virtual memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
-	virtual memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tap, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapr, std::function<void (offs_t offset, u8  &data, u8  mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapr, std::function<void (offs_t offset, u16 &data, u16 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapr, std::function<void (offs_t offset, u32 &data, u32 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
+	virtual memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapr, std::function<void (offs_t offset, u64 &data, u64 mem_mask)> tapw, memory_passthrough_handler *mph = nullptr);
 
 	// install views
 	void install_view(offs_t addrstart, offs_t addrend, memory_view &view) { install_view(addrstart, addrend, 0, view); }
@@ -1981,7 +2009,7 @@ public:
 
 	u64 unmap() const { return m_unmap; }
 
-	memory_passthrough_handler *make_mph();
+	std::shared_ptr<emu::detail::memory_passthrough_handler_impl> make_mph(memory_passthrough_handler *mph);
 
 	// debug helpers
 	virtual std::string get_handler_string(read_or_write readorwrite, offs_t byteaddress) const = 0;
@@ -2088,7 +2116,7 @@ protected:
 	handler_entry           *m_nop_r;
 	handler_entry           *m_nop_w;
 
-	std::vector<std::unique_ptr<memory_passthrough_handler>> m_mphs;
+	std::vector<std::shared_ptr<emu::detail::memory_passthrough_handler_impl>> m_mphs;
 
 	std::vector<notifier_t> m_notifiers;        // notifier list for address map change
 	int                     m_notifier_id;      // next notifier id
@@ -2397,7 +2425,7 @@ write_native(offs_t address, typename emu::detail::handler_entry_size<Width>::uX
 	m_cache_w->write(address, data, mask);
 }
 
-void memory_passthrough_handler::remove()
+inline void emu::detail::memory_passthrough_handler_impl::remove()
 {
 	m_space.remove_passthrough(m_handlers);
 }

--- a/src/emu/emumem_aspace.cpp
+++ b/src/emu/emumem_aspace.cpp
@@ -810,7 +810,6 @@ address_space::address_space(memory_manager &manager, device_memory_interface &m
 		m_spacenum(spacenum),
 		m_log_unmap(true),
 		m_name(memory.space_config(spacenum)->name()),
-		m_notifier_id(0),
 		m_in_notification(0)
 {
 }
@@ -1296,19 +1295,7 @@ template<int Level, int Width, int AddrShift, endianness_t Endian> void address_
 //  MEMORY MAPPING HELPERS
 //**************************************************************************
 
-int address_space::add_change_notifier(std::function<void (read_or_write)> n)
+util::notifier_subscription address_space::add_change_notifier(delegate<void (read_or_write)> &&n)
 {
-	int id = m_notifier_id++;
-	m_notifiers.emplace_back(notifier_t{ std::move(n), id });
-	return id;
-}
-
-void address_space::remove_change_notifier(int id)
-{
-	for(auto i = m_notifiers.begin(); i != m_notifiers.end(); i++)
-		if (i->m_id == id) {
-			m_notifiers.erase(i);
-			return;
-		}
-	fatalerror("Unknown notifier id %d, double remove?\n", id);
+	return m_notifiers.subscribe(std::move(n));
 }

--- a/src/emu/emumem_aspace.cpp
+++ b/src/emu/emumem_aspace.cpp
@@ -292,9 +292,9 @@ public:
 	using address_space::install_write_tap;
 	using address_space::install_readwrite_tap;
 
-	virtual memory_passthrough_handler *install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph) override;
-	virtual memory_passthrough_handler *install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph) override;
-	virtual memory_passthrough_handler *install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapr, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapw, memory_passthrough_handler *mph) override;
+	virtual memory_passthrough_handler install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph) override;
+	virtual memory_passthrough_handler install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph) override;
+	virtual memory_passthrough_handler install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapr, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapw, memory_passthrough_handler *mph) override;
 
 	// construction/destruction
 	address_space_specific(memory_manager &manager, device_memory_interface &memory, int spacenum, int address_width)
@@ -1084,73 +1084,78 @@ template<int Level, int Width, int AddrShift, endianness_t Endian> void address_
 	view.make_subdispatch(""); // Must be called after populate
 }
 
-memory_passthrough_handler *address_space::make_mph()
+std::shared_ptr<emu::detail::memory_passthrough_handler_impl> address_space::make_mph(memory_passthrough_handler *mph)
 {
-	m_mphs.emplace_back(std::make_unique<memory_passthrough_handler>(*this));
-	return m_mphs.back().get();
+	if (mph)
+	{
+		auto impl(mph->m_impl.lock());
+		if (impl)
+		{
+			assert(&impl->m_space == this);
+			return impl;
+		}
+	}
+	return m_mphs.emplace_back(std::make_shared<emu::detail::memory_passthrough_handler_impl>(*this));
 }
 
 //-------------------------------------------------
 //  install_read_tap - install a read tap on the bus
 //-------------------------------------------------
 
-template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler *address_space_specific<Level, Width, AddrShift, Endian>::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph)
+template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler address_space_specific<Level, Width, AddrShift, Endian>::install_read_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	offs_t nstart, nend, nmask, nmirror;
 	check_optimize_mirror("install_read_tap", addrstart, addrend, addrmirror, nstart, nend, nmask, nmirror);
-	if (!mph)
-		mph = make_mph();
+	auto impl = make_mph(mph);
 
-	auto handler = new handler_entry_read_tap<Width, AddrShift>(this, *mph, name, tap);
+	auto handler = new handler_entry_read_tap<Width, AddrShift>(this, *impl, name, tap);
 	m_root_read->populate_passthrough(nstart, nend, nmirror, handler);
 	handler->unref();
 
 	invalidate_caches(read_or_write::READ);
 
-	return mph;
+	return impl;
 }
 
 //-------------------------------------------------
 //  install_write_tap - install a write tap on the bus
 //-------------------------------------------------
 
-template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler *address_space_specific<Level, Width, AddrShift, Endian>::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph)
+template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler address_space_specific<Level, Width, AddrShift, Endian>::install_write_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap, memory_passthrough_handler *mph)
 {
 	offs_t nstart, nend, nmask, nmirror;
 	check_optimize_mirror("install_write_tap", addrstart, addrend, addrmirror, nstart, nend, nmask, nmirror);
-	if (!mph)
-		mph = make_mph();
+	auto impl = make_mph(mph);
 
-	auto handler = new handler_entry_write_tap<Width, AddrShift>(this, *mph, name, tap);
+	auto handler = new handler_entry_write_tap<Width, AddrShift>(this, *impl, name, tap);
 	m_root_write->populate_passthrough(nstart, nend, nmirror, handler);
 	handler->unref();
 
 	invalidate_caches(read_or_write::WRITE);
 
-	return mph;
+	return impl;
 }
 //-------------------------------------------------
 //  install_write_tap - install a read and a write tap on the bus
 //-------------------------------------------------
 
-template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler *address_space_specific<Level, Width, AddrShift, Endian>::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapr, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapw, memory_passthrough_handler *mph)
+template<int Level, int Width, int AddrShift, endianness_t Endian> memory_passthrough_handler address_space_specific<Level, Width, AddrShift, Endian>::install_readwrite_tap(offs_t addrstart, offs_t addrend, offs_t addrmirror, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapr, std::function<void (offs_t offset, uX &data, uX mem_mask)> tapw, memory_passthrough_handler *mph)
 {
 	offs_t nstart, nend, nmask, nmirror;
 	check_optimize_mirror("install_readwrite_tap", addrstart, addrend, addrmirror, nstart, nend, nmask, nmirror);
-	if (!mph)
-		mph = make_mph();
+	auto impl = make_mph(mph);
 
-	auto rhandler = new handler_entry_read_tap <Width, AddrShift>(this, *mph, name, tapr);
+	auto rhandler = new handler_entry_read_tap <Width, AddrShift>(this, *impl, name, tapr);
 	m_root_read ->populate_passthrough(nstart, nend, nmirror, rhandler);
 	rhandler->unref();
 
-	auto whandler = new handler_entry_write_tap<Width, AddrShift>(this, *mph, name, tapw);
+	auto whandler = new handler_entry_write_tap<Width, AddrShift>(this, *impl, name, tapw);
 	m_root_write->populate_passthrough(nstart, nend, nmirror, whandler);
 	whandler->unref();
 
 	invalidate_caches(read_or_write::READWRITE);
 
-	return mph;
+	return impl;
 }
 
 

--- a/src/emu/emumem_hep.h
+++ b/src/emu/emumem_hep.h
@@ -10,7 +10,7 @@ template<int Width, int AddrShift> class handler_entry_read_passthrough : public
 public:
 	using uX = typename emu::detail::handler_entry_size<Width>::uX;
 
-	handler_entry_read_passthrough(address_space *space, memory_passthrough_handler &mph) : handler_entry_read<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(nullptr) {}
+	handler_entry_read_passthrough(address_space *space, emu::detail::memory_passthrough_handler_impl &mph) : handler_entry_read<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(nullptr) {}
 	~handler_entry_read_passthrough();
 
 	virtual handler_entry_read_passthrough<Width, AddrShift> *instantiate(handler_entry_read<Width, AddrShift> *next) const = 0;
@@ -20,10 +20,10 @@ public:
 	void detach(const std::unordered_set<handler_entry *> &handlers) override;
 
 protected:
-	memory_passthrough_handler &m_mph;
+	emu::detail::memory_passthrough_handler_impl &m_mph;
 	handler_entry_read<Width, AddrShift> *m_next;
 
-	handler_entry_read_passthrough(address_space *space, memory_passthrough_handler &mph, handler_entry_read<Width, AddrShift> *next) : handler_entry_read<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(next) { next->ref(); mph.add_handler(this); }
+	handler_entry_read_passthrough(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, handler_entry_read<Width, AddrShift> *next) : handler_entry_read<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(next) { next->ref(); mph.add_handler(this); }
 };
 
 template<int Width, int AddrShift> class handler_entry_write_passthrough : public handler_entry_write<Width, AddrShift>
@@ -31,7 +31,7 @@ template<int Width, int AddrShift> class handler_entry_write_passthrough : publi
 public:
 	using uX = typename emu::detail::handler_entry_size<Width>::uX;
 
-	handler_entry_write_passthrough(address_space *space, memory_passthrough_handler &mph) : handler_entry_write<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(nullptr) {}
+	handler_entry_write_passthrough(address_space *space, emu::detail::memory_passthrough_handler_impl &mph) : handler_entry_write<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(nullptr) {}
 	~handler_entry_write_passthrough();
 
 	virtual handler_entry_write_passthrough<Width, AddrShift> *instantiate(handler_entry_write<Width, AddrShift> *next) const = 0;
@@ -41,8 +41,8 @@ public:
 	void detach(const std::unordered_set<handler_entry *> &handlers) override;
 
 protected:
-	memory_passthrough_handler &m_mph;
+	emu::detail::memory_passthrough_handler_impl &m_mph;
 	handler_entry_write<Width, AddrShift> *m_next;
 
-	handler_entry_write_passthrough(address_space *space, memory_passthrough_handler &mph, handler_entry_write<Width, AddrShift> *next) : handler_entry_write<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(next) { next->ref(); mph.add_handler(this); }
+	handler_entry_write_passthrough(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, handler_entry_write<Width, AddrShift> *next) : handler_entry_write<Width, AddrShift>(space, handler_entry::F_PASSTHROUGH), m_mph(mph), m_next(next) { next->ref(); mph.add_handler(this); }
 };

--- a/src/emu/emumem_het.h
+++ b/src/emu/emumem_het.h
@@ -14,7 +14,7 @@ template<int Width, int AddrShift> class handler_entry_read_tap : public handler
 public:
 	using uX = typename emu::detail::handler_entry_size<Width>::uX;
 
-	handler_entry_read_tap(address_space *space, memory_passthrough_handler &mph, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_read_passthrough<Width, AddrShift>(space, mph), m_name(name), m_tap(std::move(tap)) {}
+	handler_entry_read_tap(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_read_passthrough<Width, AddrShift>(space, mph), m_name(name), m_tap(std::move(tap)) {}
 	~handler_entry_read_tap() = default;
 
 	uX read(offs_t offset, uX mem_mask) const override;
@@ -28,7 +28,7 @@ protected:
 	std::string m_name;
 	std::function<void (offs_t offset, uX &data, uX mem_mask)> m_tap;
 
-	handler_entry_read_tap(address_space *space, memory_passthrough_handler &mph, handler_entry_read<Width, AddrShift> *next, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_read_passthrough<Width, AddrShift>(space, mph, next), m_name(name), m_tap(tap) {}
+	handler_entry_read_tap(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, handler_entry_read<Width, AddrShift> *next, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_read_passthrough<Width, AddrShift>(space, mph, next), m_name(name), m_tap(tap) {}
 };
 
 template<int Width, int AddrShift> class handler_entry_write_tap : public handler_entry_write_passthrough<Width, AddrShift>
@@ -36,7 +36,7 @@ template<int Width, int AddrShift> class handler_entry_write_tap : public handle
 public:
 	using uX = typename emu::detail::handler_entry_size<Width>::uX;
 
-	handler_entry_write_tap(address_space *space, memory_passthrough_handler &mph, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_write_passthrough<Width, AddrShift>(space, mph), m_name(name), m_tap(std::move(tap)) {}
+	handler_entry_write_tap(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_write_passthrough<Width, AddrShift>(space, mph), m_name(name), m_tap(std::move(tap)) {}
 	~handler_entry_write_tap() = default;
 
 	void write(offs_t offset, uX data, uX mem_mask) const override;
@@ -50,7 +50,7 @@ protected:
 	std::string m_name;
 	std::function<void (offs_t offset, uX &data, uX mem_mask)> m_tap;
 
-	handler_entry_write_tap(address_space *space, memory_passthrough_handler &mph, handler_entry_write<Width, AddrShift> *next, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_write_passthrough<Width, AddrShift>(space, mph, next), m_name(name), m_tap(tap) {}
+	handler_entry_write_tap(address_space *space, emu::detail::memory_passthrough_handler_impl &mph, handler_entry_write<Width, AddrShift> *next, std::string name, std::function<void (offs_t offset, uX &data, uX mem_mask)> tap) : handler_entry_write_passthrough<Width, AddrShift>(space, mph, next), m_name(name), m_tap(tap) {}
 };
 
 #endif // MAME_EMU_EMUMEM_HET_H

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -28,6 +28,7 @@
 #include "uiinput.h"
 
 #include "corestr.h"
+#include "notifier.h"
 
 #include <cstring>
 #include <thread>
@@ -740,6 +741,10 @@ void lua_engine::initialize()
 			[] (device_t &dev) { return devenum<slot_interface_enumerator>(dev); },
 			[] (device_t &dev, int maxdepth) { return devenum<slot_interface_enumerator>(dev, maxdepth); });
 
+
+	auto notifier_subscription_type = sol().registry().new_usertype<util::notifier_subscription>("notifier_subscription", sol::no_constructor);
+	notifier_subscription_type["unsubscribe"] = &util::notifier_subscription::reset;
+	notifier_subscription_type["is_active"] = sol::property(&util::notifier_subscription::operator bool);
 
 	auto attotime_type = emu.new_usertype<attotime>(
 			"attotime",

--- a/src/lib/util/notifier.h
+++ b/src/lib/util/notifier.h
@@ -1,0 +1,240 @@
+// license:BSD-3-Clause
+// copyright-holders:Vas Crabb
+/// \file
+/// \brief Simple broadcast notifier
+///
+/// Classes for managing subscriptions and calling multiple listener
+/// functions for notifications.
+#ifndef MAME_LIB_UTIL_NOTIFIER_H
+#define MAME_LIB_UTIL_NOTIFIER_H
+
+#pragma once
+
+#include "delegate.h"
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+
+namespace util {
+
+/// \brief A subscription to a notification source
+///
+/// Class for representing a subscription to a notifier.  Automatically
+/// unsubscribes on destruction, if explicitly reset, if assigned to, or
+/// when taking ownership of a different subscription by move
+/// assignment.
+/// \sa notifier
+class notifier_subscription
+{
+public:
+	/// \brief Create an empty subscription
+	///
+	/// Initialises an instance not referring to a subscription.
+	notifier_subscription() noexcept : m_token(), m_live(nullptr), m_index(0U) { }
+
+	/// \brief Transfer ownership of a subscription
+	///
+	/// Transfers ownership of a subscription to a new instance.
+	/// \param [in,out] that The subscription to transfer ownership
+	///   from.  Will no longer refer to a subscription after ownership
+	///   is transferred away.
+	notifier_subscription(notifier_subscription &&that) noexcept :
+		m_token(std::move(that.m_token)),
+		m_live(that.m_live),
+		m_index(that.m_index)
+	{
+		that.m_token.reset();
+	}
+
+	/// \brief Unsubscribe and destroy a subscription
+	///
+	/// Unsubscribes if the subscription is active and cleans up the
+	/// subscription instance.
+	~notifier_subscription() noexcept
+	{
+		auto token(m_token.lock());
+		if (token)
+			(*m_live)[m_index] = false;
+	}
+
+	/// \brief Swap two subscriptions
+	///
+	/// Exchanges ownership of subscriptions between two instances.
+	/// \param [in,out] that The subscription to exchange ownership
+	///   with.
+	void swap(notifier_subscription &that) noexcept
+	{
+		using std::swap;
+		swap(m_token, that.m_token);
+		swap(m_live, that.m_live);
+		swap(m_index, that.m_index);
+	}
+
+	/// \brief Unsubscribe from notifications
+	///
+	/// If the instance refers to an active subscription, cancel it so
+	/// no future notifications will be received.
+	void reset() noexcept
+	{
+		auto token(m_token.lock());
+		if (token)
+			(*m_live)[m_index] = false;
+		m_token.reset();
+	}
+
+	/// \brief Test whether a subscription is active
+	///
+	/// Tests whether a subscription is active.  A subscription will be
+	/// inactive if it is default constructed, reset, transferred away,
+	/// or if the underlying notifier is destructed.
+	/// \return True if the subscription is active, false otherwise.
+	explicit operator bool() const noexcept { return bool(m_token.lock()); }
+
+	/// \brief Transfer ownership of a subscription
+	///
+	/// Transfers ownership of a subscription to an existing instance.
+	/// If the subscription is active, it will be cancelled before it
+	/// takes ownership of the other subscription.
+	/// \param [in,out] that The subscription to transfer ownership
+	///   from.  Will no longer refer to a subscription after ownership
+	///   is transferred away.
+	/// \return A reference to the instance that ownership was
+	///   transferred to.
+	notifier_subscription &operator=(notifier_subscription &&that) noexcept
+	{
+		{
+			auto token(m_token.lock());
+			if (token)
+				(*m_live)[m_index] = false;
+		}
+		m_token = std::move(that.m_token);
+		m_live = that.m_live;
+		m_index = that.m_index;
+		that.m_token.reset();
+		return *this;
+	}
+
+protected:
+	notifier_subscription(
+			std::shared_ptr<int> const &token,
+			std::vector<bool> &live,
+			std::vector<bool>::size_type index) :
+		m_token(token),
+		m_live(&live),
+		m_index(index)
+	{
+	}
+
+private:
+	notifier_subscription(notifier_subscription const &) = delete;
+	notifier_subscription &operator=(notifier_subscription const &) = delete;
+
+	std::weak_ptr<int> m_token;
+	std::vector<bool> *m_live;
+	std::vector<bool>::size_type m_index;
+};
+
+
+/// \brief Broadcast notifier
+///
+/// Calls multiple listener functions.  Allows listeners to subscribe
+/// and unsubscribe.  Subscriptions are managed using
+/// \c notifier_subscription instances.
+/// \tparam Params Argument types for the listener functions.
+/// \sa notifier_subscription
+template <typename... Params>
+class notifier
+{
+public:
+	/// \brief Listener delegate type
+	///
+	/// The delegate type used to represent listener functions.
+	using delegate_type = delegate<void (Params...)>;
+
+	/// \brief Create a new notifier
+	///
+	/// Creates a new notifier with no initial subscribers.
+	notifier() : m_token(std::make_shared<int>(0)) { }
+
+	/// \brief Destroy a notifier
+	///
+	/// Destroys a notifier, causing any subscriptions to become
+	/// inactive.
+	~notifier() noexcept { m_token.reset(); }
+
+	/// \brief Add a listener
+	///
+	/// Adds a listener function subscription, returning an object for
+	/// managing the subscription.
+	/// \param [in] listener The function to be called on notifications.
+	/// \return A subscription object.  Destroy the object or call its
+	///   \c reset member function to unsubscribe.
+	notifier_subscription subscribe(delegate_type &&listener)
+	{
+		struct subscription_impl : notifier_subscription
+		{
+			subscription_impl(notifier &host, std::size_t index) noexcept :
+				notifier_subscription(host.m_token, host.m_live, index)
+			{
+			}
+		};
+		for (std::size_t i = 0U; m_listeners.size() > i; ++i)
+		{
+			if (!m_live[i])
+			{
+				m_live[i] = true;
+				m_listeners[i] = std::move(listener);
+				return subscription_impl(*this, i);
+			}
+		}
+		m_live.emplace_back(true);
+		try
+		{
+			m_listeners.emplace_back(std::move(listener));
+		}
+		catch (...)
+		{
+			m_live.pop_back();
+			throw;
+		}
+		return subscription_impl(*this, m_listeners.size() - 1);
+	}
+
+	/// \brief Call listeners
+	///
+	/// Calls all active listener functions.
+	/// \param [in] args Arguments to pass to the listener functions.
+	void operator()(Params... args) const
+	{
+		for (std::size_t i = 0U; m_listeners.size() > i; ++i)
+		{
+			if (m_live[i])
+				m_listeners[i](args...);
+		}
+	}
+
+private:
+	notifier(notifier const &) = delete;
+	notifier &operator=(notifier const &) = delete;
+
+	std::shared_ptr<int> m_token;
+	std::vector<bool> m_live;
+	std::vector<delegate_type> m_listeners;
+};
+
+
+/// \brief Swap two notifier subscriptions
+///
+/// Exchanges ownership of two notifier subscriptions.  Allows the
+/// swappable idiom to be used with notifier subscriptions.
+/// \param [in,out] x Takes ownership of the subscription from \p y.
+/// \param [in,out] y Takes ownership of the subscription from \p x.
+/// \sa notifier_subscription
+inline void swap(notifier_subscription &x, notifier_subscription &y) noexcept { x.swap(y); }
+
+} // namespace util
+
+#endif // MAME_LIB_UTIL_NOTIFIER_H

--- a/src/mame/drivers/apogee.cpp
+++ b/src/mame/drivers/apogee.cpp
@@ -23,6 +23,8 @@
 #include "formats/rk_cas.h"
 
 
+namespace {
+
 class apogee_state : public radio86_state
 {
 public:
@@ -178,20 +180,22 @@ void apogee_state::machine_reset()
 {
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x0fff, m_rom+0x0800);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xf000, 0xffff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xf000, 0xffff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void apogee_state::machine_start()
@@ -306,6 +310,8 @@ ROM_START( apogee )
 	ROM_REGION(0x0800, "chargen",0)
 	ROM_LOAD ("apogee.fnt", 0x0000, 0x0800, CRC(fe5867f0) SHA1(82c5aca63ada5e4533eb0516384aaa7b77a1f8e2))
 ROM_END
+
+} // anonymous namespace
 
 /* Driver */
 

--- a/src/mame/drivers/argo.cpp
+++ b/src/mame/drivers/argo.cpp
@@ -27,18 +27,22 @@ ToDo:
 ****************************************************************************************/
 
 #include "emu.h"
+
 #include "cpu/z80/z80.h"
-#include "machine/i8251.h"
-#include "machine/pit8253.h"
-#include "machine/i8257.h"
-#include "video/i8275.h"
 #include "imagedev/cassette.h"
-//#include "sound/spkrdev.h"
-#include "speaker.h"
+#include "machine/i8251.h"
+#include "machine/i8257.h"
+#include "machine/pit8253.h"
 #include "machine/timer.h"
+//#include "sound/spkrdev.h"
+#include "video/i8275.h"
+
 #include "emupal.h"
 #include "screen.h"
+#include "speaker.h"
 
+
+namespace {
 
 class argo_state : public driver_device
 {
@@ -76,7 +80,7 @@ private:
 	void io_map(address_map &map);
 	void mem_map(address_map &map);
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<z80_device> m_maincpu;
 	required_region_ptr<u8> m_rom;
 	required_shared_ptr<u8> m_ram;
@@ -426,20 +430,22 @@ void argo_state::machine_reset()
 {
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x07ff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xf800, 0xffff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xf800, 0xffff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void argo_state::machine_start()
@@ -517,6 +523,8 @@ ROM_START( argo )
 	ROM_REGION( 0x2000, "chargen", 0 )
 	ROM_LOAD( "c10_char.bin", 0x0000, 0x2000, BAD_DUMP CRC(cb530b6f) SHA1(95590bbb433db9c4317f535723b29516b9b9fcbf))
 ROM_END
+
+} // anonymous namespace
 
 /* Driver */
 

--- a/src/mame/drivers/blit.cpp
+++ b/src/mame/drivers/blit.cpp
@@ -56,6 +56,8 @@
 #define LOGDBG(...) LOGMASKED(LOG_DEBUG, __VA_ARGS__)
 
 
+namespace {
+
 class blit_state : public driver_device
 {
 public:
@@ -95,7 +97,7 @@ private:
 	required_shared_ptr<uint16_t> m_p_ram;
 	required_region_ptr<uint16_t> m_sysrom;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	int m_videostart = 0;
 };
 
@@ -211,20 +213,22 @@ void blit_state::machine_reset()
 {
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x000000, 0x000007, m_sysrom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0x040000, 0x045fff, "rom_shadow_r",[this](offs_t offset, u16 &data, u16 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0x040000, 0x045fff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u16 &data, u16 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x000000, 0x000007, m_p_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall ram over the rom shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x000000, 0x000007, m_p_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 
 	*m_misccr = 0;
 }
@@ -283,6 +287,8 @@ ROM_START( blit )
 	ROMX_LOAD("rom4.bin", 0x4001, 0x08bf, CRC(2af93f8b) SHA1(1168cb341bfe2a5bc283281f6afe42837adb60f1), ROM_BIOS(0)|ROM_SKIP(1))
 	ROMX_LOAD("rom5.bin", 0x4000, 0x08bf, CRC(d87f121f) SHA1(6e776ac29554b8a8bb332168c155bcc502c927b5), ROM_BIOS(0)|ROM_SKIP(1))
 ROM_END
+
+} // anonymous namespace
 
 /* Driver */
 //    YEAR  NAME      PARENT  COMPAT  MACHINE   INPUT     CLASS        INIT           COMPANY  FULLNAME     FLAGS

--- a/src/mame/drivers/z80ne.cpp
+++ b/src/mame/drivers/z80ne.cpp
@@ -128,12 +128,15 @@ Natural Keyboard and Paste:
 
 /* Core includes */
 #include "emu.h"
-#include "cpu/z80/z80.h"
 #include "includes/z80ne.h"
-#include "formats/dmk_dsk.h"
+
+#include "cpu/z80/z80.h"
 #include "machine/ram.h"
+
 #include "softlist_dev.h"
 #include "speaker.h"
+
+#include "formats/dmk_dsk.h"
 
 /* Layout */
 #include "z80ne.lh"

--- a/src/mame/includes/dai.h
+++ b/src/mame/includes/dai.h
@@ -9,13 +9,15 @@
 #ifndef MAME_INCLUDES_DAI_H
 #define MAME_INCLUDES_DAI_H
 
-#include "cpu/i8085/i8085.h"
 #include "audio/dai_snd.h"
+
+#include "cpu/i8085/i8085.h"
+#include "imagedev/cassette.h"
 #include "machine/i8255.h"
 #include "machine/pit8253.h"
-#include "machine/tms5501.h"
-#include "imagedev/cassette.h"
 #include "machine/timer.h"
+#include "machine/tms5501.h"
+
 #include "emupal.h"
 
 
@@ -65,7 +67,7 @@ private:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<cpu_device> m_maincpu;
 	required_device<pit8253_device> m_pit;
 	required_device<tms5501_device> m_tms5501;

--- a/src/mame/includes/mikro80.h
+++ b/src/mame/includes/mikro80.h
@@ -11,8 +11,8 @@
 
 #pragma once
 
-#include "machine/i8255.h"
 #include "imagedev/cassette.h"
+#include "machine/i8255.h"
 #include "sound/dac.h"
 
 class mikro80_state : public driver_device
@@ -59,7 +59,7 @@ private:
 	void mikro80_mem(address_map &map);
 	void radio99_io(address_map &map);
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_shared_ptr<uint8_t> m_aram;
 	required_shared_ptr<uint8_t> m_vram;
 	required_device<i8255_device> m_ppi;

--- a/src/mame/includes/mikromik.h
+++ b/src/mame/includes/mikromik.h
@@ -7,7 +7,6 @@
 
 #include "bus/rs232/rs232.h"
 #include "cpu/i8085/i8085.h"
-#include "formats/mm_dsk.h"
 #include "imagedev/floppy.h"
 #include "machine/am9517a.h"
 #include "machine/bankdev.h"
@@ -15,11 +14,14 @@
 #include "machine/mm1kb.h"
 #include "machine/pit8253.h"
 #include "machine/ram.h"
-#include "machine/z80sio.h"
 #include "machine/upd765.h"
+#include "machine/z80sio.h"
 #include "video/i8275.h"
 #include "video/upd7220.h"
+
 #include "emupal.h"
+
+#include "formats/mm_dsk.h"
 
 #define SCREEN_TAG      "screen"
 #define I8085A_TAG      "ic40"

--- a/src/mame/includes/radio86.h
+++ b/src/mame/includes/radio86.h
@@ -81,7 +81,7 @@ protected:
 	uint8_t memory_read_byte(offs_t offset);
 	void memory_write_byte(offs_t offset, uint8_t data);
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<cpu_device> m_maincpu;
 	required_device<cassette_image_device> m_cassette;
 	optional_device<generic_slot_device> m_cart;    // for ROMDisk - only Radio86K & Orion?

--- a/src/mame/includes/sorcerer.h
+++ b/src/mame/includes/sorcerer.h
@@ -10,22 +10,23 @@
 
 #pragma once
 
+#include "bus/centronics/ctronics.h"
+#include "bus/generic/carts.h"
+#include "bus/generic/slot.h"
+#include "bus/rs232/rs232.h"
 #include "cpu/z80/z80.h"
+#include "imagedev/cassette.h"
+#include "imagedev/floppy.h"
+#include "imagedev/snapquik.h"
 #include "machine/ay31015.h"
 #include "machine/clock.h"
-#include "bus/centronics/ctronics.h"
-#include "bus/rs232/rs232.h"
-#include "machine/ram.h"
-#include "imagedev/cassette.h"
-#include "imagedev/snapquik.h"
-#include "imagedev/floppy.h"
-#include "formats/sorc_dsk.h"
-#include "formats/sorc_cas.h"
 #include "machine/micropolis.h"
+#include "machine/ram.h"
 #include "machine/wd_fdc.h"
 #include "machine/z80dma.h"
-#include "bus/generic/slot.h"
-#include "bus/generic/carts.h"
+
+#include "formats/sorc_cas.h"
+#include "formats/sorc_dsk.h"
 
 
 class sorcerer_state : public driver_device
@@ -141,7 +142,7 @@ protected:
 	required_ioport m_iop_config;
 	required_ioport m_iop_vs;
 	required_ioport_array<16> m_iop_x;
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 
 private:
 	u8 m_port48;

--- a/src/mame/includes/super80.h
+++ b/src/mame/includes/super80.h
@@ -19,8 +19,10 @@
 #include "sound/samples.h"
 #include "sound/spkrdev.h"
 #include "video/mc6845.h"
+
 #include "emupal.h"
 #include "screen.h"
+
 
 /* Bits in m_portf0 variable:
     d5 cassette LED
@@ -84,7 +86,7 @@ protected:
 	required_device<screen_device> m_screen;
 	required_device<z80_device> m_maincpu;
 	required_region_ptr<u8> m_rom;
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_shared_ptr<u8> m_ram;
 	required_region_ptr<u8> m_p_chargen;
 	required_device<z80pio_device> m_pio;
@@ -99,11 +101,12 @@ protected:
 	output_finder<> m_cass_led;
 
 private:
-
 	void machine_reset() override;
 	void machine_start() override;
+
 	void portf1_w(u8 data);
 	TIMER_DEVICE_CALLBACK_MEMBER(timer_h);
+
 	uint32_t screen_update_super80(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_super80d(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	uint32_t screen_update_super80e(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);

--- a/src/mame/includes/ut88.h
+++ b/src/mame/includes/ut88.h
@@ -11,11 +11,13 @@
 #pragma once
 
 #include "cpu/i8085/i8085.h"
-#include "sound/dac.h"
-#include "machine/i8255.h"
 #include "imagedev/cassette.h"
+#include "machine/i8255.h"
 #include "machine/timer.h"
+#include "sound/dac.h"
+
 #include "emupal.h"
+
 
 class ut88_common : public driver_device
 {
@@ -79,7 +81,7 @@ private:
 
 	int m_keyboard_mask;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<i8255_device> m_ppi;
 	required_device<dac_bit_interface> m_dac;
 	required_shared_ptr<uint8_t> m_vram;

--- a/src/mame/includes/z80ne.h
+++ b/src/mame/includes/z80ne.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include "video/mc6847.h"
 #include "imagedev/cassette.h"
 #include "imagedev/floppy.h"
 #include "machine/ay31015.h"
@@ -23,6 +22,7 @@
 #include "machine/kr2376.h"
 #include "machine/ram.h"
 #include "machine/wd_fdc.h"
+#include "video/mc6847.h"
 
 /***************************************************************************
     CONSTANTS
@@ -120,7 +120,7 @@ protected:
 
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param) override;
 
-	memory_passthrough_handler *m_rom_shadow_tap;
+	memory_passthrough_handler m_rom_shadow_tap;
 	required_device<ay31015_device> m_uart;
 	required_device<clock_device> m_uart_clock;
 	required_device<cpu_device> m_maincpu;

--- a/src/mame/machine/dai.cpp
+++ b/src/mame/machine/dai.cpp
@@ -73,20 +73,22 @@ void dai_state::machine_reset()
 {
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x07ff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xc000, 0xc7ff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xc000, 0xc7ff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 /***************************************************************************

--- a/src/mame/machine/fidel_clockdiv.h
+++ b/src/mame/machine/fidel_clockdiv.h
@@ -36,8 +36,8 @@ protected:
 private:
 	inline void div_set_cpu_freq(offs_t offset);
 
-	memory_passthrough_handler *m_read_tap = nullptr;
-	memory_passthrough_handler *m_write_tap = nullptr;
+	memory_passthrough_handler m_read_tap;
+	memory_passthrough_handler m_write_tap;
 
 	u16 m_div_status;
 	double m_div_scale;

--- a/src/mame/machine/mikro80.cpp
+++ b/src/mame/machine/mikro80.cpp
@@ -65,25 +65,27 @@ void mikro80_state::machine_reset()
 
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x07ff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xf800, 0xffff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xf800, 0xffff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void mikro80_state::tape_w(u8 data)
 {
-	// Todo: this is incorrect, to be fixed when the CMT schematic can be found
+	// TODO: this is incorrect, to be fixed when the CMT schematic can be found
 	m_cassette->output(BIT(data, 0) ? 1.0 : -1.0);
 }
 

--- a/src/mame/machine/radio86.cpp
+++ b/src/mame/machine/radio86.cpp
@@ -142,20 +142,22 @@ void radio86_state::machine_reset()
 
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x0fff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xf000, 0xffff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xf000, 0xffff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void radio86_state::machine_start()

--- a/src/mame/machine/sorcerer.cpp
+++ b/src/mame/machine/sorcerer.cpp
@@ -498,20 +498,22 @@ void sorcerer_state::machine_reset_common()
 	portfe_w(0);
 
 	space.install_rom(0x0000, 0x0fff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = space.install_read_tap(0xe000, 0xefff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = space.install_read_tap(
+			0xe000, 0xefff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram->pointer());
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram->pointer());
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void sorcerer_state::machine_reset()

--- a/src/mame/machine/super80.cpp
+++ b/src/mame/machine/super80.cpp
@@ -230,20 +230,22 @@ void super80_state::machine_reset_common()
 
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x0fff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xc000, 0xcfff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xc000, 0xcfff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x0fff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void super80_state::machine_reset()

--- a/src/mame/machine/ut88.cpp
+++ b/src/mame/machine/ut88.cpp
@@ -70,20 +70,22 @@ void ut88_state::machine_reset()
 	m_keyboard_mask = 0;
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x07ff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0xf800, 0xffff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0xf800, 0xffff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x07ff, m_ram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void ut88_state::machine_start()

--- a/src/mame/machine/z80ne.cpp
+++ b/src/mame/machine/z80ne.cpp
@@ -265,20 +265,22 @@ void z80ne_state::machine_reset()
 
 	address_space &program = m_maincpu->space(AS_PROGRAM);
 	program.install_rom(0x0000, 0x03ff, m_rom);   // do it here for F3
-	m_rom_shadow_tap = program.install_read_tap(0x8000, 0x83ff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-	{
-		if (!machine().side_effects_disabled())
-		{
-			// delete this tap
-			m_rom_shadow_tap->remove();
+	m_rom_shadow_tap.remove();
+	m_rom_shadow_tap = program.install_read_tap(
+			0x8000, 0x83ff,
+			"rom_shadow_r",
+			[this] (offs_t offset, u8 &data, u8 mem_mask)
+			{
+				if (!machine().side_effects_disabled())
+				{
+					// delete this tap
+					m_rom_shadow_tap.remove();
 
-			// reinstall ram over the rom shadow
-			m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x03ff, m_mram);
-		}
-
-		// return the original data
-		return data;
-	});
+					// reinstall RAM over the ROM shadow
+					m_maincpu->space(AS_PROGRAM).install_ram(0x0000, 0x03ff, m_mram);
+				}
+			},
+			&m_rom_shadow_tap);
 }
 
 void z80net_state::machine_reset()
@@ -303,20 +305,22 @@ void z80netf_state::machine_reset()
 	if ((m_io_config->read() & 0x07) != 2)
 	{
 		address_space &program = m_maincpu->space(AS_PROGRAM);
-		m_rom_shadow_tap = program.install_read_tap(0x8000, 0xf3ff, "rom_shadow_r",[this](offs_t offset, u8 &data, u8 mem_mask)
-		{
-			if (!machine().side_effects_disabled())
-			{
-				// delete this tap
-				m_rom_shadow_tap->remove();
+		m_rom_shadow_tap.remove();
+		m_rom_shadow_tap = program.install_read_tap(
+				0x8000, 0xf3ff,
+				"rom_shadow_r",
+				[this] (offs_t offset, u8 &data, u8 mem_mask)
+				{
+					if (!machine().side_effects_disabled())
+					{
+						// delete this tap
+						m_rom_shadow_tap.remove();
 
-				// reinstall ram over the rom shadow
-				m_bank1->set_entry(0);
-			}
-
-			// return the original data
-			return data;
-		});
+						// reinstall RAM over the ROM shadow
+						m_bank1->set_entry(0);
+					}
+				},
+				&m_rom_shadow_tap);
 	}
 }
 


### PR DESCRIPTION
This addresses several pitfalls in the Lua scripting interface:
* Addressed pure virtual function call crash on end of emulation session if you haven’t explicitly removed all address space taps.
* Addressed memory corruption on end of emulation session if you haven’t explicitly removed all address space change notifiers.
* Symbol tables won’t be garbage-collected out from under you while you have parsed expressions or other symbol tables that depend on them.
* Removed the copy constructor for parsed expressions as the underlying C++ copy constructor appears to be broken.
* Fixed breakpoint/watchpoint objects being inappropriately copied into the tables returned by `bplist()` and `wplist()`, which allows the `enabled` property to be modifiable for breakpoint and watchpoint objects in Lua.
* Fixed some errors in the Lua API reference documentation.

Drivers and devices that use taps have been updated for the API changes.  Also fixed drivers and devices causing a new memory pass-through handler to be allocated on each soft reset, and fixed multiple instances of taps being installed in the event the machine is reset before the tap is removed.

Also adds classes for managing broadcast subscriptions, and adapts address spaces to use this for change notifications.  They’re currently built to minimise dynamic allocations, avoid the need for any virtual member functions, and keep the subscription objects light-weight.  If the trade-offs are deemed inappropriate, the implementation can be changed without breaking source compatibility.