### PR TITLE
clcd.cpp: Use 1 MHz for system clock.

### DIFF
--- a/src/mame/drivers/clcd.cpp
+++ b/src/mame/drivers/clcd.cpp
@@ -662,25 +662,25 @@ INPUT_PORTS_END
 void clcd_state::clcd(machine_config &config)
 {
 	/* basic machine hardware */
-	M65C02(config, m_maincpu, 2000000);
+	M65C02(config, m_maincpu, 1000000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &clcd_state::clcd_mem);
 
 	INPUT_MERGER_ANY_HIGH(config, "mainirq").output_handler().set_inputline("maincpu", m65c02_device::IRQ_LINE);
 
-	via6522_device &via0(R65C22(config, "via0", 2000000));
+	via6522_device &via0(R65C22(config, "via0", 1000000));
 	via0.writepa_handler().set(FUNC(clcd_state::via0_pa_w));
 	via0.writepb_handler().set(FUNC(clcd_state::via0_pb_w));
 	via0.cb1_handler().set(FUNC(clcd_state::via0_cb1_w));
 	via0.irq_handler().set("mainirq", FUNC(input_merger_device::in_w<0>));
 
-	via6522_device &via1(R65C22(config, "via1", 2000000));
+	via6522_device &via1(R65C22(config, "via1", 1000000));
 	via1.writepa_handler().set(FUNC(clcd_state::via1_pa_w));
 	via1.writepb_handler().set(FUNC(clcd_state::via1_pb_w));
 	via1.irq_handler().set("mainirq", FUNC(input_merger_device::in_w<1>));
 	via1.ca2_handler().set(m_centronics, FUNC(centronics_device::write_strobe)).invert();
 	via1.cb2_handler().set("speaker", FUNC(speaker_sound_device::level_w));
 
-	MOS6551(config, m_acia, 2000000);
+	MOS6551(config, m_acia, 1000000);
 	m_acia->set_xtal(XTAL(1'843'200));
 	m_acia->irq_handler().set("mainirq", FUNC(input_merger_device::in_w<2>));
 	m_acia->txd_handler().set("rs232", FUNC(rs232_port_device::write_txd));


### PR DESCRIPTION

Use 1 MHz for the system clock of the Commodore LCD based on hardware and firmware evidence from [Bil Herd's prototype](http://c128.com/commodore-lcd-teardown).  The emulator uses the ROM code dumped from this same prototype.

### Hardware

A [photo](https://flickr.com/photos/mnaberez/31314601462) of Bil Herd's prototype shows a 4.0 MHz crystal above the G65SC102.  It is likely that the crystal is connected to pins 35 (XTLI) and 37 (XTLO).  The [GTE 65SC102 datasheet](http://archive.6502.org/datasheets/cmd_g65scxxx_mpu_family.pdf) says, "the 65SC10X Series is supplied with an internal clock generator operating at four times the Φ2 frequency."  The [Rockwell R65C102 datasheet](http://archive.6502.org/datasheets/rockwell_r65c00_microprocessors.pdf) agrees, saying, "The R65C102 internal clocks may be generated by a TTL level single phase input, an RC time base input, (÷ 4) using the XTLO and XTLI input pins.  See Figure 7 for an example of a crystal time base circuit."  Figure 7 reiterates, "R65C102 crystal frequency is divided by 4, i.e. Φ2 (OUT) = F/4."

### Firmware

The following code snippets are disassemblies of the [KERNAL ROM](https://github.com/mamedev/mame/blob/mame0243/src/mame/drivers/clcd.cpp#L742).

VIA1 Timer 1 is configured here:

```text
877E                    ;TOD clock code in IRQ handler expects to be called at 60 Hz.
877E                    ;60 Hz has a period of 16666 microseconds.
877E                    ;Timer 1 fires every 16666 microseconds by counting Phi2.
877E                    ;Phi2 must be 1 MHz, since 1 MHz has a period of 1 microsecond.
877E  A9 1A             lda     #<16666
8780  8D 06 F8          sta     VIA1_T1LL
8783  A9 41             lda     #>16666
8785  8D 05 F8          sta     VIA1_T1CH
```

IRQ handler that runs when Timer 1 elapses:

```text
FA3C  2C 0D F8  LFA3C:  bit     VIA1_IFR
FA3F  10 02             bpl     LFA43               ;Branch if IRQ was not caused by VIA1
FA41  70 01             bvs     LFA44_VIA1_T1_IRQ   ;Branch if VIA1 Timer 1 caused the interrupt
FA43  60        LFA43:  rts
FA44
FA44            LFA44_VIA1_T1_IRQ:
FA44  AD 04 F8          lda     VIA1_T1CL
FA47  AD 06 F8          lda     VIA1_T1LL
FA4A  20 08 B5          jsr     SCNKEY
FA4D  20 EF B2          jsr     BLINK
FA50  20 4F BF          jsr     UDTIM               ;TOD clock is updated here
```

The handler calls this routine to update the TOD clock, which expects to be called at 60 Hz:

```text
BF4F  CE 8F 03  UDTIM:  dec     JIFFIES
BF52  10 69             bpl     UDTIM_RTS       ;JIFFIES has not reached zero yet
BF54
BF54                    ;JIFFIES=0 which means 1 second has elapsed
BF54
BF54                    ;Reset jiffies for next time
BF54  A9 3B             lda     #59
BF56  8D 8F 03          sta     JIFFIES
BF59
BF59                    ;Increment seconds
BF59  A9 3B             lda     #59
BF5B  EE 90 03          inc     TOD_SECS
BF5E  CD 90 03          cmp     TOD_SECS
BF61  B0 1B             bcs     UDTIM_UNKNOWN
BF63
BF63                    ;Seconds rolled over, increment minutes
BF63                    ;Seconds=0, Increment minutes
BF63  9C 90 03          stz     TOD_SECS
BF66  EE 91 03          inc     TOD_MINS
```
