### PR TITLE
c64_cass.xml: Added 10 items (8 working, 2 not working)

### DIFF
--- a/hash/c64_cass.xml
+++ b/hash/c64_cass.xml
@@ -12907,6 +12907,36 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="skytwice">
+		<description>Sky Twice</description>
+		<year>1987</year>
+		<publisher>American Action</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="576310">
+				<rom name="Sky_Twice.tap" size="576310" crc="54470654" sha1="24adf11aacc9fa0040eaeefe5b3d450b047d9246"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="skylinea" supported="no"> <!-- game loads fully with a working loader game but unable to launch main game with CBM key -->
+		<description>Skyline Attack</description>
+		<year>1984</year>
+		<publisher>Century Software</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="512730">
+				<rom name="Skyline_Attack.tap" size="512730" crc="57dd56b9" sha1="cf40fda84bc561617a70e1d6480ea151891cbf07"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="512730">
+				<rom name="Skyline_Attack_a1.tap" size="512730" crc="1d420d29" sha1="38088228873da8187956ebb30be5b5984e81dbf2"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="slamball">
 		<description>Slamball</description>
 		<year>1986</year>
@@ -12923,10 +12953,24 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<description>Slap Fight</description>
 		<year>1987</year>
 		<publisher>Erbe</publisher>
+		<info name="alt_title" value="A.L.C.O.N."/>
 
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="741546">
 				<rom name="Slap_Fight.tap" size="741546" crc="b5ed9e3d" sha1="7e3e72246d69eaeafaf7bb50ac1112a7188c0fc1"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="slapfighti" cloneof="slapfight">
+		<description>Slap Fight (Imagine)</description>
+		<year>1987</year>
+		<publisher>Imagine</publisher>
+		<info name="alt_title" value="A.L.C.O.N."/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="741546">
+				<rom name="Slap_Fight.tap" size="741546" crc="fc13cc4d" sha1="9bd170a7c10d2c4240a5667fdcd90eb14f1eb4bb"/>
 			</dataarea>
 		</part>
 	</software>
@@ -12945,6 +12989,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass2" interface="cbm_cass">
 			<dataarea name="cass" size="558162">
 				<rom name="Slayer_a1.tap" size="558162" crc="40d026b3" sha1="4112ce4bc133f3a713847190e58fbf5ed2af1262"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="slayerp" cloneof="slayer">
+		<description>Slayer (Prism Leisure)</description>
+		<year>1992</year>
+		<publisher>Prism Leisure</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="558796">
+				<rom name="Slayer.tap" size="558796" crc="85a42476" sha1="ec796fef649534c0660e3159c3804bf8443cec09"/>
 			</dataarea>
 		</part>
 	</software>
@@ -12997,6 +13053,26 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="snare" supported="no"> <!-- game loads fully and music starts playing but no picture (black screen) -->
+		<description>Snare</description>
+		<year>1989</year>
+		<publisher>Thalamus</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<feature name="part_id" value="Side A"/>
+			<dataarea name="cass" size="502275">
+				<rom name="Snare_Side_1.tap" size="502275" crc="c69499b3" sha1="c1b4400da017bf2623b2bf9b2bb80c8624705811"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<feature name="part_id" value="Side B"/>
+			<dataarea name="cass" size="246831">
+				<rom name="Snare_Side_2.tap" size="246831" crc="f2e8a6d4" sha1="3788f337482852dc65510d1ffeea1405ff68f8bd"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="snokie">
 		<description>Snokie</description>
 		<year>1983</year>
@@ -13009,6 +13085,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="soloflig">
+		<description>Solo Flight</description>
+		<year>1985</year>
+		<publisher>U.S. Gold</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="427654">
+				<rom name="Solo_Flight.tap" size="427654" crc="2630b009" sha1="a21391736854f8b7bbb9694bcd18793ed8edc921"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="solomon">
 		<description>Solomon's Key</description>
 		<year>1987</year>
@@ -13017,6 +13105,18 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="619120">
 				<rom name="Solomon's_Key.tap" size="619120" crc="6424a48a" sha1="1bef7867a3369fed16d8b93d60f978ba2437b08f"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sonofbla">
+		<description>Son of Blagger</description>
+		<year>1984</year>
+		<publisher>Alligata</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="379074">
+				<rom name="Son_of_Blagger.tap" size="379074" crc="312d7428" sha1="a7bdf3d6d445bc65d3c7b09abad8d20637a9df84"/>
 			</dataarea>
 		</part>
 	</software>
@@ -13051,6 +13151,24 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="sdoubt">
+		<description>Space Doubt</description>
+		<year>1985</year>
+		<publisher>CRL</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="555648">
+				<rom name="Space_Doubt.tap" size="555648" crc="3a484f34" sha1="fce799d2458ff283ca6c362205cb7c5b0291de50"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="555624">
+				<rom name="Space_Doubt_a1.tap" size="555624" crc="5c81c740" sha1="f132f2ad7a40001e1dbb06c034ee3fa02a063b56"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="sharrier">
 		<description>Space Harrier</description>
 		<year>1990</year>
@@ -13069,18 +13187,57 @@ Some are based on the C64 Tape Archive at https://archive.org/download/c64tapes/
 		</part>
 	</software>
 
+	<software name="sharrierz" cloneof="sharrier">
+		<description>Space Harrier (Zafiro Software Division)</description>
+		<year>198?</year>
+		<publisher>Zafiro Software Division</publisher>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="718105">
+				<rom name="Space_Harrier.tap" size="718105" crc="a4f96b37" sha1="cd56330bb22292c29ab4f340c0ad1bec18106b20"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="718105">
+				<rom name="Space_Harrier_a1.tap" size="718105" crc="6f993620" sha1="45408498a97f8758d5f9a2fd988937403242747c"/>
+			</dataarea>
+		</part>
+	</software>
+
 	<software name="spacehnt">
 		<description>Space Hunter</description>
 		<year>1985</year>
 		<publisher>Mastertronic</publisher>
+
 		<part name="cass1" interface="cbm_cass">
 			<dataarea name="cass" size="565246">
 				<rom name="space hunter side a.tap" size="565246" crc="11c74761" sha1="5ee2e011ea5afa76823964000d7bd5c57e1ec863"/>
 			</dataarea>
 		</part>
+
 		<part name="cass2" interface="cbm_cass">
 			<dataarea name="cass" size="562360">
 				<rom name="space hunter side b.tap" size="562360" crc="3f93d15b" sha1="27c9d41cb322cae98a40e462ffbd596ee289268a"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="sinvasion" cloneof="commando">
+		<description>Space Invasion</description>
+		<year>1985</year>
+		<publisher>Elite Systems</publisher>
+		<info name="alt_title" value="Commando"/>
+
+		<part name="cass1" interface="cbm_cass">
+			<dataarea name="cass" size="606572">
+				<rom name="Space_Invasion.tap" size="606572" crc="42139ece" sha1="eaa00c96d8f0339a5dc7cf525c35c457ad3b99ae"/>
+			</dataarea>
+		</part>
+
+		<part name="cass2" interface="cbm_cass">
+			<dataarea name="cass" size="606572">
+				<rom name="Space_Invasion_a1.tap" size="606572" crc="e2fc73a4" sha1="cdb0bb60fd46ffda79a7d546e2b03c5096b2c4cc"/>
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
New working software list additions
---------------------------------------
Sky Twice (American Action) [C64 Ultimate Tape Archive V2.0]
Slap Fight (Imagine) [C64 Ultimate Tape Archive V2.0]
Slayer (Prism Leisure) [C64 Ultimate Tape Archive V2.0]
Solo Flight (U.S. Gold) [C64 Ultimate Tape Archive V2.0]
Son of Blagger (Alligata) [C64 Ultimate Tape Archive V2.0]
Space Doubt (CRL) [C64 Ultimate Tape Archive V2.0]
Space Harrier (Zafiro Software Division) [C64 Ultimate Tape Archive V2.0]
Space Invasion (Elite Systems) [C64 Ultimate Tape Archive V2.0]

New NOT_WORKING software list additions
---------------------------------------
Skyline Attack (Century Software) [C64 Ultimate Tape Archive V2.0]
Snare (Thalamus) [C64 Ultimate Tape Archive V2.0]