### PR TITLE
z80scc: add support for WR15_ZEROCOUNT interrupts.

### DIFF
--- a/src/devices/machine/z80scc.h
+++ b/src/devices/machine/z80scc.h
@@ -245,14 +245,12 @@ protected:
 		TIMER_ID_TRXC
 	};
 
-#if Z80SCC_USE_LOCAL_BRG
-	emu_timer *baudtimer;
+	emu_timer *m_baudtimer;
 	uint16_t m_brg_counter;
-#else
 	unsigned int m_brg_rate;
-#endif
 	unsigned int m_delayed_tx_brg_change;
 	unsigned int get_brg_rate();
+	void update_baudtimer();
 
 	void scc_register_write(uint8_t reg, uint8_t data);
 	uint8_t scc_register_read(uint8_t reg);


### PR DESCRIPTION
> If this bit is set to "1," an External/Status interrupt is generated whenever the counter in the baud rate generator reaches "0." This bit is set to "0" by a channel or hardware reset.

Fixes MT 8239, Apple IIgs: Diversi-Tune 1.1 crashes/hangs emulation on song start of playback
https://mametesters.org/view.php?id=8239

It overlaps somewhat with the unused and incomplete Z80SCC_USE_LOCAL_BRG code so I tried to leave that unchanged.