### PR TITLE
[powervr2.cpp] Naomi Rendering Fixes

### DIFF
--- a/src/mame/video/powervr2.cpp
+++ b/src/mame/video/powervr2.cpp
@@ -2076,6 +2076,41 @@ void powervr2_device::process_ta_fifo()
 						rd->verts_size += 4;
 					}
 				}
+				else
+				{
+					if (rd->verts_size <= (MAX_VERTS - 6) && grp->strips_size < MAX_STRIPS)
+					{
+						strip *ts;
+						vert *tv = &rd->verts[rd->verts_size];
+						tv[0].x = u2f(tafifo_buff[0x1]);
+						tv[0].y = u2f(tafifo_buff[0x2]);
+						tv[0].w = u2f(tafifo_buff[0x3]);
+						tv[1].x = u2f(tafifo_buff[0x4]);
+						tv[1].y = u2f(tafifo_buff[0x5]);
+						tv[1].w = u2f(tafifo_buff[0x6]);
+						tv[3].x = u2f(tafifo_buff[0x7]);
+						tv[3].y = u2f(tafifo_buff[0x8]);
+						tv[3].w = u2f(tafifo_buff[0x9]);
+						tv[2].x = u2f(tafifo_buff[0xa]);
+						tv[2].y = u2f(tafifo_buff[0xb]);
+						tv[2].w = tv[0].w+tv[3].w-tv[1].w;
+
+						int idx;
+						for (idx = 0; idx < 4; idx++) {
+							memcpy(tv[idx].b, poly_base_color,
+								   sizeof(tv[idx].b));
+							memcpy(tv[idx].o, poly_offs_color,
+								   sizeof(tv[idx].o));
+						}
+
+						ts = &grp->strips[grp->strips_size++];
+						tex_get_info(&ts->ti);
+						ts->svert = rd->verts_size;
+						ts->evert = rd->verts_size + 3;
+
+						rd->verts_size += 4;
+					}
+				}
 			}
 			else if (global_paratype == 4)
 			{

--- a/src/mame/video/powervr2.cpp
+++ b/src/mame/video/powervr2.cpp
@@ -745,7 +745,7 @@ void powervr2_device::tex_get_info(texinfo *t)
 	t->cd = dilatechose[t->sizes];
 	t->palbase = 0;
 	t->vqbase = t->address;
-	t->blend = use_alpha ? blend_functions[t->blend_mode] : bl10;
+	t->blend = ignoretexalpha ? bl10 : blend_functions[t->blend_mode];
 
 	t->coltype = coltype;
 	t->tsinstruction = tsinstruction;
@@ -1817,7 +1817,7 @@ void powervr2_device::process_ta_fifo()
 		volume=(objcontrol >> 6) & 1;
 		coltype=(objcontrol >> 4) & 3;
 		texture=(objcontrol >> 3) & 1;
-		offset_color_enable=(objcontrol >> 2) & 1;
+		offset_color_enable=texture ? (objcontrol >> 2) & 1 : 0;
 		gouraud=(objcontrol >> 1) & 1;
 		uv16bit=(objcontrol >> 0) & 1;
 	}
@@ -1992,6 +1992,13 @@ void powervr2_device::process_ta_fifo()
 				paletteselector=(tafifo_buff[3] >> 21) & 0x3F;
 
 				LOGTATILE(" Texture at %08x format %d\n", (tafifo_buff[3] & 0x1FFFFF) << 3, pixelformat);
+			}
+			if (use_alpha == 0)
+			{
+				// Alpha value in base/offset color is to be treated as 1.0/0xFF.
+				poly_base_color[0] = 1.0;
+				if (offset_color_enable)
+					poly_offs_color[0] = 1.0;
 			}
 			if (paratype == 4)
 			{

--- a/src/mame/video/powervr2.cpp
+++ b/src/mame/video/powervr2.cpp
@@ -694,15 +694,10 @@ void powervr2_device::tex_get_info(texinfo *t)
 	int miptype = 0;
 
 	t->textured    = texture;
-
-	// not textured, abort.
-//  if (!t->textured) return;
-
 	t->address     = textureaddress;
 	t->pf          = pixelformat;
 	t->palette     = 0;
-
-	t->mode = (vqcompressed<<1);
+	t->mode        = (vqcompressed<<1);
 
 	// scanorder is ignored for palettized textures (palettized textures are ALWAYS twiddled)
 	// (the same bits are used for palette select instead)
@@ -716,7 +711,7 @@ void powervr2_device::tex_get_info(texinfo *t)
 	}
 
 	/* When scan order is 1 (non-twiddled) mipmap is ignored */
-	t->mipmapped  = t->mode & 1 ? 0 : mipmapped;
+	t->mipmapped = t->mode & 1 ? 0 : mipmapped;
 
 	// Mipmapped textures are always square, ignore v size
 	if (t->mipmapped)
@@ -2040,24 +2035,24 @@ void powervr2_device::process_ta_fifo()
 					u2f(tafifo_buff[10]), u2f(tafifo_buff[11])
 				);
 
-				if (texture == 1)
+				if (rd->verts_size <= (MAX_VERTS - 6) && grp->strips_size < MAX_STRIPS)
 				{
-					if (rd->verts_size <= (MAX_VERTS - 6) && grp->strips_size < MAX_STRIPS)
+					vert * const tv = &rd->verts[rd->verts_size];
+					tv[0].x = u2f(tafifo_buff[0x1]);
+					tv[0].y = u2f(tafifo_buff[0x2]);
+					tv[0].w = u2f(tafifo_buff[0x3]);
+					tv[1].x = u2f(tafifo_buff[0x4]);
+					tv[1].y = u2f(tafifo_buff[0x5]);
+					tv[1].w = u2f(tafifo_buff[0x6]);
+					tv[3].x = u2f(tafifo_buff[0x7]);
+					tv[3].y = u2f(tafifo_buff[0x8]);
+					tv[3].w = u2f(tafifo_buff[0x9]);
+					tv[2].x = u2f(tafifo_buff[0xa]);
+					tv[2].y = u2f(tafifo_buff[0xb]);
+					tv[2].w = tv[0].w+tv[3].w-tv[1].w;
+
+					if (texture == 1)
 					{
-						strip *ts;
-						vert *tv = &rd->verts[rd->verts_size];
-						tv[0].x = u2f(tafifo_buff[0x1]);
-						tv[0].y = u2f(tafifo_buff[0x2]);
-						tv[0].w = u2f(tafifo_buff[0x3]);
-						tv[1].x = u2f(tafifo_buff[0x4]);
-						tv[1].y = u2f(tafifo_buff[0x5]);
-						tv[1].w = u2f(tafifo_buff[0x6]);
-						tv[3].x = u2f(tafifo_buff[0x7]);
-						tv[3].y = u2f(tafifo_buff[0x8]);
-						tv[3].w = u2f(tafifo_buff[0x9]);
-						tv[2].x = u2f(tafifo_buff[0xa]);
-						tv[2].y = u2f(tafifo_buff[0xb]);
-						tv[2].w = tv[0].w+tv[3].w-tv[1].w;
 						tv[0].u = u2f(tafifo_buff[0xd] & 0xffff0000);
 						tv[0].v = u2f(tafifo_buff[0xd] << 16);
 						tv[1].u = u2f(tafifo_buff[0xe] & 0xffff0000);
@@ -2066,57 +2061,20 @@ void powervr2_device::process_ta_fifo()
 						tv[3].v = u2f(tafifo_buff[0xf] << 16);
 						tv[2].u = tv[0].u+tv[3].u-tv[1].u;
 						tv[2].v = tv[0].v+tv[3].v-tv[1].v;
-
-						int idx;
-						for (idx = 0; idx < 4; idx++) {
-							memcpy(tv[idx].b, poly_base_color,
-								   sizeof(tv[idx].b));
-							memcpy(tv[idx].o, poly_offs_color,
-								   sizeof(tv[idx].o));
-						}
-
-						ts = &grp->strips[grp->strips_size++];
-						tex_get_info(&ts->ti);
-						ts->svert = rd->verts_size;
-						ts->evert = rd->verts_size + 3;
-
-						rd->verts_size += 4;
 					}
-				}
-				else
-				{
-					if (rd->verts_size <= (MAX_VERTS - 6) && grp->strips_size < MAX_STRIPS)
+
+					for (int idx = 0; idx < 4; idx++)
 					{
-						strip *ts;
-						vert *tv = &rd->verts[rd->verts_size];
-						tv[0].x = u2f(tafifo_buff[0x1]);
-						tv[0].y = u2f(tafifo_buff[0x2]);
-						tv[0].w = u2f(tafifo_buff[0x3]);
-						tv[1].x = u2f(tafifo_buff[0x4]);
-						tv[1].y = u2f(tafifo_buff[0x5]);
-						tv[1].w = u2f(tafifo_buff[0x6]);
-						tv[3].x = u2f(tafifo_buff[0x7]);
-						tv[3].y = u2f(tafifo_buff[0x8]);
-						tv[3].w = u2f(tafifo_buff[0x9]);
-						tv[2].x = u2f(tafifo_buff[0xa]);
-						tv[2].y = u2f(tafifo_buff[0xb]);
-						tv[2].w = tv[0].w+tv[3].w-tv[1].w;
-
-						int idx;
-						for (idx = 0; idx < 4; idx++) {
-							memcpy(tv[idx].b, poly_base_color,
-								   sizeof(tv[idx].b));
-							memcpy(tv[idx].o, poly_offs_color,
-								   sizeof(tv[idx].o));
-						}
-
-						ts = &grp->strips[grp->strips_size++];
-						tex_get_info(&ts->ti);
-						ts->svert = rd->verts_size;
-						ts->evert = rd->verts_size + 3;
-
-						rd->verts_size += 4;
+						memcpy(tv[idx].b, poly_base_color, sizeof(tv[idx].b));
+						memcpy(tv[idx].o, poly_offs_color, sizeof(tv[idx].o));
 					}
+
+					strip * const ts = &grp->strips[grp->strips_size++];
+					tex_get_info(&ts->ti);
+					ts->svert = rd->verts_size;
+					ts->evert = rd->verts_size + 3;
+
+					rd->verts_size += 4;
 				}
 			}
 			else if (global_paratype == 4)


### PR DESCRIPTION
This fixes a few miscellaneous rendering bugs with Naomi1/2 that I noticed while trying to debug my doom port in MAME. 

1. Hooks up non-textured sprite rendering. Not sure why this was excluded (aside from UV stuff not applicable?) since all code worked just fine on hooking up. Without this fix, the boxes behind the next/previous instructions at the bottom of this test code do not appear. With this fix, they appear matching hardware. Also, with fix 2 below they properly render translucently (I don't have any photos of this but I did test on actual HW, demul and MAME and saw them all working identically).

![boxes](https://user-images.githubusercontent.com/421365/167968988-3b2a171a-a690-4cd9-8c61-e00b51dc8f26.png)

3. Fixes the "enable alpha" bit to enable alpha on base/offset color, with the alpha set to full when unset, and hooked up "disable texture alpha" to disabling texture alpha instead of "enable alpha". This fixes hardware-assisted font rendering in all of my test code and appears to match demul and actual HW. Note that I think this fix will probably fix a lot of the black pixels instead of alpha issues seen on various Naomi games, but I didn't test. I only compared test binaries that I've previously verified on demul and actual HW.

Before the fix:

![before](https://user-images.githubusercontent.com/421365/167969023-47a0e6bb-7b4c-4513-9a03-0aa25851f8d0.png)

After the fix:

![after](https://user-images.githubusercontent.com/421365/167969036-b27ef613-6a2d-4ddb-8187-f2aba4825da7.png)

I still don't know why MAME won't properly render my doom port, but the behavior points at incorrect handling of interrupts and I will try to fix that and submit another PR.