### PR TITLE
Add warnings:

### DIFF
--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -468,6 +468,7 @@ void mame_ui_manager::display_startup_screens(bool first_time)
 				warning_text = machine_info().game_info_string();
 			if (!warning_text.empty())
 			{
+				warning_text.append(_("\n\nHINT: Use '-skip_gameinfo' to get rid of this message in the future."));
 				warning_text.append(_("\n\nPress any key to continue"));
 				set_handler(ui_callback_type::MODAL, handler_callback_func(handler_messagebox_anykey));
 			}

--- a/src/osd/sdl/video.cpp
+++ b/src/osd/sdl/video.cpp
@@ -196,6 +196,7 @@ void sdl_osd_interface::extract_video_config()
 #elif (defined SDLMAME_MACOSX)
 		stemp = "bgfx";
 #else
+		osd_printf_warning("Warning: -video not provided. Using 'soft' which can cause slowness in emulation.\n");
 		stemp = "soft";
 #endif
 	}


### PR DESCRIPTION
* HINT: Use '-skip_gameinfo' to get rid of this message in the future.
* Warning: -video not provided. Using 'soft' which can cause slowness in emulation.