### PR TITLE
Lua engine: Enable checks for debug builds, kill sol::buffer

### DIFF
--- a/src/frontend/mame/luaengine.h
+++ b/src/frontend/mame/luaengine.h
@@ -21,7 +21,11 @@
 #include <tuple>
 #include <vector>
 
+#ifdef MAME_DEBUG
+#define SOL_ALL_SAFETIES_ON 1
+#else
 #define SOL_SAFE_USERTYPE 1
+#endif
 #include "sol/sol.hpp"
 
 struct lua_State;
@@ -30,6 +34,7 @@ class lua_engine
 {
 public:
 	// helper structures
+	class buffer_helper;
 	template <typename T> struct devenum;
 	template <typename T> struct simple_list_wrapper;
 	template <typename T> struct tag_object_ptr_map;


### PR DESCRIPTION
This does two things: enables all of Sol’s safety checks in debug builds, and replaces the `sol::buffer` class with another helper for using Lua string buffers.

The first change is simpler.  It means that for debug builds, you get somewhat helpful error messages when you do something like using `.` instead of `:` when calling instance member function rather than MAME just crashing twenty levels inside Sol (@galibert might appreciate this).  Of course, this does cost performance in debug builds.  However, this can’t be done without doing something about `sol::buffer` (see [MT08242](https://mametesters.org/view.php?id=8242)), which brings us to the second change.

The point of `sol::buffer` was to allow returning a Lua string from C++ without needing the copy you’d get if you return a std::string object, as this could be quite significant when doing something like reading a file into memory.  However, the implementation was dangerous, particularly easy to result in a memory leak, and didn’t allow building the Lua string piecemeal if you want to do that.  Lua buffers do require some care to use, as they put multiple things on the stack, so all stack operations need to be balanced when using them.  This means it’s not a great idea to hide the implementation details too much, lest developers forget they’re playing with fire.

The replacement for `sol::buffer` allows building a string piecemeal before finalising the result on the stack.  Currently only prepare/add operations are exposed, but other operations supported by Lua buffers would be easy to add if desirable.  I’m using `sol::stack::pop` to get the result in a form that can be returned back to Sol without resorting to using raw Lua functions.  I *think* it doesn’t need to copy the finalised string, but if it does, please tell me.