### PR TITLE
spectrum48: fix floating int

### DIFF
--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -32,6 +32,7 @@ class z80_device : public cpu_device, public z80_daisy_chain_interface
 public:
 	z80_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
+	int	cycles_from_irq() { return total_cycles() - m_irq_at; }
 	void z80_set_cycle_tables(const uint8_t *op, const uint8_t *cb, const uint8_t *ed, const uint8_t *xy, const uint8_t *xycb, const uint8_t *ex);
 	template <typename... T> void set_memory_map(T &&... args) { set_addrmap(AS_PROGRAM, std::forward<T>(args)...); }
 	template <typename... T> void set_m1_map(T &&... args) { set_addrmap(AS_OPCODES, std::forward<T>(args)...); }
@@ -154,7 +155,7 @@ protected:
 	void rm16(uint16_t addr, PAIR &r);
 	virtual void wm(uint16_t addr, uint8_t value);
 	void wm16(uint16_t addr, PAIR &r);
-	void wm16back(uint16_t addr, PAIR &r);
+	void wm16_sp(PAIR &r);
 	virtual uint8_t rop();
 	virtual uint8_t arg();
 	virtual uint16_t arg16();
@@ -282,6 +283,7 @@ protected:
 	uint8_t           m_after_ldair;        /* same, but for LD A,I or LD A,R */
 	uint32_t          m_ea;
 
+	int               m_irq_at;
 	int               m_icount;
 	int               m_icount_executing;
 	uint8_t           m_rtemp;

--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -174,12 +174,13 @@ void spectrum_128_state::video_start()
 
 uint8_t spectrum_128_state::spectrum_128_pre_opcode_fetch_r(offs_t offset)
 {
+	if (is_contended(offset)) content_early();
+
 	/* this allows expansion devices to act upon opcode fetches from MEM addresses
 	   for example, interface1 detection fetches requires fetches at 0008 / 0708 to
 	   enable paged ROM and then fetches at 0700 to disable it
 	*/
 	m_exp->pre_opcode_fetch(offset);
-	if (is_contended(offset)) content_early();
 	uint8_t retval = m_maincpu->space(AS_PROGRAM).read_byte(offset);
 	m_exp->post_opcode_fetch(offset);
 	return retval;

--- a/src/mame/drivers/spectrum.cpp
+++ b/src/mame/drivers/spectrum.cpp
@@ -769,7 +769,6 @@ void spectrum_state::device_timer(emu_timer &timer, device_timer_id id, int para
 	case TIMER_IRQ_ON:
 		m_maincpu->set_input_line(0, HOLD_LINE);
 		timer_set(m_maincpu->clocks_to_attotime(32), TIMER_IRQ_OFF, 0);
-		m_irq_start_cycle = m_maincpu->total_cycles();
 		break;
 	case TIMER_IRQ_OFF:
 		m_maincpu->set_input_line(0, CLEAR_LINE);

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -180,7 +180,6 @@ protected:
 	optional_ioport m_io_joy1;
 	optional_ioport m_io_joy2;
 
-	u64 m_irq_start_cycle;
 	virtual u8 get_border_color(u16 hpos = ~0, u16 vpos = ~0);
 	// Defines position of main screen excluding border
 	virtual rectangle get_screen_area();

--- a/src/mame/video/spectrum.cpp
+++ b/src/mame/video/spectrum.cpp
@@ -183,7 +183,7 @@ void spectrum_state::content_early(s8 shift)
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->total_cycles() - m_irq_start_cycle + shift;
+	u64 now = m_maincpu->cycles_from_irq() + shift;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() - 1;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 
@@ -201,7 +201,7 @@ void spectrum_state::content_late()
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->total_cycles() - m_irq_start_cycle + 1;
+	u64 now = m_maincpu->cycles_from_irq() + 1;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() - 1;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 	for(auto i = 0x04; i; i >>= 1)


### PR DESCRIPTION
Fixed "floating" int. Now border in demos stays steady and not shaking.

![shock_after](https://user-images.githubusercontent.com/58155/165519456-f042f4c5-a0a4-47c8-9485-ed4537fc6a1b.jpg)
![ula48](https://user-images.githubusercontent.com/58155/165519470-ff8ebf1f-194c-4110-8113-364fd25dc642.jpg)
![tacts_after](https://user-images.githubusercontent.com/58155/165519488-6ca2e44c-f592-4d73-be1d-1920299eee00.jpg)
