### PR TITLE
Changinging osd_subst_env() to take an std::string_view and return an std::string

### DIFF
--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1707,10 +1707,8 @@ void cli_frontend::execute_commands(std::string_view exename)
 		path_iterator iter(m_options.plugins_path());
 		std::string pluginpath;
 		while (iter.next(pluginpath))
-		{
-			pluginpath = osd_subst_env(pluginpath);
-			plugin_opts.scan_directory(pluginpath, true);
-		}
+			plugin_opts.scan_directory(osd_subst_env(pluginpath), true);
+
 		emu_file file_plugin(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);
 		if (file_plugin.open("plugin.ini"))
 			throw emu_fatalerror("Unable to create file plugin.ini\n");

--- a/src/frontend/mame/clifront.cpp
+++ b/src/frontend/mame/clifront.cpp
@@ -1708,7 +1708,7 @@ void cli_frontend::execute_commands(std::string_view exename)
 		std::string pluginpath;
 		while (iter.next(pluginpath))
 		{
-			osd_subst_env(pluginpath, pluginpath);
+			pluginpath = osd_subst_env(pluginpath);
 			plugin_opts.scan_directory(pluginpath, true);
 		}
 		emu_file file_plugin(OPEN_FLAG_WRITE | OPEN_FLAG_CREATE | OPEN_FLAG_CREATE_PATHS);

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -716,11 +716,7 @@ void lua_engine::initialize()
 			static_cast<char const *(*)(char const *)>(&lang_translate),
 			static_cast<char const *(*)(char const *, char const *)>(&lang_translate));
 	emu["pid"] = &osd_getpid;
-	emu["subst_env"] =
-		[] (const std::string &str)
-		{
-			return osd_subst_env(str);
-		};
+	emu.set_function("subst_env", &osd_subst_env);
 	emu["device_enumerator"] = sol::overload(
 			[] (device_t &dev) { return devenum<device_enumerator>(dev); },
 			[] (device_t &dev, int maxdepth) { return devenum<device_enumerator>(dev, maxdepth); });

--- a/src/frontend/mame/luaengine.cpp
+++ b/src/frontend/mame/luaengine.cpp
@@ -719,9 +719,7 @@ void lua_engine::initialize()
 	emu["subst_env"] =
 		[] (const std::string &str)
 		{
-			std::string result;
-			osd_subst_env(result, str);
-			return result;
+			return osd_subst_env(str);
 		};
 	emu["device_enumerator"] = sol::overload(
 			[] (device_t &dev) { return devenum<device_enumerator>(dev); },

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -143,7 +143,7 @@ void mame_machine_manager::start_luaengine()
 		while (iter.next(pluginpath))
 		{
 			// user may specify environment variables; subsitute them
-			osd_subst_env(pluginpath, pluginpath);
+			pluginpath = osd_subst_env(pluginpath);
 
 			// and then scan the directory recursively
 			m_plugins->scan_directory(pluginpath, true);
@@ -202,8 +202,7 @@ void mame_machine_manager::start_luaengine()
 		std::error_condition const filerr = file.open("boot.lua");
 		if (!filerr)
 		{
-			std::string exppath;
-			osd_subst_env(exppath, file.fullpath());
+			std::string exppath = osd_subst_env(file.fullpath());
 			auto &l(*lua());
 			auto load_result = l.load_script(exppath);
 			if (!load_result.valid())

--- a/src/frontend/mame/mame.cpp
+++ b/src/frontend/mame/mame.cpp
@@ -202,7 +202,7 @@ void mame_machine_manager::start_luaengine()
 		std::error_condition const filerr = file.open("boot.lua");
 		if (!filerr)
 		{
-			std::string exppath = osd_subst_env(file.fullpath());
+			const std::string exppath = osd_subst_env(file.fullpath());
 			auto &l(*lua());
 			auto load_result = l.load_script(exppath);
 			if (!load_result.valid())

--- a/src/osd/modules/file/posixdir.cpp
+++ b/src/osd/modules/file/posixdir.cpp
@@ -193,7 +193,7 @@ bool posix_directory::open_impl(std::string const &dirname)
 {
 	assert(!m_fd);
 
-	osd_subst_env(m_path, dirname);
+	m_path = osd_subst_env(dirname);
 	m_fd.reset(::opendir(m_path.c_str()));
 	return bool(m_fd);
 }
@@ -224,7 +224,7 @@ directory::ptr directory::open(std::string const &dirname)
 //  osd_subst_env
 //============================================================
 
-void osd_subst_env(std::string &dst, std::string const &src)
+std::string osd_subst_env(std::string_view src)
 {
 	std::string result, var;
 	auto start = src.begin();
@@ -292,5 +292,5 @@ void osd_subst_env(std::string &dst, std::string const &src)
 		}
 	}
 
-	dst = std::move(result);
+	return result;
 }

--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -257,8 +257,7 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 	for (auto it = dst.begin(); it != dst.end(); ++it)
 		*it = (INVPATHSEPCH == *it) ? PATHSEPCH : *it;
 #endif
-	try { osd_subst_env(dst, dst); }
-	catch (...) { return std::errc::not_enough_memory; }
+	dst = osd_subst_env(dst);
 
 	// attempt to open the file
 	int fd = -1;

--- a/src/osd/modules/file/posixfile.cpp
+++ b/src/osd/modules/file/posixfile.cpp
@@ -257,7 +257,8 @@ std::error_condition osd_file::open(std::string const &path, std::uint32_t openf
 	for (auto it = dst.begin(); it != dst.end(); ++it)
 		*it = (INVPATHSEPCH == *it) ? PATHSEPCH : *it;
 #endif
-	dst = osd_subst_env(dst);
+	try { dst = osd_subst_env(dst); }
+	catch (...) { return std::errc::not_enough_memory; }
 
 	// attempt to open the file
 	int fd = -1;

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -163,7 +163,9 @@ DWORD create_path_recursive(TCHAR *path)
 
 std::error_condition osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize) noexcept
 {
-	std::string path = osd_subst_env(orig_path);
+	std::string path;
+	try { path = osd_subst_env(orig_path); }
+	catch (...) { return std::errc::not_enough_memory; }
 
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);

--- a/src/osd/modules/file/winfile.cpp
+++ b/src/osd/modules/file/winfile.cpp
@@ -163,9 +163,7 @@ DWORD create_path_recursive(TCHAR *path)
 
 std::error_condition osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize) noexcept
 {
-	std::string path;
-	try { osd_subst_env(path, orig_path); }
-	catch (...) { return std::errc::not_enough_memory; }
+	std::string path = osd_subst_env(orig_path);
 
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);

--- a/src/osd/modules/file/winrtfile.cpp
+++ b/src/osd/modules/file/winrtfile.cpp
@@ -162,7 +162,9 @@ DWORD create_path_recursive(TCHAR *path)
 
 osd_file::error osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize)
 {
-	std::string path = osd_subst_env(orig_path);
+	std::string path;
+	try { path = osd_subst_env(orig_path); }
+	catch (...) { return std::errc::not_enough_memory; }
 
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);

--- a/src/osd/modules/file/winrtfile.cpp
+++ b/src/osd/modules/file/winrtfile.cpp
@@ -162,9 +162,7 @@ DWORD create_path_recursive(TCHAR *path)
 
 osd_file::error osd_file::open(std::string const &orig_path, uint32_t openflags, ptr &file, std::uint64_t &filesize)
 {
-	std::string path;
-	try { osd_subst_env(path, orig_path); }
-	catch (...) { return error::OUT_OF_MEMORY; }
+	std::string path = osd_subst_env(orig_path);
 
 	if (win_check_socket_path(path))
 		return win_open_socket(path, openflags, file, filesize);

--- a/src/osd/modules/render/bgfx/chainmanager.cpp
+++ b/src/osd/modules/render/bgfx/chainmanager.cpp
@@ -73,8 +73,7 @@ void chain_manager::refresh_available_chains()
 	m_available_chains.clear();
 	m_available_chains.push_back(chain_desc("none", ""));
 
-	std::string chains_path;
-	osd_subst_env(chains_path, util::string_format("%s" PATH_SEPARATOR "chains", m_options.bgfx_path()));
+	std::string chains_path  = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains", m_options.bgfx_path()));
 	find_available_chains(chains_path, "");
 
 	destroy_unloaded_chains();
@@ -151,8 +150,7 @@ bgfx_chain* chain_manager::load_chain(std::string name, uint32_t screen_index)
 	{
 		name = name + ".json";
 	}
-	std::string path;
-	osd_subst_env(path, util::string_format("%s" PATH_SEPARATOR "chains" PATH_SEPARATOR, m_options.bgfx_path()));
+	std::string path = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains" PATH_SEPARATOR, m_options.bgfx_path()));
 	path += name;
 
 	bx::FileReader reader;

--- a/src/osd/modules/render/bgfx/chainmanager.cpp
+++ b/src/osd/modules/render/bgfx/chainmanager.cpp
@@ -73,7 +73,7 @@ void chain_manager::refresh_available_chains()
 	m_available_chains.clear();
 	m_available_chains.push_back(chain_desc("none", ""));
 
-	std::string chains_path  = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains", m_options.bgfx_path()));
+	const std::string chains_path  = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "chains", m_options.bgfx_path()));
 	find_available_chains(chains_path, "");
 
 	destroy_unloaded_chains();

--- a/src/osd/modules/render/bgfx/effectmanager.cpp
+++ b/src/osd/modules/render/bgfx/effectmanager.cpp
@@ -31,8 +31,7 @@ static bool prepare_effect_document(std::string &name, osd_options &options, rap
 		full_name = full_name + ".json";
 	}
 
-	std::string path;
-	osd_subst_env(path, util::string_format("%s" PATH_SEPARATOR "effects" PATH_SEPARATOR, options.bgfx_path()));
+	std::string path = osd_subst_env(util::string_format("%s" PATH_SEPARATOR "effects" PATH_SEPARATOR, options.bgfx_path()));
 	path += full_name;
 
 	bx::FileReader reader;

--- a/src/osd/modules/render/bgfx/shadermanager.cpp
+++ b/src/osd/modules/render/bgfx/shadermanager.cpp
@@ -116,9 +116,7 @@ std::string shader_manager::make_path_string(osd_options &options, std::string n
 			fatalerror("Unknown BGFX renderer type %d", bgfx::getRendererType());
 	}
 	shader_path += PATH_SEPARATOR;
-	shader_path = osd_subst_env(shader_path);
-
-	return shader_path;
+	return osd_subst_env(shader_path);
 }
 
 const bgfx::Memory* shader_manager::load_mem(std::string name)

--- a/src/osd/modules/render/bgfx/shadermanager.cpp
+++ b/src/osd/modules/render/bgfx/shadermanager.cpp
@@ -116,7 +116,7 @@ std::string shader_manager::make_path_string(osd_options &options, std::string n
 			fatalerror("Unknown BGFX renderer type %d", bgfx::getRendererType());
 	}
 	shader_path += PATH_SEPARATOR;
-	osd_subst_env(shader_path, shader_path);
+	shader_path = osd_subst_env(shader_path);
 
 	return shader_path;
 }

--- a/src/osd/osdcore.h
+++ b/src/osd/osdcore.h
@@ -390,11 +390,10 @@ void osd_list_network_adapters();
 
     Parameters:
 
-        dst - result pointer
         src - source string
 
 -----------------------------------------------------------------------------*/
-void osd_subst_env(std::string &dst, std::string const &src);
+std::string osd_subst_env(std::string_view src);
 
 class osd_gpu
 {

--- a/src/osd/windows/winutil.cpp
+++ b/src/osd/windows/winutil.cpp
@@ -101,7 +101,7 @@ BOOL win_is_gui_application()
 //============================================================
 //  osd_subst_env
 //============================================================
-void osd_subst_env(std::string &dst, const std::string &src)
+std::string osd_subst_env(std::string_view src)
 {
 	std::wstring const w_src = osd::text::to_wstring(src);
 	std::vector<wchar_t> buffer(w_src.size() + 2);
@@ -112,10 +112,11 @@ void osd_subst_env(std::string &dst, const std::string &src)
 		buffer.resize(length + 1);
 		length = ExpandEnvironmentStringsW(w_src.c_str(), &buffer[0], buffer.size());
 	}
+
+	std::string dst;
 	if (length)
 		osd::text::from_wstring(dst, &buffer[0]);
-	else
-		dst.clear();
+	return dst;
 }
 
 //-------------------------------------------------


### PR DESCRIPTION
It looks like #9859 is not going to be merged anytime soon, so with this PR we do part of the process - updating `osd_subst_env()` for the C++17 era