### PR TITLE
galaxold.cpp: update DIP switch labelling for bullsdrtg (MT08283)

### DIFF
--- a/src/mame/drivers/galaxold.cpp
+++ b/src/mame/drivers/galaxold.cpp
@@ -1444,6 +1444,24 @@ static INPUT_PORTS_START( trvchlng )
 INPUT_PORTS_END
 
 
+static INPUT_PORTS_START( bullsdrtg )
+	PORT_INCLUDE( racknrol )
+
+	PORT_MODIFY("IN1")
+	PORT_DIPNAME( 0x40, 0x00, DEF_STR( Cabinet ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( Upright ) )
+	PORT_DIPSETTING(    0x40, DEF_STR( Cocktail ) )
+
+	PORT_MODIFY("DSW0")
+	PORT_DIPNAME( 0x01, 0x00, DEF_STR( Coinage ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( 1C_1C ) )
+	PORT_DIPSETTING(    0x01, DEF_STR( 2C_1C ) )
+	PORT_DIPNAME( 0x02, 0x00, "Award Free Game" )
+	PORT_DIPSETTING(    0x02, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+INPUT_PORTS_END
+
+
 
 
 static const gfx_layout galaxold_charlayout =
@@ -2513,4 +2531,4 @@ GAME( 1986, racknrol,  0,        racknrol,  racknrol,  galaxold_state, empty_ini
 GAME( 1986, hexpool,   racknrol, racknrol,  racknrol,  galaxold_state, empty_init,     ROT90,  "Senko Industries (Shinkai Inc. license)",             "Hex Pool (Shinkai)",                                          MACHINE_SUPPORTS_SAVE ) // still has Senko logo in gfx rom
 GAME( 1985, hexpoola,  racknrol, hexpoola,  racknrol,  galaxold_state, empty_init,     ROT90,  "Senko Industries",                                    "Hex Pool (Senko)",                                            MACHINE_SUPPORTS_SAVE )
 GAME( 1985, trvchlng,  0,        racknrol,  trvchlng,  galaxold_state, empty_init,     ROT90,  "Joyland (Senko license)",                             "Trivia Challenge",                                            MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE )
-GAME( 1985, bullsdrtg, bullsdrt, bullsdrtg, racknrol,  galaxold_state, init_bullsdrtg, ROT90,  "Senko Industries",                                    "Bulls Eye Darts (Galaxian conversion)",                       MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS )
+GAME( 1985, bullsdrtg, bullsdrt, bullsdrtg, bullsdrtg, galaxold_state, init_bullsdrtg, ROT90,  "Senko Industries",                                    "Bulls Eye Darts (Galaxian conversion)",                       MACHINE_SUPPORTS_SAVE | MACHINE_IMPERFECT_GRAPHICS | MACHINE_WRONG_COLORS )


### PR DESCRIPTION
Would it be possible to add credit for the MAME testers in the whatsnew_xxxx.txt file going forward?