### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -20,6 +20,9 @@ on:
     - 'COPYING'
     - 'makefile'
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -18,6 +18,9 @@ on:
     - 'COPYING'
     - 'makefile'
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     runs-on: macOS-latest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,6 +18,9 @@ on:
     - 'COPYING'
     - 'makefile'
 
+permissions:
+  contents: read
+
 jobs:
 
   build-windows-gcc:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
     - '.github/**'
     - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/hash.yml
+++ b/.github/workflows/hash.yml
@@ -14,6 +14,9 @@ on:
     - 'hash/*'
     - 'plugins/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/language.yml
+++ b/.github/workflows/language.yml
@@ -10,6 +10,9 @@ on:
     - '.github/**'
     - 'language/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-language:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
