### PR TITLE
bus/rc2014/edge.cpp: Fix typos in comments

### DIFF
--- a/src/devices/bus/rc2014/edge.cpp
+++ b/src/devices/bus/rc2014/edge.cpp
@@ -2,7 +2,7 @@
 // copyright-holders:Miodrag Milanovic
 /***************************************************************************
 
-    RC2014 Modulare Backplane Extensions
+    RC2014 Modular Backplane Extensions
 
 ****************************************************************************/
 

--- a/src/devices/bus/rc2014/edge.h
+++ b/src/devices/bus/rc2014/edge.h
@@ -2,7 +2,7 @@
 // copyright-holders:Miodrag Milanovic
 /**********************************************************************
 
-    RC2014 Modulare Backplane Extensions
+    RC2014 Modular Backplane Extensions
 
 **********************************************************************/
 


### PR DESCRIPTION
@mmicko there are a couple of typos introduced by da0cf02007ac3e70b4d470fd7f188c5b1274f83d