### PR TITLE
Changed floppy_image_device::init_fs() to set the dirty bit on the floppy image

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -844,6 +844,9 @@ void floppy_image_device::init_fs(const fs_info *fs, const fs::meta_data &meta)
 	} else {
 		fs::unformatted_image::format(fs->m_key, image.get());
 	}
+
+	// intializing a file system makes the floppy dirty
+	image_dirty = true;
 }
 
 /* write protect, active high


### PR DESCRIPTION
This is not an actual user facing bug right now, because in the MAME UI the call to `init_fs()` is followed up by a call to `setup_write()`, which forces the image to commit without regard to the dirty bit.  There is an argument that this is itself code smell; `setup_write()` perhaps should be `set_output_format()` and not arbitrarily perform a commit.