### PR TITLE
diexec: resynchronize to the implicit clock domain on clock frequency change

### DIFF
--- a/src/emu/diexec.cpp
+++ b/src/emu/diexec.cpp
@@ -492,6 +492,9 @@ void device_execute_interface::interface_clock_changed()
 	m_cycles_per_second = clocks_to_cycles(device().clock());
 	m_attoseconds_per_cycle = HZ_TO_ATTOSECONDS(m_cycles_per_second);
 
+	// resynchronize the localtime to the clock domain
+	m_localtime = attotime::from_ticks(m_localtime.as_ticks(device().clock())+1, device().clock());
+
 	// update the device's divisor
 	s64 attos = m_attoseconds_per_cycle;
 	m_divshift = 0;


### PR DESCRIPTION
I don't think it's disruptive, but I'm not sure.  At least it fixes floppy writes on apple3, which lost its phase with the diskiii due to the clock changes.