### PR TITLE
Consolidated floppy_image_device::m_create_fs and floppy_image_device::m_io_fs vectors

### DIFF
--- a/src/devices/imagedev/floppy.cpp
+++ b/src/devices/imagedev/floppy.cpp
@@ -320,15 +320,12 @@ void floppy_image_device::setup_led_cb(led_cb cb)
 
 void floppy_image_device::fs_enum::add(const floppy_image_format_t &type, u32 image_size, const char *name, const char *description)
 {
-	if(m_manager->can_format())
-		m_fid->m_create_fs.emplace_back(fs_info(m_manager, &type, image_size, name, description));
-	if(m_manager->can_read())
-		m_fid->m_io_fs.emplace_back(fs_info(m_manager, &type, image_size, name, description));
+	m_fid->m_fs.emplace_back(fs_info(m_manager, &type, image_size, name, description));
 }
 
 void floppy_image_device::fs_enum::add_raw(const char *name, u32 key, const char *description)
 {
-	m_fid->m_create_fs.emplace_back(fs_info(name, key, description));
+	m_fid->m_fs.emplace_back(fs_info(name, key, description));
 }
 
 void floppy_image_device::register_formats()

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -80,8 +80,7 @@ public:
 
 	void set_formats(std::function<void (format_registration &fr)> formats);
 	const std::vector<const floppy_image_format_t *> &get_formats() const;
-	const std::vector<fs_info> &get_create_fs() const { return m_create_fs; }
-	const std::vector<fs_info> &get_io_fs() const { return m_io_fs; }
+	const std::vector<fs_info> &get_fs() const { return m_fs; }
 	const floppy_image_format_t *get_load_format() const;
 	const floppy_image_format_t *identify(std::string filename);
 	void set_rpm(float rpm);
@@ -189,7 +188,7 @@ protected:
 	std::unique_ptr<floppy_image> image;
 	char                  extension_list[256];
 	std::vector<const floppy_image_format_t *> fif_list;
-	std::vector<fs_info>  m_create_fs, m_io_fs;
+	std::vector<fs_info>  m_fs;
 	std::vector<const fs::manager_t *> m_fs_managers;
 	emu_timer             *index_timer;
 

--- a/src/frontend/mame/ui/filecreate.cpp
+++ b/src/frontend/mame/ui/filecreate.cpp
@@ -290,9 +290,9 @@ SELECT FORMAT MENU
 //  ctor
 //-------------------------------------------------
 
-menu_select_floppy_init::menu_select_floppy_init(mame_ui_manager &mui, render_container &container, const std::vector<floppy_image_device::fs_info> &fs, int *result)
+menu_select_floppy_init::menu_select_floppy_init(mame_ui_manager &mui, render_container &container, std::vector<std::reference_wrapper<const floppy_image_device::fs_info>> &&fs, int *result)
 	: menu(mui, container),
-	  m_fs(fs),
+	  m_fs(std::move(fs)),
 	  m_result(result)
 
 {
@@ -316,7 +316,7 @@ void menu_select_floppy_init::populate(float &customtop, float &custombottom)
 {
 	item_append(_("Select initial contents"), FLAG_DISABLE, nullptr);
 	int id = 0;
-	for (const auto &fmt : m_fs)
+	for (const floppy_image_device::fs_info &fmt : m_fs)
 		item_append(fmt.m_description, fmt.m_name, 0, (void *)(uintptr_t)(id++));
 }
 

--- a/src/frontend/mame/ui/filecreate.h
+++ b/src/frontend/mame/ui/filecreate.h
@@ -86,7 +86,7 @@ class menu_select_floppy_init : public menu
 {
 public:
 	menu_select_floppy_init(mame_ui_manager &mui, render_container &container,
-		const std::vector<floppy_image_device::fs_info> &fs, int *result);
+		std::vector<std::reference_wrapper<const floppy_image_device::fs_info>> &&fs, int *result);
 	virtual ~menu_select_floppy_init() override;
 
 private:
@@ -94,8 +94,8 @@ private:
 	virtual void handle(event const *ev) override;
 
 	// internal state
-	const std::vector<floppy_image_device::fs_info> &m_fs;
-	int *                                            m_result;
+	std::vector<std::reference_wrapper<const floppy_image_device::fs_info>>	m_fs;
+	int *																	m_result;
 };
 
 

--- a/src/frontend/mame/ui/floppycntrl.cpp
+++ b/src/frontend/mame/ui/floppycntrl.cpp
@@ -153,7 +153,6 @@ void menu_control_floppy_image::menu_activated()
 		// figure out which (if any) create file system was selected
 		create_fs = nullptr;
 		if(m_submenu_result.i >= 0) {
-			const auto &fs = fd.get_fs();
 			int i = 0;
 			for (const auto &this_fs : fd.get_fs()) {
 				if (can_format(this_fs)) {

--- a/src/frontend/mame/ui/floppycntrl.cpp
+++ b/src/frontend/mame/ui/floppycntrl.cpp
@@ -94,6 +94,11 @@ void menu_control_floppy_image::hook_load(const std::string &filename)
 	}
 }
 
+bool menu_control_floppy_image::can_format(const floppy_image_device::fs_info &fs)
+{
+	return !fs.m_manager || fs.m_manager->can_format();
+}
+
 void menu_control_floppy_image::menu_activated()
 {
 	switch (m_state) {
@@ -124,26 +129,47 @@ void menu_control_floppy_image::menu_activated()
 			m_state = START_FILE;
 			menu_activated();
 		} else {
-			const auto &fs = fd.get_create_fs();
+			// get all formatable file systems
+			std::vector<std::reference_wrapper<const floppy_image_device::fs_info>> fs;
+			for (const auto &this_fs : fd.get_fs()) {
+				if (can_format(this_fs))
+					fs.emplace_back(std::ref(this_fs));
+			}
+
 			output_filename = util::zippath_combine(m_current_directory, m_current_file);
 			if(fs.size() == 1) {
-				create_fs = &fs[0];
+				create_fs = &(fs[0].get());
 				do_load_create();
 				stack_pop();
 			} else {
 				m_submenu_result.i = -1;
-				menu::stack_push<menu_select_floppy_init>(ui(), container(), fs, &m_submenu_result.i);
+				menu::stack_push<menu_select_floppy_init>(ui(), container(), std::move(fs), &m_submenu_result.i);
 				m_state = SELECT_INIT;
 			}
 		}
 		break;
 
 	case SELECT_INIT:
-		if(m_submenu_result.i == -1) {
+		// figure out which (if any) create file system was selected
+		create_fs = nullptr;
+		if(m_submenu_result.i >= 0) {
+			const auto &fs = fd.get_fs();
+			int i = 0;
+			for (const auto &this_fs : fd.get_fs()) {
+				if (can_format(this_fs)) {
+					if (i == m_submenu_result.i) {
+						create_fs = &this_fs;
+						break;
+					}
+					i++;
+				}
+			}
+		}
+
+		if(!create_fs) {
 			m_state = START_FILE;
 			menu_activated();
 		} else {
-			create_fs = &fd.get_create_fs()[m_submenu_result.i];
 			do_load_create();
 			stack_pop();
 		}

--- a/src/frontend/mame/ui/floppycntrl.h
+++ b/src/frontend/mame/ui/floppycntrl.h
@@ -39,6 +39,7 @@ private:
 
 	void do_load_create();
 	virtual void hook_load(const std::string &filename) override;
+	static bool can_format(const floppy_image_device::fs_info &fs);
 };
 
 } // namespace ui


### PR DESCRIPTION
We had two separate memebers in floppy_image_device (m_create_fs and m_io_fs) that contained the same data.  Whether the file systems can be formatted or read can be identified by querying fs::manager_t.

For this reason, it seems bad to have these separate members, the seemingly only reason to make the UI code slightly less complicated.  For this reason I consolidated these two members and moved the burden of selecting which ones are creatable to the UI code.