### PR TITLE
Updated cdi.xml sha1 to match 0.240 chdman output

### DIFF
--- a/hash/cdi.xml
+++ b/hash/cdi.xml
@@ -22,7 +22,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="3rd degree (1993)(philips)(us)" sha1="2cc0223253e2d2454bafa56e905643905a8af161"/>
+				<disk name="3rd degree (1993)(philips)(us)" sha1="f6d01f6e1f2b856f51bfb2f77673cca1dcc61c6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -48,13 +48,13 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="The Game" />
 			<diskarea name="cdrom">
-				<disk name="7th guest, the (1994)(philips)(eu)(disc 1 of 2)[the game][dvc][8110033v113 50404169 02]" sha1="d1ef3e8c9f05f6d928cb459c116e422b391d6758"/>
+				<disk name="7th guest, the (1994)(philips)(eu)(disc 1 of 2)[the game][dvc][8110033v113 50404169 02]" sha1="c78e023c77a11a8e46727e7864163220b6eb7ac2"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<feature name="part_id" value="The Music" />
 			<diskarea name="cdrom">
-				<disk name="7th guest, the (1994)(philips)(eu)(disc 2 of 2)[the music, die musik][cd-audio]" sha1="baa165adf76678353cd9d97bd8e7d09d80af1914"/>
+				<disk name="7th guest, the (1994)(philips)(eu)(disc 2 of 2)[the music, die musik][cd-audio]" sha1="5a24176e261e6f6e4fac1dd0ac450648da87e514"/>
 			</diskarea>
 		</part>
 	</software>
@@ -80,7 +80,7 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="The Game" />
 			<diskarea name="cdrom">
-				<disk name="7th guest, the (1994)(philips)(eu)(disc 1 of 2)[the game][dvc][8111033v113 50404169 01]" sha1="f08256a2719f0f4f3010cb95d3f8e2c3ff63d0fe"/>
+				<disk name="7th guest, the (1994)(philips)(eu)(disc 1 of 2)[the game][dvc][8111033v113 50404169 01]" sha1="e6419a5215bd17038fa93de498ef2580b4039b4d"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
@@ -166,7 +166,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="a great day at the races (1993)(philips)(eu)" sha1="dcc658f7a3f73f21c064b29a962a634bb30294f2"/>
+				<disk name="a great day at the races (1993)(philips)(eu)" sha1="64d69efb7d2b60e9cef2fed3d88a188cb463055d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -182,7 +182,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="a great day at the races (1993)(philips)(us)" sha1="ffb3909edbf80770552dd817a75b69a8592f33a8"/>
+				<disk name="a great day at the races (1993)(philips)(us)" sha1="590e21a139365c4f8470c2952eb306ea6881b603"/>
 			</diskarea>
 		</part>
 	</software>
@@ -199,7 +199,7 @@ license:CC0
 		<publisher>Titus</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="affaire morlov, l' (1996)(titus)(eu)(en-fr)[the morlov affair][cd-i-pc]" sha1="3325ce50053fcfe32386224013051f9a483c9aea"/>
+				<disk name="affaire morlov, l' (1996)(titus)(eu)(en-fr)[the morlov affair][cd-i-pc]" sha1="21a565951f41f71023e246f97ee435f86f085f13"/>
 			</diskarea>
 		</part>
 	</software>
@@ -215,7 +215,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alice in wonderland (1992)(philips)(us)" sha1="4f7089c5bcc5311c75480f45daf9f437e4a80836"/>
+				<disk name="alice in wonderland (1992)(philips)(us)" sha1="8388985627842d057fbf45e46377a9002252d206"/>
 			</diskarea>
 		</part>
 	</software>
@@ -231,7 +231,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alice in wonderland (1993)(philips)(nl)" sha1="3e9b0a04b219f1ed579003fd096b4a38ef80cfa8"/>
+				<disk name="alice in wonderland (1993)(philips)(nl)" sha1="40d9720eb897a3d261011ee40c3b48679643cedc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -247,7 +247,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="alice au pays des merveilles (1992)(philips)(fr)" sha1="a97388c17f9655d201aad85de657bddd369d8e0a"/>
+				<disk name="alice au pays des merveilles (1992)(philips)(fr)" sha1="6fc8427b34bd44e8b8db3d12e2f69d1335049598"/>
 			</diskarea>
 		</part>
 	</software>
@@ -263,7 +263,7 @@ license:CC0
 		<publisher>Namco ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="arcade classics (1996)(namco - philips)(eu)[compilation]" sha1="f8f6305fdd06703cb645bf2282e6288e75bc57f4"/>
+				<disk name="arcade classics (1996)(namco - philips)(eu)[compilation]" sha1="fa476b7b71498275b7949a1ebe86703246730a1b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -279,7 +279,7 @@ license:CC0
 		<publisher>Dutch Electronic Publishers</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="archeon cd-i quiz (1994)(dutch electronic publishers)(nl)(en-nl)" sha1="f85cfe8b15a86c163b5ccce9312640035d2f37cf"/>
+				<disk name="archeon cd-i quiz (1994)(dutch electronic publishers)(nl)(en-nl)" sha1="ec503b60a941ae915e0ab17779a0019113f7ea30"/>
 			</diskarea>
 		</part>
 	</software>
@@ -295,7 +295,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - caesar's challenge v3.9 (1995)(pathe - philips)(eu)" sha1="3777794ec0639337600d54e35d8db6923c394f39"/>
+				<disk name="asterix - caesar's challenge v3.9 (1995)(pathe - philips)(eu)" sha1="6979d1aeb03395d8836cde5eac974bd1775a9333"/>
 			</diskarea>
 		</part>
 	</software>
@@ -311,7 +311,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - de uitdaging van caesar v3.9 (1995)(pathe - philips)(nl)" sha1="0290879cd9965aebdc2d0132d6ec7e43656873c6"/>
+				<disk name="asterix - de uitdaging van caesar v3.9 (1995)(pathe - philips)(nl)" sha1="5b62d5c91b8613f23e56037ceb4e742d1f971c4f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -327,7 +327,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - die grosse reise v3.9 (1995)(pathe - philips)(de)" sha1="96410b35ab85ff47eabfa5b3cbb70f3946bd518b"/>
+				<disk name="asterix - die grosse reise v3.9 (1995)(pathe - philips)(de)" sha1="a28da02f2494152f94c6af8d1ff8ea877149265a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -343,7 +343,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - el desafio de cesar v3.9 (1995)(pathe - philips)(es)" sha1="fe8ad664dbd702cb406a17f1a92134af5e5335e5"/>
+				<disk name="asterix - el desafio de cesar v3.9 (1995)(pathe - philips)(es)" sha1="6dfd9b43a20c4ac4a65ea04911cfc0444205db6e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -359,7 +359,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - la sfida di cesare v3.9 (1995)(pathe - philips)(it)" sha1="e19cd89c1b61f162a2d0ae06e7c2bba83bcb7850"/>
+				<disk name="asterix - la sfida di cesare v3.9 (1995)(pathe - philips)(it)" sha1="4e65b630ac897baa83a02b7c4c39da925ee570e2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -375,7 +375,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="asterix - le defi de cesar v3.9 (1995)(pathe - philips)(fr)" sha1="bd0e135f1bbb71f7f7b18544d5e465f848b92945"/>
+				<disk name="asterix - le defi de cesar v3.9 (1995)(pathe - philips)(fr)" sha1="694b76ad8d4deb39648f23d1072112bbffded4ec"/>
 			</diskarea>
 		</part>
 	</software>
@@ -392,7 +392,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="atlantis - the last resort v1.11 (1996)(philips)(eu)[dvc]" sha1="efa8c1fa2ccff5bd7166fbc1ed464f974beac93d"/>
+				<disk name="atlantis - the last resort v1.11 (1996)(philips)(eu)[dvc]" sha1="1300dabf8ac273ad51f01bda8a9a9b334cf304ed"/>
 			</diskarea>
 		</part>
 	</software>
@@ -408,7 +408,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="axis and allies (1994)(philips)(us)" sha1="a54f59e8182b0b260639702404551d7775551089"/>
+				<disk name="axis and allies (1994)(philips)(us)" sha1="3877ca27cb73e9b7f09bfb63fe5f099f3d098adc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -424,7 +424,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="backgammon (1992)(philips)(eu-us)" sha1="b40690ce0eb3ee2ab9a273d24c16a319a9bc02ba"/>
+				<disk name="backgammon (1992)(philips)(eu-us)" sha1="7a14b7bbe1a8773195c10de4fa560c8a99574a7e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -440,7 +440,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="battleship (1991)(philips)(eu-us)" sha1="86eace40e9ae0bb7757eda1f24af1f37cd976c36"/>
+				<disk name="battleship (1991)(philips)(eu-us)" sha1="55727aca71a56aae03e8fb7b26f2b94374445431"/>
 			</diskarea>
 		</part>
 	</software>
@@ -457,7 +457,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="brain dead 13 v1.07 (1997)(philips)(eu)[dvc]" sha1="81781f6c70f7f4985642fd3b60567c4b07268d52"/>
+				<disk name="brain dead 13 v1.07 (1997)(philips)(eu)[dvc]" sha1="00b1b4d644eb41f9159d64688e44d016296c8bb4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -473,7 +473,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burn-cycle (1994)(philips)(eu)" sha1="0f66e0ad6dc73a0e3f3a6533a43e52b14fed7470"/>
+				<disk name="burn-cycle (1994)(philips)(eu)" sha1="5ab6a1a433db661e23c71eb598e27e505588d379"/>
 			</diskarea>
 		</part>
 	</software>
@@ -489,7 +489,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burn-cycle (1994)(philips)(es)" sha1="1ab708d7ce2b2f31ce9ba59a29e4ec8c2686129e"/>
+				<disk name="burn-cycle (1994)(philips)(es)" sha1="07a22d41f83b73d7245da14bce6be70b295c0508"/>
 			</diskarea>
 		</part>
 	</software>
@@ -505,7 +505,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burn-cycle (1995)(philips)(de)" sha1="fcac5add4b00945db5e6519888d951162eb59f14"/>
+				<disk name="burn-cycle (1995)(philips)(de)" sha1="f7bd6c6ebca5a52cd4ea380f46600a044e1d3902"/>
 			</diskarea>
 		</part>
 	</software>
@@ -521,7 +521,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="burn-cycle (1995)(philips)(it)" sha1="294ad51e4d13ba089ae8244f6ada98d2ea815689"/>
+				<disk name="burn-cycle (1995)(philips)(it)" sha1="8f488e313cbbc65a1b7fd101e7531c9a4134aceb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -554,7 +554,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="caesars world of boxing (1993)(philips)(eu)[dvc]" sha1="dc7975a8e8c8230215e18e5444a030a9cce36bee"/>
+				<disk name="caesars world of boxing (1993)(philips)(eu)[dvc]" sha1="e6e1e95a26ffa57ec568c1c44a8489df0d07bbeb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -570,7 +570,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="caesars world of boxing (1993)(philips)(us)[18621209 01]" sha1="a28a910b0a830922696705ca35157501709698be"/>
+				<disk name="caesars world of boxing (1993)(philips)(us)[18621209 01]" sha1="4b3af900086c3bfa6dc065657369b69d322ef136"/>
 			</diskarea>
 		</part>
 	</software>
@@ -586,7 +586,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="caesars world of boxing (1993)(philips)(us)[18621217 03]" sha1="8f5195dc317c8e512350297573ffa0de888e75b8"/>
+				<disk name="caesars world of boxing (1993)(philips)(us)[18621217 03]" sha1="684307f3f5b80fec0f27946e8bd04315281fe6ea"/>
 			</diskarea>
 		</part>
 	</software>
@@ -602,7 +602,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="caesars world of gambling (1992)(philips)(eu-us)" sha1="8265630e29394ed077a268bea08972d53639ebe0"/>
+				<disk name="caesars world of gambling (1992)(philips)(eu-us)" sha1="c0fd8db1bdb1180883a0f270c80cdbf204a33565"/>
 			</diskarea>
 		</part>
 	</software>
@@ -618,7 +618,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cd shoot (1992)(philips)(eu)(m8)" sha1="32ff756a0d73fdfb355442c88ece89cdb8229a0d"/>
+				<disk name="cd shoot (1992)(philips)(eu)(m8)" sha1="0d77da293da13019779498c3e021f3f892b280dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -634,7 +634,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cd shoot (1992)(philips)(us)" sha1="ca8ce0b749505701d09bfd216ed79fd2c2feafbe"/>
+				<disk name="cd shoot (1992)(philips)(us)" sha1="f37c7a569994dcfe06460c2cabc718b030b78b09"/>
 			</diskarea>
 		</part>
 	</software>
@@ -651,7 +651,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="centurion (1995)(philips)(nl)[dvc]" sha1="e37575220bf3d1fff5e16fe76765118e7af00bcf"/>
+				<disk name="centurion (1995)(philips)(nl)[dvc]" sha1="6720c7259cb617c08bf2defe9f38e941d667b292"/>
 			</diskarea>
 		</part>
 	</software>
@@ -668,7 +668,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chaos control v1.15 (1995)(philips)(eu)[dvc]" sha1="7edc539334eb37dfd82f2e3f540967f8be9a3354"/>
+				<disk name="chaos control v1.15 (1995)(philips)(eu)[dvc]" sha1="825ed1ff1089b0512d1296ce7b409f7d0209f229"/>
 			</diskarea>
 		</part>
 	</software>
@@ -685,7 +685,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chaos control v1.15 (1995)(philips)(fr)[dvc]" sha1="901447443d0ef41b847fd97ea55a14fb87532d08"/>
+				<disk name="chaos control v1.15 (1995)(philips)(fr)[dvc]" sha1="391989088ad6019f3aba6c249103cbb354ebede7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -702,7 +702,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chaos control v1.15 (1995)(philips)(de)[dvc]" sha1="a7d73fc368276e88efff52fbd4f2237b4fc92c00"/>
+				<disk name="chaos control v1.15 (1995)(philips)(de)[dvc]" sha1="5127d90ee50a06df4c8222d802280d27b0117b76"/>
 			</diskarea>
 		</part>
 	</software>
@@ -719,7 +719,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="chaos control v1.15 (1995)(philips)(us)[dvc]" sha1="f7c2baef338a8034e2d2a6d1e5a106e4da8b3483"/>
+				<disk name="chaos control v1.15 (1995)(philips)(us)[dvc]" sha1="e68ff22dea7dfe8ca2ac4aa71f8ea9312dbe25b9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -736,7 +736,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="christmas country (1996)(creative media)(eu)[dvc]" sha1="2101a562897b8374b8e3cf9b27c330fa39b3327e"/>
+				<disk name="christmas country (1996)(creative media)(eu)[dvc]" sha1="bd1bc7514c23e17a7d1dd5a773d8e9674fb6d15e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -753,7 +753,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="christmas crisis (1995)(dima - philips)(eu)[dvc]" sha1="abd547a3b4ff916e19de6338625db166602a7906"/>
+				<disk name="christmas crisis (1995)(dima - philips)(eu)[dvc]" sha1="51f34c7dae960d5a718d84e4b9ef449175d2aa38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -770,7 +770,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cluedo (1994)(philips)(eu)[dvc]" sha1="1ae6ae15b53089f4fbff81d5b83150f12c826df9"/>
+				<disk name="cluedo (1994)(philips)(eu)[dvc]" sha1="b81c0c138b8955c1b3f4e00031ae8ed7b410eb4f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -787,7 +787,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="clue (1994)(philips)(us)[dvc]" sha1="119a042e7dcd52e367fdc0ff6dec3952bfa6d61d"/>
+				<disk name="clue (1994)(philips)(us)[dvc]" sha1="9daa541f5394794062790604a015b89e63df4d9e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -804,7 +804,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="cluedo - the mysteries continue (1995)(philips)(eu)[dvc]" sha1="41555ab802aa58777dd01bcff44c3c89357236d6"/>
+				<disk name="cluedo - the mysteries continue (1995)(philips)(eu)[dvc]" sha1="0b1091b3e8d11ea1dbbf7d01f1b1e374d4068448"/>
 			</diskarea>
 		</part>
 	</software>
@@ -820,7 +820,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="connect four v1 (1991)(philips)(eu-us)" sha1="f9dd892664d02398bd1cd1ab6ad82711a7b1e721"/>
+				<disk name="connect four v1 (1991)(philips)(eu-us)" sha1="7fe2001f9fec990b0e85080697634302d44fb3b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -839,12 +839,12 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom1" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="creature shock (1996)(philips - virgin)(eu)(disc 1 of 2)[dvc]" sha1="d490b2771ad307ac7dc623e6e6f7a2cc008cc6ed"/>
+				<disk name="creature shock (1996)(philips - virgin)(eu)(disc 1 of 2)[dvc]" sha1="452acdb00bfcfe18d56860eb2308648a9055c922"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="creature shock (1996)(philips - virgin)(eu)(disc 2 of 2)[dvc]" sha1="ba6d8e1ce7177f39670c7ab4dcda340a0e07cd1e"/>
+				<disk name="creature shock (1996)(philips - virgin)(eu)(disc 2 of 2)[dvc]" sha1="f6aaa3be90981842748658b57bb652b3a28a17d7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -860,7 +860,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dark castle (1992)(philips)(eu-us)" sha1="7a3ea3e374e1012ec0d605aa5f5fba45474c4fa0"/>
+				<disk name="dark castle (1992)(philips)(eu-us)" sha1="0be07fc9269d96716dd5c681d48694c7a968cd77"/>
 			</diskarea>
 		</part>
 	</software>
@@ -876,7 +876,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="defender of the crown (1992)(philips)(eu-us)" sha1="f29d4d8e5079f15bc7efed81aef5ac639f5cccc5"/>
+				<disk name="defender of the crown (1992)(philips)(eu-us)" sha1="ad40d1f0c1c21e2f70e6ec150f5bfc8baa1737d4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -892,7 +892,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="do you remember the '60's (1996)(philips)(eu)" sha1="e7a0feafa637b4192aaad70bc7e2c50f965046a4"/>
+				<disk name="do you remember the '60's (1996)(philips)(eu)" sha1="b76bb04b2e3f32d620ad655d72b530dd6072647c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -908,7 +908,7 @@ license:CC0
 		<publisher>Haarlems Uitgeef Bedrijf</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="domino - het oudste spel, het nieuwste medium (1997)(haarlems uitgeef bedrijf)(nl)" sha1="a23f8bae5cd942344d09f17b1971bd4fdf362dcb"/>
+				<disk name="domino - het oudste spel, het nieuwste medium (1997)(haarlems uitgeef bedrijf)(nl)" sha1="eeeb03ba7dc5e521dc8c7cb57c25087b35ffc892"/>
 			</diskarea>
 		</part>
 	</software>
@@ -925,7 +925,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (1994)(philips)(eu)[dvc]" sha1="ae039a16098a58257fba0d0b3145fe4efabd017c"/>
+				<disk name="dragon's lair (1994)(philips)(eu)[dvc]" sha1="6b77170583b5035bab1d8698712780e207837b1f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -942,7 +942,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair (1994)(philips)(us)[dvc]" sha1="d52877389d012f7f2b8ee8f1485717410103eef6"/>
+				<disk name="dragon's lair (1994)(philips)(us)[dvc]" sha1="dcb2b3fe8795fca14fdb6a7a439f16033cf927f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -958,7 +958,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair ii - time warp (1994)(philips)(eu)" sha1="984f82d53cfcdb9e224c71c719be7f44114d9fd5"/>
+				<disk name="dragon's lair ii - time warp (1994)(philips)(eu)" sha1="9e74b34b4d19a6e9796c3e0332f2d8afe9894997"/>
 			</diskarea>
 		</part>
 	</software>
@@ -975,7 +975,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair ii - time warp (1994)(philips)(us)[dvc][13920805 02]" sha1="bb92a302ef1698825bf740e76ce71fae2da0b64d"/>
+				<disk name="dragon's lair ii - time warp (1994)(philips)(us)[dvc][13920805 02]" sha1="18d1ac3cb255fa31ae3d10f3a545587fabc14b99"/>
 			</diskarea>
 		</part>
 	</software>
@@ -992,7 +992,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="dragon's lair ii - time warp (1994)(philips)(us)[dvc][13920805 01]" sha1="a7ece8eb49cd2235fb7b1d1bacbfbad9912b6440"/>
+				<disk name="dragon's lair ii - time warp (1994)(philips)(us)[dvc][13920805 01]" sha1="7de64343df5fa48fefa71a51e62b3ebb70dcb852"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1009,7 +1009,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="drug wars (1996)(philips)(eu)[dvc]" sha1="e54420063121466529348630145dbb75f524a92b"/>
+				<disk name="drug wars (1996)(philips)(eu)[dvc]" sha1="38735d0db6c9044f06b2e6ec401d7409d9c14d89"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1025,7 +1025,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earth command - the future of our world is in your hands v1.05 (1994)(philips)(eu)" sha1="0e7995dba96b0bde58934722bc61178e086af7f2"/>
+				<disk name="earth command - the future of our world is in your hands v1.05 (1994)(philips)(eu)" sha1="930aff6bc953be88d2590a0b22bff95750ee007a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1041,7 +1041,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earth command - de toekomst van de wereld ligt in jouw handen v1.05 (1994)(philips)(nl)" sha1="cfd569efec5c5962269a748e3c76221583fd96ad"/>
+				<disk name="earth command - de toekomst van de wereld ligt in jouw handen v1.05 (1994)(philips)(nl)" sha1="58d0830b54c5a552d6a55f887cf8db3db6e69533"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1057,7 +1057,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earth command - die zukunft unserer welt liegt in ihrer hand v1.05 (1994)(philips)(de)" sha1="8f4b8205bf95c55dee468099eeb0170f99c3cf80"/>
+				<disk name="earth command - die zukunft unserer welt liegt in ihrer hand v1.05 (1994)(philips)(de)" sha1="a8de5813d2ff1cae784cea5eb81d5365b3a70161"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1073,7 +1073,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earth command - the future of our world is in your hands v1.05 (1994)(philips)(us)" sha1="648441c116bd93ef24b8a452b5bf1fecb2507005"/>
+				<disk name="earth command - the future of our world is in your hands v1.05 (1994)(philips)(us)" sha1="930cc7e6405f26711b5a1ec62223f14119cc03e1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1089,7 +1089,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="earth command v1.05 (1994)(philips)(fr)" sha1="0e4695f175aeb6b966eef4cd80da3cfad8b636cc"/>
+				<disk name="earth command v1.05 (1994)(philips)(fr)" sha1="36968b7261ee17cde9f8a790a51420355574049d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1105,7 +1105,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="effacer - hangman of the 25th century (1994)(philips)(us)" sha1="523a29cab1152763cb6587fa192bbe7ffa8c4924"/>
+				<disk name="effacer - hangman of the 25th century (1994)(philips)(us)" sha1="a2a8423ad722f8f7f321b11fe773034aba563bbc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1121,7 +1121,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="escape from cybercity (1992)(philips)(eu-us)" sha1="23fc4cde1ba3bec728524b0fe15e6b4e16f876a6"/>
+				<disk name="escape from cybercity (1992)(philips)(eu-us)" sha1="edbe88d59991dc25e6626d0e270a47b19460d201"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1137,7 +1137,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="family games i (1995)(philips)(eu)[compilation]" sha1="43216e96bf14d7a2816bedd56770e247aee843fe"/>
+				<disk name="family games i (1995)(philips)(eu)[compilation]" sha1="c51e5f4aab5826ab7b1889acfeb9814c4f1f9743"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1153,7 +1153,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="family games ii - junk food jive (1995)(philips)(eu)[compilation]" sha1="25dd2d8dc84ab5dfb694e86a6a2da6bd7bd37dd0"/>
+				<disk name="family games ii - junk food jive (1995)(philips)(eu)[compilation]" sha1="fcae46827eeb68e9c5a35ecc94193cfa698e8ebe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1169,7 +1169,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="flashback (1995)(philips)(eu)(m7)" sha1="1bd16c1a03ac86ab22556d15f2f2090bbb0b6b34"/>
+				<disk name="flashback (1995)(philips)(eu)(m7)" sha1="d8abb30aa0ef23081665adef5e965d04218255bf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1185,7 +1185,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="girl's club - the fantasy dating game (1993)(philips)(us)" sha1="336cdf39f13e5c11611253f7508a51beb907ce59"/>
+				<disk name="girl's club - the fantasy dating game (1993)(philips)(us)" sha1="ad30cbd95d441b9d5efdb608778fa37dffdf4d6f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1201,7 +1201,7 @@ license:CC0
 		<publisher>SPC Vision</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="golden oldies i (1997)(spc vision)(eu)[compilation]" sha1="cbf24035f2d0489b11d1b445814001c1341465e7"/>
+				<disk name="golden oldies i (1997)(spc vision)(eu)[compilation]" sha1="9997c9e71f57e5e17fb4db4175b64a91a43c95ce"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1217,7 +1217,7 @@ license:CC0
 		<publisher>SPC Vision</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="golden oldies ii (1997)(spc vision)(eu)[compilation]" sha1="c029022a00949985778ef504dee1216877fedfbb"/>
+				<disk name="golden oldies ii (1997)(spc vision)(eu)[compilation]" sha1="4a641a603e859a9fe36f72d577b05c44b59beea1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1234,7 +1234,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="guignols de l'info, les - le jeu (1996)(canal+ - philips)(fr)[dvc]" sha1="f85f3fa97e65664bacba69489ab5ecf539dc0e6b"/>
+				<disk name="guignols de l'info, les - le jeu (1996)(canal+ - philips)(fr)[dvc]" sha1="d72770426e1cc35ca7b2bd98a1e6db037a0f79ac"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1250,7 +1250,7 @@ license:CC0
 		<publisher>ZYX-Music</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hieroglyph (1994)(zyx-music)(de)" sha1="77739c44f7bd4bbe54efb4d6e239987391d6518b"/>
+				<disk name="hieroglyph (1994)(zyx-music)(de)" sha1="9466425d5fb8217b4b22a4b915e04add5845491c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1266,7 +1266,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hotel mario (1994)(philips)(eu)" sha1="f24e118b807bc2479794eaa6cc35526e70be5bf0"/>
+				<disk name="hotel mario (1994)(philips)(eu)" sha1="db5d930839dbb9e8afee640a66331c8345e6c961"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1282,7 +1282,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="hotel mario (1994)(philips)(us)" sha1="5478517aa0cd42bbdd2503f8d687adbae5a0c387"/>
+				<disk name="hotel mario (1994)(philips)(us)" sha1="497c29f172931113ff5635393338f0b809658d90"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1298,7 +1298,7 @@ license:CC0
 		<publisher>Coktel Vision ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="inca (1993)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][8100126 50341 698 01]" sha1="589f7388811de359c9c1f8c6c81b4530befb419a"/>
+				<disk name="inca (1993)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][8100126 50341 698 01]" sha1="740adf6562bdfd7c86666aa5e3282be44b01b9ae"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1314,7 +1314,7 @@ license:CC0
 		<publisher>Coktel Vision ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="inca (1993-04-21)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][fpd testing - phase 1]" sha1="5321567ce25cff3615754db6133cd3126fd8f221"/>
+				<disk name="inca (1993-04-21)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][fpd testing - phase 1]" sha1="ad4602a4056e17caa83840824f7abaf0ef565c44"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1330,7 +1330,7 @@ license:CC0
 		<publisher>Coktel Vision ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="inca (1994)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][8100126v206 50399445 01]" sha1="06f34b281008583940d00bb38a2e030ed55740b0"/>
+				<disk name="inca (1994)(coktel vision - philips)(eu)(m4)[en-de-fr-nl][8100126v206 50399445 01]" sha1="a09b7d186f5e4da2f5455978327c26121e1ce292"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1346,7 +1346,7 @@ license:CC0
 		<publisher>Coktel Vision ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="inca (1994)(coktel vision - philips)(eu)(m4)[es-fr-it-pt]" sha1="07ddb72c8a3a2f683bb8547471a2d7d917359c44"/>
+				<disk name="inca (1994)(coktel vision - philips)(eu)(m4)[es-fr-it-pt]" sha1="4d384ec096508339099e41582bbcd57b2eda1183"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1362,7 +1362,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open (1993)(pathe - philips)(eu-us)(en-fr)" sha1="0e2337d13cf9910070e594d58710197beee65141"/>
+				<disk name="international tennis open (1993)(pathe - philips)(eu-us)(en-fr)" sha1="d7915907fb74966728164a684e1c114d799650de"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1378,7 +1378,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v2.01 (1993)(pathe - philips)(es)(en-es)" sha1="2a7fec285e7d06a24a696fe3f9e2b542476bccd0"/>
+				<disk name="international tennis open v2.01 (1993)(pathe - philips)(es)(en-es)" sha1="6a39817c8d1d6284996eb98e8fe369455ef4f4fc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1394,7 +1394,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v3.01 (1993)(pathe - philips)(de)(en-de)" sha1="37b5402572b7d36f12ca1d4c5dcf7e520e074b86"/>
+				<disk name="international tennis open v3.01 (1993)(pathe - philips)(de)(en-de)" sha1="363b4ca841b0b603b89e26ab362a86c7619647ee"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1410,7 +1410,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v3.01 (1994)(pathe - philips)(de)(en-de)[2 players]" sha1="50aeaa318cfef5b96a8f3dcc27b8e41370778895"/>
+				<disk name="international tennis open v3.01 (1994)(pathe - philips)(de)(en-de)[2 players]" sha1="3328cc18a13b7fa88e1f0c82ffe4ecb069d3eede"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1426,7 +1426,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v1.01 (1994)(pathe - philips)(it)(en-it)[2 players]" sha1="a53cce7156a2c63ce196c0a516f5d86080dd5f25"/>
+				<disk name="international tennis open v1.01 (1994)(pathe - philips)(it)(en-it)[2 players]" sha1="d3be5c82f1ca5f56d0f8e8d2f91cd1c378e4046e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1442,7 +1442,7 @@ license:CC0
 		<publisher>Pathe ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v3.03 (1994)(pathe - philips)(eu)(en-fr)[2 players]" sha1="1b0c0f0dee5520b5eec8fd7803fbff0c6f9e5fd6"/>
+				<disk name="international tennis open v3.03 (1994)(pathe - philips)(eu)(en-fr)[2 players]" sha1="35a70d27d916022f4f811a8c890dfd2132a39528"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1458,7 +1458,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="international tennis open v3.03 (1994)(philips)(us)(en-fr)[2 players]" sha1="91b20094bf9a71767fb07d6d3e572df9778da010"/>
+				<disk name="international tennis open v3.03 (1994)(philips)(us)(en-fr)[2 players]" sha1="b89efb2efc71c459249cedbf0cd39a3e88885dbe"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1474,7 +1474,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jeopardy (1994)(philips)(us)" sha1="1e22a814391dd417ef968baed80cf33ad3552098"/>
+				<disk name="jeopardy (1994)(philips)(us)" sha1="976cdb57c7b53e4473ddb68f512abcf6a5140971"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1490,7 +1490,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="jigsaw - the ultimate electronic challenge (1992)(philips)(us)" sha1="5798df3e0978d371b087ab810c73d9c83d522713"/>
+				<disk name="jigsaw - the ultimate electronic challenge (1992)(philips)(us)" sha1="701127e9821877cd79fe09d832d5d44e2afeaf9a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1506,7 +1506,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joker's wild jr., the (1994)(philips)(us)" sha1="e5e6fe4f7b766e82c4f381bd3d57402f6f098189"/>
+				<disk name="joker's wild jr., the (1994)(philips)(us)" sha1="c66e7e04baf4c13f4fa26c2734fe6fd99e20735c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1522,7 +1522,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="joker's wild, the (1994)(philips)(us)" sha1="a5609953241b49d64bfdfd671edfdffc93b4b3dd"/>
+				<disk name="joker's wild, the (1994)(philips)(us)" sha1="95ddd78fde39b87d1add2e29ab9d3df4b451d2b0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1538,7 +1538,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.11 (1994)(philips)(eu)(en-fr)" sha1="d869629ca9d5531cf1ae0ea7daee3a205b2531cf"/>
+				<disk name="kether v3.11 (1994)(philips)(eu)(en-fr)" sha1="23e98e78813d1307b2284055203da9ef0c6b050d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1554,7 +1554,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.09 (1993)(philips)(eu)(en-fr)" sha1="657e2538b153dc92f2356a8a13bc1655be441322"/>
+				<disk name="kether v3.09 (1993)(philips)(eu)(en-fr)" sha1="351aa678edcdd4500feb76a59e22e094b45cab6a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1570,7 +1570,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.09 (1993)(philips)(eu)(en-fr)[a]" sha1="344f5e256e3d3281c649aee1ebcb02c2529e1267"/>
+				<disk name="kether v3.09 (1993)(philips)(eu)(en-fr)[a]" sha1="18d85e7c3a7ec74cd830f1e96de0dceb93ff3ba7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1586,7 +1586,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.12 (1994)(philips)(nl)(en-nl)" sha1="0e5001555c053184965a6586a6075f7978afff57"/>
+				<disk name="kether v3.12 (1994)(philips)(nl)(en-nl)" sha1="14bafb74e9b4c3fe8f278767227760a79495e07e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1602,7 +1602,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.08 (1993)(philips)(de)(en-de)" sha1="c49f476b2dd23449937b56f93c19663364017ea3"/>
+				<disk name="kether v3.08 (1993)(philips)(de)(en-de)" sha1="9ce4445d515de16d9ff79a1977c1b0b1b4f82e75"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1618,7 +1618,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.11 (1994)(philips)(de)(en-de)" sha1="4c3eb8713f7cfcca271d711ec493f822170b06d3"/>
+				<disk name="kether v3.11 (1994)(philips)(de)(en-de)" sha1="ae48e1223404a27c95491e046c4412b373477cba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1634,7 +1634,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kether v3.11 (1994)(philips)(us)(en-fr)" sha1="96bb5d15f5fef4e63a649c31c026b085f4d01f3f"/>
+				<disk name="kether v3.11 (1994)(philips)(us)(en-fr)" sha1="d02ed12339c447c84c6aa302f8b0e39144f1a503"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1651,7 +1651,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kingdom - shadoan (1996)(philips)(eu)[dvc]" sha1="8da46f34c91ee11e7df9ec67eb64818ee74c01ec"/>
+				<disk name="kingdom - shadoan (1996)(philips)(eu)[dvc]" sha1="e36e1b155de6323d4f3552ee36d6bbce11ffd7a5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1668,7 +1668,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="kingdom - the far reaches (1995)(philips)(us)[dvc]" sha1="55077066216a3173694766749969d3f639e56f3c"/>
+				<disk name="kingdom - the far reaches (1995)(philips)(us)[dvc]" sha1="ea96b370b6bf8263a927e899d0876a3e9793e285"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1684,7 +1684,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="l'ange et le demon (1993)(philips)(fr)" sha1="5579221a2d7aef06c3f5badc726225a0ee20aeab"/>
+				<disk name="l'ange et le demon (1993)(philips)(fr)" sha1="d5b248fe47453a6c15edc5d4686b60b34237f104"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1701,7 +1701,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="labyrinth of crete (1995)(philips)(eu)[dvc]" sha1="79f3f512452d6f00cdca07e5842ce532de101463"/>
+				<disk name="labyrinth of crete (1995)(philips)(eu)[dvc]" sha1="902adca74f7ac88986123ee40747175c374fff89"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1717,7 +1717,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="laser lords (1992)(philips)(us)[07420911 01]" sha1="a1a4443789508a34d7d65121933878bdf66a9863"/>
+				<disk name="laser lords (1992)(philips)(us)[07420911 01]" sha1="1ccc30d65f40b35e0a6d178f9cd1ba994b9c9be9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1733,7 +1733,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="laser lords (1992)(philips)(us)[3106900742 50273 097 01]" sha1="807696f0cf7b1d622d8f6bb33bd5e559e01d5129"/>
+				<disk name="laser lords (1992)(philips)(us)[3106900742 50273 097 01]" sha1="fbdcc60c29feffd141ee63733e22ad8774ae616c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1749,7 +1749,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="last bounty hunter, the (1996)(philips)(eu)" sha1="1be78bddb43eb9e1b11c76d0563a5fa43e6d9674"/>
+				<disk name="last bounty hunter, the (1996)(philips)(eu)" sha1="f6b579905ec99263ac6bd5feb313d32b1f9653c4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1765,7 +1765,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lemmings (1994)(philips)(eu)" sha1="bd345d28bc439d4e3f43f12b188788eaf17d4c53"/>
+				<disk name="lemmings (1994)(philips)(eu)" sha1="b9777c1a4783616eff276416467b0d76058c1e21"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1781,7 +1781,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lingo v1.07 (1995)(philips)(nl)" sha1="3b79620a45d21e9aa699943ef093d21f5ef0afae"/>
+				<disk name="lingo v1.07 (1995)(philips)(nl)" sha1="e7ea1da4e3c0ec8bed76fa06838aea5d72b49b7d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1797,7 +1797,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="link - the faces of evil (1993)(philips)(eu)" sha1="e51a56fdf657f7cba2b5f556708fa20b9c30824a"/>
+				<disk name="link - the faces of evil (1993)(philips)(eu)" sha1="1757955d12aed0d1db434f69121ffe253f08f2ad"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1813,7 +1813,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="link - the faces of evil (1993)(philips)(fr)" sha1="13f28734d7c0093831e9bb142c7cbe4b53eae650"/>
+				<disk name="link - the faces of evil (1993)(philips)(fr)" sha1="ad53522075b730eaad370dae6a6159c75e8b77b1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1829,7 +1829,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="link - de gezichten van het kwaad (1993)(philips)(nl)" sha1="ecd2a331b4cd33972a924b43f696774756aad378"/>
+				<disk name="link - de gezichten van het kwaad (1993)(philips)(nl)" sha1="6ee87974d9e76629415bb9d5f9e20f8d22f77e57"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1845,7 +1845,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="link - die fratzen des boesen (1993)(philips)(de)" sha1="3ad711cd1f5a7768a74dc608b5e4381115053d57"/>
+				<disk name="link - die fratzen des boesen (1993)(philips)(de)" sha1="78df93e6373bdbe77a7d4fe740268bc231250d00"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1862,7 +1862,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="litil divil (1994)(philips)(eu)[dvc]" sha1="1f342cbca16defa5aae923aaaf3b12b0f55ceca4"/>
+				<disk name="litil divil (1994)(philips)(eu)[dvc]" sha1="50c366e6ae7647e3f6ecb816529d6c5600421ed5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1879,7 +1879,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="litil divil (1994)(philips)(us)[dvc]" sha1="ec46239ffeb6158e6184c0a5010f821000f12b08"/>
+				<disk name="litil divil (1994)(philips)(us)[dvc]" sha1="e8acdbdc6dd3e05f2ba14c0a3f0d5df799496329"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1895,7 +1895,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lords of the rising sun (1992)(philips)(us)" sha1="1a5e88e2a432c985f0c033850f736294e8998f1e"/>
+				<disk name="lords of the rising sun (1992)(philips)(us)" sha1="a0f23a0765b40842eb4c7a4fb041ffb107575ddb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1912,7 +1912,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lost eden (1995)(philips)(eu)[dvc]" sha1="9578b91f9e84f05b5d954033456b38187110238a"/>
+				<disk name="lost eden (1995)(philips)(eu)[dvc]" sha1="428781773603c1b16903eee40fdb1f04d553ab3e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1929,7 +1929,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lost eden (1995)(philips)(de)[dvc]" sha1="099652b449a96190dd54c5b990bc467c4dc8b73d"/>
+				<disk name="lost eden (1995)(philips)(de)[dvc]" sha1="16d0559c892af36c9b8dfe43f2ff1859d7d0ad7e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1946,7 +1946,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lost eden (1995)(philips)(nl)(m4)[dvc]" sha1="82b9327e88b127be1304761a8e8b2461d4b7ec76"/>
+				<disk name="lost eden (1995)(philips)(nl)(m4)[dvc]" sha1="e8356a322d144cfccb033bc5992e337bf87dbc8d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1963,7 +1963,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="lost ride, the (1998)(philips)(eu)[dvc]" sha1="8793e577a122f69f89ced13cda0c59a775361ea4"/>
+				<disk name="lost ride, the (1998)(philips)(eu)[dvc]" sha1="025f7d28ff37d53d8e3f215db916ae6d89dd8a5b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1980,7 +1980,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog ii - the lost gold (1995)(philips)(eu)[dvc]" sha1="f999b9890510aa5226bacfe443ae680014c56833"/>
+				<disk name="mad dog ii - the lost gold (1995)(philips)(eu)[dvc]" sha1="a5fdc7a307444035b3a16471b72dbd207c7a9d56"/>
 			</diskarea>
 		</part>
 	</software>
@@ -1997,7 +1997,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog 2 - le tresor perdu (1996)(philips)(fr)[dvc]" sha1="1b5596d3da6da191614fafca36b4f9d7ce116904"/>
+				<disk name="mad dog 2 - le tresor perdu (1996)(philips)(fr)[dvc]" sha1="e72981def218e38e4a4b58943382d71f8225e74e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2014,7 +2014,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (1994)(philips)(eu)[dvc]" sha1="7a2e986f5da5d522a73c0016e073299475ec69b5"/>
+				<disk name="mad dog mccree (1994)(philips)(eu)[dvc]" sha1="b304d27dbe1616f14eee37fc0e5bc0cf4a45e916"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2031,7 +2031,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (1994)(philips)(us)[dvc][05820818 n01]" sha1="6b1aba75c335d1886ad174eabf6449d39703464c"/>
+				<disk name="mad dog mccree (1994)(philips)(us)[dvc][05820818 n01]" sha1="ce0b963a66e507846c46da0b4ba88c78cf9c4d38"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2048,7 +2048,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mad dog mccree (1994)(philips)(us)[dvc][05820826 01]" sha1="9e4f2d303a9b21ada0c307d9005c9b3305d3258e"/>
+				<disk name="mad dog mccree (1994)(philips)(us)[dvc][05820826 01]" sha1="ba397ec13610f662fbbe943be356874df18a9a46"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2064,7 +2064,7 @@ license:CC0
 		<publisher>ZYX-Music</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="magic eraser (1994)(zyx-music)(de)" sha1="c1818a44a608b4c61cbc030f895de6c39712bd61"/>
+				<disk name="magic eraser (1994)(zyx-music)(de)" sha1="3360b8235ec443d007f3a4f4e4727d42d590b615"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2081,7 +2081,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="making the grade v0.90 (1994)(philips)(eu)[pre-release][dvc]" sha1="7ca4555f802581304c591eb3dc98bb845a779748"/>
+				<disk name="making the grade v0.90 (1994)(philips)(eu)[pre-release][dvc]" sha1="61a4c7dae75a4cfcc863ffaf667703dcdeac65e5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2100,13 +2100,13 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="The Game" />
 			<diskarea name="cdrom">
-				<disk name="marco polo (1995)(philips)(eu)(disc 1 of 2)[the game]" sha1="f785d70e556a38b0e2ab6d9bb300d8df63011e97"/>
+				<disk name="marco polo (1995)(philips)(eu)(disc 1 of 2)[the game]" sha1="5492eada78fadbf11f61fd3bd80af15e5b3ee238"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<feature name="part_id" value="The Documentation" />
 			<diskarea name="cdrom">
-				<disk name="marco polo (1995)(philips)(eu)(disc 2 of 2)[the documentation]" sha1="6c31873f8f3898ab8e44d03bf0a1485000f9018a"/>
+				<disk name="marco polo (1995)(philips)(eu)(disc 2 of 2)[the documentation]" sha1="c5a112818022714487089ecede8e169f5326b244"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2125,13 +2125,13 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="Le Jeu" />
 			<diskarea name="cdrom">
-				<disk name="marco polo (1995)(philips)(fr)(disc 1 of 2)[le jeu]" sha1="63549bc7398028e80c83aa3f2c03d60ab582ec38"/>
+				<disk name="marco polo (1995)(philips)(fr)(disc 1 of 2)[le jeu]" sha1="4a00d1e9579b72f73337f9328280cc1f133678ff"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<feature name="part_id" value="La Documentation" />
 			<diskarea name="cdrom">
-				<disk name="marco polo (1995)(philips)(fr)(disc 2 of 2)[la documentation]" sha1="d3e7164f28869198076792ad9ea2019b9ba7a1f1"/>
+				<disk name="marco polo (1995)(philips)(fr)(disc 2 of 2)[la documentation]" sha1="afda8381432dbedaf7cb2f5346f473b14d3874c4"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2148,7 +2148,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="master labyrinth v1.06 (1995)(pack-in-video)(eu)[dvc]" sha1="8e9d3f6e9e9f62cd611ffcf0a3651dd485b1eb58"/>
+				<disk name="master labyrinth v1.06 (1995)(pack-in-video)(eu)[dvc]" sha1="660733e97a8442edbd45e756f03e90ad54f6a661"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2164,7 +2164,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega maze v1.06 (1994)(philips)(eu)" sha1="f90ed728571bceba3a5b8e306cf4f853b846bd50"/>
+				<disk name="mega maze v1.06 (1994)(philips)(eu)" sha1="c5b37aac8756c4171d035ab9b6d41622be83380d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2180,7 +2180,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mega maze v1.06 (1994)(philips)(us)" sha1="352d7700954249d35d0dedff3644577ecbec2cd7"/>
+				<disk name="mega maze v1.06 (1994)(philips)(us)" sha1="75a9bfc4f22441b756c3be8cae3efbd5cc780675"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2196,7 +2196,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="merlin's apprentice v1.1 (1995)(philips)(eu)" sha1="c2a2ecb0287e43fb18d36dbc0328b3ae700bd914"/>
+				<disk name="merlin's apprentice v1.1 (1995)(philips)(eu)" sha1="f1ccb3d76d1b36272ae0e6791b7beeb6f9a76e47"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2212,7 +2212,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="merlin's apprentice v1.2 (1995)(philips)(us)" sha1="5229610a90047e660021b630aca1025e66f6bb08"/>
+				<disk name="merlin's apprentice v1.2 (1995)(philips)(us)" sha1="83727d68955724d0cbd91fac7012a480d0aa9af6"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2228,7 +2228,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="micro machines (1995)(philips)(eu)" sha1="80ca15fa486b20cacee7d6f74204723c6721c17f"/>
+				<disk name="micro machines (1995)(philips)(eu)" sha1="9fef212fe119a8ef5c313b2079dc43307ec103c8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2261,7 +2261,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mutant rampage - bodyslam (1994)(philips)(eu)[dvc]" sha1="a9bab3fff44c3979a368e986fdae2432de49a63c"/>
+				<disk name="mutant rampage - bodyslam (1994)(philips)(eu)[dvc]" sha1="f97244910544f5bc69756b342ac388ff05cc274e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2278,7 +2278,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mutant rampage - bodyslam (1994)(philips)(us)[dvc]" sha1="b661c94d9bf667b317e879e519e796262824f315"/>
+				<disk name="mutant rampage - bodyslam (1994)(philips)(us)[dvc]" sha1="dbc56d0524495f8f87380cb9027b187f77696aa5"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2294,7 +2294,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="myst (1996)(philips)(eu)" sha1="8c8b649fd00f36429879894bc0f253f6b1dcadf7"/>
+				<disk name="myst (1996)(philips)(eu)" sha1="be4b0f19dc8e62c1adde6fe89cb46a316a0fffae"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2310,7 +2310,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mystic midway - phantom express (1993)(philips)(eu)" sha1="1d4a53be21f561c8550a9263279b4b56116cccd0"/>
+				<disk name="mystic midway - phantom express (1993)(philips)(eu)" sha1="f583ba22b7e4015263782cc91eb9f6415b136b14"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2326,7 +2326,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mystic midway - rest in pieces (1992)(philips)(eu-us)" sha1="85440db8f32a38ac81d302b1301202ea294b0915"/>
+				<disk name="mystic midway - rest in pieces (1992)(philips)(eu-us)" sha1="1769eafbad97b267a583433bf25599044e3a89b8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2342,7 +2342,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="mystic midway - rest in pieces (1992)(philips)(jp)" sha1="91255626ece7575910bdbe72c69049f609f4963b"/>
+				<disk name="mystic midway - rest in pieces (1992)(philips)(jp)" sha1="40f90b1993c3abe4b13618c4b54b807410b138b7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2358,7 +2358,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl football trivia challenge '94-'95 edition (1994)(philips)(eu)" sha1="d146440debf5935a759e4516fc5b31c47a206c91"/>
+				<disk name="nfl football trivia challenge '94-'95 edition (1994)(philips)(eu)" sha1="fedd6f88d5be4f87d00c9b0921fd0f0cd435c87a"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2374,7 +2374,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl football trivia challenge (1993)(philips)(us)" sha1="d930a62379bdaf0bb1767cae8be7315570607d41"/>
+				<disk name="nfl football trivia challenge (1993)(philips)(us)" sha1="44badb72922ceb5e76f9789537de8be3d5db9efc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2391,7 +2391,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="nfl hall of fame football (1994)(philips)(eu)[dvc]" sha1="ece5b8bc3a70d7fd93c53fcb74c1fdac723e7608"/>
+				<disk name="nfl hall of fame football (1994)(philips)(eu)[dvc]" sha1="5deb7dc9cc7b188f35266dfc7ace9c2544b0764d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2407,7 +2407,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="othello (1993)(philips)(eu)" sha1="5a228539d1704b953dce182230c503712d27578f"/>
+				<disk name="othello (1993)(philips)(eu)" sha1="ad5b654bce8fcc5bd620b6dde574bcf44222b8cc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2423,7 +2423,7 @@ license:CC0
 		<publisher>Namco ~ Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pac-panic (1995)(namco - philips)(eu)" sha1="cebfdbb61f4900cc14887b689a3a6df2707814f8"/>
+				<disk name="pac-panic (1995)(namco - philips)(eu)" sha1="3c6ce2c606d64915e7e67864d291ea02034d6cbb"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2439,7 +2439,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="palm springs open, the (1991)(philips)(eu-us)" sha1="aded26e3aa1ba4422a02d733261b71f2e6fed3b6"/>
+				<disk name="palm springs open, the (1991)(philips)(eu-us)" sha1="c4abe6113d60552f319dc9061a81838ae2225476"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2455,7 +2455,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="palm springs open, die (1992)(philips)(de)" sha1="f75e3bc2f6e4256477c104786793c1d506a8194d"/>
+				<disk name="palm springs open, die (1992)(philips)(de)" sha1="b644cc915d1ed6a890946517b305dae0109588d1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2471,7 +2471,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="l'open de palm springs (1992)(philips)(fr)" sha1="86a5f6d52bae2b8064c3c88cffb261d48c44012b"/>
+				<disk name="l'open de palm springs (1992)(philips)(fr)" sha1="4a8b3c995c1cc60ebe427616939eb61704f3cb8b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2487,7 +2487,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="palm springs open, the (1992)(philips)(it)" sha1="95bad384f658714cb64e23b53bb1a52c10711a12"/>
+				<disk name="palm springs open, the (1992)(philips)(it)" sha1="3311a2ee27f295e964f707beeea0a18dad44d2f0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2503,7 +2503,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="palm springs open, the (1991)(philips)(us)" sha1="6d43807b55ad663c4db44aca2dd527be2b63d374"/>
+				<disk name="palm springs open, the (1991)(philips)(us)" sha1="c4abe6113d60552f319dc9061a81838ae2225476"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2519,7 +2519,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pinball (1992)(philips)(us)[3106900342 50238 037 03]" sha1="66efa836b24a1dc7e4baf5dc4deb57ad4787a74f"/>
+				<disk name="pinball (1992)(philips)(us)[3106900342 50238 037 03]" sha1="dab9189a14b846f9d83b34e5e93dfffa35e1f1dc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2535,7 +2535,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="pinball (1992)(philips)(us)[3106900342 50238 037 04]" sha1="874349861d21240a70688d921f320410f58ed10d"/>
+				<disk name="pinball (1992)(philips)(us)[3106900342 50238 037 04]" sha1="4bb352c882e3af7d25ed54ca1dfe04652d5947bf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2551,7 +2551,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power hitter (1992)(philips)(eu)" sha1="d6a4b075f8a2796c4b0e1fb272147f5df12080b4"/>
+				<disk name="power hitter (1992)(philips)(eu)" sha1="72b94e3c1be236d14b2fbc1757139a2d544b2be3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2567,7 +2567,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power hitter (1993)(philips)(us)[08120804 01]" sha1="f293d5321d416127117155f2efe9bb23a7befa4c"/>
+				<disk name="power hitter (1993)(philips)(us)[08120804 01]" sha1="576279d7bdaaad4f60382435f6fd6d254262fcfc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2583,7 +2583,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="power hitter (1993)(philips)(us)[08120908 01]" sha1="2c250d49b1b45181cdae83ee0acd77ee0095f58b"/>
+				<disk name="power hitter (1993)(philips)(us)[08120908 01]" sha1="96f8ea8d25bbaf37566bbcef7fb53773cd462904"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2600,7 +2600,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="rise of the robots (1995)(philips)(eu)[dvc]" sha1="73c7e39a0c6a83b772e417eb2f21ca8a68ea8d33"/>
+				<disk name="rise of the robots (1995)(philips)(eu)[dvc]" sha1="a7f113adc5149ba1d43a99b8ddd3ceadd384062f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2616,7 +2616,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sargon chess (1992)(philips)(us)[690 030-2 50253 278 01]" sha1="c039575bdb8f9db14ceebcd33c61a8dce1e3371a"/>
+				<disk name="sargon chess (1992)(philips)(us)[690 030-2 50253 278 01]" sha1="6b5defdbff1d71dfc071088b3a64c8bdb809441d"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2632,7 +2632,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sargon chess (1992)(philips)(us)[03020320 01]" sha1="5b5eb50c1df41bece49225663476db67a8954c50"/>
+				<disk name="sargon chess (1992)(philips)(us)[03020320 01]" sha1="6325f2774d8a9ef75ca4b7d78ff4904de644ea2e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2648,7 +2648,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scotland yard - interactive v1.03 (1994)(philips)(eu)" sha1="240a5364b6c774ada3e09f1e0673fedf52ccf380"/>
+				<disk name="scotland yard - interactive v1.03 (1994)(philips)(eu)" sha1="859efa228cb31dc6731f706e19f9d27ba432c8cf"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2664,7 +2664,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scotland yard - interactif v1.04 (1994)(philips)(fr)" sha1="5ea998ca2917f88b1a1a40ea7cc5d7e133d51745"/>
+				<disk name="scotland yard - interactif v1.04 (1994)(philips)(fr)" sha1="e892888e3fc8d648d0214b6adf8b83ab31e579b2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2680,7 +2680,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="scotland yard - interactive v1.09 (1993)(philips)(de)" sha1="b2d75c0cfa6e352638efa7a7e296dfc7d0780a67"/>
+				<disk name="scotland yard - interactive v1.09 (1993)(philips)(de)" sha1="b1e0765b5812ded6d789242890f2d8634b8baeb0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2696,7 +2696,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="secret mission v1.03 (1996)(philips)(eu)" sha1="919c0ddbeb6b8f0b9082c93cb8c0486fb2b97239"/>
+				<disk name="secret mission v1.03 (1996)(philips)(eu)" sha1="0b4e184067a8a30ce1976cd908f559dd39e0caf3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2712,7 +2712,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="secret mission v1.03 (1996)(philips)(de)" sha1="e8824c6263f5efc9ea14a4b15a33d459192b8333"/>
+				<disk name="secret mission v1.03 (1996)(philips)(de)" sha1="6e28ddee39585f54f34ce99fe95a37c2bb3f4cb9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2728,7 +2728,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="secret mission v1.03 (1996)(philips)(nl)" sha1="508796aa6d285e93090c18af941b617f6cd25974"/>
+				<disk name="secret mission v1.03 (1996)(philips)(nl)" sha1="7f5b330fb1a2f533b75dee618e5a0609e08522fc"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2744,7 +2744,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="shaolin's road (1995)(philips)(eu)(en-fr)" sha1="0d74de6ca404e75bb7a194771cc36903b51e5521"/>
+				<disk name="shaolin's road (1995)(philips)(eu)(en-fr)" sha1="9ae4ab9ec0b0349db7156c08f7d78719f2cc084e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2761,7 +2761,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (1994)(philips)(eu)[dvc]" sha1="8c74b9a3184c433137d1b072858117c03e38dfcd"/>
+				<disk name="space ace (1994)(philips)(eu)[dvc]" sha1="11eb66ae27c8471acf79445308ca8dd3bb8d188c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2778,7 +2778,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="space ace (1994)(philips)(us)[dvc]" sha1="382ef7f1d46bb050678615294f506f64c5b62b8a"/>
+				<disk name="space ace (1994)(philips)(us)[dvc]" sha1="5698f08a2f3fa9b83fd528b2927a972e240b2d12"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2794,7 +2794,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="sport freaks (1996)(philips)(nl)" sha1="5c97086155e8892e0c96f1d546b8ed09de4c8fb3"/>
+				<disk name="sport freaks (1996)(philips)(nl)" sha1="44f7a47203271e020560c95ea1b5dc5b5fd3d095"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2810,7 +2810,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="striker pro (1994)(philips)(eu)(m6)" sha1="60ceedab75579214354968e924a6d6d269b2e652"/>
+				<disk name="striker pro (1994)(philips)(eu)(m6)" sha1="2b527c05585363b346b767c75778b16a745311af"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2826,7 +2826,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="striker pro (1994)(philips)(us)(m6)" sha1="e61ed9f27a4acd2ad663f092e5e5e004497be11c"/>
+				<disk name="striker pro (1994)(philips)(us)(m6)" sha1="43ca2560fa2b5898adb7d8d3a85c15db6e66b826"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2842,7 +2842,7 @@ license:CC0
 		<publisher>Green Pig Production</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strip poker live (1995)(green pig production)(eu)" sha1="5034032d979d22fef4ce0f80d3390b4519c4deef"/>
+				<disk name="strip poker live (1995)(green pig production)(eu)" sha1="dc8b58d724f6cc9c530a2e8f07ccc796b991ec33"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2858,7 +2858,7 @@ license:CC0
 		<publisher>Hot Stage</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="strip-poker pro (1994)(hot stage)(fr)(en-fr)" sha1="eff455a09352f56ac42a3fae5450002e9a50437c"/>
+				<disk name="strip-poker pro (1994)(hot stage)(fr)(en-fr)" sha1="1fefbf8867811b9abe578cf81759e0c0319f3064"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2874,7 +2874,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tangram - the ultimate chinese game (1992)(philips)(eu)(m8)" sha1="245309b5e0feab2207bc44f0ae4a9c12043da5d5"/>
+				<disk name="tangram - the ultimate chinese game (1992)(philips)(eu)(m8)" sha1="7cae9e60ed8cc4ef06a0df264752ca267b53cef7"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2890,7 +2890,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tetris (1992)(philips)(eu-us)" sha1="6502f5d0263007875c08f0c8a1225cfd9a449855"/>
+				<disk name="tetris (1992)(philips)(eu-us)" sha1="838df69378949d3bdb9f506fc516819623294ee2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2907,7 +2907,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="tetsuo gaiden (1997)(new frontier)(eu)[dvc]" sha1="a0659d9165b09bcaad54273af4509e21222048a6"/>
+				<disk name="tetsuo gaiden (1997)(new frontier)(eu)[dvc]" sha1="625ffaaf01406fee4a87075cce16707acdf267a1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2923,7 +2923,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="texttiles v1 (1992)(philips)(us)" sha1="9a82b7019004bdd0f745c228b33346cc471eee3a"/>
+				<disk name="texttiles v1 (1992)(philips)(us)" sha1="cb2056dcf6c7064b7bf8d0824a66cf7cda0d6f2e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2946,13 +2946,13 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="The Game" />
 			<diskarea name="cdrom">
-				<disk name="thunder in paradise (1995)(philips)(eu)(disc 1 of 2)[the game][dvc]" sha1="8e4844ff6f3aabfb4520110475811875009e3808"/>
+				<disk name="thunder in paradise (1995)(philips)(eu)(disc 1 of 2)[the game][dvc]" sha1="ca689cd8ae8d2f30d14f42434263fd958f6a257f"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<feature name="part_id" value="The Episode" />
 			<diskarea name="cdrom">
-				<disk name="thunder in paradise (1995)(philips)(eu)(disc 2 of 2)[the episode][dvc]" sha1="39b0a2825d6254095a3a97649b0bcc52cabd8f1b"/>
+				<disk name="thunder in paradise (1995)(philips)(eu)(disc 2 of 2)[the episode][dvc]" sha1="a9899cc725d57f41ace071f7abb4670030176390"/>
 			</diskarea>
 		</part>
 	</software>
@@ -2975,13 +2975,13 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="The Game" />
 			<diskarea name="cdrom">
-				<disk name="thunder in paradise (1995)(philips)(us)(disc 1 of 2)[the game][dvc]" sha1="c3915a61ad43c43a9105ac0c271ac431b8d3d4b2"/>
+				<disk name="thunder in paradise (1995)(philips)(us)(disc 1 of 2)[the game][dvc]" sha1="59e235e94b306c97d713e3a99588e53d2cb330d3"/>
 			</diskarea>
 		</part>
 		<part name="cdrom2" interface="cdi_cdrom">
 			<feature name="part_id" value="The Episode" />
 			<diskarea name="cdrom">
-				<disk name="thunder in paradise (1995)(philips)(us)(disc 2 of 2)[the episode][dvc]" sha1="27c8cf91919c286a0e98e7d63ca0e70e26e56edd"/>
+				<disk name="thunder in paradise (1995)(philips)(us)(disc 2 of 2)[the episode][dvc]" sha1="dc883d5e412d4f0637362bf734179baca2e6935e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3004,7 +3004,7 @@ license:CC0
 		<part name="cdrom1" interface="cdi_cdrom">
 			<feature name="part_id" value="Das Spiel" />
 			<diskarea name="cdrom">
-				<disk name="thunder in paradise (1996)(philips)(de)(disc 1 of 2)[das spiel][dvc]" sha1="f90a4dc07c7571c2680426228de4706aab9c204c"/>
+				<disk name="thunder in paradise (1996)(philips)(de)(disc 1 of 2)[das spiel][dvc]" sha1="5cd547ad44f57d7f402213097f613479aa86cd16"/>
 			</diskarea>
 		</part>
 	<!-- Is this correct as disc 2? -->
@@ -3027,7 +3027,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultimate noah's ark, the (1994)(philips)(eu)" sha1="4610bf0608fdf692c18cd4416018c679be0aa2e1"/>
+				<disk name="ultimate noah's ark, the (1994)(philips)(eu)" sha1="bfc2e186d0bfcde42e99aa16a63ee7aeddecbe96"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3043,7 +3043,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultimate noah's ark, the (1994)(philips)(us)" sha1="5c3a54f1fd5ce523847557dc0fbea741c0196181"/>
+				<disk name="ultimate noah's ark, the (1994)(philips)(us)" sha1="a9a93de79ac9107bc0a69edff78c605e6e88cad8"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3060,7 +3060,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="ultra cd-i soccer (1997)(philips)(eu)[dvc]" sha1="cb0aea09b6da6007bf2b2446892d8b00177d1daf"/>
+				<disk name="ultra cd-i soccer (1997)(philips)(eu)[dvc]" sha1="48c0198540e4f2b0f674777b83d47229dffbb2f3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3077,7 +3077,7 @@ license:CC0
 		<info name="usage" value="Access code 1234" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="vegas girls (1995)(status)(eu)[adult, access code 1234]" sha1="bd613b4be11eaa6104c69947b2c6b1e52083d82c"/>
+				<disk name="vegas girls (1995)(status)(eu)[adult, access code 1234]" sha1="c942d84f305e4c46ef3052b346da144aecb8b59f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3093,7 +3093,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="video grand prix speedway (1993)(philips)(fr)" sha1="d9c2c6bfb7b66fec2a51867a9c5f1503cd059bc7"/>
+				<disk name="video grand prix speedway (1993)(philips)(fr)" sha1="9ccd468128a092f3f5df2ff4129d6a6b9217b3b3"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3109,7 +3109,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="video speedway - the ultimate racing experience (1993)(philips)(eu)" sha1="6b8a07eb1ea506da5e18447148b6da29e94a29a5"/>
+				<disk name="video speedway - the ultimate racing experience (1993)(philips)(eu)" sha1="d4fd4b1485d0fd154caf510bc979f442bf389bee"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3125,7 +3125,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="video speedway - the ultimate racing experience (1993)(philips)(us)" sha1="7cfeab2b65efe734b729f3eafbe33a0c6ddb815f"/>
+				<disk name="video speedway - the ultimate racing experience (1993)(philips)(us)" sha1="17e342df0a866f88a97bee5980c72995db5915f2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3142,7 +3142,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voetbal v1.04 (1994)(philips)(nl)[dvc]" sha1="7a14a3770888a83757667d55fdc20acc4948659b"/>
+				<disk name="voetbal v1.04 (1994)(philips)(nl)[dvc]" sha1="7884b05daf5857647be7dde6fe51224a596140a9"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3159,7 +3159,7 @@ license:CC0
 		<info name="usage" value="Access code 3333" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voyeur ...don't get caught (1993)(philips)(eu)[adult, access code 3333]" sha1="8f68bab3336b932481bfe0fe7163814d8f528d23"/>
+				<disk name="voyeur ...don't get caught (1993)(philips)(eu)[adult, access code 3333]" sha1="3ae1d15a14ca0271030de847919fa6632927ee49"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3176,7 +3176,7 @@ license:CC0
 		<info name="usage" value="Access code 3333" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voyeur ...don't get caught (1993)(philips)(us)[adult, access code 3333][11220909 01]" sha1="755ddaa5c1787a04af329f234bbbe88eb9fca54d"/>
+				<disk name="voyeur ...don't get caught (1993)(philips)(us)[adult, access code 3333][11220909 01]" sha1="ea7b5676c0a1185e7410ca8c96c2df7bec575fd2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3193,7 +3193,7 @@ license:CC0
 		<info name="usage" value="Access code 3333" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voyeur ...don't get caught (1993)(philips)(us)[adult, access code 3333][11220928 03]" sha1="807b674c7281f93805944093a240538754493792"/>
+				<disk name="voyeur ...don't get caught (1993)(philips)(us)[adult, access code 3333][11220928 03]" sha1="347a58607e38c58510454b14d0f21a02b533043c"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3210,7 +3210,7 @@ license:CC0
 		<info name="usage" value="Access code 3333" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voyeur ...lass dich nicht erwischen (1995)(philips)(de)[adult, access code 3333]" sha1="5aadbe13fc19a892837bca715a5e38f572aeb762"/>
+				<disk name="voyeur ...lass dich nicht erwischen (1995)(philips)(de)[adult, access code 3333]" sha1="c52b7fbe6b9d3ff69b064e5ab1e008dd1114c0ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3227,7 +3227,7 @@ license:CC0
 		<info name="usage" value="Access code 3333" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="voyeur ...soyez prudent (1995)(philips)(fr)[adult, access code 3333]" sha1="9a6abac469376d70ddea3275795ec89a1b2f0e36"/>
+				<disk name="voyeur ...soyez prudent (1995)(philips)(fr)[adult, access code 3333]" sha1="a596f354ce7e7425a0051dcb52a87e52664b5570"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3243,7 +3243,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wacky world of minature golf, the - with eugene levy (1993)(philips)(eu)" sha1="57588d78b78ce9a49dcd9f1d6e7376200ad60a8a"/>
+				<disk name="wacky world of minature golf, the - with eugene levy (1993)(philips)(eu)" sha1="093dedfca6586cfe9b8a47edb0f00cb2ab8f143b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3259,7 +3259,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wacky world of minature golf, the - with eugene levy (1993)(philips)(us)" sha1="37734eac08c39e70dda887addaaf9d0b92da1a3c"/>
+				<disk name="wacky world of minature golf, the - with eugene levy (1993)(philips)(us)" sha1="d57aafa8159164b7bcba903c725b2e66d8234622"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3275,7 +3275,7 @@ license:CC0
 		<publisher>New Frontier</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="whack a bubble (1997)(new frontier)(eu)" sha1="50b67dfbb435488a427f3544174e292ca0b8289b"/>
+				<disk name="whack a bubble (1997)(new frontier)(eu)" sha1="6122526623af25730bf78bf9bd675b1ee5a2319b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3292,7 +3292,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who shot johnny rock (1995)(philips)(eu)[dvc]" sha1="4bf2fcf4231e958c3b7da366feff4aac1a0551ac"/>
+				<disk name="who shot johnny rock (1995)(philips)(eu)[dvc]" sha1="10b516592291d3e27f259f94d3bac26650f694d1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3309,7 +3309,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="who shot johnny rock (1995)(philips)(us)[dvc]" sha1="a62b04e1868ad4cfba6b9130d5e9100662b902ca"/>
+				<disk name="who shot johnny rock (1995)(philips)(us)[dvc]" sha1="2e5129bd200d6c4fc716bf918416fbb8d70b8f8e"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3325,7 +3325,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wimbledon challenge - the official wimbledon quiz game (1993)(philips)(eu)(m6)" sha1="6b4135efe7e641feb12819c86d27d67c41d8a1cc"/>
+				<disk name="wimbledon challenge - the official wimbledon quiz game (1993)(philips)(eu)(m6)" sha1="9eafebe5539b88592ba5e1cc80b2f5e97225da7b"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3341,7 +3341,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="wordplay (1994)(philips)(eu)" sha1="43d795b276298ca9d1a99df22f577a9da7bbbb92"/>
+				<disk name="wordplay (1994)(philips)(eu)" sha1="84d46322dd6b39b09712ec27888a8ee6cf846281"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3358,7 +3358,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="world cup golf (1995)(philips)(eu)[dvc]" sha1="9debd983029ef28f576119425d456aa96bf9e5e0"/>
+				<disk name="world cup golf (1995)(philips)(eu)[dvc]" sha1="b28f5bb1c38e2a73680f066842535c8e6d792938"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3375,7 +3375,7 @@ license:CC0
 		<sharedfeat name="compatibility" value="DVC" />
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zaak van sam, de - interactieve detective (1997)(nob-interactive)(nl)[dvc]" sha1="ff2f912f1d6738c51d8d9fb125b41e373344d240"/>
+				<disk name="zaak van sam, de - interactieve detective (1997)(nob-interactive)(nl)[dvc]" sha1="ac0a75ae5a03458e36654e8379700c5fc80eefb0"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3391,7 +3391,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda - the wand of gamelon (1993)(philips)(eu)" sha1="0c7b977fe42373a8aaff106d637aa39081927f0c"/>
+				<disk name="zelda - the wand of gamelon (1993)(philips)(eu)" sha1="79cd322969e22d8d4cebbd3f93e4a9521d2adb74"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3407,7 +3407,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda - de toverstaf van gamelon (1993)(philips)(nl)" sha1="d21cfb0b525553c1305a55725bddf95e9f82260b"/>
+				<disk name="zelda - de toverstaf van gamelon (1993)(philips)(nl)" sha1="e84d790b733ac5e4dfb2a7c027a32249743a41ce"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3423,7 +3423,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda - der zauberstab von gamelon (1993)(philips)(de)" sha1="3e4fc92bec8fad6c7ea13a03b2a117a358d46c06"/>
+				<disk name="zelda - der zauberstab von gamelon (1993)(philips)(de)" sha1="bc7a55c2d4ea387019a2f5a4ba6422a66c6372c1"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3439,7 +3439,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda - the wand of gamelon (1993)(philips)(fr)" sha1="8384bccaf5cbfc57e5e910af64049cc41decf678"/>
+				<disk name="zelda - the wand of gamelon (1993)(philips)(fr)" sha1="57c86c88de6ff4db61f50106643a434670199c92"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3455,7 +3455,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda - the wand of gamelon (1993)(philips)(us)" sha1="d1e6a5621656e7c33fefda611710817ba0359502"/>
+				<disk name="zelda - the wand of gamelon (1993)(philips)(us)" sha1="096a108adfc3455377547d25c0bb215749069d16"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3471,7 +3471,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zelda's adventure (1995)(philips)(eu)" sha1="543fcc04d617cb2641af9fddf5eef9db32d863da"/>
+				<disk name="zelda's adventure (1995)(philips)(eu)" sha1="c862ae32d9e35af41a266eaea06e41cf958efc84"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3487,7 +3487,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zenith (1997)(philips)(eu)" sha1="43b51bfbeb844ff98d5ee8ccce1cc50a0f18cf0b"/>
+				<disk name="zenith (1997)(philips)(eu)" sha1="73e10d206a46dfab34b71c270bc2f941c23c3512"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3503,7 +3503,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zombie dinos from planet zeltoid (1992)(philips)(eu)" sha1="aefce9c6d8298e29d07bac198e96089ad32408a6"/>
+				<disk name="zombie dinos from planet zeltoid (1992)(philips)(eu)" sha1="6654c5481b6b3a8c975d3009ea45ae2f9c68f815"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3519,7 +3519,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zombie dinos de la planete zeltoide (1993)(philips)(fr)" sha1="d4cb6895738edf15297f35e7270ca806a4f98b8b"/>
+				<disk name="zombie dinos de la planete zeltoide (1993)(philips)(fr)" sha1="5658badb139f0ff559206ffc477222eb0e07a99f"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3535,7 +3535,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zombie dinos from planet zeltoid (1992)(philips)(us)" sha1="101a3eb8507f822f4b9df6601b28648652f377ae"/>
+				<disk name="zombie dinos from planet zeltoid (1992)(philips)(us)" sha1="64899887b78aad198267636eaf95d7a8e3c14614"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3551,7 +3551,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zombie dinos van de planeet zeltoid (1993)(philips)(nl)" sha1="b705075be41f424a23c43e2e26c7ffd1e0d78ced"/>
+				<disk name="zombie dinos van de planeet zeltoid (1993)(philips)(nl)" sha1="2fb7722e86812b2994e902c0d9519f38bfd810c2"/>
 			</diskarea>
 		</part>
 	</software>
@@ -3567,7 +3567,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="zombie dinos vom planeten zeltoid (1994)(philips)(de)" sha1="8989945e53bf489fec53934bb037d1e07a611d4e"/>
+				<disk name="zombie dinos vom planeten zeltoid (1994)(philips)(de)" sha1="4190172f9078041ca925ddef40198472dfaad3ba"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10626,7 +10626,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="super mario wacky worlds (prototype)" sha1="a3178428ed39f7a461e693d9a1a927b4daaa677f"/>
+				<disk name="super mario wacky worlds (prototype)" sha1="882a01ff0b8250eb41ad599414bf1250"/>
 			</diskarea>
 		</part>
 	</software>
@@ -10979,7 +10979,7 @@ license:CC0
 		<publisher>The Vision Factory</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="go - special edition" sha1="abcb043a29b8c5f432b8c1097a76a8b45e9c946c" status="baddump"/>
+				<disk name="go - special edition" sha1="230cf74eb7f64491239245331bd87e271e37f1b5" status="baddump"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
Updated many game sha1s, based off TOSEC. 
Couldn't use redump since many images have at least one track type of [CDI/2352] which chdman doesn't support yet (issue #2784)


Hopefully should resolve many instances in issues #2517.