### PR TITLE
fix version detection in str_to_version for versions formatted as (n).(n)-suffix

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -39,7 +39,7 @@ function str_to_version(str)
 		return val
 	end
 	local cnt = 10000
-	for word in string.gmatch(str, '([^.]+)') do
+	for word in string.gmatch(str, '([^.-]+)') do
 		if(tonumber(word) == nil) then
 			return val
 		end


### PR DESCRIPTION
This fixes version detection in  str_to_version where the version include a type suffix like `-posix`. Windows cross-compilation is currently broken on linux. The currently `x86_64-w64-mingw32-gcc -dumpversion` returns `10-win32` on Ubuntu 22.04. Since this version doesn't contain a `.` char it fails the `string.gmatch` in `str_to_version` resulting in a `0` return. We then fall into into  
the version check block at `genie.lua` ln:1063

https://github.com/mamedev/mame/blob/afb0469e485d19671cfbff48969daea030918917/scripts/genie.lua#L42

https://github.com/mamedev/mame/blob/afb0469e485d19671cfbff48969daea030918917/scripts/genie.lua#L1063

falling into this block results in `os.exit(-1)` that presents to the user as:
 `make: *** [makefile:1105: build/projects/windows/mame/gmake-mingw64-gcc/Makefile] Error 255`

This change also makes version numbers reported consistent with those where a `-suffix` is not present

```
version:  10-posix   old:  0       new:  100000
version:  10-win32   old:  0       new:  100000
version:  9.3-posix  old:  90000   new:  90300
version:  9.3-win32  old:  90000   new:  90300
version:  11         old:  110000  new:  110000
version:  10         old:  100000  new:  100000
version:  9.3.0      old:  90300   new:  90300
version:  9.3        old:  90300   new:  90300
version:  11.2       old:  110200  new:  110200
version:  11.2.0     old:  110200  new:  110200
version:  6.0        old:  60000   new:  60000
version:  6          old:  60000   new:  60000
version:  7.3.4      old:  70304   new:  70304
version:  8.7        old:  80700   new:  80700
```

e.g where `9.3-win32` used to report `90000` it now reports `90300` which is consistent with what is reports for `9.3` and `9.3.0`