### PR TITLE
alpha68k_n: correct audio clock for sstingry

### DIFF
--- a/src/mame/drivers/alpha68k_n.cpp
+++ b/src/mame/drivers/alpha68k_n.cpp
@@ -430,11 +430,11 @@ void sstingray_state::sound_map(address_map &map)
 void alpha68k_N_state::sound_iomap(address_map &map)
 {
 	map.global_mask(0xff);
-	map(0x10, 0x11).w("ym1", FUNC(ym2203_device::write));
-	map(0x80, 0x80).w("ym2", FUNC(ym2203_device::data_w));
-	map(0x81, 0x81).w("ym2", FUNC(ym2203_device::address_w));
-	map(0x90, 0x90).w("ym3", FUNC(ym2203_device::data_w));
-	map(0x91, 0x91).w("ym3", FUNC(ym2203_device::address_w));
+	map(0x10, 0x11).w("ym", FUNC(ym2203_device::write));
+	map(0x80, 0x80).w("aysnd1", FUNC(ay8910_device::data_w));
+	map(0x81, 0x81).w("aysnd1", FUNC(ay8910_device::address_w));
+	map(0x90, 0x90).w("aysnd2", FUNC(ay8910_device::data_w));
+	map(0x91, 0x91).w("aysnd2", FUNC(ay8910_device::address_w));
 }
 
 void jongbou_state::sound_map(address_map &map)
@@ -758,16 +758,15 @@ void sstingray_state::sstingry(machine_config &config)
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_sstingry);
 	video_config(config, 0x40, 0, true);
 
-	/* sound hardware */
+	// sound hardware
+	ym2203_device &ym(YM2203(config, "ym", 2000000));            // Verified from video by PCB, 24MHz/12?
+	ym.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ym2203_device &ym1(YM2203(config, "ym1", 3000000));
-	ym1.add_route(ALL_OUTPUTS, "speaker", 0.30);
+	ay8910_device &aysnd1(AY8910(config, "aysnd1", 2000000));    // Verified from video by PCB, 24MHz/12?
+	aysnd1.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ym2203_device &ym2(YM2203(config, "ym2", 3000000));
-	ym2.add_route(ALL_OUTPUTS, "speaker", 0.30);
-
-	ym2203_device &ym3(YM2203(config, "ym3", 3000000));
-	ym3.add_route(ALL_OUTPUTS, "speaker", 0.45);
+	ay8910_device &aysnd2(AY8910(config, "aysnd2", 2000000));    // Verified from video by PCB, 24MHz/12?
+	aysnd2.add_route(ALL_OUTPUTS, "speaker", 0.45);
 
 	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.50); // unknown DAC
 }
@@ -792,15 +791,15 @@ void kyros_state::kyros(machine_config &config)
 
 	GFXDECODE(config, m_gfxdecode, m_palette, gfx_kyros);
 
-	/* sound hardware */
-	ym2203_device &ym1(YM2203(config, "ym1", 24_MHz_XTAL / 12));    /* Verified on bootleg PCB */
-	ym1.add_route(ALL_OUTPUTS, "speaker", 0.30);
+	// sound hardware
+	ym2203_device &ym(YM2203(config, "ym", 24_MHz_XTAL / 12));            // Verified on bootleg PCB
+	ym.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ym2203_device &ym2(YM2203(config, "ym2", 24_MHz_XTAL / 12));    /* Verified on bootleg PCB */
-	ym2.add_route(ALL_OUTPUTS, "speaker", 0.30);
+	ay8910_device &aysnd1(AY8910(config, "aysnd1", 24_MHz_XTAL / 12));    // Verified on bootleg PCB
+	aysnd1.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ym2203_device &ym3(YM2203(config, "ym3", 24_MHz_XTAL / 12));    /* Verified on bootleg PCB */
-	ym3.add_route(ALL_OUTPUTS, "speaker", 0.6);
+	ay8910_device &aysnd2(AY8910(config, "aysnd2", 24_MHz_XTAL / 12));    // Verified on bootleg PCB
+	aysnd2.add_route(ALL_OUTPUTS, "speaker", 0.6);
 
 	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.50); // unknown DAC
 }

--- a/src/mame/drivers/alpha68k_n.cpp
+++ b/src/mame/drivers/alpha68k_n.cpp
@@ -759,13 +759,13 @@ void sstingray_state::sstingry(machine_config &config)
 	video_config(config, 0x40, 0, true);
 
 	// sound hardware
-	ym2203_device &ym(YM2203(config, "ym", 2000000));            // Verified from video by PCB, 24MHz/12?
+	ym2203_device &ym(YM2203(config, "ym", 2'000'000));            // Verified from video by PCB, 24MHz/12?
 	ym.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ay8910_device &aysnd1(AY8910(config, "aysnd1", 2000000));    // Verified from video by PCB, 24MHz/12?
+	ay8910_device &aysnd1(AY8910(config, "aysnd1", 2'000'000));    // Verified from video by PCB, 24MHz/12?
 	aysnd1.add_route(ALL_OUTPUTS, "speaker", 0.30);
 
-	ay8910_device &aysnd2(AY8910(config, "aysnd2", 2000000));    // Verified from video by PCB, 24MHz/12?
+	ay8910_device &aysnd2(AY8910(config, "aysnd2", 2'000'000));    // Verified from video by PCB, 24MHz/12?
 	aysnd2.add_route(ALL_OUTPUTS, "speaker", 0.45);
 
 	DAC_8BIT_R2R(config, "dac", 0).add_route(ALL_OUTPUTS, "speaker", 0.50); // unknown DAC


### PR DESCRIPTION
According to [video by PCB](https://youtu.be/dA2lsgwdrU0?t=6222), audio clocks need to be corrected.
Also, former 2nd and 3rd YM2203 are actually AY-3-8910s.