### PR TITLE
qx10: Implement floppy motor on timer

### DIFF
--- a/src/mame/drivers/qx10.cpp
+++ b/src/mame/drivers/qx10.cpp
@@ -116,10 +116,12 @@ private:
 	void prom_sel_w(uint8_t data);
 	void cmos_sel_w(uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER( qx10_upd765_interrupt );
+	void update_fdd_motor(uint8_t state);
 	void fdd_motor_w(uint8_t data);
 	uint8_t qx10_30_r();
 	void zoom_w(uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER( tc_w );
+	void sqw_out(uint8_t state);
 	uint8_t mc146818_r(offs_t offset);
 	void mc146818_w(offs_t offset, uint8_t data);
 	IRQ_CALLBACK_MEMBER( inta_call );
@@ -185,7 +187,8 @@ private:
 
 	/* FDD */
 	int     m_fdcint;
-	int     m_fdcmotor;
+	uint8_t  m_motor_clk;
+	uint16_t m_counter;
 	//int     m_fdcready;
 
 	int m_spkr_enable;
@@ -476,12 +479,22 @@ WRITE_LINE_MEMBER( qx10_state::qx10_upd765_interrupt )
 	m_pic_m->ir6_w(state);
 }
 
+void qx10_state::update_fdd_motor(uint8_t state)
+{
+	for (auto& fdd : m_floppy)
+	{
+		floppy_image_device *floppy = fdd->get_device();
+		if (floppy)
+		{
+			floppy->mon_w(state);
+		}
+	}
+}
+
 void qx10_state::fdd_motor_w(uint8_t data)
 {
-	m_fdcmotor = 1;
-
-	m_floppy[0]->get_device()->mon_w(false);
-	m_floppy[1]->get_device()->mon_w(false);
+	m_counter = 0;
+	update_fdd_motor(0);
 	// motor off controlled by clock
 }
 
@@ -493,7 +506,7 @@ uint8_t qx10_state::qx10_30_r()
 	floppy2 = m_floppy[1]->get_device();
 
 	return m_fdcint |
-			/*m_fdcmotor*/ 0 << 1 |
+			BIT(m_counter, 11) << 1 |
 			((floppy1 != nullptr) || (floppy2 != nullptr) ? 1 : 0) << 3 |
 			m_membank << 4;
 }
@@ -589,6 +602,22 @@ void qx10_state::memory_write_byte(offs_t offset, uint8_t data)
 /*
     MC146818
 */
+void qx10_state::sqw_out(uint8_t state)
+{
+	uint8_t clk = !(state || BIT(m_counter, 11));
+	uint16_t cnt = m_counter;
+
+	if (!clk && m_motor_clk)
+	{
+		cnt = (cnt + 1) & 0xfff;
+	}
+	if (BIT(cnt, 11) && !BIT(m_counter, 11)) {
+		update_fdd_motor(1);
+	}
+
+	m_motor_clk = clk;
+	m_counter = cnt;
+}
 
 void qx10_state::mc146818_w(offs_t offset, uint8_t data)
 {
@@ -962,6 +991,7 @@ void qx10_state::qx10(machine_config &config)
 
 	MC146818(config, m_rtc, 32.768_kHz_XTAL);
 	m_rtc->irq().set(m_pic_s, FUNC(pic8259_device::ir2_w));
+	m_rtc->sqw().set(FUNC(qx10_state::sqw_out));
 
 	UPD765A(config, m_fdc, 8'000'000, true, true);
 	m_fdc->intrq_wr_callback().set(FUNC(qx10_state::qx10_upd765_interrupt));


### PR DESCRIPTION
This commit fixes the floppy motor on signal so that it actually turns off after a set amount of time as per the original hardware.

The timer uses a 12 bit counter with the MSB being used as the motor on signal. When it is zero the floppy motor is turned on and when it goes to 1 the motor turns off. This counter is driven by the NOR of the rtc's square wave generator and the MSB of the counter.  When IO port 30 is written to the counter is reset to zero enabling the motor and will count until the MSB goes high at which point the counter is halted and the motor turns off.