### PR TITLE
Bubble Trouble (bubbletr) diorama/scoreboard setup

### DIFF
--- a/src/mame/drivers/namcos2.cpp
+++ b/src/mame/drivers/namcos2.cpp
@@ -43,9 +43,6 @@ TODO:
        Does a checksum on area 0x181000 - 0x183fff, in 0x20 bytes block chunks. Game doesn't init it properly so you either have to go into service menu and do
        an "all data clear" or play once to get rid of the message.
 
-    Bubble Trouble (Golly Ghost II)
-    - no artwork
-
     Metal Hawk
     - ROZ wraparound isn't implemented (see large battleship in 2nd stage)
 
@@ -627,6 +624,36 @@ void namcos2_state::GollyGhostUpdateDiorama_c0(int data)
 	}
 }
 
+void namcos2_state::BubbleTroubleUpdateDiorama_c0( int data )
+{
+	if (data & 0x80)
+	{
+		output().set_value("undersea", 1); /* diorama is lit up */
+
+		/* diorama controller; solenoids control physical components */
+		output().set_value("shell",   (data >> 0) & 1);
+		output().set_value("ship",    (data >> 1) & 1);
+		output().set_value("trapdoor",(data >> 2) & 1);
+		output().set_value("chest",   (data >> 3) & 1);
+		//output().set_value("porch", (data >> 4) & 1); /* appears to be unused */
+		/* gun recoils */
+		output().set_value("Player1_Gun_Recoil",(data & 0x20)>>5);
+		output().set_value("Player2_Gun_Recoil",(data & 0x40)>>6);
+
+	}
+	else
+	{
+		output().set_value("undersea",0);
+		output().set_value("shell", 0);
+		output().set_value("ship", 0);
+		output().set_value("trapdoor", 0);
+		output().set_value("chest", 0);
+		//output().set_value("porch", 0); /* appears to be unused */
+		output().set_value("Player1_Gun_Recoil",0);
+		output().set_value("Player2_Gun_Recoil",0);
+	}
+}
+
 uint16_t namcos2_state::dpram_word_r(offs_t offset)
 {
 	return m_dpram[offset];
@@ -644,6 +671,22 @@ void namcos2_state::dpram_word_w(offs_t offset, uint16_t data, uint16_t mem_mask
 			switch( offset )
 			{
 			case 0xc0/2: GollyGhostUpdateDiorama_c0(data); break;
+			case 0xc2/2:
+				/* unknown; 0x00 or 0x01 - probably lights up guns */
+			break;
+			case 0xc4/2: GollyGhostUpdateLED_c4(data); break;
+			case 0xc6/2: GollyGhostUpdateLED_c6(data); break;
+			case 0xc8/2: GollyGhostUpdateLED_c8(data); break;
+			case 0xca/2: GollyGhostUpdateLED_ca(data); break;
+			default:
+				break;
+			}
+		}
+		if( m_gametype==NAMCOS2_BUBBLE_TROUBLE )
+		{
+			switch( offset )
+			{
+			case 0xc0/2: BubbleTroubleUpdateDiorama_c0(data); break;
 			case 0xc2/2:
 				/* unknown; 0x00 or 0x01 - probably lights up guns */
 			break;

--- a/src/mame/includes/namcos2.h
+++ b/src/mame/includes/namcos2.h
@@ -252,6 +252,7 @@ enum
 	void GollyGhostUpdateLED_c8(int data);
 	void GollyGhostUpdateLED_ca(int data);
 	void GollyGhostUpdateDiorama_c0(int data);
+	void BubbleTroubleUpdateDiorama_c0(int data);
 	void TilemapCB(uint16_t code, int *tile, int *mask);
 	void TilemapCB_finalap2(uint16_t code, int *tile, int *mask);
 	void RozCB_luckywld(uint16_t code, int *tile, int *mask, int which);


### PR DESCRIPTION
Hello,

Thanks to the tremendous efforts of @Widge-5, who meticulously restored the Bubble Trouble diorama artwork from YouTube footage of the game and constructed a corresponding MAME lay file, it is now possible to play Bubble Trouble (bubbletr) with a full, moving undersea-diorama setup with these code additions.

[Widge's video](https://www.youtube.com/watch?v=enQ9NGaPGQY) explains the restoration process, shows the working diorama, and has a link to the artwork/layout files.

The gist is that the Bubble Trouble diorama is a drop-in replacement for the Golly Ghost diorama that has only 4 moving pieces (ship, ship trapdoor, treasure chest, and clam) instead of Golly Ghost's 5. We were able to identify the Bubble Trouble moving pieces by activating the Golly Ghost diorama for bubbletr in the MAME code and then applying its artwork to Bubble Trouble. The scoreboard appears to function exactly the same as Golly Ghost's.

Now, everyone should be able to enjoy this game closer to the originally intended way of playing it 😃.

If anyone out there has access to the physical diorama pieces and can provide higher-quality photos, please let us know!