### PR TITLE
snes.cpp: partial revert DMA cycle function

### DIFF
--- a/src/mame/machine/snes.cpp
+++ b/src/mame/machine/snes.cpp
@@ -1222,7 +1222,7 @@ inline int snes_state::dma_abus_valid( uint32_t address )
 
 inline uint8_t snes_state::abus_read( address_space &space, uint32_t abus )
 {
-	m_maincpu->adjust_icount(-8); // 8 master cycle per memory access
+	// m_maincpu->adjust_icount(-8); // 8 master cycle per memory access
 	if (!dma_abus_valid(abus))
 		return 0;
 
@@ -1233,7 +1233,7 @@ inline void snes_state::dma_transfer( address_space &space, uint8_t dma, uint32_
 {
 	if (m_dma_channel[dma].dmap & 0x80)  /* PPU->CPU */
 	{
-		m_maincpu->adjust_icount(-8); // 8 master cycle per memory access
+		// m_maincpu->adjust_icount(-8); // 8 master cycle per memory access
 		if (bbus == 0x2180 && ((abus & 0xfe0000) == 0x7e0000 || (abus & 0x40e000) == 0x0000))
 		{
 			//illegal WRAM->WRAM transfer (bus conflict)


### PR DESCRIPTION
this commit fixes some regression after [this commit](https://github.com/mamedev/mame/commit/db40a44d0093bdb2ffa508a9452a81e05750f56e).