### PR TITLE
Various software list kana metadata cleanups.

### DIFF
--- a/hash/dc.xml
+++ b/hash/dc.xml
@@ -632,7 +632,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Sega</publisher>
 		<info name="serial" value="HDR-0080"/>
 		<info name="release" value="20001012"/>
-		<info name="alt_title" value="エイティーン･ホイーラー"/>
+		<info name="alt_title" value="エイティーン・ホイーラー"/>
 		<info name="ring_code" value="&lt;HDR-0080-0529&gt;HK919C"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
@@ -791,7 +791,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<!-- Front Inlay ID: 673-01375 -->
 		<!-- Back Inlay ID: 673-01376 -->
 		<info name="release" value="20000622"/>
-		<info name="alt_title" value="アドバンスド大戦略～ヨーロッパの嵐･ドイツ電撃作戦～"/>
+		<info name="alt_title" value="アドバンスド大戦略～ヨーロッパの嵐・ドイツ電撃作戦～"/>
 		<info name="ring_code" value="HDR-0066-0405A   10M2   C   05"/>
 		<info name="barcode" value="4 974365 500665"/>
 		<part interface="cdrom" name="cdrom">
@@ -4019,7 +4019,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 	    <publisher>Abel</publisher>
 	    <info name="serial" value="T-44406M"/>
 	    <info name="release" value="20020328"/>
-	    <info name="alt_title" value="カード･オブ･デスティニー 〜光と闇の統合者〜"/>
+	    <info name="alt_title" value="カード・オブ・デスティニー 〜光と闇の統合者〜"/>
 	    <part interface="cdrom" name="cdrom">
 	        <diskarea name="cdrom">
 	            <disk name="card of destiny hikari to yami no tougousha (jpn)" status="nodump"/>
@@ -4062,7 +4062,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Abel</publisher>
 		<info name="serial" value="T-44405M"/>
 		<info name="release" value="20020328"/>
-		<info name="alt_title" value="カード･オブ･デスティニー 〜光と闇の統合者〜 限定版"/>
+		<info name="alt_title" value="カード・オブ・デスティニー 〜光と闇の統合者〜 限定版"/>
 		<info name="ring_code" value="&lt;T-44406M-0815&gt;HM220A (Game), T-44405M   OP222A (Talk CD)"/>
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Card of Destiny: Hikari to Yami no Tougousha"/>
@@ -7393,7 +7393,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Broccoli</publisher>
 		<info name="serial" value="T-46302M"/>
 		<info name="release" value="20010906"/>
-		<info name="alt_title" value="デ･ジ･キャラット ファンタジー"/>
+		<info name="alt_title" value="デ・ジ・キャラット ファンタジー"/>
 		<info name="ring_code" value="T-46302M-0753 MT   B04"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
@@ -7427,7 +7427,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Broccoli</publisher>
 		<info name="serial" value="T-46301M"/>
 		<info name="release" value="20010906"/>
-		<info name="alt_title" value="デ･ジ･キャラット ファンタジー 初回限定版"/>
+		<info name="alt_title" value="デ・ジ・キャラット ファンタジー 初回限定版"/>
 		<info name="ring_code" value="T-46302M-0753 MT   B04 (Game), GCFC-21   2MM1   C   18 (Audio CD)"/>
 		<part interface="cdrom" name="cdrom1">
 			<feature name="part_id" value="Di Gi Charat Fantasy"/>
@@ -13316,7 +13316,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Sega</publisher>
 		<info name="serial" value="HDR-0013"/>
 		<info name="release" value="19990325"/>
-		<info name="alt_title" value="スーパースピード･レーシング"/>
+		<info name="alt_title" value="スーパースピード・レーシング"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
 				<disk name="super speed racing (jpn)" sha1="8465a0af4d7726be89be45e3e0e838ec64b3d8b0"/>
@@ -18771,7 +18771,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Sega</publisher>
 		<info name="serial" value="HDR-0149"/>
 		<info name="release" value="20010315"/>
-		<info name="alt_title" value="ル･マン24アワーズ"/>
+		<info name="alt_title" value="ル・マン24アワーズ"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
 				<disk name="le mans 24 hours (jpn)" sha1="483dc1ba8da6e1af5b8017c84579837403804486"/>
@@ -19146,7 +19146,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Sega</publisher>
 		<info name="serial" value="HDR-0102, HDR-0112 (Limited Box)"/>
 		<info name="release" value="20000928"/>
-		<info name="alt_title" value="ラブひな 突然のエンゲージ･ハプニング, ラブひな 突然のエンゲージ･ハプニング LIMITED BOX"/>
+		<info name="alt_title" value="ラブひな 突然のエンゲージ・ハプニング, ラブひな 突然のエンゲージ・ハプニング LIMITED BOX"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
 				<disk name="love hina totsuzen no engage happening (jpn)" sha1="157ba9560a8fa359e8a9d27caa33a4e0538fb672"/>
@@ -19506,7 +19506,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 	    <publisher>Kool Kizz</publisher>
 	    <info name="serial" value="T-44701M"/>
 	    <info name="release" value="20011115"/>
-	    <info name="alt_title" value="マリー&amp;エリーのアトリエ 〜ザールブルグの錬金術士1･2〜"/>
+	    <info name="alt_title" value="マリー&amp;エリーのアトリエ 〜ザールブルグの錬金術士1・2〜"/>
 	    <part interface="cdrom" name="cdrom1">
 	        <feature name="part_id" value="Game Disc"/>
 	        <diskarea name="cdrom">
@@ -20309,7 +20309,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 	    <publisher>KID</publisher>
 	    <info name="serial" value="T-19713M"/>
 	    <info name="release" value="20020228"/>
-	    <info name="alt_title" value="ミルキィ･シーズン"/>
+	    <info name="alt_title" value="ミルキィ・シーズン"/>
 	    <part interface="cdrom" name="cdrom">
 	        <diskarea name="cdrom">
 	            <disk name="milky season (jpn)" status="nodump"/>
@@ -20360,7 +20360,7 @@ P830-****-** : Appears to be a Sega part number for promo discs.
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="T-18702M"/>
 		<info name="release" value="20010621"/>
-		<info name="alt_title" value="ミス･ムーンライト"/>
+		<info name="alt_title" value="ミス・ムーンライト"/>
 		<part interface="cdrom" name="cdrom">
 			<diskarea name="cdrom">
 				<disk name="miss moonlight (jpn)" sha1="05967f4e85e2b9415165de304bbb52070fccc065"/>

--- a/hash/ibm5170_cdrom.xml
+++ b/hash/ibm5170_cdrom.xml
@@ -2515,7 +2515,7 @@ license:CC0
 		<description>PoiPon (Japan)</description>
 		<year>1997</year>
 		<publisher>Witty Wolf</publisher>
-		<info name="alt_title" value="ﾎﾟｲﾎﾟﾝ" />
+		<info name="alt_title" value="ポイポン" />
 		<part name="cdrom" interface="cdrom">
 			<diskarea name="cdrom">
 				<disk name="poipon" sha1="91c230bd6e14551794a1c28fd65c901187ce7786" />

--- a/hash/pc8801_flop.xml
+++ b/hash/pc8801_flop.xml
@@ -4566,7 +4566,7 @@ ExtractDisk  [04]"Disk 2          " -> "battle gorilla_04.d88"
 		<description>Bishoujo Shashinkan  - Moving School (alt?)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="美少女写真館 ｽｸｰﾙ"/>
+		<info name="alt_title" value="美少女写真館 -ムービング・スクール-"/>
 
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="348848">
@@ -4708,7 +4708,7 @@ ExtractDisk  [04]"Disk 2          " -> "battle gorilla_04.d88"
 		<description>Bishoujo Shashinkan - Studio Cut (alt?)</description>
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<info name="alt_title" value="美少女写真館 ｽﾀｼﾞｵ"/>
+		<info name="alt_title" value="美少女写真館スタジオ・カット"/>
 		<part name="flop1" interface="floppy_5_25">
 			<dataarea name="flop" size="348848">
 				<rom name="bishojo shashinkan studio.d88" size="348848" crc="3d19fe3c" sha1="083096a803a487b6a04c1acde9e377b5c44a8c3d"/>
@@ -35289,7 +35289,7 @@ ExtractDisk  [02]"DISK B          " -> "telenet music box (b)_02.d88"
 		<description>Tokyo Joshikosei Sailor-fuku Nyumon (1 &amp; 2 &amp; 3)</description>
 		<year>1988?</year>
 		<publisher>フェアリーテール (Fairytale)</publisher>
-		<info name="alt_title" value="東京女子高生ｾｰﾗｰ服123"/>
+		<info name="alt_title" value="東京女子高生セーラー服123"/>
 		<!--combined image-->
 		<!--rom name="tokyo joshikosei sailor-fuku nyumon(1&amp;2&amp;3).d88" size="1046272" crc="63a79526" sha1="ca85e86628503edc15c4d40cba981e1123c0f04c"/-->
 

--- a/hash/pcecd.xml
+++ b/hash/pcecd.xml
@@ -124,7 +124,7 @@ license:CC0
 		<publisher>NCS</publisher>
 		<info name="serial" value="NSCD5018"/>
 		<info name="release" value="19950224"/>
-		<info name="alt_title" value="愛･超兄貴"/>
+		<info name="alt_title" value="愛・超兄貴"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -3689,7 +3689,7 @@ license:CC0
 		<publisher>Hudson</publisher>
 		<info name="serial" value="HCD4062"/>
 		<info name="release" value="19940729"/>
-		<info name="alt_title" value="ネオ･ネクタリス"/>
+		<info name="alt_title" value="ネオ・ネクタリス"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -4070,7 +4070,7 @@ license:CC0
 		<publisher>Hudson</publisher>
 		<info name="serial" value="HCD1021"/>
 		<info name="release" value="19911025"/>
-		<info name="alt_title" value="ポピュラス ザ･プロミストランド"/>
+		<info name="alt_title" value="ポピュラス ザ・プロミストランド"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -5435,7 +5435,7 @@ license:CC0
 		<publisher>NEC Avenue</publisher>
 		<info name="serial" value="NAPR-1050"/>
 		<info name="release" value="19950728"/>
-		<info name="alt_title" value="スペースインベーダー･ジ･オリジナルゲーム"/>
+		<info name="alt_title" value="スペースインベーダー・ジ・オリジナルゲーム"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -5595,7 +5595,7 @@ license:CC0
 		<publisher>Nihon Telenet</publisher>
 		<info name="serial" value="TJCD1021"/>
 		<info name="release" value="19911220"/>
-		<info name="alt_title" value="なりトレ ザ･スゴロク'92"/>
+		<info name="alt_title" value="なりトレ ザ・スゴロク'92"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="cdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -5755,7 +5755,7 @@ license:CC0
 		<publisher>Naxat Soft</publisher>
 		<info name="serial" value="NXCD4030"/>
 		<info name="release" value="19940805"/>
-		<info name="alt_title" value="スーパーリアル麻雀PII･PIIIカスタム"/>
+		<info name="alt_title" value="スーパーリアル麻雀PII・PIIIカスタム"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -6152,7 +6152,7 @@ license:CC0
 		<publisher>Micro World</publisher>
 		<info name="serial" value="MWCD2002"/>
 		<info name="release" value="19920401"/>
-		<info name="alt_title" value="ザ･デビスカップテニス"/>
+		<info name="alt_title" value="ザ・デビスカップテニス"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -6168,7 +6168,7 @@ license:CC0
 		<publisher>Micro World</publisher>
 		<info name="serial" value="MWCD2001"/>
 		<info name="release" value="19920731"/>
-		<info name="alt_title" value="ザ･キックボクシング"/>
+		<info name="alt_title" value="ザ・キックボクシング"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="scdsys"/>
 		<part name="cdrom" interface="pce_cdrom">
@@ -6868,7 +6868,7 @@ license:CC0
 		<publisher>Hudson</publisher>
 		<info name="serial" value="HCD9009"/>
 		<info name="release" value="19891221"/>
-		<info name="alt_title" value="イースI･II"/>
+		<info name="alt_title" value="イースI・II"/>
 		<info name="usage" value="CD-Rom System Card required" />
 		<sharedfeat name="requirement" value="cdsys"/>
 		<part name="cdrom" interface="pce_cdrom">

--- a/hash/pico.xml
+++ b/hash/pico.xml
@@ -29,7 +29,7 @@ Published by Sega/Sega Toys (HPC-6*** serial codes)
 * ドラえもん のびたの まちなか ドキドキ たんけん!<10th> - Doraemon - Nobita no Machinaka Dokidoki Tanken! ~10th Anniversary Edition~ (Sega Toys - 200308xx - HPC-6126) [reprint HPC-6009]
 * トイストーリー2 ウッディ そうさく だいさくせん!!<10th> - Toy Story 2 - Woody Sousaku Daisakusen!! ~10th Anniversary Edition~ (Sega Toys - 20030714 - HPC-6127) [reprint HPC-6090]
 * ミッキーと大きな古時計<10th> - Mickey To Ooki na Furudokei ~10th Anniversary Edition~ (Sega Toys - 200308xx - HPC-6129) [reprint HPC-6023]
-* それいけ!アンパンマン はじめてあそぶピコソフト アンパンマンのいろ･かず･かたち ぬりえもできちゃうぞ! - Soreike! Anpanman Hajimete Asobu Pico Soft - Anpanman Noiro-Kazu-Katachi Nuriemo Dekichauzo! (Sega Toys - ???? - HPC-????)
+* それいけ!アンパンマン はじめてあそぶピコソフト アンパンマンのいろ・かず・かたち ぬりえもできちゃうぞ! - Soreike! Anpanman Hajimete Asobu Pico Soft - Anpanman Noiro-Kazu-Katachi Nuriemo Dekichauzo! (Sega Toys - ???? - HPC-????)
 * ディズニープリンセス 白雪姫 ～しらゆきひめ～ <Best> - Disney Princesses - Shirayukihime Best Selection (Sega Toys - 20040426 - HPC-6139)
 
 to be verified
@@ -908,7 +908,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<publisher>Sega Toys</publisher>
 		<info name="serial" value="HPC-6145" />
 		<info name="release" value="20041018"/>
-		<info name="alt_title" value="ディズニープリンセス すてきにレッスン! ひらがな･カタカナ"/>
+		<info name="alt_title" value="ディズニープリンセス すてきにレッスン! ひらがな・カタカナ"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="EPOXY BLOCK IC1" />
@@ -1070,7 +1070,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<year>199?</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="T-226030"/>
-		<info name="alt_title" value="ドラえもん えんそく･いもほり･うんどうかい"/>
+		<info name="alt_title" value="ドラえもん えんそく・いもほり・うんどうかい"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-6883A" />
 			<feature name="ic1" value="MPR-20221 J50" />
@@ -1086,7 +1086,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="T-226090"/>
 		<info name="release" value="200309xx"/>
-		<info name="alt_title" value="ドラえもん えんそく･いもほり･うんどうかい &lt;10th&gt;"/>
+		<info name="alt_title" value="ドラえもん えんそく・いもほり・うんどうかい &lt;10th&gt;"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="EPOXY BLOCK U1" />
@@ -1101,7 +1101,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<year>199?</year>
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="T-226050"/>
-		<info name="alt_title" value="ドラえもん かぞえて･かんたん かず とけい"/>
+		<info name="alt_title" value="ドラえもん かぞえて・かんたん かず とけい"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="EPOXY BLOCK U1" />
@@ -1163,7 +1163,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<publisher>Shogakukan</publisher>
 		<info name="serial" value="T-226040"/>
 		<info name="release" value="199908xx"/>
-		<info name="alt_title" value="ドラえもん よめたよ･かけたよ ひらがな カタカナ"/>
+		<info name="alt_title" value="ドラえもん よめたよ・かけたよ ひらがな カタカナ"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="9K0-0004-S" />
@@ -1211,7 +1211,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<publisher>Bandai</publisher>
 		<info name="serial" value="T-133390"/>
 		<info name="release" value="20020315"/>
-		<info name="alt_title" value="どうぶつピコ ハムスターランド &lt;初回限定･ハムスター人形付属&gt;"/>
+		<info name="alt_title" value="どうぶつピコ ハムスターランド &lt;初回限定・ハムスター人形付属&gt;"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7967" />
 			<feature name="ic1" value="9K0-0052-RV08" />
@@ -1594,7 +1594,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<year>2001</year>
 		<publisher>Gakken</publisher>
 		<info name="serial" value="T-169080"/>
-		<info name="alt_title" value="学研はじめての もじ･ことば"/>
+		<info name="alt_title" value="学研はじめての もじ・ことば"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="9K0-0034-RV" />
@@ -1670,7 +1670,7 @@ Published by Others (T-yyy*** serial codes, for yyy depending on the publisher)
 		<publisher>Gakken</publisher>
 		<info name="serial" value="T-169050"/>
 		<info name="release" value="199512xx"/>
-		<info name="alt_title" value="学研のおべんきょうソフト かず･すうじ"/>
+		<info name="alt_title" value="学研のおべんきょうソフト かず・すうじ"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="MPR-18585-16MX" />
@@ -2233,7 +2233,7 @@ But how do later protos fit with this theory? Maybe the later protos were from t
 		<year>1996?</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="HPC-6035"/>
-		<info name="alt_title" value="怪盗セイント･テール セイントテールとワン･ツー･スリー!"/>
+		<info name="alt_title" value="怪盗セイント・テール セイントテールとワン・ツー・スリー!"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-6883A" />
 			<feature name="ic1" value="MPR-18799 J42" />
@@ -2478,7 +2478,7 @@ But how do later protos fit with this theory? Maybe the later protos were from t
 		<year>1998</year>
 		<publisher>Kodansha</publisher>
 		<info name="serial" value="T-255040"/>
-		<info name="alt_title" value="くまのプーさん クリストファー･ロビンを さがせ!"/>
+		<info name="alt_title" value="くまのプーさん クリストファー・ロビンを さがせ!"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-6883A" />
 			<feature name="ic1" value="MPR-21835-S" />
@@ -4578,7 +4578,7 @@ But how do later protos fit with this theory? Maybe the later protos were from t
 		<year>1994</year>
 		<publisher>Bandai</publisher>
 		<info name="serial" value="T-133010"/>
-		<info name="alt_title" value="それいけ! アンパンマンのｹﾞｰﾑであそぼうアンパンマン"/>
+		<info name="alt_title" value="それいけ! アンパンマンのゲームであそぼうアンパンマン"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-6434C" />
 			<feature name="ic1" value="MPR-16369-H" />
@@ -4928,7 +4928,7 @@ But how do later protos fit with this theory? Maybe the later protos were from t
 		<publisher>Sega Toys</publisher>
 		<info name="serial" value="HPC-6114"/>
 		<info name="release" value="200207xx"/>
-		<info name="alt_title" value="トミカ・ピコ レスキューパーキング きんきゅうしゅつどう! はたらくのりもの &lt;初回･トミカ付属&gt; - Tomica Pico Rescue Parking Kinkyuushutsudou! Hataraku Norimono ~Shokai-Tomica Fuzoku~"/>
+		<info name="alt_title" value="トミカ・ピコ レスキューパーキング きんきゅうしゅつどう! はたらくのりもの &lt;初回・トミカ付属&gt; - Tomica Pico Rescue Parking Kinkyuushutsudou! Hataraku Norimono ~Shokai-Tomica Fuzoku~"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7438B" />
 			<feature name="u1" value="9B1-0014AR2" />
@@ -4947,7 +4947,7 @@ But how do later protos fit with this theory? Maybe the later protos were from t
 		<publisher>Sega Toys</publisher>
 		<info name="serial" value="HPC-6101"/>
 		<info name="release" value="200112xx"/>
-		<info name="alt_title" value="とっとこハム太郎 はる･なつ･あき･ふゆ とっとこなかよし! ハムちゃんず!"/>
+		<info name="alt_title" value="とっとこハム太郎 はる・なつ・あき・ふゆ とっとこなかよし! ハムちゃんず!"/>
 		<part name="cart" interface="pico_cart">
 			<feature name="pcb" value="171-7090A" />
 			<feature name="ic1" value="EPOXY BLOCK U1" />

--- a/hash/psx.xml
+++ b/hash/psx.xml
@@ -37289,7 +37289,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Hamster</publisher>
 		<info name="serial" value="SLPM-86656" />
 		<info name="release" value="20001026" />
-		<info name="alt_title" value="雷電ディー･エックス"/>
+		<info name="alt_title" value="雷電ディー・エックス"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -49818,7 +49818,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Global A</publisher>
 		<info name="serial" value="SLPM-86684" />
 		<info name="release" value="20001207" />
-		<info name="alt_title" value="ザ マエストロムジーク･メリークリスマス･アペンド"/>
+		<info name="alt_title" value="ザ マエストロムジーク・メリークリスマス・アペンド"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -51903,7 +51903,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Media Entertainment</publisher>
 		<info name="serial" value="SLPS-03245" />
 		<info name="release" value="20010830" />
-		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル5 〜レースクイーン2･トムキャット〜"/>
+		<info name="alt_title" value="パチスロ帝王 メーカー推奨マニュアル5 〜レースクイーン2・トムキャット〜"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">
@@ -58797,7 +58797,7 @@ The entries in this section are intended to replace the existing "low-grade" Jap
 		<publisher>Hudson</publisher>
 		<info name="serial" value="SLPS-01451" />
 		<info name="release" value="19980625" />
-		<info name="alt_title" value="銀河お嬢様伝説ユナ ファイナル･エディション"/>
+		<info name="alt_title" value="銀河お嬢様伝説ユナ ファイナル・エディション"/>
 		<sharedfeat name="compatibility" value="NTSC-J"/>
 		<part name="cdrom" interface="psx_cdrom">
 			<diskarea name="cdrom">

--- a/hash/smc777.xml
+++ b/hash/smc777.xml
@@ -215,7 +215,7 @@ Known to be dumped, but no longer available: (If you do have any of these please
 		<description>Striz B.H.</description>
 		<year>1984</year>
 		<publisher>Sony</publisher>
-		<info name="alt_title" value="ストリッツb.h." />
+		<info name="alt_title" value="ストリッツ・ベーハー" />
 
 		<part name="flop1" interface="floppy_3_5">
 			<dataarea name="flop" size="305328">
@@ -241,7 +241,7 @@ Known to be dumped, but no longer available: (If you do have any of these please
 		<description>Yakyuu-Kyou</description>
 		<year>1984</year>
 		<publisher>Hudson Soft</publisher>
-		<info name="alt_title" value="ヤキュウキョウ" />
+		<info name="alt_title" value="野球狂" />
 		<!-- Crashes after displaying "ヤキュウキョウ" -->
 
 		<part name="flop1" interface="floppy_3_5">

--- a/hash/sms.xml
+++ b/hash/sms.xml
@@ -6834,7 +6834,7 @@ license:CC0
 		<publisher>Sega</publisher>
 		<info name="serial" value="G-1318"/>
 		<info name="release" value="19870419"/>
-		<info name="alt_title" value="デカ - スケバン刑事II 少女鉄仮面伝説" />
+		<info name="alt_title" value="スケバン刑事II 少女鉄仮面伝説" />
 		<part name="cart" interface="sms_cart">
 			<dataarea name="rom" size="131072">
 				<rom name="sukeban deka ii - shoujo tekkamen densetsu (japan).bin" size="131072" crc="b13df647" sha1="5cd041990c7418ba63cde54f83d3e0e323b42c3b" offset="000000" />

--- a/hash/x1_flop.xml
+++ b/hash/x1_flop.xml
@@ -2128,7 +2128,7 @@ Plus, some games crash MAME at exit (e.g. some sorcer disks or some arcus disks)
 	<software name="revolty2">
 		<description>Revolty 2</description>
 		<year>1989</year>
-		<publisher>風雅ｼｽﾃﾑ (Fuga System)</publisher>
+		<publisher>風雅システム (Fuga System)</publisher>
 		<info name="release" value="198901xx"/>
 		<info name="alt_title" value="リボルティーII"/>
 		<part name="flop1" interface="floppy_5_25">


### PR DESCRIPTION
- Replaced halfwidth characters (including middle dot) with fullwidth ones.
- Fixed a few alt titles.