### PR TITLE
File handling cleanup

### DIFF
--- a/src/emu/diimage.h
+++ b/src/emu/diimage.h
@@ -113,7 +113,7 @@ public:
 	const util::option_guide &device_get_creation_option_guide() const { return create_option_guide(); }
 
 	std::string_view error();
-	void seterror(std::error_condition err, const char *message);
+	void seterror(std::error_condition err, const char *message = nullptr);
 	void message(const char *format, ...) ATTR_PRINTF(2,3);
 
 	bool exists() const noexcept { return !m_image_name.empty(); }
@@ -126,7 +126,7 @@ public:
 	bool is_filetype(std::string_view candidate_filetype) const;
 
 	bool is_open() const noexcept { return bool(m_file); }
-	util::core_file &image_core_file() const noexcept { return *m_file; }
+	util::core_file &image_core_file() const noexcept { assert(is_open()); return *m_file; }
 	bool is_readonly() const noexcept { return m_readonly; }
 
 	// image file I/O wrappers
@@ -165,27 +165,10 @@ public:
 		m_file->tell(result);
 		return result;
 	}
-	int fgetc()
-	{
-		char ch;
-		if (fread(&ch, 1) != 1)
-			ch = '\0';
-		return ch;
-	}
-	char *fgets(char *buffer, u32 length)
-	{
-		check_for_file();
-		return m_file->gets(buffer, length);
-	}
 	bool image_feof()
 	{
 		check_for_file();
 		return m_file->eof();
-	}
-	const void *ptr()
-	{
-		check_for_file();
-		return m_file->buffer();
 	}
 
 	// allocate and read into buffers

--- a/src/emu/fileio.cpp
+++ b/src/emu/fileio.cpp
@@ -259,7 +259,7 @@ util::hash_collection &emu_file::hashes(std::string_view types)
 	// determine which hashes we need
 	std::string needed;
 	for (char scan : types)
-		if (already_have.find_first_of(scan) == -1)
+		if (already_have.find_first_of(scan) == std::string::npos)
 			needed.push_back(scan);
 
 	// if we need nothing, skip it
@@ -279,15 +279,25 @@ util::hash_collection &emu_file::hashes(std::string_view types)
 		return m_hashes;
 	}
 
-	// read the data if we can
-	const u8 *filedata = (const u8 *)m_file->buffer();
-	if (filedata == nullptr)
+	std::uint64_t length, pos = 0;
+	if (m_file->length(length))
 		return m_hashes;
 
-	// compute the hash
-	std::uint64_t length;
-	if (!m_file->length(length))
-		m_hashes.compute(filedata, length, needed.c_str());
+	// keep the old position
+	(void)m_file->tell(pos);
+	if (m_file->seek(0, SEEK_SET))
+		return m_hashes;
+
+	// hash the data
+	util::write_stream::ptr creator = m_hashes.create(needed.c_str());
+	size_t actual;
+	if (m_file->copy(*creator, length, actual) || length != actual)
+		return m_hashes;
+
+	// clean up
+	(void)creator->finalize();
+	(void)m_file->seek(pos, SEEK_SET);
+
 	return m_hashes;
 }
 
@@ -805,7 +815,7 @@ std::error_condition emu_file::load_zipped_file()
 	m_zipdata.resize(m_ziplength);
 
 	// read the data into our buffer and return
-	auto const ziperr = m_zipfile->decompress(&m_zipdata[0], m_zipdata.size());
+	auto const ziperr = m_zipfile->decompress(m_zipdata.data(), m_zipdata.size());
 	if (ziperr)
 	{
 		m_zipdata.clear();
@@ -813,7 +823,7 @@ std::error_condition emu_file::load_zipped_file()
 	}
 
 	// convert to RAM file
-	std::error_condition const filerr = util::core_file::open_ram(&m_zipdata[0], m_zipdata.size(), m_openflags, m_file);
+	std::error_condition const filerr = util::core_file::open_ram(m_zipdata.data(), m_zipdata.size(), m_openflags, m_file);
 	if (filerr)
 	{
 		m_zipdata.clear();

--- a/src/frontend/mame/media_ident.cpp
+++ b/src/frontend/mame/media_ident.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Aaron Giles
 /***************************************************************************
 
-    media_ident.c
+    media_ident.cpp
 
     Media identify.
 
@@ -260,33 +260,29 @@ void media_identifier::digest_file(std::vector<file_info> &info, char const *pat
 
 		// load the file and process if it opens and has a valid length
 		util::core_file::ptr file;
-		if (util::core_file::open(path, OPEN_FLAG_READ, file) || !file)
+		std::error_condition err = util::core_file::open(path, OPEN_FLAG_READ, file);
+		if (err || !file)
 		{
-			osd_printf_error("%s: error opening file\n", path);
+			osd_printf_error("%s: error opening file (%s)\n", path, err ? err.message() : std::string("could not allocate pointer"));
 			return;
 		}
 		std::uint64_t length;
-		if (file->length(length))
+		err = file->length(length);
+		if (err)
 		{
-			osd_printf_error("%s: error getting file length\n", path);
+			osd_printf_error("%s: error getting file length (%s)\n", path, err.message());
 			return;
 		}
 		util::hash_collection hashes;
-		hashes.begin(util::hash_collection::HASH_TYPES_CRC_SHA1);
-		std::uint8_t buf[1024];
-		for (std::uint64_t remaining = length; remaining; )
+		util::write_stream::ptr creator(hashes.create(util::hash_collection::HASH_TYPES_CRC_SHA1));
+		std::size_t actual;
+		err = file->copy(*creator, length, actual);
+		if (err)
 		{
-			std::size_t const block = std::min<std::uint64_t>(remaining, sizeof(buf));
-			std::size_t actual;
-			if (file->read(buf, block, actual) || !actual)
-			{
-				osd_printf_error("%s: error reading file\n", path);
-				return;
-			}
-			remaining -= actual;
-			hashes.buffer(buf, actual);
+			osd_printf_error("%s: error reading file (%s)\n", path, err.message());
+			return;
 		}
-		hashes.end();
+		(void)creator->finalize();
 		info.emplace_back(path, length, std::move(hashes), file_flavour::RAW);
 		m_total++;
 	}

--- a/src/lib/util/corefile.cpp
+++ b/src/lib/util/corefile.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Aaron Giles, Vas Crabb
 /***************************************************************************
 
-    corefile.c
+    corefile.cpp
 
     File access functions.
 
@@ -53,6 +53,7 @@ public:
 
 	virtual std::error_condition read(void *buffer, std::size_t length, std::size_t &actual) noexcept override { return m_file.read(buffer, length, actual); }
 	virtual std::error_condition read_at(std::uint64_t offset, void *buffer, std::size_t length, std::size_t &actual) noexcept override { return m_file.read_at(offset, buffer, length, actual); }
+	virtual std::error_condition copy(write_stream &stream, std::size_t length, std::size_t &actual) noexcept override { return m_file.copy(stream, length, actual); }
 
 	virtual std::error_condition finalize() noexcept override { return m_file.finalize(); }
 	virtual std::error_condition flush() noexcept override { return m_file.flush(); }
@@ -64,7 +65,6 @@ public:
 	virtual int getc() override { return m_file.getc(); }
 	virtual int ungetc(int c) override { return m_file.ungetc(c); }
 	virtual char *gets(char *s, int n) override { return m_file.gets(s, n); }
-	virtual void const *buffer() override { return m_file.buffer(); }
 
 	virtual int puts(std::string_view s) override { return m_file.puts(s); }
 	virtual int vprintf(util::format_argument_pack<std::ostream> const &args) override { return m_file.vprintf(args); }
@@ -121,15 +121,45 @@ private:
 };
 
 
-class core_in_memory_file : public core_text_file
+class core_basic_file : public core_text_file
+{
+public:
+	virtual std::error_condition seek(std::int64_t offset, int whence) noexcept override;
+	virtual std::error_condition tell(std::uint64_t &result) noexcept override { result = m_index; return std::error_condition(); }
+	virtual std::error_condition length(std::uint64_t &result) noexcept override { result = m_size; return std::error_condition(); }
+
+	virtual bool eof() const override;
+
+protected:
+	core_basic_file(std::uint32_t openflags, std::size_t size) noexcept
+		: core_text_file(openflags)
+		, m_index(0)
+		, m_size(size)
+	{
+	}
+
+	std::uint64_t index() const noexcept { return m_index; }
+	void add_offset(std::size_t increment) noexcept { m_index += increment; m_size = (std::max)(m_size, m_index); }
+	std::uint64_t size() const noexcept { return m_size; }
+	void set_size(std::uint64_t value) noexcept { m_size = value; }
+
+	static std::size_t safe_buffer_copy(
+			void const *source, std::size_t sourceoffs, std::size_t sourcelen,
+			void *dest, std::size_t destoffs, std::size_t destlen) noexcept;
+
+private:
+	std::uint64_t   m_index;            // current file offset
+	std::uint64_t   m_size;             // total file length
+};
+
+
+class core_in_memory_file final : public core_basic_file
 {
 public:
 	core_in_memory_file(std::uint32_t openflags, void const *data, std::size_t length, bool copy) noexcept
-		: core_text_file(openflags)
+		: core_basic_file(openflags, length)
 		, m_data_allocated(false)
 		, m_data(copy ? nullptr : data)
-		, m_offset(0)
-		, m_length(length)
 	{
 		if (copy)
 		{
@@ -141,41 +171,25 @@ public:
 
 	~core_in_memory_file() override { purge(); }
 
-	virtual std::error_condition seek(std::int64_t offset, int whence) noexcept override;
-	virtual std::error_condition tell(std::uint64_t &result) noexcept override { result = m_offset; return std::error_condition(); }
-	virtual std::error_condition length(std::uint64_t &result) noexcept override { result = m_length; return std::error_condition(); }
-
 	virtual std::error_condition read(void *buffer, std::size_t length, std::size_t &actual) noexcept override;
 	virtual std::error_condition read_at(std::uint64_t offset, void *buffer, std::size_t length, std::size_t &actual) noexcept override;
+	virtual std::error_condition copy(write_stream &stream, std::size_t length, std::size_t &actual) noexcept override;
 
 	virtual std::error_condition finalize() noexcept override { return std::error_condition(); }
 	virtual std::error_condition flush() noexcept override { clear_putback(); return std::error_condition(); }
 	virtual std::error_condition write(void const *buffer, std::size_t length, std::size_t &actual) noexcept override { actual = 0; return std::errc::bad_file_descriptor; }
 	virtual std::error_condition write_at(std::uint64_t offset, void const *buffer, std::size_t length, std::size_t &actual) noexcept override { actual = 0; return std::errc::bad_file_descriptor; }
 
-	virtual bool eof() const override;
-
-	virtual void const *buffer() override { return m_data; }
+	void const *buffer() const { return m_data; }
 
 	virtual std::error_condition truncate(std::uint64_t offset) override;
 
 protected:
-	core_in_memory_file(std::uint32_t openflags, std::uint64_t length) noexcept
-		: core_text_file(openflags)
-		, m_data_allocated(false)
-		, m_data(nullptr)
-		, m_offset(0)
-		, m_length(length)
-	{
-	}
-
-	bool is_loaded() const noexcept { return nullptr != m_data; }
-
 	void *allocate() noexcept
 	{
-		if (m_data || (std::numeric_limits<std::size_t>::max() < m_length))
+		if (m_data || (std::numeric_limits<std::size_t>::max() < size()))
 			return nullptr;
-		void *data = malloc(m_length);
+		void *data = malloc(size());
 		if (data)
 		{
 			m_data_allocated = true;
@@ -192,28 +206,17 @@ protected:
 		m_data = nullptr;
 	}
 
-	std::uint64_t offset() const noexcept { return m_offset; }
-	void add_offset(std::size_t increment) noexcept { m_offset += increment; m_length = (std::max)(m_length, m_offset); }
-	std::uint64_t length() const noexcept { return m_length; }
-	void set_length(std::uint64_t value) noexcept { m_length = value; }
-
-	static std::size_t safe_buffer_copy(
-			void const *source, std::size_t sourceoffs, std::size_t sourcelen,
-			void *dest, std::size_t destoffs, std::size_t destlen) noexcept;
-
 private:
 	bool            m_data_allocated;   // was the data allocated by us?
 	void const *    m_data;             // file data, if RAM-based
-	std::uint64_t   m_offset;           // current file offset
-	std::uint64_t   m_length;           // total file length
 };
 
 
-class core_osd_file final : public core_in_memory_file
+class core_osd_file final : public core_basic_file
 {
 public:
 	core_osd_file(std::uint32_t openmode, osd_file::ptr &&file, std::uint64_t length)
-		: core_in_memory_file(openmode, length)
+		: core_basic_file(openmode, length)
 		, m_file(std::move(file))
 	{
 	}
@@ -227,12 +230,9 @@ public:
 	virtual std::error_condition write(void const *buffer, std::size_t length, std::size_t &actual) noexcept override;
 	virtual std::error_condition write_at(std::uint64_t offset, void const *buffer, std::size_t length, std::size_t &actual) noexcept override;
 
-	virtual void const *buffer() override;
-
 	virtual std::error_condition truncate(std::uint64_t offset) override;
 
 protected:
-
 	bool is_buffered(std::uint64_t offset) const noexcept { return (offset >= m_bufferbase) && (offset < (m_bufferbase + m_bufferbytes)); }
 
 private:
@@ -558,7 +558,7 @@ int core_text_file::vprintf(util::format_argument_pack<std::ostream> const &args
     seek - seek within a file
 -------------------------------------------------*/
 
-std::error_condition core_in_memory_file::seek(std::int64_t offset, int whence) noexcept
+std::error_condition core_basic_file::seek(std::int64_t offset, int whence) noexcept
 {
 	// flush any buffered char
 	clear_putback(); // TODO: report errors; also, should the argument check happen before this?
@@ -569,33 +569,33 @@ std::error_condition core_in_memory_file::seek(std::int64_t offset, int whence) 
 	case SEEK_SET:
 		if (0 > offset)
 			return std::errc::invalid_argument;
-		m_offset = offset;
+		m_index = offset;
 		return std::error_condition();
 
 	case SEEK_CUR:
 		if (0 > offset)
 		{
-			if (std::uint64_t(-offset) > m_offset)
+			if (std::uint64_t(-offset) > m_index)
 				return std::errc::invalid_argument;
 		}
-		else if ((std::numeric_limits<std::uint64_t>::max() - offset) < m_offset)
+		else if ((std::numeric_limits<std::uint64_t>::max() - offset) < m_index)
 		{
 			return std::errc::invalid_argument;
 		}
-		m_offset += offset;
+		m_index += offset;
 		return std::error_condition();
 
 	case SEEK_END:
 		if (0 > offset)
 		{
-			if (std::uint64_t(-offset) > m_length)
+			if (std::uint64_t(-offset) > m_size)
 				return std::errc::invalid_argument;
 		}
-		else if ((std::numeric_limits<std::uint64_t>::max() - offset) < m_length)
+		else if ((std::numeric_limits<std::uint64_t>::max() - offset) < m_size)
 		{
 			return std::errc::invalid_argument;
 		}
-		m_offset = m_length + offset;
+		m_index = m_size + offset;
 		return std::error_condition();
 
 	default:
@@ -608,14 +608,14 @@ std::error_condition core_in_memory_file::seek(std::int64_t offset, int whence) 
     eof - return 1 if we're at the end of file
 -------------------------------------------------*/
 
-bool core_in_memory_file::eof() const
+bool core_basic_file::eof() const
 {
 	// check for buffered chars
 	if (has_putback())
 		return false;
 
 	// if the offset == length, we're at EOF
-	return (m_offset >= m_length);
+	return (m_index >= m_size);
 }
 
 
@@ -628,11 +628,11 @@ std::error_condition core_in_memory_file::read(void *buffer, std::size_t length,
 	clear_putback();
 
 	// handle RAM-based files
-	if (m_offset < m_length)
-		actual = safe_buffer_copy(m_data, std::size_t(m_offset), std::size_t(m_length), buffer, 0, length);
+	if (index() < size())
+		actual = safe_buffer_copy(m_data, std::size_t(index()), std::size_t(size()), buffer, 0, length);
 	else
 		actual = 0U;
-	m_offset += actual;
+	add_offset(actual);
 	return std::error_condition();
 }
 
@@ -641,11 +641,40 @@ std::error_condition core_in_memory_file::read_at(std::uint64_t offset, void *bu
 	clear_putback();
 
 	// handle RAM-based files
-	if (offset < m_length)
-		actual = safe_buffer_copy(m_data, std::size_t(offset), std::size_t(m_length), buffer, 0, length);
+	if (offset < size())
+		actual = safe_buffer_copy(m_data, std::size_t(offset), std::size_t(size()), buffer, 0, length);
 	else
 		actual = 0U;
 	return std::error_condition();
+}
+
+
+/*-------------------------------------------------
+    copy - copy from one stream to another
+-------------------------------------------------*/
+
+std::error_condition core_in_memory_file::copy(write_stream &stream, std::size_t length, std::size_t &actual) noexcept
+{
+	clear_putback();
+
+	// handle RAM-based files
+	std::error_condition err;
+	if (index() < size())
+	{
+		length = std::min(length, std::size_t(size()) - std::size_t(index()));
+		if (length)
+		{
+			err = stream.write(reinterpret_cast<std::uint8_t const *>(m_data) + index(), length, actual);
+			add_offset(length);
+		}
+		else
+			actual = 0U;
+	}
+	else
+		actual = 0U;
+
+	// return any errors
+	return err;
 }
 
 
@@ -655,11 +684,11 @@ std::error_condition core_in_memory_file::read_at(std::uint64_t offset, void *bu
 
 std::error_condition core_in_memory_file::truncate(std::uint64_t offset)
 {
-	if (m_length < offset)
+	if (size() < offset)
 		return std::errc::io_error; // TODO: revisit this error code
 
 	// adjust to new length and offset
-	set_length(offset);
+	set_size(offset);
 	return std::error_condition();
 }
 
@@ -669,7 +698,7 @@ std::error_condition core_in_memory_file::truncate(std::uint64_t offset)
     bounded buffer to another
 -------------------------------------------------*/
 
-std::size_t core_in_memory_file::safe_buffer_copy(
+std::size_t core_basic_file::safe_buffer_copy(
 		void const *source, std::size_t sourceoffs, std::size_t sourcelen,
 		void *dest, std::size_t destoffs, std::size_t destlen) noexcept
 {
@@ -710,7 +739,7 @@ std::error_condition core_osd_file::read(void *buffer, std::size_t length, std::
 {
 	// since osd_file works like pread/pwrite, implement in terms of read_at
 	// core_osd_file is declared final, so a derived class can't interfere
-	std::error_condition err = read_at(offset(), buffer, length, actual);
+	std::error_condition err = read_at(index(), buffer, length, actual);
 	add_offset(actual);
 	return err;
 }
@@ -718,8 +747,11 @@ std::error_condition core_osd_file::read(void *buffer, std::size_t length, std::
 
 std::error_condition core_osd_file::read_at(std::uint64_t offset, void *buffer, std::size_t length, std::size_t &actual) noexcept
 {
-	if (!m_file || is_loaded())
-		return core_in_memory_file::read_at(offset, buffer, length, actual);
+	if (!m_file)
+	{
+		actual = 0;
+		return std::errc::bad_file_descriptor;
+	}
 
 	// flush any buffered char
 	clear_putback();
@@ -769,46 +801,6 @@ std::error_condition core_osd_file::read_at(std::uint64_t offset, void *buffer, 
 
 
 /*-------------------------------------------------
-    buffer - return a pointer to the file buffer;
-    if it doesn't yet exist, load the file into
-    RAM first
--------------------------------------------------*/
-
-void const *core_osd_file::buffer()
-{
-	// if we already have data, just return it
-	if (!is_loaded() && length())
-	{
-		// allocate some memory
-		void *const buf = allocate();
-		if (!buf)
-			return nullptr;
-
-		// read the file
-		std::uint64_t bytes_read = 0;
-		std::uint64_t remaining = length();
-		std::uint8_t *ptr = reinterpret_cast<std::uint8_t *>(buf);
-		while (remaining)
-		{
-			std::uint32_t const chunk = std::min<std::common_type_t<std::uint32_t, std::size_t> >(std::numeric_limits<std::uint32_t>::max(), remaining);
-			std::uint32_t read_length;
-			std::error_condition const filerr = m_file->read(ptr, bytes_read, chunk, read_length);
-			if (filerr || !read_length)
-			{
-				purge();
-				return core_in_memory_file::buffer();
-			}
-			bytes_read += read_length;
-			remaining -= read_length;
-			ptr += read_length;
-		}
-		m_file.reset(); // close the file because we don't need it anymore
-	}
-	return core_in_memory_file::buffer();
-}
-
-
-/*-------------------------------------------------
     write - write to a file
 -------------------------------------------------*/
 
@@ -816,7 +808,7 @@ std::error_condition core_osd_file::write(void const *buffer, std::size_t length
 {
 	// since osd_file works like pread/pwrite, implement in terms of write_at
 	// core_osd_file is declared final, so a derived class can't interfere
-	std::error_condition err = write_at(offset(), buffer, length, actual);
+	std::error_condition err = write_at(index(), buffer, length, actual);
 	add_offset(actual);
 	return err;
 }
@@ -824,10 +816,6 @@ std::error_condition core_osd_file::write(void const *buffer, std::size_t length
 
 std::error_condition core_osd_file::write_at(std::uint64_t offset, void const *buffer, std::size_t length, std::size_t &actual) noexcept
 {
-	// can't write to RAM-based stuff
-	if (is_loaded())
-		return core_in_memory_file::write_at(offset, buffer, length, actual);
-
 	// flush any buffered char
 	clear_putback();
 
@@ -849,7 +837,7 @@ std::error_condition core_osd_file::write_at(std::uint64_t offset, void const *b
 		buffer = reinterpret_cast<std::uint8_t const *>(buffer) + bytes_written;
 		length -= bytes_written;
 		actual += bytes_written;
-		set_length((std::max)(this->length(), offset));
+		set_size((std::max)(size(), offset));
 	}
 	return std::error_condition();
 }
@@ -861,16 +849,13 @@ std::error_condition core_osd_file::write_at(std::uint64_t offset, void const *b
 
 std::error_condition core_osd_file::truncate(std::uint64_t offset)
 {
-	if (is_loaded())
-		return core_in_memory_file::truncate(offset);
-
 	// truncate file
 	std::error_condition err = m_file->truncate(offset);
 	if (err)
 		return err;
 
 	// and adjust to new length and offset
-	set_length(offset);
+	set_size(offset);
 	return std::error_condition();
 }
 
@@ -881,18 +866,12 @@ std::error_condition core_osd_file::truncate(std::uint64_t offset)
 
 std::error_condition core_osd_file::finalize() noexcept
 {
-	if (is_loaded())
-		return core_in_memory_file::finalize();
-
 	return std::error_condition();
 }
 
 
 std::error_condition core_osd_file::flush() noexcept
 {
-	if (is_loaded())
-		return core_in_memory_file::flush();
-
 	// flush any buffered char
 	clear_putback();
 
@@ -979,7 +958,7 @@ std::error_condition core_file::open_ram_copy(void const *data, std::size_t leng
 	if (std::uint64_t(length) != length)
 		return std::errc::file_too_large;
 
-	ptr result(new (std::nothrow) core_in_memory_file(openflags, data, length, true));
+	std::unique_ptr<core_in_memory_file> result(new (std::nothrow) core_in_memory_file(openflags, data, length, true));
 	if (!result || !result->buffer())
 		return std::errc::not_enough_memory;
 

--- a/src/lib/util/corefile.h
+++ b/src/lib/util/corefile.h
@@ -76,10 +76,6 @@ public:
 	// read a full line of text from the file
 	virtual char *gets(char *s, int n) = 0;
 
-	// get a pointer to a buffer that holds the full file data in RAM
-	// this function may cause the full file data to be read
-	virtual const void *buffer() = 0;
-
 	// open a file with the specified filename, read it into memory, and return a pointer
 	static std::error_condition load(std::string_view filename, void **data, std::uint32_t &length) noexcept;
 	static std::error_condition load(std::string_view filename, std::vector<uint8_t> &data) noexcept;

--- a/src/lib/util/hash.h
+++ b/src/lib/util/hash.h
@@ -16,6 +16,9 @@
 #pragma once
 
 #include "hashing.h"
+#include "utilfwd.h"
+
+#include <memory>
 
 
 //**************************************************************************
@@ -56,9 +59,8 @@ public:
 
 	// construction/destruction
 	hash_collection();
-	hash_collection(std::string_view string);
-	hash_collection(const hash_collection &src);
-	~hash_collection();
+	hash_collection(std::string_view string) : hash_collection() { from_internal_string(string); }
+	hash_collection(const hash_collection &src) : hash_collection() { copyfrom(src); }
 
 	// operators
 	hash_collection &operator=(const hash_collection &src);
@@ -89,10 +91,8 @@ public:
 	bool from_internal_string(std::string_view string);
 
 	// creation
-	void begin(const char *types = nullptr);
-	void buffer(const uint8_t *data, uint32_t length);
-	void end();
-	void compute(const uint8_t *data, uint32_t length, const char *types = nullptr) { begin(types); buffer(data, length); end(); }
+	std::unique_ptr<write_stream> create(const char *types = nullptr);
+	void compute(const uint8_t *data, uint32_t length, const char *types = nullptr);
 
 private:
 	// internal helpers
@@ -104,16 +104,6 @@ private:
 	crc32_t                 m_crc32;
 	bool                    m_has_sha1;
 	sha1_t                  m_sha1;
-
-	// creators
-	struct hash_creator
-	{
-		bool                    m_doing_crc32;
-		crc32_creator           m_crc32_creator;
-		bool                    m_doing_sha1;
-		sha1_creator            m_sha1_creator;
-	};
-	hash_creator *          m_creator;
 };
 
 

--- a/src/lib/util/ioprocs.h
+++ b/src/lib/util/ioprocs.h
@@ -57,6 +57,23 @@ public:
 	///   be less than or equal to the requested length.
 	/// \return An error condition if reading stopped due to an error.
 	virtual std::error_condition read(void *buffer, std::size_t length, std::size_t &actual) noexcept = 0;
+
+	/// \brief Copy from the current position in the stream
+	///
+	/// Copies the specified number of bytes from the stream to the
+	/// supplied destination stream.  May read or write less than the
+	/// requested number of bytes if the end of the stream is reached or
+	/// an error occurs.  If the stream supports seeking, reading starts
+	/// at the current position in the stream, and the current position
+	/// is incremented by the number of bytes read.  Copied data is
+	/// written by invoking the stream's write method, either once or
+	/// iteratively.
+	/// \param [in] stream Destination stream to write to.
+	/// \param [in] length Maximum number of bytes to copy.
+	/// \param [out] actual Number of bytes actually written.  Will always
+	///   be less than or equal to the requested length.
+	/// \return An error condition if reading stopped due to an error.
+	virtual std::error_condition copy(write_stream &stream, std::size_t length, std::size_t &actual) noexcept;
 };
 
 

--- a/src/tools/romcmp.cpp
+++ b/src/tools/romcmp.cpp
@@ -211,9 +211,7 @@ struct fileinfo
 			{
 				printf("%-23s %-23s 1ST AND 2ND HALF IDENTICAL\n", (side & 1) ? name.c_str() : "", (side & 2) ? name.c_str() : "");
 				util::hash_collection hash;
-				hash.begin();
-				hash.buffer(buf.get(), size / 2);
-				hash.end();
+				hash.compute(buf.get(), size / 2);
 				printf("%-23s %-23s                  %s\n", (side & 1) ? name.c_str() : "", (side & 2) ? name.c_str() : "", hash.attribute_string().c_str());
 			}
 			else


### PR DESCRIPTION
- Remove fgetc, fgets and ptr methods from device_image_interface.
- Remove the buffer method from core_file and rewrite emu_file::hashes to not depend on it.
- Make core_osd_file independent of core_in_memory_file rather than a direct subclass of it.
- Rename the offset() and length() methods used internally in core_file implementations to index() and size() due to frequent clashes with parameter names.
- Change hash_creator from a pointer member of hash_collection to an externally managed but internally implemented subclass of write_stream. Hash creation is now accomplished by obtaining a pointer to a new stream object and writing data to it, calling the finalize method to write the hashes back.
- Add a generic method for copying blocks of data from a read_stream to a write_stream, with the default implementation breaking up large operations into 2K chunks. This has been made a member of read_stream so it can be overridden for implementations that can submit their own private buffers instead.
- Enhance error messages for the frontend media identifier when it encounters file errors.