### PR TITLE
Intel MDS-II: correct dump for PIO & regression fixes

### DIFF
--- a/src/devices/bus/multibus/isbc202.cpp
+++ b/src/devices/bus/multibus/isbc202.cpp
@@ -266,11 +266,11 @@ uint8_t isbc202_device::io_r(address_space &space, offs_t offset)
 
 	case 3:
 		// Read result byte (no auto XACK)
-		if (m_cpu == nullptr) {
-			m_cpu = dynamic_cast<cpu_device*>(&space.device());
+		if (!m_rd_2nd_pass) {
 			set_start(3 , true);
+			m_rd_2nd_pass = true;
 		} else {
-			m_cpu = nullptr;
+			m_rd_2nd_pass = false;
 			res = m_data_low_out;
 		}
 		break;
@@ -297,10 +297,10 @@ void isbc202_device::io_w(address_space &space, offs_t offset, uint8_t data)
 	case 4:
 	case 5:
 	case 6:
-		if (m_cpu != nullptr) {
-			LOG("CPU != NULL!\n");
+		if (m_rd_2nd_pass) {
+			LOG("Read 2nd pass when writing!\n");
 		}
-		m_cpu = dynamic_cast<cpu_device*>(&space.device());
+		m_rd_2nd_pass = false;
 		m_cpu_data = data;
 		set_start(offset , false);
 		break;
@@ -361,7 +361,7 @@ void isbc202_device::device_start()
 	save_item(NAME(m_op_us));
 	save_item(NAME(m_px_s1s0));
 	save_item(NAME(m_cmd));
-	save_item(NAME(m_cpu_rd));
+	save_item(NAME(m_rd_2nd_pass));
 	save_item(NAME(m_ready_in));
 	save_item(NAME(m_ready_ff));
 	save_item(NAME(m_gate_lower));
@@ -419,7 +419,7 @@ void isbc202_device::device_reset()
 	m_inputs[ IN_SEL_TIMEOUT ] = true;
 	m_inputs[ IN_SEL_F ] = false;
 
-	m_cpu = nullptr;
+	m_rd_2nd_pass = false;
 
 	m_irq = false;
 
@@ -740,18 +740,15 @@ void isbc202_device::set_output()
 		// 1        Reset RDY latches (0)
 		// 0        -
 		if (BIT(m_mask , 5)) {
-			if (m_cpu != nullptr) {
-				// Release CPU from wait state
-				LOG_BUS("CPU out of wait state\n");
-				m_cpu->trigger(1);
-				if (!m_cpu_rd) {
-					m_cpu = nullptr;
-				}
-				// Ensure the MCU executes a few instruction before the CPU
-				machine().scheduler().boost_interleave(attotime::from_usec(1) , attotime::from_usec(5));
+			// Release CPU from wait state
+			LOG_BUS("CPU out of wait state\n");
+			if (m_cpu_rd) {
+				set_wait_io_rd(0);
 			} else {
-				LOG("No CPU to wake up?\n");
+				set_wait_io_wr(0);
 			}
+			// Ensure the MCU executes a few instruction before the CPU
+			machine().scheduler().boost_interleave(attotime::from_usec(1) , attotime::from_usec(5));
 			m_inputs[ IN_SEL_START ] = false;
 		}
 		if (BIT(m_mask , 4)) {
@@ -1007,14 +1004,13 @@ void isbc202_device::set_start(uint8_t off , bool read)
 	m_cmd = off;
 	m_inputs[ IN_SEL_START ] = true;
 	// Put CPU in wait state
-	m_cpu->spin_until_trigger(1);
+	if (read) {
+		set_wait_io_rd(1);
+	} else {
+		set_wait_io_wr(1);
+	}
 	m_cpu_rd = read;
 	LOG_BUS("CPU in wait state (rd=%d)\n" , read);
-	if (read) {
-		// If CPU is suspended when reading, rewind PC so that the
-		// "IN" instruction is repeated when CPU is released
-		m_cpu->set_pc(m_cpu->pc() - 2);
-	}
 }
 
 void isbc202_device::set_rd_wr(bool new_rd , bool new_wr)

--- a/src/devices/bus/multibus/isbc202.cpp
+++ b/src/devices/bus/multibus/isbc202.cpp
@@ -316,7 +316,7 @@ void isbc202_device::io_w(address_space &space, offs_t offset, uint8_t data)
 	}
 }
 
-void isbc202_device::co_w(bool state)
+WRITE_LINE_MEMBER(isbc202_device::co_w)
 {
 	m_inputs[ IN_SEL_CO ] = state;
 	m_mcu->fi_w(state);
@@ -510,19 +510,19 @@ void isbc202_device::device_add_mconfig(machine_config &config)
 	m_cpes[ 3 ]->set_ro_w_cb(m_cpes[ 2 ] , FUNC(i3002_device::li_w));
 
 	// Connect M-bus
-	m_cpes[ 0 ]->set_mbus_r_cb([this]() { return mbus_r(); } , "");
-	m_cpes[ 1 ]->set_mbus_r_cb([this]() { return mbus_r() >> 2; } , "");
-	m_cpes[ 2 ]->set_mbus_r_cb([this]() { return mbus_r() >> 4; } , "");
-	m_cpes[ 3 ]->set_mbus_r_cb([this]() { return mbus_r() >> 6; } , "");
+	m_cpes[ 0 ]->set_mbus_r_cb(NAME([this]() { return mbus_r(); }));
+	m_cpes[ 1 ]->set_mbus_r_cb(NAME([this]() { return mbus_r() >> 2; }));
+	m_cpes[ 2 ]->set_mbus_r_cb(NAME([this]() { return mbus_r() >> 4; }));
+	m_cpes[ 3 ]->set_mbus_r_cb(NAME([this]() { return mbus_r() >> 6; }));
 
 	// Connect I-bus
-	m_cpes[ 0 ]->set_ibus_r_cb([this]() { return ibus_r(); } , "");
-	m_cpes[ 1 ]->set_ibus_r_cb([this]() { return ibus_r() >> 2; } , "");
-	m_cpes[ 2 ]->set_ibus_r_cb([this]() { return ibus_r() >> 4; } , "");
-	m_cpes[ 3 ]->set_ibus_r_cb([this]() { return ibus_r() >> 6; } , "");
+	m_cpes[ 0 ]->set_ibus_r_cb(NAME([this]() { return ibus_r(); }));
+	m_cpes[ 1 ]->set_ibus_r_cb(NAME([this]() { return ibus_r() >> 2; }));
+	m_cpes[ 2 ]->set_ibus_r_cb(NAME([this]() { return ibus_r() >> 4; }));
+	m_cpes[ 3 ]->set_ibus_r_cb(NAME([this]() { return ibus_r() >> 6; }));
 
 	// Connect SX input
-	m_mcu->set_sx_r_cb([this]() { return m_microcode_addr & 0xf; } , "");
+	m_mcu->set_sx_r_cb(NAME([this]() { return m_microcode_addr & 0xf; }));
 	// Connect PX input
 	m_mcu->set_px_r_cb(FUNC(isbc202_device::px_r));
 

--- a/src/devices/bus/multibus/isbc202.cpp
+++ b/src/devices/bus/multibus/isbc202.cpp
@@ -316,7 +316,7 @@ void isbc202_device::io_w(address_space &space, offs_t offset, uint8_t data)
 	}
 }
 
-WRITE_LINE_MEMBER(isbc202_device::co_w)
+void isbc202_device::co_w(bool state)
 {
 	m_inputs[ IN_SEL_CO ] = state;
 	m_mcu->fi_w(state);
@@ -497,34 +497,34 @@ void isbc202_device::device_add_mconfig(machine_config &config)
 	}
 
 	// Connect CO/CI signals
-	m_mcu->fo_w().set(m_cpes[ 0 ] , FUNC(i3002_device::ci_w));
-	m_cpes[ 0 ]->co_w().set(m_cpes[ 1 ] , FUNC(i3002_device::ci_w));
-	m_cpes[ 1 ]->co_w().set(m_cpes[ 2 ] , FUNC(i3002_device::ci_w));
-	m_cpes[ 2 ]->co_w().set(m_cpes[ 3 ] , FUNC(i3002_device::ci_w));
-	m_cpes[ 3 ]->co_w().set(FUNC(isbc202_device::co_w));
+	m_mcu->set_fo_w_cb(m_cpes[ 0 ] , FUNC(i3002_device::ci_w));
+	m_cpes[ 0 ]->set_co_w_cb(m_cpes[ 1 ] , FUNC(i3002_device::ci_w));
+	m_cpes[ 1 ]->set_co_w_cb(m_cpes[ 2 ] , FUNC(i3002_device::ci_w));
+	m_cpes[ 2 ]->set_co_w_cb(m_cpes[ 3 ] , FUNC(i3002_device::ci_w));
+	m_cpes[ 3 ]->set_co_w_cb(FUNC(isbc202_device::co_w));
 
 	// Connect RO/LI signals
-	m_cpes[ 0 ]->ro_w().set(FUNC(isbc202_device::co_w));
-	m_cpes[ 1 ]->ro_w().set(m_cpes[ 0 ] , FUNC(i3002_device::li_w));
-	m_cpes[ 2 ]->ro_w().set(m_cpes[ 1 ] , FUNC(i3002_device::li_w));
-	m_cpes[ 3 ]->ro_w().set(m_cpes[ 2 ] , FUNC(i3002_device::li_w));
+	m_cpes[ 0 ]->set_ro_w_cb(FUNC(isbc202_device::co_w));
+	m_cpes[ 1 ]->set_ro_w_cb(m_cpes[ 0 ] , FUNC(i3002_device::li_w));
+	m_cpes[ 2 ]->set_ro_w_cb(m_cpes[ 1 ] , FUNC(i3002_device::li_w));
+	m_cpes[ 3 ]->set_ro_w_cb(m_cpes[ 2 ] , FUNC(i3002_device::li_w));
 
 	// Connect M-bus
-	m_cpes[ 0 ]->mbus_r().set([this]() { return mbus_r(); });
-	m_cpes[ 1 ]->mbus_r().set([this]() { return mbus_r() >> 2; });
-	m_cpes[ 2 ]->mbus_r().set([this]() { return mbus_r() >> 4; });
-	m_cpes[ 3 ]->mbus_r().set([this]() { return mbus_r() >> 6; });
+	m_cpes[ 0 ]->set_mbus_r_cb([this]() { return mbus_r(); } , "");
+	m_cpes[ 1 ]->set_mbus_r_cb([this]() { return mbus_r() >> 2; } , "");
+	m_cpes[ 2 ]->set_mbus_r_cb([this]() { return mbus_r() >> 4; } , "");
+	m_cpes[ 3 ]->set_mbus_r_cb([this]() { return mbus_r() >> 6; } , "");
 
 	// Connect I-bus
-	m_cpes[ 0 ]->ibus_r().set([this]() { return ibus_r(); });
-	m_cpes[ 1 ]->ibus_r().set([this]() { return ibus_r() >> 2; });
-	m_cpes[ 2 ]->ibus_r().set([this]() { return ibus_r() >> 4; });
-	m_cpes[ 3 ]->ibus_r().set([this]() { return ibus_r() >> 6; });
+	m_cpes[ 0 ]->set_ibus_r_cb([this]() { return ibus_r(); } , "");
+	m_cpes[ 1 ]->set_ibus_r_cb([this]() { return ibus_r() >> 2; } , "");
+	m_cpes[ 2 ]->set_ibus_r_cb([this]() { return ibus_r() >> 4; } , "");
+	m_cpes[ 3 ]->set_ibus_r_cb([this]() { return ibus_r() >> 6; } , "");
 
 	// Connect SX input
-	m_mcu->sx_r().set([this]() { return m_microcode_addr & 0xf; });
+	m_mcu->set_sx_r_cb([this]() { return m_microcode_addr & 0xf; } , "");
 	// Connect PX input
-	m_mcu->px_r().set(FUNC(isbc202_device::px_r));
+	m_mcu->set_px_r_cb(FUNC(isbc202_device::px_r));
 
 	// Drives
 	for (auto& finder : m_drives) {

--- a/src/devices/bus/multibus/isbc202.h
+++ b/src/devices/bus/multibus/isbc202.h
@@ -31,7 +31,7 @@ public:
 	uint8_t io_r(address_space &space, offs_t offset);
 	void io_w(address_space &space, offs_t offset, uint8_t data);
 
-	void co_w(bool state);
+	DECLARE_WRITE_LINE_MEMBER(co_w);
 
 	uint8_t px_r();
 

--- a/src/devices/bus/multibus/isbc202.h
+++ b/src/devices/bus/multibus/isbc202.h
@@ -100,7 +100,7 @@ private:
 	floppy_image_device *m_current_drive;
 	uint8_t m_px_s1s0;  // C-A16-11 & C-A16-13
 	uint8_t m_cmd;      // C-A8
-	bool m_rd_2nd_pass;
+	bool m_2nd_pass;
 	bool m_cpu_rd;
 	uint8_t m_ready_in;
 	uint8_t m_ready_ff; // I-A44 & I-A43

--- a/src/devices/bus/multibus/isbc202.h
+++ b/src/devices/bus/multibus/isbc202.h
@@ -31,7 +31,7 @@ public:
 	uint8_t io_r(address_space &space, offs_t offset);
 	void io_w(address_space &space, offs_t offset, uint8_t data);
 
-	DECLARE_WRITE_LINE_MEMBER(co_w);
+	void co_w(bool state);
 
 	uint8_t px_r();
 

--- a/src/devices/bus/multibus/isbc202.h
+++ b/src/devices/bus/multibus/isbc202.h
@@ -100,7 +100,7 @@ private:
 	floppy_image_device *m_current_drive;
 	uint8_t m_px_s1s0;  // C-A16-11 & C-A16-13
 	uint8_t m_cmd;      // C-A8
-	cpu_device *m_cpu;  // When != nullptr: CPU is suspended in wait state
+	bool m_rd_2nd_pass;
 	bool m_cpu_rd;
 	uint8_t m_ready_in;
 	uint8_t m_ready_ff; // I-A44 & I-A43

--- a/src/devices/bus/multibus/multibus.cpp
+++ b/src/devices/bus/multibus/multibus.cpp
@@ -30,8 +30,7 @@ multibus_device::multibus_device(machine_config const &mconfig, char const *tag,
 	, m_mem_config("mem", ENDIANNESS_LITTLE, 16, 24)
 	, m_pio_config("pio", ENDIANNESS_LITTLE, 16, 16)
 	, m_int_cb(*this)
-	, m_wait_rd_cb(*this)
-	, m_wait_wr_cb(*this)
+	, m_xack_cb(*this)
 {
 }
 
@@ -43,8 +42,7 @@ device_memory_interface::space_config_vector multibus_device::memory_space_confi
 void multibus_device::device_start()
 {
 	m_int_cb.resolve_all_safe();
-	m_wait_rd_cb.resolve_safe();
-	m_wait_wr_cb.resolve_safe();
+	m_xack_cb.resolve_safe();
 }
 
 multibus_slot_device::multibus_slot_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)

--- a/src/devices/bus/multibus/multibus.cpp
+++ b/src/devices/bus/multibus/multibus.cpp
@@ -30,6 +30,8 @@ multibus_device::multibus_device(machine_config const &mconfig, char const *tag,
 	, m_mem_config("mem", ENDIANNESS_LITTLE, 16, 24)
 	, m_pio_config("pio", ENDIANNESS_LITTLE, 16, 16)
 	, m_int_cb(*this)
+	, m_wait_rd_cb(*this)
+	, m_wait_wr_cb(*this)
 {
 }
 
@@ -41,6 +43,8 @@ device_memory_interface::space_config_vector multibus_device::memory_space_confi
 void multibus_device::device_start()
 {
 	m_int_cb.resolve_all_safe();
+	m_wait_rd_cb.resolve_safe();
+	m_wait_wr_cb.resolve_safe();
 }
 
 multibus_slot_device::multibus_slot_device(machine_config const &mconfig, char const *tag, device_t *owner, u32 clock)

--- a/src/devices/bus/multibus/multibus.h
+++ b/src/devices/bus/multibus/multibus.h
@@ -87,9 +87,11 @@ public:
 	template <unsigned I> auto int_callback() { return m_int_cb[I].bind(); }
 	template <unsigned I> void int_w(int state) { m_int_cb[I](state); }
 
-	// wait signal (split for read/write operations)
+	// wait signal callbacks (split for read/write operations)
 	auto wait_io_rd_cb() { return m_wait_rd_cb.bind(); }
 	auto wait_io_wr_cb() { return m_wait_wr_cb.bind(); }
+
+	// Set wait signals (these are meant for "device_multibus_interface" devices)
 	void set_wait_io_rd(int state) { m_wait_rd_cb(state); }
 	void set_wait_io_wr(int state) { m_wait_wr_cb(state); }
 

--- a/src/devices/bus/multibus/multibus.h
+++ b/src/devices/bus/multibus/multibus.h
@@ -87,13 +87,11 @@ public:
 	template <unsigned I> auto int_callback() { return m_int_cb[I].bind(); }
 	template <unsigned I> void int_w(int state) { m_int_cb[I](state); }
 
-	// wait signal callbacks (split for read/write operations)
-	auto wait_io_rd_cb() { return m_wait_rd_cb.bind(); }
-	auto wait_io_wr_cb() { return m_wait_wr_cb.bind(); }
+	// XACK/
+	auto xack_cb() { return m_xack_cb.bind(); }
 
-	// Set wait signals (these are meant for "device_multibus_interface" devices)
-	void set_wait_io_rd(int state) { m_wait_rd_cb(state); }
-	void set_wait_io_wr(int state) { m_wait_wr_cb(state); }
+	// Set XACK/ signal (this is meant for "device_multibus_interface" devices)
+	void xack_w(int state) { m_xack_cb(state); }
 
 protected:
 	// device_t overrides
@@ -107,8 +105,7 @@ private:
 	address_space_config const m_pio_config;
 
 	devcb_write_line::array<8> m_int_cb;
-	devcb_write_line m_wait_rd_cb;
-	devcb_write_line m_wait_wr_cb;
+	devcb_write_line m_xack_cb;
 };
 
 class multibus_slot_device
@@ -149,8 +146,7 @@ protected:
 	template <unsigned I> void int_w(int state) { m_bus->int_w<I>(state); }
 	void int_w(unsigned number, int state);
 
-	void set_wait_io_rd(int state) { m_bus->set_wait_io_rd(state); }
-	void set_wait_io_wr(int state) { m_bus->set_wait_io_wr(state); }
+	void xack_w(int state) { m_bus->xack_w(state); }
 
 	multibus_device *m_bus;
 };

--- a/src/devices/bus/multibus/multibus.h
+++ b/src/devices/bus/multibus/multibus.h
@@ -87,6 +87,12 @@ public:
 	template <unsigned I> auto int_callback() { return m_int_cb[I].bind(); }
 	template <unsigned I> void int_w(int state) { m_int_cb[I](state); }
 
+	// wait signal (split for read/write operations)
+	auto wait_io_rd_cb() { return m_wait_rd_cb.bind(); }
+	auto wait_io_wr_cb() { return m_wait_wr_cb.bind(); }
+	void set_wait_io_rd(int state) { m_wait_rd_cb(state); }
+	void set_wait_io_wr(int state) { m_wait_wr_cb(state); }
+
 protected:
 	// device_t overrides
 	virtual void device_start() override;
@@ -99,6 +105,8 @@ private:
 	address_space_config const m_pio_config;
 
 	devcb_write_line::array<8> m_int_cb;
+	devcb_write_line m_wait_rd_cb;
+	devcb_write_line m_wait_wr_cb;
 };
 
 class multibus_slot_device
@@ -138,6 +146,9 @@ protected:
 
 	template <unsigned I> void int_w(int state) { m_bus->int_w<I>(state); }
 	void int_w(unsigned number, int state);
+
+	void set_wait_io_rd(int state) { m_bus->set_wait_io_rd(state); }
+	void set_wait_io_wr(int state) { m_bus->set_wait_io_wr(state); }
 
 	multibus_device *m_bus;
 };

--- a/src/devices/machine/i3001.cpp
+++ b/src/devices/machine/i3001.cpp
@@ -47,7 +47,9 @@ void i3001_device::fc_w(uint8_t fc)
 		m_fo = true;
 		break;
 	}
-	m_fo_handler(m_fo);
+	if (!m_fo_handler.isnull()) {
+		m_fo_handler(m_fo);
+	}
 }
 
 WRITE_LINE_MEMBER(i3001_device::clk_w)
@@ -57,9 +59,9 @@ WRITE_LINE_MEMBER(i3001_device::clk_w)
 
 void i3001_device::device_start()
 {
-	m_fo_handler.resolve_safe();
-	m_px_handler.resolve_safe(0);
-	m_sx_handler.resolve_safe(0);
+	m_fo_handler.resolve();
+	m_px_handler.resolve();
+	m_sx_handler.resolve();
 
 	save_item(NAME(m_addr));
 	save_item(NAME(m_pr));
@@ -130,8 +132,8 @@ void i3001_device::update()
 		m_addr = pack_row_col((get_row(m_addr) & 0b11000) | 0b00100 | (m_ac & 0b00011) , 0b1100 | (m_pr & 0b0011));
 	} else {
 		// JPX
-		uint8_t px = m_px_handler() & 0b1111;
-		m_pr = m_sx_handler() & 0b1111;
+		uint8_t px = !m_px_handler.isnull() ? m_px_handler() & 0b1111 : 0;
+		m_pr = !m_sx_handler.isnull() ? m_sx_handler() & 0b1111 : 0;
 		m_addr = pack_row_col((get_row(m_addr) & 0b11100) | (m_ac & 0b00011) , px);
 	}
 }

--- a/src/devices/machine/i3001.h
+++ b/src/devices/machine/i3001.h
@@ -54,7 +54,7 @@ public:
 	void fc_w(uint8_t fc);
 
 	// Write Flag Input
-	DECLARE_WRITE_LINE_MEMBER(fi_w) { m_fi = state; }
+	void fi_w(bool state) { m_fi = state; }
 
 	// Read Flag Output
 	DECLARE_READ_LINE_MEMBER(fo_r) { return m_fo; }
@@ -64,11 +64,11 @@ public:
 	DECLARE_READ_LINE_MEMBER(zero_r) { return m_zero; }
 
 	// Output callbacks
-	auto fo_w() { return m_fo_handler.bind(); }
+	template <typename... T> void set_fo_w_cb(T &&... args) { m_fo_handler.set(std::forward<T>(args)...); }
 
 	// Input callbacks
-	auto px_r() { return m_px_handler.bind(); }
-	auto sx_r() { return m_sx_handler.bind(); }
+	template <typename... T> void set_px_r_cb(T &&... args) { m_px_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_sx_r_cb(T &&... args) { m_sx_handler.set(std::forward<T>(args)...); }
 
 	// Load address (in real hw address is loaded through PX/SX buses)
 	void addr_w(uint16_t addr) { m_addr = addr & ADDR_MASK; }
@@ -80,9 +80,9 @@ protected:
 	virtual void device_start() override;
 
 private:
-	devcb_write_line m_fo_handler;
-	devcb_read8 m_px_handler;
-	devcb_read8 m_sx_handler;
+	device_delegate<void (bool)> m_fo_handler;
+	device_delegate<uint8_t (void)> m_px_handler;
+	device_delegate<uint8_t (void)> m_sx_handler;
 
 	uint16_t m_addr;
 	uint8_t m_pr;

--- a/src/devices/machine/i3001.h
+++ b/src/devices/machine/i3001.h
@@ -41,6 +41,13 @@ class i3001_device : public device_t
 public:
 	i3001_device(const machine_config &mconfig , const char *tag , device_t *owner , uint32_t clock = 0);
 
+	// Output callbacks
+	template <typename... T> void set_fo_w_cb(T &&... args) { m_fo_handler.set(std::forward<T>(args)...); }
+
+	// Input callbacks
+	template <typename... T> void set_px_r_cb(T &&... args) { m_px_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_sx_r_cb(T &&... args) { m_sx_handler.set(std::forward<T>(args)...); }
+
 	// Mask of valid bits in address
 	static constexpr uint16_t ADDR_MASK = ((1U << 9) - 1);
 
@@ -54,7 +61,7 @@ public:
 	void fc_w(uint8_t fc);
 
 	// Write Flag Input
-	void fi_w(bool state) { m_fi = state; }
+	DECLARE_WRITE_LINE_MEMBER(fi_w) { m_fi = state; }
 
 	// Read Flag Output
 	DECLARE_READ_LINE_MEMBER(fo_r) { return m_fo; }
@@ -62,13 +69,6 @@ public:
 	// Read carry/zero flags
 	DECLARE_READ_LINE_MEMBER(carry_r) { return m_carry; }
 	DECLARE_READ_LINE_MEMBER(zero_r) { return m_zero; }
-
-	// Output callbacks
-	template <typename... T> void set_fo_w_cb(T &&... args) { m_fo_handler.set(std::forward<T>(args)...); }
-
-	// Input callbacks
-	template <typename... T> void set_px_r_cb(T &&... args) { m_px_handler.set(std::forward<T>(args)...); }
-	template <typename... T> void set_sx_r_cb(T &&... args) { m_sx_handler.set(std::forward<T>(args)...); }
 
 	// Load address (in real hw address is loaded through PX/SX buses)
 	void addr_w(uint16_t addr) { m_addr = addr & ADDR_MASK; }
@@ -80,9 +80,9 @@ protected:
 	virtual void device_start() override;
 
 private:
-	device_delegate<void (bool)> m_fo_handler;
-	device_delegate<uint8_t (void)> m_px_handler;
-	device_delegate<uint8_t (void)> m_sx_handler;
+	device_delegate<void (int)> m_fo_handler;
+	device_delegate<uint8_t ()> m_px_handler;
+	device_delegate<uint8_t ()> m_sx_handler;
 
 	uint16_t m_addr;
 	uint8_t m_pr;

--- a/src/devices/machine/i3002.cpp
+++ b/src/devices/machine/i3002.cpp
@@ -125,7 +125,7 @@ bool i3002_device::update_ro()
 	decode_fc(m_fc , fg , rg , reg);
 
 	if (fg == 0 && rg == 2) {
-		uint8_t ik = m_ibus_handler() & m_kbus;
+		uint8_t ik = !m_ibus_handler.isnull() ? m_ibus_handler() & m_kbus : 0;
 		uint8_t at = m_reg[ reg ];
 		set_ro(BIT(at , 0) && !BIT(ik , 0));
 		return true;
@@ -136,10 +136,10 @@ bool i3002_device::update_ro()
 
 void i3002_device::device_start()
 {
-	m_co_handler.resolve_safe();
-	m_ro_handler.resolve_safe();
-	m_ibus_handler.resolve_safe(0);
-	m_mbus_handler.resolve_safe(0);
+	m_co_handler.resolve();
+	m_ro_handler.resolve();
+	m_ibus_handler.resolve();
+	m_mbus_handler.resolve();
 
 	save_item(NAME(m_reg));
 	save_item(NAME(m_fc));
@@ -173,7 +173,7 @@ void i3002_device::update()
 		case 1:
 			// FC 0 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = (m_reg[ REG_AC ] & m_kbus) + m + m_ci;
 				m_reg[ reg ] = tmp & WORD_MASK;
 				set_co(BIT(tmp , SLICE_SIZE));
@@ -184,7 +184,7 @@ void i3002_device::update()
 			// FC 0 RG III
 			{
 				// Who designed this mess???
-				uint8_t ik = m_ibus_handler() & WORD_MASK & m_kbus;
+				uint8_t ik = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK & m_kbus : 0;
 				uint8_t at = m_reg[ reg ];
 				m_reg[ reg ] = 0;
 				set_ro(BIT(at , 0) && !BIT(ik , 0));
@@ -214,7 +214,7 @@ void i3002_device::update()
 		case 1:
 			// FC 1 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				m_reg[ REG_MAR ] = m_kbus | m;
 				uint8_t tmp = m + m_kbus + m_ci;
 				m_reg[ reg ] = tmp & WORD_MASK;
@@ -249,7 +249,7 @@ void i3002_device::update()
 		case 2:
 			// FC 2 RG III
 			{
-				uint8_t i = m_ibus_handler() & WORD_MASK;
+				uint8_t i = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK : 0;
 				uint8_t tmp = (i & m_kbus) + WORD_MASK + m_ci;
 				m_reg[ reg ] = tmp & WORD_MASK;
 				set_co(BIT(tmp , SLICE_SIZE));
@@ -272,7 +272,7 @@ void i3002_device::update()
 		case 1:
 			// FC 3 RG II (== FC 0 RG II)
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = (m_reg[ REG_AC ] & m_kbus) + m + m_ci;
 				m_reg[ reg ] = tmp & WORD_MASK;
 				set_co(BIT(tmp , SLICE_SIZE));
@@ -282,7 +282,7 @@ void i3002_device::update()
 		case 2:
 			// FC 3 RG III
 			{
-				uint8_t i = m_ibus_handler() & WORD_MASK;
+				uint8_t i = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK : 0;
 				uint8_t tmp = (i & m_kbus) + m_reg[ reg ] + m_ci;
 				m_reg[ reg ] = tmp & WORD_MASK;
 				set_co(BIT(tmp , SLICE_SIZE));
@@ -305,7 +305,7 @@ void i3002_device::update()
 		case 1:
 			// FC 4 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = m & m_reg[ REG_AC ] & m_kbus;
 				m_reg[ reg ] = tmp;
 				set_co(m_ci || tmp != 0);
@@ -315,7 +315,7 @@ void i3002_device::update()
 		case 2:
 			// FC 4 RG III
 			{
-				uint8_t i = m_ibus_handler() & WORD_MASK;
+				uint8_t i = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK : 0;
 				uint8_t tmp = i & m_reg[ reg ] & m_kbus;
 				m_reg[ reg ] = tmp;
 				set_co(m_ci || tmp != 0);
@@ -340,7 +340,7 @@ void i3002_device::update()
 		case 1:
 			// FC 5 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = m & m_kbus;
 				m_reg[ reg ] = tmp;
 				set_co(m_ci || tmp != 0);
@@ -363,7 +363,7 @@ void i3002_device::update()
 		case 1:
 			// FC 6 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = m_reg[ REG_AC ] & m_kbus;
 				m_reg[ reg ] = m | tmp;
 				set_co(m_ci || tmp != 0);
@@ -373,7 +373,7 @@ void i3002_device::update()
 		case 2:
 			// FC 6 RG III
 			{
-				uint8_t ik = m_ibus_handler() & WORD_MASK & m_kbus;
+				uint8_t ik = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK & m_kbus : 0;
 				m_reg[ reg ] |= ik;
 				set_co(m_ci || ik != 0);
 			}
@@ -395,7 +395,7 @@ void i3002_device::update()
 		case 1:
 			// FC 7 RG II
 			{
-				uint8_t m = m_mbus_handler() & WORD_MASK;
+				uint8_t m = !m_mbus_handler.isnull() ? m_mbus_handler() & WORD_MASK : 0;
 				uint8_t tmp = m_reg[ REG_AC ] & m_kbus;
 				set_co(m_ci || (m & tmp) != 0);
 				m_reg[ reg ] = m ^ tmp ^ WORD_MASK;
@@ -405,7 +405,7 @@ void i3002_device::update()
 		case 2:
 			// FC 7 RG III
 			{
-				uint8_t ik = m_ibus_handler() & WORD_MASK & m_kbus;
+				uint8_t ik = !m_ibus_handler.isnull() ? m_ibus_handler() & WORD_MASK & m_kbus : 0;
 				set_co(m_ci || (m_reg[ reg ] & ik) != 0);
 				m_reg[ reg ] = m_reg[ reg ] ^ ik ^ WORD_MASK;
 			}
@@ -418,11 +418,15 @@ void i3002_device::update()
 void i3002_device::set_co(bool co)
 {
 	m_co = co;
-	m_co_handler(m_co);
+	if (!m_co_handler.isnull()) {
+		m_co_handler(m_co);
+	}
 }
 
 void i3002_device::set_ro(bool ro)
 {
 	m_ro = ro;
-	m_ro_handler(m_ro);
+	if (!m_ro_handler.isnull()) {
+		m_ro_handler(m_ro);
+	}
 }

--- a/src/devices/machine/i3002.h
+++ b/src/devices/machine/i3002.h
@@ -35,6 +35,14 @@ class i3002_device : public device_t
 public:
 	i3002_device(const machine_config &mconfig , const char *tag , device_t *owner , uint32_t clock = 0);
 
+	// Output callbacks
+	template <typename... T> void set_co_w_cb(T &&... args) { m_co_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_ro_w_cb(T &&... args) { m_ro_handler.set(std::forward<T>(args)...); }
+
+	// Input bus callbacks
+	template <typename... T> void set_ibus_r_cb(T &&... args) { m_ibus_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_mbus_r_cb(T &&... args) { m_mbus_handler.set(std::forward<T>(args)...); }
+
 	// Width of bit-slice
 	static constexpr unsigned SLICE_SIZE = 2;
 
@@ -68,24 +76,16 @@ public:
 	void fc_kbus_w(uint8_t fc , uint8_t k);
 
 	// Write Carry Input
-	void ci_w(bool state) { m_ci = state; }
+	DECLARE_WRITE_LINE_MEMBER(ci_w) { m_ci = state; }
 
 	// Write Left Input
-	void li_w(bool state) { m_li = state; }
+	DECLARE_WRITE_LINE_MEMBER(li_w) { m_li = state; }
 
 	// Read Carry Output
 	DECLARE_READ_LINE_MEMBER(co_r) const { return m_co; }
 
 	// Read Right Output
 	DECLARE_READ_LINE_MEMBER(ro_r) const { return m_ro; }
-
-	// Output callbacks
-	template <typename... T> void set_co_w_cb(T &&... args) { m_co_handler.set(std::forward<T>(args)...); }
-	template <typename... T> void set_ro_w_cb(T &&... args) { m_ro_handler.set(std::forward<T>(args)...); }
-
-	// Input bus callbacks
-	template <typename... T> void set_ibus_r_cb(T &&... args) { m_ibus_handler.set(std::forward<T>(args)...); }
-	template <typename... T> void set_mbus_r_cb(T &&... args) { m_mbus_handler.set(std::forward<T>(args)...); }
 
 	// Read output buses
 	uint8_t abus_r() const { return m_reg[ REG_MAR ]; }
@@ -106,10 +106,10 @@ protected:
 	virtual void device_start() override;
 
 private:
-	device_delegate<void (bool)> m_co_handler;
-	device_delegate<void (bool)> m_ro_handler;
-	device_delegate<uint8_t (void)> m_ibus_handler;
-	device_delegate<uint8_t (void)> m_mbus_handler;
+	device_delegate<void (int)> m_co_handler;
+	device_delegate<void (int)> m_ro_handler;
+	device_delegate<uint8_t ()> m_ibus_handler;
+	device_delegate<uint8_t ()> m_mbus_handler;
 
 	uint8_t m_reg[ REG_COUNT ];
 	uint8_t m_fc;

--- a/src/devices/machine/i3002.h
+++ b/src/devices/machine/i3002.h
@@ -68,10 +68,10 @@ public:
 	void fc_kbus_w(uint8_t fc , uint8_t k);
 
 	// Write Carry Input
-	DECLARE_WRITE_LINE_MEMBER(ci_w) { m_ci = state != 0; }
+	void ci_w(bool state) { m_ci = state; }
 
 	// Write Left Input
-	DECLARE_WRITE_LINE_MEMBER(li_w) { m_li = state != 0; }
+	void li_w(bool state) { m_li = state; }
 
 	// Read Carry Output
 	DECLARE_READ_LINE_MEMBER(co_r) const { return m_co; }
@@ -80,12 +80,12 @@ public:
 	DECLARE_READ_LINE_MEMBER(ro_r) const { return m_ro; }
 
 	// Output callbacks
-	auto co_w() { return m_co_handler.bind(); }
-	auto ro_w() { return m_ro_handler.bind(); }
+	template <typename... T> void set_co_w_cb(T &&... args) { m_co_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_ro_w_cb(T &&... args) { m_ro_handler.set(std::forward<T>(args)...); }
 
 	// Input bus callbacks
-	auto ibus_r() { return m_ibus_handler.bind(); }
-	auto mbus_r() { return m_mbus_handler.bind(); }
+	template <typename... T> void set_ibus_r_cb(T &&... args) { m_ibus_handler.set(std::forward<T>(args)...); }
+	template <typename... T> void set_mbus_r_cb(T &&... args) { m_mbus_handler.set(std::forward<T>(args)...); }
 
 	// Read output buses
 	uint8_t abus_r() const { return m_reg[ REG_MAR ]; }
@@ -106,10 +106,10 @@ protected:
 	virtual void device_start() override;
 
 private:
-	devcb_write_line m_co_handler;
-	devcb_write_line m_ro_handler;
-	devcb_read8 m_ibus_handler;
-	devcb_read8 m_mbus_handler;
+	device_delegate<void (bool)> m_co_handler;
+	device_delegate<void (bool)> m_ro_handler;
+	device_delegate<uint8_t (void)> m_ibus_handler;
+	device_delegate<uint8_t (void)> m_mbus_handler;
 
 	uint8_t m_reg[ REG_COUNT ];
 	uint8_t m_fc;

--- a/src/mame/intel/imds2.cpp
+++ b/src/mame/intel/imds2.cpp
@@ -103,8 +103,7 @@ public:
 
 	void imds2(machine_config &config);
 
-	DECLARE_WRITE_LINE_MEMBER(wait_io_rd);
-	DECLARE_WRITE_LINE_MEMBER(wait_io_wr);
+	DECLARE_WRITE_LINE_MEMBER(xack);
 
 private:
 	uint8_t ipc_mem_read(offs_t offset);
@@ -307,29 +306,17 @@ void imds2_state::imds2(machine_config &config)
 	m_ioc->parallel_int_cb().set(m_ipclocpic, FUNC(pic8259_device::ir5_w));
 
 	MULTIBUS(config, m_bus, 9'830'400);
-	m_bus->wait_io_rd_cb().set(FUNC(imds2_state::wait_io_rd));
-	m_bus->wait_io_wr_cb().set(FUNC(imds2_state::wait_io_wr));
+	m_bus->xack_cb().set(FUNC(imds2_state::xack));
 	MULTIBUS_SLOT(config, m_slot, m_bus, imds2_cards, nullptr, false); // FIXME: isbc202
 }
 
-WRITE_LINE_MEMBER(imds2_state::wait_io_rd)
+WRITE_LINE_MEMBER(imds2_state::xack)
 {
 	if (state) {
 		// Put CPU in wait state
 		m_ipccpu->spin_until_trigger(1);
-		// Rewind PC so that the "IN" instruction is repeated when CPU is released
+		// Rewind PC so that the "IN" & "OUT" instructions are repeated when CPU is released
 		m_ipccpu->set_pc(m_ipccpu->pc() - 2);
-	} else {
-		// Release CPU from wait state
-		m_ipccpu->trigger(1);
-	}
-}
-
-WRITE_LINE_MEMBER(imds2_state::wait_io_wr)
-{
-	if (state) {
-		// Put CPU in wait state
-		m_ipccpu->spin_until_trigger(1);
 	} else {
 		// Release CPU from wait state
 		m_ipccpu->trigger(1);

--- a/src/mame/intel/imds2ioc.cpp
+++ b/src/mame/intel/imds2ioc.cpp
@@ -2,13 +2,7 @@
 // copyright-holders:F. Ulivi
 // I/O controller for Intel Intellec MDS series-II
 //
-// NOTE:
-// Firmware running on PIO is NOT original because a dump is not available at the moment.
-// Emulator runs a version of PIO firmware that was specifically developed by me to implement
-// line printer output.
-//
 // TODO:
-// - Find a dump of the original PIO firmware
 // - Adjust speed of processors. Wait states are not accounted for yet.
 
 #include "emu.h"
@@ -328,20 +322,10 @@ WRITE_LINE_MEMBER(imds2ioc_device::pio_lpt_ack_w)
 
 WRITE_LINE_MEMBER(imds2ioc_device::pio_lpt_busy_w)
 {
-	// Busy is active high in centronics_device whereas it's active low in MDS
-	if (!state) {
+	if (state) {
 		m_device_status_byte |= 0x10;
 	} else {
 		m_device_status_byte &= ~0x10;
-	}
-}
-
-WRITE_LINE_MEMBER(imds2ioc_device::pio_lpt_select_w)
-{
-	if (state) {
-		m_device_status_byte |= 0x40;
-	} else {
-		m_device_status_byte &= ~0x40;
 	}
 }
 
@@ -641,7 +625,6 @@ void imds2ioc_device::device_add_mconfig(machine_config &config)
 	CENTRONICS(config, m_centronics, centronics_devices, "printer");
 	m_centronics->ack_handler().set(FUNC(imds2ioc_device::pio_lpt_ack_w));
 	m_centronics->busy_handler().set(FUNC(imds2ioc_device::pio_lpt_busy_w));
-	m_centronics->perror_handler().set(FUNC(imds2ioc_device::pio_lpt_select_w));
 }
 
 ROM_START(imds2ioc)
@@ -665,10 +648,8 @@ ROM_START(imds2ioc)
 	ROMX_LOAD("104593-004.a53", 0x1800, 0x0800, CRC(04407e2a) SHA1(ecd65e4337d2bb7f5f6fdaae95696c9207ba57ee), ROM_BIOS(2))
 
 	// ROM definition of PIO controller (8041A)
-	// For the time being a specially developed PIO firmware is used until a dump of the original PIO is
-	// available.
 	ROM_REGION(0x400, "iocpio", 0)
-	ROM_LOAD("pio_a72.bin", 0, 0x400, BAD_DUMP CRC(8c8e740b) SHA1(9b9333a9dc9585aa8f630721d13e551a5c87defc))
+	ROM_LOAD("104566-0012.bin", 0, 0x400, CRC(f999e5da) SHA1(77ac1fab5443a16f906b25926ab3ba3ae42db6bb))
 
 	// ROM definition of keyboard controller (8741)
 	ROM_REGION(0x400, "kbcpu", 0)

--- a/src/mame/intel/imds2ioc.h
+++ b/src/mame/intel/imds2ioc.h
@@ -67,7 +67,6 @@ private:
 	void pio_port_p2_w(uint8_t data);
 	DECLARE_WRITE_LINE_MEMBER(pio_lpt_ack_w);
 	DECLARE_WRITE_LINE_MEMBER(pio_lpt_busy_w);
-	DECLARE_WRITE_LINE_MEMBER(pio_lpt_select_w);
 
 	I8275_DRAW_CHARACTER_MEMBER(crtc_display_pixels);
 


### PR DESCRIPTION
Hi,
this PR is for a couple of changes to imds2 driver.

- The correct dump for PIO controller has been added
- A regression introduced by 4287970 has been fixed. The iSBC202 floppy controller broke because of this regression.

Thanks.
--F.Ulivi