### PR TITLE
osborne1.cpp: revert floppy device back to SSDD

### DIFF
--- a/src/mame/drivers/osborne1.cpp
+++ b/src/mame/drivers/osborne1.cpp
@@ -258,7 +258,7 @@ INPUT_PORTS_END
 static void osborne1_floppies(device_slot_interface &device)
 {
 	device.option_add("525sssd", FLOPPY_525_SSSD); // Siemens FDD 100-5, custom Osborne electronics
-	device.option_add("525ssdd", FLOPPY_525_QD); // SSDD) // MPI 52(?), custom Osborne electronics
+	device.option_add("525ssdd", FLOPPY_525_SSDD); // MPI 52(?), custom Osborne electronics
 }
 
 


### PR DESCRIPTION
Partially reverts an old commit from @Robbbert (https://github.com/mamedev/mame/commit/247939853301565efd348cad12b04fc957707bc2) where the floppy device was (mistakenly?) set to FLOPPY_525_QD (quad density) from FLOPPY_525_SSDD (single-sided double-density). 

As far as I am aware, the Osborne1 only supported SSSD and SSDD disks. Revert appears to resolve known Osborne1 issues [5792](https://mametesters.org/view.php?id=5792) (thanks to @Osso13 for pointing this out) and [8100](https://mametesters.org/view.php?id=8100) @cuavas.