### PR TITLE
a2600.xml: Remove "Atari VCS Point-of-Purchase ROM" (nw)

### DIFF
--- a/hash/a2600.xml
+++ b/hash/a2600.xml
@@ -1239,17 +1239,6 @@ X-1414 : Streetracer
 		</part>
 	</software>
 
-	<software name="avcspop">
-		<description>Atari VCS Point-of-Purchase ROM</description>
-		<year>1982</year>
-		<publisher>Atari</publisher>
-		<part name="cart" interface="a2600_cart">
-			<dataarea name="rom" size="2048">
-				<rom name="atari vcs point-of-purchase rom.bin" size="2048" crc="9d3cfba6" sha1="b84c34aaedd84fca30b6e8223ee062439acf4fe0"/>
-			</dataarea>
-		</part>
-	</software>
-
 	<software name="avc">
 		<description>Atari Video Cube</description>
 		<year>1982</year>


### PR DESCRIPTION
This has its own driver in a2600.cpp