### PR TITLE
mpu4bwb.cpp - set identification / defaults for booting

### DIFF
--- a/src/mame/drivers/mpu4bwb.cpp
+++ b/src/mame/drivers/mpu4bwb.cpp
@@ -139,6 +139,103 @@ void mpu4bwb_machines_state::mpu4_memmap_characteriser_bwb(address_map &map)
 	map(0x0800, 0x083f).rw(m_characteriser_bwb, FUNC(mpu4_characteriser_pal_bwb::read), FUNC(mpu4_characteriser_pal_bwb::write));
 }
 
+#define USE_STAKE_PORT_VALUE(value) \
+	PORT_MODIFY("ORANGE1") \
+	PORT_CONFNAME( 0xe0, value, "Stake Key" ) \
+	PORT_CONFSETTING(    0x00, "Not fitted / 5p" ) \
+	PORT_CONFSETTING(    0x20, "10p" ) \
+	PORT_CONFSETTING(    0x40, "20p" ) \
+	PORT_CONFSETTING(    0x60, "25p" ) \
+	PORT_CONFSETTING(    0x80, "30p" ) \
+	PORT_CONFSETTING(    0xa0, "40p" ) \
+	PORT_CONFSETTING(    0xc0, "50p" ) \
+	PORT_CONFSETTING(    0xe0, "1 GBP" )
+
+#define USE_JACKPOT_PORT_VALUE(value) \
+	PORT_MODIFY("ORANGE2") \
+	PORT_CONFNAME( 0x0f, value, "Jackpot / Prize Key" ) \
+	PORT_CONFSETTING(    0x00, "Not fitted" ) \
+	PORT_CONFSETTING(    0x01, "3 GBP" ) \
+	PORT_CONFSETTING(    0x02, "4 GBP" ) \
+	PORT_CONFSETTING(    0x08, "5 GBP" ) \
+	PORT_CONFSETTING(    0x03, "6 GBP" ) \
+	PORT_CONFSETTING(    0x04, "6 GBP Token" ) \
+	PORT_CONFSETTING(    0x05, "8 GBP" ) \
+	PORT_CONFSETTING(    0x06, "8 GBP Token" ) \
+	PORT_CONFSETTING(    0x07, "10 GBP" ) \
+	PORT_CONFSETTING(    0x09, "15 GBP" ) \
+	PORT_CONFSETTING(    0x0a, "25 GBP" ) \
+	PORT_CONFSETTING(    0x0b, "25 GBP (Licensed Betting Office Profile)" ) \
+	PORT_CONFSETTING(    0x0c, "35 GBP" ) \
+	PORT_CONFSETTING(    0x0d, "70 GBP" ) \
+	PORT_CONFSETTING(    0x0e, "Reserved" ) \
+	PORT_CONFSETTING(    0x0f, "Reserved" )
+
+#define USE_PERCENT_PORT_VALUE(value) \
+	PORT_MODIFY("ORANGE2") \
+	PORT_CONFNAME( 0xf0, value, "Percentage Key" ) \
+	PORT_CONFSETTING(    0x00, "Not fitted / 68% (Invalid for UK Games)" ) \
+	PORT_CONFSETTING(    0x10, "70" ) \
+	PORT_CONFSETTING(    0x20, "72" ) \
+	PORT_CONFSETTING(    0x30, "74" ) \
+	PORT_CONFSETTING(    0x40, "76" ) \
+	PORT_CONFSETTING(    0x50, "78" ) \
+	PORT_CONFSETTING(    0x60, "80" ) \
+	PORT_CONFSETTING(    0x70, "82" ) \
+	PORT_CONFSETTING(    0x80, "84" ) \
+	PORT_CONFSETTING(    0x90, "86" ) \
+	PORT_CONFSETTING(    0xa0, "88" ) \
+	PORT_CONFSETTING(    0xb0, "90" ) \
+	PORT_CONFSETTING(    0xc0, "92" ) \
+	PORT_CONFSETTING(    0xd0, "94" ) \
+	PORT_CONFSETTING(    0xe0, "96" ) \
+	PORT_CONFSETTING(    0xf0, "98" )
+
+INPUT_PORTS_START( mpu4impcoin_20p )
+	PORT_INCLUDE( mpu4_impcoin )
+
+	USE_STAKE_PORT_VALUE(0x40)
+INPUT_PORTS_END
+
+INPUT_PORTS_START( mpu4impcoin_jackpot10_20p )
+	PORT_INCLUDE( mpu4impcoin_20p )
+
+	USE_JACKPOT_PORT_VALUE(0x07)
+INPUT_PORTS_END
+
+INPUT_PORTS_START( mpu4impcoin_jackpot15_20p )
+	PORT_INCLUDE( mpu4impcoin_20p )
+
+	USE_JACKPOT_PORT_VALUE(0x09)
+INPUT_PORTS_END
+
+INPUT_PORTS_START( mpu4impcoin_jackpot15_20p_90pc )
+	PORT_INCLUDE( mpu4impcoin_jackpot15_20p )
+
+	USE_PERCENT_PORT_VALUE(0xb0)
+INPUT_PORTS_END
+
+
+INPUT_PORTS_START( mpu4impcoin_jackpot8tkn_20p )
+	PORT_INCLUDE( mpu4impcoin_20p )
+
+	USE_JACKPOT_PORT_VALUE(0x06)
+INPUT_PORTS_END
+
+INPUT_PORTS_START( mpu4impcoin_jackpot8tkn_20p_90pc )
+	PORT_INCLUDE( mpu4impcoin_jackpot8tkn_20p )
+
+	USE_PERCENT_PORT_VALUE(0xb0)
+INPUT_PORTS_END
+
+INPUT_PORTS_START( mpu4impcoin_jackpot5_5p )
+	PORT_INCLUDE( mpu4_impcoin )
+
+	USE_JACKPOT_PORT_VALUE(0x08)
+INPUT_PORTS_END
+
+
+
 } // anonymous namespace
 
 #define GAME_FLAGS (MACHINE_NOT_WORKING|MACHINE_REQUIRES_ARTWORK|MACHINE_MECHANICAL)
@@ -147,7 +244,6 @@ void mpu4bwb_machines_state::mpu4_memmap_characteriser_bwb(address_map &map)
 /*****************************************************************************************************************************************************************************
 *
 * Abracadabra
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -158,18 +254,19 @@ static const uint32_t m4abra_keys[2] = { 0x11, 0x192703 };
 	/* missing? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4ABRA_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4abra_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4abra,       0,      "nn_sj___.4_0", 0x0000, 0x040000, CRC(48437d29) SHA1(72a2e9337fc0a004c382931f3af856253c44ed61), "BWB","Abracadabra (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4abra__a,    m4abra, "nn_sja__.4_0", 0x0000, 0x040000, CRC(766cd4ae) SHA1(4d630b967ede615d325f524c2e4c92c7e7a60886), "BWB","Abracadabra (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4abra__b,    m4abra, "nn_sjb__.4_0", 0x0000, 0x040000, CRC(ca77a68a) SHA1(e753c065d299038bae4c451e647b9bcda36421d9), "BWB","Abracadabra (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4abra__c,    m4abra, "nn_sjk__.4_0", 0x0000, 0x040000, CRC(19018556) SHA1(6df993939e70a24621d4e732d0670d64fac1cf56), "BWB","Abracadabra (BWB) (MPU4) (set 4)" )
+
+GAME_CUSTOM( 199?, m4abra,       0,      bwboki_chr_cheat<m4abra_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "nn_sj___.4_0", 0x0000, 0x040000, CRC(48437d29) SHA1(72a2e9337fc0a004c382931f3af856253c44ed61), "BWB",u8"Abracadabra (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4abra__a,    m4abra, bwboki_chr_cheat<m4abra_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "nn_sja__.4_0", 0x0000, 0x040000, CRC(766cd4ae) SHA1(4d630b967ede615d325f524c2e4c92c7e7a60886), "BWB",u8"Abracadabra (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 2)" )
+GAME_CUSTOM( 199?, m4abra__b,    m4abra, bwboki_chr_cheat<m4abra_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "nn_sjb__.4_0", 0x0000, 0x040000, CRC(ca77a68a) SHA1(e753c065d299038bae4c451e647b9bcda36421d9), "BWB",u8"Abracadabra (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4abra__c,    m4abra, bwboki_chr_cheat<m4abra_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big, "nn_sjk__.4_0", 0x0000, 0x040000, CRC(19018556) SHA1(6df993939e70a24621d4e732d0670d64fac1cf56), "BWB",u8"Abracadabra (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 4)" ) // % key
 
 
 /*****************************************************************************************************************************************************************************
@@ -201,7 +298,6 @@ GAME_CUSTOM( 199?, m4bigmt__a,  m4bigmt,    "tb_20___.7_1", 0x0000, 0x010000, CR
 GAME_CUSTOM( 199?, m4bigmt__b,  m4bigmt,    "tb_20_b_.7_1", 0x0000, 0x010000, CRC(40d140a3) SHA1(fd4de8dd827db933481f671e4f10684c3b7a363a), "BWB","The Big Match (BWB) (MPU4) (set 3)" )
 GAME_CUSTOM( 199?, m4bigmt__c,  m4bigmt,    "tb_20_d_.7_1", 0x0000, 0x010000, CRC(86ed18c5) SHA1(1699645532134bd830e3fc2c3ff4b67b5d67ba3e), "BWB","The Big Match (BWB) (MPU4) (set 4)" )
 GAME_CUSTOM( 199?, m4bigmt__d,  m4bigmt,    "tb_20_k_.7_1", 0x0000, 0x010000, CRC(e4c6b896) SHA1(ccf656d14ad68edb0aea99d4d3621540b899cdb7), "BWB","The Big Match (BWB) (MPU4) (set 5)" )
-//GAME_CUSTOM( 199?, m4bigmt__e,  m4bigmt,    "tb______.1_2", 0x0000, 0x004000, CRC(be2a3989) SHA1(5ef857101335f90cd9f6147ec330ae281bb97b2b), "BWB","The Big Match (BWB) (MPU4) (set 6)" ) // this is just a corrupt sound ROM with garbage after 0x2000
 GAME_CUSTOM( 199?, m4bigmt__f,  m4bigmt,    "tbi20___.7_1", 0x0000, 0x010000, CRC(104f45cc) SHA1(c28c08b44c46db9d0eade1f60aeda120c3981a03), "BWB","The Big Match (BWB) (MPU4) (set 7)" )
 
 
@@ -373,7 +469,6 @@ GAME_CUSTOM( 199?, m4blsbys__ad,   m4blsbys,   "bsix3___.2v1", 0x0000, 0x020000,
 /*****************************************************************************************************************************************************************************
 *
 * Championship Soccer
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -386,25 +481,30 @@ static const uint32_t m4csoc_keys[2] = { 0x11, 0x101230 };
 	ROM_LOAD( "ch_socc.s3", 0x100000, 0x080000, CRC(064224b0) SHA1(99a8bacfd3a42f72e40b93d1f7eeea633c3cf366) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4CSOC_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4csoc_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4csoc,       0,      "chsoc8ac",     0x0000, 0x040000, CRC(8e0471ba) SHA1(3b7e6edbb3490e99af148c0cfe8d39c13c282880), "BWB","Championship Soccer (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4csoc__a,    m4csoc, "sg_sj___.1_0", 0x0000, 0x040000, CRC(f21cd1aa) SHA1(dc010a315a8d738ad9e5e384197499e08a8d5ef6), "BWB","Championship Soccer (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4csoc__b,    m4csoc, "sg_sj___.2_0", 0x0000, 0x040000, CRC(5513f2a3) SHA1(e9e59461a007be02beae6cd1610b8582d367c15e), "BWB","Championship Soccer (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4csoc__c,    m4csoc, "sg_sj_d_.2_0", 0x0000, 0x040000, CRC(b0058d0f) SHA1(635c4f729c27c5cb4356f62dcc13127043ea0e5c), "BWB","Championship Soccer (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4csoc__d,    m4csoc, "so_sj___.b_0", 0x0000, 0x040000, CRC(65d5bb2d) SHA1(61c6896d97ed79e2f31b37b9d8998980ceac4fc5), "BWB","Championship Soccer (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4csoc__e,    m4csoc, "so_sj_d_.b_0", 0x0000, 0x040000, CRC(5e79ba34) SHA1(cb8c689319b5f94ce0385b3b7846a49589358ccc), "BWB","Championship Soccer (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4csoc__f,    m4csoc, "so_sjs__.b_0", 0x0000, 0x040000, CRC(2f50675e) SHA1(baed8e3a455ec5bfa810e64dc4c66996d6746bbc), "BWB","Championship Soccer (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4csoc__g,    m4csoc, "so_vc___.c_0", 0x0000, 0x040000, CRC(d683b202) SHA1(95803008a50229bc85ed177b587fdf05cb152df3), "BWB","Championship Soccer (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4csoc__h,    m4csoc, "so_vc_d_.c_0", 0x0000, 0x040000, CRC(ed2fb31b) SHA1(de72d8abbb4a22125ed312e6ccfcab6b3e591ec2), "BWB","Championship Soccer (BWB) (MPU4) (set 9)" )
-GAME_CUSTOM( 199?, m4csoc__i,    m4csoc, "ch_socc",      0x0000, 0x040000, CRC(ea9af5bd) SHA1(99319995ee886196ddd540bf37960a4e5b9d4f34), "BWB","Championship Soccer (BWB) (MPU4) (set 10)" )
-GAME_CUSTOM( 199?, m4csoc__j,    m4csoc, "ch_socc.5",    0x0000, 0x040000, CRC(1b2ea78d) SHA1(209534ccd537c0ca9d02301830a52ebc29b93cb7), "BWB","Championship Soccer (BWB) (MPU4) (set 11)" )
+
+GAME_CUSTOM( 199?, m4csoc,       0,      bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"sg_sj___.1_0", 0x0000, 0x040000, CRC(f21cd1aa) SHA1(dc010a315a8d738ad9e5e384197499e08a8d5ef6), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4csoc__a,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"sg_sj___.2_0", 0x0000, 0x040000, CRC(5513f2a3) SHA1(e9e59461a007be02beae6cd1610b8582d367c15e), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £10/£15 jackpot) (set 2)" )
+GAME_CUSTOM( 199?, m4csoc__b,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"sg_sj_d_.2_0", 0x0000, 0x040000, CRC(b0058d0f) SHA1(635c4f729c27c5cb4356f62dcc13127043ea0e5c), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £10/£15 jackpot) (set 3)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4csoc__c,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"so_sj___.b_0", 0x0000, 0x040000, CRC(65d5bb2d) SHA1(61c6896d97ed79e2f31b37b9d8998980ceac4fc5), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4csoc__d,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"so_sj_d_.b_0", 0x0000, 0x040000, CRC(5e79ba34) SHA1(cb8c689319b5f94ce0385b3b7846a49589358ccc), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4csoc__e,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"so_sjs__.b_0", 0x0000, 0x040000, CRC(2f50675e) SHA1(baed8e3a455ec5bfa810e64dc4c66996d6746bbc), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4csoc__f,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"ch_socc.5",    0x0000, 0x040000, CRC(1b2ea78d) SHA1(209534ccd537c0ca9d02301830a52ebc29b93cb7), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 4)" )
+//
+GAME_CUSTOM( 199?, m4csoc__g,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big ,"so_vc___.c_0", 0x0000, 0x040000, CRC(d683b202) SHA1(95803008a50229bc85ed177b587fdf05cb152df3), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10p stake / £5 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4csoc__h,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big ,"so_vc_d_.c_0", 0x0000, 0x040000, CRC(ed2fb31b) SHA1(de72d8abbb4a22125ed312e6ccfcab6b3e591ec2), "BWB",u8"Championship Soccer (BWB) (MPU4) (5/10p stake / £5 jackpot) (set 2)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4csoc__i,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"ch_socc",      0x0000, 0x040000, CRC(ea9af5bd) SHA1(99319995ee886196ddd540bf37960a4e5b9d4f34), "BWB",u8"Championship Soccer (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot)" )
+//
+GAME_CUSTOM( 199?, m4csoc__j,    m4csoc, bwboki_chr_cheat<m4csoc_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,"chsoc8ac",     0x0000, 0x040000, CRC(8e0471ba) SHA1(3b7e6edbb3490e99af148c0cfe8d39c13c282880), "hack",u8"Championship Soccer (BWB) (MPU4) (5/10/20/25/30p stake / £8 jackpot, 20/25/30p stake / £15 jackpot) (hack)" ) // BWB string at the start of the demo has been blanked out
 
 
 /*****************************************************************************************************************************************************************************
@@ -495,7 +595,7 @@ GAME_CUSTOM( 199?, m4danced__w,    m4danced,   "dd_sja__.2_1", 0x0000, 0x020000,
 /*****************************************************************************************************************************************************************************
 *
 * Daytona
-* - 3.2 MPU Lamp Drv error
+* - Multi-stake game (player chooses the stake, not operator)
 *
 *****************************************************************************************************************************************************************************/
 
@@ -571,7 +671,6 @@ GAME_CUSTOM( 199?, m4excal__j,  m4excal,    "ex_20sd8.6_1", 0x0000, 0x020000, CR
 /*****************************************************************************************************************************************************************************
 *
 * Exotic Fruits
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -582,26 +681,27 @@ static const uint32_t m4exotic_keys[2] = { 0x34, 0x3f0e26 };
 	/* missing? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4EXOTIC_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4exotic_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4exotic,       0,          "eo_49bg_.2_0", 0x0000, 0x020000, CRC(c3bf2286) SHA1(74090fd0a103a6c311d426f4aae8e7af8b1d3bc0), "BWB","Exotic Fruits (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4exotic__a,    m4exotic,   "eo_49bm_.2_0", 0x0000, 0x020000, CRC(c748c4ca) SHA1(7d0d498f9edd792ed861c8bf9cf1bb03698d144d), "BWB","Exotic Fruits (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4exotic__b,    m4exotic,   "eo_49bmd.2_0", 0x0000, 0x020000, CRC(98436c04) SHA1(1db7c95f7a0297aa3da7f1ce27c790ffa1fa4ebe), "BWB","Exotic Fruits (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4exotic__c,    m4exotic,   "eo_49bmd.2g0", 0x0000, 0x020000, CRC(425a0152) SHA1(6a235c613f52c4b8985a589f89542eebd3574fde), "BWB","Exotic Fruits (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4exotic__d,    m4exotic,   "eo_s9bt_.2g0", 0x0000, 0x020000, CRC(c527d333) SHA1(083d7be95d73d259fe8ec1d87a3a41089a4c44df), "BWB","Exotic Fruits (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4exotic__e,    m4exotic,   "eo_sja__.2_0", 0x0000, 0x020000, CRC(5ca9557f) SHA1(5fa42c56c67b505272d358a54ebe911fdb0b905e), "BWB","Exotic Fruits (BWB) (MPU4) (set 6)" )
+// don't require stake/jp set
+GAME_CUSTOM( 199?, m4exotic,       0,        bwboki_chr_cheat<m4exotic_keys>, mpu4_impcoin,              init_m4default_big, "eo_49bm_.2_0", 0x0000, 0x020000, CRC(c748c4ca) SHA1(7d0d498f9edd792ed861c8bf9cf1bb03698d144d), "BWB",u8"Exotic Fruits (BWB) (MPU4) (30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4exotic__a,    m4exotic, bwboki_chr_cheat<m4exotic_keys>, mpu4_impcoin,              init_m4default_big, "eo_49bmd.2_0", 0x0000, 0x020000, CRC(98436c04) SHA1(1db7c95f7a0297aa3da7f1ce27c790ffa1fa4ebe), "BWB",u8"Exotic Fruits (BWB) (MPU4) (30p stake / £15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4exotic__b,    m4exotic, bwboki_chr_cheat<m4exotic_keys>, mpu4_impcoin,              init_m4default_big, "eo_49bmd.2g0", 0x0000, 0x020000, CRC(425a0152) SHA1(6a235c613f52c4b8985a589f89542eebd3574fde), "BWB",u8"Exotic Fruits (BWB) (MPU4) (30p stake / £15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4exotic__c,    m4exotic, bwboki_chr_cheat<m4exotic_keys>, mpu4_impcoin,              init_m4default_big, "eo_49bg_.2_0", 0x0000, 0x020000, CRC(c3bf2286) SHA1(74090fd0a103a6c311d426f4aae8e7af8b1d3bc0), "BWB",u8"Exotic Fruits (BWB) (MPU4) (30p stake / £15 jackpot) (set 4)" ) // Datapak
+// require stake/jp set
+GAME_CUSTOM( 199?, m4exotic__d,    m4exotic, bwboki_chr_cheat<m4exotic_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "eo_s9bt_.2g0", 0x0000, 0x020000, CRC(c527d333) SHA1(083d7be95d73d259fe8ec1d87a3a41089a4c44df), "BWB",u8"Exotic Fruits (BWB) (MPU4) (20/25/30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4exotic__e,    m4exotic, bwboki_chr_cheat<m4exotic_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "eo_sja__.2_0", 0x0000, 0x020000, CRC(5ca9557f) SHA1(5fa42c56c67b505272d358a54ebe911fdb0b905e), "BWB",u8"Exotic Fruits (BWB) (MPU4) (20/25/30p stake / £15 jackpot) (set 2)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
 *
 * Fire & Ice
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -614,26 +714,27 @@ static const uint32_t m4firice_keys[2] = { 0x11, 0x162413 };
 	ROM_LOAD( "fire_ice.s3", 0x100000, 0x080000, CRC(75f349b3) SHA1(1505bec7b69e1eabd679b70d95ae58fd264ca698) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4FIRICE_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4firice_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4firice,       0,          "fi_20__d.5_0", 0x0000, 0x040000, CRC(ab46574c) SHA1(d233b137f8f42b9b644b34a627fbcc5b662e8ae1), "BWB","Fire & Ice (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4firice__a,    m4firice,   "fi_20_bd.5_0", 0x0000, 0x040000, CRC(9b2bc052) SHA1(34b970659218fde097238b852dadedcb928f69fd), "BWB","Fire & Ice (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4firice__b,    m4firice,   "fi_20_dd.5_0", 0x0000, 0x040000, CRC(2bbc9855) SHA1(84d51eeadc01ac74d630a05b933343f01f04b2af), "BWB","Fire & Ice (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4firice__c,    m4firice,   "fi_20_kd.5_0", 0x0000, 0x040000, CRC(529b43b1) SHA1(80d4d928918fdc869b1693e21a5c25045e5c9449), "BWB","Fire & Ice (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4firice__d,    m4firice,   "fi_20a_d.5_0", 0x0000, 0x040000, CRC(8d6ce79d) SHA1(05954ed4b34af73c065b6203a50da9af7d8373fe), "BWB","Fire & Ice (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4firice__e,    m4firice,   "fi_20s_d.5_0", 0x0000, 0x040000, CRC(d0aa53af) SHA1(f71801344c17a759ec4eb8958377bbcf4b4cae65), "BWB","Fire & Ice (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4firice__f,    m4firice,   "fi_sj___.e_0", 0x0000, 0x040000, CRC(7f12e37a) SHA1(fb09ff782f66972b8bdeff105c5f3d1f9f676809), "BWB","Fire & Ice (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4firice__g,    m4firice,   "fi_sj_b_.e_0", 0x0000, 0x040000, CRC(5aef48d2) SHA1(73f410951a737f75f3e7c14e704eca9c26cfa750), "BWB","Fire & Ice (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4firice__h,    m4firice,   "fi_sj_d_.e_0", 0x0000, 0x040000, CRC(61822af2) SHA1(8c721229a5ce9f491cbc638b8c5fa5c0c3032700), "BWB","Fire & Ice (BWB) (MPU4) (set 9)" )
-GAME_CUSTOM( 199?, m4firice__i,    m4firice,   "fi_sj_k_.e_0", 0x0000, 0x040000, CRC(2b57036b) SHA1(60cec130770ff643af1148f16a3afe3b102e94e2), "BWB","Fire & Ice (BWB) (MPU4) (set 10)" )
-GAME_CUSTOM( 199?, m4firice__j,    m4firice,   "fi_sja__.e_0", 0x0000, 0x040000, CRC(da5e0eff) SHA1(9f5ddce366786bdf898c9410be417c8028cebeb4), "BWB","Fire & Ice (BWB) (MPU4) (set 11)" )
-
+// allows you to boot with 50p stake, but still shows '20p'
+GAME_CUSTOM( 199?, m4firice,       0,        bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20__d.5_0", 0x0000, 0x040000, CRC(ab46574c) SHA1(d233b137f8f42b9b644b34a627fbcc5b662e8ae1), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4firice__a,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20_bd.5_0", 0x0000, 0x040000, CRC(9b2bc052) SHA1(34b970659218fde097238b852dadedcb928f69fd), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4firice__b,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20_dd.5_0", 0x0000, 0x040000, CRC(2bbc9855) SHA1(84d51eeadc01ac74d630a05b933343f01f04b2af), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4firice__c,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20_kd.5_0", 0x0000, 0x040000, CRC(529b43b1) SHA1(80d4d928918fdc869b1693e21a5c25045e5c9449), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 4)" ) // % key
+GAME_CUSTOM( 199?, m4firice__d,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20a_d.5_0", 0x0000, 0x040000, CRC(8d6ce79d) SHA1(05954ed4b34af73c065b6203a50da9af7d8373fe), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 5)" )
+GAME_CUSTOM( 199?, m4firice__e,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,  "fi_20s_d.5_0", 0x0000, 0x040000, CRC(d0aa53af) SHA1(f71801344c17a759ec4eb8958377bbcf4b4cae65), "BWB",u8"Fire & Ice (BWB) (MPU4) (20p stake / £8 token jackpot) (set 6)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4firice__f,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,  "fi_sj___.e_0", 0x0000, 0x040000, CRC(7f12e37a) SHA1(fb09ff782f66972b8bdeff105c5f3d1f9f676809), "BWB",u8"Fire & Ice (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4firice__g,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,  "fi_sj_b_.e_0", 0x0000, 0x040000, CRC(5aef48d2) SHA1(73f410951a737f75f3e7c14e704eca9c26cfa750), "BWB",u8"Fire & Ice (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4firice__h,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,  "fi_sj_d_.e_0", 0x0000, 0x040000, CRC(61822af2) SHA1(8c721229a5ce9f491cbc638b8c5fa5c0c3032700), "BWB",u8"Fire & Ice (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4firice__i,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,  "fi_sj_k_.e_0", 0x0000, 0x040000, CRC(2b57036b) SHA1(60cec130770ff643af1148f16a3afe3b102e94e2), "BWB",u8"Fire & Ice (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 4)" ) // % key
+GAME_CUSTOM( 199?, m4firice__j,    m4firice, bwboki_chr_cheat<m4firice_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,  "fi_sja__.e_0", 0x0000, 0x040000, CRC(da5e0eff) SHA1(9f5ddce366786bdf898c9410be417c8028cebeb4), "BWB",u8"Fire & Ice (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 5)" )
 
 /*****************************************************************************************************************************************************************************
 *
@@ -688,7 +789,6 @@ GAME_CUSTOM( 199?, m4harle__x,  m4harle,    "ph_20sk_.1_1", 0x0000, 0x010000, CR
 /*****************************************************************************************************************************************************************************
 *
 * Heaven & Hell
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -700,31 +800,34 @@ static const uint32_t m4hvhel_keys[2] = { 0x11, 0x3f0b26 };
 	ROM_LOAD( "hh___snd.1_2", 0x080000, 0x080000, CRC(ec1ec822) SHA1(3fdee0526cb70f4951b7bbced74e32641ded9b7b) ) \
 	ROM_LOAD( "hh___snd.1_3", 0x100000, 0x080000, CRC(d4119155) SHA1(b61c71e1ee0dbfc0bb9eff1a8c019cf11731ee11) )
 
+
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4HVHEL_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4hvhel_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4hvhel,     0,          "hh_20__d.2_0",     0x0000, 0x040000, CRC(801de788) SHA1(417b985714d8f0ebed93b65a3f865e03474ce9e5), "BWB","Heaven & Hell (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4hvhel__a,  m4hvhel,    "hh_20a_d.2_0",     0x0000, 0x040000, CRC(ea4e7876) SHA1(5bf711c2bdff50fe745edefa0eebf719824d9e5b), "BWB","Heaven & Hell (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4hvhel__b,  m4hvhel,    "hh_20s_d.2_0",     0x0000, 0x040000, CRC(a519a441) SHA1(f3c19d316c82d1ebbcfdabb6d4eaa6cfa369d287), "BWB","Heaven & Hell (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4hvhel__c,  m4hvhel,    "hh_sj___",         0x0000, 0x040000, CRC(04577b99) SHA1(48689c3a96bc42ad64dc4d363dad38c967f0cdcc), "BWB","Heaven & Hell (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4hvhel__d,  m4hvhel,    "hh_sj___.f_0",     0x0000, 0x040000, CRC(8ab33720) SHA1(0c9283a20c3f008baa8ce027d1266e4ef49ca56b), "BWB","Heaven & Hell (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4hvhel__e,  m4hvhel,    "hh_sjs__.f_0",     0x0000, 0x040000, CRC(8854763d) SHA1(323bd76a014e52e3b12427998b0e2851463246c8), "BWB","Heaven & Hell (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4hvhel__f,  m4hvhel,    "hh_vc___.g_0",     0x0000, 0x040000, CRC(db338fb7) SHA1(e7e92293374721e7360493e9ef189991dad0a1ee), "BWB","Heaven & Hell (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4hvhel__g,  m4hvhel,    "hh_vc_d_.g_0",     0x0000, 0x040000, CRC(292468bd) SHA1(f9b19f57a49c1afd670c68b7acd85d4141adfce1), "BWB","Heaven & Hell (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4hvhel__h,  m4hvhel,    "h_hell._pound5",   0x0000, 0x040000, CRC(cd59c0d0) SHA1(8caad9043a277fa39a3ad2d5ec3388c121e7f697), "BWB","Heaven & Hell (BWB) (MPU4) (set 9)" )
+GAME_CUSTOM( 199?, m4hvhel,     0,       bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,   "hh_20__d.2_0",     0x0000, 0x040000, CRC(801de788) SHA1(417b985714d8f0ebed93b65a3f865e03474ce9e5), "BWB", u8"Heaven & Hell (BWB) (MPU4) (20p stake / £8 token jackpot, set 1)" )
+GAME_CUSTOM( 199?, m4hvhel__a,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,   "hh_20a_d.2_0",     0x0000, 0x040000, CRC(ea4e7876) SHA1(5bf711c2bdff50fe745edefa0eebf719824d9e5b), "BWB", u8"Heaven & Hell (BWB) (MPU4) (20p stake / £8 token jackpot, set 2)" )
+GAME_CUSTOM( 199?, m4hvhel__b,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot8tkn_20p, init_m4default_big,   "hh_20s_d.2_0",     0x0000, 0x040000, CRC(a519a441) SHA1(f3c19d316c82d1ebbcfdabb6d4eaa6cfa369d287), "BWB", u8"Heaven & Hell (BWB) (MPU4) (20p stake / £8 token jackpot, set 3)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4hvhel__c,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot10_20p,   init_m4default_big,   "hh_sj___",         0x0000, 0x040000, CRC(04577b99) SHA1(48689c3a96bc42ad64dc4d363dad38c967f0cdcc), "BWB", u8"Heaven & Hell (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot)" )
+//
+GAME_CUSTOM( 199?, m4hvhel__d,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot15_20p,   init_m4default_big,   "hh_sj___.f_0",     0x0000, 0x040000, CRC(8ab33720) SHA1(0c9283a20c3f008baa8ce027d1266e4ef49ca56b), "BWB", u8"Heaven & Hell (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4hvhel__e,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot15_20p,   init_m4default_big,   "hh_sjs__.f_0",     0x0000, 0x040000, CRC(8854763d) SHA1(323bd76a014e52e3b12427998b0e2851463246c8), "BWB", u8"Heaven & Hell (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4hvhel__f,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot15_20p,   init_m4default_big,   "h_hell._pound5",   0x0000, 0x040000, CRC(cd59c0d0) SHA1(8caad9043a277fa39a3ad2d5ec3388c121e7f697), "BWB", u8"Heaven & Hell (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 3)" )
+//
+GAME_CUSTOM( 199?, m4hvhel__g,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot5_5p,     init_m4default_big,   "hh_vc___.g_0",     0x0000, 0x040000, CRC(db338fb7) SHA1(e7e92293374721e7360493e9ef189991dad0a1ee), "BWB", u8"Heaven & Hell (BWB) (MPU4) (5/10p stake / £5 jackpot, set 1)" )
+GAME_CUSTOM( 199?, m4hvhel__h,  m4hvhel, bwboki_chr_cheat<m4hvhel_keys>, mpu4impcoin_jackpot5_5p,     init_m4default_big,   "hh_vc_d_.g_0",     0x0000, 0x040000, CRC(292468bd) SHA1(f9b19f57a49c1afd670c68b7acd85d4141adfce1), "BWB", u8"Heaven & Hell (BWB) (MPU4) (5/10p stake / £5 jackpot, set 2)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
 *
 * Indy Cars
 * - note, the GAL dumps appear to be characterisers, are the equations valid?
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -741,27 +844,27 @@ static const uint32_t m4indycr_keys[2] = { 0x13, 0x102233 };
 	ROM_LOAD( "da______.1_4", 0x180000, 0x080000, CRC(8e254a3b) SHA1(bc3643ea5878bbde110ee6971c5149b3320bcffc) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4INDYCR_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4indycr_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4indycr,       0,          "ic_sj___.1_0", 0x0000, 0x040000, CRC(4dea0d17) SHA1(4fa19896dbb5e8f21ac7e74efc56de5cadd5bf54), "BWB","Indy Cars (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4indycr__a,    m4indycr,   "ic_sj___.2_0", 0x0000, 0x040000, CRC(6d0ddf54) SHA1(0985aa9fddb71a499d266c12893aabbab8755319), "BWB","Indy Cars (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4indycr__b,    m4indycr,   "ic_sj_b_.1_0", 0x0000, 0x040000, CRC(4bc0cb73) SHA1(d4c048ba9578add0104f0c529f20356c3502ea71), "BWB","Indy Cars (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4indycr__c,    m4indycr,   "ic_sj_d_.1_0", 0x0000, 0x040000, CRC(165ad977) SHA1(daa444e0d128859832094d3b07026483cd3466ce), "BWB","Indy Cars (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4indycr__d,    m4indycr,   "ic_sj_d_.2_0", 0x0000, 0x040000, CRC(36bd0b34) SHA1(306d6e6536a4137353f9b895e64c7e9a5c79561a), "BWB","Indy Cars (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4indycr__e,    m4indycr,   "ic_sj_k_.1_0", 0x0000, 0x040000, CRC(857fda64) SHA1(3eb230ea1adf9acb4cf83422c4bb1cde40756310), "BWB","Indy Cars (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4indycr__f,    m4indycr,   "ic_sjs__.1_0", 0x0000, 0x040000, CRC(6310b904) SHA1(0f2cd7ed83f77423bcfb2a71144fab2047dfea13), "BWB","Indy Cars (BWB) (MPU4) (set 7)" )
 
+GAME_CUSTOM( 199?, m4indycr,       0,        bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sj___.1_0", 0x0000, 0x040000, CRC(4dea0d17) SHA1(4fa19896dbb5e8f21ac7e74efc56de5cadd5bf54), u8"BWB","Indy Cars (BWB) (MPU4) (20/25/30p stake / £5/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4indycr__a,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sj_b_.1_0", 0x0000, 0x040000, CRC(4bc0cb73) SHA1(d4c048ba9578add0104f0c529f20356c3502ea71), u8"BWB","Indy Cars (BWB) (MPU4) (20/25/30p stake / £5/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4indycr__b,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sj_d_.1_0", 0x0000, 0x040000, CRC(165ad977) SHA1(daa444e0d128859832094d3b07026483cd3466ce), u8"BWB","Indy Cars (BWB) (MPU4) (20/25/30p stake / £5/£15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4indycr__c,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big,  "ic_sj_k_.1_0", 0x0000, 0x040000, CRC(857fda64) SHA1(3eb230ea1adf9acb4cf83422c4bb1cde40756310), u8"BWB","Indy Cars (BWB) (MPU4) (20/25/30p stake / £5/£15 jackpot) (set 4)" ) // % key
+GAME_CUSTOM( 199?, m4indycr__d,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sjs__.1_0", 0x0000, 0x040000, CRC(6310b904) SHA1(0f2cd7ed83f77423bcfb2a71144fab2047dfea13), u8"BWB","Indy Cars (BWB) (MPU4) (20/25/30p stake / £5/£15 jackpot) (set 5)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4indycr__e,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sj___.2_0", 0x0000, 0x040000, CRC(6d0ddf54) SHA1(0985aa9fddb71a499d266c12893aabbab8755319), u8"BWB","Indy Cars (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4indycr__f,    m4indycr, bwboki_chr_cheat<m4indycr_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "ic_sj_d_.2_0", 0x0000, 0x040000, CRC(36bd0b34) SHA1(306d6e6536a4137353f9b895e64c7e9a5c79561a), u8"BWB","Indy Cars (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 2)" ) // Datapak
 
 /*****************************************************************************************************************************************************************************
 *
 * Jackpot Jokers
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -772,19 +875,22 @@ static const uint32_t m4jakjok_keys[2] = { 0x11, 0x103218 };
 	ROM_LOAD( "jj_____.1_1", 0x000000, 0x080000, CRC(e759a958) SHA1(b107f4ef5a2805e56d4024940bfc632155de1eb1) ) \
 	ROM_LOAD( "jj_____.1_2", 0x080000, 0x080000, CRC(aa215ff0) SHA1(4bf2c6f8153730cc3ca86f78ec14063ece7d8700) ) \
 	ROM_LOAD( "jj_____.1_3", 0x100000, 0x080000, CRC(03c0ffc3) SHA1(2572f62362325df8b235b487d4a764218e7f1589) )
+
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4JAKJOK_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4jakjok_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4jakjok,       0,          "jj_sj___.6_0", 0x0000, 0x040000, CRC(7bc45b0e) SHA1(f30fef8fccdac04859f1ff93198a497eff723020), "BWB","Jackpot Jokers (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4jakjok__a,    m4jakjok,   "jj_sj_k_.3_0", 0x0000, 0x040000, CRC(c33dd82f) SHA1(c1f3f6ca1c45503b7f71e897e5c27368f5efb439), "BWB","Jackpot Jokers (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4jakjok__b,    m4jakjok,   "jj_sjs__.6_0", 0x0000, 0x040000, CRC(4bcac6f5) SHA1(7dc07a7a61a6ba044020d6c2496143168c103a70), "BWB","Jackpot Jokers (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4jakjok__c,    m4jakjok,   "jj_vc___.7_0", 0x0000, 0x040000, CRC(4cdca8da) SHA1(ee7448b12380416a3bea2713ed5feca7473be8aa), "BWB","Jackpot Jokers (BWB) (MPU4) (set 4)" )
+GAME_CUSTOM( 2000, m4jakjok,       0,        bwboki_chr_cheat<m4jakjok_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "jj_sj___.6_0", 0x0000, 0x040000, CRC(7bc45b0e) SHA1(f30fef8fccdac04859f1ff93198a497eff723020), "BWB",u8"Jackpot Jokers (BWB) (MPU4) (ver. 6) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot)" )
+//
+GAME_CUSTOM( 1998, m4jakjok__a,    m4jakjok, bwboki_chr_cheat<m4jakjok_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big,  "jj_sj_k_.3_0", 0x0000, 0x040000, CRC(c33dd82f) SHA1(c1f3f6ca1c45503b7f71e897e5c27368f5efb439), "BWB",u8"Jackpot Jokers (BWB) (MPU4) (ver. 3) (20/25/30p stake / £5/£15 jackpot)" ) // % key
+GAME_CUSTOM( 2000, m4jakjok__b,    m4jakjok, bwboki_chr_cheat<m4jakjok_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "jj_sjs__.6_0", 0x0000, 0x040000, CRC(4bcac6f5) SHA1(7dc07a7a61a6ba044020d6c2496143168c103a70), "BWB",u8"Jackpot Jokers (BWB) (MPU4) (ver. 6) (20/25/30p stake / £5/£15 jackpot)" ) // Datapak
+//
+GAME_CUSTOM( 2000, m4jakjok__c,    m4jakjok, bwboki_chr_cheat<m4jakjok_keys>, mpu4impcoin_jackpot5_5p,        init_m4default_big,  "jj_vc___.7_0", 0x0000, 0x040000, CRC(4cdca8da) SHA1(ee7448b12380416a3bea2713ed5feca7473be8aa), "BWB",u8"Jackpot Jokers (BWB) (MPU4) (ver. 7) (5/10p stake / £5 jackpot)" )
 
 #define M4JAKJOKA_EXTRA_ROMS \
 	ROM_REGION( 0x200000, "msm6376", 0 ) \
@@ -793,14 +899,15 @@ GAME_CUSTOM( 199?, m4jakjok__c,    m4jakjok,   "jj_vc___.7_0", 0x0000, 0x040000,
 	ROM_LOAD( "j_joker.s3", 0x0000, 0x080000, CRC(2ed74890) SHA1(a3d039b4c3c9dd792300eb045e542a212d4d50ae) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4JAKJOKA_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4jakjok_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
-GAME_CUSTOM( 199?, m4jakjoka, m4jakjok,   "j_joker", 0x0000, 0x040000, CRC(4f0c7ab8) SHA1(af962863ee55f6c2752bbe8a997e3b2102e42431), "BWB","Jackpot Jokers (alt) (BWB) (MPU4)" )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
+
+GAME_CUSTOM( 1998, m4jakjoka, m4jakjok, bwboki_chr_cheat<m4jakjok_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big,  "j_joker", 0x0000, 0x040000, CRC(4f0c7ab8) SHA1(af962863ee55f6c2752bbe8a997e3b2102e42431), "BWB",u8"Jackpot Jokers (BWB) (MPU4) (ver. 2) (20/25/30p stake / £5/£15 jackpot)" )
 
 
 /*****************************************************************************************************************************************************************************
@@ -953,7 +1060,6 @@ GAME_CUSTOM( 199?, m4madmnc__w,    m4madmnc,   "cm_49btc.4_1", 0x0000, 0x020000,
 /*****************************************************************************************************************************************************************************
 *
 * Money Mummy Money
-* - 3.2 MPU Lamp Drv error (trying extender board A doesn't help)
 *
 *****************************************************************************************************************************************************************************/
 
@@ -967,21 +1073,21 @@ static const uint32_t m4mmm_keys[2] = { 0x11, 0x320926 };
 	ROM_LOAD( "mu___snd.1_4", 0x180000, 0x080000, CRC(54b193d8) SHA1(ab24624ce69d352a14f6bd3db127fa1c8c5f07db) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4MMM_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4mmm_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_big_extenda ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4mmm,     0,      "mu_sj___.3_0", 0x0000, 0x040000, CRC(abdf9d1c) SHA1(e8c6a056025b44e4ec995b42b2720e6366a97283), "BWB","Money Mummy Money (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4mmm__a,  m4mmm,  "mu_sja__.3_0", 0x0000, 0x040000, CRC(3d2a9ea4) SHA1(f2ec904c8cef84affaad603edf26a864bd34be29), "BWB","Money Mummy Money (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4mmm__b,  m4mmm,  "mu_sjk__.3_0", 0x0000, 0x040000, CRC(34e4f8ba) SHA1(606d607faeb43190f5167aa3d10c55d9986b7e58), "BWB","Money Mummy Money (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4mmm__c,  m4mmm,  "mu_sjs__.3_0", 0x0000, 0x040000, CRC(26fb12b3) SHA1(d341181be75c87b44e4066653225911ce3460ed8), "BWB","Money Mummy Money (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4mmm__d,  m4mmm,  "mu_ssj__.2_0", 0x0000, 0x040000, CRC(935b6602) SHA1(d5fa5688895fe3c2ae3ad7dbbc35d9b12574c93d), "BWB","Money Mummy Money (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4mmm__e,  m4mmm,  "mu_ssja_.2_0", 0x0000, 0x040000, CRC(ff97814c) SHA1(8d9d74e6b0096cdc3226cfa91d7b653855600d5a), "BWB","Money Mummy Money (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4mmm__f,  m4mmm,  "mu_ssjb_.2_0", 0x0000, 0x040000, CRC(5728973a) SHA1(2cd9c866fcc33150fb8d456f741ac809e0bd2b15), "BWB","Money Mummy Money (BWB) (MPU4) (set 7)" )
+GAME_CUSTOM( 199?, m4mmm,     0,     bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_sj___.3_0", 0x0000, 0x040000, CRC(abdf9d1c) SHA1(e8c6a056025b44e4ec995b42b2720e6366a97283), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4mmm__a,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_sja__.3_0", 0x0000, 0x040000, CRC(3d2a9ea4) SHA1(f2ec904c8cef84affaad603edf26a864bd34be29), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 2)" )
+GAME_CUSTOM( 199?, m4mmm__b,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big, "mu_sjk__.3_0", 0x0000, 0x040000, CRC(34e4f8ba) SHA1(606d607faeb43190f5167aa3d10c55d9986b7e58), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 3)" ) // % key
+GAME_CUSTOM( 199?, m4mmm__c,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_sjs__.3_0", 0x0000, 0x040000, CRC(26fb12b3) SHA1(d341181be75c87b44e4066653225911ce3460ed8), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 4)" ) // Datapak
+GAME_CUSTOM( 199?, m4mmm__d,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_ssj__.2_0", 0x0000, 0x040000, CRC(935b6602) SHA1(d5fa5688895fe3c2ae3ad7dbbc35d9b12574c93d), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 5)" )
+GAME_CUSTOM( 199?, m4mmm__e,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_ssja_.2_0", 0x0000, 0x040000, CRC(ff97814c) SHA1(8d9d74e6b0096cdc3226cfa91d7b653855600d5a), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 6)" )
+GAME_CUSTOM( 199?, m4mmm__f,  m4mmm, bwboki_chr_cheat<m4mmm_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "mu_ssjb_.2_0", 0x0000, 0x040000, CRC(5728973a) SHA1(2cd9c866fcc33150fb8d456f741ac809e0bd2b15), "BWB",u8"Money Mummy Money (BWB) (MPU4) (20/25/30p stake / £10/£15 jackpot) (set 7)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
@@ -1108,7 +1214,6 @@ GAME_CUSTOM( 199?, m4quidis__d,    m4quidis,   "pq_20sk_.3_1", 0x0000, 0x010000,
 /*****************************************************************************************************************************************************************************
 *
 * Rack Em Up
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1127,13 +1232,13 @@ static const uint32_t m4rackem_keys[2] = { 0x11, 0x13222f };
 		ROM_LOAD( name, offset, length, hash ) \
 		M4RACKEM_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4rackem_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME(year, setname, parent, bwboki_chr_cheat<m4rackem_keys>, mpu4impcoin_jackpot15_20p, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4rackem,       0,          "re_sj___.2_0", 0x0000, 0x040000, CRC(e36d3f86) SHA1(a5f522c86482517b8dc735b1012f8f7668c2f18d), "BWB","Rack Em Up (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4rackem__a,    m4rackem,   "re_sj___.3_0", 0x0000, 0x040000, CRC(2f463d2f) SHA1(3410cc8a6d097a4edfcb4c57c237d1d514b507ba), "BWB","Rack Em Up (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4rackem__b,    m4rackem,   "re_sj_d_.2_0", 0x0000, 0x040000, CRC(7a31658c) SHA1(4fade421b3a1a732a99f7cb6346279ad82f55362), "BWB","Rack Em Up (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4rackem__c,    m4rackem,   "re_sjs__.2_0", 0x0000, 0x040000, CRC(d7c499c8) SHA1(73542f54322f5ffb87d16f5f66cc3a22c2849f20), "BWB","Rack Em Up (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4rackem__d,    m4rackem,   "re_sjsw_.2_0", 0x0000, 0x040000, CRC(66355370) SHA1(d54aab7403e64a67edf2baeaf1321ee5c4aa553d), "BWB","Rack Em Up (BWB) (MPU4) (set 5)" )
+GAME_CUSTOM( 1999, m4rackem,       0,          "re_sj___.3_0", 0x0000, 0x040000, CRC(2f463d2f) SHA1(3410cc8a6d097a4edfcb4c57c237d1d514b507ba), "BWB",u8"Rack Em Up (BWB) (MPU4) (ver. 3) (20/25/30p stake / £5/£15 jackpot)" )
+GAME_CUSTOM( 1999, m4rackem__a,    m4rackem,   "re_sj___.2_0", 0x0000, 0x040000, CRC(e36d3f86) SHA1(a5f522c86482517b8dc735b1012f8f7668c2f18d), "BWB",u8"Rack Em Up (BWB) (MPU4) (ver. 2) (20/25/30p stake / £5/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 1999, m4rackem__b,    m4rackem,   "re_sj_d_.2_0", 0x0000, 0x040000, CRC(7a31658c) SHA1(4fade421b3a1a732a99f7cb6346279ad82f55362), "BWB",u8"Rack Em Up (BWB) (MPU4) (ver. 2) (20/25/30p stake / £5/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 1999, m4rackem__c,    m4rackem,   "re_sjs__.2_0", 0x0000, 0x040000, CRC(d7c499c8) SHA1(73542f54322f5ffb87d16f5f66cc3a22c2849f20), "BWB",u8"Rack Em Up (BWB) (MPU4) (ver. 2) (20/25/30p stake / £5/£15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 1999, m4rackem__d,    m4rackem,   "re_sjsw_.2_0", 0x0000, 0x040000, CRC(66355370) SHA1(d54aab7403e64a67edf2baeaf1321ee5c4aa553d), "BWB",u8"Rack Em Up (BWB) (MPU4) (ver. 2) (20/25/30p stake / £5/£15 jackpot) (set 4)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
@@ -1181,7 +1286,6 @@ GAME_CUSTOM( 199?, m4rbgold__q,    m4rbgold,   "rbixe___.2s1", 0x0000, 0x010000,
 /*****************************************************************************************************************************************************************************
 *
 * Red Hot Fever
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1195,19 +1299,21 @@ static const uint32_t m4rhfev_keys[2] = { 0x11, 0x3f0e27 };
 	ROM_LOAD( "rf_____.1_4", 0x180000, 0x080000, CRC(4f7e7b49) SHA1(f9d421eeab73e0c795a08cf166c8807e0b14ec82) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4RHFEV_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4rhfev_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4rhfev,     0,          "rt_sj___.7_0", 0x0000, 0x040000, CRC(3dd895ef) SHA1(433ecc268956c94c51dbccefd006b72e0ad8567b), "BWB","Red Hot Fever (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4rhfev__a,  m4rhfev,    "rt_sja__.7_0", 0x0000, 0x040000, CRC(0ab59402) SHA1(485b4d2efd8f99085ed6ce5b7e07ede001c982c4), "BWB","Red Hot Fever (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4rhfev__b,  m4rhfev,    "rt_sjs__.7_0", 0x0000, 0x040000, CRC(1a8feafb) SHA1(83151f63b7ebe1c538f9334e9c3d6889d0730144), "BWB","Red Hot Fever (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4rhfev__c,  m4rhfev,    "rt_vc___.1_0", 0x0000, 0x040000, CRC(2a8df147) SHA1(df0e7021e9d169575a1297f9851b5a64e20d1a40), "BWB","Red Hot Fever (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4rhfev__d,  m4rhfev,    "rt_vc_d_.1_0", 0x0000, 0x040000, CRC(7adef22b) SHA1(d6a584581745c0ce64f646ef0b49cb68343990d0), "BWB","Red Hot Fever (BWB) (MPU4) (set 5)" )
+
+GAME_CUSTOM( 1999, m4rhfev,     0,       bwboki_chr_cheat<m4rhfev_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "rt_sj___.7_0", 0x0000, 0x040000, CRC(3dd895ef) SHA1(433ecc268956c94c51dbccefd006b72e0ad8567b), "BWB",u8"Red Hot Fever (BWB) (MPU4) (ver. 7) (20/25/30p stake / £5/£10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 1999, m4rhfev__a,  m4rhfev, bwboki_chr_cheat<m4rhfev_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "rt_sja__.7_0", 0x0000, 0x040000, CRC(0ab59402) SHA1(485b4d2efd8f99085ed6ce5b7e07ede001c982c4), "BWB",u8"Red Hot Fever (BWB) (MPU4) (ver. 7) (20/25/30p stake / £5/£10/£15 jackpot) (set 2)" )
+GAME_CUSTOM( 1999, m4rhfev__b,  m4rhfev, bwboki_chr_cheat<m4rhfev_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "rt_sjs__.7_0", 0x0000, 0x040000, CRC(1a8feafb) SHA1(83151f63b7ebe1c538f9334e9c3d6889d0730144), "BWB",u8"Red Hot Fever (BWB) (MPU4) (ver. 7) (20/25/30p stake / £5/£10/£15 jackpot) (set 3)" ) // Datapak
+//
+GAME_CUSTOM( 1999, m4rhfev__c,  m4rhfev, bwboki_chr_cheat<m4rhfev_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big, "rt_vc___.1_0", 0x0000, 0x040000, CRC(2a8df147) SHA1(df0e7021e9d169575a1297f9851b5a64e20d1a40), "BWB",u8"Red Hot Fever (BWB) (MPU4) (ver. 1) (5/10p stake / £5/£8 jackpot) (set 1)" )
+GAME_CUSTOM( 1999, m4rhfev__d,  m4rhfev, bwboki_chr_cheat<m4rhfev_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big, "rt_vc_d_.1_0", 0x0000, 0x040000, CRC(7adef22b) SHA1(d6a584581745c0ce64f646ef0b49cb68343990d0), "BWB",u8"Red Hot Fever (BWB) (MPU4) (ver. 1) (5/10p stake / £5/£8 jackpot) (set 2)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
@@ -1264,7 +1370,6 @@ GAME_CUSTOM( 199?, m4sinbd__x,  m4sinbd,    "sinbadbwb1_1game.bin", 0x0000, 0x02
 /*****************************************************************************************************************************************************************************
 *
 * Sky Sports
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1275,19 +1380,20 @@ static const uint32_t m4sky_keys[2] = { 0x11, 0x1f2d3b };
 	/* missing? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4SKY_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4sky_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4sky,     0,      "sk_s____.3_1", 0x0000, 0x040000, CRC(749af008) SHA1(036514f2bcb84193cfa84313f0617f3196aea73e), "BWB","Sky Sports (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4sky__a,  m4sky,  "sk_sj___.5_0", 0x0000, 0x040000, CRC(45ae0423) SHA1(94d5b3d4aacb69a18ff3f45681eb5f7fba7657e8), "BWB","Sky Sports (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4sky__b,  m4sky,  "sk_sj_k_.5_0", 0x0000, 0x040000, CRC(e1bab980) SHA1(1c8b127809422ab0baf1875ca907f18269a0cc17), "BWB","Sky Sports (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4sky__c,  m4sky,  "sk_sja__.5_0", 0x0000, 0x040000, CRC(b2a16ef7) SHA1(9012dcc320e8af8fef53e0dc91d3bcd6cbafa5ee), "BWB","Sky Sports (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4sky__d,  m4sky,  "sk_sjs__.5_0", 0x0000, 0x040000, CRC(d176431f) SHA1(8ca90ef61486fc5a5b6527f913cd05b42ceabe3e), "BWB","Sky Sports (BWB) (MPU4) (set 5)" )
+GAME_CUSTOM( 199?, m4sky,     0,     bwboki_chr_cheat<m4sky_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "sk_s____.3_1", 0x0000, 0x040000, CRC(749af008) SHA1(036514f2bcb84193cfa84313f0617f3196aea73e), "BWB",u8"Sky Sports Super Soccer (BWB) (MPU4) (20/25/30p stake / £8 token/£10/£15 jackpot)" )
+// unusual 1.8 hopper error on sets below
+GAME_CUSTOM( 199?, m4sky__a,  m4sky, bwboki_chr_cheat<m4sky_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big, "sk_sj___.5_0", 0x0000, 0x040000, CRC(45ae0423) SHA1(94d5b3d4aacb69a18ff3f45681eb5f7fba7657e8), "BWB",u8"Sky Sports Super Soccer (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 1)" ) // % key
+GAME_CUSTOM( 199?, m4sky__b,  m4sky, bwboki_chr_cheat<m4sky_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big, "sk_sj_k_.5_0", 0x0000, 0x040000, CRC(e1bab980) SHA1(1c8b127809422ab0baf1875ca907f18269a0cc17), "BWB",u8"Sky Sports Super Soccer (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 2)" ) // % key
+GAME_CUSTOM( 199?, m4sky__c,  m4sky, bwboki_chr_cheat<m4sky_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "sk_sja__.5_0", 0x0000, 0x040000, CRC(b2a16ef7) SHA1(9012dcc320e8af8fef53e0dc91d3bcd6cbafa5ee), "BWB",u8"Sky Sports Super Soccer (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 3)" ) 
+GAME_CUSTOM( 199?, m4sky__d,  m4sky, bwboki_chr_cheat<m4sky_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "sk_sjs__.5_0", 0x0000, 0x040000, CRC(d176431f) SHA1(8ca90ef61486fc5a5b6527f913cd05b42ceabe3e), "BWB",u8"Sky Sports Super Soccer (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 4)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
@@ -1326,7 +1432,7 @@ GAME_CUSTOM( 199?, m4souls__f,  m4souls,    "ss_26sk_.2_1", 0x0000, 0x020000, CR
 /*****************************************************************************************************************************************************************************
 *
 * Spin The Bottle
-* - 3.2 MPU Lamp Drv error
+* - Reel D needs different hookup
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1347,8 +1453,8 @@ static const uint32_t m4spinbt_keys[2] = { 0x45, 0x250603 };
 
 GAME_CUSTOM( 199?, m4spinbt,       0,          "sn_37ad_.5_0", 0x0000, 0x040000, CRC(42d6faaa) SHA1(3789e85981b33ffae7c50ccca3278ae62974972d), "BWB","Spin The Bottle (BWB) (MPU4) (set 1)" )
 GAME_CUSTOM( 199?, m4spinbt__a,    m4spinbt,   "sn_37b__.5_0", 0x0000, 0x040000, CRC(3a259a6f) SHA1(1acabb9e725ae1374b87808c4b3d06a329c824d0), "BWB","Spin The Bottle (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4spinbt__b,    m4spinbt,   "sn_37bd_.5_0", 0x0000, 0x040000, CRC(f4e3f395) SHA1(545b2ea1cf4231ba1663bea0e6770976b0797cf3), "BWB","Spin The Bottle (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4spinbt__c,    m4spinbt,   "sn_37bg_.5_0", 0x0000, 0x040000, CRC(c3ad8312) SHA1(9463903fe65462e5e9b09a992dc4625dba8452f0), "BWB","Spin The Bottle (BWB) (MPU4) (set 4)" )
+GAME_CUSTOM( 199?, m4spinbt__b,    m4spinbt,   "sn_37bd_.5_0", 0x0000, 0x040000, CRC(f4e3f395) SHA1(545b2ea1cf4231ba1663bea0e6770976b0797cf3), "BWB","Spin The Bottle (BWB) (MPU4) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4spinbt__c,    m4spinbt,   "sn_37bg_.5_0", 0x0000, 0x040000, CRC(c3ad8312) SHA1(9463903fe65462e5e9b09a992dc4625dba8452f0), "BWB","Spin The Bottle (BWB) (MPU4) (set 4)" ) // Datapak
 GAME_CUSTOM( 199?, m4spinbt__d,    m4spinbt,   "sn_37bt_.5_0", 0x0000, 0x040000, CRC(9fd1df18) SHA1(4c647bc887cdaa2415d0308787c710c83ce1c0d3), "BWB","Spin The Bottle (BWB) (MPU4) (set 5)" )
 GAME_CUSTOM( 199?, m4spinbt__e,    m4spinbt,   "sn_s7a__.5_0", 0x0000, 0x040000, CRC(69d39933) SHA1(ec2a9fb7c4977532a7a431745eb2d82d4e282159), "BWB","Spin The Bottle (BWB) (MPU4) (set 6)" )
 GAME_CUSTOM( 199?, m4spinbt__f,    m4spinbt,   "sn_s7ad_.5_0", 0x0000, 0x040000, CRC(a715f0c9) SHA1(bec188edcd0580465859876f8bff2ff5a392a9e1), "BWB","Spin The Bottle (BWB) (MPU4) (set 7)" )
@@ -1358,7 +1464,6 @@ GAME_CUSTOM( 199?, m4spinbt__g,    m4spinbt,   "sn_s7s__.5_0", 0x0000, 0x040000,
 /*****************************************************************************************************************************************************************************
 *
 * Stars & Stripes
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1369,31 +1474,31 @@ static const uint32_t m4starst_keys[2] = { 0x11, 0x3f0a26 };
 	ROM_LOAD( "starsnd3", 0x0000, 0x080000, CRC(96882952) SHA1(bf366670aec5cb545c56caac3c63855db03d8c14) )/* (?)strange id number? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4STARST_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4starst_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4starst,       0,          "sr_20__d.3_0", 0x0000, 0x040000, CRC(98f6619b) SHA1(fc0a568e6695c9ad0fda7bc6703c752af26a7777), "BWB","Stars & Stripes (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4starst__a,    m4starst,   "sr_20_bd.3_0", 0x0000, 0x040000, CRC(ff8209de) SHA1(41a4c20c89b3a04612ad6298276472b888915c89), "BWB","Stars & Stripes (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4starst__b,    m4starst,   "sr_20_kd.3_0", 0x0000, 0x040000, CRC(4c9a53d5) SHA1(43ebf6c06db58de9c3934e2dbba0d8126f3e2dda), "BWB","Stars & Stripes (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4starst__c,    m4starst,   "sr_20a_d.3_0", 0x0000, 0x040000, CRC(e9eebb4c) SHA1(60d8010140d9debe8f12d7f810de223d9abd02a4), "BWB","Stars & Stripes (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4starst__d,    m4starst,   "sr_20s_d.3_0", 0x0000, 0x040000, CRC(725b50e6) SHA1(3efde346022e37b09df08b8188ac76dcdfac8a4e), "BWB","Stars & Stripes (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4starst__e,    m4starst,   "sr_sj___.5_0", 0x0000, 0x040000, CRC(7964bd86) SHA1(7078de5a61b52dedb776993643f7edd8a2c863c3), "BWB","Stars & Stripes (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4starst__f,    m4starst,   "sr_sj_b_.5_0", 0x0000, 0x040000, CRC(4ee1f95b) SHA1(1e3d52afd19a9489608d5446ef2118561c6411b0), "BWB","Stars & Stripes (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4starst__g,    m4starst,   "sr_sj_d_.5_0", 0x0000, 0x040000, CRC(b4d78711) SHA1(c864c944b3fa74aa1fed22afe656a37413b024ce), "BWB","Stars & Stripes (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4starst__h,    m4starst,   "sr_sj_k_.5_0", 0x0000, 0x040000, CRC(c7681e28) SHA1(a8c1c75df33c85301257147c97d6af8808dad0d2), "BWB","Stars & Stripes (BWB) (MPU4) (set 9)" )
-GAME_CUSTOM( 199?, m4starst__i,    m4starst,   "sr_sja__.5_0", 0x0000, 0x040000, CRC(aa86c4f2) SHA1(e90fd91f1d14b89714e3fb8236ac9e8a641e4c71), "BWB","Stars & Stripes (BWB) (MPU4) (set 10)" )
-GAME_CUSTOM( 199?, m4starst__j,    m4starst,   "sr_sjs__.5_0", 0x0000, 0x040000, CRC(89e405e4) SHA1(5aa9053e08c27570731f65502c7fb31f0ea0a678), "BWB","Stars & Stripes (BWB) (MPU4) (set 11)" )
+GAME_CUSTOM( 199?, m4starst,       0,        bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot8tkn_20p,      init_m4default_big, "sr_20__d.3_0", 0x0000, 0x040000, CRC(98f6619b) SHA1(fc0a568e6695c9ad0fda7bc6703c752af26a7777), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20p stake / £8 token jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4starst__a,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot8tkn_20p,      init_m4default_big, "sr_20_bd.3_0", 0x0000, 0x040000, CRC(ff8209de) SHA1(41a4c20c89b3a04612ad6298276472b888915c89), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20p stake / £8 token jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4starst__b,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot8tkn_20p_90pc, init_m4default_big, "sr_20_kd.3_0", 0x0000, 0x040000, CRC(4c9a53d5) SHA1(43ebf6c06db58de9c3934e2dbba0d8126f3e2dda), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20p stake / £8 token jackpot) (set 3)" ) // % key
+GAME_CUSTOM( 199?, m4starst__c,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot8tkn_20p,      init_m4default_big, "sr_20a_d.3_0", 0x0000, 0x040000, CRC(e9eebb4c) SHA1(60d8010140d9debe8f12d7f810de223d9abd02a4), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20p stake / £8 token jackpot) (set 4)" )
+GAME_CUSTOM( 199?, m4starst__d,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot8tkn_20p,      init_m4default_big, "sr_20s_d.3_0", 0x0000, 0x040000, CRC(725b50e6) SHA1(3efde346022e37b09df08b8188ac76dcdfac8a4e), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20p stake / £8 token jackpot) (set 5)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4starst__e,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "sr_sj___.5_0", 0x0000, 0x040000, CRC(7964bd86) SHA1(7078de5a61b52dedb776993643f7edd8a2c863c3), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4starst__f,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "sr_sj_b_.5_0", 0x0000, 0x040000, CRC(4ee1f95b) SHA1(1e3d52afd19a9489608d5446ef2118561c6411b0), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4starst__g,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "sr_sj_d_.5_0", 0x0000, 0x040000, CRC(b4d78711) SHA1(c864c944b3fa74aa1fed22afe656a37413b024ce), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 3)" ) // Datapak
+GAME_CUSTOM( 199?, m4starst__h,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big,  "sr_sj_k_.5_0", 0x0000, 0x040000, CRC(c7681e28) SHA1(a8c1c75df33c85301257147c97d6af8808dad0d2), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 4)" ) // % key
+GAME_CUSTOM( 199?, m4starst__i,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "sr_sja__.5_0", 0x0000, 0x040000, CRC(aa86c4f2) SHA1(e90fd91f1d14b89714e3fb8236ac9e8a641e4c71), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 5)" )
+GAME_CUSTOM( 199?, m4starst__j,    m4starst, bwboki_chr_cheat<m4starst_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big,  "sr_sjs__.5_0", 0x0000, 0x040000, CRC(89e405e4) SHA1(5aa9053e08c27570731f65502c7fb31f0ea0a678), "BWB",u8"Stars & Stripes (BWB) (MPU4) (20/25/30p stake £10/£15 jackpot) (set 6)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
 *
 * Super League
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1406,19 +1511,21 @@ static const uint32_t m4supleg_keys[2] = { 0x11, 0x310926 };
 	ROM_LOAD( "sls3.hex", 0x100000, 0x080000, CRC(dcba96a1) SHA1(d474c63b37cb18a0b3b1299b5cacadfd8cd5458b) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4SUPLEG_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4supleg_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4supleg,       0,          "sl_sj.hex",    0x0000, 0x040000, CRC(254835f7) SHA1(2fafaa3da747edd27d393ad106008e898e465283), "BWB","Super League (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4supleg__a,    m4supleg,   "sl_sjs.hex",   0x0000, 0x040000, CRC(98942cd3) SHA1(858fde0a350159d089c6a0e0cc2e2eed6ab2092c), "BWB","Super League (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4supleg__b,    m4supleg,   "sl_vc.hex",    0x0000, 0x040000, CRC(1940d117) SHA1(ae7338483ac39e9e1973dde5eb837443512630dd), "BWB","Super League (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4supleg__c,    m4supleg,   "sl_vcd.hex",   0x0000, 0x040000, CRC(7aab16d1) SHA1(6da4e0d9883a48937d00bfc5929b3557de51f60e), "BWB","Super League (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4supleg__d,    m4supleg,   "sls.hex",      0x0000, 0x040000, CRC(5ad6dbb9) SHA1(ff6f9dcf14df22c7bb2b949fcd5c70f31d4c1928), "BWB","Super League (BWB) (MPU4) (set 5)" )
+GAME_CUSTOM( 199?, m4supleg,       0,        bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "sl_sj.hex",    0x0000, 0x040000, CRC(254835f7) SHA1(2fafaa3da747edd27d393ad106008e898e465283), "BWB",u8"Super League (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4supleg__a,    m4supleg, bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "sl_sjs.hex",   0x0000, 0x040000, CRC(98942cd3) SHA1(858fde0a350159d089c6a0e0cc2e2eed6ab2092c), "BWB",u8"Super League (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 2)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4supleg__b,    m4supleg, bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big, "sl_vc.hex",    0x0000, 0x040000, CRC(1940d117) SHA1(ae7338483ac39e9e1973dde5eb837443512630dd), "BWB",u8"Super League (BWB) (MPU4) (5/10p stake / £5 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4supleg__c,    m4supleg, bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big, "sl_vcd.hex",   0x0000, 0x040000, CRC(7aab16d1) SHA1(6da4e0d9883a48937d00bfc5929b3557de51f60e), "BWB",u8"Super League (BWB) (MPU4) (5/10p stake / £5 jackpot) (set 2)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4supleg__d,    m4supleg, bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "sls.hex",      0x0000, 0x040000, CRC(5ad6dbb9) SHA1(ff6f9dcf14df22c7bb2b949fcd5c70f31d4c1928), "BWB",u8"Super League (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot)" )
 
 #define M4SUPLEGW_EXTRA_ROMS \
 	ROM_REGION( 0x200000, "msm6376", 0 ) \
@@ -1427,21 +1534,21 @@ GAME_CUSTOM( 199?, m4supleg__d,    m4supleg,   "sls.hex",      0x0000, 0x040000,
 	ROM_LOAD( "sls3.hex", 0x100000, 0x080000, CRC(dcba96a1) SHA1(d474c63b37cb18a0b3b1299b5cacadfd8cd5458b) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4SUPLEGW_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4supleg_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4suplegw, m4supleg,   "s_leag._pound5", 0x0000, 0x040000, CRC(4c6bd78e) SHA1(f67793a2a16adacc8d92b57050f02cffa50a1283), "BWB","Super League (Whitbread / Bwb) (MPU4)" ) //Whitbread?
+GAME_CUSTOM( 199?, m4suplegw, m4supleg, bwboki_chr_cheat<m4supleg_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "s_leag._pound5", 0x0000, 0x040000, CRC(4c6bd78e) SHA1(f67793a2a16adacc8d92b57050f02cffa50a1283), "BWB",u8"Super League (BWB) (MPU4) (5/10/20/25/30p stake / £5 jackpot, 20/25/30p stake / £15 jackpot) (set 3)" ) // maybe a Whitbread set, but not shown in attract
 
 
 /*****************************************************************************************************************************************************************************
 *
 * Super Soccer
-* - 3.2 MPU Lamp Drv error
+* - Multi-stake game (player chooses the stake, not operator)
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1460,21 +1567,21 @@ static const uint32_t m4supscr_keys[2] = { 0x11, 0x101231 };
 	ROM_END \
 	GAME(year, setname, parent, bwboki_chr_cheat<m4supscr_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4supscr,       0,          "multistakesoccer.bin", 0x0000, 0x040000, CRC(ce27b6a7) SHA1(f9038336137b0642da4d1520b5d71a047d8fbe12), "BWB","Super Soccer (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4supscr__a,    m4supscr,   "sm_78___.6_0",         0x0000, 0x040000, CRC(e7022c44) SHA1(da3a5b9954f7e50dce73aeb9c46bd4631c8350d5), "BWB","Super Soccer (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4supscr__b,    m4supscr,   "sm_78_d_.6_0",         0x0000, 0x040000, CRC(4dbe6a87) SHA1(fe2ce1fca7105afbf459ee6558744f8fee417169), "BWB","Super Soccer (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4supscr__c,    m4supscr,   "sm_80___.6_0",         0x0000, 0x040000, CRC(7e9831ec) SHA1(d0e645ea1f6d34c507103550c248200313d033ef), "BWB","Super Soccer (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4supscr__d,    m4supscr,   "sm_80_d_.6_0",         0x0000, 0x040000, CRC(d424772f) SHA1(938eb7a35e59db704b0737d309b7989b35ed43e0), "BWB","Super Soccer (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4supscr__e,    m4supscr,   "sm_82___.6_0",         0x0000, 0x040000, CRC(019b4d42) SHA1(b27894f99dc2945fccb0de66f34eacc5b02a3463), "BWB","Super Soccer (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4supscr__f,    m4supscr,   "sm_82_d_.6_0",         0x0000, 0x040000, CRC(ab270b81) SHA1(6af522e78b9b263c96cb350cbc8585be206dcd0a), "BWB","Super Soccer (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4supscr__g,    m4supscr,   "sm_84___.6_0",         0x0000, 0x040000, CRC(809ec8b0) SHA1(965edf407a1fd7dfda2817b884ef65b3d57d51e5), "BWB","Super Soccer (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4supscr__h,    m4supscr,   "sm_84_d_.6_0",         0x0000, 0x040000, CRC(2a228e73) SHA1(04c8d17b2f2800dac9aca81e926e6e48eb02c5ac), "BWB","Super Soccer (BWB) (MPU4) (set 9)" )
-GAME_CUSTOM( 199?, m4supscr__i,    m4supscr,   "sm_86___.6_0",         0x0000, 0x040000, CRC(ff9db41e) SHA1(5996438e801534ebf5d9755b340fada67cadc942), "BWB","Super Soccer (BWB) (MPU4) (set 10)" )
-GAME_CUSTOM( 199?, m4supscr__j,    m4supscr,   "sm_86_d_.6_0",         0x0000, 0x040000, CRC(5521f2dd) SHA1(add1b70a6cddc4e176697660aeff331535d92898), "BWB","Super Soccer (BWB) (MPU4) (set 11)" )
-GAME_CUSTOM( 199?, m4supscr__k,    m4supscr,   "sm_88___.6_0",         0x0000, 0x040000, CRC(59e4c515) SHA1(5a76962dc6530d326bfe6ef6498c8f2ad481d6f1), "BWB","Super Soccer (BWB) (MPU4) (set 12)" )
-GAME_CUSTOM( 199?, m4supscr__l,    m4supscr,   "sm_88_d_.6_0",         0x0000, 0x040000, CRC(f35883d6) SHA1(1948e06e302cdb01fbd32d711374957e9e6bd64a), "BWB","Super Soccer (BWB) (MPU4) (set 13)" )
-GAME_CUSTOM( 199?, m4supscr__m,    m4supscr,   "sm_90___.6_0",         0x0000, 0x040000, CRC(cdc7c594) SHA1(acb829257472bc4420c141932b6f4c708ea04f1b), "BWB","Super Soccer (BWB) (MPU4) (set 14)" )
-GAME_CUSTOM( 199?, m4supscr__n,    m4supscr,   "sm_90_d_.6_0",         0x0000, 0x040000, CRC(677b8357) SHA1(4ec54f8b7d28c0459152309a58bd5c0db1a2f036), "BWB","Super Soccer (BWB) (MPU4) (set 15)" )
+GAME_CUSTOM( 199?, m4supscr,       0,          "sm_78___.6_0",         0x0000, 0x040000, CRC(e7022c44) SHA1(da3a5b9954f7e50dce73aeb9c46bd4631c8350d5), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 1)" )
+GAME_CUSTOM( 199?, m4supscr__a,    m4supscr,   "sm_78_d_.6_0",         0x0000, 0x040000, CRC(4dbe6a87) SHA1(fe2ce1fca7105afbf459ee6558744f8fee417169), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 2)" )
+GAME_CUSTOM( 199?, m4supscr__b,    m4supscr,   "sm_80___.6_0",         0x0000, 0x040000, CRC(7e9831ec) SHA1(d0e645ea1f6d34c507103550c248200313d033ef), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 3)" )
+GAME_CUSTOM( 199?, m4supscr__c,    m4supscr,   "sm_80_d_.6_0",         0x0000, 0x040000, CRC(d424772f) SHA1(938eb7a35e59db704b0737d309b7989b35ed43e0), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 4)" )
+GAME_CUSTOM( 199?, m4supscr__d,    m4supscr,   "sm_82___.6_0",         0x0000, 0x040000, CRC(019b4d42) SHA1(b27894f99dc2945fccb0de66f34eacc5b02a3463), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 5)" )
+GAME_CUSTOM( 199?, m4supscr__e,    m4supscr,   "sm_82_d_.6_0",         0x0000, 0x040000, CRC(ab270b81) SHA1(6af522e78b9b263c96cb350cbc8585be206dcd0a), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 6)" )
+GAME_CUSTOM( 199?, m4supscr__f,    m4supscr,   "sm_84___.6_0",         0x0000, 0x040000, CRC(809ec8b0) SHA1(965edf407a1fd7dfda2817b884ef65b3d57d51e5), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 7)" )
+GAME_CUSTOM( 199?, m4supscr__g,    m4supscr,   "sm_84_d_.6_0",         0x0000, 0x040000, CRC(2a228e73) SHA1(04c8d17b2f2800dac9aca81e926e6e48eb02c5ac), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 8)" )
+GAME_CUSTOM( 199?, m4supscr__h,    m4supscr,   "sm_86___.6_0",         0x0000, 0x040000, CRC(ff9db41e) SHA1(5996438e801534ebf5d9755b340fada67cadc942), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 9)" )
+GAME_CUSTOM( 199?, m4supscr__i,    m4supscr,   "sm_86_d_.6_0",         0x0000, 0x040000, CRC(5521f2dd) SHA1(add1b70a6cddc4e176697660aeff331535d92898), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 10)" )
+GAME_CUSTOM( 199?, m4supscr__j,    m4supscr,   "sm_88___.6_0",         0x0000, 0x040000, CRC(59e4c515) SHA1(5a76962dc6530d326bfe6ef6498c8f2ad481d6f1), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 11)" )
+GAME_CUSTOM( 199?, m4supscr__k,    m4supscr,   "sm_88_d_.6_0",         0x0000, 0x040000, CRC(f35883d6) SHA1(1948e06e302cdb01fbd32d711374957e9e6bd64a), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 12)" )
+GAME_CUSTOM( 199?, m4supscr__l,    m4supscr,   "sm_90___.6_0",         0x0000, 0x040000, CRC(cdc7c594) SHA1(acb829257472bc4420c141932b6f4c708ea04f1b), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 13)" )
+GAME_CUSTOM( 199?, m4supscr__m,    m4supscr,   "sm_90_d_.6_0",         0x0000, 0x040000, CRC(677b8357) SHA1(4ec54f8b7d28c0459152309a58bd5c0db1a2f036), "BWB","Super Soccer (ver. 6) (BWB) (MPU4) (set 14)" )
+GAME_CUSTOM( 199?, m4supscr__n,    m4supscr,   "multistakesoccer.bin", 0x0000, 0x040000, CRC(ce27b6a7) SHA1(f9038336137b0642da4d1520b5d71a047d8fbe12), "BWB","Super Soccer (ver. 3) (BWB) (MPU4)" )
 
 
 /*****************************************************************************************************************************************************************************
@@ -1582,7 +1689,6 @@ GAME_CUSTOM( 199?, m4tutbwb_j,     m4tutbwb,   "tui05___.1a3",         0x0000, 0
 /*****************************************************************************************************************************************************************************
 *
 * Volcano
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1596,28 +1702,28 @@ static const uint32_t m4volcan_keys[2] = { 0x11, 0x3f0d26 };
 	ROM_LOAD( "vo___snd.1_4", 0x180000, 0x080000, CRC(fec0fbe9) SHA1(26f651c5558a80e88666403d01cf916c3a13d948) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4VOLCAN_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4volcan_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4volcan,       0,          "vo_sj___.5_0",         0x0000, 0x040000, CRC(78096ebf) SHA1(96915bc2eca00fbd82fab8b3f62e697da118acdd), "BWB","Volcano (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4volcan__a,    m4volcan,   "vo_sj_d_.5_0",         0x0000, 0x040000, CRC(87e0347d) SHA1(be5d5b90739fa8ac10f6504290aa58fcf147f323), "BWB","Volcano (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4volcan__b,    m4volcan,   "vo_sj_k_.5_0",         0x0000, 0x040000, CRC(8604d102) SHA1(34c7df0257ba02ace4a74ffd5b0eed11eea0c333), "BWB","Volcano (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4volcan__c,    m4volcan,   "vo_sja__.5_0",         0x0000, 0x040000, CRC(d73bade2) SHA1(7e02493ec0710f109ae45e523ef3d7d275aaefab), "BWB","Volcano (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4volcan__d,    m4volcan,   "vo_sjs__.5_0",         0x0000, 0x040000, CRC(51eff796) SHA1(d0efb1eb4be176906726a438fcffb50cf5ddd217), "BWB","Volcano (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4volcan__e,    m4volcan,   "vo_vc___.2_0",         0x0000, 0x040000, CRC(24a9e5d6) SHA1(dd4223c3b5c024eb9d56bb45426e327b49f78dde), "BWB","Volcano (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4volcan__f,    m4volcan,   "vo_vc_d_.2_0",         0x0000, 0x040000, CRC(7f7341b6) SHA1(23d46ca0eed1e942b2a0d33d6ada2434ded5819b), "BWB","Volcano (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4volcan__g,    m4volcan,   "volcano_bwb_2-0.bin",  0x0000, 0x040000, CRC(20688684) SHA1(fe533341417a3a0b16f485351cb635f4e7d823db), "BWB","Volcano (BWB) (MPU4) (set 8)" )
+GAME_CUSTOM( 199?, m4volcan,       0,        bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "vo_sj___.5_0",         0x0000, 0x040000, CRC(78096ebf) SHA1(96915bc2eca00fbd82fab8b3f62e697da118acdd), "BWB",u8"Volcano (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4volcan__a,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "vo_sj_d_.5_0",         0x0000, 0x040000, CRC(87e0347d) SHA1(be5d5b90739fa8ac10f6504290aa58fcf147f323), "BWB",u8"Volcano (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4volcan__b,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot15_20p_90pc, init_m4default_big, "vo_sj_k_.5_0",         0x0000, 0x040000, CRC(8604d102) SHA1(34c7df0257ba02ace4a74ffd5b0eed11eea0c333), "BWB",u8"Volcano (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 3)" ) // % key
+GAME_CUSTOM( 199?, m4volcan__c,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "vo_sja__.5_0",         0x0000, 0x040000, CRC(d73bade2) SHA1(7e02493ec0710f109ae45e523ef3d7d275aaefab), "BWB",u8"Volcano (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 4)" )
+GAME_CUSTOM( 199?, m4volcan__d,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot15_20p,      init_m4default_big, "vo_sjs__.5_0",         0x0000, 0x040000, CRC(51eff796) SHA1(d0efb1eb4be176906726a438fcffb50cf5ddd217), "BWB",u8"Volcano (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 5)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4volcan__e,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot5_5p,        init_m4default_big, "vo_vc___.2_0",         0x0000, 0x040000, CRC(24a9e5d6) SHA1(dd4223c3b5c024eb9d56bb45426e327b49f78dde), "BWB",u8"Volcano (BWB) (MPU4) (5/10p stake / £5/£8 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4volcan__f,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot5_5p,        init_m4default_big, "vo_vc_d_.2_0",         0x0000, 0x040000, CRC(7f7341b6) SHA1(23d46ca0eed1e942b2a0d33d6ada2434ded5819b), "BWB",u8"Volcano (BWB) (MPU4) (5/10p stake / £5/£8 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4volcan__g,    m4volcan, bwboki_chr_cheat<m4volcan_keys>, mpu4impcoin_jackpot5_5p,        init_m4default_big, "volcano_bwb_2-0.bin",  0x0000, 0x040000, CRC(20688684) SHA1(fe533341417a3a0b16f485351cb635f4e7d823db), "BWB",u8"Volcano (BWB) (MPU4) (5/10p stake / £5/£8 jackpot) (set 3)" )
 
 
 /*****************************************************************************************************************************************************************************
 *
 * Voodoo Express
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1631,25 +1737,25 @@ static const uint32_t m4vdexpr_keys[2] = { 0x11, 0x3f0d27 };
 	ROM_LOAD( "vd___snd.1_4", 0x180000, 0x080000, CRC(a6753f41) SHA1(b4af3054b62c3f00f2b5a19b816507fc3a62bef4) )
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4VDEXPR_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4vdexpr_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4vdexpr,       0,          "vd_sj___.2_0", 0x0000, 0x040000, CRC(03efd2a5) SHA1(4fc3695c24335aef11ba168f660fb519d8c9d473), "BWB","Voodoo Express (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4vdexpr__a,    m4vdexpr,   "vd_sj_d_.2_0", 0x0000, 0x040000, CRC(5073b98e) SHA1(66b020b8c096e78e1c9694f1cbc139e97314ab48), "BWB","Voodoo Express (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4vdexpr__b,    m4vdexpr,   "vd_sja__.2_0", 0x0000, 0x040000, CRC(c53dbf48) SHA1(ceee2de3ea8cb511540d90b87bc67bec3309de35), "BWB","Voodoo Express (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4vdexpr__c,    m4vdexpr,   "vd_sjs__.2_0", 0x0000, 0x040000, CRC(036157b3) SHA1(b575751006c3ee59bf0404fa0e177fee9ef9c5db), "BWB","Voodoo Express (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4vdexpr__d,    m4vdexpr,   "vd_vc___.1_0", 0x0000, 0x040000, CRC(6326e14a) SHA1(3dbfbb1cfb60dc10c6972aa2fda89c8e3c3107ea), "BWB","Voodoo Express (BWB) (MPU4) (set 5)" )
+GAME_CUSTOM( 199?, m4vdexpr,       0,        bwboki_chr_cheat<m4vdexpr_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "vd_sj___.2_0", 0x0000, 0x040000, CRC(03efd2a5) SHA1(4fc3695c24335aef11ba168f660fb519d8c9d473), "BWB","Voodoo Express (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4vdexpr__a,    m4vdexpr, bwboki_chr_cheat<m4vdexpr_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "vd_sj_d_.2_0", 0x0000, 0x040000, CRC(5073b98e) SHA1(66b020b8c096e78e1c9694f1cbc139e97314ab48), "BWB","Voodoo Express (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4vdexpr__b,    m4vdexpr, bwboki_chr_cheat<m4vdexpr_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "vd_sja__.2_0", 0x0000, 0x040000, CRC(c53dbf48) SHA1(ceee2de3ea8cb511540d90b87bc67bec3309de35), "BWB","Voodoo Express (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 3)" )
+GAME_CUSTOM( 199?, m4vdexpr__c,    m4vdexpr, bwboki_chr_cheat<m4vdexpr_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "vd_sjs__.2_0", 0x0000, 0x040000, CRC(036157b3) SHA1(b575751006c3ee59bf0404fa0e177fee9ef9c5db), "BWB","Voodoo Express (BWB) (MPU4) (20/25/30p stake / £5/£10/£15 jackpot) (set 4)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4vdexpr__d,    m4vdexpr, bwboki_chr_cheat<m4vdexpr_keys>, mpu4impcoin_jackpot5_5p,   init_m4default_big, "vd_vc___.1_0", 0x0000, 0x040000, CRC(6326e14a) SHA1(3dbfbb1cfb60dc10c6972aa2fda89c8e3c3107ea), "BWB","Voodoo Express (BWB) (MPU4) (5/10p stake / £5/£8 jackpot)" )
 
 
 /*****************************************************************************************************************************************************************************
 *
 * X-change
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1657,46 +1763,41 @@ static const uint32_t m4xch_keys[2] = { 0x42, 0x3f0c26 };
 
 #define M4XCH_EXTRA_ROMS \
 	ROM_REGION( 0x200000, "msm6376", 0 ) \
-	ROM_LOAD( "xchasnd.bin", 0x0000, 0x080000, CRC(32c44cd5) SHA1(baafb48e6f95ba152942d1e1c273ffb3c95afa82) )
+	ROM_LOAD( "xchasnd.bin", 0x0000, 0x080000, CRC(32c44cd5) SHA1(baafb48e6f95ba152942d1e1c273ffb3c95afa82) ) // BADADDR     --xxxxxxxxxxxxxxxxx
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4XCH_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4xch,     0,      "ec_25b__.b_0", 0x0000, 0x020000, CRC(cec9e836) SHA1(460ec38566d7608e51b62f1ffebc18a395002ed4), "BWB","X-change (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4xch__a,  m4xch,  "ec_36bg_.bv0", 0x0000, 0x020000, CRC(c5d1523a) SHA1(813916008d7e7576e4594a6eb79a76c514470f31), "BWB","X-change (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4xch__b,  m4xch,  "ec_36bgn.bv0", 0x0000, 0x020000, CRC(4be33ee1) SHA1(888009e09c59f30649eac3238e0b70dec258cb3c), "BWB","X-change (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4xch__c,  m4xch,  "ec_39b__.b_0", 0x0000, 0x020000, CRC(e5d5961d) SHA1(ac3916cba91a13d1e0820982a1cefabd378647c9), "BWB","X-change (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4xch__d,  m4xch,  "ec_39bg_.b_0", 0x0000, 0x020000, CRC(49b2be01) SHA1(dbf808d0949a9658d23e57e7eaaa520891a4f0e0), "BWB","X-change (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4xch__e,  m4xch,  "ec_39bm_.b_0", 0x0000, 0x020000, CRC(29c86cf0) SHA1(384a475d34ad5d15b68d019c3771aba471f89b4d), "BWB","X-change (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4xch__f,  m4xch,  "ec_49bd_.b_0", 0x0000, 0x020000, CRC(02854189) SHA1(beab97ccd9889cfdb24e1fb6fb373bf9fd114eab), "BWB","X-change (BWB) (MPU4) (set 7)" )
-GAME_CUSTOM( 199?, m4xch__g,  m4xch,  "ec_49bmd.b_0", 0x0000, 0x020000, CRC(2a5578e3) SHA1(d8f100bc83721b6b0f365be7a962249af79d6162), "BWB","X-change (BWB) (MPU4) (set 8)" )
-GAME_CUSTOM( 199?, m4xch__h,  m4xch,  "ec_s9bt_.b_0", 0x0000, 0x020000, CRC(7e0a27d1) SHA1(d4a23a6c358e38a1a66a06b82af85c844f684830), "BWB","X-change (BWB) (MPU4) (set 9)" )
-GAME_CUSTOM( 199?, m4xch__i,  m4xch,  "ec_sja__.a_0", 0x0000, 0x020000, CRC(1f923f89) SHA1(84486287d55591c7e81c59a10e8cc722ec21e8f9), "BWB","X-change (BWB) (MPU4) (set 10)" )
-GAME_CUSTOM( 199?, m4xch__j,  m4xch,  "ec_sja__.b_0", 0x0000, 0x020000, CRC(16d7b8bb) SHA1(be8ab98a64aa976e25cb302b68323c6781034f2b), "BWB","X-change (BWB) (MPU4) (set 11)" )
-
-#undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
-	ROM_START( setname ) \
-		ROM_REGION( length, "maincpu", 0 ) \
-		ROM_LOAD( name, offset, length, hash ) \
-		M4XCH_EXTRA_ROMS \
-	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default ,ROT0,company,title,GAME_FLAGS )
-
-// possibly just a bad dump (half size)
-GAME_CUSTOM( 199?, m4xch__k,  m4xch,  "xchange.bin",  0x0000, 0x010000, CRC(c96cd014) SHA1(6e32d10c18b6b34dbcb21e75925a77e810ffe892), "BWB","X-change (BWB) (MPU4) (set 12)" )
+// these don't require stake/jp to be set
+GAME_CUSTOM( 199?, m4xch,     0,     bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_25b__.b_0", 0x0000, 0x020000, CRC(cec9e836) SHA1(460ec38566d7608e51b62f1ffebc18a395002ed4), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £10 jackpot)" )
+//
+GAME_CUSTOM( 199?, m4xch__a,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_36bg_.bv0", 0x0000, 0x020000, CRC(c5d1523a) SHA1(813916008d7e7576e4594a6eb79a76c514470f31), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £8 jackpot) (set 1)" ) // Datapak
+GAME_CUSTOM( 199?, m4xch__b,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_36bgn.bv0", 0x0000, 0x020000, CRC(4be33ee1) SHA1(888009e09c59f30649eac3238e0b70dec258cb3c), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £8 jackpot) (set 2)" )
+//
+GAME_CUSTOM( 199?, m4xch__c,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_39b__.b_0", 0x0000, 0x020000, CRC(e5d5961d) SHA1(ac3916cba91a13d1e0820982a1cefabd378647c9), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4xch__d,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_39bg_.b_0", 0x0000, 0x020000, CRC(49b2be01) SHA1(dbf808d0949a9658d23e57e7eaaa520891a4f0e0), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4xch__e,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_39bm_.b_0", 0x0000, 0x020000, CRC(29c86cf0) SHA1(384a475d34ad5d15b68d019c3771aba471f89b4d), "BWB",u8"X-change (BWB) (MPU4) (25p stake / £15 jackpot) (set 3)" )
+//
+GAME_CUSTOM( 199?, m4xch__f,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_49bd_.b_0", 0x0000, 0x020000, CRC(02854189) SHA1(beab97ccd9889cfdb24e1fb6fb373bf9fd114eab), "BWB",u8"X-change (BWB) (MPU4) (30p stake / £15 jackpot) (set 1)" ) // Datapak
+GAME_CUSTOM( 199?, m4xch__g,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default_big, "ec_49bmd.b_0", 0x0000, 0x020000, CRC(2a5578e3) SHA1(d8f100bc83721b6b0f365be7a962249af79d6162), "BWB",u8"X-change (BWB) (MPU4) (30p stake / £15 jackpot) (set 2)" )
+//
+GAME_CUSTOM( 199?, m4xch__h,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "ec_s9bt_.b_0", 0x0000, 0x020000, CRC(7e0a27d1) SHA1(d4a23a6c358e38a1a66a06b82af85c844f684830), "BWB",u8"X-change (BWB) (MPU4) (20/25/30p stake / £15 jackpot)" )
+//
+GAME_CUSTOM( 199?, m4xch__i,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "ec_sja__.a_0", 0x0000, 0x020000, CRC(1f923f89) SHA1(84486287d55591c7e81c59a10e8cc722ec21e8f9), "BWB",u8"X-change (BWB) (MPU4) (10/20/25/30p stake / £5/£8/£10 jackpot, 20/25/30p stake / £15 jackpot) (set 1)" ) // 10p stake not valid with £15 jackpot
+GAME_CUSTOM( 199?, m4xch__j,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big, "ec_sja__.b_0", 0x0000, 0x020000, CRC(16d7b8bb) SHA1(be8ab98a64aa976e25cb302b68323c6781034f2b), "BWB",u8"X-change (BWB) (MPU4) (10/20/25/30p stake / £5/£8/£10 jackpot, 20/25/30p stake / £15 jackpot) (set 2)" )
+// probably just a bad dump (half size) very close to the first half of ec_sja__.a_0
+GAME_CUSTOM( 199?, m4xch__k,  m4xch, bwboki_chr_cheat<m4xch_keys>, mpu4_impcoin,              init_m4default,     "xchange.bin",  0x0000, 0x010000, CRC(c96cd014) SHA1(6e32d10c18b6b34dbcb21e75925a77e810ffe892), "BWB",u8"X-change (BWB) (MPU4) (unknown set, bad?)" )
 
 
 /*****************************************************************************************************************************************************************************
 *
 * X-s
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1707,27 +1808,29 @@ static const uint32_t m4xs_keys[2] = { 0x34, 0x3f0e26 };
 	/* missing? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4XS_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4xs,       0,      "es_39b__.3_0", 0x0000, 0x020000, CRC(ba478372) SHA1(c13f9cc4261e91119aa694ec3ac81d94d9f32d22), "BWB","X-s (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4xs__a,    m4xs,   "es_39bg_.3_0", 0x0000, 0x020000, CRC(b689f14f) SHA1(0c3253e1f747a979f55d53fe637fc61cf50e01a3), "BWB","X-s (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4xs__b,    m4xs,   "es_39bm_.3_0", 0x0000, 0x020000, CRC(934f5d1e) SHA1(1ffd462d561d4a16f2392cc90a139499b74a234a), "BWB","X-s (BWB) (MPU4) (set 3)" )
-GAME_CUSTOM( 199?, m4xs__c,    m4xs,   "es_39bmd.3_0", 0x0000, 0x020000, CRC(cf663dcc) SHA1(620e65528687eb5fd6fd879e305e8b7da9b95253), "BWB","X-s (BWB) (MPU4) (set 4)" )
-GAME_CUSTOM( 199?, m4xs__d,    m4xs,   "es_49bg_.3_0", 0x0000, 0x020000, CRC(b76f1d7d) SHA1(9b43a9e847db3d4024f978b6f996534b8d52368b), "BWB","X-s (BWB) (MPU4) (set 5)" )
-GAME_CUSTOM( 199?, m4xs__e,    m4xs,   "es_49bmd.3_0", 0x0000, 0x020000, CRC(1150e499) SHA1(25d2c37e5287f73d2b11608c50f21072422850f0), "BWB","X-s (BWB) (MPU4) (set 6)" )
-GAME_CUSTOM( 199?, m4xs__f,    m4xs,   "es_sja__.3_0", 0x0000, 0x020000, CRC(5909092d) SHA1(64df6ad5ba5ac74592b525af2f4cab8a092a5766), "BWB","X-s (BWB) (MPU4) (set 7)" )
+// these sets don't require stake/jp set
+GAME_CUSTOM( 199?, m4xs,       0,    bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_39b__.3_0", 0x0000, 0x020000, CRC(ba478372) SHA1(c13f9cc4261e91119aa694ec3ac81d94d9f32d22), "BWB",u8"X-s (BWB) (MPU4) (25p stake / £15 jackpot) (set 1)" )
+GAME_CUSTOM( 199?, m4xs__a,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_39bg_.3_0", 0x0000, 0x020000, CRC(b689f14f) SHA1(0c3253e1f747a979f55d53fe637fc61cf50e01a3), "BWB",u8"X-s (BWB) (MPU4) (25p stake / £15 jackpot) (set 2)" ) // Datapak
+GAME_CUSTOM( 199?, m4xs__b,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_39bm_.3_0", 0x0000, 0x020000, CRC(934f5d1e) SHA1(1ffd462d561d4a16f2392cc90a139499b74a234a), "BWB",u8"X-s (BWB) (MPU4) (25p stake / £15 jackpot) (set 3)" )
+GAME_CUSTOM( 199?, m4xs__c,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_39bmd.3_0", 0x0000, 0x020000, CRC(cf663dcc) SHA1(620e65528687eb5fd6fd879e305e8b7da9b95253), "BWB",u8"X-s (BWB) (MPU4) (25p stake / £15 jackpot) (set 4)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4xs__d,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_49bg_.3_0", 0x0000, 0x020000, CRC(b76f1d7d) SHA1(9b43a9e847db3d4024f978b6f996534b8d52368b), "BWB",u8"X-s (BWB) (MPU4) (30p stake / £15 jackpot) (set 1)" ) // Datapak
+GAME_CUSTOM( 199?, m4xs__e,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4_impcoin,              init_m4default_big ,  "es_49bmd.3_0", 0x0000, 0x020000, CRC(1150e499) SHA1(25d2c37e5287f73d2b11608c50f21072422850f0), "BWB",u8"X-s (BWB) (MPU4) (30p stake / £15 jackpot) (set 2)" ) // Datapak
+// requires stake/jp
+GAME_CUSTOM( 199?, m4xs__f,    m4xs, bwboki_chr_cheat<m4xs_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big ,  "es_sja__.3_0", 0x0000, 0x020000, CRC(5909092d) SHA1(64df6ad5ba5ac74592b525af2f4cab8a092a5766), "BWB",u8"X-s (BWB) (MPU4) (20/25/30p stake / £15 jackpot)" )
 
 
 /*****************************************************************************************************************************************************************************
 *
 * X-treme
-* - 3.2 MPU Lamp Drv error
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1738,17 +1841,20 @@ static const uint32_t m4xtrm_keys[2] = { 0x36, 0x301210 };
 	/* missing? */
 
 #undef GAME_CUSTOM
-#define GAME_CUSTOM(year, setname,parent,name,offset,length,hash,company,title) \
+#define GAME_CUSTOM(year, setname,parent, machine, inputs, init, name,offset,length,hash,company,title) \
 	ROM_START( setname ) \
 		ROM_REGION( length, "maincpu", 0 ) \
 		ROM_LOAD( name, offset, length, hash ) \
 		M4XTRM_EXTRA_ROMS \
 	ROM_END \
-	GAME(year, setname, parent, bwboki_chr_cheat<m4xtrm_keys>, mpu4_impcoin, mpu4bwb_machines_state, init_m4default_big ,ROT0,company,title,GAME_FLAGS )
+	GAME( year, setname, parent, machine, inputs, mpu4bwb_machines_state, init, ROT0, company, title, GAME_FLAGS )
 
-GAME_CUSTOM( 199?, m4xtrm,       0,      "et_39bg_.2_0", 0x0000, 0x020000, CRC(db1a3c3c) SHA1(081c934ebfc0a9dfa195bb20f51e025e53d9c4b9), "BWB","X-treme (BWB) (MPU4) (set 1)" )
-GAME_CUSTOM( 199?, m4xtrm__a,    m4xtrm, "et_49bg_.2_0", 0x0000, 0x020000, CRC(f858d927) SHA1(e7ab84c8898a95075a41fb0249e4b103d60e7d85), "BWB","X-treme (BWB) (MPU4) (set 2)" )
-GAME_CUSTOM( 199?, m4xtrm__b,    m4xtrm, "et_sja__.2_0", 0x0000, 0x020000, CRC(8ee2602b) SHA1(b9a779b900ac71ec842dd7eb1643f7a2f1cb6a38), "BWB","X-treme (BWB) (MPU4) (set 3)" )
+// state/jp needed
+GAME_CUSTOM( 199?, m4xtrm,       0,      bwboki_chr_cheat<m4xtrm_keys>, mpu4impcoin_jackpot15_20p, init_m4default_big , "et_sja__.2_0", 0x0000, 0x020000, CRC(8ee2602b) SHA1(b9a779b900ac71ec842dd7eb1643f7a2f1cb6a38), "BWB",u8"X-treme (BWB) (MPU4) (20/25/30p stake / £8/£15 jackpot)" )
+// no stake/jp needed on sets below
+GAME_CUSTOM( 199?, m4xtrm__a,    m4xtrm, bwboki_chr_cheat<m4xtrm_keys>, mpu4_impcoin,              init_m4default_big , "et_49bg_.2_0", 0x0000, 0x020000, CRC(f858d927) SHA1(e7ab84c8898a95075a41fb0249e4b103d60e7d85), "BWB",u8"X-treme (BWB) (MPU4) (30p stake / £15 jackpot)" ) // Datapak
+//
+GAME_CUSTOM( 199?, m4xtrm__b,    m4xtrm, bwboki_chr_cheat<m4xtrm_keys>, mpu4_impcoin,              init_m4default_big , "et_39bg_.2_0", 0x0000, 0x020000, CRC(db1a3c3c) SHA1(081c934ebfc0a9dfa195bb20f51e025e53d9c4b9), "BWB",u8"X-treme (BWB) (MPU4) (25p stake / £15 jackpot)" ) // Datapak
 
 
 /*****************************************************************************************************************************************************************************
@@ -1763,6 +1869,7 @@ GAME_CUSTOM( 199?, m4xtrm__b,    m4xtrm, "et_sja__.2_0", 0x0000, 0x020000, CRC(8
 /*****************************************************************************************************************************************************************************
 *
 * Blues Boys (Nova, German version)
+*  - error 1.7
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1790,6 +1897,7 @@ GAME_CUSTOM( 199?, m4bluesn,   m4blsbys,   "bluesboys.bin", 0x0000, 0x020000, CR
 /*****************************************************************************************************************************************************************************
 *
 * Cup Final (Nova, German version)
+*  - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1815,6 +1923,7 @@ GAME_CUSTOM( 199?, m4cfinln__a,    m4cpfinl,   "cfd_d0.bin",   0x0000, 0x020000,
 /*****************************************************************************************************************************************************************************
 *
 * World Cup (Nova, German version)
+*  - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1839,6 +1948,7 @@ GAME_CUSTOM( 199?, m4wcnov,     0,  "wcdsxh__.5_0", 0x0000, 0x080000, CRC(a82d11
 /*****************************************************************************************************************************************************************************
 *
 * Excalibur (Nova, German version)
+*  - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1864,6 +1974,7 @@ GAME_CUSTOM( 199?, m4excaln__a,m4excal,    "exdsx_e_.6_0", 0x0000, 0x080000, CRC
 /*****************************************************************************************************************************************************************************
 *
 * Olympic Gold (Nova, German version)
+*  - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1889,7 +2000,7 @@ GAME_CUSTOM( 199?, m4olygn__a,  m4olygn,    "ogdsxe__.8_0", 0x0000, 0x040000, CR
 /*****************************************************************************************************************************************************************************
 *
 * Find The Lady (Nova, German version)
-* - mech error
+* - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 
@@ -1914,7 +2025,7 @@ GAME_CUSTOM( 199?, m4ftladn,   0,      "fidse___.5_0", 0x00000, 0x20000, CRC(623
 /*****************************************************************************************************************************************************************************
 *
 * Sinbad (Nova, German version)
-* - all give errors
+* - error 1.0
 *
 *****************************************************************************************************************************************************************************/
 


### PR DESCRIPTION
this identifies the settings various sets in mpu4bwb.cpp expect, and configures them better by default.

these don't boot fully without the changes from JW (and one other change) but I've tried to be careful not to stop on any toes while documenting these (I've only touched mpu4bwb.cpp, which he hasn't touched)
