### PR TITLE
Update Daze before Christmas entry in megadriv software list

### DIFF
--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -14233,6 +14233,7 @@ but dumps still have to be confirmed.
 		<description>Daze Before Christmas (Oceania)</description>
 		<year>1994</year>
 		<publisher>Sunsoft</publisher>
+		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="daze before christmas (aus).bin" size="2097152" crc="b95e25c9" sha1="240c0d9487d7659a4b2999e0394d552ab17bee8a"/>
@@ -14244,7 +14245,6 @@ but dumps still have to be confirmed.
 		<description>Daze Before Christmas (Oceania, Prototype)</description>
 		<year>1994</year>
 		<publisher>Sunsoft</publisher>
-		<sharedfeat name="compatibility" value="PAL"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="2097152">
 				<rom name="daze before christmas (aus) (beta).bin" size="2097152" crc="317c9491" sha1="a63cdb54c31b1c1219467987a81e761ee92feee3"/>

--- a/hash/megadriv.xml
+++ b/hash/megadriv.xml
@@ -10351,7 +10351,7 @@ but dumps still have to be confirmed.
 		<description>The Adventures of Mighty Max (USA)</description>
 		<year>1994</year>
 		<publisher>Ocean</publisher>
-        <sharedfeat name="compatibility" value="NTSC-U,NTSC-J"/>
+		<sharedfeat name="compatibility" value="NTSC-U,NTSC-J"/>
 		<part name="cart" interface="megadriv_cart">
 			<dataarea name="rom" width="16" endianness="big" size="1048576">
 				<rom name="adventures of mighty max, the (usa).bin" size="1048576" crc="55f13a00" sha1="147364ce2de49a85bb64dd7f1075d9687d4fe89e"/>


### PR DESCRIPTION
In PR https://github.com/mamedev/mame/pull/9688 I updated the wrong "Daze before Christmas" ROM entry.

It is the released version which has PAL region lock (it displays a message).

The prototype has no region locking in place and will run on all three console regions.

This error was also mentioned in the unmerged closed PR https://github.com/mamedev/mame/pull/9691

This PR also corrects a minor formatting issue (spaces instead of tabs) that I made in PR 9688.