### PR TITLE
Properly set BIOS under slot

### DIFF
--- a/src/emu/emuopts.cpp
+++ b/src/emu/emuopts.cpp
@@ -1220,8 +1220,8 @@ void slot_option::set_bios(std::string &&text)
 {
 	if (!m_specified)
 	{
-		m_specified = true;
 		m_specified_value = value();
+		m_specified = true;
 	}
 	m_specified_bios = std::move(text);
 }


### PR DESCRIPTION
`value()` is using `m_specified` flag internally. Without fix setting bios trough the UI caused selected slot name to be lost. 