### PR TITLE
8x300 subcycle improvements

### DIFF
--- a/src/devices/cpu/8x300/8x300.h
+++ b/src/devices/cpu/8x300/8x300.h
@@ -46,7 +46,11 @@ public:
 	n8x300_cpu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	auto sc_callback() { return m_sc_callback.bind(); }
-
+	auto wc_callback() { return m_wc_callback.bind(); }
+	auto mclk_callback() { return m_mclk_callback.bind(); }
+	auto lb_callback() { return m_lb_callback.bind(); }
+	auto rb_callback() { return m_rb_callback.bind(); }
+	auto iv_callback() { return m_iv_callback.bind(); }
 protected:
 	n8x300_cpu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
 
@@ -73,8 +77,8 @@ protected:
 	virtual void set_reg(uint8_t reg, uint8_t val, bool xmit);
 	virtual uint8_t get_reg(uint8_t reg);
 
-	void xmit_lb(uint8_t dst, uint8_t mask);
-	void xmit_rb(uint8_t dst, uint8_t mask);
+	void xmit_lb(uint8_t dst, uint8_t mask, bool with_sc, bool with_wc);
+	void xmit_rb(uint8_t dst, uint8_t mask, bool with_sc, bool with_wc);
 
 	address_space_config m_program_config;
 	address_space_config m_io_config;
@@ -86,7 +90,12 @@ protected:
 	memory_access<13, 1, -1, ENDIANNESS_BIG>::specific m_program;
 	memory_access< 9, 0,  0, ENDIANNESS_BIG>::specific m_io;
 
-	devcb_write8 m_sc_callback;  // Select Command (address latch)
+	devcb_write_line m_sc_callback;	// address latch
+	devcb_write_line m_wc_callback;	// data latch
+	devcb_write_line m_lb_callback;
+	devcb_write_line m_rb_callback;
+	devcb_write_line m_mclk_callback;
+	devcb_write8 m_iv_callback;
 
 	uint16_t m_PC;  // Program Counter
 	uint16_t m_AR;  // Address Register


### PR DESCRIPTION
Add subcycle-accurate state pin callbacks to the 8X305 core. This is necessary for its use as an embedded processor in disk drives and supporting its extended microcode system.