### PR TITLE
Added dmovt opcode to i960 cpu

### DIFF
--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -1455,62 +1455,6 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				}
 				break;
 
-			case 0x2:   // daddc
-				/*
-					Adds bits 0 through 3 of src2 and src1 and bit 1 of the condition code (used
-					here: as a carry bit). The result is stored in bits 0 through 3 of dst. If the
-					addition results in a carry, bit 1 of the condition code is set. Bits 4 through
-					31 of src are copied to dst unchanged.
-
-					This instruction is intended to be used iteratively to add binary-coded decimal
-					(BCD) values in which the least-significant four bits of the operands
-					represent the decimal numbers 0 to 9. The instruction asssumes that the least
-					significant 4 bits of both operands are valid BCD numbers. If these bits are
-					not valid BCD numbers, the resulting value in dst is unpredictable.
-				*/
-				{
-					uint64_t res;
-
-					m_icount -= 2;
-					t1 = get_1_ri(opcode) & 0x0000000f;
-					t2 = get_2_ri(opcode) & 0x0000000f;
-					res = t2+(t1+((m_AC>>1)&1));
-					set_ri(opcode, res&0xffffffff);
-
-					m_AC &= ~0x2;   // clear C
-					// set carry
-					m_AC |= ((res) & (((uint64_t)1) << 32)) ? 0x2 : 0;
-				}
-				break;
-
-			case 0x3:   // dsubc
-				/*
-					Subtracts bits 0 through 3 of src2 and srcl and bit I of the condition code
-					(used here as a carry bit). The result is stored in bits 0 through 3 of dst. If
-					the subtraction results in a carry, bit 1 of the condition code is set. Bits 4
-					through 31 of src are copied to dst unchanged. 
-					
-					This instruction is intended to be used iteratively to add binary-coded decimal
-					(BCD) values in which the least-significant four bits of the operands
-					represent the decimal numbers 0 to 9. The instruction asssumes that the least
-					significant 4 bits of both operands are valid BCD numbers. If these bits are
-					not valid BCD numbers, the resulting value in dst is unpredictable.
-				*/
-				{
-					uint64_t res;
-
-					m_icount -= 2;
-					t1 = get_1_ri(opcode) & 0x0000000f;
-					t2 = get_2_ri(opcode) & 0x0000000f;
-					res = t2-(t1+((m_AC>>1)&1));
-					set_ri(opcode, res&0xffffffff);
-
-					m_AC &= ~0x2;   // clear C
-					// set carry
-					m_AC |= ((res) & (((uint64_t)1) << 32)) ? 0x2 : 0;
-				}
-				break;
-
 			case 0x4: // dmovt
 				/*
 					The dmovt instruction moves a 32-bit word from one register to another

--- a/src/devices/cpu/i960/i960.cpp
+++ b/src/devices/cpu/i960/i960.cpp
@@ -1455,6 +1455,78 @@ void i960_cpu_device::execute_op(uint32_t opcode)
 				}
 				break;
 
+			case 0x2:   // daddc
+				/*
+					Adds bits 0 through 3 of src2 and src1 and bit 1 of the condition code (used
+					here: as a carry bit). The result is stored in bits 0 through 3 of dst. If the
+					addition results in a carry, bit 1 of the condition code is set. Bits 4 through
+					31 of src are copied to dst unchanged.
+
+					This instruction is intended to be used iteratively to add binary-coded decimal
+					(BCD) values in which the least-significant four bits of the operands
+					represent the decimal numbers 0 to 9. The instruction asssumes that the least
+					significant 4 bits of both operands are valid BCD numbers. If these bits are
+					not valid BCD numbers, the resulting value in dst is unpredictable.
+				*/
+				{
+					uint64_t res;
+
+					m_icount -= 2;
+					t1 = get_1_ri(opcode) & 0x0000000f;
+					t2 = get_2_ri(opcode) & 0x0000000f;
+					res = t2+(t1+((m_AC>>1)&1));
+					set_ri(opcode, res&0xffffffff);
+
+					m_AC &= ~0x2;   // clear C
+					// set carry
+					m_AC |= ((res) & (((uint64_t)1) << 32)) ? 0x2 : 0;
+				}
+				break;
+
+			case 0x3:   // dsubc
+				/*
+					Subtracts bits 0 through 3 of src2 and srcl and bit I of the condition code
+					(used here as a carry bit). The result is stored in bits 0 through 3 of dst. If
+					the subtraction results in a carry, bit 1 of the condition code is set. Bits 4
+					through 31 of src are copied to dst unchanged. 
+					
+					This instruction is intended to be used iteratively to add binary-coded decimal
+					(BCD) values in which the least-significant four bits of the operands
+					represent the decimal numbers 0 to 9. The instruction asssumes that the least
+					significant 4 bits of both operands are valid BCD numbers. If these bits are
+					not valid BCD numbers, the resulting value in dst is unpredictable.
+				*/
+				{
+					uint64_t res;
+
+					m_icount -= 2;
+					t1 = get_1_ri(opcode) & 0x0000000f;
+					t2 = get_2_ri(opcode) & 0x0000000f;
+					res = t2-(t1+((m_AC>>1)&1));
+					set_ri(opcode, res&0xffffffff);
+
+					m_AC &= ~0x2;   // clear C
+					// set carry
+					m_AC |= ((res) & (((uint64_t)1) << 32)) ? 0x2 : 0;
+				}
+				break;
+
+			case 0x4: // dmovt
+				/*
+					The dmovt instruction moves a 32-bit word from one register to another
+					and tests the least-significant byte of the operand to determine if it is a
+					valid ASCII-coded decimal digit (001100002 through 001110012,
+					corresponding to the decimal digits 0 through 9). For valid digits, the
+					condition code (CC) is set to 000; otherwise the condition code is set to
+					010.
+				*/
+				t1 = get_1_ri(opcode);
+				set_ri(opcode, t1);
+				m_AC &= 0xfff8;
+				if ((t1 & 0xff) < 0x30 || (t1 & 0xff) > 0x39)
+					m_AC |= 2;
+				break;
+
 			case 0x5: // modac
 				m_icount -= 10;
 				t1 = get_1_ri(opcode);


### PR DESCRIPTION
Primarily added dmovt opcode to prevent occasional crashes in VF2 (and likely other Model 2 games) when in debug mode, as outlined here:
https://mametesters.org/view.php?id=7800

Also added daddc/dsubc to round out the decimal opcodes. Code for these is based on the existing addc/subc code. There is a little confusion on these, as the newer [i960 manual](file:///mnt/aine/Library/Development/CPU/Intel%20i960%20Processor%20Assembler%20Users%20Guide.pdf)  seems to imply these should work with ASCII coded decimals, like dmovt does. However, the older [80960 manual](http://www.bitsavers.org/components/intel/i960/80960KB_Programmers_Reference_Manual_Mar88.pdf) indicates they should work with BCD values. I have implemented the BCD 4 bit versions from the older manual as it is more explicit on what effects the opcodes should have on the CPU status.