### PR TITLE
snes.xml: Added bootleg Dragon Ball Z Final Bout dumps.

### DIFF
--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -38812,6 +38812,31 @@ List of unclassified roms
 		</part>
 	</software>
 
+	<software name="dbzfb" supported="no">
+		<description>Dragon Ball Z - Final Bout (pirate)</description>
+		<year>199?</year>
+		<publisher>&lt;unlicensed&gt;</publisher>
+		<part name="cart" interface="snes_cart">
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dragon ball z - final bout (pirate).sfc" size="4194304" crc="85164f9d" sha1="a27dde45890be69d6921c77c0b36b5f33a576cb4" offset="0x000000" />
+			</dataarea>
+		</part>
+	</software>
+
+<!-- FIXME: this cracked version should be removed once the real dump above is emulated. -->
+	<software name="dbzfbh" cloneof="dbzfb">
+		<description>Dragon Ball Z - Final Bout (pirate, hacked)</description>
+		<year>199?</year>
+		<publisher>&lt;unlicensed&gt;</publisher>
+		<part name="cart" interface="snes_cart">
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dragon ball z - final bout (pirate - hacked).sfc" size="4194304" crc="a911c842" sha1="48ebb510529ab0c52ec792a44ccfc112929b49b6" offset="0x000000" />
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="dbzhypd">
 		<description>Dragon Ball Z - Hyper Dimension (Fra)</description>
 		<year>1996</year>

--- a/hash/snes.xml
+++ b/hash/snes.xml
@@ -4660,7 +4660,7 @@ Beyond that last category are the roms waiting to be classified.
 		</part>
 	</software>
 
-	<!-- This is temporarily included for reference, until we fix emulation of the good dump -->
+	<!-- Notes: this is temporarily included for reference, until we fix emulation of the good dump -->
 	<software name="aladdi2kh" cloneof="aladdi2k">
 		<description>Aladdin 2000 (Bra, Mega Drive Bootleg, Cracked)</description>
 		<year>199?</year>
@@ -4725,7 +4725,7 @@ more investigation needed...
 		</part>
 	</software>
 
-	<!--Notes: this is temporarily included for reference, until we fix emulation of the good dump -->
+	<!-- Notes: this is temporarily included for reference, until we fix emulation of the good dump -->
 	<software name="bugslifeh" cloneof="bugslife">
 		<description>A Bug's Life (Bra, Cracked)</description>
 		<year>199?</year>
@@ -4760,6 +4760,31 @@ more investigation needed...
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
 				<rom name="digimon adventure (cracked).sfc" size="2097152" crc="aea5e0ba" sha1="d00689883bbf5504996490088250a479647f94a3" offset="0x000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="dbzfb" supported="no">
+		<description>Dragon Ball Z - Final Bout (pirate)</description>
+		<year>199?</year>
+		<publisher>&lt;unlicensed&gt;</publisher>
+		<part name="cart" interface="snes_cart">
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dragon ball z - final bout (pirate).sfc" size="4194304" crc="85164f9d" sha1="a27dde45890be69d6921c77c0b36b5f33a576cb4" offset="0x000000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<!-- Notes: this is temporarily included for reference, until we fix emulation of the good dump -->
+	<software name="dbzfbh" cloneof="dbzfb">
+		<description>Dragon Ball Z - Final Bout (pirate, hacked)</description>
+		<year>199?</year>
+		<publisher>&lt;unlicensed&gt;</publisher>
+		<part name="cart" interface="snes_cart">
+			<feature name="slot" value="lorom" />
+			<dataarea name="rom" size="4194304">
+				<rom name="dragon ball z - final bout (pirate - hacked).sfc" size="4194304" crc="a911c842" sha1="48ebb510529ab0c52ec792a44ccfc112929b49b6" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -38808,31 +38833,6 @@ List of unclassified roms
 			<feature name="slot" value="lorom" />
 			<dataarea name="rom" size="2097152">
 				<rom name="dragon ball z - chomutujeon (korea).sfc" size="2097152" crc="2bf7cd65" sha1="f13e1e4cb439f03d76590628a6590d705c709c4e" offset="0x000000" />
-			</dataarea>
-		</part>
-	</software>
-
-	<software name="dbzfb" supported="no">
-		<description>Dragon Ball Z - Final Bout (pirate)</description>
-		<year>199?</year>
-		<publisher>&lt;unlicensed&gt;</publisher>
-		<part name="cart" interface="snes_cart">
-			<feature name="slot" value="lorom" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dragon ball z - final bout (pirate).sfc" size="4194304" crc="85164f9d" sha1="a27dde45890be69d6921c77c0b36b5f33a576cb4" offset="0x000000" />
-			</dataarea>
-		</part>
-	</software>
-
-<!-- FIXME: this cracked version should be removed once the real dump above is emulated. -->
-	<software name="dbzfbh" cloneof="dbzfb">
-		<description>Dragon Ball Z - Final Bout (pirate, hacked)</description>
-		<year>199?</year>
-		<publisher>&lt;unlicensed&gt;</publisher>
-		<part name="cart" interface="snes_cart">
-			<feature name="slot" value="lorom" />
-			<dataarea name="rom" size="4194304">
-				<rom name="dragon ball z - final bout (pirate - hacked).sfc" size="4194304" crc="a911c842" sha1="48ebb510529ab0c52ec792a44ccfc112929b49b6" offset="0x000000" />
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
-----------------------------------
Dragon Ball Z - Final Bout (pirate, hacked) [d4s]

New NOT_WORKING software list additions
---------------------------------------
Dragon Ball Z - Final Bout (pirate) [VGHF]