### PR TITLE
bus/nes: Updated Taito X1-017 boards.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -21301,7 +21301,7 @@ license:CC0
 	</software>
 
 	<software name="khkoshn" supported="no">
-		<description>Kyuukyoku Harikiri Koushien (Jpn)</description>
+		<description>Kyuukyoku Harikiri Koushien (Japan)</description>
 		<year>1992</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="TFC-KHK-6900 (42)"/>
@@ -21312,7 +21312,7 @@ license:CC0
 			<feature name="pcb" value="TAITO-X1-017" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
-				<rom name="d23-01" size="131072" crc="265167e1" sha1="9e587587b2685ca1b320bd0a137eedbb6b274797" offset="00000" />
+				<rom name="d23-01" size="131072" crc="f45c0971" sha1="46e76efbd5e2eca206abe80329fbd5df0ef5bc79" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="262144">
 				<rom name="d23-02" size="262144" crc="63ca0132" sha1="1fd70de7748ec7f42619f182bc8c86573b96abf6" offset="00000" />
@@ -21374,7 +21374,7 @@ license:CC0
 	</software>
 
 	<software name="khstad3">
-		<description>Kyuukyoku Harikiri Stadium III (Jpn)</description>
+		<description>Kyuukyoku Harikiri Stadium III (Japan)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="TFC-KHIII-6900 (34)"/>
@@ -21385,7 +21385,7 @@ license:CC0
 			<feature name="pcb" value="TAITO-X1-017" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
-				<rom name="c75-01" size="131072" crc="49aa5257" sha1="974e0af88ca48d491d34a15661dc45bdba7dbe03" offset="00000" />
+				<rom name="c75-01" size="131072" crc="b15e8be2" sha1="d5047b27e37ec33ed2c4a198aecea3966e032e29" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="262144">
 				<rom name="c75-02" size="262144" crc="0d6a9893" sha1="079c20f0ba98aa846440e988f2d989b003ee9909" offset="00000" />
@@ -21397,7 +21397,7 @@ license:CC0
 	</software>
 
 	<software name="khstadh" supported="no">
-		<description>Kyuukyoku Harikiri Stadium - Heisei Gannen Ban (Jpn)</description>
+		<description>Kyuukyoku Harikiri Stadium - Heisei Gannen Ban (Japan)</description>
 		<year>1989</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="TFC-KHH-6800 (25)"/>
@@ -21408,7 +21408,7 @@ license:CC0
 			<feature name="pcb" value="TAITO-X1-017" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
-				<rom name="prg-x3-025b" size="131072" crc="4819a595" sha1="4479fe8316d8dec8927d58650d6707a048e2a274" offset="00000" />
+				<rom name="prg-x3-025b" size="131072" crc="c2339468" sha1="1c5c9a192a27b848f3f84f2dffb59b1a30749046" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="262144">
 				<rom name="chr-x3-026" size="262144" crc="1c36a136" sha1="37d36fcc65b56858a5b5aa628c8c8765b064028a" offset="00000" />
@@ -32467,7 +32467,7 @@ license:CC0
 	</software>
 
 	<software name="sdkeiji">
-		<description>SD Keiji - Blader (Jpn)</description>
+		<description>SD Keiji - Blader (Japan)</description>
 		<year>1991</year>
 		<publisher>Taito</publisher>
 		<info name="serial" value="TFC-SKB-6400 (39)"/>
@@ -32478,7 +32478,7 @@ license:CC0
 			<feature name="pcb" value="TAITO-X1-017" />
 			<feature name="batt" value="yes" />
 			<dataarea name="prg" size="131072">
-				<rom name="c94-01" size="131072" crc="ee711afb" sha1="4a6f0c928e068dd0cdb8b38ff45ade6512191fb2" offset="00000" />
+				<rom name="c94-01" size="131072" crc="40bc248e" sha1="f01de343bd9b6fb4458731b44d385e36d999fc08" offset="00000" />
 			</dataarea>
 			<dataarea name="chr" size="131072">
 				<rom name="c94-02" size="131072" crc="1e234045" sha1="98ed114cf467a6f25f7e07d9b045df476e5df790" offset="00000" />

--- a/src/devices/bus/nes/nes_ines.hxx
+++ b/src/devices/bus/nes/nes_ines.hxx
@@ -114,7 +114,7 @@ static const nes_mmc mmc_list[] =
 	{ 79, AVE_NINA06 },
 	{ 80, TAITO_X1_005 },
 	{ 81, NTDEC_N715021 }, // 81 Super Gun
-	{ 82, TAITO_X1_017 },
+	// 82 Taito X1-017 mapper for old mis-ordered PRG dumps
 	{ 83, CONY_BOARD },
 	// 84 Pasofami hacked images?
 	{ 85, KONAMI_VRC7 },
@@ -529,7 +529,7 @@ static const nes_mmc mmc_list[] =
 	{ 549, KAISER_KS7016B },       // Meikyuu Jiin Dababa alt FDS conversion
 	{ 550, BMC_JY820845C },
 	{ 551, JNCOTA_KT1001 },
-	// 552 TAITO_X1_017, this is a correction of mapper 82. We should drop 82 and only support the accurate dumps of 552?
+	{ 552, TAITO_X1_017 },
 	{ 553, SACHEN_3013 },          // Dong Dong Nao 1
 	{ 554, KAISER_KS7010 },        // Akumajo Dracula FDS conversion
 	{ 555, STD_EVENT2 },

--- a/src/devices/bus/nes/taito.h
+++ b/src/devices/bus/nes/taito.h
@@ -79,24 +79,34 @@ class nes_x1_017_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_x1_017_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_x1_017_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual u8 read_ex(offs_t offset) override { return 0; } // no open bus
+	virtual u8 read_l(offs_t offset) override { return 0; } // no open bus
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
 	// device-level overrides
 	virtual void device_start() override;
+	virtual void device_timer(emu_timer &timer, device_timer_id id, int param) override;
 
 private:
 	void set_chr();
-	uint8_t m_latch;
-	uint8_t m_reg[3]; //mapper ram protect
-	uint8_t m_mmc_vrom_bank[6];
+	u8 m_latch;
+	u8 m_reg[3]; // mapper ram enable
+	u8 m_mmc_vrom_bank[6];
 	// Taito X1-017 chip contains 5K of internal ram, battery backed up
-	uint8_t m_x1_017_ram[0x1400];
+	u8 m_x1_017_ram[0x1400];
+
+	u16 m_irq_count;
+	u8 m_irq_count_latch;
+	u8 m_irq_enable;
+
+	static constexpr device_timer_id TIMER_IRQ = 0;
+	emu_timer *irq_timer;
 };
 
 
@@ -105,6 +115,5 @@ DECLARE_DEVICE_TYPE(NES_TC0190FMC,         nes_tc0190fmc_device)
 DECLARE_DEVICE_TYPE(NES_TC0190FMC_PAL16R4, nes_tc0190fmc_pal16r4_device)
 DECLARE_DEVICE_TYPE(NES_X1_005,            nes_x1_005_device)
 DECLARE_DEVICE_TYPE(NES_X1_017,            nes_x1_017_device)
-
 
 #endif // MAME_BUS_NES_TAITO_H


### PR DESCRIPTION
- Replaced bad program ROMs with dumps with proper page order.
- Updated banking to work with proper dumps.
- Fixed CHR banking from possibly ignoring first writes.
- Added special latching bytes to internal X1-017 RAM.
- Added IRQ support (no games exist that use it).