### PR TITLE
add notes: SD2000 and SU2000 hardware, list of games

### DIFF
--- a/src/mame/drivers/su2000.cpp
+++ b/src/mame/drivers/su2000.cpp
@@ -6,20 +6,22 @@
 
     preliminary driver by Phil Bennett
 
-   Known games (needs to be determined as to what games are SU2000 or SD2000 specific):
+   Known SU2000 games:
         * Boxing
-		* Buggy Ball
 		* Dactyl Nightmare SP
         * Dactyl Nightmare 2 - Race For The Eggs!
-		* Ghost Train
-		* Missile Command VR
 		* PacManVR
 		* Shoot For Loot
 		* Sphere
-		* X-Treme Strike
         * Zone Hunter
-
-   SU2000 Hardware Info:
+		
+    Known SD2000 games:
+		* Buggy Ball
+		* Ghost Train
+		* Missile Command VR
+		* X-Treme Strike
+		
+   SU2000 Hardware Info sources:
         An owner's breakdown of system: http://arianchen.de/su2000/status.html
 		Technical Manual: http://arianchen.de/su2000/files/su2000tech.pdf
 

--- a/src/mame/drivers/su2000.cpp
+++ b/src/mame/drivers/su2000.cpp
@@ -24,6 +24,12 @@
    SU2000 Hardware Info sources:
         An owner's breakdown of system: http://arianchen.de/su2000/status.html
 		Technical Manual: http://arianchen.de/su2000/files/su2000tech.pdf
+    
+   SU2000 and SD2000 share the same base hardware:
+        -Intel 486 DX-33 processor
+		-8MB RAM
+		-customised `Expality PIX 1000` card with 16MB Video RAM 
+		 (has Dual Motorola MC88110 CPU, and each game comes with independent firmware for both CPUs)
 
 
     TODO:

--- a/src/mame/drivers/su2000.cpp
+++ b/src/mame/drivers/su2000.cpp
@@ -2,20 +2,26 @@
 // copyright-holders:Philip Bennett
 /***************************************************************************
 
-    Virtuality SU2000 hardware
+    Virtuality SU2000 (Stand Up) and SD2000 (Sit Down) hardware
 
     preliminary driver by Phil Bennett
 
-    Known games:
-        * Dactyl Nightmare SP
-        * Virtual Boxing
-        * Buggy Ball
-        * Missile Command
+   Known games (needs to be determined as to what games are SU2000 or SD2000 specific):
+        * Boxing
+		* Buggy Ball
+		* Dactyl Nightmare SP
+        * Dactyl Nightmare 2 - Race For The Eggs!
+		* Ghost Train
+		* Missile Command VR
+		* PacManVR
+		* Shoot For Loot
+		* Sphere
+		* X-Treme Strike
         * Zone Hunter
 
-
-    Hardware Info:
-        See: http://arianchen.de/su2000/status.html
+   SU2000 Hardware Info:
+        An owner's breakdown of system: http://arianchen.de/su2000/status.html
+		Technical Manual: http://arianchen.de/su2000/files/su2000tech.pdf
 
 
     TODO:


### PR DESCRIPTION
(this is just info for when someone does start a driver)
-First attempt at listing that there are SU2000 (Stand Up) and SD2000 (Sit Down) models
-Attempt at listing the 2000 platform's software (same base hardware, so each system theoretically runs the same software)
-Added a link to SU2000 Technical Manual
-Listed the main base hardware (shared by SD2000 and SU2000)