### PR TITLE
pgm2: update comments

### DIFF
--- a/src/mame/drivers/pgm2.cpp
+++ b/src/mame/drivers/pgm2.cpp
@@ -34,10 +34,10 @@
     Dodonpachi Daioujou Tamashii
     Knights of Valour 3
 
-    These were only released as single board PGM2 based hardware, seen for sale in Japan for around $250-$300
+    These were only released in Japan, seen for sale for around $250-$300
 
     Jigsaw World Arena
-    Puzzle of Ocha / Ochainu No Pazuru
+    Ochaken no Puzzle
 
 
     ToDo (emulation issues):
@@ -1518,6 +1518,6 @@ GAME( 2011, kov3_100,     kov3,   pgm2_hires,  pgm2, pgm2_state, init_kov3_100, 
 // King of Fighters '98: Ultimate Match Hero
 GAME( 2009, kof98umh,     0,      pgm2_lores,  pgm2, pgm2_state, init_kof98umh, ROT0, "IGS / SNK Playmore / New Channel", "The King of Fighters '98: Ultimate Match HERO (China, V100, 09-08-23)", MACHINE_SUPPORTS_SAVE )
 
-// Jigsaw World Arena
+// ジグソーワールドアリーナ/Jigsaw World Arena
 
 // お茶犬のパズル/Ochaken no Puzzle (V101JP exists but undumped, Puzzle game of Japanese お茶犬/Ochaken franchises)


### PR DESCRIPTION
This makes a couple of minor updates to the comments on the main PGM2 driver source file.

The comment about the two Japanese games indicates they were only released as a single-board PCB, but the one photo I've found of Ochaken no Puzzle shows a cart in a standard PGM2: https://www.dentsubo.net/~nosuke/diary/diary.html?y=2015&m=1&d=17&n=0&x=5&a=2&mode=comment

I've also added the Japanese spelling for Jigsaw World Arena, based on this AM-NET blog post from when it was location tested: https://blog.am-net.jp/?p=376