### PR TITLE
nes_apu.cpp: A few cleanups.

### DIFF
--- a/src/devices/sound/nes_apu.h
+++ b/src/devices/sound/nes_apu.h
@@ -56,7 +56,7 @@ public:
 	void write(offs_t offset, u8 data);
 
 protected:
-	nesapu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nesapu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
@@ -75,8 +75,7 @@ private:
 	apu_t   m_APU;                   /* Actual APUs */
 	int     m_is_pal;
 	u32     m_samps_per_sync;        /* Number of samples per vsync */
-	u32     m_buffer_size;           /* Actual buffer size in bytes */
-	u32     m_vbl_times[0x20];       /* VBL durations in samples */
+	u32     m_vbl_times[SYNCS_MAX1];   /* VBL durations in samples */
 	u32     m_sync_times1[SYNCS_MAX1]; /* Samples per sync table */
 	u32     m_sync_times2[SYNCS_MAX2]; /* Samples per sync table */
 	stream_buffer::sample_t m_square_lut[31];       // Non-linear Square wave output LUT
@@ -87,12 +86,10 @@ private:
 	devcb_read8 m_mem_read_cb;
 
 	void calculate_rates();
-	void create_syncs(unsigned long sps);
 	void apu_square(apu_t::square_t *chan);
 	void apu_triangle(apu_t::triangle_t *chan);
 	void apu_noise(apu_t::noise_t *chan);
 	void apu_dpcm(apu_t::dpcm_t *chan);
-	inline void apu_regwrite(int address, u8 value);
 };
 
 DECLARE_DEVICE_TYPE(NES_APU, nesapu_device)

--- a/src/devices/sound/nes_defs.h
+++ b/src/devices/sound/nes_defs.h
@@ -32,15 +32,6 @@
 /* APU type */
 struct apu_t
 {
-	/* REGULAR TYPE DEFINITIONS */
-	typedef int8_t          int8;
-	typedef int16_t         int16;
-	typedef int32_t         int32;
-	typedef uint8_t         uint8;
-	typedef uint16_t        uint16;
-	typedef uint32_t        uint32;
-
-
 	/* CHANNEL TYPE DEFINITIONS */
 
 	/* Square Wave */
@@ -52,16 +43,16 @@ struct apu_t
 				elem = 0;
 		}
 
-		uint8 regs[4];
+		u8 regs[4];
 		int vbl_length = 0;
 		int freq = 0;
 		float phaseacc = 0.0;
 		float env_phase = 0.0;
 		float sweep_phase = 0.0;
-		uint8 adder = 0;
-		uint8 env_vol = 0;
+		u8 adder = 0;
+		u8 env_vol = 0;
 		bool enabled = false;
-		uint8 output = 0;
+		u8 output = 0;
 	};
 
 	/* Triangle Wave */
@@ -73,16 +64,16 @@ struct apu_t
 				elem = 0;
 		}
 
-		uint8 regs[4]; /* regs[1] unused */
+		u8 regs[4]; /* regs[1] unused */
 		int linear_length = 0;
 		bool linear_reload = false;
 		int vbl_length = 0;
 		int write_latency = 0;
 		float phaseacc = 0.0;
-		uint8 adder = 0;
+		u8 adder = 0;
 		bool counter_started = false;
 		bool enabled = false;
-		uint8 output = 0;
+		u8 output = 0;
 	};
 
 	/* Noise Wave */
@@ -94,14 +85,14 @@ struct apu_t
 				elem = 0;
 		}
 
-		uint8 regs[4]; /* regs[1] unused */
+		u8 regs[4]; /* regs[1] unused */
 		u32 seed = 1;
 		int vbl_length = 0;
 		float phaseacc = 0.0;
 		float env_phase = 0.0;
-		uint8 env_vol = 0;
+		u8 env_vol = 0;
 		bool enabled = false;
-		uint8 output = 0;
+		u8 output = 0;
 	};
 
 	/* DPCM Wave */
@@ -113,16 +104,16 @@ struct apu_t
 				elem = 0;
 		}
 
-		uint8 regs[4];
-		uint32 address = 0;
-		uint32 length = 0;
+		u8 regs[4];
+		u32 address = 0;
+		u32 length = 0;
 		int bits_left = 0;
 		float phaseacc = 0.0;
-		uint8 cur_byte = 0;
+		u8 cur_byte = 0;
 		bool enabled = false;
 		bool irq_occurred = false;
-		int16 vol = 0;
-		uint8 output = 0;
+		s16 vol = 0;
+		u8 output = 0;
 	};
 
 
@@ -148,45 +139,11 @@ struct apu_t
 	static constexpr unsigned SMASK   = 0x15;
 	static constexpr unsigned IRQCTRL = 0x17;
 
-	apu_t()
-	{
-		memset(regs, 0, sizeof(regs));
-	}
-
 	/* Sound channels */
 	square_t   squ[2];
 	triangle_t tri;
 	noise_t    noi;
 	dpcm_t     dpcm;
-
-	/* APU registers */
-	unsigned char regs[0x18];
-
-	/* Sound pointers */
-	void *buffer = nullptr;
-
-#ifdef USE_QUEUE
-
-	static constexpr unsigned QUEUE_SIZE = 0x2000;
-	static constexpr unsigned QUEUE_MAX  = QUEUE_SIZE - 1;
-
-	struct queue_t
-	{
-		queue_t() { }
-
-		int pos = 0;
-		unsigned char reg = 0, val = 0;
-	};
-
-	/* Event queue */
-	queue_t queue[QUEUE_SIZE];
-	int head, tail;
-
-#else
-
-	int buf_pos = 0;
-
-#endif
 
 	int step_mode = 0;
 };
@@ -194,10 +151,10 @@ struct apu_t
 /* CONSTANTS */
 
 /* vblank length table used for squares, triangle, noise */
-static const apu_t::uint8 vbl_length[32] =
+static const u8 vbl_length[32] =
 {
-	5, 127, 10, 1, 20,  2, 40,  3, 80,  4, 30,  5, 7,  6, 13,  7,
-	6,   8, 12, 9, 24, 10, 48, 11, 96, 12, 36, 13, 8, 14, 16, 15
+	10, 254, 20,  2, 40,  4, 80,  6, 160,  8, 60, 10, 14, 12, 26, 14,
+	12,  16, 24, 18, 48, 20, 96, 22, 192, 24, 72, 26, 16, 28, 32, 30
 };
 
 /* frequency limit of square channels */


### PR DESCRIPTION
- Removed old, unused, or redundant code, variables, and comments.
- Removed array used for reading back registers. APU registers cannot be read.
- Updated length counter table to match hardware counts.
- Consolidated some functions.