### PR TITLE
zx spectrum drivers - restore irq length == 32 / border timings

### DIFF
--- a/src/mame/drivers/pentagon.cpp
+++ b/src/mame/drivers/pentagon.cpp
@@ -219,9 +219,6 @@ void pentagon_state::video_start()
 {
 	spectrum_128_state::video_start();
 	m_contention_pattern = {};
-	/* TODO (minor) Must be 4 but that requires draw of previous border chunk and significantly complicates the code.
-	Will see if we really have case for this change. */
-	m_border4t_render_at = /*4*/ 3;
 }
 
 static const gfx_layout spectrum_charlayout =

--- a/src/mame/drivers/pentagon.cpp
+++ b/src/mame/drivers/pentagon.cpp
@@ -217,10 +217,11 @@ void pentagon_state::machine_reset()
 
 void pentagon_state::video_start()
 {
-	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
-
-	m_frame_invert_count = 16;
-	m_screen_location = m_ram->pointer() + (5 << 14);
+	spectrum_128_state::video_start();
+	m_contention_pattern = {};
+	/* XXX Must be 4 but that requires draw of previous border chunk and significantly complicates the code.
+	Will see if we really have case for this change. */
+	m_border4t_render_at = /*4*/ 3;
 }
 
 static const gfx_layout spectrum_charlayout =

--- a/src/mame/drivers/pentagon.cpp
+++ b/src/mame/drivers/pentagon.cpp
@@ -219,7 +219,7 @@ void pentagon_state::video_start()
 {
 	spectrum_128_state::video_start();
 	m_contention_pattern = {};
-	/* XXX Must be 4 but that requires draw of previous border chunk and significantly complicates the code.
+	/* TODO (minor) Must be 4 but that requires draw of previous border chunk and significantly complicates the code.
 	Will see if we really have case for this change. */
 	m_border4t_render_at = /*4*/ 3;
 }

--- a/src/mame/drivers/pentagon.cpp
+++ b/src/mame/drivers/pentagon.cpp
@@ -217,6 +217,8 @@ void pentagon_state::machine_reset()
 
 void pentagon_state::video_start()
 {
+	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
+
 	m_frame_invert_count = 16;
 	m_screen_location = m_ram->pointer() + (5 << 14);
 }

--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -167,11 +167,9 @@ resulting mess can be seen in the F4 viewer display.
 
 void spectrum_128_state::video_start()
 {
-	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
-
-	m_frame_invert_count = 16;
+	spectrum_state::video_start();
 	m_screen_location = m_ram->pointer() + (5 << 14);
-	m_contention_pattern = {6, 5, 4, 3, 2, 1, 0, 0};
+	m_border4t_render_at = 6;
 }
 
 uint8_t spectrum_128_state::spectrum_128_pre_opcode_fetch_r(offs_t offset)

--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -167,6 +167,8 @@ resulting mess can be seen in the F4 viewer display.
 
 void spectrum_128_state::video_start()
 {
+	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
+
 	m_frame_invert_count = 16;
 	m_screen_location = m_ram->pointer() + (5 << 14);
 	m_contention_pattern = {6, 5, 4, 3, 2, 1, 0, 0};
@@ -230,8 +232,6 @@ void spectrum_128_state::spectrum_128_port_7ffd_w(offs_t offset, uint8_t data)
 	/* disable paging? */
 	if (m_port_7ffd_data & 0x20) return;
 
-	if ((m_port_7ffd_data ^ data) & 0x08) m_screen->update_now();
-
 	/* store new state */
 	m_port_7ffd_data = data;
 
@@ -293,6 +293,10 @@ void spectrum_128_state::spectrum_128_fetch(address_map &map)
 
 void spectrum_128_state::machine_start()
 {
+	spectrum_state::machine_start();
+
+	save_item(NAME(m_port_7ffd_data));
+
 	/* rom 0 is 128K rom, rom 1 is 48 BASIC */
 	memory_region *rom = memregion("maincpu");
 	m_bank_rom[0]->configure_entries(0, 2, rom->base() + 0x10000, 0x4000);
@@ -313,7 +317,6 @@ void spectrum_128_state::machine_reset()
 
 	/* set initial ram config */
 	m_port_7ffd_data = 0;
-	m_port_1ffd_data = -1;
 	spectrum_128_update_memory();
 }
 

--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -319,17 +319,15 @@ void spectrum_128_state::machine_reset()
 }
 
 bool spectrum_128_state::is_vram_write(offs_t offset) {
-	// TODO respect banks 2,5 mapped to 0xc000
-	return (BIT(m_port_7ffd_data, 3))
-		? offset >= 0x8000 && offset < 0x9b00
+	return (BIT(m_port_7ffd_data, 3) && m_bank_ram[3]->entry() == 7)
+		? offset >= 0xc000 && offset < 0xdb00
 		: spectrum_state::is_vram_write(offset);
 }
 
 bool spectrum_128_state::is_contended(offs_t offset) {
-	// Memory banks 1,3,5 and 7 are contended
 	u8 bank = m_bank_ram[3]->entry();
 	return spectrum_state::is_contended(offset)
-		|| ((offset >= 0xc000 && offset <= 0xffff) && (bank && 1));
+		|| ((offset >= 0xc000 && offset <= 0xffff) && (bank && 1)); // Memory banks 1,3,5 and 7 are contended
 }
 
 static const gfx_layout spectrum_charlayout =

--- a/src/mame/drivers/specpls3.cpp
+++ b/src/mame/drivers/specpls3.cpp
@@ -266,8 +266,6 @@ void specpls3_state::port_7ffd_w(offs_t offset, uint8_t data)
 	/* paging disabled? */
 	if (m_port_7ffd_data & 0x20) return;
 
-	if ((m_port_7ffd_data ^ data) & 0x08) m_screen->update_now();
-
 	/* store new state */
 	m_port_7ffd_data = data;
 
@@ -342,6 +340,8 @@ void specpls3_state::machine_start()
 {
 	spectrum_128_state::machine_start();
 
+	save_item(NAME(m_port_1ffd_data));
+
 	// reconfigure ROMs
 	memory_region *rom = memregion("maincpu");
 	m_bank_rom[0]->configure_entries(0, 4, rom->base() + 0x10000, 0x4000);
@@ -352,6 +352,7 @@ void specpls3_state::machine_start()
 void specpls3_state::machine_reset()
 {
 	/* Initial configuration */
+	m_port_fe_data = -1;
 	m_port_7ffd_data = 0;
 	m_port_1ffd_data = 0;
 	plus3_update_memory();

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -115,6 +115,7 @@ protected:
 
 	int m_ROMSelection = 0; // FIXME: this is used for various things in derived classes, but not by this base class, and should be removed
 	std::vector<u8> m_contention_pattern;
+	u8 m_border4t_render_at = 0;
 	/* Defines offset in CPU cycles from screen left side. Early model (48/128/+2) typically use -1, later (+2A/+3) +1 */
 	s8 m_contention_offset = -1;
 	u64 m_int_at;

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -117,6 +117,9 @@ protected:
 	std::vector<u8> m_contention_pattern;
 	/* Defines offset in CPU cycles from screen left side. Early model (48/128/+2) typically use -1, later (+2A/+3) +1 */
 	s8 m_contention_offset = -1;
+	u64 m_int_at;
+
+	emu_timer *m_irq_off_timer;
 
 	uint8_t m_ram_disabled_by_beta;
 	uint8_t pre_opcode_fetch_r(offs_t offset);
@@ -140,7 +143,6 @@ protected:
 	void spectrum_palette(palette_device &palette) const;
 	virtual u32 screen_update_spectrum(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &cliprect);
 	INTERRUPT_GEN_MEMBER(spec_interrupt);
-	virtual attotime time_until_int();
 
 	DECLARE_SNAPSHOT_LOAD_MEMBER(snapshot_cb);
 	DECLARE_QUICKLOAD_LOAD_MEMBER(quickload_cb);

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -115,6 +115,7 @@ protected:
 
 	int m_ROMSelection = 0; // FIXME: this is used for various things in derived classes, but not by this base class, and should be removed
 	std::vector<u8> m_contention_pattern;
+	/* Pixel offset in 8px chunk (4T) when current chunk is rendered. */
 	u8 m_border4t_render_at = 0;
 	/* Defines offset in CPU cycles from screen left side. Early model (48/128/+2) typically use -1, later (+2A/+3) +1 */
 	s8 m_contention_offset = -1;

--- a/src/mame/machine/tsconf.cpp
+++ b/src/mame/machine/tsconf.cpp
@@ -763,7 +763,7 @@ void tsconf_state::dma_ready(int line)
 	if (BIT(m_regs[INT_MASK], 4))
 	{
 		m_maincpu->set_input_line_and_vector(line, ASSERT_LINE, 0xfb);
-		timer_set(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))), TIMER_IRQ_OFF, 0);
+		m_irq_off_timer->adjust(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))));
 	}
 }
 
@@ -776,7 +776,7 @@ void tsconf_state::device_timer(emu_timer &timer, device_timer_id id, int param)
 		if (BIT(m_regs[INT_MASK], 0))
 		{
 			m_maincpu->set_input_line_and_vector(0, ASSERT_LINE, 0xff);
-			timer_set(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))), TIMER_IRQ_OFF, 0);
+			m_irq_off_timer->adjust(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))));
 		}
 		break;
 	}
@@ -788,12 +788,12 @@ void tsconf_state::device_timer(emu_timer &timer, device_timer_id id, int param)
 		{
 			m_maincpu->set_input_line_and_vector(0, ASSERT_LINE, 0xfd);
 			// Not quite precise. Scanline can't be skipped.
-			timer_set(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))), TIMER_IRQ_OFF, 0);
+			m_irq_off_timer->adjust(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))));
 		}
 		if (BIT(m_regs[INT_MASK], 0) && OFFS_512(VS_INT_L) == screen_vpos && m_regs[HS_INT] == 0)
 		{
 			m_maincpu->set_input_line_and_vector(0, ASSERT_LINE, 0xff);
-			timer_set(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))), TIMER_IRQ_OFF, 0);
+			m_irq_off_timer->adjust(m_maincpu->clocks_to_attotime(32 * (1 << (m_regs[SYS_CONFIG] & 0x03))));
 		}
 
 		m_screen->update_now();

--- a/src/mame/machine/tsconf.cpp
+++ b/src/mame/machine/tsconf.cpp
@@ -755,7 +755,7 @@ void tsconf_state::update_frame_timer()
 INTERRUPT_GEN_MEMBER(tsconf_state::tsconf_vblank_interrupt)
 {
 	update_frame_timer();
-	m_line_irq_timer->adjust(m_screen->time_until_pos(0));
+	m_line_irq_timer->adjust(attotime::zero);
 }
 
 void tsconf_state::dma_ready(int line)

--- a/src/mame/video/agat7.cpp
+++ b/src/mame/video/agat7.cpp
@@ -87,7 +87,7 @@ void agat7video_device::device_start()
 
 void agat7video_device::device_reset()
 {
-	// XXX to be confirmed
+	// TODO to be confirmed
 	m_video_mode = TEXT_LORES;
 	m_start_address = 0x7800;
 }

--- a/src/mame/video/agat9.cpp
+++ b/src/mame/video/agat9.cpp
@@ -135,7 +135,7 @@ void agat9video_device::device_start()
 
 void agat9video_device::device_reset()
 {
-	// XXX to be confirmed
+	// TODO to be confirmed
 	m_video_mode = TEXT_LORES;
 	m_start_address = 0x7800;
 	m_mode = palette_index = 0;
@@ -152,7 +152,7 @@ uint8_t agat9video_device::read(offs_t offset)
 {
 	if(!machine().side_effects_disabled())
 		do_io(offset);
-	// XXX only 'Moscow' revision
+	// FIXME only 'Moscow' revision
 	return m_mode;
 }
 

--- a/src/mame/video/spectrum.cpp
+++ b/src/mame/video/spectrum.cpp
@@ -24,6 +24,8 @@
 ***************************************************************************/
 void spectrum_state::video_start()
 {
+	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
+
 	m_frame_invert_count = 16;
 	m_screen_location = m_video_ram;
 	m_contention_pattern = {6, 5, 4, 3, 2, 1, 0, 0};
@@ -182,7 +184,7 @@ void spectrum_state::content_early(s8 shift)
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->attotime_to_clocks(m_screen->frame_period() - time_until_int()) + shift;
+	u64 now = m_maincpu->total_cycles() - m_int_at + shift;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() + m_contention_offset;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 
@@ -200,7 +202,7 @@ void spectrum_state::content_late()
 	if (m_contention_pattern.empty() || vpos < get_screen_area().top() || vpos > get_screen_area().bottom())
 		return;
 
-	u64 now = m_maincpu->attotime_to_clocks(m_screen->frame_period() - time_until_int()) + 1;
+	u64 now = m_maincpu->total_cycles() - m_int_at + 1;
 	u64 cf = vpos * m_screen->width() * m_maincpu->clock() / m_screen->clock() + m_contention_offset;
 	u64 ct = cf + get_screen_area().width() * m_maincpu->clock() / m_screen->clock();
 	for(auto i = 0x04; i; i >>= 1)

--- a/src/mame/video/spectrum.cpp
+++ b/src/mame/video/spectrum.cpp
@@ -120,8 +120,8 @@ u32 spectrum_state::screen_update_spectrum(screen_device &screen, bitmap_ind16 &
 
 void spectrum_state::spectrum_update_border(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &border)
 {
-	u8 mod = m_contention_pattern.empty() ? 4 : 8;
-	u8 at = m_border4t_render_at;
+	u8 mod = m_contention_pattern.empty() ? 1 : 8;
+	u8 at = m_contention_pattern.empty() ? 0 : m_border4t_render_at;
 	for (auto y = border.top(); y <= border.bottom(); y++)
 	{
 		u16 *pix = &(bitmap.pix(y, border.left()));

--- a/src/mame/video/spectrum.cpp
+++ b/src/mame/video/spectrum.cpp
@@ -29,6 +29,8 @@ void spectrum_state::video_start()
 	m_frame_invert_count = 16;
 	m_screen_location = m_video_ram;
 	m_contention_pattern = {6, 5, 4, 3, 2, 1, 0, 0};
+	m_contention_offset = -1;
+	m_border4t_render_at = 2;
 }
 
 /***************************************************************************
@@ -118,14 +120,17 @@ u32 spectrum_state::screen_update_spectrum(screen_device &screen, bitmap_ind16 &
 
 void spectrum_state::spectrum_update_border(screen_device &screen, bitmap_ind16 &bitmap, const rectangle &border)
 {
-	u8 mod = m_contention_pattern.empty() ? 1 : m_contention_pattern.size();
+	u8 mod = m_contention_pattern.empty() ? 4 : 8;
+	u8 at = m_border4t_render_at;
 	for (auto y = border.top(); y <= border.bottom(); y++)
 	{
 		u16 *pix = &(bitmap.pix(y, border.left()));
 		for (auto x = border.left(); x <= border.right(); )
 		{
-			if (x % mod == 0)
+			if (x % mod == at)
 			{
+				pix -= at;
+				x -= at;
 				for (auto m = 0; m < mod; m++, x++)
 					*pix++ = get_border_color(y, x);
 			}

--- a/src/mame/video/timex.cpp
+++ b/src/mame/video/timex.cpp
@@ -29,6 +29,8 @@ inline void tc2048_state::spectrum_plot_pixel(bitmap_ind16 &bitmap, int x, int y
 /* Update FLASH status for ts2068. Assumes flash update every 1/2s. */
 void ts2068_state::video_start()
 {
+	m_irq_off_timer = timer_alloc(TIMER_IRQ_OFF);
+
 	m_frame_invert_count = 30;
 	m_screen_location = m_video_ram;
 }


### PR DESCRIPTION
zx spectrum drivers - restore irq length 32
more precise timings for screen and border updates
simplify current frame shift calculation which improves performance
minor: some states init/save