### PR TITLE
r4000.cpp: Set TLB global bit in EntryLo0/1 on TLBR instruction

### DIFF
--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -55,6 +55,8 @@
 // experimental primary instruction cache
 #define ICACHE 0
 
+#define SCACHE !(m_cp0[CP0_Config] & CONFIG_SC)
+
 #include "logmacro.h"
 
 #define USE_ABI_REG_NAMES 1
@@ -196,6 +198,45 @@ void r4000_base_device::device_start()
 	m_icache_data = std::make_unique<u32 []>((0x1000U << config_ic) >> 2);
 
 	R4000_ENDIAN_LE_BE(accessors(m_le), accessors(m_be));
+
+	/*
+	 * MIPS-III secondary cache tag size depends on the cache line size
+	 * (how many bytes are transferred with one cache operation) and the
+	 * size of the cache itself.
+	 * For example, the Sony NEWS NWS-5000X has a 1MB secondary cache
+	 * and a cache line size of 16 words. So, the slice of the physical
+	 * address used to index into the cache is bits 19:6.
+	 * See chapter 11 of the R4000 user manual for more details.
+	 */
+	if (SCACHE)
+	{
+		if (m_scache_line_size == 0)
+			fatalerror("SCACHE line size was not set!");
+
+		if (m_scache_line_size <= 0x10)
+			m_scache_line_index = 4;
+		else if (m_scache_line_size <= 0x20)
+		{
+			m_scache_line_index = 5;
+			m_cp0[CP0_Config] |= 1 << 22;
+		}
+		else if (m_scache_line_size <= 0x40)
+		{
+			m_scache_line_index = 6;
+			m_cp0[CP0_Config] |= 2 << 22;
+		}
+		else
+		{
+			m_scache_line_index = 7;
+			m_cp0[CP0_Config] |= 3 << 22;
+		}
+
+		m_scache_tag_size = m_scache_size >> m_scache_line_index;
+		m_scache_tag_mask = m_scache_size - 1;
+
+		m_scache_tag = std::make_unique<u32[]>(m_scache_tag_size);
+		save_pointer(NAME(m_scache_tag), m_scache_tag_size);
+	}
 }
 
 void r4000_base_device::device_reset()
@@ -944,75 +985,7 @@ void r4000_base_device::cpu_execute(u32 const op)
 		cpu_swr(op);
 		break;
 	case 0x2f: // CACHE
-		if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
-		{
-			cpu_exception(EXCEPTION_CP0);
-			break;
-		}
-
-		switch ((op >> 16) & 0x1f)
-		{
-		case 0x00: // index invalidate (I)
-			if (ICACHE)
-			{
-				m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] &= ~ICACHE_V;
-				break;
-			}
-			[[fallthrough]];
-		case 0x04: // index load tag (I)
-			if (ICACHE)
-			{
-				u32 const tag = m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift];
-
-				m_cp0[CP0_TagLo] = ((tag & ICACHE_PTAG) << 8) | ((tag & ICACHE_V) >> 18) | ((tag & ICACHE_P) >> 25);
-				m_cp0[CP0_ECC] = 0; // data ecc or parity
-
-				break;
-			}
-			[[fallthrough]];
-		case 0x08: // index store tag (I)
-			if (ICACHE)
-			{
-				// FIXME: compute parity
-				m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] =
-					(m_cp0[CP0_TagLo] & TAGLO_PTAGLO) >> 8 | (m_cp0[CP0_TagLo] & TAGLO_PSTATE) << 18;
-
-				break;
-			}
-			[[fallthrough]];
-		case 0x01: // index writeback invalidate (D)
-		case 0x02: // index invalidate (SI)
-		case 0x03: // index writeback invalidate (SD)
-
-		case 0x05: // index load tag (D)
-		case 0x06: // index load tag (SI)
-		case 0x07: // index load tag (SI)
-
-		case 0x09: // index store tag (D)
-		case 0x0a: // index store tag (SI)
-		case 0x0b: // index store tag (SD)
-
-		case 0x0d: // create dirty exclusive (D)
-		case 0x0f: // create dirty exclusive (SD)
-
-		case 0x10: // hit invalidate (I)
-		case 0x11: // hit invalidate (D)
-		case 0x12: // hit invalidate (SI)
-		case 0x13: // hit invalidate (SD)
-
-		case 0x14: // fill (I)
-		case 0x15: // hit writeback invalidate (D)
-		case 0x17: // hit writeback invalidate (SD)
-
-		case 0x18: // hit writeback (I)
-		case 0x19: // hit writeback (D)
-		case 0x1b: // hit writeback (SD)
-
-		case 0x1e: // hit set virtual (SI)
-		case 0x1f: // hit set virtual (SD)
-			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-			break;
-		}
+		cp0_cache(op);
 		break;
 	case 0x30: // LL
 		load_linked<u32>(ADDR(m_r[RSREG], s16(op)),
@@ -1262,6 +1235,143 @@ void r4000_base_device::cpu_sdr(u32 const op)
 	store<u64, false>(offset, m_r[RTREG] << shift, ~u64(0) << shift);
 }
 
+void r4000_base_device::cp0_cache(u32 const op)
+{
+	if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
+	{
+		cpu_exception(EXCEPTION_CP0);
+		return;
+	}
+
+	switch ((op >> 16) & 0x1f)
+	{
+	case 0x00: // index invalidate (I)
+		if (ICACHE)
+		{
+			m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] &= ~ICACHE_V;
+		}
+		else
+		{
+			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		}
+		break;
+	case 0x04: // index load tag (I)
+		if (ICACHE)
+		{
+			u32 const tag = m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift];
+
+			m_cp0[CP0_TagLo] = ((tag & ICACHE_PTAG) << 8) | ((tag & ICACHE_V) >> 18) | ((tag & ICACHE_P) >> 25);
+			m_cp0[CP0_ECC] = 0; // data ecc or parity
+		}
+		else
+		{
+			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		}
+		break;
+	case 0x08: // index store tag (I)
+		if (ICACHE)
+		{
+			// FIXME: compute parity
+			m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] =
+				(m_cp0[CP0_TagLo] & TAGLO_PTAGLO) >> 8 | (m_cp0[CP0_TagLo] & TAGLO_PSTATE) << 18;
+		}
+		else
+		{
+			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		}
+		break;
+	case 0x01: // index writeback invalidate (D)
+	case 0x02: // index invalidate (SI)
+	case 0x03: // index writeback invalidate (SD)
+	case 0x05: // index load tag (D)
+		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		break;
+	case 0x06: // index load tag (SI)
+	case 0x07: // index load tag (SD)
+		if (SCACHE)
+		{
+			// Get physical address and extract tag
+			// TODO: translation type for CACHE instruction?
+			u64 physical_address = ADDR(m_r[RSREG], s16(op));
+			translate_result const t = translate(TRANSLATE_READ, physical_address);
+			if (t == ERROR || t == MISS)
+				return;
+
+			u32 const index = (physical_address & m_scache_tag_mask) >> m_scache_line_index;
+			if (index < m_scache_tag_size)
+			{
+				u32 const tag = m_scache_tag[index];
+
+				// Decode entry and marshal each field to the TagLo register
+				// TODO: Load the ECC register here
+				u32 const cs = (tag & SCACHE_CS) >> 22;
+				u32 const stag = (tag & SCACHE_STAG);
+				u32 const pidx = (tag & SCACHE_PIDX) >> 19;
+				m_cp0[CP0_TagLo] = (stag << 13) | (cs << 10) | (pidx << 7);
+			}
+			else
+				fatalerror("r4000 scache load tag index out of range!");
+		}
+		else
+			LOGMASKED(LOG_CACHE, "cache 0x%08x called without scache enabled (%s)\n", op, machine().describe_context());
+		break;
+	case 0x09: // index store tag (D)
+		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		break;
+	case 0x0a: // index store tag (SI)
+	case 0x0b: // index store tag (SD)
+		if (SCACHE)
+		{
+			// Get virtual and physical addresses
+			u64 const virtual_address = ADDR(m_r[RSREG], s16(op));
+
+			// TODO: translation type for CACHE instruction?
+			u64 physical_address = virtual_address;
+			translate_result const t = translate(TRANSLATE_READ, physical_address);
+			if (t == ERROR || t == MISS)
+				return;
+
+			// Prepare index for tag
+			u64 const index = (physical_address & m_scache_tag_mask) >> m_scache_line_index;
+			if (index < m_scache_tag_size)
+			{
+				// Assemble and set tag entry
+				// TODO: Calculate ECC bits here
+				u64 const tag_lo = m_cp0[CP0_TagLo];
+				u32 const cs = (tag_lo & TAGLO_CS) >> 10;
+				u32 const stag = (tag_lo & TAGLO_STAG) >> 13;
+				u32 const pidx = (virtual_address & 0x7000) >> 12;
+				m_scache_tag[index] = cs << 22 | pidx << 19 | stag;
+			}
+			else
+				fatalerror("r4000 scache store tag index out of range!");
+		}
+		else
+			LOGMASKED(LOG_CACHE, "cache 0x%08x called without scache enabled (%s)\n", op, machine().describe_context());
+		break;
+	case 0x0d: // create dirty exclusive (D)
+	case 0x0f: // create dirty exclusive (SD)
+
+	case 0x10: // hit invalidate (I)
+	case 0x11: // hit invalidate (D)
+	case 0x12: // hit invalidate (SI)
+	case 0x13: // hit invalidate (SD)
+
+	case 0x14: // fill (I)
+	case 0x15: // hit writeback invalidate (D)
+	case 0x17: // hit writeback invalidate (SD)
+
+	case 0x18: // hit writeback (I)
+	case 0x19: // hit writeback (D)
+	case 0x1b: // hit writeback (SD)
+
+	case 0x1e: // hit set virtual (SI)
+	case 0x1f: // hit set virtual (SD)
+		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+		break;
+	}
+}
+
 void r4000_base_device::cp0_execute(u32 const op)
 {
 	if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
@@ -1437,8 +1547,8 @@ void r4000_base_device::cp0_set(unsigned const reg, u64 const data)
 		break;
 	case CP0_Compare:
 		m_cp0[CP0_Compare] = u32(data);
-		CAUSE &= ~CAUSE_IPEX5;
-
+		if (m_timer_interrupt_enabled)
+			CAUSE &= ~CAUSE_IPEX5;
 		cp0_update_timer(true);
 		break;
 	case CP0_Status:
@@ -1512,8 +1622,9 @@ void r4000_base_device::cp0_tlbr()
 
 		m_cp0[CP0_PageMask] = entry.mask;
 		m_cp0[CP0_EntryHi] = entry.vpn;
-		m_cp0[CP0_EntryLo0] = entry.pfn[0];
-		m_cp0[CP0_EntryLo1] = entry.pfn[1];
+		u64 const global = (entry.vpn & EH_G) ? EL_G : 0x0;
+		m_cp0[CP0_EntryLo0] = entry.pfn[0] | global;
+		m_cp0[CP0_EntryLo1] = entry.pfn[1] | global;
 	}
 }
 
@@ -1587,7 +1698,8 @@ void r4000_base_device::cp0_update_timer(bool start)
 
 TIMER_CALLBACK_MEMBER(r4000_base_device::cp0_timer_callback)
 {
-	m_cp0[CP0_Cause] |= CAUSE_IPEX5;
+	if (m_timer_interrupt_enabled)
+		m_cp0[CP0_Cause] |= CAUSE_IPEX5;
 }
 
 bool r4000_base_device::cp0_64() const

--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -55,8 +55,6 @@
 // experimental primary instruction cache
 #define ICACHE 0
 
-#define SCACHE !(m_cp0[CP0_Config] & CONFIG_SC)
-
 #include "logmacro.h"
 
 #define USE_ABI_REG_NAMES 1
@@ -198,45 +196,6 @@ void r4000_base_device::device_start()
 	m_icache_data = std::make_unique<u32 []>((0x1000U << config_ic) >> 2);
 
 	R4000_ENDIAN_LE_BE(accessors(m_le), accessors(m_be));
-
-	/*
-	 * MIPS-III secondary cache tag size depends on the cache line size
-	 * (how many bytes are transferred with one cache operation) and the
-	 * size of the cache itself.
-	 * For example, the Sony NEWS NWS-5000X has a 1MB secondary cache
-	 * and a cache line size of 16 words. So, the slice of the physical
-	 * address used to index into the cache is bits 19:6.
-	 * See chapter 11 of the R4000 user manual for more details.
-	 */
-	if (SCACHE)
-	{
-		if (m_scache_line_size == 0)
-			fatalerror("SCACHE line size was not set!");
-
-		if (m_scache_line_size <= 0x10)
-			m_scache_line_index = 4;
-		else if (m_scache_line_size <= 0x20)
-		{
-			m_scache_line_index = 5;
-			m_cp0[CP0_Config] |= 1 << 22;
-		}
-		else if (m_scache_line_size <= 0x40)
-		{
-			m_scache_line_index = 6;
-			m_cp0[CP0_Config] |= 2 << 22;
-		}
-		else
-		{
-			m_scache_line_index = 7;
-			m_cp0[CP0_Config] |= 3 << 22;
-		}
-
-		m_scache_tag_size = m_scache_size >> m_scache_line_index;
-		m_scache_tag_mask = m_scache_size - 1;
-
-		m_scache_tag = std::make_unique<u32[]>(m_scache_tag_size);
-		save_pointer(NAME(m_scache_tag), m_scache_tag_size);
-	}
 }
 
 void r4000_base_device::device_reset()
@@ -985,7 +944,75 @@ void r4000_base_device::cpu_execute(u32 const op)
 		cpu_swr(op);
 		break;
 	case 0x2f: // CACHE
-		cp0_cache(op);
+		if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
+		{
+			cpu_exception(EXCEPTION_CP0);
+			break;
+		}
+
+		switch ((op >> 16) & 0x1f)
+		{
+		case 0x00: // index invalidate (I)
+			if (ICACHE)
+			{
+				m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] &= ~ICACHE_V;
+				break;
+			}
+			[[fallthrough]];
+		case 0x04: // index load tag (I)
+			if (ICACHE)
+			{
+				u32 const tag = m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift];
+
+				m_cp0[CP0_TagLo] = ((tag & ICACHE_PTAG) << 8) | ((tag & ICACHE_V) >> 18) | ((tag & ICACHE_P) >> 25);
+				m_cp0[CP0_ECC] = 0; // data ecc or parity
+
+				break;
+			}
+			[[fallthrough]];
+		case 0x08: // index store tag (I)
+			if (ICACHE)
+			{
+				// FIXME: compute parity
+				m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] =
+					(m_cp0[CP0_TagLo] & TAGLO_PTAGLO) >> 8 | (m_cp0[CP0_TagLo] & TAGLO_PSTATE) << 18;
+
+				break;
+			}
+			[[fallthrough]];
+		case 0x01: // index writeback invalidate (D)
+		case 0x02: // index invalidate (SI)
+		case 0x03: // index writeback invalidate (SD)
+
+		case 0x05: // index load tag (D)
+		case 0x06: // index load tag (SI)
+		case 0x07: // index load tag (SI)
+
+		case 0x09: // index store tag (D)
+		case 0x0a: // index store tag (SI)
+		case 0x0b: // index store tag (SD)
+
+		case 0x0d: // create dirty exclusive (D)
+		case 0x0f: // create dirty exclusive (SD)
+
+		case 0x10: // hit invalidate (I)
+		case 0x11: // hit invalidate (D)
+		case 0x12: // hit invalidate (SI)
+		case 0x13: // hit invalidate (SD)
+
+		case 0x14: // fill (I)
+		case 0x15: // hit writeback invalidate (D)
+		case 0x17: // hit writeback invalidate (SD)
+
+		case 0x18: // hit writeback (I)
+		case 0x19: // hit writeback (D)
+		case 0x1b: // hit writeback (SD)
+
+		case 0x1e: // hit set virtual (SI)
+		case 0x1f: // hit set virtual (SD)
+			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
+			break;
+		}
 		break;
 	case 0x30: // LL
 		load_linked<u32>(ADDR(m_r[RSREG], s16(op)),
@@ -1235,143 +1262,6 @@ void r4000_base_device::cpu_sdr(u32 const op)
 	store<u64, false>(offset, m_r[RTREG] << shift, ~u64(0) << shift);
 }
 
-void r4000_base_device::cp0_cache(u32 const op)
-{
-	if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
-	{
-		cpu_exception(EXCEPTION_CP0);
-		return;
-	}
-
-	switch ((op >> 16) & 0x1f)
-	{
-	case 0x00: // index invalidate (I)
-		if (ICACHE)
-		{
-			m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] &= ~ICACHE_V;
-		}
-		else
-		{
-			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		}
-		break;
-	case 0x04: // index load tag (I)
-		if (ICACHE)
-		{
-			u32 const tag = m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift];
-
-			m_cp0[CP0_TagLo] = ((tag & ICACHE_PTAG) << 8) | ((tag & ICACHE_V) >> 18) | ((tag & ICACHE_P) >> 25);
-			m_cp0[CP0_ECC] = 0; // data ecc or parity
-		}
-		else
-		{
-			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		}
-		break;
-	case 0x08: // index store tag (I)
-		if (ICACHE)
-		{
-			// FIXME: compute parity
-			m_icache_tag[(ADDR(m_r[RSREG], s16(op)) & m_icache_mask_hi) >> m_icache_shift] =
-				(m_cp0[CP0_TagLo] & TAGLO_PTAGLO) >> 8 | (m_cp0[CP0_TagLo] & TAGLO_PSTATE) << 18;
-		}
-		else
-		{
-			//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		}
-		break;
-	case 0x01: // index writeback invalidate (D)
-	case 0x02: // index invalidate (SI)
-	case 0x03: // index writeback invalidate (SD)
-	case 0x05: // index load tag (D)
-		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		break;
-	case 0x06: // index load tag (SI)
-	case 0x07: // index load tag (SD)
-		if (SCACHE)
-		{
-			// Get physical address and extract tag
-			// TODO: translation type for CACHE instruction?
-			u64 physical_address = ADDR(m_r[RSREG], s16(op));
-			translate_result const t = translate(TRANSLATE_READ, physical_address);
-			if (t == ERROR || t == MISS)
-				return;
-
-			u32 const index = (physical_address & m_scache_tag_mask) >> m_scache_line_index;
-			if (index < m_scache_tag_size)
-			{
-				u32 const tag = m_scache_tag[index];
-
-				// Decode entry and marshal each field to the TagLo register
-				// TODO: Load the ECC register here
-				u32 const cs = (tag & SCACHE_CS) >> 22;
-				u32 const stag = (tag & SCACHE_STAG);
-				u32 const pidx = (tag & SCACHE_PIDX) >> 19;
-				m_cp0[CP0_TagLo] = (stag << 13) | (cs << 10) | (pidx << 7);
-			}
-			else
-				fatalerror("r4000 scache load tag index out of range!");
-		}
-		else
-			LOGMASKED(LOG_CACHE, "cache 0x%08x called without scache enabled (%s)\n", op, machine().describe_context());
-		break;
-	case 0x09: // index store tag (D)
-		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		break;
-	case 0x0a: // index store tag (SI)
-	case 0x0b: // index store tag (SD)
-		if (SCACHE)
-		{
-			// Get virtual and physical addresses
-			u64 const virtual_address = ADDR(m_r[RSREG], s16(op));
-
-			// TODO: translation type for CACHE instruction?
-			u64 physical_address = virtual_address;
-			translate_result const t = translate(TRANSLATE_READ, physical_address);
-			if (t == ERROR || t == MISS)
-				return;
-
-			// Prepare index for tag
-			u64 const index = (physical_address & m_scache_tag_mask) >> m_scache_line_index;
-			if (index < m_scache_tag_size)
-			{
-				// Assemble and set tag entry
-				// TODO: Calculate ECC bits here
-				u64 const tag_lo = m_cp0[CP0_TagLo];
-				u32 const cs = (tag_lo & TAGLO_CS) >> 10;
-				u32 const stag = (tag_lo & TAGLO_STAG) >> 13;
-				u32 const pidx = (virtual_address & 0x7000) >> 12;
-				m_scache_tag[index] = cs << 22 | pidx << 19 | stag;
-			}
-			else
-				fatalerror("r4000 scache store tag index out of range!");
-		}
-		else
-			LOGMASKED(LOG_CACHE, "cache 0x%08x called without scache enabled (%s)\n", op, machine().describe_context());
-		break;
-	case 0x0d: // create dirty exclusive (D)
-	case 0x0f: // create dirty exclusive (SD)
-
-	case 0x10: // hit invalidate (I)
-	case 0x11: // hit invalidate (D)
-	case 0x12: // hit invalidate (SI)
-	case 0x13: // hit invalidate (SD)
-
-	case 0x14: // fill (I)
-	case 0x15: // hit writeback invalidate (D)
-	case 0x17: // hit writeback invalidate (SD)
-
-	case 0x18: // hit writeback (I)
-	case 0x19: // hit writeback (D)
-	case 0x1b: // hit writeback (SD)
-
-	case 0x1e: // hit set virtual (SI)
-	case 0x1f: // hit set virtual (SD)
-		//LOGMASKED(LOG_CACHE, "cache 0x%08x unimplemented (%s)\n", op, machine().describe_context());
-		break;
-	}
-}
-
 void r4000_base_device::cp0_execute(u32 const op)
 {
 	if ((SR & SR_KSU) && !(SR & SR_CU0) && !(SR & (SR_EXL | SR_ERL)))
@@ -1547,8 +1437,8 @@ void r4000_base_device::cp0_set(unsigned const reg, u64 const data)
 		break;
 	case CP0_Compare:
 		m_cp0[CP0_Compare] = u32(data);
-		if (m_timer_interrupt_enabled)
-			CAUSE &= ~CAUSE_IPEX5;
+		CAUSE &= ~CAUSE_IPEX5;
+
 		cp0_update_timer(true);
 		break;
 	case CP0_Status:
@@ -1698,8 +1588,7 @@ void r4000_base_device::cp0_update_timer(bool start)
 
 TIMER_CALLBACK_MEMBER(r4000_base_device::cp0_timer_callback)
 {
-	if (m_timer_interrupt_enabled)
-		m_cp0[CP0_Cause] |= CAUSE_IPEX5;
+	m_cp0[CP0_Cause] |= CAUSE_IPEX5;
 }
 
 bool r4000_base_device::cp0_64() const

--- a/src/devices/cpu/mips/r4000.h
+++ b/src/devices/cpu/mips/r4000.h
@@ -45,25 +45,6 @@ public:
 
 	void bus_error() { m_bus_error = true; }
 
-	/*
-	 * This method allows bit 19 of the Boot-Mode Settings to be flipped. See Chapter 9, page 223 of the R4000 User Manual.
-	 * When this bit is 0 (interrupt_disabled = false), then the CP0 timer will set interrupt 5 whenever it expires.
-	 * When this bit is 1 (interrupt_disabled = true), the CP0 timer interrupt is disabled.
-	 * When the timer interrupt is disabled, interrupt 5 becomes a standard general-purpose interrupt.
-	 */
-	void set_timer_interrupt_disable(bool interrupt_disabled) { m_timer_interrupt_enabled = !interrupt_disabled; }
-
-	// Secondary cache configuration
-	void set_scache_size(u32 size)
-	{
-		if (size != 0)
-			m_cp0[CP0_Config] &= ~CONFIG_SC;
-
-		m_scache_size = size;
-	}
-
-	void set_secondary_cache_line_size(u8 size) { m_scache_line_size = size; }
-
 protected:
 	enum cache_size
 	{
@@ -310,8 +291,6 @@ protected:
 		TAGLO_PTAGLO = 0xffffff00, // physical adddress bits 35:12
 		TAGLO_PSTATE = 0x000000c0, // primary cache state
 		TAGLO_P      = 0x00000001, // primary tag even parity
-		TAGLO_CS     = 0x00001c00, // scache status
-		TAGLO_STAG   = 0xffffe000, // scache tag
 	};
 	enum icache_mask : u32
 	{
@@ -326,12 +305,6 @@ protected:
 		DCACHE_P    = 0x02000000, // even parity for ptag and cs
 		DCACHE_W    = 0x02000000, // write-back
 		DCACHE_WP   = 0x02000000, // even parity for write-back
-	};
-	enum scache_mask : u32
-	{
-		SCACHE_CS   = 0x01c00000, // cache state
-		SCACHE_STAG = 0x0007ffff, // physical tag
-		SCACHE_PIDX = 0x00380000, // primary cache index
 	};
 
 	// device_t overrides
@@ -369,7 +342,6 @@ protected:
 	void cpu_sdr(u32 const op);
 
 	// cp0 implementation
-	void cp0_cache(u32 const op);
 	void cp0_execute(u32 const op);
 	u64 cp0_get(unsigned const reg);
 	void cp0_set(unsigned const reg, u64 const data);
@@ -470,7 +442,6 @@ protected:
 	}
 	m_tlb[48];
 	unsigned m_tlb_mru[3][48];
-	bool m_timer_interrupt_enabled = true;
 
 	// cp1 state
 	u64 m_f[32]; // floating point registers
@@ -485,14 +456,6 @@ protected:
 	unsigned m_icache_shift;
 	std::unique_ptr<u32[]> m_icache_tag;
 	std::unique_ptr<u32[]> m_icache_data;
-
-	// experimental scache state
-	u32 m_scache_size; // Size in bytes
-	u8 m_scache_line_size;
-	u32 m_scache_line_index; // Secondary cache line shift
-	u32 m_scache_tag_mask; // Mask for extracting the tag from a physical address
-	u32 m_scache_tag_size;
-	std::unique_ptr<u32[]> m_scache_tag;
 
 	// statistics
 	u64 m_tlb_scans;
@@ -519,7 +482,7 @@ public:
 	r4400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 		: r4000_base_device(mconfig, R4400, tag, owner, clock, 0x0440, 0x0500, CACHE_16K, CACHE_16K, 10, 20, 69, 133)
 	{
-		// no secondary cache by default
+		// no secondary cache
 		m_cp0[CP0_Config] |= CONFIG_SC;
 	}
 };


### PR DESCRIPTION
Per the MIPS R4000/R4400 User's Manual, the G bit should be written into both EntryLo0 and EntryLo1 when a TLBR instruction is executed. Sony NEWS-OS 4.2.1aRD expects this bit to be set if it writes it into the TLB when it reads information back out. This is something mips3 has.

EntryLo0/1 definition:
![image](https://user-images.githubusercontent.com/32155223/155894229-67089b63-f967-4f4e-97b2-aa195e79a1b2.png)

TLBR description:
![image](https://user-images.githubusercontent.com/32155223/155894249-3a0443ec-676d-4c6b-abb4-31c5d2511ef7.png)
