### PR TITLE
Fixed Arcade build

### DIFF
--- a/src/mame/arcade.flt
+++ b/src/mame/arcade.flt
@@ -1558,5 +1558,7 @@ zwackery.cpp
 -saturnjp
 -saturnkr
 -vsaturn
+//sis630.cpp
+-shutms11
 //vectrex.cpp
 -vectrex


### PR DESCRIPTION
Removed "Shuttle MS11 PC" computer from Arcade build/Listxml.