### PR TITLE
z80: remove undesired state var in cpu implementation

### DIFF
--- a/src/devices/cpu/z80/z80.cpp
+++ b/src/devices/cpu/z80/z80.cpp
@@ -3677,7 +3677,6 @@ void z80_device::execute_set_input(int inputnum, int state)
 		break;
 
 	case INPUT_LINE_IRQ0:
-		if(state && !m_irq_state) m_irq_at = total_cycles() + m_icount;
 		/* update the IRQ state via the daisy chain */
 		m_irq_state = state;
 		if (daisy_chain_present())

--- a/src/devices/cpu/z80/z80.h
+++ b/src/devices/cpu/z80/z80.h
@@ -32,7 +32,6 @@ class z80_device : public cpu_device, public z80_daisy_chain_interface
 public:
 	z80_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	int	cycles_from_irq() { return total_cycles() - m_irq_at; }
 	void z80_set_cycle_tables(const uint8_t *op, const uint8_t *cb, const uint8_t *ed, const uint8_t *xy, const uint8_t *xycb, const uint8_t *ex);
 	template <typename... T> void set_memory_map(T &&... args) { set_addrmap(AS_PROGRAM, std::forward<T>(args)...); }
 	template <typename... T> void set_m1_map(T &&... args) { set_addrmap(AS_OPCODES, std::forward<T>(args)...); }
@@ -283,7 +282,6 @@ protected:
 	uint8_t           m_after_ldair;        /* same, but for LD A,I or LD A,R */
 	uint32_t          m_ea;
 
-	int               m_irq_at;
 	int               m_icount;
 	int               m_icount_executing;
 	uint8_t           m_rtemp;

--- a/src/mame/drivers/spectrum.cpp
+++ b/src/mame/drivers/spectrum.cpp
@@ -778,9 +778,13 @@ void spectrum_state::device_timer(emu_timer &timer, device_timer_id id, int para
 	}
 }
 
+attotime spectrum_state::time_until_int() {
+	return m_screen->time_until_pos(0, get_screen_area().left());
+};
+
 INTERRUPT_GEN_MEMBER(spectrum_state::spec_interrupt)
 {
-	timer_set(m_screen->time_until_pos(0, get_screen_area().left()), TIMER_IRQ_ON, 0);
+	timer_set(time_until_int(), TIMER_IRQ_ON, 0);
 }
 
 void spectrum_state::spectrum_common(machine_config &config)

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -138,6 +138,7 @@ protected:
 	void spectrum_palette(palette_device &palette) const;
 	virtual u32 screen_update_spectrum(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	INTERRUPT_GEN_MEMBER(spec_interrupt);
+	virtual attotime time_until_int();
 
 	DECLARE_SNAPSHOT_LOAD_MEMBER(snapshot_cb);
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);

--- a/src/mame/video/spectrum.cpp
+++ b/src/mame/video/spectrum.cpp
@@ -183,7 +183,7 @@ void spectrum_state::content_early(s8 shift)
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->cycles_from_irq() + shift;
+	u64 now = m_maincpu->attotime_to_clocks(m_screen->frame_period() - time_until_int()) + shift;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() - 1;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 
@@ -201,7 +201,7 @@ void spectrum_state::content_late()
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->cycles_from_irq() + 1;
+	u64 now = m_maincpu->attotime_to_clocks(m_screen->frame_period() - time_until_int()) + 1;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() - 1;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 	for(auto i = 0x04; i; i >>= 1)


### PR DESCRIPTION
Removes undesired state variable (m_irq_at) in z80 implementation per @happppp and @angelosa request in #9637