### PR TITLE
bus/nes: Various minor cleanups.

### DIFF
--- a/hash/nes.xml
+++ b/hash/nes.xml
@@ -49718,6 +49718,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="oekakids" />
 			<feature name="pcb" value="BANDAI-OEKAKIDS" />
+			<feature name="mirroring" value="vertical" />
 			<dataarea name="prg" size="131072">
 				<rom name="oeka kids - anpanman no hiragana daisuki (japan).prg" size="131072" crc="c3c0811d" sha1="32d71dd6c5a8d78a918fe1b9d6d6c4a570d9652d" offset="00000" status="baddump" />
 			</dataarea>
@@ -56021,6 +56022,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="serial" value="MGC-002"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="txc_22110" />
+			<feature name="mirroring" value="vertical" />
 			<feature name="peripheral" value="bandai_hypershot" />
 			<dataarea name="prg" size="262144">
 				<rom name="2-in-1 uzi lightgun (mgc-002).prg" size="262144" crc="7349c91a" sha1="00d0c7a423b9c8c18974022c619d9f3084c4fd8d" status="baddump" />
@@ -56377,6 +56379,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			</dataarea>
 		</part>
 	</software>
 
@@ -56393,6 +56399,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -56412,8 +56422,9 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
-			<!-- 8k WRAM on cartridge -->
-			<dataarea name="wram" size="8192">
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -56431,8 +56442,9 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
-			<!-- 8k WRAM on cartridge -->
-			<dataarea name="wram" size="8192">
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -57642,6 +57654,10 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			</dataarea>
 		</part>
 	</software>
 
@@ -58426,6 +58442,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="alt_title" value="荊軻新傳"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="jncota_kt1001" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="131072">
 				<rom name="[kt-1001] jing ke xin zhuan (c).chr" size="131072" crc="0024a801" sha1="ba7a408c852c5ec611851f3f1ae75ce6056837f2" offset="00000" status="baddump" />
 			</dataarea>
@@ -58448,6 +58465,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="alt_title" value="聖火列傳"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="jncota_kt1001" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="131072">
 				<rom name="[kt-1002] sheng huo lie zhuan (c).chr" size="131072" crc="7c6f37fc" sha1="3a4da287653ec929adac7362c38687f14ca42080" offset="00000" status="baddump" />
 			</dataarea>
@@ -58580,6 +58598,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="alt_title" value="战国风云"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="jncota_kt1001" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="131072">
 				<rom name="[kt-1013] zhan guo feng yun (c).chr" size="131072" crc="4026c277" sha1="31bca971eab6f2c3d9a3e58fd2441730d8e666e1" offset="00000" status="baddump" />
 			</dataarea>
@@ -58602,6 +58621,7 @@ preliminary proto for the PAL version, still running on NTSC systems) or the gfx
 		<info name="alt_title" value="侠客传奇"/>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="jncota_kt1001" />
+			<feature name="mirroring" value="horizontal" />
 			<dataarea name="chr" size="131072">
 				<rom name="[kt-1014] xia ke chuan qi (c).chr" size="131072" crc="f6d312af" sha1="3261d2f7f8cf9bb366a9d0361251161dbce81033" offset="00000" status="baddump" />
 			</dataarea>
@@ -67344,6 +67364,10 @@ from the NEStopia source, hence they would require confirmation. -->
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			</dataarea>
 		</part>
 	</software>
 
@@ -67361,6 +67385,10 @@ from the NEStopia source, hence they would require confirmation. -->
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
 			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
+			</dataarea>
 		</part>
 	</software>
 
@@ -67376,6 +67404,10 @@ from the NEStopia source, hence they would require confirmation. -->
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -68626,6 +68658,10 @@ All musics were removed in this game.
 			</dataarea>
 			<!-- 8k VRAM on cartridge -->
 			<dataarea name="vram" size="8192">
+			</dataarea>
+			<!-- 8k WRAM on cartridge, battery backed up -->
+			<dataarea name="bwram" size="8192">
+				<rom value="0x00" size="8192" offset="0" loadflag="fill" />
 			</dataarea>
 		</part>
 	</software>
@@ -84122,6 +84158,7 @@ be better to redump them properly. -->
 		<publisher>&lt;pirate&gt;</publisher>
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="bmc_830425c" />
+			<feature name="mirroring" value="vertical" />
 			<dataarea name="prg" size="1048576">
 				<rom name="super hik 6-in-1 a-030.prg" size="1048576" crc="ee62ac32" sha1="6f7dbfdbdc1633e45c84d2e1b7f833d2ef7741c3" status="baddump" />
 			</dataarea>
@@ -86395,6 +86432,7 @@ be better to redump them properly. -->
 		<part name="cart" interface="nes_cart">
 			<feature name="slot" value="sgun20in1" />
 			<feature name="pcb" value="BMC-SUPERGUN-20IN1" />
+			<feature name="mirroring" value="vertical" />
 			<feature name="peripheral" value="zapper" />
 			<dataarea name="chr" size="32768">
 				<rom name="super gun 20-in-1 [p1].chr" size="32768" crc="2d5d160c" sha1="887efc66eca7af81b11c94874d15add6c156da09" offset="00000" status="baddump" />

--- a/src/devices/bus/nes/2a03pur.cpp
+++ b/src/devices/bus/nes/2a03pur.cpp
@@ -51,8 +51,6 @@ void nes_2a03pur_device::device_start()
 
 void nes_2a03pur_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	chr8(0, m_chr_source);
 	// register content is not touched by reset
 }
 

--- a/src/devices/bus/nes/act53.cpp
+++ b/src/devices/bus/nes/act53.cpp
@@ -58,7 +58,6 @@ void nes_action53_device::pcb_start(running_machine &machine, u8 *ciram_ptr, boo
 
 void nes_action53_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	// register content is not touched by reset
 }
 

--- a/src/devices/bus/nes/ave.cpp
+++ b/src/devices/bus/nes/ave.cpp
@@ -38,12 +38,12 @@ DEFINE_DEVICE_TYPE(NES_NINA006, nes_nina006_device, "nes_nina006", "NES Cart AVE
 DEFINE_DEVICE_TYPE(NES_MAXI15,  nes_maxi15_device,  "nes_maxi15",  "NES Cart AVE Maxi 15 PCB")
 
 
-nes_nina001_device::nes_nina001_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_nina001_device::nes_nina001_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_NINA001, tag, owner, clock)
 {
 }
 
-nes_nina006_device::nes_nina006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_nina006_device::nes_nina006_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_NINA006, tag, owner, clock)
 {
 }
@@ -66,7 +66,6 @@ void nes_maxi15_device::pcb_reset()
 {
 	prg32(0);
 	chr8(0, CHRROM);
-	set_nt_mirroring(PPU_MIRROR_VERT);
 
 	m_reg[0] = m_reg[1] = 0;
 }
@@ -93,9 +92,11 @@ void nes_maxi15_device::pcb_reset()
 
  -------------------------------------------------*/
 
-void nes_nina001_device::write_m(offs_t offset, uint8_t data)
+void nes_nina001_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("nina-001 write_m, offset: %04x, data: %02x\n", offset, data));
+
+	device_nes_cart_interface::write_m(offset, data); // write WRAM
 
 	switch (offset)
 	{
@@ -109,8 +110,6 @@ void nes_nina001_device::write_m(offs_t offset, uint8_t data)
 			chr4_4(data, CHRROM);
 			break;
 	}
-
-	m_prgram[offset] = data;
 }
 
 /*-------------------------------------------------
@@ -126,7 +125,7 @@ void nes_nina001_device::write_m(offs_t offset, uint8_t data)
 
  -------------------------------------------------*/
 
-void nes_nina006_device::write_l(offs_t offset, uint8_t data)
+void nes_nina006_device::write_l(offs_t offset, u8 data)
 {
 	LOG_MMC(("nina-006 write_l, offset: %04x, data: %02x\n", offset, data));
 

--- a/src/devices/bus/nes/ave.h
+++ b/src/devices/bus/nes/ave.h
@@ -14,9 +14,9 @@ class nes_nina001_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_nina001_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_nina001_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 };
 
 
@@ -26,9 +26,9 @@ class nes_nina006_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_nina006_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_nina006_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_l(offs_t offset, uint8_t data) override;
+	virtual void write_l(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/bandai.cpp
+++ b/src/devices/bus/nes/bandai.cpp
@@ -115,7 +115,6 @@ void nes_oekakids_device::pcb_reset()
 	prg32(0);
 	chr4_0(0, CHRRAM);
 	chr4_4(3, CHRRAM);
-	set_nt_mirroring(PPU_MIRROR_LOW);
 	m_latch = 0;
 	m_reg = 0;
 }
@@ -132,7 +131,6 @@ void nes_fcg_device::device_start()
 
 void nes_fcg_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -154,7 +152,6 @@ void nes_lz93d50_24c01_device::device_start()
 
 void nes_lz93d50_24c01_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/batlab.cpp
+++ b/src/devices/bus/nes/batlab.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 /***********************************************************************************************************
 
 
@@ -51,7 +51,6 @@ nes_batmap_srrx_device::nes_batmap_srrx_device(const machine_config &mconfig, co
 
 void nes_batmap_000_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0xff, 0);
 
 	prg16_89ab(0);

--- a/src/devices/bus/nes/batlab.h
+++ b/src/devices/bus/nes/batlab.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 #ifndef MAME_BUS_NES_BATLAB_H
 #define MAME_BUS_NES_BATLAB_H
 

--- a/src/devices/bus/nes/bootleg.cpp
+++ b/src/devices/bus/nes/bootleg.cpp
@@ -249,7 +249,6 @@ void nes_sc127_device::device_start()
 
 void nes_sc127_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0xff);
 	chr8(0, m_chr_source);
 
@@ -271,7 +270,6 @@ void nes_mbaby_device::device_start()
 void nes_mbaby_device::pcb_reset()
 {
 	prg32((m_prg_chunks - 1) >> 1);
-	chr8(0, CHRRAM);
 
 	m_irq_enable = 0;
 	m_irq_count = 0;
@@ -286,7 +284,6 @@ void nes_asn_device::device_start()
 
 void nes_asn_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32((m_prg_chunks - 1) >> 1);
 	chr8(0, m_chr_source);
 
@@ -349,7 +346,6 @@ void nes_btl_dn_device::device_start()
 
 void nes_btl_dn_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -418,7 +414,6 @@ void nes_smb2jb_device::pcb_reset()
 	prg8_ab(0x09);
 	prg8_cd(0);    // switchable bank
 	prg8_ef(0x0b);
-	chr8(0, CHRRAM);
 
 	m_irq_enable = 0;
 	m_irq_count = 0;
@@ -443,7 +438,6 @@ void nes_0353_device::device_start()
 void nes_0353_device::pcb_reset()
 {
 	prg32((m_prg_chunks >> 1) - 1);    // fixed 32K bank
-	chr8(0, CHRRAM);
 
 	m_reg = 0;
 }
@@ -461,7 +455,6 @@ void nes_09034a_device::device_start()
 
 void nes_09034a_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -498,7 +491,6 @@ void nes_palthena_device::pcb_reset()
 	prg8_89(0x0c);
 	// 0xa000-0xbfff switchable bank
 	prg16_cdef(m_prg_chunks - 1);
-	chr8(0, CHRRAM);
 
 	m_reg = 0;
 }
@@ -511,9 +503,7 @@ void nes_tobidase_device::device_start()
 
 void nes_tobidase_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(2);
-	chr8(0, m_chr_source);
 
 	m_latch = 0;
 }
@@ -526,7 +516,6 @@ void nes_whirlwind_device::device_start()
 
 void nes_whirlwind_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32((m_prg_chunks >> 1) - 1);      // upper PRG: banks are always fixed
 	chr8(0, m_chr_source);
 
@@ -541,8 +530,6 @@ void nes_lh32_device::device_start()
 
 void nes_lh32_device::pcb_reset()
 {
-	chr8(0, CHRRAM);
-
 	prg32((m_prg_chunks - 1) >> 1);
 	// 0xc000-0xdfff reads/writes WRAM
 	m_latch = 0xf;
@@ -610,8 +597,6 @@ void nes_lh53_device::device_start()
 
 void nes_lh53_device::pcb_reset()
 {
-	chr8(0, CHRRAM);
-
 	prg8_89(0xc);
 	prg8_ab(0xd);   // last 2K are overlaid by WRAM
 	prg8_cd(0xe);   // first 6K are overlaid by WRAM
@@ -629,8 +614,6 @@ void nes_2708_device::device_start()
 
 void nes_2708_device::pcb_reset()
 {
-	chr8(0, CHRRAM);
-
 	prg32(7);
 	// the upper PRG banks never change, but there are 8K of WRAM overlaid to the ROM area based on reg1
 	m_reg[0] = 0;
@@ -645,8 +628,6 @@ void nes_ac08_device::device_start()
 
 void nes_ac08_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	chr8(0, m_chr_source);
 	prg32(0xff);
 	m_latch = 0xff;
 }
@@ -1059,7 +1040,7 @@ void nes_lh31_device::write_h(offs_t offset, u8 data)      // submapper 2
 	if (offset >= 0x6000)
 	{
 		m_reg = data;
-		chr8(data & (m_vrom_chunks - 1), m_chr_source);
+		chr8(data, m_chr_source);
 	}
 }
 

--- a/src/devices/bus/nes/cne.cpp
+++ b/src/devices/bus/nes/cne.cpp
@@ -37,17 +37,17 @@ DEFINE_DEVICE_TYPE(NES_CNE_FSB,     nes_cne_fsb_device,     "nes_cne_fsb",  "NES
 DEFINE_DEVICE_TYPE(NES_CNE_SHLZ,    nes_cne_shlz_device,    "nes_cne_shlz", "NES Cart C&E Sheng Huo Lie Zhuan PCB")
 
 
-nes_cne_decathl_device::nes_cne_decathl_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_cne_decathl_device::nes_cne_decathl_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_CNE_DECATHL, tag, owner, clock)
 {
 }
 
-nes_cne_fsb_device::nes_cne_fsb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_cne_fsb_device::nes_cne_fsb_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_CNE_FSB, tag, owner, clock)
 {
 }
 
-nes_cne_shlz_device::nes_cne_shlz_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_cne_shlz_device::nes_cne_shlz_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_CNE_SHLZ, tag, owner, clock)
 {
 }
@@ -56,7 +56,6 @@ nes_cne_shlz_device::nes_cne_shlz_device(const machine_config &mconfig, const ch
 
 void nes_cne_fsb_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0xff);
 	chr8(0, m_chr_source);
 }
@@ -79,24 +78,20 @@ void nes_cne_fsb_device::pcb_reset()
 
  iNES: mapper 244
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_cne_decathl_device::write_h(offs_t offset, uint8_t data)
+void nes_cne_decathl_device::write_h(offs_t offset, u8 data)
 {
 	LOG_MMC(("cne_decathl_w, offset: %04x, data: %02x\n", offset, data));
 
-	if (offset < 0x0065)
-		return;
-	if (offset < 0x00a5)
+	if (offset >= 0x0065)
 	{
-		prg32((offset - 0x0065) & 0x03);
-		return;
-	}
-	if (offset < 0x00e5)
-	{
-		chr8((offset - 0x00a5) & 0x07, CHRROM);
+		if (offset < 0x00a5)
+			prg32((offset - 0x0065) & 0x03);
+		else if (offset < 0x00e5)
+			chr8((offset - 0x00a5) & 0x07, CHRROM);
 	}
 }
 
@@ -113,11 +108,11 @@ void nes_cne_decathl_device::write_h(offs_t offset, uint8_t data)
 
  iNES: mapper 246
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_cne_fsb_device::write_m(offs_t offset, uint8_t data)
+void nes_cne_fsb_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("cne_fsb write_m, offset: %04x, data: %02x\n", offset, data));
 
@@ -126,43 +121,31 @@ void nes_cne_fsb_device::write_m(offs_t offset, uint8_t data)
 		switch (offset & 0x0007)
 		{
 			case 0x0000:
-				prg8_89(data);
-				break;
 			case 0x0001:
-				prg8_ab(data);
-				break;
 			case 0x0002:
-				prg8_cd(data);
-				break;
 			case 0x0003:
-				prg8_ef(data);
+				prg8_x(offset & 0x03, data);
 				break;
 			case 0x0004:
-				chr2_0(data, CHRROM);
-				break;
 			case 0x0005:
-				chr2_2(data, CHRROM);
-				break;
 			case 0x0006:
-				chr2_4(data, CHRROM);
-				break;
 			case 0x0007:
-				chr2_6(data, CHRROM);
+				chr2_x((offset & 0x03) << 1, data, CHRROM);
 				break;
 		}
 	}
 	else
-		m_battery[offset] = data;
+		device_nes_cart_interface::write_m(offset, data);
 }
 
-uint8_t nes_cne_fsb_device::read_m(offs_t offset)
+u8 nes_cne_fsb_device::read_m(offs_t offset)
 {
 	LOG_MMC(("cne_fsb read_m, offset: %04x\n", offset));
 
 	if (offset >= 0x0800)
-		return m_battery[offset];
+		return device_nes_cart_interface::read_m(offset);
 
-	return 0xff;
+	return get_open_bus();
 }
 
 /*-------------------------------------------------
@@ -178,11 +161,11 @@ uint8_t nes_cne_fsb_device::read_m(offs_t offset)
 
  iNES: mapper 240
 
- In MESS: Supported.
+ In MAME: Supported.
 
  -------------------------------------------------*/
 
-void nes_cne_shlz_device::write_l(offs_t offset, uint8_t data)
+void nes_cne_shlz_device::write_l(offs_t offset, u8 data)
 {
 	LOG_MMC(("cne_shlz write_l, offset: %04x, data: %02x\n", offset, data));
 

--- a/src/devices/bus/nes/cne.h
+++ b/src/devices/bus/nes/cne.h
@@ -14,9 +14,9 @@ class nes_cne_decathl_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_cne_decathl_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_cne_decathl_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -26,10 +26,10 @@ class nes_cne_fsb_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_cne_fsb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_cne_fsb_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 };
@@ -41,9 +41,9 @@ class nes_cne_shlz_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_cne_shlz_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_cne_shlz_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_l(offs_t offset, uint8_t data) override;
+	virtual void write_l(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/datach.cpp
+++ b/src/devices/bus/nes/datach.cpp
@@ -243,7 +243,6 @@ void nes_datach_device::device_start()
 
 void nes_datach_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/event.cpp
+++ b/src/devices/bus/nes/event.cpp
@@ -98,8 +98,6 @@ void nes_event2_device::device_start()
 
 void nes_event2_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_tqrom_mode = false;
 	mmc3_common_initialize(0x07, 0x7f, 0);
 

--- a/src/devices/bus/nes/jncota.cpp
+++ b/src/devices/bus/nes/jncota.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 /***********************************************************************************************************
 
 
@@ -50,7 +50,6 @@ void nes_jncota_kt1001_device::pcb_reset()
 {
 	prg32(0);
 	chr8(0, CHRROM);
-	set_nt_mirroring(PPU_MIRROR_HORZ);
 
 	m_reg[0] = m_reg[1] = m_reg[2] = 0;
 }

--- a/src/devices/bus/nes/jncota.h
+++ b/src/devices/bus/nes/jncota.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 #ifndef MAME_BUS_NES_JNCOTA_H
 #define MAME_BUS_NES_JNCOTA_H
 

--- a/src/devices/bus/nes/jy.cpp
+++ b/src/devices/bus/nes/jy.cpp
@@ -98,7 +98,6 @@ void nes_jy_typea_device::device_start()
 
 void nes_jy_typea_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 

--- a/src/devices/bus/nes/karastudio.cpp
+++ b/src/devices/bus/nes/karastudio.cpp
@@ -198,7 +198,6 @@ void nes_karaokestudio_device::device_start()
 
 void nes_karaokestudio_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef((m_prg_chunks - 1) ^ 0x08);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/konami.cpp
+++ b/src/devices/bus/nes/konami.cpp
@@ -95,7 +95,6 @@ void nes_konami_vrc1_device::device_start()
 
 void nes_konami_vrc1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -112,7 +111,6 @@ void nes_konami_vrc2_device::device_start()
 
 void nes_konami_vrc2_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -136,7 +134,6 @@ void nes_konami_vrc3_device::device_start()
 
 void nes_konami_vrc3_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -251,10 +248,8 @@ u8 nes_konami_vrc2_device::read_m(offs_t offset)
 {
 	LOG_MMC(("VRC-2 read_m, offset: %04x\n", offset));
 
-	if (!m_battery.empty())
-		return m_battery[offset & (m_battery.size() - 1)];
-	else if (!m_prgram.empty())
-		return m_prgram[offset & (m_prgram.size() - 1)];
+	if (!m_battery.empty() || !m_prgram.empty())
+		return device_nes_cart_interface::read_m(offset);
 	else    // VRC2 was planned with EEPROM support; the non-working feature behaves as a vestigial 1-bit latch in $6000-$6fff on certain boards (contraj, ggoemon2 depend on this)
 		return (offset < 0x1000) ? (get_open_bus() & 0xfe) | (m_latch & 1) : get_open_bus();
 }
@@ -263,10 +258,8 @@ void nes_konami_vrc2_device::write_m(offs_t offset, u8 data)
 {
 	LOG_MMC(("VRC-2 write_m, offset: %04x, data: %02x\n", offset, data));
 
-	if (!m_battery.empty())
-		m_battery[offset & (m_battery.size() - 1)] = data;
-	else if (!m_prgram.empty())
-		m_prgram[offset & (m_prgram.size() - 1)] = data;
+	if (!m_battery.empty() || !m_prgram.empty())
+		device_nes_cart_interface::write_m(offset, data);
 	else if (offset < 0x1000)
 		m_latch = data;
 }

--- a/src/devices/bus/nes/legacy.cpp
+++ b/src/devices/bus/nes/legacy.cpp
@@ -76,7 +76,6 @@ void nes_ffe4_device::device_start()
 
 void nes_ffe4_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(7);
 	chr8(0, m_chr_source);
@@ -92,7 +91,6 @@ void nes_ffe4_device::pcb_reset()
 
 void nes_ffe8_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0xff);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/mmc1.h
+++ b/src/devices/bus/nes/mmc1.h
@@ -14,33 +14,36 @@ class nes_sxrom_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_sxrom_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_sxrom_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_m(offs_t offset, uint8_t data) override;
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
 protected:
-	nes_sxrom_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+	nes_sxrom_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock);
 
 	// device-level overrides
 	virtual void device_start() override;
 
 	TIMER_CALLBACK_MEMBER(resync_callback);
 
-	virtual void update_regs(int reg);      // this is needed to simplify NES-EVENT pcb implementation, which handle differently some regs!
+	virtual void update_regs(int reg);
 	void set_prg(int prg_base, int prg_mask);
 	void set_chr(int chr_base, int chr_mask);
 	virtual void set_prg();
 //  virtual void set_prg() { set_prg(0x00, 0x0f); }
 	virtual void set_chr() { set_chr(0x00, 0x1f); }
+	virtual void set_mirror();
 
-	uint8_t m_reg[4];
-	int m_reg_write_enable;
-	int m_latch;
-	int m_count;
+	u8 m_reg[4];
+
+private:
+	u8 m_reg_write_enable;
+	u8 m_latch;
+	u8 m_count;
 };
 
 
@@ -50,10 +53,10 @@ class nes_sorom_device : public nes_sxrom_device
 {
 public:
 	// construction/destruction
-	nes_sorom_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_sorom_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual uint8_t read_m(offs_t offset) override;
-	virtual void write_m(offs_t offset, uint8_t data) override;
+	virtual u8 read_m(offs_t offset) override;
+	virtual void write_m(offs_t offset, u8 data) override;
 };
 
 

--- a/src/devices/bus/nes/mmc1_clones.cpp
+++ b/src/devices/bus/nes/mmc1_clones.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 /***********************************************************************************************************
 
 
@@ -152,7 +152,6 @@ void nes_txc_22110_device::device_start()
 void nes_txc_22110_device::pcb_reset()
 {
 	nes_sxrom_device::pcb_reset();
-	set_nt_mirroring(PPU_MIRROR_VERT);
 
 	m_latch0 = 0;
 	m_mode = 0;

--- a/src/devices/bus/nes/mmc1_clones.h
+++ b/src/devices/bus/nes/mmc1_clones.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 #ifndef MAME_BUS_NES_MMC1_CLONES_H
 #define MAME_BUS_NES_MMC1_CLONES_H
 
@@ -165,6 +165,7 @@ protected:
 
 	virtual void set_prg() override { nes_sxrom_device::set_prg(0x08, 0x07); }
 	virtual void set_chr() override { nes_sxrom_device::set_chr(0x20, 0x1f); }
+	virtual void set_mirror() override {} // hardwired to vertical mirroring
 
 private:
 	void update_banks();

--- a/src/devices/bus/nes/mmc2.cpp
+++ b/src/devices/bus/nes/mmc2.cpp
@@ -59,7 +59,6 @@ void nes_pxrom_device::device_start()
 
 void nes_pxrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg8_89(0);
 	prg8_ab((m_prg_chunks << 1) - 3);
 	prg8_cd((m_prg_chunks << 1) - 2);
@@ -73,7 +72,6 @@ void nes_pxrom_device::pcb_reset()
 
 void nes_fxrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/mmc3.cpp
+++ b/src/devices/bus/nes/mmc3.cpp
@@ -154,7 +154,6 @@ void nes_txrom_device::mmc3_common_initialize( int prg_mask, int chr_mask, int i
 
 void nes_txrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	// 4-screen mirroring is taken care in pcb_start, if needed...
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
@@ -174,7 +173,6 @@ void nes_hkrom_device::device_start()
 
 void nes_hkrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0xff, 0xff, 1);
 	m_mmc6_reg = 0xf0;
 	m_wram_enable = 0;

--- a/src/devices/bus/nes/mmc3_clones.cpp
+++ b/src/devices/bus/nes/mmc3_clones.cpp
@@ -504,8 +504,6 @@ void nes_bmw8544_device::device_start()
 
 void nes_bmw8544_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0x0f, 0xff, 0);
 }
@@ -518,8 +516,6 @@ void nes_family4646_device::device_start()
 
 void nes_family4646_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	mmc3_common_initialize(0x1f, 0xff, 0);
 	set_nt_mirroring(PPU_MIRROR_HORZ); // Space Shuttle on CB-4035 doesn't set mirroring bit. Whether this cart is hard-wired to reset correctly to horizontal mirroring is not clear.
@@ -533,8 +529,6 @@ void nes_pikay2k_device::device_start()
 
 void nes_pikay2k_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = 0xff;
 	m_reg[1] = 0;
 	mmc3_common_initialize(0xff, 0xff, 0);
@@ -548,7 +542,6 @@ void nes_8237_device::device_start()
 
 void nes_8237_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 
 	m_reg[0] = 0;
@@ -577,7 +570,6 @@ void nes_kasing_device::device_start()
 
 void nes_kasing_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	m_mmc3_mode = true;
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
@@ -591,8 +583,6 @@ void nes_kay_device::device_start()
 
 void nes_kay_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	m_low_reg = 0;
 	mmc3_common_initialize(0x1f, 0xff, 0);
@@ -607,8 +597,6 @@ void nes_h2288_device::device_start()
 
 void nes_h2288_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mmc3_mode = true;
 	mmc3_common_initialize(0x3f, 0xff, 0);
 }
@@ -621,9 +609,7 @@ void nes_6035052_device::device_start()
 
 void nes_6035052_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0xff, 0xff, 0);
-
 	m_prot = 0;
 }
 
@@ -635,14 +621,12 @@ void nes_kof96_device::device_start()
 
 void nes_kof96_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	m_mmc3_mode = true;
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
 
 void nes_cocoma_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
 
@@ -654,8 +638,7 @@ void nes_gouder_device::device_start()
 
 void nes_gouder_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	memset(m_reg, 0, sizeof(m_reg));
+	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
 
@@ -668,8 +651,6 @@ void nes_sa9602b_device::device_start()
 
 void nes_sa9602b_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	m_prg_chip = 0;
 	mmc3_common_initialize(0x1ff, 0xff, 0);    // 1.5MB of PRG-ROM, no CHR-ROM but 32K CHR-RAM
@@ -683,8 +664,6 @@ void nes_sachen_shero_device::device_start()
 
 void nes_sachen_shero_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
@@ -711,8 +690,6 @@ void nes_a9746_device::device_start()
 
 void nes_a9746_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = 0;
 	m_reg[1] = 0;
 	m_reg[2] = 0;
@@ -731,14 +708,12 @@ void nes_a88s1_device::device_start()
 
 void nes_a88s1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 	update_banks();
 }
 
 void nes_bmc_el86xc_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize((m_outer_prg_size >> 3) - 1, 0x7f, 0);
 }
 
@@ -751,8 +726,6 @@ void nes_fk23c_device::device_start()
 
 void nes_fk23c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mmc_cmd1 = 0;
 	m_reg[0] = 4;
 	m_reg[1] = 0xff;
@@ -765,8 +738,6 @@ void nes_fk23c_device::pcb_reset()
 
 void nes_fk23ca_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mmc_cmd1 = 0;
 	m_reg[0] = m_reg[1] = m_reg[2] = m_reg[3] = 0;
 	m_reg[4] = m_reg[5] = m_reg[6] = m_reg[7] = 0xff;
@@ -777,7 +748,6 @@ void nes_fk23ca_device::pcb_reset()
 
 void nes_nt639_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0xff, 0);
 }
 
@@ -790,7 +760,6 @@ void nes_resettxrom_device::device_start()
 
 void nes_resettxrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize((m_outer_prg_size >> 3) - 1, m_outer_chr_size - 1, 0);
 
 	m_count = (m_count + 1) & 3;
@@ -808,8 +777,6 @@ void nes_s24in1sc03_device::device_start()
 
 void nes_s24in1sc03_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = 0x24;
 	m_reg[1] = 0x9f;
 	m_reg[2] = 0;
@@ -824,35 +791,29 @@ void nes_tech9in1_device::device_start()
 
 void nes_tech9in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = m_reg[1] = m_reg[2] = 0;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 }
 
 void nes_bmc_5in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 	prg32(0);
 }
 
 void nes_bmc_8in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 	prg32(0);
 }
 
 void nes_bmc_15in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 }
 
 void nes_bmc_sbig7_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
 
@@ -865,7 +826,6 @@ void nes_bmc_hik8_device::device_start()
 
 void nes_bmc_hik8_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	set_nt_mirroring(PPU_MIRROR_VERT);  // necessary since some boards/games don't reliably set mirroring (Rockman 1 on mc_s13 at least)
 
 	m_count = 0;
@@ -888,14 +848,12 @@ void nes_bmc_hik4_device::device_start()
 
 void nes_bmc_hik4_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	m_mmc3_mode = true;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
 
 void nes_bmc_f15_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 	prg16_89ab(0);
 	prg16_cdef(0);
@@ -921,8 +879,6 @@ void nes_bmc_gn45_device::device_start()
 
 void nes_bmc_gn45_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_lock = false;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
@@ -941,7 +897,6 @@ void nes_bmc_gold7in1_device::pcb_reset()
 
 void nes_bmc_k3006_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 	prg16_89ab(0);
 	prg16_cdef(0);
@@ -955,8 +910,6 @@ void nes_bmc_k3033_device::device_start()
 
 void nes_bmc_k3033_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mmc3_mode = false;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 	prg16_89ab(0);
@@ -971,8 +924,6 @@ void nes_bmc_l6in1_device::device_start()
 
 void nes_bmc_l6in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0x0f, 0x07, 0);
 }
@@ -985,8 +936,6 @@ void nes_bmc_00202650_device::device_start()
 
 void nes_bmc_00202650_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mmc3_mode = false;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 
@@ -1003,8 +952,6 @@ void nes_bmc_411120c_device::device_start()
 
 void nes_bmc_411120c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
@@ -1029,27 +976,22 @@ void nes_bmc_820720c_device::device_start()
 
 void nes_bmc_820720c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0x0f, 0xff, 0);
 }
 
 void nes_bmc_830118c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
 
 void nes_bmc_830832c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x1f, 0xff, 0);
 }
 
 void nes_bmc_yy841101c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
 
@@ -1061,8 +1003,6 @@ void nes_bmc_yy841155c_device::device_start()
 
 void nes_bmc_yy841155c_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = m_reg[1];
 	mmc3_common_initialize(0x0f, 0x7f, 0);
 }
@@ -1075,9 +1015,7 @@ void nes_pjoy84_device::device_start()
 
 void nes_pjoy84_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
-	memset(m_reg, 0, sizeof(m_reg));
+	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	set_base_mask();
 	mmc3_common_initialize(m_prg_mask, m_chr_mask, 0);
 }
@@ -1090,8 +1028,6 @@ void nes_smd133_device::device_start()
 
 void nes_smd133_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
 	mmc3_common_initialize(0x3f, 0xff, 0);
 }

--- a/src/devices/bus/nes/mmc5.cpp
+++ b/src/devices/bus/nes/mmc5.cpp
@@ -96,7 +96,6 @@ void nes_exrom_device::device_start()
 
 void nes_exrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(m_prg_chunks - 2);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/multigame.cpp
+++ b/src/devices/bus/nes/multigame.cpp
@@ -574,7 +574,6 @@ void nes_rumblestat_device::device_start()
 
 void nes_rumblestat_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -592,7 +591,6 @@ void nes_svision16_device::device_start()
 void nes_svision16_device::pcb_reset()
 {
 	prg32(0);
-	chr8(0, CHRRAM);
 
 	m_latch1 = 0;
 	m_latch2 = 0;
@@ -608,7 +606,6 @@ void nes_farid_unrom_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_reg &= 0x87;    // only middle four bits cleared on soft reset
 }
@@ -624,16 +621,12 @@ void nes_kn42_device::pcb_reset()
 	m_latch ^= 0x10;
 	prg16_89ab(m_latch);
 	prg16_cdef(m_latch | 0x0f);    // fixed to last bank for either game
-	chr8(0, CHRRAM);
 }
 
 void nes_a65as_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(7);
-	set_nt_mirroring(PPU_MIRROR_VERT);
-	chr8(0, m_chr_source);
 }
 
 void nes_t262_device::device_start()
@@ -646,7 +639,6 @@ void nes_t262_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -656,7 +648,6 @@ void nes_sgun20in1_device::pcb_reset()
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, CHRROM);
-	set_nt_mirroring(PPU_MIRROR_VERT);
 }
 
 void nes_vt5201_device::device_start()
@@ -684,8 +675,6 @@ void nes_bmc_80013b_device::device_start()
 
 void nes_bmc_80013b_device::pcb_reset()
 {
-	chr8(0, CHRRAM);
-
 	m_latch = 0x80;
 	m_reg[0] = m_reg[1] = 0;
 	update_prg();
@@ -708,8 +697,6 @@ void nes_bmc_830425c_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(0x0f);
-	chr8(0, CHRRAM);
-	set_nt_mirroring(PPU_MIRROR_VERT);
 
 	m_latch = 0;
 }
@@ -724,7 +711,6 @@ void nes_bmc_830928c_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -739,7 +725,6 @@ void nes_bmc_850437c_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_reg[0] = m_reg[1] = 0;
 }
@@ -754,7 +739,6 @@ void nes_bmc_970630c_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -810,7 +794,6 @@ void nes_bmc_gn91b_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -819,14 +802,12 @@ void nes_bmc_k3036_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 }
 
 void nes_bmc_k3046_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 }
 
 void nes_bmc_k3071_device::pcb_reset()
@@ -846,7 +827,6 @@ void nes_bmc_s009_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_reg = 0;
 }
@@ -884,7 +864,6 @@ void nes_bmc_th2348_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -897,7 +876,6 @@ void nes_bmc_ws_device::device_start()
 
 void nes_bmc_ws_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -927,7 +905,6 @@ void nes_bmc_8157_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(0);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 }
@@ -948,7 +925,6 @@ void nes_bmc_ball11_device::device_start()
 void nes_bmc_ball11_device::pcb_reset()
 {
 	prg32(0);
-	chr8(0, CHRRAM);
 
 	m_reg[0] = 2;
 	m_reg[1] = 0;
@@ -975,7 +951,6 @@ void nes_bmc_22games_device::pcb_reset()
 		set_nt_mirroring(PPU_MIRROR_VERT);
 		m_reset = 1;
 	}
-	chr8(0, CHRRAM);
 }
 
 void nes_bmc_64y2k_device::device_start()
@@ -1004,7 +979,6 @@ void nes_bmc_420y2k_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(7);
-	chr8(0, CHRRAM);
 
 	m_latch = 0;
 	m_reg = 0;
@@ -1024,7 +998,6 @@ void nes_bmc_12in1_device::pcb_reset()
 
 void nes_bmc_35in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, m_chr_source);
@@ -1032,7 +1005,6 @@ void nes_bmc_35in1_device::pcb_reset()
 
 void nes_bmc_36in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(m_prg_chunks - 1);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -1040,7 +1012,6 @@ void nes_bmc_36in1_device::pcb_reset()
 
 void nes_bmc_64in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, m_chr_source);
@@ -1054,7 +1025,6 @@ void nes_bmc_70in1_device::device_start()
 
 void nes_bmc_70in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	chr8(0, m_chr_source);
 
 	m_latch[0] = m_latch[1] = 0;
@@ -1076,7 +1046,6 @@ void nes_bmc_76in1_device::device_start()
 void nes_bmc_76in1_device::pcb_reset()
 {
 	prg32(0);
-	chr8(0, CHRRAM);
 
 	m_reg[0] = m_reg[1] = 0;
 }
@@ -1096,7 +1065,6 @@ void nes_bmc_1200in1_device::device_start()
 
 void nes_bmc_1200in1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, m_chr_source);
@@ -1131,7 +1099,6 @@ void nes_bmc_42in1reset_device::pcb_reset()
 {
 	m_latch ^= 0x20;
 	prg32(m_latch >> 1);
-	chr8(0, CHRRAM);
 }
 
 void nes_vram_protect_device::device_start()
@@ -1143,7 +1110,6 @@ void nes_vram_protect_device::device_start()
 void nes_vram_protect_device::pcb_reset()
 {
 	prg32(0);
-	chr8(0, CHRRAM);
 	m_vram_protect = false;
 }
 

--- a/src/devices/bus/nes/multigame.h
+++ b/src/devices/bus/nes/multigame.h
@@ -559,7 +559,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	u8 m_reg = 0;
+	u8 m_reg;
 };
 
 
@@ -620,7 +620,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	u8 m_latch = 0;
+	u8 m_latch;
 };
 
 

--- a/src/devices/bus/nes/namcot.cpp
+++ b/src/devices/bus/nes/namcot.cpp
@@ -98,7 +98,6 @@ void nes_namcot3433_device::device_start()
 
 void nes_namcot3433_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(m_prg_chunks - 2);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -114,7 +113,6 @@ void nes_namcot3446_device::device_start()
 
 void nes_namcot3446_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -131,7 +129,6 @@ void nes_namcot3425_device::device_start()
 
 void nes_namcot3425_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -156,7 +153,6 @@ void nes_namcot340_device::device_start()
 
 void nes_namcot340_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -183,7 +179,6 @@ void nes_namcot175_device::device_start()
 
 void nes_namcot175_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -231,7 +226,6 @@ void nes_namcot163_device::device_start()
 
 void nes_namcot163_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/nanjing.cpp
+++ b/src/devices/bus/nes/nanjing.cpp
@@ -60,7 +60,6 @@ void nes_nanjing_device::device_start()
 
 void nes_nanjing_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(m_prg_chunks - 2);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/nes_pcb.hxx
+++ b/src/devices/bus/nes/nes_pcb.hxx
@@ -678,8 +678,6 @@ void nes_cart_slot_device::call_load_pcb()
 				m_cart->set_mmc1_type(mmc1_type::MMC1A);
 			else if (!strncmp(type, "MMC1B", 5)) // common prefix of several variants
 				m_cart->set_mmc1_type(mmc1_type::MMC1B);
-			else if (!strcmp(type, "MMC1C"))
-				m_cart->set_mmc1_type(mmc1_type::MMC1C);
 		}
 	}
 

--- a/src/devices/bus/nes/nes_slot.h
+++ b/src/devices/bus/nes/nes_slot.h
@@ -182,7 +182,7 @@ enum
 class device_nes_cart_interface : public device_interface
 {
 public:
-	enum class mmc1_type : u8 { MMC1, MMC1A, MMC1B, MMC1C };
+	enum class mmc1_type : u8 { MMC1, MMC1A, MMC1B };
 
 	// construction/destruction
 	virtual ~device_nes_cart_interface();

--- a/src/devices/bus/nes/ntdec.cpp
+++ b/src/devices/bus/nes/ntdec.cpp
@@ -79,7 +79,6 @@ void nes_ntdec_fh_device::pcb_reset()
 {
 	prg32((m_prg_chunks - 1) >> 1);
 	chr8(0, CHRROM);
-	set_nt_mirroring(PPU_MIRROR_VERT);
 }
 
 void nes_ntdec_n715021_device::pcb_reset()

--- a/src/devices/bus/nes/nxrom.cpp
+++ b/src/devices/bus/nes/nxrom.cpp
@@ -147,14 +147,12 @@ void nes_nrom_device::common_start()
 
 void nes_nrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 }
 
 void nes_axrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -169,7 +167,6 @@ void nes_cnrom_device::device_start()
 
 void nes_cnrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -178,7 +175,6 @@ void nes_cnrom_device::pcb_reset()
 
 void nes_cprom_device::pcb_reset()
 {
-	m_chr_source = CHRRAM;
 	prg32(0);
 	chr4_0(0, m_chr_source);
 	chr4_4(0, m_chr_source);
@@ -186,7 +182,6 @@ void nes_cprom_device::pcb_reset()
 
 void nes_uxrom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -194,7 +189,6 @@ void nes_uxrom_device::pcb_reset()
 
 void nes_un1rom_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/pirate.cpp
+++ b/src/devices/bus/nes/pirate.cpp
@@ -47,12 +47,12 @@ DEFINE_DEVICE_TYPE(NES_43272,       nes_43272_device,       "nes_43272",       "
 DEFINE_DEVICE_TYPE(NES_EH8813A,     nes_eh8813a_device,     "nes_eh8813a",     "NES Cart UNL-EH8813A PCB")
 
 
-nes_agci_device::nes_agci_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_agci_device::nes_agci_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_AGCI_50282, tag, owner, clock)
 {
 }
 
-nes_dreamtech_device::nes_dreamtech_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_dreamtech_device::nes_dreamtech_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_DREAMTECH01, tag, owner, clock)
 {
 }
@@ -72,7 +72,7 @@ nes_magseries_device::nes_magseries_device(const machine_config &mconfig, const 
 {
 }
 
-nes_daou306_device::nes_daou306_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+nes_daou306_device::nes_daou306_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: nes_nrom_device(mconfig, NES_DAOU306, tag, owner, clock)
 {
 }
@@ -112,10 +112,8 @@ nes_eh8813a_device::nes_eh8813a_device(const machine_config &mconfig, const char
 
 void nes_dreamtech_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(8);
-	chr8(0, m_chr_source);
 }
 
 void nes_fukutake_device::device_start()
@@ -129,7 +127,6 @@ void nes_fukutake_device::device_start()
 
 void nes_fukutake_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, m_chr_source);
@@ -163,18 +160,24 @@ void nes_daou306_device::device_start()
 
 void nes_daou306_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(m_prg_chunks - 2);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
 	set_nt_mirroring(PPU_MIRROR_LOW);
 
-	memset(m_reg, 0, sizeof(m_reg));
+	std::fill(std::begin(m_reg), std::end(m_reg), 0x00);
+}
+
+void nes_cc21_device::pcb_reset()
+{
+	prg32(0);
+	chr4_0(0, CHRROM);
+	chr4_4(0, CHRROM);
+	set_nt_mirroring(PPU_MIRROR_LOW);
 }
 
 void nes_xiaozy_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32((m_prg_chunks - 1) >> 1);
 	chr8(0, m_chr_source);
 }
@@ -187,7 +190,6 @@ void nes_edu2k_device::device_start()
 
 void nes_edu2k_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -223,7 +225,6 @@ void nes_43272_device::device_start()
 
 void nes_43272_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32((m_prg_chunks - 1) >> 1);
 	chr8(0, m_chr_source);
 
@@ -290,12 +291,12 @@ void nes_agci_device::write_h(offs_t offset, u8 data)
 
  -------------------------------------------------*/
 
-void nes_dreamtech_device::write_l(offs_t offset, uint8_t data)
+void nes_dreamtech_device::write_l(offs_t offset, u8 data)
 {
 	LOG_MMC(("dreamtech write_l, offset: %04x, data: %02x\n", offset, data));
-	offset += 0x100;
 
-	if (offset == 0x1020)   /* 0x5020 */
+	offset += 0x100;
+	if (offset >= 0x1000)
 		prg16_89ab(data);
 }
 
@@ -732,7 +733,6 @@ void nes_fujiya_device::device_start()
 
 void nes_fujiya_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/pirate.h
+++ b/src/devices/bus/nes/pirate.h
@@ -14,9 +14,9 @@ class nes_agci_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_agci_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_agci_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 };
 
 
@@ -26,9 +26,9 @@ class nes_dreamtech_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_dreamtech_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_dreamtech_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_l(offs_t offset, uint8_t data) override;
+	virtual void write_l(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 };
@@ -100,9 +100,9 @@ class nes_daou306_device : public nes_nrom_device
 {
 public:
 	// construction/destruction
-	nes_daou306_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+	nes_daou306_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
-	virtual void write_h(offs_t offset, uint8_t data) override;
+	virtual void write_h(offs_t offset, u8 data) override;
 
 	virtual void pcb_reset() override;
 
@@ -111,7 +111,7 @@ protected:
 	virtual void device_start() override;
 
 private:
-	uint8_t m_reg[16];
+	u8 m_reg[16];
 };
 
 
@@ -124,6 +124,8 @@ public:
 	nes_cc21_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock);
 
 	virtual void write_h(offs_t offset, u8 data) override;
+
+	virtual void pcb_reset() override;
 };
 
 

--- a/src/devices/bus/nes/racermate.cpp
+++ b/src/devices/bus/nes/racermate.cpp
@@ -51,7 +51,6 @@ void nes_racermate_device::device_start()
 
 void nes_racermate_device::pcb_reset()
 {
-//  m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr4_0(0, CHRRAM);

--- a/src/devices/bus/nes/rexsoft.cpp
+++ b/src/devices/bus/nes/rexsoft.cpp
@@ -59,7 +59,6 @@ void nes_rex_dbz5_device::device_start()
 
 void nes_rex_dbz5_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	m_extra = 0;
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
@@ -75,8 +74,6 @@ void nes_rex_sl1632_device::device_start()
 
 void nes_rex_sl1632_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_mode = 0;
 	m_mirror[0] = m_mirror[1] = 0;
 	m_vrc2_prg_bank[0] = m_vrc2_prg_bank[1] = 0;

--- a/src/devices/bus/nes/sachen.cpp
+++ b/src/devices/bus/nes/sachen.cpp
@@ -21,10 +21,6 @@
  * Sachen Discrete PCBs [mapper 150 & 243]
  * Sachen 8259 [mapper 141 (A), 138 (B), 139 (C), 137 (D)]
 
- Known issues on specific mappers:
-
- * 133 Qi Wang starts with corrupted graphics (ingame seems better)
-
 
  ***********************************************************************************************************/
 
@@ -159,7 +155,6 @@ nes_sachen_8259d_device::nes_sachen_8259d_device(const machine_config &mconfig, 
 
 void nes_sachen_tca01_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(1);
 	chr8(0, m_chr_source);
@@ -173,7 +168,6 @@ void nes_sachen_tcu02_device::device_start()
 
 void nes_sachen_tcu02_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -203,7 +197,6 @@ void nes_sachen_74x374_device::device_start()
 
 void nes_sachen_74x374_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -220,7 +213,6 @@ void nes_sachen_8259a_device::device_start()
 
 void nes_sachen_8259a_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 	set_nt_mirroring(PPU_MIRROR_VERT);
@@ -231,7 +223,6 @@ void nes_sachen_8259a_device::pcb_reset()
 
 void nes_sachen_8259d_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(m_vrom_chunks - 1, CHRROM);
 	set_nt_mirroring(PPU_MIRROR_VERT);

--- a/src/devices/bus/nes/sealie.cpp
+++ b/src/devices/bus/nes/sealie.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 /***********************************************************************************************************
 
 
@@ -77,7 +77,6 @@ void nes_dpcmcart_device::pcb_reset()
 {
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
-	chr8(0, CHRRAM);
 }
 
 void nes_unrom512_device::pcb_reset()

--- a/src/devices/bus/nes/sealie.h
+++ b/src/devices/bus/nes/sealie.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders: kmg, Fabio Priuli
+// copyright-holders:kmg
 #ifndef MAME_BUS_NES_SEALIE_H
 #define MAME_BUS_NES_SEALIE_H
 

--- a/src/devices/bus/nes/somari.cpp
+++ b/src/devices/bus/nes/somari.cpp
@@ -73,8 +73,6 @@ void nes_somari_device::device_start()
 void nes_somari_device::pcb_reset()
 {
 	m_board_mode = SOMARI_MMC3_MODE;
-
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0xff, 0xff, 0);
 
 	// MMC1 regs

--- a/src/devices/bus/nes/subor.cpp
+++ b/src/devices/bus/nes/subor.cpp
@@ -98,7 +98,6 @@ void nes_subor2_device::device_start()
 
 void nes_subor0_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0x20);
 	chr8(0, m_chr_source);
@@ -108,7 +107,6 @@ void nes_subor0_device::pcb_reset()
 
 void nes_subor1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0x07);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/sunsoft.cpp
+++ b/src/devices/bus/nes/sunsoft.cpp
@@ -93,7 +93,6 @@ nes_sunsoft_5_device::nes_sunsoft_5_device(const machine_config &mconfig, const 
 
 void nes_sunsoft_1_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -101,7 +100,6 @@ void nes_sunsoft_1_device::pcb_reset()
 
 void nes_sunsoft_2_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -122,7 +120,6 @@ void nes_sunsoft_3_device::device_start()
 
 void nes_sunsoft_3_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -141,7 +138,6 @@ void nes_sunsoft_4_device::device_start()
 
 void nes_sunsoft_4_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);
@@ -164,7 +160,6 @@ void nes_sunsoft_fme7_device::device_start()
 
 void nes_sunsoft_fme7_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(m_prg_chunks - 1);
 	chr8(0, m_chr_source);

--- a/src/devices/bus/nes/txc.cpp
+++ b/src/devices/bus/nes/txc.cpp
@@ -85,7 +85,6 @@ void nes_txc_22211_device::device_start()
 
 void nes_txc_22211_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 	m_reg[0] = m_reg[1] = m_reg[2] = m_reg[3] = 0;

--- a/src/devices/bus/nes/waixing.cpp
+++ b/src/devices/bus/nes/waixing.cpp
@@ -183,7 +183,6 @@ void nes_waixing_a_device::device_start()
 
 void nes_waixing_a_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0xff, 0xff, 0);
 
 	std::fill(std::begin(mapper_ram), std::end(mapper_ram), 0x00);
@@ -191,7 +190,6 @@ void nes_waixing_a_device::pcb_reset()
 
 void nes_waixing_g_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	mmc3_common_initialize(0xff, 0xff, 0);
 
 	std::fill(std::begin(mapper_ram), std::end(mapper_ram), 0x00);
@@ -219,8 +217,6 @@ void nes_waixing_j_device::device_start()
 
 void nes_waixing_j_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg[0] = 0x01;
 	m_reg[1] = 0x02;
 	m_reg[2] = 0x7e;
@@ -250,8 +246,6 @@ void nes_waixing_sec_device::device_start()
 
 void nes_waixing_sec_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-
 	m_reg = 0;
 	mmc3_common_initialize(0xff, 0xff, 0);
 }
@@ -264,7 +258,6 @@ void nes_waixing_sgzlz_device::device_start()
 
 void nes_waixing_sgzlz_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 
@@ -279,20 +272,11 @@ void nes_waixing_ffv_device::device_start()
 
 void nes_waixing_ffv_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg16_89ab(0);
 	prg16_cdef(0x1f);
 	chr8(0, m_chr_source);
 
 	m_reg[0] = m_reg[1] = 0;
-}
-
-void nes_waixing_wxzs2_device::pcb_reset()
-{
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
-	prg32(0);
-	chr8(0, m_chr_source);
-	set_nt_mirroring(PPU_MIRROR_VERT);
 }
 
 void nes_waixing_fs304_device::device_start()
@@ -303,7 +287,6 @@ void nes_waixing_fs304_device::device_start()
 
 void nes_waixing_fs304_device::pcb_reset()
 {
-	m_chr_source = m_vrom_chunks ? CHRROM : CHRRAM;
 	prg32(0);
 	chr8(0, m_chr_source);
 

--- a/src/devices/bus/nes/waixing.h
+++ b/src/devices/bus/nes/waixing.h
@@ -327,8 +327,6 @@ public:
 	nes_waixing_wxzs2_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	virtual void write_h(offs_t offset, uint8_t data) override;
-
-	virtual void pcb_reset() override;
 };
 
 

--- a/src/devices/bus/nes_ctrl/dorepiano.cpp
+++ b/src/devices/bus/nes_ctrl/dorepiano.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:kmg, Fabio Priuli
+// copyright-holders:kmg
 /**********************************************************************
 
     Nintendo Family Computer Konami 'Doremikko' RJ250 Piano Keyboard

--- a/src/devices/bus/nes_ctrl/dorepiano.h
+++ b/src/devices/bus/nes_ctrl/dorepiano.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:kmg, Fabio Priuli
+// copyright-holders:kmg
 /**********************************************************************
 
     Nintendo Family Computer Konami 'Doremikko' RJ250 Piano Keyboard

--- a/src/devices/bus/nes_ctrl/konamibag.cpp
+++ b/src/devices/bus/nes_ctrl/konamibag.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:kmg, Fabio Priuli
+// copyright-holders:kmg
 /**********************************************************************
 
     Nintendo Family Computer - Konami Exciting Boxing Air Bag

--- a/src/devices/bus/nes_ctrl/konamibag.h
+++ b/src/devices/bus/nes_ctrl/konamibag.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:kmg, Fabio Priuli
+// copyright-holders:kmg
 /**********************************************************************
 
     Nintendo Family Computer - Konami Exciting Boxing Air Bag


### PR DESCRIPTION
- MMC1: Made mirroring bits overridable for derivative boards. Also removed code for rumored MMC1C variant.
- Moved various boards' hardwired mirroring from pcb_reset() to the software list.
- Removed redundant banking of VRAM for non-banking boards and redundant variable setting at PCB reset.