### PR TITLE
bus/nes: Updated Jaleco boards.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -25479,8 +25479,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="0.chr" size="131072" crc="7375d251" sha1="c240631e734fec873f546f20edaa81e0d31b4e27" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25501,8 +25501,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="0.chr" size="131072" crc="221f85cf" sha1="9379b8b4d440f039993a2f156e67667b38668094" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25526,8 +25526,8 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="moejudo" supported="partial">
-		<description>Moero!! Juudou Warriors (Jpn)</description>
+	<software name="moejudo" supported="no">
+		<description>Moero!! Juudou Warriors (Japan)</description>
 		<year>1990</year>
 		<publisher>Jaleco</publisher>
 		<info name="serial" value="JF-28"/>
@@ -25563,8 +25563,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="jf-17 chr" size="131072" crc="43e86efa" sha1="5aaba33768eaf8bc66090f28a2aecb89e496b135" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25586,8 +25586,8 @@ license:CC0
 			<dataarea name="chr" size="65536">
 				<rom name="chr" size="65536" crc="26a94526" sha1="c06ef1f446c4e66ce5efc4e8b282e5f7b9eb3baa" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25609,8 +25609,8 @@ license:CC0
 			<dataarea name="chr" size="65536">
 				<rom name="chr" size="65536" crc="26a94526" sha1="c06ef1f446c4e66ce5efc4e8b282e5f7b9eb3baa" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25632,8 +25632,8 @@ license:CC0
 			<dataarea name="chr" size="65536">
 				<rom name="chr" size="65536" crc="26a94526" sha1="c06ef1f446c4e66ce5efc4e8b282e5f7b9eb3baa" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25655,8 +25655,8 @@ license:CC0
 			<dataarea name="chr" size="65536">
 				<rom name="chr" size="65536" crc="26a94526" sha1="c06ef1f446c4e66ce5efc4e8b282e5f7b9eb3baa" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -25678,8 +25678,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="0.chr" size="131072" crc="f20e819f" sha1="93c693f222586e51836fd41ef369fac9af2356e5" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -33867,8 +33867,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="jf-23 chr" size="131072" crc="81bf8283" sha1="ac024e7bfe2fef7300c5d21702a03b5ca8117529" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -39118,8 +39118,8 @@ license:CC0
 			<dataarea name="chr" size="131072">
 				<rom name="0.chr" size="131072" crc="a7c1010e" sha1="afd6fb56d97f35ee19a4b297845c995b47bc3ade" offset="00000" />
 			</dataarea>
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7755c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="12288">
+				<rom name="d7755c" size="12288" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>
@@ -49135,8 +49135,8 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 				<rom name="chr" size="65536" crc="26a94526" sha1="c06ef1f446c4e66ce5efc4e8b282e5f7b9eb3baa" offset="00000" />
 			</dataarea>
 			<!-- was this present on the proto board? -->
-			<dataarea name="adpcm" size="262144">
-				<rom name="upd7756c" size="262144" status="nodump" offset="00000" />
+			<dataarea name="adpcm" size="32768">
+				<rom name="d7756c" size="32768" status="nodump" offset="00000" />
 			</dataarea>
 		</part>
 	</software>

--- a/src/devices/bus/nes/discrete.cpp
+++ b/src/devices/bus/nes/discrete.cpp
@@ -38,22 +38,22 @@ DEFINE_DEVICE_TYPE(NES_74X377,        nes_74x377_device,        "nes_74x377",   
 DEFINE_DEVICE_TYPE(NES_74X161X138,    nes_74x161x138_device,    "nes_bitcorp_dis", "NES Cart Discrete Logic (74*161/138) PCB")
 
 
-nes_74x161x161x32_device::nes_74x161x161x32_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_74x161x161x32_device::nes_74x161x161x32_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_74X161X161X32, tag, owner, clock)
 {
 }
 
-nes_74x139x74_device::nes_74x139x74_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_74x139x74_device::nes_74x139x74_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_74X139X74, tag, owner, clock)
 {
 }
 
-nes_74x377_device::nes_74x377_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_74x377_device::nes_74x377_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_74X377, tag, owner, clock)
 {
 }
 
-nes_74x161x138_device::nes_74x161x138_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_74x161x138_device::nes_74x161x138_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_74X161X138, tag, owner, clock)
 {
 }
@@ -63,18 +63,11 @@ nes_74x161x138_device::nes_74x161x138_device(const machine_config &mconfig, cons
 
 void nes_74x161x161x32_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
-}
-
-void nes_74x139x74_device::pcb_reset()
-{
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg16_89ab(0);
-	prg16_cdef(m_prg_chunks - 1);
-	chr8(0, m_chr_source);
+	if (m_pcb_ctrl_mirror)
+		set_nt_mirroring(PPU_MIRROR_LOW);
 }
 
 
@@ -97,7 +90,7 @@ void nes_74x139x74_device::pcb_reset()
  -------------------------------------------------*/
 
 // there are two 'variants' depending on hardwired or mapper ctrl mirroring
-void nes_74x161x161x32_device::write_h(offs_t offset, uint8_t data)
+void nes_74x161x161x32_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("74x161x161x32 write_h, offset: %04x, data: %02x\n", offset, data));
 
@@ -118,7 +111,7 @@ void nes_74x161x161x32_device::write_h(offs_t offset, uint8_t data)
 
  -------------------------------------------------*/
 
-void nes_74x139x74_device::write_m(offs_t offset, uint8_t data)
+void nes_74x139x74_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("74x139x74 write_m, offset: %04x, data: %02x\n", offset, data));
 
@@ -133,7 +126,7 @@ void nes_74x139x74_device::write_m(offs_t offset, uint8_t data)
 
  iNES: mapper 11
 
- In MESS: Supported
+ In MAME: Supported
 
  Note: bit2 & bit3 are actually related to CIC lockout
  defeating, and real Color Dreams titles use only
@@ -142,7 +135,7 @@ void nes_74x139x74_device::write_m(offs_t offset, uint8_t data)
 
  -------------------------------------------------*/
 
-void nes_74x377_device::write_h(offs_t offset, uint8_t data)
+void nes_74x377_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("74x377 write_h, offset: %04x, data: %02x\n", offset, data));
 
@@ -163,7 +156,7 @@ void nes_74x377_device::write_h(offs_t offset, uint8_t data)
 
  -------------------------------------------------*/
 
-void nes_74x161x138_device::write_m(offs_t offset, uint8_t data)
+void nes_74x161x138_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("74x161x138 write_m, offset: %04x, data: %02x\n", offset, data));
 

--- a/src/devices/bus/nes/discrete.h
+++ b/src/devices/bus/nes/discrete.h
@@ -14,9 +14,9 @@ class nes_74x161x161x32_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_74x161x161x32_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_74x161x161x32_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 };
@@ -28,11 +28,9 @@ class nes_74x139x74_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_74x139x74_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_74x139x74_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_m(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
+	virtual void write_m(offs_t offset, u8 data) override;
 };
 
 
@@ -42,9 +40,9 @@ class nes_74x377_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_74x377_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_74x377_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -54,9 +52,9 @@ class nes_74x161x138_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_74x161x138_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_74x161x138_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/jaleco.cpp
+++ b/src/devices/bus/nes/jaleco.cpp
@@ -51,90 +51,84 @@ DEFINE_DEVICE_TYPE(NES_JF29,       nes_jf29_device,       "nes_jf29",     "NES C
 DEFINE_DEVICE_TYPE(NES_JF33,       nes_jf33_device,       "nes_jf33",     "NES Cart Jaleco JF-33 (Moe Pro! Saikyou-hen) PCB")
 
 
-nes_jf11_device::nes_jf11_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_jf11_device::nes_jf11_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_JF11, tag, owner, clock)
 {
 }
 
-nes_jf13_device::nes_jf13_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_jf13_device::nes_jf13_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_JF13, tag, owner, clock)
 	, m_samples(*this, "samples")
 {
 }
 
-nes_jf16_device::nes_jf16_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_jf16_device::nes_jf16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_JF16, tag, owner, clock)
 {
 }
 
-nes_jf17_device::nes_jf17_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: nes_nrom_device(mconfig, type, tag, owner, clock), m_latch(0)
-{
-}
-
-nes_jf17_device::nes_jf17_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_jf17_device(mconfig, NES_JF17, tag, owner, clock)
-{
-}
-
-nes_jf17_adpcm_device::nes_jf17_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_jf17_device(mconfig, NES_JF17_ADPCM, tag, owner, clock)
-	, m_samples(*this, "samples")
-{
-}
-
-nes_jf19_device::nes_jf19_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
+nes_jf17_device::nes_jf17_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, bool prg_flip)
 	: nes_nrom_device(mconfig, type, tag, owner, clock)
-{
-}
-
-nes_jf19_device::nes_jf19_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_jf19_device(mconfig, NES_JF19, tag, owner, clock)
-{
-}
-
-nes_jf19_adpcm_device::nes_jf19_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_jf19_device(mconfig, NES_JF19_ADPCM, tag, owner, clock)
 	, m_samples(*this, "samples")
+	, m_latch(0)
+	, m_prg_flip(prg_flip)
 {
 }
 
-nes_ss88006_device::nes_ss88006_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: nes_nrom_device(mconfig, type, tag, owner, clock), m_irq_count(0), m_irq_count_latch(0), m_irq_mode(0), m_irq_enable(0), irq_timer(nullptr), m_latch(0)
+nes_jf17_device::nes_jf17_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_jf17_device(mconfig, NES_JF17, tag, owner, clock, false)
 {
 }
 
-nes_ss88006_device::nes_ss88006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_jf17_adpcm_device::nes_jf17_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_jf17_device(mconfig, NES_JF17_ADPCM, tag, owner, clock, false)
+{
+}
+
+nes_jf19_device::nes_jf19_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_jf17_device(mconfig, NES_JF19, tag, owner, clock, true)
+{
+}
+
+nes_jf19_adpcm_device::nes_jf19_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_jf17_device(mconfig, NES_JF19_ADPCM, tag, owner, clock, true)
+{
+}
+
+nes_ss88006_device::nes_ss88006_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
+	: nes_nrom_device(mconfig, type, tag, owner, clock)
+	, m_samples(*this, "samples")
+	, m_irq_count(0)
+	, m_irq_count_latch(0)
+	, m_irq_mode(0)
+	, m_irq_enable(0)
+	, irq_timer(nullptr)
+	, m_wram_protect(0)
+{
+}
+
+nes_ss88006_device::nes_ss88006_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_ss88006_device(mconfig, NES_SS88006, tag, owner, clock)
 {
 }
 
-nes_ss88006_adpcm_device::nes_ss88006_adpcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock)
-	: nes_ss88006_device(mconfig, type, tag, owner, clock)
+nes_jf23_device::nes_jf23_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_ss88006_device(mconfig, NES_JF23, tag, owner, clock)
 {
 }
 
-nes_jf23_device::nes_jf23_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_ss88006_adpcm_device(mconfig, NES_JF23, tag, owner, clock)
-	, m_samples(*this, "samples")
+nes_jf24_device::nes_jf24_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_ss88006_device(mconfig, NES_JF24, tag, owner, clock)
 {
 }
 
-nes_jf24_device::nes_jf24_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_ss88006_adpcm_device(mconfig, NES_JF24, tag, owner, clock)
-	, m_samples(*this, "samples")
+nes_jf29_device::nes_jf29_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_ss88006_device(mconfig, NES_JF29, tag, owner, clock)
 {
 }
 
-nes_jf29_device::nes_jf29_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_ss88006_adpcm_device(mconfig, NES_JF29, tag, owner, clock)
-	, m_samples(*this, "samples")
-{
-}
-
-nes_jf33_device::nes_jf33_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: nes_ss88006_adpcm_device(mconfig, NES_JF33, tag, owner, clock)
-	, m_samples(*this, "samples")
+nes_jf33_device::nes_jf33_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+	: nes_ss88006_device(mconfig, NES_JF33, tag, owner, clock)
 {
 }
 
@@ -142,10 +136,10 @@ nes_jf33_device::nes_jf33_device(const machine_config &mconfig, const char *tag,
 
 void nes_jf16_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
+	set_nt_mirroring(PPU_MIRROR_LOW);
 }
 
 void nes_jf17_device::device_start()
@@ -156,9 +150,8 @@ void nes_jf17_device::device_start()
 
 void nes_jf17_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
-	prg16_cdef(m_prg_chunks - 1);
+	prg16_cdef(m_prg_flip ? 0 : m_prg_chunks - 1);
 	chr8(0, m_chr_source);
 	m_latch = 0;
 }
@@ -175,23 +168,22 @@ void nes_ss88006_device::device_start()
 	save_item(NAME(m_irq_count));
 	save_item(NAME(m_irq_count_latch));
 	save_item(NAME(m_irq_mode));
-	save_item(NAME(m_latch));
+	save_item(NAME(m_wram_protect));
 }
 
 void nes_ss88006_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
 
-	memset(m_mmc_prg_bank, 0, sizeof(m_mmc_prg_bank));
-	memset(m_mmc_vrom_bank, 0, sizeof(m_mmc_vrom_bank));
+	std::fill(std::begin(m_mmc_prg_bank), std::end(m_mmc_prg_bank), 0x00);
+	std::fill(std::begin(m_mmc_vrom_bank), std::end(m_mmc_vrom_bank), 0x00);
 	m_irq_enable = 0;
 	m_irq_mode = 0;
 	m_irq_count = 0;
 	m_irq_count_latch = 0;
-	m_latch = 0;
+	m_wram_protect = 0;
 }
 
 
@@ -203,15 +195,16 @@ void nes_ss88006_device::pcb_reset()
 
  Jaleco JF-11, JF-12 & JF-14 boards emulation
 
- Games: Bio Senshi Dan, Mississippi Satsujin Jiken
+ Games: Bio Senshi Dan, Mississippi Satsujin Jiken,
+ Yousai Club
 
  iNES: mapper 140
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_jf11_device::write_m(offs_t offset, uint8_t data)
+void nes_jf11_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("jf11 write_m, offset: %04x, data: %02x\n", offset, data));
 	chr8(data, CHRROM);
@@ -228,11 +221,11 @@ void nes_jf11_device::write_m(offs_t offset, uint8_t data)
 
  iNES: mapper 86
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_jf13_device::write_m(offs_t offset, uint8_t data)
+void nes_jf13_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("jf13 write_m, offset: %04x, data: %02x\n", offset, data));
 
@@ -241,25 +234,21 @@ void nes_jf13_device::write_m(offs_t offset, uint8_t data)
 		prg32(BIT(data, 4, 2));
 		chr8(bitswap<3>(data, 6, 1, 0), CHRROM);
 	}
-	else
-	{
-//      printf("sample write: offset: %04x, data: %02x\n", offset, data);
-		if (data & 0x20)
-			m_samples->start(data & 0x0f, data & 0x0f);
-		else
-			m_samples->stop_all();
-	}
+	else if ((data & 0x30) == 0x20)
+		m_samples->start(data & 0x0f, data & 0x0f);
 }
 
 /*-------------------------------------------------
 
  Jaleco JF-16 board emulation
 
+ Games: Uchuusen Cosmo Carrier
+
  iNES: mapper 78 (shared with a diff Irem board)
 
  -------------------------------------------------*/
 
-void nes_jf16_device::write_h(offs_t offset, uint8_t data)
+void nes_jf16_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("jf16 write_h, offset: %04x, data: %02x\n", offset, data));
 
@@ -274,98 +263,42 @@ void nes_jf16_device::write_h(offs_t offset, uint8_t data)
 
 /*-------------------------------------------------
 
- Jaleco JF-17 boards emulation
+ Jaleco JF-17 & JF-19 boards emulation
 
  Note: we don't emulate the additional sound hardware
        for Moero!! Pro Tennis
 
  Games: Moero!! Juudou Warriors, Moero!! Pro Tennis, Pinball
- Quest Jpn
+ Quest Jpn, Moero Pro Soccer, Moero Pro Yakyuu '88
 
- iNES: mapper 72
+ iNES: mapper 72 & 92
 
- In MESS: Supported, see below for the Moero Pro Tennis
+ In MAME: Supported, see below for the games with samples
 
  -------------------------------------------------*/
 
-void nes_jf17_device::write_h(offs_t offset, uint8_t data)
+void nes_jf17_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("jf17 write_h, offset: %04x, data: %02x\n", offset, data));
 
 	// this pcb is subject to bus conflict
 	data = account_bus_conflict(offset, data);
 
-	if (BIT(m_latch, 7) && !BIT(data, 7))
-		prg16_89ab(m_latch & 0x07);
-	if (BIT(m_latch, 6) && !BIT(data, 6))
-		chr8(m_latch & 0x0f, CHRROM);
+	if (BIT(data, 7) && !BIT(m_latch, 7))  // 74174 clocks on 0 -> 1
+	{
+		if (m_prg_flip)
+			prg16_cdef(data & 0x0f);
+		else
+			prg16_89ab(data & 0x07);
+	}
+	if (BIT(data, 6) && !BIT(m_latch, 6))  // 74174 clocks on 0 -> 1
+		chr8(data & 0x0f, CHRROM);
 
 	m_latch = data;
-}
 
-void nes_jf17_adpcm_device::write_h(offs_t offset, uint8_t data)
-{
-	LOG_MMC(("jf17 + ADPCM write_h, offset: %04x, data: %02x\n", offset, data));
-
-	// this pcb is subject to bus conflict
-	data = account_bus_conflict(offset, data);
-
-	if (BIT(m_latch, 7) && !BIT(data, 7))
-		prg16_89ab(m_latch & 0x07);
-	if (BIT(m_latch, 6) && !BIT(data, 6))
-		chr8(m_latch & 0x0f, CHRROM);
-	if (BIT(data, 5) && !BIT(data,4))
-	{
-//      printf("sample write: offset: %04x, data: %02x\n", offset, data);
-		m_samples->start(offset & 0x1f, offset & 0x1f);
-	}
-
-	m_latch = data;
-}
-
-/*-------------------------------------------------
-
- Jaleco JF-19 boards emulation
-
- Note: we don't emulate the additional sound hardware.
-
- Games: Moero Pro Soccer, Moero Pro Yakyuu '88
-
- iNES: mapper 92
-
- In MESS: Supported, see below for the Moero Pro Yakyuu '88
-
- -------------------------------------------------*/
-
-void nes_jf19_device::write_h(offs_t offset, uint8_t data)
-{
-	LOG_MMC(("jf19 write_h, offset: %04x, data: %02x\n", offset, data));
-
-	// this pcb is subject to bus conflict
-	data = account_bus_conflict(offset, data);
-
-	if (BIT(data, 7))
-		prg16_cdef(data & 0x0f);
-	if (BIT(data, 6))
-		chr8(data & 0x0f, CHRROM);
-}
-
-void nes_jf19_adpcm_device::write_h(offs_t offset, uint8_t data)
-{
-	LOG_MMC(("jf19 + ADPCM write_h, offset: %04x, data: %02x\n", offset, data));
-
-	// this pcb is subject to bus conflict
-	data = account_bus_conflict(offset, data);
-
-	if (BIT(data, 7))
-		prg16_cdef(data & 0x0f);
-	if (BIT(data, 6))
-		chr8(data & 0x0f, CHRROM);
-	if (BIT(data, 5) && !BIT(data,4))
-	{
-//      printf("sample write: offset: %04x, data: %02x\n", offset, data);
-		m_samples->start(offset & 0x1f, offset & 0x1f);
-	}
+	if (m_samples)
+		if ((data & 0x30) == 0x20)
+			m_samples->start(offset & 0x1f, offset & 0x1f);
 }
 
 /*-------------------------------------------------
@@ -378,7 +311,7 @@ void nes_jf19_adpcm_device::write_h(offs_t offset, uint8_t data)
 
  iNES: mapper 18
 
- In MESS: Supported, see below for the games with samples
+ In MAME: Supported, see below for the games with samples
 
  -------------------------------------------------*/
 
@@ -388,110 +321,86 @@ void nes_ss88006_device::device_timer(emu_timer &timer, device_timer_id id, int 
 	{
 		if (m_irq_enable)
 		{
-			if (m_irq_mode & 0x08)  // 4bits counter
-			{
-				if (!(m_irq_count & 0x000f))
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = (m_irq_count & 0xfff0) | 0x000f;
-				}
-				else
-					m_irq_count = (m_irq_count & 0xfff0) | ((m_irq_count & 0x000f) - 1);
-			}
-			else if (m_irq_mode & 0x04) // 8bits counter
-			{
-				if (!(m_irq_count & 0x00ff))
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = (m_irq_count & 0xff00) | 0x00ff;
-				}
-				else
-					m_irq_count = (m_irq_count & 0xff00) | ((m_irq_count & 0x00ff) - 1);
-			}
-			else if (m_irq_mode & 0x02) // 12bits counter
-			{
-				if (!(m_irq_count & 0x0fff))
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = (m_irq_count & 0xf000) | 0x0fff;
-				}
-				else
-					m_irq_count = (m_irq_count & 0xf000) | ((m_irq_count & 0x0fff) - 1);
-			}
-			else    // 16bits counter
-			{
-				if (!m_irq_count)
-				{
-					set_irq_line(ASSERT_LINE);
-					m_irq_count = 0xffff;
-				}
-				else
-					m_irq_count = m_irq_count - 1;
-			}
+			u16 mask = 0xffff;            // 16-bit counter (default)
+
+			if (BIT(m_irq_mode, 3))       // 4-bit counter
+				mask = 0x000f;
+			else if (BIT(m_irq_mode, 2))  // 8-bit counter
+				mask = 0x00ff;
+			else if (BIT(m_irq_mode, 1))  // 12-bit counter
+				mask = 0x0fff;
+
+			m_irq_count = (m_irq_count & ~mask) | ((m_irq_count - 1) & mask);
+
+			if ((m_irq_count & mask) == mask)
+				set_irq_line(ASSERT_LINE);
 		}
 	}
 }
 
-void nes_ss88006_device::ss88006_write(offs_t offset, uint8_t data)
+u8 nes_ss88006_device::read_m(offs_t offset)
 {
-	uint8_t bank;
+	LOG_MMC(("ss88006 read_m, offset: %04x\n", offset));
+
+	if (m_wram_protect & 1) // RAM enabled
+		return device_nes_cart_interface::read_m(offset);
+
+	return get_open_bus();
+}
+
+void nes_ss88006_device::write_m(offs_t offset, u8 data)
+{
+	LOG_MMC(("ss88006 write_m, offset: %04x, data: %02x\n", offset, data));
+
+	if (m_wram_protect == 0x03) // RAM enabled and writable
+		device_nes_cart_interface::write_m(offset, data);
+}
+
+void nes_ss88006_device::write_h(offs_t offset, u8 data)
+{
 	LOG_MMC(("ss88006 write_h, offset: %04x, data: %02x\n", offset, data));
+
+	int bank, shift;
 
 	switch (offset & 0x7003)
 	{
 		case 0x0000:
-			m_mmc_prg_bank[0] = (m_mmc_prg_bank[0] & 0xf0) | (data & 0x0f);
-			prg8_89(m_mmc_prg_bank[0]);
-			break;
 		case 0x0001:
-			m_mmc_prg_bank[0] = (m_mmc_prg_bank[0] & 0x0f) | (data << 4);
-			prg8_89(m_mmc_prg_bank[0]);
-			break;
 		case 0x0002:
-			m_mmc_prg_bank[1] = (m_mmc_prg_bank[1] & 0xf0) | (data & 0x0f);
-			prg8_ab(m_mmc_prg_bank[1]);
-			break;
 		case 0x0003:
-			m_mmc_prg_bank[1] = (m_mmc_prg_bank[1] & 0x0f) | (data << 4);
-			prg8_ab(m_mmc_prg_bank[1]);
-			break;
 		case 0x1000:
-			m_mmc_prg_bank[2] = (m_mmc_prg_bank[2] & 0xf0) | (data & 0x0f);
-			prg8_cd(m_mmc_prg_bank[2]);
-			break;
 		case 0x1001:
-			m_mmc_prg_bank[2] = (m_mmc_prg_bank[2] & 0x0f) | (data << 4);
-			prg8_cd(m_mmc_prg_bank[2]);
+			bank = bitswap<2>(offset, 12, 1);
+			shift = (offset & 1) << 2;
+			m_mmc_prg_bank[bank] &= ~(0x0f << shift);
+			m_mmc_prg_bank[bank] |= (data & 0x0f) << shift;
+			prg8_x(bank, m_mmc_prg_bank[bank]);
 			break;
 
-			/* $9002, 3 (1002, 3) uncaught = Jaleco Baseball writes 0 */
-			/* believe it's related to battery-backed ram enable/disable */
+		case 0x1002:
+			m_wram_protect = data & 0x03;
+			break;
 
 		case 0x2000: case 0x2001: case 0x2002: case 0x2003:
 		case 0x3000: case 0x3001: case 0x3002: case 0x3003:
 		case 0x4000: case 0x4001: case 0x4002: case 0x4003:
 		case 0x5000: case 0x5001: case 0x5002: case 0x5003:
 			bank = 2 * (BIT(offset, 12, 3) - 2) + BIT(offset, 1);
-			if (offset & 0x0001)
-				m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & 0x0f) | ((data & 0x0f) << 4);
-			else
-				m_mmc_vrom_bank[bank] = (m_mmc_vrom_bank[bank] & 0xf0) | (data & 0x0f);
-
+			shift = (offset & 1) << 2;
+			m_mmc_vrom_bank[bank] &= ~(0x0f << shift);
+			m_mmc_vrom_bank[bank] |= (data & 0x0f) << shift;
 			chr1_x(bank, m_mmc_vrom_bank[bank], CHRROM);
 			break;
 
 		case 0x6000:
-			m_irq_count_latch = (m_irq_count_latch & 0xfff0) | (data & 0x0f);
-			break;
 		case 0x6001:
-			m_irq_count_latch = (m_irq_count_latch & 0xff0f) | ((data & 0x0f) << 4);
-			break;
 		case 0x6002:
-			m_irq_count_latch = (m_irq_count_latch & 0xf0ff) | ((data & 0x0f) << 8);
-			break;
 		case 0x6003:
-			m_irq_count_latch = (m_irq_count_latch & 0x0fff) | ((data & 0x0f) << 12);
+			shift = 4 * (offset & 0x03);
+			m_irq_count_latch &= ~(0x000f << shift);
+			m_irq_count_latch |= (data & 0x0f) << shift;
 			break;
+
 		case 0x7000:
 			m_irq_count = m_irq_count_latch;
 			set_irq_line(CLEAR_LINE);
@@ -512,34 +421,14 @@ void nes_ss88006_device::ss88006_write(offs_t offset, uint8_t data)
 			}
 			break;
 
+		case 0x7003:
+			if (m_samples)
+				if ((data & 0x03) == 0x02)
+					m_samples->start(BIT(data, 2, 5), BIT(data, 2, 5));
+			break;
+
 		default:
 			logerror("Jaleco SS88006 uncaught write, addr: %04x, value: %02x\n", offset + 0x8000, data);
-			break;
-	}
-}
-
-
-// bits2-bits6 are sample number, bit1 is setup/enable/disable
-// program first write sample # + bit1 set to 'init' the sample
-// then it writes sample # + bit1 clear to 'start' the sample
-void nes_ss88006_adpcm_device::ss88006_adpcm_write(offs_t offset, uint8_t data, samples_device &dev)
-{
-	LOG_MMC(("ss88006 write_h, offset: %04x, data: %02x\n", offset, data));
-
-	switch (offset & 0x7003)
-	{
-		case 0x7003:
-			if ((m_latch & 0x7c) == (data & 0x7c))
-			{
-//              printf("sample write: data: %02x\n", data);
-				if ((m_latch & 2) && !(data & 2))
-					dev.start(BIT(data, 2, 5), BIT(data, 2, 5));
-			}
-			m_latch = data;
-			break;
-
-		default:
-			ss88006_write(offset, data);
 			break;
 	}
 }
@@ -570,13 +459,13 @@ static const char *const jf13_sample_names[] =
 	"04",   // safe
 	"05",   // foul
 	"06",   // (catcher obtains the ball)
-	"07",   // you're out
+	"07",   // batter out
 	"08",   // play ball
 	"09",   // ball four
 	"10",   // home run
 	"11",   // new pitcher
 	"12",   // ouch (pitcher hits batter)
-	"13",   // ??
+	"13",   // aho (idiot)
 	"14",   // (bat hits the ball)
 	"15",   // (crowd)
 	nullptr

--- a/src/devices/bus/nes/jaleco.h
+++ b/src/devices/bus/nes/jaleco.h
@@ -15,9 +15,9 @@ class nes_jf11_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_jf11_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf11_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 };
 
 
@@ -27,9 +27,9 @@ class nes_jf13_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_jf13_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf13_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 
 protected:
 	// device-level overrides
@@ -46,9 +46,9 @@ class nes_jf16_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_jf16_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf16_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 };
@@ -60,19 +60,23 @@ class nes_jf17_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_jf17_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf17_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
-	nes_jf17_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf17_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock, bool m_prg_flip);
 
 	// device-level overrides
 	virtual void device_start() override;
 
-	uint8_t m_latch;
+	optional_device<samples_device> m_samples;
+
+private:
+	u8 m_latch;
+	bool m_prg_flip;
 };
 
 
@@ -82,48 +86,33 @@ class nes_jf17_adpcm_device : public nes_jf17_device
 {
 public:
 	// construction/destruction
-	nes_jf17_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	nes_jf17_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	required_device<samples_device> m_samples;
 };
 
 
 // ======================> nes_jf19_device
 
-class nes_jf19_device : public nes_nrom_device
+class nes_jf19_device : public nes_jf17_device
 {
 public:
 	// construction/destruction
-	nes_jf19_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual void write_h(offs_t offset, uint8_t data) override;
-
-protected:
-	nes_jf19_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf19_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 };
 
 
 // ======================> nes_jf19_adpcm_device
 
-class nes_jf19_adpcm_device : public nes_jf19_device
+class nes_jf19_adpcm_device : public nes_jf17_device
 {
 public:
 	// construction/destruction
-	nes_jf19_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	nes_jf19_adpcm_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	required_device<samples_device> m_samples;
 };
 
 
@@ -133,115 +122,86 @@ class nes_ss88006_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_ss88006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_ss88006_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	void ss88006_write(offs_t offset, uint8_t data);
-	virtual void write_h(offs_t offset, uint8_t data) override { ss88006_write(offset, data); }
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
-	nes_ss88006_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_ss88006_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
 	virtual void device_timer(emu_timer &timer, device_timer_id id, int param) override;
 
-	uint16_t m_irq_count, m_irq_count_latch;
-	uint8_t m_irq_mode;
-	int m_irq_enable;
+	optional_device<samples_device> m_samples;
 
-	static const device_timer_id TIMER_IRQ = 0;
+private:
+	u16 m_irq_count, m_irq_count_latch;
+	u8 m_irq_mode;
+	u8 m_irq_enable;
+
+	static constexpr device_timer_id TIMER_IRQ = 0;
 	emu_timer *irq_timer;
 
-	uint8_t m_mmc_prg_bank[3];
-	uint8_t m_mmc_vrom_bank[8];
-
-	uint8_t m_latch; // used for samples, in derived classes
-};
-
-
-// ======================> nes_ss88006_adpcm_device
-
-class nes_ss88006_adpcm_device : public nes_ss88006_device
-{
-protected:
-	// construction/destruction
-	nes_ss88006_adpcm_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
-
-	void ss88006_adpcm_write(offs_t offset, uint8_t data, samples_device &dev);
+	u8 m_mmc_prg_bank[3];
+	u8 m_mmc_vrom_bank[8];
+	u8 m_wram_protect;
 };
 
 
 // ======================> nes_jf23_device
 
-class nes_jf23_device : public nes_ss88006_adpcm_device
+class nes_jf23_device : public nes_ss88006_device
 {
 public:
 	// construction/destruction
-	nes_jf23_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf23_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	virtual void write_h(offs_t offset, uint8_t data) override { ss88006_adpcm_write(offset, data, *m_samples); }
-
-	required_device<samples_device> m_samples;
 };
 
 
 // ======================> nes_jf24_device
 
-class nes_jf24_device : public nes_ss88006_adpcm_device
+class nes_jf24_device : public nes_ss88006_device
 {
 public:
 	// construction/destruction
-	nes_jf24_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf24_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	virtual void write_h(offs_t offset, uint8_t data) override { ss88006_adpcm_write(offset, data, *m_samples); }
-
-	required_device<samples_device> m_samples;
 };
 
 
 // ======================> nes_jf29_device
 
-class nes_jf29_device : public nes_ss88006_adpcm_device
+class nes_jf29_device : public nes_ss88006_device
 {
 public:
 	// construction/destruction
-	nes_jf29_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf29_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	virtual void write_h(offs_t offset, uint8_t data) override { ss88006_adpcm_write(offset, data, *m_samples); }
-
-	required_device<samples_device> m_samples;
 };
 
 
 // ======================> nes_jf33_device
 
-class nes_jf33_device : public nes_ss88006_adpcm_device
+class nes_jf33_device : public nes_ss88006_device
 {
 public:
 	// construction/destruction
-	nes_jf33_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_jf33_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 protected:
 	virtual void device_add_mconfig(machine_config &config) override;
-
-private:
-	virtual void write_h(offs_t offset, uint8_t data) override { ss88006_adpcm_write(offset, data, *m_samples); }
-
-	required_device<samples_device> m_samples;
 };
 
 


### PR DESCRIPTION
- JF-13: fixed simultaneous samples playing at boot of Moero Pro Yakyuu.
- JF-16, discrete 74x161: set hardware-valid one-screen mirroring mode at reset.
- JF-17/19: Streamlined by putting common details in base class. Fixed latches which switch banks on low to high transition. Demoted moejudo since it's not playable.
- SS88006 boards: Also streamlined everything into common base class. Parameterized common code patterns. Added WRAM enable bits.
- nes.xml: Corrected ROM sizes of undumped uPD775xC chips.