### PR TITLE
Fix interface to upd7759 sounds in brkball

### DIFF
--- a/src/mame/drivers/bfcobra.cpp
+++ b/src/mame/drivers/bfcobra.cpp
@@ -2603,9 +2603,8 @@ void bfcobjam_state::genio_w( uint8_t data )
 	}
 
 	//bits 1 and 2 are for upd7759
-	m_upd7759_int->md_w(0);
+	m_upd7759_int->md_w(!BIT(data,1));
 	m_upd7759_int->reset_w(!BIT(data,2));
-	m_upd7759_int->start_w(BIT(data,1));
 }
 
 void bfcobjam_state::upd7759_w(uint8_t data)


### PR DESCRIPTION
Interface to slave upd7759 was using start and reset inputs when should've been using mode and reset.
This used to work but recent PR #9614 meant it stopped working.
Change to mode and reset inputs confirmed on schematics.