### PR TITLE
Fixed string constructor for fs::meta_value

### DIFF
--- a/src/lib/formats/fsmeta.h
+++ b/src/lib/formats/fsmeta.h
@@ -54,6 +54,7 @@ public:
 	meta_value() { value = false; }
 	meta_value(std::string &&str) { value = std::move(str); }
 	meta_value(std::string_view str) { value = std::string(str); }
+	meta_value(const char *str) { value = std::string(str); }
 	meta_value(bool b) { value = b; }
 	meta_value(int32_t num) { value = uint64_t(num); }
 	meta_value(uint32_t num) { value = uint64_t(num); }


### PR DESCRIPTION
In absence of a constructor that explicitly took 'const char *', passing a const char * would be interpretted as a bool