### PR TITLE
Fix out of bounds access to std::string_view

### DIFF
--- a/src/emu/input.cpp
+++ b/src/emu/input.cpp
@@ -860,7 +860,7 @@ std::string input_manager::code_to_token(input_code code) const
 	std::string str(devclass);
 	if (!devindex.empty())
 		str.append("_").append(devindex);
-	if (devcode[0] != 0)
+	if (!devcode.empty())
 		str.append("_").append(devcode);
 	if (modifier != nullptr)
 		str.append("_").append(modifier);


### PR DESCRIPTION
In practice this was probably benign, because a trailing NUL was there.  But this should still be fixed.