### PR TITLE
xavix2: Fix scaling of background in ltv_naru

### DIFF
--- a/src/mame/drivers/xavix2.cpp
+++ b/src/mame/drivers/xavix2.cpp
@@ -366,10 +366,11 @@ void xavix2_state::gpu_update(u16 count, u16 adr)
 					avail = 64;
 				}
 				u32 color = m_palette[palette | (v & mask)];
-				if(color)
-				for(u32 yyy = 0; yyy<scaley; yyy++) {
-					for(u32 xxx = 0; xxx < scalex; xxx++) {
-						m_sd[y+(yy*scaley)+yyy][x+(xx*scalex)+xxx] = color;
+				if(color) {
+					for(u32 yyy = 0; yyy<scaley; yyy++) {
+						for(u32 xxx = 0; xxx < scalex; xxx++) {
+							m_sd[y+(yy*scaley)+yyy][x+(xx*scalex)+xxx] = color;
+						}
 					}
 				}
 				v >>= bpp;

--- a/src/mame/drivers/xavix2.cpp
+++ b/src/mame/drivers/xavix2.cpp
@@ -342,6 +342,8 @@ void xavix2_state::gpu_update(u16 count, u16 adr)
 		u32 y = (command >> 11) &  0x3ff;
 		u32 sx = 1+(descsize & 0xff);
 		u32 sy = 1 + ((descsize >> 8) & 0xff);
+		u32 scalex = (command >> 40) & 0x3;
+		u32 scaley = (command >> 46) & 0x3;
 		u32 bpp = 1 + ((descsize >> 24) & 7);
 		logerror("gpu    - data %06x size %08x w=%x h=%x ?=%x bpp=%x pal=%x\n", sadr, descsize, sx, sy, (descsize >> 16) & 0xff, bpp, descsize >> 27);
 
@@ -364,7 +366,12 @@ void xavix2_state::gpu_update(u16 count, u16 adr)
 					avail = 64;
 				}
 				u32 color = m_palette[palette | (v & mask)];
-				if (color) m_sd[y+yy][x+xx] = color;
+				if(color)
+				for(u32 yyy = 0; yyy<scaley; yyy++) {
+					for(u32 xxx = 0; xxx < scalex; xxx++) {
+						m_sd[y+(yy*scaley)+yyy][x+(xx*scalex)+xxx] = color;
+					}
+				}
 				v >>= bpp;
 				avail -= bpp;
 			}

--- a/src/mame/drivers/xavix2.cpp
+++ b/src/mame/drivers/xavix2.cpp
@@ -342,7 +342,7 @@ void xavix2_state::gpu_update(u16 count, u16 adr)
 		u32 y = (command >> 11) &  0x3ff;
 		u32 sx = 1+(descsize & 0xff);
 		u32 sy = 1 + ((descsize >> 8) & 0xff);
-		u32 scalex = (command >> 40) & 0x3;
+		u32 scalex = (command >> 40) & 0x3; //only 1 and 2 seen as values for these two so far
 		u32 scaley = (command >> 46) & 0x3;
 		u32 bpp = 1 + ((descsize >> 24) & 7);
 		logerror("gpu    - data %06x size %08x w=%x h=%x ?=%x bpp=%x pal=%x\n", sadr, descsize, sx, sy, (descsize >> 16) & 0xff, bpp, descsize >> 27);


### PR DESCRIPTION
Any further fixes to the title screen will require better CRTC emulation.

This fix was found by realizing that the background, which was the only part that required scaling to match hardware, was the only sprite in the list with w and h in the command set to 0x20 instead of 0x10. Guessing that this was some sort of scaling factor turned out to be fruitful.

After the change: 
![screen](https://user-images.githubusercontent.com/956763/165385873-47818129-ec1b-4bc1-b96d-a95f20f57caf.jpg)

