### PR TITLE
Added FIXME comments to badly behaved I2C target devices

### DIFF
--- a/src/devices/machine/pcf8593.cpp
+++ b/src/devices/machine/pcf8593.cpp
@@ -77,7 +77,7 @@ void pcf8593_device::device_reset()
 	m_pin_scl = 1;
 	m_pin_sda = 1;
 	m_active  = false;
-	m_inp     = 0;
+	m_inp     = 0; // FIXME: sda should default 1 not 0.
 	m_mode    = RTC_MODE_RECV;
 	m_bits    = 0;
 	m_pos     = 0;
@@ -161,6 +161,10 @@ bool pcf8593_device::nvram_write(util::write_stream &file)
 WRITE_LINE_MEMBER(pcf8593_device::scl_w)
 {
 	// send bit
+	// FIXME: Processing on the rising edge of the clock causes sda output to
+	// change while clock is high. This is not allowed.
+	// All received data is currently acknowledge, need to add checks for
+	// valid device-id and ACK/NAK as required.
 	if ((m_active) && (!m_pin_scl) && (state))
 	{
 		switch (m_mode)

--- a/src/devices/machine/x76f041.cpp
+++ b/src/devices/machine/x76f041.cpp
@@ -362,6 +362,9 @@ WRITE_LINE_MEMBER( x76f041_device::write_scl )
 		case STATE_RESET_READ_PASSWORD:
 		case STATE_MASS_PROGRAM:
 		case STATE_MASS_ERASE:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed. Also need to ensure that only valid device-id's and commands
+			// are acknowledged.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )
@@ -592,6 +595,8 @@ WRITE_LINE_MEMBER( x76f041_device::write_scl )
 
 		case STATE_READ_DATA:
 		case STATE_READ_CONFIGURATION_REGISTERS:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )

--- a/src/devices/machine/x76f100.cpp
+++ b/src/devices/machine/x76f100.cpp
@@ -220,6 +220,9 @@ WRITE_LINE_MEMBER( x76f100_device::write_scl )
 		case STATE_LOAD_PASSWORD:
 		case STATE_VERIFY_PASSWORD:
 		case STATE_WRITE_DATA:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed. Also need to ensure that only valid device-id's and commands
+			// are acknowledged.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )
@@ -341,6 +344,8 @@ WRITE_LINE_MEMBER( x76f100_device::write_scl )
 			break;
 
 		case STATE_READ_DATA:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )

--- a/src/devices/sound/mas3507d.cpp
+++ b/src/devices/sound/mas3507d.cpp
@@ -131,7 +131,8 @@ void mas3507d_device::i2c_scl_w(bool line)
 	if(line == i2c_scli)
 		return;
 	i2c_scli = line;
-
+	// FIXME: sda output should only change state when clock is low.
+	// On wrong device-id ensure sda is left high (Think it's OK but not certain)
 	if(i2c_scli) {
 		if(i2c_bus_state == STARTED) {
 			if(i2c_sdai)

--- a/src/mame/machine/zs01.cpp
+++ b/src/mame/machine/zs01.cpp
@@ -378,6 +378,8 @@ WRITE_LINE_MEMBER( zs01_device::write_scl )
 			break;
 
 		case STATE_LOAD_COMMAND:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed. Also need to ensure that only valid device-id's and commands are acknowledged.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )
@@ -542,6 +544,8 @@ WRITE_LINE_MEMBER( zs01_device::write_scl )
 			break;
 
 		case STATE_READ_DATA:
+			// FIXME: Processing on the rising edge of the clock causes sda to change state while clock is high
+			// which is not allowed.
 			if( m_scl == 0 && state != 0 )
 			{
 				if( m_bit < 8 )


### PR DESCRIPTION
I2C slaves should only ACK their own device-id and NAK all others.
SDA output should only change state while clock is low.
Idle state of SDA must be high.