### PR TITLE
slapfght.cpp: Hooked up flip screen output to MCU for alcon and slapfigh

### DIFF
--- a/src/mame/drivers/slapfght.cpp
+++ b/src/mame/drivers/slapfght.cpp
@@ -14,8 +14,6 @@
 
   TODO:
   - proper MCU emulation (mame/machine/slapfght.cpp)
-  - alcon cocktail/flipscreen, it doesn't write to the flipscreen reg
-
 
 ****************************************************************************
 
@@ -1021,7 +1019,6 @@ void slapfght_state::slapfigh(machine_config &config)
 
 	ls259_device &mainlatch(LS259(config, "mainlatch"));
 	mainlatch.q_out_cb<0>().set(FUNC(slapfght_state::sound_reset_w));
-	mainlatch.q_out_cb<1>().set(FUNC(slapfght_state::flipscreen_w));
 	mainlatch.q_out_cb<3>().set(FUNC(slapfght_state::irq_enable_w));
 	mainlatch.q_out_cb<4>().set_membank("bank1");
 
@@ -1030,6 +1027,7 @@ void slapfght_state::slapfigh(machine_config &config)
 	m_audiocpu->set_periodic_int(FUNC(slapfght_state::sound_nmi), attotime::from_hz(180));
 
 	TAITO68705_MCU(config, m_bmcu, 36_MHz_XTAL/12); // 3MHz
+	m_bmcu->aux_out_cb<5>().set(FUNC(slapfght_state::flipscreen_w));
 	m_bmcu->aux_strobe_cb().set(FUNC(slapfght_state::scroll_from_mcu_w));
 
 	config.set_perfect_quantum(m_maincpu);
@@ -1057,6 +1055,15 @@ void slapfght_state::slapfigh(machine_config &config)
 	ay2.port_a_read_callback().set_ioport("DSW1");
 	ay2.port_b_read_callback().set_ioport("DSW2");
 	ay2.add_route(ALL_OUTPUTS, "mono", 0.25);
+}
+
+void slapfght_state::slapfigha(machine_config &config)
+{
+	slapfigh(config);
+
+	subdevice<ls259_device>("mainlatch")->q_out_cb<1>().set(FUNC(slapfght_state::flipscreen_w));
+
+	m_bmcu->aux_out_cb<5>().set_nop();
 }
 
 void slapfght_state::slapfighb1(machine_config &config)
@@ -2083,9 +2090,9 @@ GAME( 1985, tigerhb2,   tigerh,   tigerhb2,   tigerh,    slapfght_state, empty_i
 GAME( 1985, tigerhb3,   tigerh,   tigerhb2,   tigerh,    slapfght_state, empty_init,     ROT270, "bootleg",                         "Tiger-Heli (bootleg set 3)", MACHINE_SUPPORTS_SAVE )
 GAME( 1985, tigerhb4,   tigerh,   tigerhb4,   tigerh,    slapfght_state, empty_init,     ROT270, "bootleg",                         "Tiger-Heli (bootleg set 4)", MACHINE_NOT_WORKING | MACHINE_SUPPORTS_SAVE ) // MCU not hooked up
 
-GAME( 1986, alcon,      0,        slapfigh,   slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito America Corp.",   "Alcon (US)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )
-GAME( 1986, slapfigh,   alcon,    slapfigh,   slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito",                 "Slap Fight (A77 set, 8606M PCB)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )
-GAME( 1986, slapfigha,  alcon,    slapfigh,   slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito",                 "Slap Fight (A76 set, GX-006-A PCB)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )
+GAME( 1986, alcon,      0,        slapfigh,   slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito America Corp.",   "Alcon (US)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, slapfigh,   alcon,    slapfigh,   slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito",                 "Slap Fight (A77 set, 8606M PCB)", MACHINE_SUPPORTS_SAVE )
+GAME( 1986, slapfigha,  alcon,    slapfigha,  slapfigh,  slapfght_state, init_slapfigh,  ROT270, "Toaplan / Taito",                 "Slap Fight (A76 set, GX-006-A PCB)", MACHINE_SUPPORTS_SAVE )
 GAME( 1986, slapfighb1, alcon,    slapfighb1, slapfigh,  slapfght_state, init_slapfigh,  ROT270, "bootleg",                         "Slap Fight (bootleg set 1)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL )
 GAME( 1986, slapfighb2, alcon,    slapfighb2, slapfigh,  slapfght_state, init_slapfigh,  ROT270, "bootleg",                         "Slap Fight (bootleg set 2)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // England?
 GAME( 1986, slapfighb3, alcon,    slapfighb2, slapfigh,  slapfght_state, init_slapfigh,  ROT270, "bootleg",                         "Slap Fight (bootleg set 3)", MACHINE_SUPPORTS_SAVE | MACHINE_NO_COCKTAIL ) // PCB labeled 'slap fighter'

--- a/src/mame/includes/slapfght.h
+++ b/src/mame/includes/slapfght.h
@@ -40,11 +40,12 @@ public:
 	void tigerhb2(machine_config &config);
 	void tigerhb4(machine_config &config);
 	void getstarb2(machine_config &config);
-	void slapfighb2(machine_config &config);
 	void getstarb1(machine_config &config);
 	void perfrman(machine_config &config);
 	void slapfigh(machine_config &config);
+	void slapfigha(machine_config &config);
 	void slapfighb1(machine_config &config);
+	void slapfighb2(machine_config &config);
 
 	void init_banks();
 	void init_getstarb1();

--- a/src/mame/machine/taito68705interface.cpp
+++ b/src/mame/machine/taito68705interface.cpp
@@ -184,6 +184,7 @@ taito68705_mcu_device::taito68705_mcu_device(const machine_config &mconfig, cons
 
 taito68705_mcu_device::taito68705_mcu_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 clock)
 	: taito68705_mcu_device_base(mconfig, type, tag, owner, clock)
+	, m_aux_out_cb(*this)
 	, m_aux_strobe_cb(*this)
 	, m_pb_output(0xff)
 {
@@ -201,6 +202,7 @@ void taito68705_mcu_device::device_start()
 {
 	taito68705_mcu_device_base::device_start();
 
+	m_aux_out_cb.resolve_all_safe();
 	m_aux_strobe_cb.resolve_safe();
 
 	save_item(NAME(m_pb_output));
@@ -239,6 +241,7 @@ void taito68705_mcu_device::mcu_portb_w(offs_t offset, u8 data, u8 mem_mask)
 {
 	// some games have additional peripherals strobed on falling edge
 	u8 const old_pa_value(pa_value());
+	u8 const aux_changed((data ^ m_pb_output) >> 2);
 	u8 const aux_strobes((mem_mask & ~data & m_pb_output) >> 2);
 
 	// rising edge on PB1 clears the host semaphore flag
@@ -248,6 +251,8 @@ void taito68705_mcu_device::mcu_portb_w(offs_t offset, u8 data, u8 mem_mask)
 	// callbacks for other peripherals
 	for (unsigned i = 0; i < 6; ++i)
 	{
+		if (BIT(aux_changed, i))
+			m_aux_out_cb[i](BIT(data, i + 2));
 		if (BIT(aux_strobes, i))
 			m_aux_strobe_cb(i, old_pa_value, 0xff);
 	}

--- a/src/mame/machine/taito68705interface.cpp
+++ b/src/mame/machine/taito68705interface.cpp
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Ernesto Corvi, Nicola Salmoria, David Haywood, Vas Crabb
+// copyright-holders:David Haywood, Vas Crabb
 #include "emu.h"
 #include "machine/taito68705interface.h"
 

--- a/src/mame/machine/taito68705interface.h
+++ b/src/mame/machine/taito68705interface.h
@@ -1,5 +1,5 @@
 // license:BSD-3-Clause
-// copyright-holders:Ernesto Corvi, Nicola Salmoria, David Haywood, Vas Crabb
+// copyright-holders:David Haywood, Vas Crabb
 #ifndef MAME_MACHINE_TAITO68705INTERFACE_H
 #define MAME_MACHINE_TAITO68705INTERFACE_H
 

--- a/src/mame/machine/taito68705interface.h
+++ b/src/mame/machine/taito68705interface.h
@@ -63,6 +63,7 @@ private:
 class taito68705_mcu_device : public taito68705_mcu_device_base
 {
 public:
+	template <unsigned N> auto aux_out_cb() { return m_aux_out_cb[N].bind(); }
 	auto aux_strobe_cb() { return m_aux_strobe_cb.bind(); }
 
 	taito68705_mcu_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
@@ -76,7 +77,8 @@ protected:
 	virtual void device_add_mconfig(machine_config &config) override;
 	virtual void device_start() override;
 
-	devcb_write8    m_aux_strobe_cb;
+	devcb_write_line::array<6>  m_aux_out_cb;
+	devcb_write8                m_aux_strobe_cb;
 
 	u8  m_pb_output;
 };


### PR DESCRIPTION
This makes the flip screen DIP switch and cocktail mode work for alcon and slapfigh.  It already worked for slapfigha which uses the same latch output as the other games for this purpose.  Screen flipping still doesn’t work in the bootlegs, but that could well be a real limitation as they lack the MCU (the bootleggers may have been too lazy to hook screen flipping up a different way).

The graphics still have offsets, but at least the offsets look the same between normal and flipped mode now.