### PR TITLE
apple2e: Disable dhires flag when turning off 80 column mode

### DIFF
--- a/src/mame/drivers/apple2e.cpp
+++ b/src/mame/drivers/apple2e.cpp
@@ -2278,6 +2278,7 @@ void apple2e_state::c000_w(offs_t offset, u8 data)
 
 		case 0x0c:  // 80COLOFF
 			m_video->m_80col = false;
+			m_video->m_dhires = false;
 			break;
 
 		case 0x0d:  // 80COLON
@@ -2586,6 +2587,7 @@ void apple2e_state::c000_iic_w(offs_t offset, u8 data)
 
 		case 0x0c:  // 80COLOFF
 			m_video->m_80col = false;
+			m_video->m_dhires = false;
 			break;
 
 		case 0x0d:  // 80COLON


### PR DESCRIPTION
Issue I created in mametesters:
https://mametesters.org/view.php?id=8293

Did some debugging and it looks like setting the m_dhires flag to false when 80 column mode is disabled fixes the issue. Most programs look like they switch out of double high res by turning off 80 column mode using soft switch $C00C.

Verified this works on Total Replay and Nox Archaist.