### PR TITLE
PGM: add Frog Feast homebrew

### DIFF
--- a/src/mame/drivers/pgm.cpp
+++ b/src/mame/drivers/pgm.cpp
@@ -5372,6 +5372,33 @@ ROM_START( ddpdojblkbl )
 	ROM_LOAD( "m04401b032.u17",  0x400000, 0x400000, CRC(5a0dbd76) SHA1(06ab202f6bd5ebfb35b9d8cc7a8fb83ec8840659) ) //music-1
 ROM_END
 
+ROM_START( frogfst )
+	ROM_REGION( 0x600000, "maincpu", 0 ) /* 68000 Code  */
+	PGM_68K_BIOS
+	ROM_LOAD16_WORD_SWAP( "p0103.rom",    0x100000, 0x200000, CRC(cdec9e8d) SHA1(183753b3f19e9b06c6059206aac85d865bf1dd66) )
+
+	ROM_REGION( 0xa00000, "tiles",  0 ) /* 8x8 Text Tiles + 32x32 BG Tiles */
+	PGM_VIDEO_BIOS
+	ROM_LOAD( "pgm_t0100.u8",     0x180000, 0x400000, CRC(8f58b6d8) SHA1(79b3b503f29593170a7faa93d75707682d800c66) )
+
+	ROM_REGION16_LE( 0x2000000, "sprcol", 0 ) /* Sprite Colour Data */
+	ROM_LOAD( "pgm_a0100.u5",     0x0000000, 0x400000, CRC(dc1eafe6) SHA1(11eb0d02c38df828ae0361bc7624c4658047df67) )
+	ROM_LOAD( "pgm_a0101.u6",     0x0400000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+	ROM_LOAD( "pgm_a0102.u7",     0x0800000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+	ROM_LOAD( "pgm_a0103.u8",     0x0c00000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+	ROM_LOAD( "pgm_a0104.u11",    0x1000000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+	ROM_LOAD( "pgm_a0105.u12",    0x1400000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+
+	ROM_REGION16_LE( 0x1000000, "sprmask", 0 ) /* Sprite Masks + Colour Indexes */
+	ROM_LOAD( "pgm_b0100.u9",     0x0000000, 0x400000, CRC(3d44b66f) SHA1(04347002bd942d320c6b8240e4485aec626f2aaa) )
+	ROM_LOAD( "pgm_b0101.u10",    0x0400000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+	ROM_LOAD( "pgm_b0102.u15",    0x0800000, 0x400000, CRC(1147406a) SHA1(2bccbd2f38f15c13eb7d5a89fd9d85f595e23bc3) )
+
+	ROM_REGION( 0x600000, "ics", 0 ) /* Samples - (8 bit mono 11025Hz) - */
+	PGM_AUDIO_BIOS
+	ROM_LOAD( "pgm_m0100.u1",     0x400000, 0x200000, CRC(05e2f761) SHA1(c93d94a8f11c41b019fcf9b6a90645416fd2c75b) )
+ROM_END
+
 
 /*** Init Stuff **************************************************************/
 
@@ -5696,3 +5723,6 @@ GAME( 200?, kovlsqh2,     kovshp,    pgm_arm_type1,          kovsh,     pgm_arm_
 //乱世街霸/Luànshì jiē bà
 GAME( 200?, kovlsjb,      kovshp,    pgm_arm_type1,          kovsh,     pgm_arm_type1_state, init_kovlsqh2, ROT0,   "bootleg", "Luanshi Jie Ba (bootleg of Knights of Valour Super Heroes Plus, ver. 200CN, set 1)", MACHINE_IMPERFECT_SOUND | MACHINE_UNEMULATED_PROTECTION | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) /* need internal rom of IGS027A */
 GAME( 200?, kovlsjba,     kovshp,    pgm_arm_type1,          kovsh,     pgm_arm_type1_state, init_kovlsqh2, ROT0,   "bootleg", "Luanshi Jie Ba (bootleg of Knights of Valour Super Heroes Plus, ver. 200CN, set 2)", MACHINE_IMPERFECT_SOUND | MACHINE_UNEMULATED_PROTECTION | MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) /* need internal rom of IGS027A */
+
+// Homebrew game released a freeware romset
+GAME( 2006, frogfst,     pgm,       pgm_asic3,              pgm,  pgm_asic3_state,   init_pgm, ROT0,   "Rastersoft", "Frog Feast", MACHINE_IMPERFECT_SOUND )

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -35193,6 +35193,7 @@ dwpc                            // (c) 2001 Dragon World Pretty Chance
 dwpc101j                        //
 espgal                          // (c) 2003 Espgaluda
 espgalbl                        //
+frogfst                         // (c) 2005 Rastersoft
 happy6                          // (c) 2004 Happy 6
 happy6101                       //
 happy6100hk                     //


### PR DESCRIPTION
I'm not 100% sure if this qualifies for MAME, but I did see versions of Frog Feast for home computers in the dat files, so maybe this counts. This is a homebrew game released as a set of ROMs online ca 2006.

The official download is named to line up with MAME's copy of Oriental Legend ca 2006; I've renamed the ROMs to match the current naming scheme used for PGM games. Several ROMs (the ones with crc32 `1147406a`) are actually empty, I'm guessing just so they had the same number of ROMs as Oriental Legend. It runs fine without them, so I can remove them from this PR.

Found here: http://frogfeast.rastersoft.net/PGM.html

Source: http://frogfeast.rastersoft.net/PGMSrc.html