### PR TITLE
osd: Add multibyte check to osd_uchar_from_osdchar

### DIFF
--- a/src/osd/strconv.cpp
+++ b/src/osd/strconv.cpp
@@ -254,6 +254,11 @@ std::string from_wstring(const WCHAR *s)
 
 int osd_uchar_from_osdchar(char32_t *uchar, const char *osdchar, size_t count)
 {
+	// FIXME: Does not handle charsets that use variable lengths encodings such
+	// as example GB18030 or UTF-8.
+	// FIXME: Assumes all characters can be converted into a single wchar_t
+	// which may not always be the case such as with surrogate pairs.
+
 	WCHAR wch;
 	CPINFO cp;
 
@@ -261,7 +266,7 @@ int osd_uchar_from_osdchar(char32_t *uchar, const char *osdchar, size_t count)
 		goto error;
 
 	// The multibyte char can't be bigger than the max character size
-	count = std::min(count, size_t(cp.MaxCharSize));
+	count = std::min(count, size_t(IsDBCSLeadByte(*osdchar) ? cp.MaxCharSize : 1));
 
 	if (MultiByteToWideChar(CP_ACP, 0, osdchar, static_cast<DWORD>(count), &wch, 1) == 0)
 		goto error;


### PR DESCRIPTION
I've only tested CP932 but I suspect other codepages that have multibyte characters are also affected. To reproduce this bug you must be using Windows and set your system locale to a locale that uses multibyte characters (Japanese for example). Create an ini file such as folders/category.ini that uses ASCII or UTF-8 **without** BOM (any encoding with a BOM is unaffected). The file will not be loaded when MAME is launched, and a debugger can be used to check that `osd_uchar_from_osdchar` is returning an error.

On CP932 specifically, `MaxCharSize` will become 2. The input count passed into `osd_uchar_from_osdchar` is anything up to 16.
https://github.com/mamedev/mame/blob/ba77706c5cea808d5e532550b7bafd78e8bf6d09/src/lib/util/corefile.cpp#L315-L326

Using the category INIs for example where the files start with "[FOLDER_SETTINGS]", `MultiByteToWideChar` is called with an output buffer size of 1 and returns `ERROR_INSUFFICIENT_BUFFER` because it sees 2 bytes from the input buffer ("[F") and wants to convert both characters but only has room for 1.

I tracked the breaking change to this commit (https://github.com/mamedev/mame/commit/1c7f05a833f3e16a3f5085349e248e803b0d5068) from 2016. The old method using `IsDBCSLeadByte` works on my system because it can see that "[" is not a multibyte character and uses a count of 1 instead of 2. The commit doesn't reference a bug it was trying to fix so I am guessing it was trying to make things more proper and overcorrected.

The same category INI files that are currently breaking in latest release build work properly if I convert them to UTF-8 with BOM (or UTF-16 etc) since they don't get processed as `text_file_type::OSD` in `core_text_file` skipping `osd_uchar_from_osdchar` entirely. At a quick glance the preset INIs included in MAME and the INIs that MAME creates (mame.ini, ui.ini, etc) are all UTF-8 with BOM already which is why I think this bug didn't seem to show up earlier.

This may also fix the issue with Chinese locales mentioned in PR https://github.com/mamedev/mame/pull/8661. I tested adding in some Japanese text into a Shift-JIS encoded INI and MAME is able to properly read the INI properly including the multibyte characters.
![image](https://user-images.githubusercontent.com/63495610/162557825-24d8e76f-824f-4ae3-ad13-e250fc13e18d.png)

Edit: After some testing, one case that isn't fixed by this is UTF-8 without BOM in a multibyte locale. The text shows up as mojibake in MAME but otherwise seems to load. Displaying mojibake for non-ASCII characters in a UTF-8 without BOM file instead of not loading the file at all is an improvement at least.