### PR TITLE
nes_apu.cpp: Improvements for triangle channel.

### DIFF
--- a/src/devices/sound/nes_defs.h
+++ b/src/devices/sound/nes_defs.h
@@ -75,6 +75,7 @@ struct apu_t
 
 		uint8 regs[4]; /* regs[1] unused */
 		int linear_length = 0;
+		bool linear_reload = false;
 		int vbl_length = 0;
 		int write_latency = 0;
 		float phaseacc = 0.0;
@@ -82,7 +83,6 @@ struct apu_t
 		bool counter_started = false;
 		bool enabled = false;
 		uint8 output = 0;
-		uint8 output_next = 0;
 	};
 
 	/* Noise Wave */


### PR DESCRIPTION
- Don't set output level to zero, it is always determined by sequencer, which cannot be reset. This eliminates most of the popping, hopefully.
- Raised artificial frequency cutoff to about 18KHz instead of 11KHz.
- Added linear counter reload flag.