### PR TITLE
slot bios handling improvements

### DIFF
--- a/src/emu/machine.cpp
+++ b/src/emu/machine.cpp
@@ -1116,7 +1116,19 @@ std::string running_machine::nvram_filename(device_t &device) const
 		if (software != nullptr && *software != '\0')
 			result << PATH_SEPARATOR << software;
 
-		std::string tag(device.tag());
+		std::string tag;
+		for (device_t *dev = &device; dev->owner() != nullptr; dev = dev->owner())
+		{
+			std::ostringstream dev_tag;
+			dev_tag << ":" << dev->basetag();
+			device_slot_interface *intf;
+			if (dev->owner() && dev->owner()->interface(intf))
+			{
+				if (dev->system_bios() != 0 && dev->default_bios() != dev->system_bios())
+					util::stream_format(dev_tag, "_%d", dev->system_bios() - 1);
+			}
+			tag = dev_tag.str() + tag;
+		}
 		tag.erase(0, 1);
 		strreplacechr(tag,':', '_');
 		result << PATH_SEPARATOR << tag;

--- a/src/frontend/mame/ui/miscmenu.cpp
+++ b/src/frontend/mame/ui/miscmenu.cpp
@@ -51,6 +51,26 @@ menu_bios_selection::menu_bios_selection(mame_ui_manager &mui, render_container 
 {
 }
 
+int menu_bios_selection::current_bios(device_t *device)
+{
+	int bios_val = device->default_bios();
+	const char *val;
+	if (device->owner())
+	{
+		const char *slot_option_name = device->owner()->tag() + 1;
+		std::string bios = machine().options().slot_option(slot_option_name).bios();
+		if (bios.empty()) val = nullptr; else val = bios.c_str();
+	}
+	else
+	{
+		val = machine().options().value("bios");
+	}
+	if (val)
+		bios_val = atoi(val) + 1;
+
+	return bios_val;
+}
+
 void menu_bios_selection::populate(float &customtop, float &custombottom)
 {
 	// cycle through all devices for this system
@@ -60,13 +80,14 @@ void menu_bios_selection::populate(float &customtop, float &custombottom)
 		device_slot_interface const *const slot(dynamic_cast<device_slot_interface const *>(parent));
 		if (!parent || (slot && (slot->get_card_device() == &device)))
 		{
+			int bios_val = current_bios(&device);
 			tiny_rom_entry const *rom(device.rom_region());
 			if (rom && !ROMENTRY_ISEND(rom))
 			{
 				char const *val = nullptr;
 				for ( ; !ROMENTRY_ISEND(rom) && !val; rom++)
 				{
-					if (ROMENTRY_ISSYSTEM_BIOS(rom) && ROM_GETBIOSFLAGS(rom) == device.system_bios())
+					if (ROMENTRY_ISSYSTEM_BIOS(rom) && ROM_GETBIOSFLAGS(rom) == bios_val)
 						val = rom->hashdata;
 				}
 				if (val)
@@ -110,7 +131,7 @@ void menu_bios_selection::handle(event const *ev)
 				case IPT_UI_LEFT: case IPT_UI_RIGHT:
 				{
 					int const cnt = ([bioses = romload::entries(dev->rom_region()).get_system_bioses()] () { return std::distance(bioses.begin(), bioses.end()); })();
-					bios_val = dev->system_bios() + ((ev->iptkey == IPT_UI_LEFT) ? -1 : +1);
+					bios_val = current_bios(dev) + ((ev->iptkey == IPT_UI_LEFT) ? -1 : +1);
 
 					// wrap
 					if (bios_val < 1)
@@ -127,7 +148,6 @@ void menu_bios_selection::handle(event const *ev)
 
 			if (bios_val > 0)
 			{
-				dev->set_system_bios(bios_val);
 				if (strcmp(dev->tag(),":")==0) {
 					machine().options().set_value("bios", bios_val-1, OPTION_PRIORITY_CMDLINE);
 				} else {

--- a/src/frontend/mame/ui/miscmenu.h
+++ b/src/frontend/mame/ui/miscmenu.h
@@ -98,6 +98,7 @@ public:
 private:
 	virtual void populate(float &customtop, float &custombottom) override;
 	virtual void handle(event const *ev) override;
+	int current_bios(device_t *device);
 };
 
 


### PR DESCRIPTION
Using `dev->set_system_bios(bios_val) `had side effect that caused `nvram_save` to save content for running system under new name, which is wrong. By using values from options we are able to keep menus working and them applied when reset is done.

Since any of slot cards can have bios selection that can affect nvram content, added bios name id (if not default) after slot card name, same as we add for bios under driver level.