### PR TITLE
Notes/typos + note changes for DDR Karaoke

### DIFF
--- a/src/mame/drivers/ksys573.cpp
+++ b/src/mame/drivers/ksys573.cpp
@@ -43,96 +43,98 @@
 
   The games that run on this system include...
 
-  Game                                         Year       Hardware Code     CD Code
-  ---------------------------------------------------------------------------------
-P Anime Champ                                   2000.12    GCA07 JA          (no CD)
-P Bass Angler                                   1998.03    GE765 JA          765 JA A02
-P Bass Angler 2                                 1998.07    GC865 JA          865 JA A02
-P DAM-DDR Dance Dance Revolution for DAM        1999.11    GQ921 JB          921 JB B02
-P *DAM-DDR Dance Dance Revolution for DAM 2nd   2000.07
-A Dance Dance Revolution                        1998.09    GC845 JA          845 JA(missing)/UA A01 / 845 JA A02
-A Dance Dance Revolution Internet Ranking ver.  1998.11    GC845 JB          845 JB A01 / 845 JA/UA A02
-A Dance Dance Revolution 2ndMIX                 1999.01    GC895 JA          895 JA A02
-A Dance Dance Revolution 2ndMIX LINK version    1999.04    GE885 JA          885 JA A02
-A DDR 2ndMIX with bmIIDX CLUB ver.              1999.05    GN896 JA          896 JA A01
-A DDR 2ndMIX AND bmIIDX substream CLUB ver. 2   1999.05    GE984 JA          984 JA A01
-D Dance Dance Revolution Solo BASS MIX          1999.08    GQ894 JA          894 JA A02
-D Dance Dance Revolution 3rdMIX                 1999.10    GN887 AA/JA/KA    887 AA/JA/KA A02
-D Dance Dance Revolution Solo 2000              1999.12    GC905 AA/JA       905 AA/JA A02
-D Dance Dance Revolution 3rdMIX PLUS            2000.06    GCA22 JA          A22 JA A02
-D Dance Dance Revolution 4thMIX                 2000.08    GCA33 JA          A33 JA A02
-D Dance Dance Revolution 4thMIX PLUS            2000.12    GCA34 JA          A34 JA A02
-D Dance Dance Revolution 5thMIX                 2001.03    GCA27 JA          A27 JA A02
-D DDRMAX Dance Dance Revolution 6thMIX          2001.10    GCB19 JA          B19 JA A02
-D DDRMAX2 Dance Dance Revolution 7thMIX         2002.03    GCB20 JA          B20 JA A02
-D Dance Dance Revolution EXTREME                2002.12    GCC36 JA          C36 JA A02
-D Dance Maniax                                  2000.06    GE874 JA          874 JA A(needs redump)
-D Dance Maniax 2ndMIX                           2000.12    GCA39 JA          A39 JA A02
-D Dance Maniax 2ndMIX APPEND J PARADISE         2001.04
-A Dancing Stage                                 1999.08    GN845 EA          845 EA(needs redump)
-D Dancing Stage Euro Mix                        2000       GE936 EA          936 EA A(needs redump)
-D Dancing Stage Euro Mix 2                      2000       G*C23 EA          C23 EA A02
-D Dancing Stage featuring Disney's Rave         2000.11    GCA37 JA          A37 JA A02
-D Dancing Stage featuring DREAMS COME TRUE      1999.12    GC910 JA          910 JA/JC A02
-A Dancing Stage featuring TRUE KiSS DESTiNATiON 1999.07    G*884 JA          884 JA A02
-P Dark Horse Legend                             1998.03    GX706 JA          706 JA A02
-A drummania                                     1999.07    GQ881 JA          881 JA D01 / 881 JA A02(missing, audio CD)
-D drummania 2ndMIX                              2000.03    GE912 JA          912 JA B02
-D drummania 3rdMIX                              2000.09    GCA23 JA          A23 JA A02
-D drummania 4thMIX                              2001.03    GEA25 JA          A25 JA A02
-D drummania 5thMIX                              2001.09    GCB05 JA          B05 JA A02
-D drummania 6thMIX                              2002.02    GCB16 JA          B16 JA A02
-N drummania 7thMIX                              2002.08    GCC07 JA          C07 JA A02
-N drummania 7thMIX power-up ver.                2002.08    GEC07 JB          C07 JC A02
-N drummania 8thMIX                              2003.04    GCC38 JA          C38 JA A02
-N drummania 9thMIX                              2003.10    GCD09 JA          D09 JA A02
-N drummania 10thMIX                             2004.04
-? Fighting Mania                                2000
-P Fisherman's Bait                              1998.06    GE765 UA          765 UA B02
-P Fisherman's Bait 2                            1998       GC865 UA          865 UA B02
-P Fisherman's Bait Marlin Challenge             1999       GX889             889 AA/EA/JA/UA(needs redump)
-P Gachagachamp                                  1999.01    GQ877 JA          GE877-JA(PCMCIA card)
-P Great Bishi Bashi Champ                       2002.??    GBA48 JA          (no CD)
-A GUITARFREAKS                                  1999.02    GQ886 EA/JA/UA    886 ** C02
-A GUITARFREAKS 2ndMIX                           1999.07    GQ883 JA          929 JB B02(needs redump)
-A *GUITARFREAKS 2ndMIX Link ver.                1999.09
-D GUITARFREAKS 3rdMIX                           2000.04    GE949 JA          949 JA C01 / 949 JA C02
-D GUITARFREAKS 4thMIX                           2000.08    GEA24 JA          A24 JA A02
-D GUITARFREAKS 5thMIX                           2001.03    GCA26 JA          A26 JA A02
-D GUITARFREAKS 6thMIX                           2001.09    GCB06 JA          B06 JA A02
-D GUITARFREAKS 7thMIX                           2002.02    GCB17 JA          B17 JA A02
-N GUITARFREAKS 8thMIX                           2002.08    GCC08 JA          C08 JA A02
-N GUITARFREAKS 8thMIX power-up ver.             2002.11    GEC08 JB          C08 JB A02
-N GUITARFREAKS 9thMIX                           2003.04    GCC39 JA          C39 JA A02
-N GUITARFREAKS 10thMIX                          2003.10    GCD10 JA          D10 JA A02
-N GUITARFREAKS 11thMIX                          2004.04
-G GunMania                                      2000.07    G?906 JA          (no CD)
-? *GunMania Zone Plus                           2000.10
-P Handle Champ                                  1997.12    GQ710 JA          (no CD)
-P Hyper Bishi Bashi Champ                       1998.07    GC876 EA          (no CD)
-P Hyper Bishi Bashi Champ - 2 Player            1999.08    GC908 JA          908    A02
-P Jikkyou Powerful Pro Yakyuu EX                1998.04    GX802 JA          802 JA B02
-P Jikkyou Powerful Pro Yakyuu EX 98             1998.08
-K Kick & Kick                                   2001       GNA36 EA          (no CD)
-P Konami 80's Arcade Gallery                    1998.11    GC826 JA          826 JA A01
-P Konami 80's AC Special                        1998       GC826 UA          826 UA A01
-D Mambo a GoGo                                  2001.06
-D Punchmania Hokuto no Ken                      2000.03                      918 JA B02
-D Punchmania Hokuto no Ken 2                    2000.12                      A09 JA A02
-P Salary Man Champ
-P Salary Man Champ - 2 Player                   2001.02    GCA18 JA          A18 JA(needs redump)
-P Step Champ                                    1999.12
+  Game                                                Year       Hardware Code     CD Code
+  --------------------------------------------------------------------------------------------
+P Anime Champ                                         2000.12    GCA07 JA          (no CD)
+P Bass Angler                                         1998.03    GE765 JA          765 JA A02
+P Bass Angler 2                                       1998.07    GC865 JA          865 JA A02
+K Dance Dance Revolution Karaoke MIX (DAM-DDR)        1999.11    GQ921 JB          921 JB B02
+K *Dance Dance Revolution Karaoke MIX (DAM-DDR) 2nd   2000.07
+A Dance Dance Revolution                              1998.09    GC845 JA          845 JA(missing)/UA A01 / 845 JA A02
+A Dance Dance Revolution Internet Ranking ver.        1998.11    GC845 JB          845 JB A01 / 845 JA/UA A02
+A Dance Dance Revolution 2ndMIX                       1999.01    GC895 JA          895 JA A02
+A Dance Dance Revolution 2ndMIX LINK version          1999.04    GE885 JA          885 JA A02
+A DDR 2ndMIX with bmIIDX CLUB ver.                    1999.05    GN896 JA          896 JA A01
+A DDR 2ndMIX AND bmIIDX substream CLUB ver. 2         1999.05    GE984 JA          984 JA A01
+D Dance Dance Revolution Solo BASS MIX                1999.08    GQ894 JA          894 JA A02
+D Dance Dance Revolution 3rdMIX                       1999.10    GN887 AA/JA/KA    887 AA/JA/KA A02
+D Dance Dance Revolution Solo 2000                    1999.12    GC905 AA/JA       905 AA/JA A02
+D Dance Dance Revolution 3rdMIX PLUS                  2000.06    GCA22 JA          A22 JA A02
+D Dance Dance Revolution 4thMIX                       2000.08    GCA33 JA          A33 JA A02
+D Dance Dance Revolution 4thMIX PLUS                  2000.12    GCA34 JA          A34 JA A02
+D Dance Dance Revolution 5thMIX                       2001.03    GCA27 JA          A27 JA A02
+D DDRMAX Dance Dance Revolution 6thMIX                2001.10    GCB19 JA          B19 JA A02
+D DDRMAX2 Dance Dance Revolution 7thMIX               2002.03    GCB20 JA          B20 JA A02
+D Dance Dance Revolution EXTREME                      2002.12    GCC36 JA          C36 JA A02
+D Dance Maniax                                        2000.06    GE874 JA          874 JA A(needs redump)
+D Dance Maniax 2ndMIX                                 2000.12    GCA39 JA          A39 JA A02
+D Dance Maniax 2ndMIX APPEND J PARADISE               2001.04
+A Dancing Stage                                       1999.08    GN845 EA          845 EA(needs redump)
+D Dancing Stage Euro Mix                              2000       GE936 EA          936 EA A(needs redump)
+D Dancing Stage Euro Mix 2                            2000       G*C23 EA          C23 EA A02
+D Dancing Stage featuring Disney's Rave               2000.11    GCA37 JA          A37 JA A02
+D Dancing Stage featuring DREAMS COME TRUE            1999.12    GC910 JA          910 JA/JC A02
+A Dancing Stage featuring TRUE KiSS DESTiNATiON       1999.07    G*884 JA          884 JA A02
+P Dark Horse Legend                                   1998.03    GX706 JA          706 JA A02
+A drummania                                           1999.07    GQ881 JA          881 JA D01 / 881 JA A02(missing, audio CD)
+D drummania 2ndMIX                                    2000.03    GE912 JA          912 JA B02
+D drummania 3rdMIX                                    2000.09    GCA23 JA          A23 JA A02
+D drummania 4thMIX                                    2001.03    GEA25 JA          A25 JA A02
+D drummania 5thMIX                                    2001.09    GCB05 JA          B05 JA A02
+D drummania 6thMIX                                    2002.02    GCB16 JA          B16 JA A02
+N drummania 7thMIX                                    2002.08    GCC07 JA          C07 JA A02
+N drummania 7thMIX power-up ver.                      2002.08    GEC07 JB          C07 JC A02
+N drummania 8thMIX                                    2003.04    GCC38 JA          C38 JA A02
+N drummania 9thMIX                                    2003.10    GCD09 JA          D09 JA A02
+N drummania 10thMIX                                   2004.04
+? Fighting Mania                                      2000
+P Fisherman's Bait                                    1998.06    GE765 UA          765 UA B02
+P Fisherman's Bait 2                                  1998       GC865 UA          865 UA B02
+P Fisherman's Bait Marlin Challenge                   1999       GX889             889 AA/EA/JA/UA(needs redump)
+P Gachagachamp                                        1999.01    GQ877 JA          GE877-JA(PCMCIA card)
+P Great Bishi Bashi Champ                             2002.??    GBA48 JA          (no CD)
+A GUITARFREAKS                                        1999.02    GQ886 EA/JA/UA    886 ** C02
+A GUITARFREAKS 2ndMIX                                 1999.07    GQ883 JA          929 JB B02(needs redump)
+A *GUITARFREAKS 2ndMIX Link ver.                      1999.09
+D GUITARFREAKS 3rdMIX                                 2000.04    GE949 JA          949 JA C01 / 949 JA C02
+D GUITARFREAKS 4thMIX                                 2000.08    GEA24 JA          A24 JA A02
+D GUITARFREAKS 5thMIX                                 2001.03    GCA26 JA          A26 JA A02
+D GUITARFREAKS 6thMIX                                 2001.09    GCB06 JA          B06 JA A02
+D GUITARFREAKS 7thMIX                                 2002.02    GCB17 JA          B17 JA A02
+N GUITARFREAKS 8thMIX                                 2002.08    GCC08 JA          C08 JA A02
+N GUITARFREAKS 8thMIX power-up ver.                   2002.11    GEC08 JB          C08 JB A02
+N GUITARFREAKS 9thMIX                                 2003.04    GCC39 JA          C39 JA A02
+N GUITARFREAKS 10thMIX                                2003.10    GCD10 JA          D10 JA A02
+N GUITARFREAKS 11thMIX                                2004.04
+G GunMania                                            2000.07    G?906 JA          (no CD)
+? *GunMania Zone Plus                                 2000.10
+P Handle Champ                                        1997.12    GQ710 JA          (no CD)
+P Hyper Bishi Bashi Champ                             1998.07    GC876 EA          (no CD)
+P Hyper Bishi Bashi Champ - 2 Player                  1999.08    GC908 JA          908    A02
+P Jikkyou Powerful Pro Yakyuu EX                      1998.04    GX802 JA          802 JA B02
+P Jikkyou Powerful Pro Yakyuu EX 98                   1998.08
+AA Kick & Kick                                        2001       GNA36 EA          (no CD)
+P Konami 80's Arcade Gallery                          1998.11    GC826 JA          826 JA A01
+P Konami 80's AC Special                              1998       GC826 UA          826 UA A01
+D Mambo a GoGo                                        2001.06
+D Punchmania Hokuto no Ken                            2000.03                      918 JA B02
+D Punchmania Hokuto no Ken 2                          2000.12                      A09 JA A02
+P *Salary Man Champ
+P Salary Man Champ - 2 Player                         2001.02    GCA18 JA          A18 JA(needs redump)
+P Step Champ                                          1999.12
 
 P: plain System573
 A: uses ext. analog I/O board GX700-PWB(F)
+AA: uses alt. ext. analog I/O board GX700-PWB(K)
 D: uses ext. digital sound and I/O board GX894-PWB(B)
 N: uses network PCB unit GUC07 + ext. digital sound and I/O board GX894-PWB(B)
 G: gun mania only, drives air soft gun (this game uses real BB bullet)
-K: uses alt. ext. analog I/O board GX700-PWB(K)
+K: uses karaoke I/O board GX921-PWB(B)
+
 
   Note:
        Not all games listed above are confirmed to run on System 573.
-       * - denotes not dumped yet.
+       * - denotes undumped.
 
   Main PCB Layout
   ---------------
@@ -6240,8 +6242,8 @@ GAME( 2001, gtrfrk6m,  sys573,   gtrfrk5m,   gtrfrks,   ksys573_state, empty_ini
 GAME( 2001, pcnfrk6m,  sys573,   drmn4m,     drmn,      ksys573_state, empty_init,    ROT0,  "Konami", "Percussion Freaks 6th Mix (G*B16 VER. AAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.95 */
 GAME( 2001, drmn6m,    pcnfrk6m, drmn4m,     drmn,      ksys573_state, empty_init,    ROT0,  "Konami", "DrumMania 6th Mix (G*B16 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.95 */
 GAME( 2001, gtrfrk7m,  sys573,   gtrfrk7m,   gtrfrks,   ksys573_state, empty_init,    ROT0,  "Konami", "Guitar Freaks 7th Mix (G*B17 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.95 */
-GAME( 2001, ddrmax,    sys573,   ddr5m,      ddr,       ksys573_state, empty_init,    ROT0,  "Konami", "DDR Max - Dance Dance Revolution 6th Mix (G*B19 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.9 */
-GAME( 2002, ddrmax2,   sys573,   ddr5m,      ddr,       ksys573_state, empty_init,    ROT0,  "Konami", "DDR Max 2 - Dance Dance Revolution 7th Mix (G*B20 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.95 */
+GAME( 2001, ddrmax,    sys573,   ddr5m,      ddr,       ksys573_state, empty_init,    ROT0,  "Konami", "DDRMAX - Dance Dance Revolution 6th Mix (G*B19 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.9 */
+GAME( 2002, ddrmax2,   sys573,   ddr5m,      ddr,       ksys573_state, empty_init,    ROT0,  "Konami", "DDRMAX2 - Dance Dance Revolution 7th Mix (G*B20 VER. JAA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.95 */
 GAME( 2002, mrtlbeat,  sys573,   ddr5m,      ddr,       ksys573_state, empty_init,    ROT0,  "Konami", "Martial Beat (G*B47 VER. JBA)", MACHINE_IMPERFECT_SOUND | MACHINE_NOT_WORKING ) /* BOOT VER 1.9 */
 GAME( 2002, gbbchmp,   sys573,   gbbchmp,    hyperbbc,  ksys573_state, init_serlamp,  ROT0,  "Konami", "Great Bishi Bashi Champ (GBA48 VER. JAB)", MACHINE_IMPERFECT_SOUND )
 GAME( 2002, pcnfrk7m,  sys573,   drmn4m,     drmn,      ksys573_state, empty_init,    ROT0,  "Konami", "Percussion Freaks 7th Mix (G*C07 VER. AAA)", MACHINE_IMPERFECT_SOUND ) /* BOOT VER 1.95 */


### PR DESCRIPTION
-The bottom of the driver says '"Dance Dance Revolution Karaoke Mix (GQ921 VER. JBB)"'
which is hard to deduce as being 'DAM-DDR Dance Dance Revolution for DAM' at the top of the driver.
As such, I've changed it to: "Dance Dance Revolution Karaoke MIX (DAM-DDR)" and "Dance Dance Revolution Karaoke MIX 2nd (DAM-DDR)" based on what I've found on the internet. This name appears to be accurate, at least for the system. The game disc itself doesn't contain the name DAM.
A few sources:
https://remywiki.com/AC_DDR_Karaoke
https://bcaweb.bai.ne.jp/miyooo/ddrd.html

-: In the list, there is a 'P' next to these names, denoting 'plain System573', but according to my first source:
DDR KAraoke "...uses a modified System 573, equipped with four video input/output and a DAM karaoke device."
As such I've changed the P to 'K' and have changed Kick and Kick's letter, which was a K, to AA since it's a similar board to the A.
A: uses ext. analog I/O board GX700-PWB(F)
AA: uses alt. ext. analog I/O board GX700-PWB(K)
K: uses karaoke I/O board GX921-PWB(B)

-'DDR max' and 'DDR max 2' to 'DDRMAX' and 'DDRMAX2'