### PR TITLE
spec128.cpp, specpls3.cpp: Added initial bus contention emulation for Spectrum 128+ models

### DIFF
--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -169,7 +169,7 @@ void spectrum_128_state::video_start()
 {
 	m_frame_invert_count = 16;
 	m_screen_location = m_ram->pointer() + (5 << 14);
-	m_contention_pattern = {1, 0, 7, 6, 5, 4, 3, 2};
+	m_contention_pattern = {6, 5, 4, 3, 2, 1, 0, 0};
 }
 
 uint8_t spectrum_128_state::spectrum_128_pre_opcode_fetch_r(offs_t offset)
@@ -212,6 +212,9 @@ uint8_t spectrum_128_state::spectrum_128_bank1_r(offs_t offset)
 
 void spectrum_128_state::spectrum_128_port_7ffd_w(offs_t offset, uint8_t data)
 {
+	if (is_contended(offset)) content_early();
+	content_early(1);
+
 	/* D0-D2: RAM page located at 0x0c000-0x0ffff */
 	/* D3 - Screen select (screen 0 in ram page 5, screen 1 in ram page 7 */
 	/* D4 - ROM select - which rom paged into 0x0000-0x03fff */
@@ -242,6 +245,7 @@ void spectrum_128_state::spectrum_128_update_memory()
 	unsigned char *ram_data = messram + (ram_page<<14);
 	membank("bank4")->set_base(ram_data);
 
+	m_screen->update_now();
 	if (BIT(m_port_7ffd_data, 3))
 		m_screen_location = messram + (7<<14);
 	else
@@ -250,6 +254,12 @@ void spectrum_128_state::spectrum_128_update_memory()
 
 uint8_t spectrum_128_state::spectrum_port_r(offs_t offset)
 {
+	if (is_contended(offset))
+	{
+		content_early();
+		content_late();
+	}
+
 	// Pass through to expansion device if present
 	if (m_exp->get_card_device())
 		return m_exp->iorq_r(offset | 1);
@@ -308,8 +318,10 @@ bool spectrum_128_state::is_vram_write(offs_t offset) {
 }
 
 bool spectrum_128_state::is_contended(offs_t offset) {
-	// TODO Unlike the base 128K machine, RAM banks 4, 5, 6 and 7 are contended.
-	return spectrum_state::is_contended(offset);// || (offset >= 0x8000 && offset < 0xc000);
+	// Unlike the base 128K machine, RAM banks 4, 5, 6 and 7 are contended.
+	u8 mapped = m_port_7ffd_data & 0x07;
+	return spectrum_state::is_contended(offset) || (
+		(offset >= 0xc000 && offset <= 0xffff) && (mapped >= 4 && mapped <= 7));
 }
 
 static const gfx_layout spectrum_charlayout =

--- a/src/mame/includes/specpls3.h
+++ b/src/mame/includes/specpls3.h
@@ -30,6 +30,7 @@ public:
 	void spectrum_plus3(machine_config &config);
 
 protected:
+	virtual void video_start() override;
 	virtual void machine_reset() override;
 	virtual void plus3_update_memory() override;
 


### PR DESCRIPTION
Makes ula128 test work for spectrum 128, +2 models
+2A, +3 uses same pattern as models above but possibly this test not expected to work on there models - nice to have confirmation from owners of physical devices. 

![ula128_pls2](https://user-images.githubusercontent.com/58155/165672813-2ae3ab91-d31a-4f46-b81a-8e411e120ad3.jpg)

compare to master:
![ula128_pls2_before](https://user-images.githubusercontent.com/58155/165675585-4a35438a-242a-4c01-9a3d-f0cf508644a6.jpg)
