### PR TITLE
Correct Video Timings for Vigilante (M75-A-C)

### DIFF
--- a/src/mame/drivers/vigilant.cpp
+++ b/src/mame/drivers/vigilant.cpp
@@ -31,8 +31,6 @@ abruptly, without time for final polish.  Seems to finish in level 10
 
 ***************************************************************************/
 
-//Insert Corrected Timings
-
 #include "emu.h"
 #include "includes/vigilant.h"
 #include "includes/iremipt.h"
@@ -625,8 +623,8 @@ void vigilant_state::vigilant(machine_config &config)
 
 	/* video hardware */
 	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
-	screen.set_refresh_hz(55);
-	screen.set_vblank_time(ATTOSECONDS_IN_USEC(2500)); /* not accurate */
+	screen.set_refresh_hz(56.34);
+	screen.set_vblank_time(ATTOSECONDS_IN_USEC(1750)); /* not accurate */
 	screen.set_size(64*8, 32*8);
 	screen.set_visarea((16*8)-1, (64-16)*8-4, 0*8, 32*8-1);
 	screen.set_screen_update(FUNC(vigilant_state::screen_update_vigilant));

--- a/src/mame/drivers/vigilant.cpp
+++ b/src/mame/drivers/vigilant.cpp
@@ -31,6 +31,8 @@ abruptly, without time for final polish.  Seems to finish in level 10
 
 ***************************************************************************/
 
+//Insert Corrected Timings
+
 #include "emu.h"
 #include "includes/vigilant.h"
 #include "includes/iremipt.h"


### PR DESCRIPTION
![Vigilante_Readings](https://user-images.githubusercontent.com/32810066/166914481-a61bd3f1-97df-4aba-9c48-be3d20fde8d5.jpg)
Board Measurements

![Vert](https://user-images.githubusercontent.com/32810066/166914515-9ad97779-d716-4c47-baf6-c8707f232c26.png)
Vertical Refresh

![Horz](https://user-images.githubusercontent.com/32810066/166914521-79f86ce3-fc78-472b-8255-7018e44e2318.png)
Horizontal Refresh

[Vigilante_-_Synchronous.zip](https://github.com/mamedev/mame/files/8630763/Vigilante_-_Synchronous.zip)
sigrok vcd export file

```
// Measured on the original PCB by atrac17
// Pixel clock is 6.144MHz
// H: 256 active pixels, 128 blank pixels
// HSync lasts for 32 pixels, from pixel 40 to 72.
// V blank lasts for 28 lines
// V sync starts 8 lines after Vblank and lasts for 6 lines
// H freq 16.00 kHz
// V freq 56.34  Hz
```

The timing function on the .vcd file is corrupted due to an older version of sigrok.  Above you will find the correct pixel clock timings for the vigilant.cpp - I'm too lazy to update everything, take this information and use it if you'd like!