### PR TITLE
Implement MB4391 as two MC3340 in a single DIP16 package

### DIFF
--- a/src/lib/netlist/generated/nld_devinc.h
+++ b/src/lib/netlist/generated/nld_devinc.h
@@ -949,6 +949,10 @@
 #define MB3614_DIP(...)                                                   \
 	NET_REGISTER_DEVEXT(MB3614_DIP, __VA_ARGS__)
 
+// usage       : MB4391_DIP(name, )
+#define MB4391_DIP(...)                                                   \
+	NET_REGISTER_DEVEXT(MB4391_DIP, __VA_ARGS__)
+
 // usage       : MC3340_DIP(name, )
 #define MC3340_DIP(...)                                                   \
 	NET_REGISTER_DEVEXT(MC3340_DIP, __VA_ARGS__)

--- a/src/lib/netlist/macro/nlm_opamp_lib.cpp
+++ b/src/lib/netlist/macro/nlm_opamp_lib.cpp
@@ -307,6 +307,25 @@ static NETLIST_START(MC3340_DIP)
 	ALIAS(8, VCC)
 NETLIST_END()
 
+static NETLIST_START(MB4391_DIP)
+	MC3340_DIP(A)
+	MC3340_DIP(B)
+	
+	DIPPINS(        /*   +--------------+   */
+		A.INPUT,    /*   |1     ++    16|   */ A.VCC,
+		A.CONTROL,  /*   |2           15|   */ A.OUTPUT,
+		A.GND,      /*   |3           14|   */ A.ROLLOFF,
+		NC.1,       /*   |4           13|   */ NC.4,
+		B.INPUT,    /*   |5           12|   */ B.VCC,
+		B.CONTROL,  /*   |6           11|   */ B.OUTPUT,
+		B.GND,      /*   |7           10|   */ B.ROLLOFF,
+		NC.2,       /*   |8            9|   */ NC.3
+					/*   +--------------+   */
+	)
+	NET_C(A.GND, B.GND)
+	NET_C(A.VCC, B.VCC)
+NETLIST_END()
+
 static NETLIST_START(TL081_DIP)
 	OPAMP(A, "TL084")
 
@@ -637,6 +656,7 @@ NETLIST_START(opamp_lib)
 	NET_MODEL("LM3900_PNP1 PNP(IS=1E-14 BF=40 TF=1E-7 CJC=1E-12 CJE=1E-12 VAF=150 RB=100 RE=5)")
 #endif
 	LOCAL_LIB_ENTRY(MB3614_DIP)
+	LOCAL_LIB_ENTRY(MB4391_DIP)
 	LOCAL_LIB_ENTRY(MC3340_DIP)
 	LOCAL_LIB_ENTRY(TL081_DIP)
 	LOCAL_LIB_ENTRY(TL082_DIP)


### PR DESCRIPTION
A SEGA-branded MB4391 chip (DIP16) seems to be pin-compatible with two units of MC3340 (DIP8) in a single DIP16 socket.

I made the comparison image below:
![mc3340_mb4391](https://user-images.githubusercontent.com/213676/166882641-81c13a0a-4927-4a1f-a0b2-d6b0f90b8527.png)

There's this odd post which seems to indicate another IC has a similar function to the MB4391:  https://forums.arcade-museum.com/threads/wtb-motorola-mc3340.154130/

In that post, a user even said "Well looks like what's listed on the schematic is not what is actually on the board at that IC position. The board has MB4391 ic chips where the schematic says there should be MC3340".

The only missing piece of insight would be for someone more knowledgeable than me to determined whether an MC3340 has the same behavior as the guessed implementation of the MB4391 that is hardcoded in the Sega/Gremlin Borderline audio netlist.

This draft pull request is the initial implementation of this. I've run the `brdrline` driver before and after this change and, unfortunately, the result is not the same (the change results is poorer audio quality and no missile sounds; truck motor can still be heard but with lots of audio noise/clicks), so maybe there's something more yet to be done here.

Some other boards that also use the MB4391 chip are Zaxxon (`src/mame/drivers/zaxxon.cpp`) and "Sega Z80-3D system" games (`src/mame/drivers/turbo.cpp`) Turbo / Indianapolis / Subroc 3D / Buck Rogers: Planet of Zoom / Zoom 909.

This is a low-quality photo of the Zaxxon audio board with the SEGA-branded chip:
![Captura_de_Tela_2022-05-04_as_18 36 26](https://user-images.githubusercontent.com/213676/166878501-b13e2fff-6914-4b5a-9cf2-24e594aba49d.png)
