### PR TITLE
ui/selgame.cpp: Avoid assert in std::vector when no items in menu

### DIFF
--- a/src/frontend/mame/ui/selgame.cpp
+++ b/src/frontend/mame/ui/selgame.cpp
@@ -164,7 +164,7 @@ void menu_select_game::menu_activated()
 
 void menu_select_game::handle(event const *ev)
 {
-	if (!m_prev_selected)
+	if (!m_prev_selected && item_count() > 0)
 		m_prev_selected = item(0).ref();
 
 	// if I have to select software, force software list submenu


### PR DESCRIPTION
At times std::vector<menu_item> m_items found in src/frontend/mame/ui/menu.h is empty, even after displaying a full list, triggering this assertion:

/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/include/g++-v11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = ui::menu_item; _Alloc = std::allocator<ui::menu_item>; std::vector<_Tp, _Alloc>::reference = ui::menu_item&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
