### PR TITLE
add TSX support for MSX

### DIFF
--- a/hash/msx1_cass.xml
+++ b/hash/msx1_cass.xml
@@ -12746,6 +12746,24 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
+	
+		<software name="sharrier2">
+		<description>Space Harrier 2</description>
+		<year>1989</year>
+		<publisher>Grandslam Entertainments</publisher>
+		<info name="usage" value="Load with BLOAD&quot;CAS:&quot;,R"/>
+
+		<part name="cass1" interface="msx_cass">
+			<dataarea name="cass" size="72802">
+				<rom name="Space Harrier II (1990)(Grandslam - Unique)(GB)(Side A)[!][BLOAD'CAS-',R][v0.8.3b].tsx" size="72802" crc="62B4C661" sha1="7D5C63354FD71F2BB26647FB86366BDDC156BDD0"/>
+			</dataarea>
+		</part>
+		<part name="cass2" interface="msx_cass">
+			<dataarea name="cass" size="87746">
+				<rom name="Space Harrier II (1990)(Grandslam - Unique)(GB)(Side B)[!][BLOAD'CAS-',R][v0.8.3b].tsx" size="87746" crc="7378A964" sha1="CFBE8557D91C3ABB4215E6B9C2A679394CBF6849"/>
+			</dataarea>
+		</part>
+	</software>
 
 	<software name="srescue">
 		<description>Space Rescue (Euro)</description>

--- a/src/lib/formats/fmsx_cas.cpp
+++ b/src/lib/formats/fmsx_cas.cpp
@@ -2,6 +2,7 @@
 // copyright-holders:Sean Young
 
 #include "fmsx_cas.h"
+#include "tzx_cas.cpp" //add TSX format from TZX
 
 #include <cstring>
 
@@ -144,4 +145,5 @@ static const cassette_image::Format fmsx_cas_format =
 
 CASSETTE_FORMATLIST_START(fmsx_cassette_formats)
 	CASSETTE_FORMAT(fmsx_cas_format)
+	CASSETTE_FORMAT(tsx_cassette_format)  //add TSX format from TZX
 CASSETTE_FORMATLIST_END

--- a/src/lib/formats/tzx_cas.h
+++ b/src/lib/formats/tzx_cas.h
@@ -17,5 +17,6 @@ extern const cassette_image::Format tzx_cassette_format;
 
 CASSETTE_FORMATLIST_EXTERN(tzx_cassette_formats);
 CASSETTE_FORMATLIST_EXTERN(cdt_cassette_formats);
+CASSETTE_FORMATLIST_EXTERN(tsx_cassette_formats);//add TSX MSX cassette format
 
 #endif // MAME_FORMATS_TZX_CAS_H

--- a/src/tools/castool.cpp
+++ b/src/tools/castool.cpp
@@ -116,6 +116,7 @@ const struct SupportedCassetteFormats formats[] = {
 	{"to7", to7_cassette_formats               ,"Thomson TO-series"},
 	{"trs80l2", trs80l2_cassette_formats       ,"TRS-80 Level 2"},
 	{"tvc64", tvc64_cassette_formats           ,"Videoton TVC 64"},
+	{"tsx", tsx_cassette_formats               ,"MSX"},//add TSX, MSX cassete format
 	{"tzx", tzx_cassette_formats               ,"Sinclair ZX Spectrum"},
 	{"vg5k", vg5k_cassette_formats             ,"Philips VG 5000"},
 	{"vtech1", vtech1_cassette_formats         ,"Video Technology Laser 110-310"},


### PR DESCRIPTION
I add support for the TSX format. A TSX file is a TZX file (http://k1.spdns.de/Develop/Projects/zasm/Info/TZX%20format.html) that contains a new block, 4B, (https://tsx.eslamejor.com/res/tsx4b.png) specific to MSX but can also be used for protections on other systems.
I have added a new entry in the MSX software list, "Space Harrier 2" in TSX format