### PR TITLE
Fix address mask for SST 39SF040

### DIFF
--- a/src/devices/machine/intelfsh.cpp
+++ b/src/devices/machine/intelfsh.cpp
@@ -258,6 +258,7 @@ intelfsh_device::intelfsh_device(const machine_config &mconfig, device_type type
 	case FLASH_SST_39SF040:
 		m_bits = 8;
 		m_size = 0x80000;
+		m_addrmask = 0x7fff;
 		m_maker_id = MFG_SST;
 		m_device_id = 0xb7;
 		m_sector_is_4k = true;


### PR DESCRIPTION
This fix running a tool to update flash as on original hardware in my WIP driver.
Before this was failing since it was entering part of code where address is masked but mask was zero

![0000](https://user-images.githubusercontent.com/3623496/168120503-2c769ea5-df8b-4e24-85bc-35a13e359d41.png)

