### PR TITLE
nes: Various minor fixes, more cleanups with bit functions.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -44844,7 +44844,7 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 			<feature name="pcb" value="NES-UNROM" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="prg" size="131072">
-				<rom name="alfred chicken (europe).prg" size="131072" crc="759418d2" sha1="3f32f7fd57790c6dd72bb3fc2727e25e125ffd6e" offset="00000" status="baddump" />
+				<rom name="alfred chicken (europe).prg" size="131072" crc="759418d2" sha1="3f32f7fd57790c6dd72bb3fc2727e25e125ffd6e" offset="00000" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -45193,10 +45193,10 @@ Also notice that VRAM, WRAM & mirror are probably incorrect for some of these se
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="262144">
-				<rom name="beauty and the beast (europe).chr" size="262144" crc="0b35f4c0" sha1="c035a8c2b0d96475e3d341c7ea5426d4d623bb7a" offset="00000" status="baddump" />
+				<rom name="beauty and the beast (europe).chr" size="262144" crc="0b35f4c0" sha1="c035a8c2b0d96475e3d341c7ea5426d4d623bb7a" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="beauty and the beast (europe).prg" size="131072" crc="b42feeb4" sha1="14937367f2941bb992ee0e3ec66158fbef48fd03" offset="00000" status="baddump" />
+				<rom name="beauty and the beast (europe).prg" size="131072" crc="b42feeb4" sha1="14937367f2941bb992ee0e3ec66158fbef48fd03" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -46075,7 +46075,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="pcb" value="NES-ANROM" />
 			<feature name="bus_conflict" value="no" />
 			<dataarea name="prg" size="131072">
-				<rom name="danny sullivan's indy heat (europe).prg" size="131072" crc="27ca0679" sha1="cd95f141e0cf702984ed5d76db2a0264947f187c" offset="00000" status="baddump" />
+				<rom name="danny sullivan's indy heat (europe).prg" size="131072" crc="27ca0679" sha1="cd95f141e0cf702984ed5d76db2a0264947f187c" offset="00000" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -46134,7 +46134,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
 			<dataarea name="prg" size="262144">
-				<rom name="defender of the crown (france).prg" size="262144" crc="2fd2e632" sha1="5700de705c481b919d7549a0fd1706e1bb1b5603" offset="00000" status="baddump" />
+				<rom name="defender of the crown (france).prg" size="262144" crc="2fd2e632" sha1="5700de705c481b919d7549a0fd1706e1bb1b5603" offset="00000" />
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
@@ -48629,10 +48629,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="mario is missing (europe).chr" size="131072" crc="0de1433a" sha1="a010fa436789fac6b8646ce459ffb6004f235cb8" offset="00000" status="baddump" />
+				<rom name="mario is missing (europe).chr" size="131072" crc="0de1433a" sha1="a010fa436789fac6b8646ce459ffb6004f235cb8" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="mario is missing (europe).prg" size="131072" crc="3c514633" sha1="64bfe58f37ad4e5e4ad311e057337b3e38778032" offset="00000" status="baddump" />
+				<rom name="mario is missing (europe).prg" size="131072" crc="3c514633" sha1="64bfe58f37ad4e5e4ad311e057337b3e38778032" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -48684,10 +48684,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="mcdonaldland (france).chr" size="131072" crc="5ffbe2bb" sha1="0832304c3ff68b77bc94c887bd259b7e702c2546" offset="00000" status="baddump" />
+				<rom name="mcdonaldland (france).chr" size="131072" crc="5ffbe2bb" sha1="0832304c3ff68b77bc94c887bd259b7e702c2546" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="mcdonaldland (france).prg" size="131072" crc="2664fc75" sha1="1ad8b7dcba91331f1f1352a54258fb5af9cf9cd7" offset="00000" status="baddump" />
+				<rom name="mcdonaldland (france).prg" size="131072" crc="2664fc75" sha1="1ad8b7dcba91331f1f1352a54258fb5af9cf9cd7" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge -->
 			<dataarea name="wram" size="8192">
@@ -49707,10 +49707,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="nrom" />
 			<feature name="pcb" value="NES-NROM-128" />
 			<dataarea name="chr" size="8192">
-				<rom name="pac-man (europe).chr" size="8192" crc="19c4aa76" sha1="6ab2a6cfd59e4e1fe9d8c5da6722bb5a6a173861" offset="00000" status="baddump" />
+				<rom name="pac-man (europe).chr" size="8192" crc="19c4aa76" sha1="6ab2a6cfd59e4e1fe9d8c5da6722bb5a6a173861" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="32768">
-				<rom name="pac-man (europe).prg" size="16384" crc="6fa1193b" sha1="8fef2bdce0c0be2ece67b26587aa22097ba3c9cf" offset="00000" status="baddump" />
+				<rom name="pac-man (europe).prg" size="16384" crc="6fa1193b" sha1="8fef2bdce0c0be2ece67b26587aa22097ba3c9cf" offset="00000" />
 				<rom size="16384" offset="0x4000" loadflag="reload" />
 			</dataarea>
 		</part>
@@ -49768,10 +49768,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="parasol stars - rainbow islands ii - the story of bubble bobble iii (europe).chr" size="131072" crc="af5400dc" sha1="68258fedf7e2ba3afcf20e8261ad93d282c10bd9" offset="00000" status="baddump" />
+				<rom name="parasol stars - rainbow islands ii - the story of bubble bobble iii (europe).chr" size="131072" crc="af5400dc" sha1="68258fedf7e2ba3afcf20e8261ad93d282c10bd9" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="parasol stars - rainbow islands ii - the story of bubble bobble iii (europe).prg" size="131072" crc="15382139" sha1="50991602680588a9e7b03e06d45ee607fc00db13" offset="00000" status="baddump" />
+				<rom name="parasol stars - rainbow islands ii - the story of bubble bobble iii (europe).prg" size="131072" crc="15382139" sha1="50991602680588a9e7b03e06d45ee607fc00db13" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -49804,10 +49804,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="pirates (europe).chr" size="131072" crc="9da6d510" sha1="df10035a97217b9e608af813b7d8b1327c5bad6c" offset="00000" status="baddump" />
+				<rom name="pirates (europe).chr" size="131072" crc="9da6d510" sha1="df10035a97217b9e608af813b7d8b1327c5bad6c" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="pirates (europe).prg" size="131072" crc="ddad2460" sha1="63df8b410ce3af69e3f6c6c78671533863736954" offset="00000" status="baddump" />
+				<rom name="pirates (europe).prg" size="131072" crc="ddad2460" sha1="63df8b410ce3af69e3f6c6c78671533863736954" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge, battery backed up -->
 			<dataarea name="bwram" size="8192">
@@ -49825,10 +49825,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="pirates (germany).chr" size="131072" crc="9da6d510" sha1="df10035a97217b9e608af813b7d8b1327c5bad6c" offset="00000" status="baddump" />
+				<rom name="pirates (germany).chr" size="131072" crc="9da6d510" sha1="df10035a97217b9e608af813b7d8b1327c5bad6c" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="pirates (germany).prg" size="131072" crc="d3d1b86c" sha1="befc9fb1e862e95b3c6face3c4d3925b242b30ef" offset="00000" status="baddump" />
+				<rom name="pirates (germany).prg" size="131072" crc="d3d1b86c" sha1="befc9fb1e862e95b3c6face3c4d3925b242b30ef" offset="00000" />
 			</dataarea>
 			<!-- 8k WRAM on cartridge, battery backed up -->
 			<dataarea name="bwram" size="8192">
@@ -49845,7 +49845,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="sxrom" />
 			<feature name="pcb" value="NES-SLROM" />
 			<dataarea name="prg" size="131072">
-				<rom name="predator (australia).prg" size="131072" crc="9fda6938" sha1="0194142f3d50062694c9873fc807456d7e957c2e" offset="00000" status="baddump" />
+				<rom name="predator (australia).prg" size="131072" crc="9fda6938" sha1="0194142f3d50062694c9873fc807456d7e957c2e" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="131072">
 				<rom name="nes-pl-0 chr" size="131072" crc="e220308a" sha1="eb233643d2d3e991c2611449c8e752f7534cd637" offset="00000" />
@@ -50007,10 +50007,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="rackets &amp; rivals (europe).chr" size="131072" crc="4a61ac30" sha1="b1836aae02bc96f28bed720258f8a0e1592917d1" offset="00000" status="baddump" />
+				<rom name="rackets &amp; rivals (europe).chr" size="131072" crc="4a61ac30" sha1="b1836aae02bc96f28bed720258f8a0e1592917d1" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="rackets &amp; rivals (europe).prg" size="131072" crc="7f60bf49" sha1="d109eeb2a6847737103a628afabc5d0f75a7d43a" offset="00000" status="baddump" />
+				<rom name="rackets &amp; rivals (europe).prg" size="131072" crc="7f60bf49" sha1="d109eeb2a6847737103a628afabc5d0f75a7d43a" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -50890,10 +50890,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="262144">
-				<rom name="star trek - 25th anniversary (germany).chr" size="262144" crc="15b00306" sha1="8616bba69f113f5275d0a2d9a0b1b6d3708a87f8" offset="00000" status="baddump" />
+				<rom name="star trek - 25th anniversary (germany).chr" size="262144" crc="15b00306" sha1="8616bba69f113f5275d0a2d9a0b1b6d3708a87f8" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="262144">
-				<rom name="star trek - 25th anniversary (germany).prg" size="262144" crc="2ec726c1" sha1="313cf399b61b9c8e64398978ab57cb394a80dd70" offset="00000" status="baddump" />
+				<rom name="star trek - 25th anniversary (germany).prg" size="262144" crc="2ec726c1" sha1="313cf399b61b9c8e64398978ab57cb394a80dd70" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -51793,10 +51793,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<feature name="slot" value="txrom" />
 			<feature name="pcb" value="NES-TLROM" />
 			<dataarea name="chr" size="131072">
-				<rom name="trolls in crazyland, the (europe).chr" size="131072" crc="192fe3a5" sha1="2d8bec71fcd37168c40df373cb1b65da411f452f" offset="00000" status="baddump" />
+				<rom name="trolls in crazyland, the (europe).chr" size="131072" crc="192fe3a5" sha1="2d8bec71fcd37168c40df373cb1b65da411f452f" offset="00000" />
 			</dataarea>
 			<dataarea name="prg" size="131072">
-				<rom name="trolls in crazyland, the (europe).prg" size="131072" crc="a37b767d" sha1="5edab1bee1f1c05058ad8408427d2ac8aeeb982e" offset="00000" status="baddump" />
+				<rom name="trolls in crazyland, the (europe).prg" size="131072" crc="a37b767d" sha1="5edab1bee1f1c05058ad8408427d2ac8aeeb982e" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -53567,8 +53567,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>19??</year>
 		<publisher>HES</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="hes" />
-			<feature name="pcb" value="HES" />
+			<feature name="slot" value="nina006" />
+			<feature name="pcb" value="AVE-NINA-06" />
 			<dataarea name="chr" size="16384">
 				<rom name="sidewinder (australia) (unl).chr" size="16384" crc="d7c4b76a" sha1="6d0b6fd1285ab8a0079344a158153eefaeab614a" offset="00000" status="baddump" />
 			</dataarea>
@@ -60682,8 +60682,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="serial" value="HKI-05"/>
 		<info name="alt_title" value="AV花名札倶楽部"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="hes" />
-			<feature name="pcb" value="HES" />
+			<feature name="slot" value="sa0037" />
+			<feature name="pcb" value="UNL-SA-0037" />
 			<dataarea name="chr" size="65536">
 				<rom name="av hanafuda club (japan) (unl).chr" size="65536" crc="54ab3688" sha1="ed11e82020eaedab2ff3af560bf008ede2179d42" offset="00000" status="baddump" />
 			</dataarea>
@@ -60776,8 +60776,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<year>19??</year>
 		<publisher>Hacker International</publisher>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="hes" />
-			<feature name="pcb" value="HES" />
+			<feature name="slot" value="sa0037" />
+			<feature name="pcb" value="UNL-SA-0037" />
 			<dataarea name="chr" size="65536">
 				<rom name="av soccer (japan) (unl).chr" size="65536" crc="44b5ea8b" sha1="6ab0e33a9f9bc5de72ed6c89bd7deb169ab0e0b4" offset="00000" status="baddump" />
 			</dataarea>
@@ -60969,8 +60969,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="serial" value="HKI-02"/>
 		<info name="alt_title" value="麻雀コンパニオン 六本木編"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="hes" />
-			<feature name="pcb" value="HES" />
+			<feature name="slot" value="nina006" />
+			<feature name="pcb" value="AVE-NINA-06" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="65536">
 				<rom name="mahjang companion (asia) (hacker) (unl).chr" size="65536" crc="745b9cf9" sha1="89f8e4f5117ab34af3d9e4dbecd85aed99c4fbfd" offset="00000" status="baddump" />
@@ -61008,8 +61008,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<publisher>Hacker International</publisher>
 		<info name="alt_title" value="Papillon Gals (on the cart label)"/>
 		<part name="cart" interface="nes_cart">
-			<feature name="slot" value="hes" />
-			<feature name="pcb" value="HES" />
+			<feature name="slot" value="nina006" />
+			<feature name="pcb" value="AVE-NINA-06" />
 			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="65536">
 				<rom name="papillon (asia) (unl).chr" size="65536" crc="48a4a69b" sha1="c960931b6bcff36ff5dbbb79e98e5bd3ac812869" offset="00000" status="baddump" />
@@ -63456,7 +63456,6 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="hes" />
 			<feature name="pcb" value="HES-6IN1" />
-			<feature name="mirroring" value="pcb_controlled" />
 			<dataarea name="chr" size="131072">
 				<rom name="hes 6 in 1 (hes).chr" size="131072" crc="5a5c3e73" sha1="86c2b8363013034fde87e4aedec12754bf2a6b4d" offset="00000" status="baddump" />
 			</dataarea>

--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -60684,6 +60684,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sa0037" />
 			<feature name="pcb" value="UNL-SA-0037" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="65536">
 				<rom name="av hanafuda club (japan) (unl).chr" size="65536" crc="54ab3688" sha1="ed11e82020eaedab2ff3af560bf008ede2179d42" offset="00000" status="baddump" />
 			</dataarea>
@@ -60778,6 +60779,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sa0037" />
 			<feature name="pcb" value="UNL-SA-0037" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="65536">
 				<rom name="av soccer (japan) (unl).chr" size="65536" crc="44b5ea8b" sha1="6ab0e33a9f9bc5de72ed6c89bd7deb169ab0e0b4" offset="00000" status="baddump" />
 			</dataarea>

--- a/src/devices/bus/nes/act53.cpp
+++ b/src/devices/bus/nes/act53.cpp
@@ -112,7 +112,7 @@ void nes_action53_device::pcb_reset()
 void nes_action53_device::update_prg()
 {
 	u16 prg_lo, prg_hi;
-	u8 size = (m_reg[2] & 0x30) >> 4;         // Game size
+	u8 size = BIT(m_reg[2], 4, 2);            // Game size
 	u16 mask = ~0 << (size + 1);              // Bits to be taken from PRG regs
 	u8 b32k = !BIT(m_reg[2], 3);              // 32K mode bit
 	u16 outer = m_reg[3] << 1;                // Outer PRG reg bits

--- a/src/devices/bus/nes/aladdin.cpp
+++ b/src/devices/bus/nes/aladdin.cpp
@@ -245,7 +245,7 @@ void nes_algq_rom_device::write_prg(uint32_t offset, uint8_t data)
 	// m_hibank = 3rd page inside the block
 	if (offset < 0x4000)
 	{
-		m_bank_base = ((data >> 3) & 3) << 2;
+		m_bank_base = (data & 0x18) >> 1;
 		m_lobank = m_bank_base | (m_lobank & 3);
 		m_hibank = m_bank_base | 3;
 	}

--- a/src/devices/bus/nes/ave.cpp
+++ b/src/devices/bus/nes/ave.cpp
@@ -154,7 +154,8 @@ void nes_nina006_device::write_l(offs_t offset, uint8_t data)
 {
 	LOG_MMC(("nina-006 write_l, offset: %04x, data: %02x\n", offset, data));
 
-	if (!(offset & 0x0100))
+	offset += 0x100;
+	if (BIT(offset, 8)) // $41xx, $43xx, ... $5fxx
 	{
 		prg32(data >> 3);
 		chr8(data & 7, CHRROM);

--- a/src/devices/bus/nes/bandai.cpp
+++ b/src/devices/bus/nes/bandai.cpp
@@ -207,32 +207,28 @@ void nes_fjump2_device::pcb_reset()
 
 void nes_oekakids_device::nt_w(offs_t offset, uint8_t data)
 {
-	int page = ((offset & 0xc00) >> 10);
-
 #if 0
 	if (!(offset & 0x1000) && (offset & 0x3ff) < 0x3c0)
 	{
-		m_latch = (offset & 0x300) >> 8;
+		m_latch = BIT(offset, 8, 2);
 		chr4_0(m_reg | m_latch, CHRRAM);
 	}
 #endif
 
-	m_nt_access[page][offset & 0x3ff] = data;
+	device_nes_cart_interface::nt_w(offset, data);
 }
 
 uint8_t nes_oekakids_device::nt_r(offs_t offset)
 {
-	int page = ((offset & 0xc00) >> 10);
-
 #if 0
 	if (!(offset & 0x1000) && (offset & 0x3ff) < 0x3c0)
 	{
-		m_latch = (offset & 0x300) >> 8;
+		m_latch = BIT(offset, 8, 2);
 		chr4_0(m_reg | m_latch, CHRRAM);
 	}
 #endif
 
-	return m_nt_access[page][offset & 0x3ff];
+	return device_nes_cart_interface::nt_r(offset);
 }
 
 void nes_oekakids_device::update_chr()
@@ -247,7 +243,7 @@ void nes_oekakids_device::ppu_latch(offs_t offset)
 #if 0
 	if ((offset & 0x3000) == 0x2000)
 	{
-		m_latch = (offset & 0x300) >> 8;
+		m_latch = BIT(offset, 8, 2);
 		update_chr();
 	}
 #endif

--- a/src/devices/bus/nes/benshieng.h
+++ b/src/devices/bus/nes/benshieng.h
@@ -14,9 +14,9 @@ class nes_benshieng_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_benshieng_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_benshieng_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -25,10 +25,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	void update_banks();
-	uint8_t m_dipsetting;
-	uint8_t m_mmc_prg_bank[4];
-	uint8_t m_mmc_vrom_bank[4];
+	u8 m_dipsetting;
 };
 
 

--- a/src/devices/bus/nes/bootleg.cpp
+++ b/src/devices/bus/nes/bootleg.cpp
@@ -1019,7 +1019,7 @@ void nes_btl_dn_device::write_h(offs_t offset, uint8_t data)
 		case 0x5002:
 		case 0x6000:
 		case 0x6002:
-			bank = ((offset & 0x7000) - 0x3000) / 0x0800 + ((offset & 0x0002) >> 1);
+			bank = 2 * (BIT(offset, 12, 3) - 3) + BIT(offset, 1);
 			chr1_x(bank, data, CHRROM);
 			break;
 		case 0x7000:

--- a/src/devices/bus/nes/hes.cpp
+++ b/src/devices/bus/nes/hes.cpp
@@ -33,24 +33,10 @@
 DEFINE_DEVICE_TYPE(NES_HES, nes_hes_device, "nes_hes", "NES Cart HES PCB")
 
 
-nes_hes_device::nes_hes_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_hes_device::nes_hes_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_HES, tag, owner, clock)
 {
 }
-
-
-void nes_hes_device::device_start()
-{
-	common_start();
-}
-
-void nes_hes_device::pcb_reset()
-{
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg32(0);
-	chr8(0, m_chr_source);
-}
-
 
 
 /*-------------------------------------------------
@@ -69,19 +55,19 @@ void nes_hes_device::pcb_reset()
 
  iNES: mapper 113
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_hes_device::write_l(offs_t offset, uint8_t data)
+void nes_hes_device::write_l(offs_t offset, u8 data)
 {
 	LOG_MMC(("hes write_l, offset: %04x, data: %02x\n", offset, data));
 
-	if (!(offset & 0x100))
+	offset += 0x100;
+	if (BIT(offset, 8)) // $41xx, $43xx, ... $5fxx
 	{
-		prg32((data & 0x38) >> 3);
-		chr8((data & 0x07) | ((data & 0x40) >> 3), CHRROM);
-		if (m_pcb_ctrl_mirror)
-			set_nt_mirroring(BIT(data, 7) ? PPU_MIRROR_VERT : PPU_MIRROR_HORZ);
+		prg32(BIT(data, 3, 3));
+		chr8(bitswap<4>(data, 6, 2, 1, 0), CHRROM);
+		set_nt_mirroring(BIT(data, 7) ? PPU_MIRROR_VERT : PPU_MIRROR_HORZ);
 	}
 }

--- a/src/devices/bus/nes/hes.h
+++ b/src/devices/bus/nes/hes.h
@@ -14,15 +14,9 @@ class nes_hes_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_hes_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_hes_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_l(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_l(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/jaleco.cpp
+++ b/src/devices/bus/nes/jaleco.cpp
@@ -513,9 +513,9 @@ void nes_ss88006_device::ss88006_write(offs_t offset, uint8_t data)
 		case 0x3000: case 0x3001: case 0x3002: case 0x3003:
 		case 0x4000: case 0x4001: case 0x4002: case 0x4003:
 		case 0x5000: case 0x5001: case 0x5002: case 0x5003:
-			bank = ((offset & 0x7000) - 0x2000) / 0x0800 + ((offset & 0x0002) >> 1);
+			bank = 2 * (BIT(offset, 12, 3) - 2) + BIT(offset, 1);
 			if (offset & 0x0001)
-				m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & 0x0f) | ((data & 0x0f)<< 4);
+				m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & 0x0f) | ((data & 0x0f) << 4);
 			else
 				m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & 0xf0) | (data & 0x0f);
 
@@ -575,7 +575,7 @@ void nes_ss88006_adpcm_device::ss88006_adpcm_write(offs_t offset, uint8_t data, 
 			{
 //              printf("sample write: data: %02x\n", data);
 				if ((m_latch & 2) && !(data & 2))
-					dev.start((data >> 2) & 0x1f, (data >> 2) & 0x1f);
+					dev.start(BIT(data, 2, 5), BIT(data, 2, 5));
 			}
 			m_latch = data;
 			break;

--- a/src/devices/bus/nes/mmc3_clones.cpp
+++ b/src/devices/bus/nes/mmc3_clones.cpp
@@ -2253,7 +2253,7 @@ void nes_fk23c_device::chr_cb(int start, int bank, int source)
 void nes_fk23c_device::fk23c_set_prg()
 {
 	if ((m_reg[0] & 0x07) == 4)
-		prg32((m_reg[1] & 0x7f) >> 1);
+		prg32(BIT(m_reg[1], 1, 6));
 	else if ((m_reg[0] & 0x07) == 3)
 	{
 		prg16_89ab(m_reg[1] & 0x7f);
@@ -3328,7 +3328,7 @@ void nes_bmc_411120c_device::write_m(offs_t offset, u8 data)
 	{
 		m_reg = offset;
 		if (BIT(m_reg, 3))
-			prg32((m_reg & 0x07) << 2 | (m_reg & 0x30) >> 4);
+			prg32(bitswap<5>(m_reg, 2, 1, 0, 5, 4));
 		else
 		{
 			m_prg_base = (m_reg & 0x07) << 4;

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -14,15 +14,9 @@ class nes_action52_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_action52_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_action52_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -393,15 +387,9 @@ class nes_ntd03_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_ntd03_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ntd03_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
-
-protected:
-	// device-level overrides
-	virtual void device_start() override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/namcot.cpp
+++ b/src/devices/bus/nes/namcot.cpp
@@ -466,7 +466,7 @@ void nes_namcot340_device::n340_hiwrite(offs_t offset, uint8_t data)
 		case 0x1000: case 0x1800:
 		case 0x2000: case 0x2800:
 		case 0x3000: case 0x3800:
-			chr1_x(offset / 0x800, data, CHRROM);
+			chr1_x(offset >> 11, data, CHRROM);
 			break;
 		case 0x4000:
 			// no cart found with wram, so it is not clear if this could work as in Namcot-175...
@@ -611,7 +611,7 @@ uint8_t nes_namcot163_device::read_m(offs_t offset)
 void nes_namcot163_device::write_m(offs_t offset, uint8_t data)
 {
 	// the pcb can separately protect each 2KB chunk of the external wram from writes
-	int bank = (offset & 0x1800) >> 11;
+	int bank = BIT(offset, 11, 2);
 	if (!m_battery.empty() && !BIT(m_wram_protect, bank))
 		m_battery[offset & (m_battery.size() - 1)] = data;
 }

--- a/src/devices/bus/nes/nes_slot.cpp
+++ b/src/devices/bus/nes/nes_slot.cpp
@@ -529,10 +529,8 @@ void device_nes_cart_interface::nt_w(offs_t offset, uint8_t data)
 {
 	int page = BIT(offset, 10, 2);
 
-	if (!m_nt_writable[page])
-		return;
-
-	m_nt_access[page][offset & 0x3ff] = data;
+	if (m_nt_writable[page])
+		m_nt_access[page][offset & 0x3ff] = data;
 }
 
 uint8_t device_nes_cart_interface::nt_r(offs_t offset)

--- a/src/devices/bus/nes/pirate.cpp
+++ b/src/devices/bus/nes/pirate.cpp
@@ -680,7 +680,7 @@ void nes_43272_device::write_h(offs_t offset, uint8_t data)
 	LOG_MMC(("unl_43272 write_h, offset: %04x, data: %02x\n", offset, data));
 
 	if ((m_latch & 0x81) == 0x81)
-		prg32((m_latch & 0x38) >> 3);
+		prg32(BIT(m_latch, 3, 3));
 
 	m_latch = offset & 0xffff;
 }
@@ -778,7 +778,7 @@ uint8_t nes_fujiya_device::read_m(offs_t offset)
 	offset += 0x6000;
 
 	if (offset == 0x7001 || offset == 0x7777)
-		return m_latch | ((offset >> 8) & 0x7f);
+		return m_latch | (BIT(offset, 8, 7));
 
 	return get_open_bus();
 }

--- a/src/devices/bus/nes/sachen.cpp
+++ b/src/devices/bus/nes/sachen.cpp
@@ -628,7 +628,7 @@ void nes_sachen_74x374_device::write_l(offs_t offset, uint8_t data)
 					chr8(m_mmc_vrom_bank, CHRROM);
 					break;
 				case 0x07:
-					set_mirror((data >> 1) & 0x03);
+					set_mirror(BIT(data, 1, 2));
 					break;
 				default:
 					break;

--- a/src/devices/bus/nes/subor.cpp
+++ b/src/devices/bus/nes/subor.cpp
@@ -185,12 +185,10 @@ void nes_subor2_device::ppu_latch(offs_t offset)
 
 uint8_t nes_subor2_device::nt_r(offs_t offset)
 {
-	int page = ((offset & 0xc00) >> 10);
+	// Nametable reads report the current page; this seems to work without issues
+	m_page = BIT(offset, 10, 2);
 
-	/* Nametable reads report the current page; this seems to work without issues */
-	m_page = page;
-
-	return m_nt_access[page][offset & 0x3ff];
+	return device_nes_cart_interface::nt_r(offset);
 }
 
 /*-------------------------------------------------
@@ -254,7 +252,7 @@ void nes_subor0_device::write_h(offs_t offset, uint8_t data)
 	uint8_t subor_helper1, subor_helper2;
 	LOG_MMC("subor0 write_h, offset: %04x, data: %02x\n", offset, data);
 
-	m_reg[(offset >> 13) & 0x03] = data;
+	m_reg[BIT(offset, 13, 2)] = data;
 	subor_helper1 = ((m_reg[0] ^ m_reg[1]) << 1) & 0x20;
 	subor_helper2 = ((m_reg[2] ^ m_reg[3]) << 0) & 0x1f;
 
@@ -284,7 +282,7 @@ void nes_subor1_device::write_h(offs_t offset, uint8_t data)
 	uint8_t subor_helper1, subor_helper2;
 	LOG_MMC("subor1 write_h, offset: %04x, data: %02x\n", offset, data);
 
-	m_reg[(offset >> 13) & 0x03] = data;
+	m_reg[BIT(offset, 13, 2)] = data;
 	subor_helper1 = ((m_reg[0] ^ m_reg[1]) << 1) & 0x20;
 	subor_helper2 = ((m_reg[2] ^ m_reg[3]) << 0) & 0x1f;
 

--- a/src/devices/bus/nes/waixing.cpp
+++ b/src/devices/bus/nes/waixing.cpp
@@ -1113,8 +1113,8 @@ void nes_waixing_dq8_device::write_h(offs_t offset, uint8_t data)
 
 void nes_waixing_wxzs2_device::write_h(offs_t offset, uint8_t data)
 {
-	uint8_t flip = (data & 0x80) >> 7;
-	uint8_t helper = (data & 0x7f) << 1;
+	uint8_t flip = BIT(data, 7);
+	uint8_t helper = data << 1;
 
 	LOG_MMC(("waixing_wxzs2 write_h, offset: %04x, data: %02x\n", offset, data));
 
@@ -1167,13 +1167,12 @@ void nes_waixing_wxzs2_device::write_h(offs_t offset, uint8_t data)
 void nes_waixing_fs304_device::write_l(offs_t offset, uint8_t data)
 {
 	LOG_MMC(("fs304 write_l, offset: %04x, data: %02x\n", offset, data));
-	int bank;
-	offset += 0x100;
 
+	offset += 0x100;
 	if (offset >= 0x1000)
 	{
-		m_reg[(offset >> 8) & 3] = data;
-		bank = ((m_reg[2] & 0x0f) << 4) | BIT(m_reg[1], 1) | (m_reg[0] & 0x0e);
+		m_reg[BIT(offset, 8, 2)] = data;
+		int bank = ((m_reg[2] & 0x0f) << 4) | BIT(m_reg[1], 1) | (m_reg[0] & 0x0e);
 		prg32(bank);
 		chr8(0, CHRRAM);
 	}

--- a/src/devices/bus/nes_ctrl/hori.cpp
+++ b/src/devices/bus/nes_ctrl/hori.cpp
@@ -5,9 +5,9 @@
     Nintendo Family Computer Hori Twin and 4 Players adapters
 
     In general these adapters work by reading pin 13 (the Famicom sees
-    this in memory location $4016, bit 1) of their subports. It is not
-    clear if other lines are pass-thru. For the moment we only emulate
-    joypads connected to these ports, which only use pin 13 when read.
+    this in memory location $4016, bit 1) of their subports. Other
+    input pins are not connected so various specialty controllers are
+    incompatible with these adapters.
 
     The Hori Twin passes subport 1's input directly through to $4016
     bit 1. It reroutes subport 2's to $4017 bit 1. Incidentally, HAL
@@ -137,6 +137,9 @@ u8 nes_hori4p_device::read_exp(offs_t offset)
 	u8 ret = 0;
 	int mode4p = m_cfg->read();
 
+	if (m_strobe)
+		reset_regs();
+
 	if (m_count[offset] < 16 || !mode4p)  // read from P1/P2 for first byte, P3/P4 for second byte if in 4P mode
 	{
 		int port = 2 * (BIT(m_count[offset], 3) & mode4p) + offset;
@@ -146,6 +149,7 @@ u8 nes_hori4p_device::read_exp(offs_t offset)
 	{
 		ret = (m_sig[offset] & 1) << 1;
 		m_sig[offset] >>= 1;
+		m_sig[offset] |= 0x80;  // reads beyond signature are always 1
 	}
 	m_count[offset]++;
 


### PR DESCRIPTION
bus/nes/benshieng.cpp: Streamline banking; no need to store variables in this device.
bus/nes/hes.cpp: Only support multicarts. Related singleton carts reassigned to relevant board types. (Fixes various graphics issues in the multicarts.)
bus/nes_ctrl/hori.cpp: Amend some minutiae involving strobing and excessive controller reading.
hash/nes.xml: Removed a few more baddump flags.