### PR TITLE
invasnab offset adjustment

### DIFF
--- a/src/mame/drivers/midzeus.cpp
+++ b/src/mame/drivers/midzeus.cpp
@@ -697,8 +697,8 @@ void midzeus_state::invasn_gun_w(offs_t offset, uint32_t data, uint32_t mem_mask
 		if (((old_control ^ m_gun_control) & pmask) != 0 && (m_gun_control & pmask) == 0)
 		{
 			const rectangle &visarea = m_screen->visible_area();
-			m_gun_x[player] = m_io_gun_x[player]->read() * visarea.width() / 255 + visarea.min_x + BEAM_XOFFS;
-			m_gun_y[player] = m_io_gun_y[player]->read() * visarea.height() / 255 + visarea.min_y;
+			m_gun_x[player] = m_io_gun_x[player]->read() * visarea.width() / 255 + (0.0127 * visarea.width()) + visarea.min_x + BEAM_XOFFS;
+			m_gun_y[player] = m_io_gun_y[player]->read() * visarea.height() / 255 + (0.0354 * visarea.height()) + visarea.min_y;
 			m_gun_timer[player]->adjust(m_screen->time_until_pos(std::max(0, m_gun_y[player] - BEAM_DY), std::max(0, m_gun_x[player] - BEAM_DX)), player);
 		}
 	}


### PR DESCRIPTION
Hello,

`invasnab` and clones have what appears to be a constant offset between in-game shots and MAME's crosshairs. This is a slight adjustment to the game's gun-coordinate formula to bring the in-game shots into better alignment with the crosshairs. We came up with these particular offset numbers by using screen shots to compare the crosshair min/max positions with the distance between in-game shots and the center of the crosshair. As such, the results are empirical and not born out of any knowledge of the inner workings of the game. 

Before and after are shown below. Even when the crosshair is left still and a keyboard is used to fire, the in-game shots do not always land at the exact same position each time. The offset values added to the gun formulas do appear to keep the in-game shots at or very near the centers of the crosshairs, though.

This does not resolve the reloading issues that this game has. Users can still only reload by shooting near the right edge of the screen.

Apologies if this is not the best way to tackle the offset issue.

![invasnab_offset](https://user-images.githubusercontent.com/80055191/172100917-7089c176-93aa-43a1-92e6-46fe5a67ddbc.png)
![invasnab_fix](https://user-images.githubusercontent.com/80055191/172100920-02afe317-9adb-4f6c-b671-e85ad581631c.png)
