### PR TITLE
Additions and changes to Spectrum-related softlists

### DIFF
--- a/hash/specpls3_flop.xml
+++ b/hash/specpls3_flop.xml
@@ -10,13 +10,21 @@ license:CC0
 <softwarelist name="specpls3_flop" description="Sinclair ZX Spectrum +3 disk images">
 
 <!--
-    SPS / CAPS Releases
-    http://www.softpres.org/_media/files:datafiles.zip?id=download&cache=cache
+	Known undumped:
+		Chichén Itzá (likely but unconfirmed)
+		Comando Tracer (dual-system Spectrum/Amstrad release)
+		Psycho Pigs UXB
 
-    Known missing IPF dumps:
+    Known missing SPS/CAPS IPF dumps (http://www.softpres.org/_media/files:datafiles.zip?id=download&cache=cache):
         3585    LED Storm: Lazer Enhanced Destruction
         3607    Rock Star Ate My Hamster
         3625    Tiger Road
+	
+	Observations:
+		Artura (alt): Side B has Hardball for the Amstrad CPC, was this edition accidentally sold like this?
+	
+	TO DO:
+		Some DSK images may come from the same releases as their respective IPFs. These cases need to be compared and verified to be the same thing before the redundant (and inferior) DSKs can be discarded.
 -->
 
 	<software name="qoscrup">
@@ -7545,17 +7553,18 @@ license:CC0
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="arturaa" cloneof="artura">
 	<!-- May be the same edition as the IPF -->
+	<!--	Side B has Hardball for the Amstrad CPC, was this edition accidentally sold like this?	-->
 		<description>Artura (alt)</description>
 		<year>1989</year>
 		<publisher>Gremlin Graphics Software</publisher>
 		<part name="flop1" interface="floppy_3">
-			<feature name="part_id" value="Side A"/>
+			<feature name="part_id" value="Side A: Artura (ZX Spectrum)"/>
 			<dataarea name="flop" size="194816">
 				<rom name="artura (1989)(gremlin graphics)(side a).dsk" size="194816" crc="a60019cb" sha1="3303b24cc705b4b6051223d653288ef115d90b2d" offset="0" />
 			</dataarea>
 		</part>
 		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B"/>
+			<feature name="part_id" value="Side B: Hardball (Amstrad CPC)"/>
 			<dataarea name="flop" size="194816">
 				<rom name="artura (1989)(gremlin graphics)(side b).dsk" size="194816" crc="9e8f9c27" sha1="4e2b395bbaf8e08341f515cdfc5744931d72872b" offset="0" />
 			</dataarea>
@@ -9066,21 +9075,13 @@ license:CC0
 
 <!-- From "Sinclair ZX Spectrum - Games - [DSK] (TOSEC-v2018-03-24_CM).dat" -->
 	<software name="comtracr">
-	<!-- This is a dual-system Spectrum/Amstrad release (Side A: ZX Spectrum, Side B: Amstrad CPC) -->
 		<description>Comando Tracer</description>
 		<year>1988</year>
 		<publisher>Dinamic Software</publisher>
 		<part name="flop1" interface="floppy_3">
-		<!-- Dump of side A might come from standalone version -->
 			<feature name="part_id" value="Side A: ZX Spectrum"/>
 			<dataarea name="flop" size="75008">
 				<rom name="comando tracer (1988)(dinamic)(es).dsk" size="75008" crc="985c2136" sha1="be76783bd8429b9f3ec2cd8702e7419b1c632ee6" offset="0" />
-			</dataarea>
-		</part>
-		<part name="flop2" interface="floppy_3">
-			<feature name="part_id" value="Side B: Amstrad CPC"/>
-			<dataarea name="flop" size = "69871">
-				<rom name="comando tracer (s) (1988) (cpm) [original].dsk" size="69871" crc="0261b785" sha1="767457b02516699c9d463f6c0ba69402fe87a813" offset="0" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/timex_cass.xml
+++ b/hash/timex_cass.xml
@@ -1341,7 +1341,7 @@ license:CC0
 			May 1988
 	-->
 	<software name="bpfeb88">
-		<description>Byte Power (Febuary 1988)</description>
+		<description>Byte Power (February 1988)</description>
 		<year>1988</year>
 		<publisher>Byte Power</publisher>
 		<part name="cass" interface="spectrum_cass">

--- a/hash/timex_cass.xml
+++ b/hash/timex_cass.xml
@@ -151,17 +151,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="assaltoa">
-		<description>Assalto A Embaixada</description>
-		<year>1982</year>
-		<publisher>TMX Portugal Ltda</publisher>
-		<part name="cass" interface="spectrum_cass">
-			<dataarea name="cass" size="18866">
-				<rom name="assalto a embaixada (1982)(tmx portugal ltda).tzx" size="18866" crc="adb7e4a1" sha1="89b661813b6fcb19aecabd93f5921e2f884ad55c"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="astrobla">
 	<!--    Thought to be a bootleg of Quicksilva's Spectrum release.   -->
 		<description>Astro Blaster (bootleg?)</description>
@@ -653,10 +642,10 @@ license:CC0
 	<software name="intrs232">
 		<description>Interface RS232</description>
 		<year>198?</year>
-		<publisher>Timex Computer Corporation</publisher>
+		<publisher>TMX Portugal Ltda</publisher>
 		<part name="cass" interface="spectrum_cass">
 			<dataarea name="cass" size="418">
-				<rom name="interface rs232 (198x)(timex computer corporation).tzx" size="418" crc="81e729fd" sha1="88c2e38ca230f2cb535f7ea404f807f2cfed9f6c"/>
+				<rom name="interface rs232 - timex computer.tzx" size="418" crc="81e729fd" sha1="88c2e38ca230f2cb535f7ea404f807f2cfed9f6c"/>
 			</dataarea>
 		</part>
 	</software>
@@ -859,18 +848,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="perigosns">
-	<!--    Portuguese adaptation of Jungle Trouble -->
-		<description>Perigos Na Selva</description>
-		<year>1983</year>
-		<publisher>TMX Portugal Ltda</publisher>
-		<part name="cass" interface="spectrum_cass">
-			<dataarea name="cass" size="23070">
-				<rom name="perigos na selva (1983)(tmx portugal ltda).tzx" size="23070" crc="61c78a5f" sha1="c5b5c0a590164db3f7f4f6d35c8d5327a804580e"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="pershofi">
 		<description>Personal Home Finance</description>
 		<year>1983</year>
@@ -918,24 +895,6 @@ license:CC0
 		</part>
 	</software>
 
-	<software name="prpresen">
-		<description>Programa de a presentaçao</description>
-		<year>1983</year>
-		<publisher>TMX Portugal Ltda</publisher>
-		<part name="cass1" interface="spectrum_cass">
-			<feature name="part_id" value="Side A"/>
-			<dataarea name="cass" size="64513">
-				<rom name="programa de a presentacao - side a (1983)(tmx portugal ltda).tzx" size="64513" crc="473f0089" sha1="3cfcc1e405f6dfcdd9f99be11651f5a680904fcc"/>
-			</dataarea>
-		</part>
-		<part name="cass2" interface="spectrum_cass">
-			<feature name="part_id" value="Side B"/>
-			<dataarea name="cass" size="87645">
-				<rom name="programa de a presentacao - side b (1983)(tmx portugal ltda).tzx" size="87645" crc="988ad0de" sha1="c4322b5a4f7560377c118746413c798f37aa6cc9"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="quadrach">
 		<description>Quadra-Chart</description>
 		<year>1983</year>
@@ -977,17 +936,6 @@ license:CC0
 		<part name="cass" interface="spectrum_cass">
 			<dataarea name="cass" size="8543">
 				<rom name="smart terminal 1 (1983)(timex computer corporation).tap" size="8543" crc="ac4ff16c" sha1="729956100e526e0fe89c1a82fc6930383259c697"/>
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="spacerai">
-		<description>Space Raiders</description>
-		<year>1983</year>
-		<publisher>TMX Portugal Ltda</publisher>
-		<part name="cass" interface="spectrum_cass">
-			<dataarea name="cass" size="22651">
-				<rom name="space raiders (1983)(tmx portugal ltda).tzx" size="22651" crc="03aaf3e4" sha1="05fb367e864377853ed63b9a3e79be00fde37eae"/>
 			</dataarea>
 		</part>
 	</software>
@@ -1376,4 +1324,31 @@ license:CC0
 			</dataarea>
 		</part>
 	</software>
+
+	<!-- ##################################################
+	      Covertapes from "Byte Power, 1st Class Magazine"
+	     ################################################## -->
+	<!--
+		Undumped covertapes confirmed to exist as of July 1988 (more may have been released afterwards):
+			August 1986
+			September 1986
+			October 1986
+			November 1986
+			December 1986 - January 1987
+			February 1987
+			Spring 1987
+			Fall 1987
+			May 1988
+	-->
+	<software name="bpfeb88">
+		<description>Byte Power (Febuary 1988)</description>
+		<year>1988</year>
+		<publisher>Byte Power</publisher>
+		<part name="cass" interface="spectrum_cass">
+			<dataarea name="cass" size="141395">
+				<rom name="byte-power-02-1988.tzx" size="141395" crc="6556dc57" sha1="c9f740a2b2f47930321c078001f6fc3ec98e119a"/>
+			</dataarea>
+		</part>
+	</software>
+
 </softwarelist>


### PR DESCRIPTION
**specpls3**
Spectrum disk version of Comando Tracer has been verified to be the standalone release, so its entry was changed.
Added list of known undumped games and other observations.

**spectrum_cass**
Added two demos and a good dump.
-Shock Megademo (Known dump on the internet was in TAP, so I created this TZX from the "SHOCKSAVER" program in the covertape for Sinclair User 85)
-The Lyra II (Full version, as opposed to the one split across several covertapes)
-Diseñador de Juegos (Microbyte): Replaced bad dump with verified one

**timex_cass**
Added a list of the known covertapes of "Byte Power, 1st Class Magazine" as well as the only known dump.
-Byte Power (February 1988)

**timex_cass and spectrum_cass**
Detected some games published by TMX Portugal but which were actually made for the Spectrum, so I moved them to the latter's softlist.
-Assalto A Embaixada (was already in both)
-Interface RS232 (now duplicated in both softlists, since the cover mentions both systems)
-Perigos Na Selva (replaces bad dump already in Spectrum softlist)
-Programa de Apresentação
-Space Raiders - Invasores Galácticos (replaces bad dump already in Spectrum softlist)