### PR TITLE
osd/modules/input: Detect joystick reconnection with SDL

### DIFF
--- a/src/osd/modules/input/input_common.h
+++ b/src/osd/modules/input/input_common.h
@@ -447,7 +447,7 @@ protected:
 public:
 
 	const osd_options *   options() const { return m_options; }
-	input_device_list *   devicelist() { return &m_devicelist; }
+	input_device_list &   devicelist() { return m_devicelist; }
 	bool                  input_enabled() const { return m_input_enabled; }
 	bool                  input_paused() const { return m_input_paused; }
 	bool                  mouse_enabled() const { return m_mouse_enabled; }
@@ -504,7 +504,7 @@ public:
 
 	virtual void exit() override
 	{
-		devicelist()->free_all_devices();
+		devicelist().free_all_devices();
 	}
 
 protected:

--- a/src/osd/modules/input/input_dinput.cpp
+++ b/src/osd/modules/input/input_dinput.cpp
@@ -238,7 +238,7 @@ public:
 		result = dinput_set_dword_property(devinfo->dinput.device, DIPROP_AXISMODE, 0, DIPH_DEVICE, DIPROPAXISMODE_REL);
 		if (result != DI_OK && result != DI_PROPNOEFFECT)
 		{
-			osd_printf_error("DirectInput: Unable to set relative mode for mouse %u (%s)\n", static_cast<unsigned int>(devicelist()->size()), devinfo->name());
+			osd_printf_error("DirectInput: Unable to set relative mode for mouse %u (%s)\n", static_cast<unsigned int>(devicelist().size()), devinfo->name());
 			goto error;
 		}
 
@@ -277,7 +277,7 @@ public:
 
 	error:
 		if (devinfo)
-			devicelist()->free_device(*devinfo);
+			devicelist().free_device(*devinfo);
 		goto exit;
 	}
 };
@@ -449,10 +449,10 @@ void dinput_joystick_device::poll()
 int dinput_joystick_device::configure()
 {
 	HRESULT result;
-	auto devicelist = static_cast<input_module_base&>(module()).devicelist();
+	auto &devicelist = static_cast<input_module_base&>(module()).devicelist();
 
 	// temporary approximation of index
-	int devindex = devicelist->size();
+	int devindex = devicelist.size();
 
 	// set absolute mode
 	result = dinput_set_dword_property(dinput.device, DIPROP_AXISMODE, 0, DIPH_DEVICE, DIPROPAXISMODE_ABS);

--- a/src/osd/modules/input/input_dinput.h
+++ b/src/osd/modules/input/input_dinput.h
@@ -72,7 +72,7 @@ public:
 		std::string utf8_instance_id = utf8_instance_name + " product_" + guid_to_string(instance->guidProduct) + " instance_" + guid_to_string(instance->guidInstance);
 
 		// allocate memory for the device object
-		TDevice &devinfo = module.devicelist()->create_device<TDevice>(machine, std::move(utf8_instance_name), std::move(utf8_instance_id), module);
+		TDevice &devinfo = module.devicelist().create_device<TDevice>(machine, std::move(utf8_instance_name), std::move(utf8_instance_id), module);
 
 		// attempt to create a device
 		result = m_dinput->CreateDevice(instance->guidInstance, devinfo.dinput.device.GetAddressOf(), nullptr);
@@ -133,7 +133,7 @@ public:
 		return &devinfo;
 
 	error:
-		module.devicelist()->free_device(devinfo);
+		module.devicelist().free_device(devinfo);
 		return nullptr;
 	}
 

--- a/src/osd/modules/input/input_rawinput.cpp
+++ b/src/osd/modules/input/input_rawinput.cpp
@@ -489,7 +489,7 @@ public:
 			m_global_inputs_enabled = downcast<windows_options &>(machine.options()).global_inputs();
 
 		// If we added no devices, no need to register for notifications
-		if (devicelist()->empty())
+		if (devicelist().empty())
 			return;
 
 		// finally, register to receive raw input WM_INPUT messages if we found devices
@@ -539,7 +539,7 @@ protected:
 
 		tname.reset();
 
-		TDevice &devinfo = devicelist()->create_device<TDevice>(machine, std::move(utf8_name), std::move(utf8_id), *this);
+		TDevice &devinfo = devicelist().create_device<TDevice>(machine, std::move(utf8_name), std::move(utf8_id), *this);
 
 		// Add the handle
 		devinfo.set_handle(rawinputdevice.hDevice);
@@ -594,14 +594,14 @@ protected:
 
 					// find the device in the list and update
 					auto target_device = std::find_if(
-							devicelist()->begin(),
-							devicelist()->end(),
+							devicelist().begin(),
+							devicelist().end(),
 							[input] (auto const &device)
 							{
 								auto devinfo = dynamic_cast<rawinput_device *>(device.get());
 								return devinfo && (input->header.hDevice == devinfo->device_handle());
 							});
-					if (devicelist()->end() == target_device)
+					if (devicelist().end() == target_device)
 						return false;
 
 					static_cast<rawinput_device *>(target_device->get())->queue_events(input, 1);
@@ -629,14 +629,14 @@ protected:
 
 				// find the device in the list and update
 				auto target_device = std::find_if(
-						devicelist()->begin(),
-						devicelist()->end(),
+						devicelist().begin(),
+						devicelist().end(),
 						[&utf8_id] (auto const &device)
 						{
 							auto devinfo = dynamic_cast<rawinput_device *>(device.get());
 							return devinfo && !devinfo->device_handle() && (devinfo->id() == utf8_id);
 						});
-				if (devicelist()->end() == target_device)
+				if (devicelist().end() == target_device)
 					return false;
 
 				static_cast<rawinput_device *>(target_device->get())->set_handle(rawinputdevice);
@@ -652,15 +652,15 @@ protected:
 
 				// find the device in the list and update
 				auto target_device = std::find_if(
-						devicelist()->begin(),
-						devicelist()->end(),
+						devicelist().begin(),
+						devicelist().end(),
 						[rawinputdevice] (auto const &device)
 						{
 							auto devinfo = dynamic_cast<rawinput_device *>(device.get());
 							return devinfo && (rawinputdevice == devinfo->device_handle());
 						});
 
-				if (devicelist()->end() == target_device)
+				if (devicelist().end() == target_device)
 					return false;
 
 				(*target_device)->reset();

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -1087,8 +1087,17 @@ public:
 			devinfo->sdl_state.joystick_id = SDL_JoystickInstanceID(joy);
 			devinfo->sdl_state.hapdevice = SDL_HapticOpenFromJoystick(joy);
 
-			osd_printf_verbose("Joystick: %s [GUID %s]\n", SDL_JoystickNameForIndex(physical_stick), guid_str);
-			osd_printf_verbose("Joystick:   ...  %d axes, %d buttons %d hats %d balls\n", SDL_JoystickNumAxes(joy), SDL_JoystickNumButtons(joy), SDL_JoystickNumHats(joy), SDL_JoystickNumBalls(joy));
+			osd_printf_verbose("Joystick: %s [GUID %s] Vendor ID %04X, Product ID %04X, Revision %04X\n",
+					SDL_JoystickNameForIndex(physical_stick),
+					guid_str,
+					SDL_JoystickGetVendor(joy),
+					SDL_JoystickGetProduct(joy),
+					SDL_JoystickGetProductVersion(joy));
+			osd_printf_verbose("Joystick:   ...  %d axes, %d buttons %d hats %d balls\n",
+					SDL_JoystickNumAxes(joy),
+					SDL_JoystickNumButtons(joy),
+					SDL_JoystickNumHats(joy),
+					SDL_JoystickNumBalls(joy));
 			osd_printf_verbose("Joystick:   ...  Physical id %d mapped to logical id %d\n", physical_stick, stick + 1);
 			if (devinfo->sdl_state.hapdevice)
 			{

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -1111,7 +1111,7 @@ public:
 				else
 					itemid = ITEM_ID_OTHER_AXIS_ABSOLUTE;
 
-				snprintf(tempname, sizeof(tempname), "A%d %s", axis, devinfo->name().c_str());
+				snprintf(tempname, sizeof(tempname), "A%d", axis + 1);
 				devinfo->device()->add_item(tempname, itemid, generic_axis_get_state<std::int32_t>, &devinfo->joystick.axes[axis]);
 			}
 
@@ -1131,7 +1131,7 @@ public:
 				else
 					itemid = ITEM_ID_OTHER_SWITCH;
 
-				snprintf(tempname, sizeof(tempname), "button %d", button);
+				snprintf(tempname, sizeof(tempname), "Button %d", button + 1);
 				devinfo->device()->add_item(tempname, itemid, generic_button_get_state<std::int32_t>, &devinfo->joystick.buttons[button]);
 			}
 
@@ -1140,16 +1140,16 @@ public:
 			{
 				input_item_id itemid;
 
-				snprintf(tempname, sizeof(tempname), "hat %d Up", hat);
+				snprintf(tempname, sizeof(tempname), "Hat %d Up", hat + 1);
 				itemid = (input_item_id)((hat < INPUT_MAX_HATS) ? ITEM_ID_HAT1UP + 4 * hat : ITEM_ID_OTHER_SWITCH);
 				devinfo->device()->add_item(tempname, itemid, generic_button_get_state<std::int32_t>, &devinfo->joystick.hatsU[hat]);
-				snprintf(tempname, sizeof(tempname), "hat %d Down", hat);
+				snprintf(tempname, sizeof(tempname), "Hat %d Down", hat + 1);
 				itemid = (input_item_id)((hat < INPUT_MAX_HATS) ? ITEM_ID_HAT1DOWN + 4 * hat : ITEM_ID_OTHER_SWITCH);
 				devinfo->device()->add_item(tempname, itemid, generic_button_get_state<std::int32_t>, &devinfo->joystick.hatsD[hat]);
-				snprintf(tempname, sizeof(tempname), "hat %d Left", hat);
+				snprintf(tempname, sizeof(tempname), "Hat %d Left", hat + 1);
 				itemid = (input_item_id)((hat < INPUT_MAX_HATS) ? ITEM_ID_HAT1LEFT + 4 * hat : ITEM_ID_OTHER_SWITCH);
 				devinfo->device()->add_item(tempname, itemid, generic_button_get_state<std::int32_t>, &devinfo->joystick.hatsL[hat]);
-				snprintf(tempname, sizeof(tempname), "hat %d Right", hat);
+				snprintf(tempname, sizeof(tempname), "Hat %d Right", hat + 1);
 				itemid = (input_item_id)((hat < INPUT_MAX_HATS) ? ITEM_ID_HAT1RIGHT + 4 * hat : ITEM_ID_OTHER_SWITCH);
 				devinfo->device()->add_item(tempname, itemid, generic_button_get_state<std::int32_t>, &devinfo->joystick.hatsR[hat]);
 			}
@@ -1164,9 +1164,9 @@ public:
 				else
 					itemid = ITEM_ID_OTHER_AXIS_RELATIVE;
 
-				snprintf(tempname, sizeof(tempname), "R%d %s", ball * 2, devinfo->name().c_str());
+				snprintf(tempname, sizeof(tempname), "R%d X", ball + 1);
 				devinfo->device()->add_item(tempname, (input_item_id)itemid, generic_axis_get_state<std::int32_t>, &devinfo->joystick.balls[ball * 2]);
-				snprintf(tempname, sizeof(tempname), "R%d %s", ball * 2 + 1, devinfo->name().c_str());
+				snprintf(tempname, sizeof(tempname), "R%d Y", ball + 1);
 				devinfo->device()->add_item(tempname, (input_item_id)(itemid + 1), generic_axis_get_state<std::int32_t>, &devinfo->joystick.balls[ball * 2 + 1]);
 			}
 		}

--- a/src/osd/modules/input/input_sdl.cpp
+++ b/src/osd/modules/input/input_sdl.cpp
@@ -1255,8 +1255,8 @@ private:
 			{
 				snprintf(tempname, std::size(tempname), "NC%d", index);
 				m_sixaxis_mode
-					? devicelist().create_device<sdl_sixaxis_joystick_device>(machine, tempname, guid_str, *this)
-					: devicelist().create_device<sdl_joystick_device>(machine, tempname, guid_str, *this);
+						? devicelist().create_device<sdl_sixaxis_joystick_device>(machine, tempname, guid_str, *this)
+						: devicelist().create_device<sdl_joystick_device>(machine, tempname, guid_str, *this);
 			}
 
 			return nullptr;

--- a/src/osd/modules/input/input_sdlcommon.cpp
+++ b/src/osd/modules/input/input_sdlcommon.cpp
@@ -267,7 +267,7 @@ void sdl_osd_interface::release_keys()
 {
 	auto keybd = dynamic_cast<input_module_base*>(m_keyboard_input);
 	if (keybd != nullptr)
-		keybd->devicelist()->reset_devices();
+		keybd->devicelist().reset_devices();
 }
 
 bool sdl_osd_interface::should_hide_mouse()

--- a/src/osd/modules/input/input_sdlcommon.h
+++ b/src/osd/modules/input/input_sdlcommon.h
@@ -8,40 +8,17 @@
 //
 //============================================================
 
-#ifndef INPUT_SDLCOMMON_H_
-#define INPUT_SDLCOMMON_H_
+#ifndef MAME_OSD_INPUT_INPUT_SDLCOMMON_H
+#define MAME_OSD_INPUT_INPUT_SDLCOMMON_H
 
-#include <unordered_map>
+#pragma once
+
 #include <algorithm>
+#include <unordered_map>
 
 #define MAX_DEVMAP_ENTRIES  16
 #define SDL_MODULE_EVENT_BUFFER_SIZE 5
 
-// state information for a keyboard
-struct keyboard_state
-{
-	int32_t   state[0x3ff];                                   // must be int32_t!
-	int8_t    oldkey[MAX_KEYS];
-	int8_t    currkey[MAX_KEYS];
-};
-
-// state information for a mouse
-struct mouse_state
-{
-	int32_t lX, lY;
-	int32_t buttons[MAX_BUTTONS];
-};
-
-
-// state information for a joystick; DirectInput state must be first element
-struct joystick_state
-{
-	SDL_Joystick *device;
-	int32_t axes[MAX_AXES];
-	int32_t buttons[MAX_BUTTONS];
-	int32_t hatsU[MAX_HATS], hatsD[MAX_HATS], hatsL[MAX_HATS], hatsR[MAX_HATS];
-	int32_t balls[MAX_AXES];
-};
 
 struct device_map_t
 {
@@ -79,15 +56,14 @@ public:
 	{
 	}
 
-	void subscribe(int* event_types, int num_event_types, TSubscriber *subscriber)
+	template <size_t N>
+	void subscribe(int const (&event_types)[N], TSubscriber *subscriber)
 	{
 		std::lock_guard<std::mutex> scope_lock(m_lock);
 
 		// Add the subscription
-		for (int i = 0; i < num_event_types; i++)
-		{
-			m_subscription_index.emplace(event_types[i], subscriber);
-		}
+		for (int i : event_types)
+			m_subscription_index.emplace(i, subscriber);
 	}
 
 	void unsubscribe(TSubscriber *subscriber)
@@ -199,4 +175,4 @@ static inline void devmap_init(running_machine &machine, device_map_t *devmap, c
 	}
 }
 
-#endif
+#endif // MAME_OSD_INPUT_INPUT_SDLCOMMON_H

--- a/src/osd/modules/input/input_win32.cpp
+++ b/src/osd/modules/input/input_win32.cpp
@@ -74,7 +74,7 @@ public:
 	virtual void input_init(running_machine &machine) override
 	{
 		// Add a single win32 keyboard device that we'll monitor using Win32
-		auto &devinfo = devicelist()->create_device<win32_keyboard_device>(machine, "Win32 Keyboard 1", "Win32 Keyboard 1", *this);
+		auto &devinfo = devicelist().create_device<win32_keyboard_device>(machine, "Win32 Keyboard 1", "Win32 Keyboard 1", *this);
 
 		keyboard_trans_table &table = keyboard_trans_table::instance();
 
@@ -106,7 +106,7 @@ public:
 			case INPUT_EVENT_KEYDOWN:
 			case INPUT_EVENT_KEYUP:
 				args = static_cast<KeyPressEventArgs*>(eventdata);
-				devicelist()->for_each_device([args](auto device)
+				devicelist().for_each_device([args](auto device)
 				{
 					auto keyboard = dynamic_cast<win32_keyboard_device*>(device);
 					if (keyboard != nullptr)
@@ -206,7 +206,7 @@ public:
 			return;
 
 		// allocate a device
-		auto &devinfo = devicelist()->create_device<win32_mouse_device>(machine, "Win32 Mouse 1", "Win32 Mouse 1", *this);
+		auto &devinfo = devicelist().create_device<win32_mouse_device>(machine, "Win32 Mouse 1", "Win32 Mouse 1", *this);
 
 		// populate the axes
 		for (int axisnum = 0; axisnum < 2; axisnum++)
@@ -235,7 +235,7 @@ public:
 			return false;
 
 		auto args = static_cast<MouseButtonEventArgs*>(eventdata);
-		devicelist()->for_each_device([args](auto device)
+		devicelist().for_each_device([args](auto device)
 		{
 			auto mouse = dynamic_cast<win32_mouse_device*>(device);
 			if (mouse != nullptr)
@@ -268,7 +268,7 @@ public:
 		m_lightgun_shared_axis_mode = downcast<windows_options &>(machine.options()).dual_lightgun();
 
 		// Since we are about to be added to the list, the current size is the zero-based index of where we will be
-		m_gun_index = downcast<wininput_module&>(module).devicelist()->size();
+		m_gun_index = downcast<wininput_module&>(module).devicelist().size();
 	}
 
 	void poll() override
@@ -391,7 +391,7 @@ public:
 			static const char *const gun_names[] = { "Win32 Gun 1", "Win32 Gun 2" };
 
 			// allocate a device
-			auto &devinfo = devicelist()->create_device<win32_lightgun_device>(machine, gun_names[gunnum], gun_names[gunnum], *this);
+			auto &devinfo = devicelist().create_device<win32_lightgun_device>(machine, gun_names[gunnum], gun_names[gunnum], *this);
 
 			// populate the axes
 			for (int axisnum = 0; axisnum < 2; axisnum++)
@@ -421,7 +421,7 @@ public:
 			return false;
 
 		auto args = static_cast<MouseButtonEventArgs*>(eventdata);
-		devicelist()->for_each_device([args](auto device)
+		devicelist().for_each_device([args](auto device)
 		{
 			auto lightgun = dynamic_cast<win32_lightgun_device*>(device);
 			if (lightgun != nullptr)

--- a/src/osd/modules/input/input_x11.cpp
+++ b/src/osd/modules/input/input_x11.cpp
@@ -538,9 +538,9 @@ public:
 			osd_printf_verbose("Device %i: Registered %i events.\n", static_cast<int>(info->id), events_registered);
 
 			// register ourself to handle events from event manager
-			int event_types[] = { motion_type, button_press_type, button_release_type };
+			int const event_types[] = { motion_type, button_press_type, button_release_type };
 			osd_printf_verbose("Events types to register: motion:%d, press:%d, release:%d\n", motion_type, button_press_type, button_release_type);
-			x11_event_manager::instance().subscribe(event_types, std::size(event_types), this);
+			x11_event_manager::instance().subscribe(event_types, this);
 		}
 
 		osd_printf_verbose("Lightgun: End initialization\n");
@@ -582,14 +582,14 @@ public:
 		}
 
 		// Figure out which lightgun this event id destined for
-		auto target_device = std::find_if(devicelist()->begin(), devicelist()->end(), [deviceid](auto &device)
+		auto target_device = std::find_if(devicelist().begin(), devicelist().end(), [deviceid](auto &device)
 		{
 			std::unique_ptr<device_info> &ptr = device;
 			return downcast<x11_input_device*>(ptr.get())->x11_state.deviceid == deviceid;
 		});
 
 		// If we find a matching lightgun, dispatch the event to the lightgun
-		if (target_device != devicelist()->end())
+		if (target_device != devicelist().end())
 		{
 			downcast<x11_input_device*>((*target_device).get())->queue_events(&xevent, 1);
 		}
@@ -604,7 +604,7 @@ private:
 			{
 				char tempname[20];
 				snprintf(tempname, std::size(tempname), "NC%d", index);
-				return &devicelist()->create_device<x11_lightgun_device>(machine, tempname, tempname, *this);
+				return &devicelist().create_device<x11_lightgun_device>(machine, tempname, tempname, *this);
 			}
 			else
 			{
@@ -612,7 +612,7 @@ private:
 			}
 		}
 
-		return &devicelist()->create_device<x11_lightgun_device>(machine, std::string(m_lightgun_map.map[index].name), std::string(m_lightgun_map.map[index].name), *this);
+		return &devicelist().create_device<x11_lightgun_device>(machine, std::string(m_lightgun_map.map[index].name), std::string(m_lightgun_map.map[index].name), *this);
 	}
 
 	void add_lightgun_buttons(XAnyClassPtr first_info_class, int num_classes, x11_lightgun_device &devinfo) const

--- a/src/osd/modules/input/input_xinput.cpp
+++ b/src/osd/modules/input/input_xinput.cpp
@@ -186,7 +186,7 @@ xinput_joystick_device * xinput_api_helper::create_xinput_device(running_machine
 	snprintf(device_name, sizeof(device_name), "XInput Player %u", index + 1);
 
 	// allocate the device object
-	auto &devinfo = module.devicelist()->create_device<xinput_joystick_device>(machine, device_name, device_name, module, shared_from_this());
+	auto &devinfo = module.devicelist().create_device<xinput_joystick_device>(machine, device_name, device_name, module, shared_from_this());
 
 	// Set the player ID
 	devinfo.xinput_state.player_index = index;


### PR DESCRIPTION
This is the most obvious approach to detecting game controllers being reconnected with SDL.  The trouble is, it behaves badly on Windows SDL builds.

The GUIDs are not unique on Windows – they just contain the bus type, vendor ID and product ID padded out with zeroes.  This means that on Windows, it can’t distinguish between similar controllers being added.  For example if you have more than one of the same kind of controller attached to a hub, and you disconnect and reconnect the hub, the joysticks may come back with different assignments.  This is possibly worse than just not detecting reconnected controllers.  SDL 2.0.14 includes a `SDL_JoystickGetSerial` function, but I don’t want to bump the required SDL version up that high right now.

It does seem to work acceptably on Linux with udev.

I don’t see a simple way to detect SDL’s joystick driver to just avoid trying to handle reconnection on Windows (I could be missing something, though).  Perhaps it’s best to just go ahead with it anyway – most people on Windows don’t use `OSD=sdl` at this point, and we can still tell people not to count on controllers working if they’re reconnected.  It would be good to get some feedback from Mac users on what it does there, though.

This also changes the display names for joystick items with SDL:
* Numbers buttons, axes and hats from 1 rather than 0 – it’s more natural and matches the labels on plain HID gamepads
* Gets rid of the SDL device name from absolute and relative axes – this seems to be a vestigial thing from when baseline MAME didn’t always include logical device names for joystick controls
* Displays X/Y for relative axes rather than just numbering the Y axes one higher than corresponding X axes