### PR TITLE
bus/iee488/hp9122c.cpp: Added floppy image formats

### DIFF
--- a/src/devices/bus/ieee488/hp9122c.cpp
+++ b/src/devices/bus/ieee488/hp9122c.cpp
@@ -393,7 +393,7 @@ void hp9122c_device::device_add_mconfig(machine_config &config)
 	m_i8291a->int_write().set(FUNC(hp9122c_device::i8291a_int_w));
 	m_i8291a->dreq_write().set(FUNC(hp9122c_device::i8291a_dreq_w));
 
-	FLOPPY_CONNECTOR(config, "floppy0" , hp9122c_floppies , "35hd" , nullptr, true).enable_sound(true);
-	FLOPPY_CONNECTOR(config, "floppy1" , hp9122c_floppies , "35hd" , nullptr, true).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "floppy0" , hp9122c_floppies , "35hd" , floppy_image_device::default_mfm_floppy_formats, true).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "floppy1" , hp9122c_floppies , "35hd" , floppy_image_device::default_mfm_floppy_formats, true).enable_sound(true);
 	config.set_default_layout(layout_hp9122c);
 }


### PR DESCRIPTION
This adds the default MFM floppy formats to the HP 9122c floppy drive. It allows the HP 9000/3xx machines to actually use the floppy images in the software list, which were failing to load before (loudly or silently, depending on the method used to load them).

HP BASIC and HP Pascal are now bootable from floppy, for example, though HP-UX 5.1 still doesn't work (for unrelated reasons, probably).