### PR TITLE
sound.cpp: Fix missed samples due to state save (#9917)

### DIFF
--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -560,6 +560,7 @@ sound_stream::sound_stream(device_t &device, u32 inputs, u32 outputs, u32 output
 	m_synchronous((flags & STREAM_SYNCHRONOUS) != 0),
 	m_resampling_disabled((flags & STREAM_DISABLE_INPUT_RESAMPLING) != 0),
 	m_sync_timer(nullptr),
+	m_last_update_end(attotime::zero),
 	m_input(inputs),
 	m_input_view(inputs),
 	m_empty_buffer(100),
@@ -579,6 +580,7 @@ sound_stream::sound_stream(device_t &device, u32 inputs, u32 outputs, u32 output
 	std::string state_tag = string_format("%d", m_device.machine().sound().unique_id());
 	auto &save = m_device.machine().save();
 	save.save_item(&m_device, "stream.sample_rate", state_tag.c_str(), 0, NAME(m_sample_rate));
+	save.save_item(&m_device, "stream.sample_rate", state_tag.c_str(), 0, NAME(m_last_update_end));
 	save.register_postload(save_prepost_delegate(FUNC(sound_stream::postload), this));
 
 	// initialize all inputs
@@ -679,7 +681,10 @@ void sound_stream::update()
 	attotime start = m_output[0].end_time();
 	attotime end = m_device.machine().time();
 	if (start >= end)
+	{
+		m_last_update_end = start;
 		return;
+	}
 
 	// regular update then
 	update_view(start, end);
@@ -697,6 +702,8 @@ read_stream_view sound_stream::update_view(attotime start, attotime end, u32 out
 {
 	sound_assert(start <= end);
 	sound_assert(outputnum < m_output.size());
+
+	m_last_update_end = end;
 
 	// clean up parameters for when the asserts go away
 	if (outputnum >= m_output.size())
@@ -859,8 +866,13 @@ void sound_stream::postload()
 {
 	// set the end time of all of our streams to now
 	for (auto &output : m_output)
-		output.set_end_time(m_device.machine().time());
-
+	{
+		// previous : machine time
+		// output.set_end_time(m_device.machine().time());
+		// printf("postload %s %f\n", name().c_str(), m_last_update_end.as_double());
+		// resampler is zero
+		output.set_end_time(m_last_update_end > attotime::zero ? m_last_update_end : m_device.machine().time());
+	}
 	// recompute the sample rate information
 	sample_rate_changed();
 }

--- a/src/emu/sound.cpp
+++ b/src/emu/sound.cpp
@@ -579,8 +579,8 @@ sound_stream::sound_stream(device_t &device, u32 inputs, u32 outputs, u32 output
 	// create a unique tag for saving
 	std::string state_tag = string_format("%d", m_device.machine().sound().unique_id());
 	auto &save = m_device.machine().save();
-	save.save_item(&m_device, "stream.sample_rate", state_tag.c_str(), 0, NAME(m_sample_rate));
-	save.save_item(&m_device, "stream.sample_rate", state_tag.c_str(), 0, NAME(m_last_update_end));
+	save.save_item(&m_device, "stream.sound_stream", state_tag.c_str(), 0, NAME(m_sample_rate));
+	save.save_item(&m_device, "stream.sound_stream", state_tag.c_str(), 0, NAME(m_last_update_end));
 	save.register_postload(save_prepost_delegate(FUNC(sound_stream::postload), this));
 
 	// initialize all inputs

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -693,6 +693,8 @@ private:
 	bool m_resampling_disabled;                    // is resampling of input streams disabled?
 	emu_timer *m_sync_timer;                       // update timer for synchronous streams
 
+	attotime m_last_update_end;                    // last end_time() in update
+
 	// input information
 	std::vector<sound_stream_input> m_input;       // list of streams we directly depend upon
 	std::vector<read_stream_view> m_input_view;    // array of output views for passing to the callback

--- a/src/emu/sound.h
+++ b/src/emu/sound.h
@@ -670,6 +670,9 @@ private:
 	// handle updates after a save state load
 	void postload();
 
+	// handle updates before a save state load
+	void presave();
+
 	// re-print the synchronization timer
 	void reprime_sync_timer();
 
@@ -693,7 +696,7 @@ private:
 	bool m_resampling_disabled;                    // is resampling of input streams disabled?
 	emu_timer *m_sync_timer;                       // update timer for synchronous streams
 
-	attotime m_last_update_end;                    // last end_time() in update
+	attotime m_last_update_end_time;               // last end_time() in update
 
 	// input information
 	std::vector<sound_stream_input> m_input;       // list of streams we directly depend upon


### PR DESCRIPTION
The PR address #9917. A save state may occur between time slices.
Sound devices through sound.cpp are updated during a timer call every
20ms. When the state is saved, these devices are not updated to the
current machine time. Consequently after a state load the devices
have a "time lag" since in postload buffer end time is forced to
machine time.
This change will save the last buffer end time so that all outstanding
samples are processed.

This is a core change. I tested it on some drivers. This needs a very
thorough review and I post the PR primarily to document a possible
solution.