### PR TITLE
cdi.xml: Fixed Link: the Faces of Evil

### DIFF
--- a/hash/cdi.xml
+++ b/hash/cdi.xml
@@ -1861,7 +1861,7 @@ license:CC0
 		<publisher>Philips</publisher>
 		<part name="cdrom" interface="cdi_cdrom">
 			<diskarea name="cdrom">
-				<disk name="link - the faces of evil (usa)" sha1="e9deb9df291474b9a4db2e5ce444bb98c149faa6"/>
+				<disk name="link - the faces of evil (usa)" sha1="63c8ae61d7e98668cb8864b909c7f7377ff5fdb4"/>
 			</diskarea>
 		</part>
 	</software>


### PR DESCRIPTION
I would like to state for the record that I am a absolute moron who didn't know the difference between "SHA1" and "Data SHA1":

$ chdman info -i Link\ -\ The\ Faces\ of\ Evil\ \(USA\).chd
chdman - MAME Compressed Hunks of Data (CHD) manager 0.243 (unknown)
Input file:   Link - The Faces of Evil (USA).chd
File Version: 5
Logical size: 626,501,952 bytes
Hunk Size:    19,584 bytes
Total Hunks:  31,991
Unit Size:    2,448 bytes
Total Units:  255,924
Compression:  cdlz (CD LZMA), cdzl (CD Deflate), cdfl (CD FLAC)
CHD size:     116,979,986 bytes
Ratio:        18.7%
SHA1:         63c8ae61d7e98668cb8864b909c7f7377ff5fdb4
Data SHA1:    e9deb9df291474b9a4db2e5ce444bb98c149faa6
Metadata:     Tag='CHT2'  Index=0  Length=93 bytes
              TRACK:1 TYPE:MODE2_RAW SUBTYPE:NONE FRAMES:255924 PREGAP:0 P