### PR TITLE
Update simplified Chinese translation for autofire button name format

### DIFF
--- a/language/Chinese_Simplified/strings.po
+++ b/language/Chinese_Simplified/strings.po
@@ -5609,7 +5609,7 @@ msgstr "按下 %s 删除"
 #, lua-format
 msgctxt "plugin-autofire"
 msgid "%s [%g Hz]"
-msgstr "%s [%d Hz]"
+msgstr "%s [%g Hz]"
 
 #: plugins/autofire/autofire_menu.lua:95
 #, lua-format


### PR DESCRIPTION
#: plugins/autofire/autofire_menu.lua:93；msgstr "%s [%d Hz]" is changed to msgstr "%s [%g Hz]"