### PR TITLE
r4000.cpp: Add TimerIntDis mux to IPEX5

### DIFF
--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -90,13 +90,14 @@ DEFINE_DEVICE_TYPE(R5000, r5000_device, "r5000", "MIPS R5000")
 u32 const r5000_device::s_fcc_masks[8] = { (1U << 23), (1U << 25), (1U << 26), (1U << 27), (1U << 28), (1U << 29), (1U << 30), (1U << 31) };
 u32 const r5000_device::s_fcc_shifts[8] = { 23, 25, 26, 27, 28, 29, 30, 31 };
 
-r4000_base_device::r4000_base_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock, u32 prid, u32 fcr, cache_size icache_size, cache_size dcache_size, unsigned m32, unsigned m64, unsigned d32, unsigned d64)
+r4000_base_device::r4000_base_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock, u32 prid, u32 fcr, cache_size icache_size, cache_size dcache_size, unsigned m32, unsigned m64, unsigned d32, unsigned d64, bool timer_interrupt_disabled)
 	: cpu_device(mconfig, type, tag, owner, clock)
 	, m_program_config_le("program", ENDIANNESS_LITTLE, 64, 32)
 	, m_program_config_be("program", ENDIANNESS_BIG, 64, 32)
 	, m_hilo_cycles{ m32, m64, d32, d64 }
 	, m_r{}
 	, m_cp0{}
+	, m_timer_interrupt_disabled(timer_interrupt_disabled)
 	, m_f{}
 	, m_fcr0(fcr)
 {
@@ -1437,7 +1438,7 @@ void r4000_base_device::cp0_set(unsigned const reg, u64 const data)
 		break;
 	case CP0_Compare:
 		m_cp0[CP0_Compare] = u32(data);
-		if (m_timer_interrupt_enabled)
+		if (!m_timer_interrupt_disabled)
 			CAUSE &= ~CAUSE_IPEX5;
 
 		cp0_update_timer(true);
@@ -1578,6 +1579,9 @@ void r4000_base_device::cp0_tlbp()
 
 void r4000_base_device::cp0_update_timer(bool start)
 {
+	if (m_timer_interrupt_disabled)
+		return;
+
 	if (start || m_cp0_timer->enabled())
 	{
 		u32 const count = (total_cycles() - m_cp0_timer_zero) / 2;
@@ -1589,8 +1593,7 @@ void r4000_base_device::cp0_update_timer(bool start)
 
 TIMER_CALLBACK_MEMBER(r4000_base_device::cp0_timer_callback)
 {
-	if (m_timer_interrupt_enabled)
-		m_cp0[CP0_Cause] |= CAUSE_IPEX5;
+	m_cp0[CP0_Cause] |= CAUSE_IPEX5;
 }
 
 bool r4000_base_device::cp0_64() const

--- a/src/devices/cpu/mips/r4000.cpp
+++ b/src/devices/cpu/mips/r4000.cpp
@@ -1437,7 +1437,8 @@ void r4000_base_device::cp0_set(unsigned const reg, u64 const data)
 		break;
 	case CP0_Compare:
 		m_cp0[CP0_Compare] = u32(data);
-		CAUSE &= ~CAUSE_IPEX5;
+		if (m_timer_interrupt_enabled)
+			CAUSE &= ~CAUSE_IPEX5;
 
 		cp0_update_timer(true);
 		break;
@@ -1588,7 +1589,8 @@ void r4000_base_device::cp0_update_timer(bool start)
 
 TIMER_CALLBACK_MEMBER(r4000_base_device::cp0_timer_callback)
 {
-	m_cp0[CP0_Cause] |= CAUSE_IPEX5;
+	if (m_timer_interrupt_enabled)
+		m_cp0[CP0_Cause] |= CAUSE_IPEX5;
 }
 
 bool r4000_base_device::cp0_64() const

--- a/src/devices/cpu/mips/r4000.h
+++ b/src/devices/cpu/mips/r4000.h
@@ -45,14 +45,6 @@ public:
 
 	void bus_error() { m_bus_error = true; }
 
-	/*
-	 * This method allows bit 19 of the Boot-Mode Settings to be configured. See Chapter 9, page 223 of the R4000 User Manual.
-	 * When this bit is 0 (interrupt_disabled = false, default), then the CP0 timer will set interrupt 5 whenever it expires.
-	 * When this bit is 1 (interrupt_disabled = true), the CP0 timer interrupt is disabled.
-	 * If the CP0 timer interrupt is disabled, interrupt 5 becomes a standard general-purpose interrupt.
-	 */
-	void set_timer_interrupt_disable(bool interrupt_disabled) { m_timer_interrupt_enabled = !interrupt_disabled; }
-
 protected:
 	enum cache_size
 	{
@@ -65,7 +57,7 @@ protected:
 		CACHE_256K = 6,
 		CACHE_512K = 7,
 	};
-	r4000_base_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock, u32 prid, u32 fcr, cache_size icache_size, cache_size dcache_size, unsigned m32, unsigned m64, unsigned d32, unsigned d64);
+	r4000_base_device(machine_config const &mconfig, device_type type, char const *tag, device_t *owner, u32 clock, u32 prid, u32 fcr, cache_size icache_size, cache_size dcache_size, unsigned m32, unsigned m64, unsigned d32, unsigned d64, bool timer_interrupt_disabled);
 
 	enum cp0_reg : int
 	{
@@ -440,7 +432,7 @@ protected:
 	bool m_hard_reset;
 	bool m_ll_active;
 	bool m_bus_error;
-	bool m_timer_interrupt_enabled = true;
+	bool m_timer_interrupt_disabled;
 	struct tlb_entry
 	{
 		u64 mask;
@@ -477,44 +469,64 @@ class r4000_device : public r4000_base_device
 {
 public:
 	// NOTE: R4000 chips prior to 3.0 have an xtlb bug
-	r4000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-		: r4000_base_device(mconfig, R4000, tag, owner, clock, 0x0430, 0x0500, CACHE_8K, CACHE_8K, 10, 20, 69, 133)
+	r4000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, bool timer_interrupt_disabled)
+		: r4000_base_device(mconfig, R4000, tag, owner, clock, 0x0430, 0x0500, CACHE_8K, CACHE_8K, 10, 20, 69, 133, timer_interrupt_disabled)
 	{
 		// no secondary cache
 		m_cp0[CP0_Config] |= CONFIG_SC;
+	}
+
+	r4000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+		: r4000_device(mconfig, tag, owner, clock, false)
+	{
 	}
 };
 
 class r4400_device : public r4000_base_device
 {
 public:
-	r4400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-		: r4000_base_device(mconfig, R4400, tag, owner, clock, 0x0440, 0x0500, CACHE_16K, CACHE_16K, 10, 20, 69, 133)
+	r4400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, bool timer_interrupt_disabled)
+		: r4000_base_device(mconfig, R4400, tag, owner, clock, 0x0440, 0x0500, CACHE_16K, CACHE_16K, 10, 20, 69, 133, timer_interrupt_disabled)
 	{
 		// no secondary cache
 		m_cp0[CP0_Config] |= CONFIG_SC;
+	}
+
+	r4400_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+		: r4400_device(mconfig, tag, owner, clock, false)
+	{
 	}
 };
 
 class r4600_device : public r4000_base_device
 {
 public:
-	r4600_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-		: r4000_base_device(mconfig, R4600, tag, owner, clock, 0x2020, 0x2020, CACHE_16K, CACHE_16K, 10, 12, 42, 74)
+	r4600_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, bool timer_interrupt_disabled)
+		: r4000_base_device(mconfig, R4600, tag, owner, clock, 0x2020, 0x2020, CACHE_16K, CACHE_16K, 10, 12, 42, 74, timer_interrupt_disabled)
 	{
 		// no secondary cache
 		m_cp0[CP0_Config] |= CONFIG_SC;
 	}
+
+	r4600_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+		: r4600_device(mconfig, tag, owner, clock, false)
+		{
+		}
 };
 
 class r5000_device : public r4000_base_device
 {
 public:
-	r5000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
-		: r4000_base_device(mconfig, R5000, tag, owner, clock, 0x2320, 0x2320, CACHE_32K, CACHE_32K, 5, 9, 36, 68)
+	r5000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock, bool timer_interrupt_disabled)
+		: r4000_base_device(mconfig, R5000, tag, owner, clock, 0x2320, 0x2320, CACHE_32K, CACHE_32K, 5, 9, 36, 68, timer_interrupt_disabled)
 	{
 		// no secondary cache
 		m_cp0[CP0_Config] |= CONFIG_SC;
+	}
+
+	r5000_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
+		: r5000_device(mconfig, tag, owner, clock, false)
+	{
 	}
 
 private:

--- a/src/devices/cpu/mips/r4000.h
+++ b/src/devices/cpu/mips/r4000.h
@@ -45,6 +45,14 @@ public:
 
 	void bus_error() { m_bus_error = true; }
 
+	/*
+	 * This method allows bit 19 of the Boot-Mode Settings to be configured. See Chapter 9, page 223 of the R4000 User Manual.
+	 * When this bit is 0 (interrupt_disabled = false, default), then the CP0 timer will set interrupt 5 whenever it expires.
+	 * When this bit is 1 (interrupt_disabled = true), the CP0 timer interrupt is disabled.
+	 * If the CP0 timer interrupt is disabled, interrupt 5 becomes a standard general-purpose interrupt.
+	 */
+	void set_timer_interrupt_disable(bool interrupt_disabled) { m_timer_interrupt_enabled = !interrupt_disabled; }
+
 protected:
 	enum cache_size
 	{
@@ -432,6 +440,7 @@ protected:
 	bool m_hard_reset;
 	bool m_ll_active;
 	bool m_bus_error;
+	bool m_timer_interrupt_enabled = true;
 	struct tlb_entry
 	{
 		u64 mask;


### PR DESCRIPTION
This change implements boot-mode setting bit 19, TimIntDis/TimerIntDis, which configures if the R4x00 will use IPEX5 as an external interrupt, or as an internal timer using the compare register as the threshold (which is the default). The Sony NEWS NWS-5000X has multiple external timers, including a free-running clock and a hardware clock that drives IPEX2. So, Sony disabled the internal timer using TimerIntDis and repurposed IPEX5 for other things.

Boot-Mode Setting Description:
![Screenshot from 2022-04-30 21-05-17](https://user-images.githubusercontent.com/32155223/167263501-0c1d3ef4-2899-441e-ad54-fa34df329782.png)

Block diagram:
![Screenshot from 2022-04-30 21-06-33](https://user-images.githubusercontent.com/32155223/167263509-2f7c334f-ad26-4397-9e4d-d5a25563f5a2.png)

Test booting `jazz.cpp` to the WinNT installer, showing that the internal timer is still functional in the default config:
![Screenshot from 2022-04-30 21-53-46](https://user-images.githubusercontent.com/32155223/167263537-b60ad2fa-3a65-4904-b268-9bad31906fd3.png)

This is another change pulled in from #8854 since that PR is way too big. Apologies for taking so much time to restart the process of breaking it up into smaller, easier to review portions. The first part of the year is the build and competition season for the robotics team I mentor, so I had essentially no free time....
