### PR TITLE
Added an 'image_display_enabled' property to mame_ui_manager and exposed it to LUA

### DIFF
--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -1780,6 +1780,7 @@ void lua_engine::initialize()
 	ui_type["single_step"] = sol::property(&mame_ui_manager::single_step, &mame_ui_manager::set_single_step);
 	ui_type["show_fps"] = sol::property(&mame_ui_manager::show_fps, &mame_ui_manager::set_show_fps);
 	ui_type["show_profiler"] = sol::property(&mame_ui_manager::show_profiler, &mame_ui_manager::set_show_profiler);
+	ui_type["image_display_enabled"] = sol::property(&mame_ui_manager::image_display_enabled, &mame_ui_manager::set_image_display_enabled);
 
 
 /*  device_state_entry library

--- a/src/frontend/mame/ui/ui.cpp
+++ b/src/frontend/mame/ui/ui.cpp
@@ -183,6 +183,7 @@ mame_ui_manager::mame_ui_manager(running_machine &machine)
 	, m_target_font_height(0)
 	, m_has_warnings(false)
 	, m_unthrottle_mute(false)
+	, m_image_display_enabled(true)
 	, m_machine_info()
 	, m_unemulated_features()
 	, m_imperfect_features()
@@ -1182,7 +1183,7 @@ void mame_ui_manager::start_load_state()
 void mame_ui_manager::image_handler_ingame()
 {
 	// run display routine for devices
-	if (machine().phase() == machine_phase::RUNNING)
+	if (m_image_display_enabled && machine().phase() == machine_phase::RUNNING)
 	{
 		auto layout = create_layout(machine().render().ui_container());
 

--- a/src/frontend/mame/ui/ui.h
+++ b/src/frontend/mame/ui/ui.h
@@ -202,6 +202,8 @@ public:
 	// other
 	void process_natural_keyboard();
 	ui::text_layout create_layout(render_container &container, float width = 1.0, ui::text_layout::text_justify justify = ui::text_layout::text_justify::LEFT, ui::text_layout::word_wrapping wrap = ui::text_layout::word_wrapping::WORD);
+	void set_image_display_enabled(bool image_display_enabled) { m_image_display_enabled = image_display_enabled; }
+	bool image_display_enabled() const { return m_image_display_enabled; }
 
 	// draw an outlined box with given line color and filled with a texture
 	void draw_textured_box(render_container &container, float x0, float y0, float x1, float y1, rgb_t backcolor, rgb_t linecolor, render_texture *texture = nullptr, uint32_t flags = PRIMFLAG_BLENDMODE(BLENDMODE_ALPHA));
@@ -248,6 +250,7 @@ private:
 	float                   m_target_font_height;
 	bool                    m_has_warnings;
 	bool                    m_unthrottle_mute;
+	bool					m_image_display_enabled;
 
 	std::unique_ptr<ui::machine_info> m_machine_info;
 	device_feature_set      m_unemulated_features;


### PR DESCRIPTION
This property allows one to disable image-specific UI displays