### PR TITLE
spectrum: fix partial updates at the end of frame

### DIFF
--- a/src/mame/drivers/spec128.cpp
+++ b/src/mame/drivers/spec128.cpp
@@ -346,7 +346,8 @@ GFXDECODE_END
 
 rectangle spectrum_128_state::get_screen_area()
 {
-	return rectangle{48, 48 + 255, 63, 63 + 191};
+	return { SPEC_LEFT_BORDER, SPEC_LEFT_BORDER + SPEC_DISPLAY_XSIZE - 1,
+			SPEC_UNSEEN_LINES + SPEC_TOP_BORDER, SPEC128_UNSEEN_LINES + SPEC_TOP_BORDER + SPEC_DISPLAY_YSIZE - 1 };
 }
 
 void spectrum_128_state::spectrum_128(machine_config &config)
@@ -363,7 +364,9 @@ void spectrum_128_state::spectrum_128(machine_config &config)
 	config.set_maximum_quantum(attotime::from_hz(60));
 
 	/* video hardware */
-	m_screen->set_raw(X1_128_SINCLAIR / 5, 456, 311, {get_screen_area().left() - 48, get_screen_area().right() + 48, get_screen_area().top() - 48, get_screen_area().bottom() + 56});
+	rectangle visarea = { get_screen_area().left() - SPEC_LEFT_BORDER, get_screen_area().right() + SPEC_RIGHT_BORDER,
+		get_screen_area().top() - SPEC_TOP_BORDER, get_screen_area().bottom() + SPEC_BOTTOM_BORDER };
+	m_screen->set_raw(X1_128_SINCLAIR / 5, SPEC128_CYCLES_PER_LINE * 2, SPEC128_UNSEEN_LINES + SPEC_SCREEN_HEIGHT, visarea);
 
 	subdevice<gfxdecode_device>("gfxdecode")->set_info(spec128);
 

--- a/src/mame/drivers/spectrum.cpp
+++ b/src/mame/drivers/spectrum.cpp
@@ -796,7 +796,9 @@ void spectrum_state::spectrum_common(machine_config &config)
 	/* video hardware */
 	SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
 
-	m_screen->set_raw(X1 / 2, 448, 312, {get_screen_area().left() - 48, get_screen_area().right() + 48, get_screen_area().top() - 48, get_screen_area().bottom() + 56});
+	rectangle visarea = { get_screen_area().left() - SPEC_LEFT_BORDER, get_screen_area().right() + SPEC_RIGHT_BORDER,
+		get_screen_area().top() - SPEC_TOP_BORDER, get_screen_area().bottom() + SPEC_BOTTOM_BORDER };
+	m_screen->set_raw(X1 / 2, SPEC_CYCLES_PER_LINE * 2, SPEC_UNSEEN_LINES + SPEC_SCREEN_HEIGHT, visarea);
 	m_screen->set_screen_update(FUNC(spectrum_state::screen_update_spectrum));
 	m_screen->set_palette("palette");
 

--- a/src/mame/includes/spectrum.h
+++ b/src/mame/includes/spectrum.h
@@ -97,9 +97,11 @@ protected:
 
 	TIMER_CALLBACK_MEMBER(irq_on);
 	TIMER_CALLBACK_MEMBER(irq_off);
+	TIMER_CALLBACK_MEMBER(finish_screen_update);
 
 	emu_timer *m_irq_on_timer;
 	emu_timer *m_irq_off_timer;
+	emu_timer *m_finish_screen_update_timer;
 
 	int m_port_fe_data;
 	int m_port_7ffd_data;


### PR DESCRIPTION
Workaround for partial update issue at the end of frame.
https://mametesters.org/view.php?id=8264
https://mametesters.org/view.php?id=8265
https://github.com/mamedev/mame/pull/9670#issuecomment-1118576555
https://github.com/mamedev/mame/pull/9750
