### PR TITLE
Fixed some issues involving fs::meta_description construction

### DIFF
--- a/src/lib/formats/fs_coco_os9.cpp
+++ b/src/lib/formats/fs_coco_os9.cpp
@@ -117,8 +117,8 @@ char coco_os9_image::directory_separator() const
 std::vector<meta_description> coco_os9_image::volume_meta_description() const
 {
 	std::vector<meta_description> results;
-	results.emplace_back(meta_description(meta_name::name, meta_type::string, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 32; }, "Volume name, up to 32 characters"));
-	results.emplace_back(meta_description(meta_name::creation_date, meta_type::date, util::arbitrary_datetime::now(), false, nullptr, "Creation time"));
+	results.emplace_back(meta_description(meta_name::name, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 32; }, "Volume name, up to 32 characters"));
+	results.emplace_back(meta_description(meta_name::creation_date, util::arbitrary_datetime::now(), false, nullptr, "Creation time"));
 	return results;
 }
 
@@ -150,11 +150,11 @@ std::vector<meta_description> coco_os9_image::directory_meta_description() const
 std::vector<meta_description> coco_os9_image::entity_meta_description() const
 {
 	std::vector<meta_description> results;
-	results.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name"));
-	results.emplace_back(meta_description(meta_name::creation_date, meta_type::date, util::arbitrary_datetime::now(), false, nullptr, "Creation time"));
-	results.emplace_back(meta_description(meta_name::owner_id, meta_type::number, 0, true, nullptr, "Owner ID"));
-	results.emplace_back(meta_description(meta_name::attributes, meta_type::string, "", true, nullptr, "File attributes"));
-	results.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
+	results.emplace_back(meta_description(meta_name::name, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name"));
+	results.emplace_back(meta_description(meta_name::creation_date, util::arbitrary_datetime::now(), false, nullptr, "Creation time"));
+	results.emplace_back(meta_description(meta_name::owner_id, 0, true, nullptr, "Owner ID"));
+	results.emplace_back(meta_description(meta_name::attributes, "", true, nullptr, "File attributes"));
+	results.emplace_back(meta_description(meta_name::length, 0, true, nullptr, "Size of the file in bytes"));
 	return results;
 }
 

--- a/src/lib/formats/fs_coco_os9.cpp
+++ b/src/lib/formats/fs_coco_os9.cpp
@@ -153,7 +153,7 @@ std::vector<meta_description> coco_os9_image::entity_meta_description() const
 	results.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name"));
 	results.emplace_back(meta_description(meta_name::creation_date, meta_type::date, util::arbitrary_datetime::now(), false, nullptr, "Creation time"));
 	results.emplace_back(meta_description(meta_name::owner_id, meta_type::number, 0, true, nullptr, "Owner ID"));
-	results.emplace_back(meta_description(meta_name::attributes, meta_type::string, 0, true, nullptr, "File attributes"));
+	results.emplace_back(meta_description(meta_name::attributes, meta_type::string, "", true, nullptr, "File attributes"));
 	results.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
 	return results;
 }

--- a/src/lib/formats/fs_coco_rsdos.cpp
+++ b/src/lib/formats/fs_coco_rsdos.cpp
@@ -62,11 +62,11 @@ bool coco_rsdos_image::has_rsrc() const
 std::vector<meta_description> coco_rsdos_image::file_meta_description() const
 {
 	std::vector<meta_description> results;
-	results.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name, 8.3"));
-	results.emplace_back(meta_description(meta_name::file_type, meta_type::number, 0, true, nullptr, "Type of the file"));
-	results.emplace_back(meta_description(meta_name::ascii_flag, meta_type::string, "B", true, nullptr, "Ascii or binary flag"));
-	results.emplace_back(meta_description(meta_name::size_in_blocks, meta_type::number, 0, true, nullptr, "Number of granules used by the file"));
-	results.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
+	results.emplace_back(meta_description(meta_name::name, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name, 8.3"));
+	results.emplace_back(meta_description(meta_name::file_type, 0, true, nullptr, "Type of the file"));
+	results.emplace_back(meta_description(meta_name::ascii_flag, "B", true, nullptr, "Ascii or binary flag"));
+	results.emplace_back(meta_description(meta_name::size_in_blocks, 0, true, nullptr, "Number of granules used by the file"));
+	results.emplace_back(meta_description(meta_name::length, 0, true, nullptr, "Size of the file in bytes"));
 	return results;
 }
 

--- a/src/lib/formats/fs_coco_rsdos.cpp
+++ b/src/lib/formats/fs_coco_rsdos.cpp
@@ -64,7 +64,7 @@ std::vector<meta_description> coco_rsdos_image::file_meta_description() const
 	std::vector<meta_description> results;
 	results.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name, 8.3"));
 	results.emplace_back(meta_description(meta_name::file_type, meta_type::number, 0, true, nullptr, "Type of the file"));
-	results.emplace_back(meta_description(meta_name::ascii_flag, meta_type::string, 0, true, nullptr, "Ascii or binary flag"));
+	results.emplace_back(meta_description(meta_name::ascii_flag, meta_type::string, "B", true, nullptr, "Ascii or binary flag"));
 	results.emplace_back(meta_description(meta_name::size_in_blocks, meta_type::number, 0, true, nullptr, "Number of granules used by the file"));
 	results.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
 	return results;

--- a/src/lib/formats/fs_oric_jasmin.cpp
+++ b/src/lib/formats/fs_oric_jasmin.cpp
@@ -159,12 +159,12 @@ bool oric_jasmin_image::validate_filename(std::string name)
 std::vector<meta_description> oric_jasmin_image::file_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name, 8.3"));
-	res.emplace_back(meta_description(meta_name::loading_address, meta_type::number, 0x501, false, [](const meta_value &m) { return m.as_number() < 0x10000; }, "Loading address of the file"));
-	res.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
-	res.emplace_back(meta_description(meta_name::size_in_blocks, meta_type::number, 0, true, nullptr, "Number of blocks used by the file"));
-	res.emplace_back(meta_description(meta_name::locked, meta_type::flag, false, false, nullptr, "File locked"));
-	res.emplace_back(meta_description(meta_name::sequential, meta_type::flag, true, false, nullptr, "File sequential"));
+	res.emplace_back(meta_description(meta_name::name, "", false, [](const meta_value &m) { return validate_filename(m.as_string()); }, "File name, 8.3"));
+	res.emplace_back(meta_description(meta_name::loading_address, 0x501, false, [](const meta_value &m) { return m.as_number() < 0x10000; }, "Loading address of the file"));
+	res.emplace_back(meta_description(meta_name::length, 0, true, nullptr, "Size of the file in bytes"));
+	res.emplace_back(meta_description(meta_name::size_in_blocks, 0, true, nullptr, "Number of blocks used by the file"));
+	res.emplace_back(meta_description(meta_name::locked, false, false, nullptr, "File locked"));
+	res.emplace_back(meta_description(meta_name::sequential, true, false, nullptr, "File sequential"));
 	return res;
 }
 
@@ -711,7 +711,7 @@ bool oric_jasmin_image::has_rsrc() const
 std::vector<meta_description> oric_jasmin_image::volume_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 8; }, "Volume name, up to 8 characters"));
+	res.emplace_back(meta_description(meta_name::name, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 8; }, "Volume name, up to 8 characters"));
 
 	return res;
 }

--- a/src/lib/formats/fs_prodos.cpp
+++ b/src/lib/formats/fs_prodos.cpp
@@ -177,41 +177,41 @@ char prodos_image::directory_separator() const
 std::vector<meta_description> prodos_image::volume_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "Volume name, up to 15 characters"));
-	res.emplace_back(meta_description(meta_name::os_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
-	res.emplace_back(meta_description(meta_name::os_minimum_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
+	res.emplace_back(meta_description(meta_name::name, "UNTITLED", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "Volume name, up to 15 characters"));
+	res.emplace_back(meta_description(meta_name::os_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
+	res.emplace_back(meta_description(meta_name::os_minimum_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
 
 	auto now = util::arbitrary_datetime::now();
-	res.emplace_back(meta_description(meta_name::creation_date, meta_type::date, now, false, nullptr, "Creation time"));
-	res.emplace_back(meta_description(meta_name::modification_date, meta_type::date, now, false, nullptr, "Modification time"));
+	res.emplace_back(meta_description(meta_name::creation_date, now, false, nullptr, "Creation time"));
+	res.emplace_back(meta_description(meta_name::modification_date, now, false, nullptr, "Modification time"));
 	return res;
 }
 
 std::vector<meta_description> prodos_image::file_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "Empty file", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "File name, up to 15 characters"));
-	res.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
-	res.emplace_back(meta_description(meta_name::rsrc_length, meta_type::number, 0, true, nullptr, "Size of the resource fork in bytes"));
-	res.emplace_back(meta_description(meta_name::os_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
-	res.emplace_back(meta_description(meta_name::os_minimum_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
+	res.emplace_back(meta_description(meta_name::name, "Empty file", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "File name, up to 15 characters"));
+	res.emplace_back(meta_description(meta_name::length, 0, true, nullptr, "Size of the file in bytes"));
+	res.emplace_back(meta_description(meta_name::rsrc_length, 0, true, nullptr, "Size of the resource fork in bytes"));
+	res.emplace_back(meta_description(meta_name::os_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
+	res.emplace_back(meta_description(meta_name::os_minimum_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
 
 	auto now = util::arbitrary_datetime::now();
-	res.emplace_back(meta_description(meta_name::creation_date, meta_type::date, now, false, nullptr, "Creation time"));
-	res.emplace_back(meta_description(meta_name::modification_date, meta_type::date, now, false, nullptr, "Modification time"));
+	res.emplace_back(meta_description(meta_name::creation_date, now, false, nullptr, "Creation time"));
+	res.emplace_back(meta_description(meta_name::modification_date, now, false, nullptr, "Modification time"));
 	return res;
 }
 
 std::vector<meta_description> prodos_image::directory_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "Empty directory", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "Directory name, up to 15 characters"));
-	res.emplace_back(meta_description(meta_name::os_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
-	res.emplace_back(meta_description(meta_name::os_minimum_version, meta_type::number, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
+	res.emplace_back(meta_description(meta_name::name, "Empty directory", false, [](const meta_value &m) { return m.as_string().size() <= 15; }, "Directory name, up to 15 characters"));
+	res.emplace_back(meta_description(meta_name::os_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Creator OS version"));
+	res.emplace_back(meta_description(meta_name::os_minimum_version, 5, false, [](const meta_value &m) { return m.as_number() <= 255; }, "Minimum OS version"));
 
 	auto now = util::arbitrary_datetime::now();
-	res.emplace_back(meta_description(meta_name::creation_date, meta_type::date, now, false, nullptr, "Creation time"));
-	res.emplace_back(meta_description(meta_name::modification_date, meta_type::date, now, false, nullptr, "Modification time"));
+	res.emplace_back(meta_description(meta_name::creation_date, now, false, nullptr, "Creation time"));
+	res.emplace_back(meta_description(meta_name::modification_date, now, false, nullptr, "Modification time"));
 	return res;
 }
 

--- a/src/lib/formats/fs_vtech.cpp
+++ b/src/lib/formats/fs_vtech.cpp
@@ -83,10 +83,10 @@ meta_data vtech_image::impl::metadata()
 std::vector<meta_description> vtech_image::file_meta_description() const
 {
 	std::vector<meta_description> res;
-	res.emplace_back(meta_description(meta_name::name, meta_type::string, "", false, [](const meta_value &m) { return m.as_string().size() <= 8; }, "File name, 8 chars"));
-	res.emplace_back(meta_description(meta_name::loading_address, meta_type::number, 0x7ae9, false, [](const meta_value &m) { return m.as_number() < 0x10000; }, "Loading address of the file"));
-	res.emplace_back(meta_description(meta_name::length, meta_type::number, 0, true, nullptr, "Size of the file in bytes"));
-	res.emplace_back(meta_description(meta_name::basic, meta_type::flag, true, true, nullptr, "Basic file"));
+	res.emplace_back(meta_description(meta_name::name, "", false, [](const meta_value &m) { return m.as_string().size() <= 8; }, "File name, 8 chars"));
+	res.emplace_back(meta_description(meta_name::loading_address, 0x7ae9, false, [](const meta_value &m) { return m.as_number() < 0x10000; }, "Loading address of the file"));
+	res.emplace_back(meta_description(meta_name::length, 0, true, nullptr, "Size of the file in bytes"));
+	res.emplace_back(meta_description(meta_name::basic, true, true, nullptr, "Basic file"));
 	return res;
 }
 

--- a/src/lib/formats/fsmeta.h
+++ b/src/lib/formats/fsmeta.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -50,7 +51,8 @@ public:
 	static meta_value from_string(meta_type type, std::string value);
 
 	meta_value() { value = false; }
-	meta_value(std::string str) { value = str; }
+	meta_value(std::string &&str) { value = std::move(str); }
+	meta_value(std::string_view str) { value = std::string(str); }
 	meta_value(bool b) { value = b; }
 	meta_value(int32_t num) { value = uint64_t(num); }
 	meta_value(uint32_t num) { value = uint64_t(num); }
@@ -77,7 +79,9 @@ public:
 	bool empty() const { return meta.empty(); }
 
 	void set(meta_name name, const meta_value &val) { meta[name] = val; }
-	void set(meta_name name, std::string str) { set(name, meta_value(str)); }
+	void set(meta_name name, meta_value &&val) { meta[name] = std::move(val); }
+	void set(meta_name name, std::string &&str) { set(name, meta_value(std::move(str))); }
+	void set(meta_name name, std::string_view str) { set(name, meta_value(str)); }
 	void set(meta_name name, bool b) { set(name, meta_value(b)); }
 	void set(meta_name name, int32_t num) { set(name, meta_value(num)); }
 	void set(meta_name name, uint32_t num) { set(name, meta_value(num)); }
@@ -95,26 +99,18 @@ public:
 
 struct meta_description {
 	meta_name m_name;
-	meta_type m_type;
 	meta_value m_default;
 	bool m_ro;
-	std::function<void (const meta_value &)> m_validator;
+	std::function<void(const meta_value &)> m_validator;
 	const char *m_tooltip;
 
-	meta_description(meta_name name, meta_type type, int def, bool ro, std::function<void (meta_value)> validator, const char *tooltip) :
-		m_name(name), m_type(type), m_default(uint64_t(def)), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
-	{
-		assert(type == meta_type::number);
-	}
+	template<typename T> meta_description(meta_name name, T def, bool ro, std::function<void(meta_value)> validator, const char *tooltip) :
+		meta_description(name, meta_value(def), ro, std::move(validator), tooltip)
+	{}
 
-	meta_description(meta_name name, meta_type type, const char *def, bool ro, std::function<void(meta_value)> validator, const char *tooltip) :
-		m_name(name), m_type(type), m_default(std::string(def)), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
-	{
-		assert(type == meta_type::string);
-	}
-
-	template<typename T> meta_description(meta_name name, meta_type type, T def, bool ro, std::function<void (meta_value)> validator, const char *tooltip) :
-		m_name(name), m_type(type), m_default(def), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
+private:
+	meta_description(meta_name name, meta_value &&def, bool ro, std::function<void(meta_value)> &&validator, const char *tooltip) :
+		m_name(name), m_default(std::move(def)), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
 	{}
 };
 

--- a/src/lib/formats/fsmeta.h
+++ b/src/lib/formats/fsmeta.h
@@ -103,7 +103,15 @@ struct meta_description {
 
 	meta_description(meta_name name, meta_type type, int def, bool ro, std::function<void (meta_value)> validator, const char *tooltip) :
 		m_name(name), m_type(type), m_default(uint64_t(def)), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
-	{}
+	{
+		assert(type == meta_type::number);
+	}
+
+	meta_description(meta_name name, meta_type type, const char *def, bool ro, std::function<void(meta_value)> validator, const char *tooltip) :
+		m_name(name), m_type(type), m_default(std::string(def)), m_ro(ro), m_validator(validator), m_tooltip(tooltip)
+	{
+		assert(type == meta_type::string);
+	}
 
 	template<typename T> meta_description(meta_name name, meta_type type, T def, bool ro, std::function<void (meta_value)> validator, const char *tooltip) :
 		m_name(name), m_type(type), m_default(def), m_ro(ro), m_validator(validator), m_tooltip(tooltip)


### PR DESCRIPTION
With the recent change to use std::variant more closely, I noticed a problem where meta_descriptions of type meta_type::String got defaults of type 't'.  This was because the templated ctor for meta_description would convert 'const char *' to 'bool'.  This change adds another overload to catch 'const char *', along with asserts to catch problems.

In the process I corrected a few meta_description ctors

It is possible that this change does not go far enough.  Perhaps the meta_type argument should be removed, and we should instead create distinct ctor types (rather than relying on templates) and specify the precise meta_type in the overload.  Or even go further and remove m_type from meta_description, and instead create an overload that calculates meta_type based on calling std::visit on the variant