### PR TITLE
netlist: more c++, less macros

### DIFF
--- a/scripts/src/netlist.lua
+++ b/scripts/src/netlist.lua
@@ -26,6 +26,13 @@ project "netlist"
 
 	addprojectflags()
 
+	configuration "Debug"
+		defines {
+			"NL_DEBUG=true",
+		}
+
+	configuration { }
+
 	defines {
 		"__STDC_CONSTANT_MACROS",
 		"NL_USE_ACADEMIC_SOLVERS=0",

--- a/src/lib/netlist/core/exec.h
+++ b/src/lib/netlist/core/exec.h
@@ -47,27 +47,19 @@ namespace netlist
 		template<typename... Args>
 		void qpush(Args&&...args) noexcept
 		{
-#if (!NL_USE_QUEUE_STATS)
-			m_queue.emplace<false>(std::forward<Args>(args)...); // NOLINT(performance-move-const-arg)
-#else
-			if (!m_use_stats)
+			if (config::use_queue_stats::value && m_use_stats)
 				m_queue.emplace<false>(std::forward<Args>(args)...); // NOLINT(performance-move-const-arg)
 			else
 				m_queue.emplace<true>(std::forward<Args>(args)...); // NOLINT(performance-move-const-arg)
-#endif
 		}
 
 		template <class R>
 		void qremove(const R &elem) noexcept
 		{
-#if (!NL_USE_QUEUE_STATS)
-			m_queue.remove<false>(elem);
-#else
-			if (!m_use_stats)
-				m_queue.remove<false>(elem);
-			else
+			if (config::use_queue_stats::value && m_use_stats)
 				m_queue.remove<true>(elem);
-#endif
+			else
+				m_queue.remove<false>(elem);
 		}
 
 		// Control functions

--- a/src/lib/netlist/nl_base.cpp
+++ b/src/lib/netlist/nl_base.cpp
@@ -91,7 +91,7 @@ namespace netlist
 	, m_time(netlist_time_ext::zero())
 	, m_mainclock(nullptr)
 	, m_use_stats(false)
-	, m_queue(config::MAX_QUEUE_SIZE::value,
+	, m_queue(config::max_queue_size::value,
 		detail::queue_t::id_delegate(&netlist_state_t :: find_net_id, &state),
 		detail::queue_t::obj_delegate(&netlist_state_t :: net_by_id, &state))
 	{
@@ -210,12 +210,12 @@ namespace netlist
 		ENTRY(PUSE_FLOAT128)
 		ENTRY(PPMF_TYPE)
 		ENTRY(PHAS_PMF_INTERNAL)
-		ENTRY(NL_USE_MEMPOOL)
-		ENTRY(NL_USE_QUEUE_STATS)
+		ENTRY_EX(config::use_mempool::value)
+		ENTRY_EX(config::use_queue_stats::value)
 		ENTRY(NL_USE_COPY_INSTEAD_OF_REFERENCE)
 		ENTRY(NL_USE_FLOAT128)
-		ENTRY(NL_USE_FLOAT_MATRIX)
-		ENTRY(NL_USE_LONG_DOUBLE_MATRIX)
+		ENTRY_EX(config::use_float_matrix::value)
+		ENTRY_EX(config::use_long_double_matrix::value)
 		ENTRY(NL_DEBUG)
 		ENTRY(NVCCBUILD)
 
@@ -411,7 +411,7 @@ namespace netlist
 		log().verbose("Total time     {1:15}", total_time);
 
 		// FIXME: clang complains about unreachable code without
-		const bool clang_workaround_unreachable_code(NL_USE_QUEUE_STATS>0);
+		const bool clang_workaround_unreachable_code(config::use_queue_stats::value);
 		if (clang_workaround_unreachable_code)
 		{
 			// Only one serialization should be counted in total time

--- a/src/lib/netlist/nl_config.h
+++ b/src/lib/netlist/nl_config.h
@@ -32,40 +32,6 @@
 //  GENERAL
 //============================================================
 
-/// \brief  Make use of a memory pool for performance related objects.
-///
-/// Set to 1 to compile netlist with memory allocations from a
-/// linear memory pool. This is based of the assumption that
-/// due to enhanced locality there will be less cache misses.
-/// Your mileage may vary.
-///
-
-#ifndef NL_USE_MEMPOOL
-#define NL_USE_MEMPOOL               (1)
-#endif
-
-/// brief default minimum alignment of mempool_arena
-///
-/// 256 is the best compromise between logic applications like MAME
-/// TTL games (e.g. pong) and analog applications like e.g. kidnikik sound.
-///
-/// Best performance for pong is achieved with a value of 16, but this degrades
-/// kidniki performance by ~10%.
-///
-/// More work is needed here.
-#define NL_MEMPOOL_ALIGN            (16)
-
-/// \brief  Enable queue statistics.
-///
-/// Queue statistics come at a performance cost. Although
-/// the cost is low, we disable them here since they are
-/// only needed during development.
-///
-
-#ifndef NL_USE_QUEUE_STATS
-#define NL_USE_QUEUE_STATS             (0)
-#endif
-
 /// \brief  Compile in academic solvers
 ///
 /// Set to 0 to disable compiling the following solvers:
@@ -94,7 +60,7 @@
 ///
 
 #ifndef NL_USE_COPY_INSTEAD_OF_REFERENCE
-#define NL_USE_COPY_INSTEAD_OF_REFERENCE (0)
+#define NL_USE_COPY_INSTEAD_OF_REFERENCE (0)//FIXME: Move to config struct later
 #endif
 
 /// \brief Use backward Euler integration
@@ -119,33 +85,6 @@
 #define NL_USE_FLOAT128 PUSE_FLOAT128
 #endif
 
-/// \brief Prefer 128bit int type for ptime if supported
-///
-/// Set this to one if you want to use 128 bit int for ptime.
-/// This is about 10% slower on a skylake processor for pongf.
-///
-#ifndef NL_PREFER_INT128
-#define NL_PREFER_INT128 (0)
-#endif
-
-/// \brief Support float type for matrix calculations.
-///
-/// Defaults to NL_USE_ACADEMIC_SOLVERS to provide faster build times
-
-#ifndef NL_USE_FLOAT_MATRIX
-#define NL_USE_FLOAT_MATRIX (NL_USE_ACADEMIC_SOLVERS)
-//#define NL_USE_FLOAT_MATRIX 1
-#endif
-
-/// \brief Support long double type for matrix calculations.
-///
-/// Defaults to NL_USE_ACADEMIC_SOLVERS to provide faster build times
-
-#ifndef NL_USE_LONG_DOUBLE_MATRIX
-#define NL_USE_LONG_DOUBLE_MATRIX (NL_USE_ACADEMIC_SOLVERS)
-//#define NL_USE_LONG_DOUBLE_MATRIX 1
-#endif
-
 //============================================================
 //  DEBUGGING
 //============================================================
@@ -155,7 +94,6 @@
 
 #ifndef NL_DEBUG
 #define NL_DEBUG                    (false)
-//#define NL_DEBUG                    (true)
 #endif
 
 ///
@@ -164,9 +102,47 @@
 
 namespace netlist
 {
-	// FIXME: need a better solution for global constants.
-	struct config
+	//============================================================
+	//  GENERAL
+	//============================================================
+
+	struct config_default
 	{
+		/// \brief  Make use of a memory pool for performance related objects.
+		///
+		/// Set to 1 to compile netlist with memory allocations from a
+		/// linear memory pool. This is based of the assumption that
+		/// due to enhanced locality there will be less cache misses.
+		/// Your mileage may vary.
+		///
+		using use_mempool = std::integral_constant<bool, true>;
+
+		/// brief default minimum alignment of mempool_arena
+		///
+		/// 256 is the best compromise between logic applications like MAME
+		/// TTL games (e.g. pong) and analog applications like e.g. kidnikik sound.
+		///
+		/// Best performance for pong is achieved with a value of 16, but this degrades
+		/// kidniki performance by ~10%.
+		///
+		/// More work is needed here.
+		using mempool_align = std::integral_constant<std::size_t, 16>;
+
+		/// \brief Prefer 128bit int type for ptime if supported
+		///
+		/// Set this to one if you want to use 128 bit int for ptime.
+		/// This is about 10% slower on a skylake processor for pongf.
+		///
+		using prefer_int128 = std::integral_constant<bool, false>;
+
+		/// \brief  Enable queue statistics.
+		///
+		/// Queue statistics come at a performance cost. Although
+		/// the cost is low, we disable them here since they are
+		/// only needed during development.
+		///
+		using use_queue_stats = std::integral_constant<bool, false>;
+
 		//============================================================
 		// Time resolution
 		//============================================================
@@ -202,17 +178,23 @@ namespace netlist
 
 		/// \brief Maximum queue size
 		///
-		using MAX_QUEUE_SIZE = std::integral_constant<std::size_t, 1024>; // NOLINT
+		using max_queue_size = std::integral_constant<std::size_t, 1024>; // NOLINT
 
 		/// \brief Maximum queue size for solvers
 		///
-		using MAX_SOLVER_QUEUE_SIZE = std::integral_constant<std::size_t, 512>; // NOLINT
+		using max_solver_queue_size = std::integral_constant<std::size_t, 512>; // NOLINT
 
-		using use_float_matrix = std::integral_constant<bool, NL_USE_FLOAT_MATRIX>;
-		using use_long_double_matrix = std::integral_constant<bool, NL_USE_LONG_DOUBLE_MATRIX>;
+		/// \brief Support float type for matrix calculations.
+		///
+		/// Defaults to NL_USE_ACADEMIC_SOLVERS to provide faster build times
+		using use_float_matrix = std::integral_constant<bool, NL_USE_ACADEMIC_SOLVERS>;
+
+		/// \brief Support long double type for matrix calculations.
+		///
+		/// Defaults to NL_USE_ACADEMIC_SOLVERS to provide faster build times
+		using use_long_double_matrix = std::integral_constant<bool, NL_USE_ACADEMIC_SOLVERS>;
+
 		using use_float128_matrix = std::integral_constant<bool, NL_USE_FLOAT128>;
-
-		using use_mempool = std::integral_constant<bool, NL_USE_MEMPOOL>;
 
 		/// \brief  Floating point types used
 		///
@@ -225,6 +207,15 @@ namespace netlist
 		///  FIXME: More work needed. Review magic numbers.
 		///
 		using fptype = double;
+	};
+
+	/// \brief  Netlist configuration.
+	///
+	/// You can override all netlist build defaults here which are defined
+	/// in \ref config_default.
+	///
+	struct config : public config_default
+	{
 	};
 
 	using nl_fptype = config::fptype;
@@ -317,11 +308,7 @@ namespace netlist
 //  Asserts
 //============================================================
 
-#if defined(MAME_DEBUG) || (NL_DEBUG == true)
-#define nl_assert(x)    passert_always(x)
-#else
-#define nl_assert(x)    do { } while (0)
-#endif
+#define nl_assert(x)    do { if (NL_DEBUG) passert_always(x); } while (0)
 #define nl_assert_always(x, msg) passert_always_msg(x, msg)
 
 #endif // NLCONFIG_H_

--- a/src/lib/netlist/nltypes.h
+++ b/src/lib/netlist/nltypes.h
@@ -144,7 +144,7 @@ namespace netlist
 	///
 
 	using device_arena = std::conditional_t<config::use_mempool::value,
-		plib::mempool_arena<plib::aligned_arena, NL_MEMPOOL_ALIGN>,
+		plib::mempool_arena<plib::aligned_arena, config::mempool_align::value>,
 		plib::aligned_arena>;
 	using host_arena   = plib::aligned_arena;
 
@@ -183,7 +183,7 @@ namespace netlist
 	} // namespace detail
 
 	using netlist_time = plib::ptime<std::int64_t, config::INTERNAL_RES::value>;
-	using netlist_time_ext = plib::ptime<std::conditional<NL_PREFER_INT128 && plib::compile_info::has_int128::value, INT128, std::int64_t>::type, config::INTERNAL_RES::value>;
+	using netlist_time_ext = plib::ptime<std::conditional<config::prefer_int128::value && plib::compile_info::has_int128::value, INT128, std::int64_t>::type, config::INTERNAL_RES::value>;
 
 	static_assert(noexcept(netlist_time::from_nsec(1)), "Not evaluated as constexpr");
 

--- a/src/lib/netlist/solver/nld_solver.cpp
+++ b/src/lib/netlist/solver/nld_solver.cpp
@@ -56,8 +56,8 @@ namespace devices
 		const netlist_time_ext now(exec().time());
 		const std::size_t nthreads = m_params.m_parallel() < 2 ? 1 : std::min(static_cast<std::size_t>(m_params.m_parallel()), plib::omp::get_max_threads());
 		const netlist_time_ext sched(now + (nthreads <= 1 ? netlist_time_ext::zero() : netlist_time_ext::from_nsec(100)));
-		plib::uninitialised_array<solver::matrix_solver_t *, config::MAX_SOLVER_QUEUE_SIZE::value> tmp; //NOLINT
-		plib::uninitialised_array<netlist_time, config::MAX_SOLVER_QUEUE_SIZE::value> nt; //NOLINT
+		plib::uninitialised_array<solver::matrix_solver_t *, config::max_solver_queue_size::value> tmp; //NOLINT
+		plib::uninitialised_array<netlist_time, config::max_solver_queue_size::value> nt; //NOLINT
 		std::size_t p=0;
 
 		while (!m_queue.empty())

--- a/src/lib/netlist/solver/nld_solver.h
+++ b/src/lib/netlist/solver/nld_solver.h
@@ -34,7 +34,7 @@ namespace devices
 		, m_fb_step(*this, "FB_step", NETLIB_DELEGATE(fb_step<false>))
 		, m_Q_step(*this, "Q_step")
 		, m_params(*this, "", solver::solver_parameter_defaults::get_instance())
-		, m_queue(config::MAX_SOLVER_QUEUE_SIZE::value,
+		, m_queue(config::max_solver_queue_size(),
 			queue_type::id_delegate(&NETLIB_NAME(solver) :: get_solver_id, this),
 			queue_type::obj_delegate(&NETLIB_NAME(solver) :: solver_by_id, this))
 		{


### PR DESCRIPTION
- Reduce the use of macros by converting defines into c++ constants.
- more minor code clean up.