### PR TITLE
fmtowns_flop_orig.xml/pc98.xml: fix incorrect mfm files

### DIFF
--- a/hash/fmtowns_flop_cracked.xml
+++ b/hash/fmtowns_flop_cracked.xml
@@ -62,33 +62,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="dinosaur">
-		<description>Dinosaur (cracked)</description>
-		<year>1991</year>
-		<publisher>日本ファルコム (Nihon Falcom)</publisher>
-		<info name="alt_title" value="ダイナソア" />
-		<info name="release" value="199110xx" />
-		<info name="usage" value="Requires 2 MB RAM"/>
-		<part name="flop1" interface="floppy_3_5">
-			<feature name="part_id" value="Program Disk" />
-			<dataarea name="flop" size="1261568">
-				<rom name="dinosaur_program_disk.hdm" size="1261568" crc="2f652873" sha1="190dc1a07c1b4ac1ccc96295e8b178c15eaf89b1"/>
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3_5">
-			<feature name="part_id" value="Scenario Disk 1" />
-			<dataarea name="flop" size="1261568">
-				<rom name="dinosaur_scenario_disk_1_cracked.hdm" size="1261568" crc="e230629d" sha1="a2d0f382a49bb8b9c71d0cd23c7ec9f7b13f823b"/>
-			</dataarea>
-		</part>
-		<part name="flop3" interface="floppy_3_5">
-			<feature name="part_id" value="Scenario Disk 2" />
-			<dataarea name="flop" size="1261568">
-				<rom name="dinosaur_scenario_disk_2_cracked.hdm" size="1261568" crc="6a449cdc" sha1="792c40cd43ab723b4832995e55ef1367a6e462ae"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<!-- All the files in these images match the original disks, except for an additional CONTENTS.GBX file. It's unclear if they are actually cracked or not. -->
 	<software name="supdaisn">
 		<description>Super Daisenryaku (cracked?)</description>

--- a/hash/fmtowns_flop_orig.xml
+++ b/hash/fmtowns_flop_orig.xml
@@ -601,7 +601,7 @@ Zurukamashi Ver 2.0                                                 Nichikonren 
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Scenario Disk 1" />
 			<dataarea name="flop" size="3528460">
-				<rom name="dinosaur_scenario_disk_1.mfm" size="3528460" crc="b2144bf0" sha1="9ca582cbb17e9f1e82535cbe91c71b5c81f05dc9"/>
+				<rom name="dinosaur_scenario_disk_1.mfm" size="3528460" crc="90ca24af" sha1="b1897a224fe0f4d80c4de6ed3e8b8a4b3c680a50"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
@@ -1398,7 +1398,7 @@ Zurukamashi Ver 2.0                                                 Nichikonren 
 		<part name="flop2" interface="floppy_3_5">
 			<feature name="part_id" value="Ending Disk" />
 			<dataarea name="flop" size="3444648">
-				<rom name="lord_monarch_ending_disk.mfm" size="3444648" crc="9bb132e0" sha1="ed720bb07be36e6706d0f42b685bfb2864fce1e3"/>
+				<rom name="lord_monarch_ending_disk.mfm" size="3444648" crc="15b9b1ce" sha1="65b4b8e7fc9031a7d7e9ba5b75bbb9a36541b9d0"/>
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_3_5">
@@ -1431,7 +1431,7 @@ Zurukamashi Ver 2.0                                                 Nichikonren 
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="3594134">
-				<rom name="maririndx_diska.mfm" size="3594134" crc="61706c9d" sha1="c6ae5412211d03e604bfc58b8d40107a4f3912fe"/>
+				<rom name="maririndx_diska.mfm" size="3594134" crc="98e3418f" sha1="f7279a025ae962b154dda7efa814071c9340abc0"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">
@@ -2210,7 +2210,7 @@ Zurukamashi Ver 2.0                                                 Nichikonren 
 		<part name="flop1" interface="floppy_3_5">
 			<feature name="part_id" value="Disk A" />
 			<dataarea name="flop" size="3444635">
-				<rom name="tenshi-tachi_no_gogo_vi_disk_a.mfm" size="3444635" crc="f7af9038" sha1="f30bfa2ba530799ff657b11957e1319e53b13c61"/>
+				<rom name="tenshi-tachi_no_gogo_vi_disk_a.mfm" size="3444635" crc="f442e05d" sha1="b548f97aeb1b07c1f89354434026adefe0020077"/>
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3_5">

--- a/hash/pc98.xml
+++ b/hash/pc98.xml
@@ -8513,8 +8513,7 @@ TODO:
 		</part>
 	</software>
 
-	<!-- Doesn't pass the protection check -->
-	<software name="brandnew" supported="no">
+	<software name="brandnew">
 		<!-- Origin: private dump (r09) -->
 		<description>Brandish Renewal</description>
 		<year>1995</year>
@@ -8530,7 +8529,7 @@ TODO:
 		<part name="flop2" interface="floppy_5_25">
 			<feature name="part_id" value="Disk 2"/>
 			<dataarea name="flop" size="3594434">
-				<rom name="brandish_renewal_disk2.mfm" size="3594434" crc="ff09f243" sha1="9c8e3c99ac406b2501aa83867fa9e78424efb408" offset="0" />
+				<rom name="brandish_renewal_disk2.mfm" size="3594434" crc="411f9f13" sha1="97054b414c002e0b6884746015026e1acb03ddaf" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop3" interface="floppy_5_25">

--- a/hash/pc98_cd.xml
+++ b/hash/pc98_cd.xml
@@ -1103,8 +1103,8 @@ license:CC0
 		</part>
 	</software>
 
-	<!-- Requires disk 2 of the floppy version (included in the box) as copy protection, but fails the check -->
-	<software name="brandnew" supported="no">
+	<!-- Requires disk 2 of the floppy version (included in the box) as copy protection -->
+	<software name="brandnew">
 		<!--
 		Origin: redump.org
 		<rom name="Brandish (Japan) (Renewal) (Track 01).bin" size="11936400" crc="07953f04" sha1="e3aba6d10495617412095fb47ae40c59c63b2237"/>
@@ -1130,7 +1130,7 @@ license:CC0
 		<info name="release" value="19950310" />
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="3594434">
-				<rom name="brandish_renewal_disk2.mfm" size="3594434" crc="ff09f243" sha1="9c8e3c99ac406b2501aa83867fa9e78424efb408" offset="0" />
+				<rom name="brandish_renewal_disk2.mfm" size="3594434" crc="411f9f13" sha1="97054b414c002e0b6884746015026e1acb03ddaf" offset="0" />
 			</dataarea>
 		</part>
 		<part name="cdrom" interface="cdrom">


### PR DESCRIPTION
After another round of re-checking I've found a few more cases of protected disks incorrectly converted to the HxC MFM format. It seems the HxC tools don't handle well the conversion when a sector crosses the index pulse, so those sometimes require a bit of manual editing. I didn't catch them originally because most of them seem to be a bit sneaky:

- Dinosaur only fails the protection check when you reload a saved game from the game itself and try to move to a different area.
- In Lord Monarch only the ending disk was affected, so the game works but it probably couldn't be finished.
- As for Maririn DX and My Fair Teacher, I have no idea since they always seemed to work, but maybe they have more protection checks further into the game?

Brandish PC-98 simply didn't work, and it does now.

This also let me confirm my suspicion that the supposedly cracked images of Dinosaur aren't actually cracked, instead they are just copied from the originals with a simple disk copy tool and fail the protection checks, so I have removed them to prevent confusion.