### PR TITLE
c64_cass.xml: Added 13 working items

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -11689,6 +11689,7 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Rad Ramp Racer</description>
 		<year>1990</year>
 		<publisher>Mastertronic Plus</publisher>
+
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="526363">
 				<rom name="rad ramp racer.tap" size="526363" crc="1ab3938b" sha1="65b7a3c1dde85ef83e2b7d139b16218d2258bfa1"/>
@@ -11764,6 +11765,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="rallycro">
+		<description>Rallycross Simulator</description>
+		<year>1989</year>
+		<publisher>Codemasters</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="1147648">
+				<rom name="Rallycross_Simulator.tap" size="1147648" crc="2034f86d" sha1="c56a491637f87de647b0385b009b4161dd643261"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="rambo3">
 		<description>Rambo III</description>
 		<year>1991</year>
@@ -11784,14 +11797,134 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="rambo3o" cloneof="rambo3">
+		<description>Rambo III (Ocean)</description>
+		<year>1988</year>
+		<publisher>Ocean</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="1540958">
+				<rom name="Rambo_III_Side_1.tap" size="1540958" crc="aa4afe3f" sha1="46797c9ed6375363cc65102b4f1a35ad078bd637"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="1338382">
+				<rom name="Rambo_III_Side_2.tap" size="1338382" crc="3d9ae4cd" sha1="25c54c1e8df305aaa436da24223b44ae7d3e3be3"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="rambo2">
 		<description>Rambo: First Blood Part II</description>
 		<year>1989</year>
 		<publisher>The Hit Squad</publisher>
+		<info name="alt_title" value="Rambo"/>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="642762">
 				<rom name="Rambo-_First_Blood_Part_II.tap" size="642762" crc="93462399" sha1="dbd106a71c21cd18d11ba140a59407417c353175"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rambo2o" cloneof="rambo2">
+		<description>Rambo: First Blood Part II (Ocean)</description>
+		<year>1985</year>
+		<publisher>Ocean</publisher>
+		<info name="alt_title" value="Rambo"/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="743231">
+				<rom name="Rambo-_First_Blood_Part_II.tap" size="743231" crc="2af567f2" sha1="54ecae7a343a97a9725ae4a48c9ba8a39f5371a0"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rampage">
+		<description>Rampage</description>
+		<year>1987</year>
+		<publisher>Activision</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="745387">
+				<rom name="Rampage.tap" size="745387" crc="9044afc8" sha1="b610ef2d6dd7e85106ec33155ed229bb5dde625c"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ramparts">
+		<description>Ramparts</description>
+		<year>1987</year>
+		<publisher>Go!</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="642102">
+				<rom name="Ramparts.tap" size="642102" crc="ab9d07c5" sha1="ce1e063f52ddc2ec1e5bdce734d9d15779a12ce2"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="ranarama">
+		<description>Rana Rama</description>
+		<year>1987</year>
+		<publisher>Hewson Consultants</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="371686">
+				<rom name="Rana_Rama.tap" size="371686" crc="eb67ad69" sha1="65a3f198c86b43066986e4e78ad6521bad033cb3"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rasputin">
+		<description>Rasputin</description>
+		<year>1985</year>
+		<publisher>Firebird</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="643649">
+				<rom name="Rasputin.tap" size="643649" crc="540ff12e" sha1="e1749fe05a2861d9696eb6033712d48f8329a655"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="632532">
+				<rom name="Rasputin_a1.tap" size="632532" crc="328d3bd2" sha1="8449ee323f51cc12ca47eb705c7248ad074f6378"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="rastan">
+		<description>Rastan</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="1397246">
+				<rom name="Rastan.tap" size="1397246" crc="46641e43" sha1="449c7c57554e937b2c442fd2c50ccd37a8334072"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="realgb">
+		<description>The Real Ghostbusters</description>
+		<year>1989</year>
+		<publisher>Activision</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side 1"/>
+			<dataarea name="cass" size="478131">
+				<rom name="Real_Ghostbusters,_The_Side_1.tap" size="478131" crc="8ae0e5ed" sha1="1f29797b08e4d33059352f8f9aa131d8bb8cf419"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side 2"/>
+			<dataarea name="cass" size="1668984">
+				<rom name="Real_Ghostbusters,_The_Side_2.tap" size="1668984" crc="30a8a94f" sha1="6c0ec5ba995e52b0cd83c33ef82aa9183a4dca15"/>
 			</dataarea>
 		</part>
 	</software>
@@ -11837,6 +11970,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="rebound">
+		<description>Re-Bounder</description>
+		<year>1987</year>
+		<publisher>Prism Leisure</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="577426">
+				<rom name="Re-Bounder.tap" size="577426" crc="177b424a" sha1="a30a383c82a5713ddbd4276d50c2bd64e881b5db"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="redheat">
 		<description>Red Heat</description>
 		<year>1991</year>
@@ -11849,6 +11994,31 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="redheato" cloneof="redheat">
+		<description>Red Heat (Ocean)</description>
+		<year>1989</year>
+		<publisher>Ocean</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="726358">
+				<rom name="Red_Heat.tap" size="726358" crc="25f06b7c" sha1="d35f4331ced8224a0edd36d2e909be286f946f37"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="redled">
+		<description>Red L.E.D.</description>
+		<year>1987</year>
+		<publisher>Dro Soft</publisher>
+		<info name="alt_title" value="Battle Droidz"/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="581262">
+				<rom name="Red_L.E.D..tap" size="581262" crc="3f5d111f" sha1="2ba56d660a799e126915b3b96807b18f707b1cc2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="redmax">
 		<description>Red Max</description>
 		<year>1987</year>
@@ -11857,6 +12027,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="956359">
 				<rom name="Red_Max.tap" size="956359" crc="bc44a834" sha1="fc9a9319dcde0c3b7c0b480869c1beb6b75d81e9"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="redmaxc" cloneof="redmax">
+		<description>Red Max (Codemasters)</description>
+		<year>1987</year>
+		<publisher>Codemasters</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="956359">
+				<rom name="Red_Max.tap" size="956359" crc="642d40ca" sha1="58f60f3c988e8f6f1d16aa49ffd3d542402c9147"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
---------------------------------------
Rallycross Simulator (Codemasters) [C64 Ultimate Tape Archive V2.0]
Rambo III (Ocean) [C64 Ultimate Tape Archive V2.0]
Rambo: First Blood Part II (Ocean) [C64 Ultimate Tape Archive V2.0]
Rampage (Activision) [C64 Ultimate Tape Archive V2.0]
Ramparts (Go!) [C64 Ultimate Tape Archive V2.0]
Rana Rama (Hewson Consultants) [C64 Ultimate Tape Archive V2.0]
Rasputin (Firebird) [C64 Ultimate Tape Archive V2.0]
Rastan (Imagine) [C64 Ultimate Tape Archive V2.0]
The Real Ghostbusters (Activision) [C64 Ultimate Tape Archive V2.0]
Re-Bounder (Prism Leisure) [C64 Ultimate Tape Archive V2.0]
Red Heat (Ocean) [C64 Ultimate Tape Archive V2.0]
Red L.E.D. (Dro Soft) [C64 Ultimate Tape Archive V2.0]
Red Max (Codemasters) [C64 Ultimate Tape Archive V2.0]