### PR TITLE
r2dtank.cpp: correct release year as per notes on MT08250

### DIFF
--- a/src/mame/drivers/r2dtank.cpp
+++ b/src/mame/drivers/r2dtank.cpp
@@ -534,4 +534,4 @@ ROM_END
  *
  *************************************/
 
-GAME( 1980, r2dtank, 0, r2dtank, r2dtank, r2dtank_state, empty_init, ROT270, "Sigma Enterprises Inc.", "R2D Tank", MACHINE_SUPPORTS_SAVE)
+GAME( 1981, r2dtank, 0, r2dtank, r2dtank, r2dtank_state, empty_init, ROT270, "Sigma Enterprises Inc.", "R2D Tank", MACHINE_SUPPORTS_SAVE )


### PR DESCRIPTION
The title screen does show a 1980 copyright date, however this game was released in late October 1981.