### PR TITLE
Minitel 2 : Modem and serial port support

### DIFF
--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -489,6 +489,22 @@ static INPUT_PORTS_START( minitel2 )
 
 INPUT_PORTS_END
 
+static DEVICE_INPUT_DEFAULTS_START( m_modem )
+	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_75 )
+	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_1200 )
+	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_7 )
+	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_EVEN )
+	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
+DEVICE_INPUT_DEFAULTS_END
+
+static DEVICE_INPUT_DEFAULTS_START( m_serport )
+	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_9600 )
+	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_9600 )
+	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_8 )
+	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_NONE )
+	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
+DEVICE_INPUT_DEFAULTS_END
+
 void minitel_state::minitel2(machine_config &config)
 {
 	/* basic machine hardware */
@@ -509,9 +525,11 @@ void minitel_state::minitel2(machine_config &config)
 
 	RS232_PORT(config, m_modem, default_rs232_devices, nullptr);
 	m_modem->rxd_handler().set_inputline(m_maincpu, MCS51_INT1_LINE).invert();
+	m_modem->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_modem));
 
 	RS232_PORT(config, m_serport, default_rs232_devices, nullptr);
 	m_serport->rxd_handler().set_inputline(m_maincpu, MCS51_RX_LINE);
+	m_serport->set_option_device_input_defaults("terminal", DEVICE_INPUT_DEFAULTS_NAME(m_serport));
 
 	lineconnected = 0;
 
@@ -529,22 +547,6 @@ void minitel_state::minitel2(machine_config &config)
 	fake_1300hz_clock.set_pulse_width(attotime::from_usec(384));
 	fake_1300hz_clock.signal_handler().set_inputline(m_maincpu, MCS51_INT0_LINE);
 }
-
-static DEVICE_INPUT_DEFAULTS_START( m_modem )
-	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_75 )
-	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_1200 )
-	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_7 )
-	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_EVEN )
-	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
-DEVICE_INPUT_DEFAULTS_END
-
-static DEVICE_INPUT_DEFAULTS_START( m_serport )
-	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_9600 )
-	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_9600 )
-	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_8 )
-	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_NONE )
-	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
-DEVICE_INPUT_DEFAULTS_END
 
 ROM_START( minitel2 )
 

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -25,7 +25,8 @@
 
     What is implemented but not working :
 
-    - The rear serial port. (Internal 8051 serial port emulation missing).
+    - The rear serial port.(Prise péri-informatique) 
+     (Internal 8051 serial port emulation missing).
 
     What is not yet implemented :
 
@@ -49,10 +50,10 @@
 
     With the official ROM you need to press F10 to switch on the CRT.
 
-    Modem and external port can be exported to the "modport0" and "serport0"
+    Modem and external port can be exported to the "modem" and "periinfo"
     interfaces.
     Example : Command line options to use to create a TCP socket linked to
-    the modem port : "-modport0 null_modem -bitb socket.127.0.0.1:20000"
+    the modem port : "-modem null_modem -bitb socket.127.0.0.1:20000"
     Once mame started you can then send vdt files with netcat to this socket.
 
 ****************************************************************************/
@@ -113,8 +114,8 @@ public:
 		, m_ts9347(*this, "ts9347")
 		, m_palette(*this, "palette")
 		, m_i2cmem(*this, "i2cmem")
-		, m_modem(*this, "modport0")
-		, m_serport(*this, "serport0")
+		, m_modem(*this, "modem")
+		, m_serport(*this, "periinfo")
 		, m_io_kbd(*this, "Y%u", 0)
 		{
 		}

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -20,12 +20,12 @@
     - Main MCU
     - Video output
     - Keyboard
+    - 24C02 EPROM
 
     What is not yet implemented :
 
     - Modem and sound output.
     - The rear serial port.
-    - Parameters I2C 24C02 EEPROM.
     - Screen should go blank when switched off
 
     The original firmware and the experimental demo rom are currently both working.
@@ -40,8 +40,8 @@
     F6 -> Guide
     F7 -> Sommaire
     F8 -> Connexion/Fin
-    F9 -> Fonction
     F10-> ON / OFF
+    Alt Gr -> Fonction
 
     With the official ROM you need to press F10 to switch on the CRT.
 
@@ -322,7 +322,7 @@ static INPUT_PORTS_START( minitel2 )
 	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_A) PORT_CHAR('a') PORT_CHAR('A')
 	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_LCONTROL)
 	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Connexion/Fin") PORT_CODE(KEYCODE_F8)
-	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Fonction") PORT_CODE(KEYCODE_F9)
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Fonction") PORT_CODE(KEYCODE_RALT)
 	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_RSHIFT) // Right maj
 	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_LSHIFT) // Left maj
 

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -102,7 +102,7 @@ private:
 	required_device<i80c32_device> m_maincpu;
 	required_device<ts9347_device> m_ts9347;
 	required_device<palette_device> m_palette;
-	optional_device<i2cmem_device> m_i2cmem;
+	required_device<i2cmem_device> m_i2cmem;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(minitel_scanline);
 

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -63,11 +63,11 @@
 // IO expander latch usage definitions
 enum
 {
-	CTRL_REG_DTMF = 0x02,
-	CTRL_REG_MCBC = 0x04,
-	CTRL_REG_OPTO = 0x08,
-	CTRL_REG_RELAY = 0x10,
-	CTRL_REG_CRTON = 0x20
+	CTRL_REG_MCBC  = 0x01,
+	CTRL_REG_DTMF  = 0x02,
+	CTRL_REG_CRTON = 0x08,
+	CTRL_REG_OPTO  = 0x10,
+	CTRL_REG_RELAY = 0x20
 };
 
 // 80C32 Port IO usage definitions

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -8,11 +8,11 @@
     can be connected to any French telephone line. This terminal was widely used in France
     during the 80's and 90's.
 
-    There are several modeles and version. Most of them are based on a mcu from the 8051 family
-    and a EF9345 like semi graphic video chip.
+    There are several models and versions. Most of them are based on 8051 compatible MCUs
+    and EF9345 semi graphic video chip.
 
     The current implementation is an Minitel 2 from "La RADIOTECHNIQUE PORTENSEIGNE" / RPIC (Philips)
-    You can found more informations about this hardware there :
+    More Minitel hardware related informations are available on this page :
     http://hxc2001.free.fr/minitel
 
     What is implemented and working :
@@ -21,11 +21,15 @@
     - Video output
     - Keyboard
     - 24C02 EPROM
+    - Modem serial interface.
+
+    What is implemented but not working :
+
+    - The rear serial port. (Internal 8051 serial port emulation missing).
 
     What is not yet implemented :
 
-    - Modem and sound output.
-    - The rear serial port.
+    - Sound output.
     - Screen should go blank when switched off
 
     The original firmware and the experimental demo rom are currently both working.
@@ -45,11 +49,18 @@
 
     With the official ROM you need to press F10 to switch on the CRT.
 
+    Modem and external port can be exported with the "modport0" and "serport0"
+    interfaces.
+    Example : Options to use to create an TCP socket connected to the modem port :
+              "-modport0 null_modem -bitb socket.127.0.0.1:20000"
+
 ****************************************************************************/
 
 #include "emu.h"
 
+#include "bus/rs232/rs232.h"
 #include "cpu/mcs51/mcs51.h"
+#include "machine/clock.h"
 #include "machine/i2cmem.h"
 #include "machine/timer.h"
 #include "video/ef9345.h"
@@ -60,27 +71,36 @@
 
 #include "logmacro.h"
 
-// IO expander latch usage definitions
+// 14174 Control register bits definition
 enum
 {
-	CTRL_REG_MCBC  = 0x01,
-	CTRL_REG_DTMF  = 0x02,
-	CTRL_REG_CRTON = 0x08,
-	CTRL_REG_OPTO  = 0x10,
-	CTRL_REG_RELAY = 0x20
+	CTRL_REG_MCBC      = 1 << 0,
+	CTRL_REG_DTMF      = 1 << 1,
+	CTRL_REG_CRTON     = 1 << 3,
+	CTRL_REG_OPTO      = 1 << 4,
+	CTRL_REG_LINERELAY = 1 << 5,
 };
 
 // 80C32 Port IO usage definitions
 enum
 {
-	PORT_1_KBSERIN = 0x01,
-	PORT_1_MDM_DCD = 0x02,
-	PORT_1_MDM_PRD = 0x04,
-	PORT_1_MDM_TXD = 0x08,
-	PORT_1_MDM_RTS = 0x10,
-	PORT_1_KBLOAD = 0x20,
-	PORT_1_SCL = 0x40,
-	PORT_1_SDA = 0x80
+	PORT_1_KBSERIN  = 1 << 0,
+	PORT_1_MDM_DCDn = 1 << 1,
+	PORT_1_MDM_PRD  = 1 << 2,
+	PORT_1_MDM_TXD  = 1 << 3,
+	PORT_1_MDM_RTS  = 1 << 4,
+	PORT_1_KBLOAD   = 1 << 5,
+	PORT_1_SCL      = 1 << 6,
+	PORT_1_SDA      = 1 << 7,
+};
+
+enum
+{
+	PORT_3_SER_RXD = 1 << 0,
+	PORT_3_SER_TXD = 1 << 1,
+	PORT_3_SER_ZCO = 1 << 2,
+	PORT_3_MDM_RXD = 1 << 3,
+	PORT_3_SER_RDY = 1 << 5,
 };
 
 class minitel_state : public driver_device
@@ -92,6 +112,8 @@ public:
 		, m_ts9347(*this, "ts9347")
 		, m_palette(*this, "palette")
 		, m_i2cmem(*this, "i2cmem")
+		, m_modem(*this, "modport0")
+		, m_serport(*this, "serport0")
 		, m_io_kbd(*this, "Y%u", 0)
 		{
 		}
@@ -103,8 +125,12 @@ private:
 	required_device<ts9347_device> m_ts9347;
 	required_device<palette_device> m_palette;
 	required_device<i2cmem_device> m_i2cmem;
+	required_device<rs232_port_device> m_modem;
+	required_device<rs232_port_device> m_serport;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(minitel_scanline);
+
+	void update_modem_state();
 
 	void port1_w(uint8_t data);
 	void port3_w(uint8_t data);
@@ -129,6 +155,9 @@ private:
 	uint8_t keyboard_x_row_reg;
 
 	uint8_t last_ctrl_reg;
+
+	int lineconnected;
+	int tonedetect;
 };
 
 void minitel_state::machine_start()
@@ -152,9 +181,9 @@ void minitel_state::port1_w(uint8_t data)
 		LOG("PORT_1_KBSERIN : %d \n", data & PORT_1_KBSERIN );
 	}
 
-	if( (port1 ^ data) & PORT_1_MDM_DCD )
+	if( (port1 ^ data) & PORT_1_MDM_DCDn )
 	{
-		LOG("PORT_1_MDM_DCD : %d \n", data & PORT_1_MDM_DCD );
+		LOG("PORT_1_MDM_DCD : %d \n", data & PORT_1_MDM_DCDn );
 	}
 
 	if( (port1 ^ data) & PORT_1_MDM_PRD )
@@ -166,7 +195,12 @@ void minitel_state::port1_w(uint8_t data)
 	{
 		LOG("PORT_1_MDM_TXD : %d \n", data & PORT_1_MDM_TXD );
 	}
-
+	
+	if(lineconnected)
+	{
+		m_modem->write_txd(!!(data & PORT_1_MDM_TXD));
+	}
+	
 	if( (port1 ^ data) & PORT_1_MDM_RTS )
 	{
 		LOG("PORT_1_MDM_RTS : %d \n", data & PORT_1_MDM_RTS );
@@ -174,7 +208,7 @@ void minitel_state::port1_w(uint8_t data)
 
 	if( (port1 ^ data) & PORT_1_KBLOAD )
 	{
-		LOG("PORT_1_KBLOAD : %d PC:0x%x\n", data & PORT_1_KBLOAD,m_maincpu->pc() );
+		LOG("PORT_1_KBLOAD : %d PC:0x%x\n", data & PORT_1_KBLOAD, m_maincpu->pc() );
 
 		if(data & PORT_1_KBLOAD)
 			keyboard_para_ser = 1;
@@ -200,8 +234,35 @@ void minitel_state::port1_w(uint8_t data)
 void minitel_state::port3_w(uint8_t data)
 {
 	LOG("port_w: write %02X to PORT3\n", data);
+
+	m_serport->write_txd( !!(data & PORT_3_SER_TXD) );
+
 	port3 = data;
 }
+
+
+
+void minitel_state::update_modem_state()
+{
+	// 1300 Hz tone detection :  PORT_1_MDM_RTS = 1, CTRL_REG_DTMF = 0, CTRL_REG_MCBC = 0
+	if(  ( last_ctrl_reg & CTRL_REG_LINERELAY ) &&
+		 ( port1 & PORT_1_MDM_RTS ) &&
+		!( last_ctrl_reg & CTRL_REG_DTMF ) &&
+		!( last_ctrl_reg & CTRL_REG_MCBC ) )
+	{
+		tonedetect = 1;
+	}
+	else
+	{
+		tonedetect = 0;
+	}
+
+	// Main transmission mode :  PORT_1_MDM_RTS = 0, CTRL_REG_DTMF = 1, CTRL_REG_MCBC = 0
+	if( last_ctrl_reg & CTRL_REG_LINERELAY )
+		lineconnected = 1;
+	else
+		lineconnected = 0;
+};
 
 uint8_t minitel_state::port1_r()
 {
@@ -212,13 +273,27 @@ uint8_t minitel_state::port1_r()
 	data = ( ( (port1 & (0xFE & ~PORT_1_SDA) ) | ( (keyboard_x_row_reg>>7)&1) ) );
 	data |= (m_i2cmem->read_sda() ? PORT_1_SDA : 0);
 
+	update_modem_state();
+
+	if( lineconnected )
+		data &= ~PORT_1_MDM_DCDn;
+	else
+		data |=  PORT_1_MDM_DCDn;
+
 	return data;
 }
 
 uint8_t minitel_state::port3_r()
 {
+	uint8_t data;
+
 	LOG("port_r: read %02X from PORT3\n", port3);
-	return port3;
+
+	update_modem_state();
+
+	data = (port3 & ~(PORT_3_SER_RDY)); // External port ready state
+
+	return data;
 }
 
 void minitel_state::dev_ctrl_reg_w(offs_t offset, uint8_t data)
@@ -242,9 +317,9 @@ void minitel_state::dev_ctrl_reg_w(offs_t offset, uint8_t data)
 			LOG("CTRL_REG_OPTO : %d \n", data & CTRL_REG_OPTO );
 		}
 
-		if( (last_ctrl_reg ^ data) & CTRL_REG_RELAY )
+		if( (last_ctrl_reg ^ data) & CTRL_REG_LINERELAY )
 		{
-			LOG("CTRL_REG_RELAY : %d \n", data & CTRL_REG_RELAY );
+			LOG("CTRL_REG_RELAY : %d \n", data & CTRL_REG_LINERELAY );
 		}
 
 		if( (last_ctrl_reg ^ data) & CTRL_REG_CRTON )
@@ -430,6 +505,14 @@ void minitel_state::minitel2(machine_config &config)
 
 	TIMER(config, "minitel_sl", 0).configure_scanline(FUNC(minitel_state::minitel_scanline), "screen", 0, 10);
 
+	RS232_PORT(config, m_modem, default_rs232_devices, nullptr);
+	m_modem->rxd_handler().set_inputline(m_maincpu, MCS51_INT1_LINE).invert();
+
+	RS232_PORT(config, m_serport, default_rs232_devices, nullptr);
+	m_serport->rxd_handler().set_inputline(m_maincpu, MCS51_RX_LINE);
+
+	lineconnected = 0;
+
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
 	screen.set_refresh_hz(60);
@@ -438,7 +521,28 @@ void minitel_state::minitel2(machine_config &config)
 	screen.set_visarea(2, 512-10, 0, 278-1);
 
 	PALETTE(config, m_palette).set_entries(8+1);
+
+	// Send a fake 1300 Hz carrier (emulate the modem ZCO output)
+	auto &fake_1300hz_clock(CLOCK(config, "fake_1300hz_clock", 1300));
+	fake_1300hz_clock.set_pulse_width(attotime::from_usec(384));
+	fake_1300hz_clock.signal_handler().set_inputline(m_maincpu, MCS51_INT0_LINE);
 }
+
+static DEVICE_INPUT_DEFAULTS_START( m_modem )
+	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_75 )
+	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_1200 )
+	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_7 )
+	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_EVEN )
+	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
+DEVICE_INPUT_DEFAULTS_END
+
+static DEVICE_INPUT_DEFAULTS_START( m_serport )
+	DEVICE_INPUT_DEFAULTS( "RS232_TXBAUD", 0xff, RS232_BAUD_9600 )
+	DEVICE_INPUT_DEFAULTS( "RS232_RXBAUD", 0xff, RS232_BAUD_9600 )
+	DEVICE_INPUT_DEFAULTS( "RS232_DATABITS", 0xff, RS232_DATABITS_8 )
+	DEVICE_INPUT_DEFAULTS( "RS232_PARITY", 0xff, RS232_PARITY_NONE )
+	DEVICE_INPUT_DEFAULTS( "RS232_STOPBITS", 0xff, RS232_STOPBITS_1 )
+DEVICE_INPUT_DEFAULTS_END
 
 ROM_START( minitel2 )
 

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -50,8 +50,8 @@
 #include "emu.h"
 
 #include "cpu/mcs51/mcs51.h"
-#include "machine/timer.h"
 #include "machine/i2cmem.h"
+#include "machine/timer.h"
 #include "video/ef9345.h"
 
 #include "emupal.h"

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -20,12 +20,12 @@
     - Main MCU
     - Video output
     - Keyboard
-    - 24C02 EPROM
 
     What is not yet implemented :
 
     - Modem and sound output.
     - The rear serial port.
+    - Parameters I2C 24C02 EEPROM.
     - Screen should go blank when switched off
 
     The original firmware and the experimental demo rom are currently both working.
@@ -40,8 +40,8 @@
     F6 -> Guide
     F7 -> Sommaire
     F8 -> Connexion/Fin
+    F9 -> Fonction
     F10-> ON / OFF
-    Alt Gr -> Fonction
 
     With the official ROM you need to press F10 to switch on the CRT.
 
@@ -50,8 +50,8 @@
 #include "emu.h"
 
 #include "cpu/mcs51/mcs51.h"
-#include "machine/i2cmem.h"
 #include "machine/timer.h"
+#include "machine/i2cmem.h"
 #include "video/ef9345.h"
 
 #include "emupal.h"
@@ -63,11 +63,11 @@
 // IO expander latch usage definitions
 enum
 {
-	CTRL_REG_MCBC  = 0x01,
-	CTRL_REG_DTMF  = 0x02,
-	CTRL_REG_CRTON = 0x08,
-	CTRL_REG_OPTO  = 0x10,
-	CTRL_REG_RELAY = 0x20
+	CTRL_REG_DTMF = 0x02,
+	CTRL_REG_MCBC = 0x04,
+	CTRL_REG_OPTO = 0x08,
+	CTRL_REG_RELAY = 0x10,
+	CTRL_REG_CRTON = 0x20
 };
 
 // 80C32 Port IO usage definitions
@@ -102,7 +102,7 @@ private:
 	required_device<i80c32_device> m_maincpu;
 	required_device<ts9347_device> m_ts9347;
 	required_device<palette_device> m_palette;
-	required_device<i2cmem_device> m_i2cmem;
+	optional_device<i2cmem_device> m_i2cmem;
 
 	TIMER_DEVICE_CALLBACK_MEMBER(minitel_scanline);
 
@@ -322,7 +322,7 @@ static INPUT_PORTS_START( minitel2 )
 	PORT_BIT(0x04, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_A) PORT_CHAR('a') PORT_CHAR('A')
 	PORT_BIT(0x08, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_LCONTROL)
 	PORT_BIT(0x10, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Connexion/Fin") PORT_CODE(KEYCODE_F8)
-	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Fonction") PORT_CODE(KEYCODE_RALT)
+	PORT_BIT(0x20, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_NAME("Fonction") PORT_CODE(KEYCODE_F9)
 	PORT_BIT(0x40, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_RSHIFT) // Right maj
 	PORT_BIT(0x80, IP_ACTIVE_LOW, IPT_KEYBOARD) PORT_CODE(KEYCODE_LSHIFT) // Left maj
 

--- a/src/mame/drivers/minitel_2_rpic.cpp
+++ b/src/mame/drivers/minitel_2_rpic.cpp
@@ -11,7 +11,7 @@
     There are several models and versions. Most of them are based on 8051 compatible MCUs
     and EF9345 semi graphic video chip.
 
-    The current implementation is an Minitel 2 from "La RADIOTECHNIQUE PORTENSEIGNE" / RPIC (Philips)
+    The current implementation is a Minitel 2 from "La RADIOTECHNIQUE PORTENSEIGNE" / RPIC (Philips)
     More Minitel hardware related informations are available on this page :
     http://hxc2001.free.fr/minitel
 
@@ -32,7 +32,7 @@
     - Sound output.
     - Screen should go blank when switched off
 
-    The original firmware and the experimental demo rom are currently both working.
+    The original firmware and the experimental demo ROM are currently both working.
 
     Please note the current special function keys assignation :
 
@@ -49,10 +49,11 @@
 
     With the official ROM you need to press F10 to switch on the CRT.
 
-    Modem and external port can be exported with the "modport0" and "serport0"
+    Modem and external port can be exported to the "modport0" and "serport0"
     interfaces.
-    Example : Options to use to create an TCP socket connected to the modem port :
-              "-modport0 null_modem -bitb socket.127.0.0.1:20000"
+    Example : Command line options to use to create a TCP socket linked to
+    the modem port : "-modport0 null_modem -bitb socket.127.0.0.1:20000"
+    Once mame started you can then send vdt files with netcat to this socket.
 
 ****************************************************************************/
 


### PR DESCRIPTION
This PR makes it possible to use the emulated minitel as if it was connected using its modem or serial line.

Since the original purpose of this device is to serve as a modem terminal, it is now possible to have an interaction with a real server.