### PR TITLE
Add region filters to Megadrive/Genesis when listing available roms

### DIFF
--- a/src/mame/sega/mdconsole.cpp
+++ b/src/mame/sega/mdconsole.cpp
@@ -418,7 +418,13 @@ void md_cons_slot_state::ms_megadriv(machine_config &config)
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	MD_CART_SLOT(config, m_cart, md_cart, nullptr).set_must_be_loaded(true);
-	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
+	SOFTWARE_LIST(config, "cart_list").set_original("megadriv").set_filter("NTSC-U");
+}
+
+void md_cons_slot_state::ms_megadrivj(machine_config &config)
+{
+	ms_megadriv(config);
+	subdevice<software_list_device>("cart_list")->set_filter("NTSC-J");
 }
 
 void md_cons_slot_state::ms_megadpal(machine_config &config)
@@ -428,7 +434,7 @@ void md_cons_slot_state::ms_megadpal(machine_config &config)
 	subdevice<screen_device>("megadriv")->screen_vblank().set(FUNC(md_cons_state::screen_vblank_console));
 
 	MD_CART_SLOT(config, m_cart, md_cart, nullptr).set_must_be_loaded(true);
-	SOFTWARE_LIST(config, "cart_list").set_original("megadriv");
+	SOFTWARE_LIST(config, "cart_list").set_original("megadriv").set_filter("PAL");
 }
 
 void md_cons_slot_state::ms_megadriv2(machine_config &config)
@@ -1159,7 +1165,7 @@ ROM_END
 /*    YEAR  NAME          PARENT    COMPAT  MACHINE          INPUT     CLASS          INIT          COMPANY   FULLNAME */
 CONS( 1989, genesis,      0,        0,      ms_megadriv,     md,       md_cons_slot_state, init_genesis, "Sega",   "Genesis (USA, NTSC)",  MACHINE_SUPPORTS_SAVE )
 CONS( 1990, megadriv,     genesis,  0,      ms_megadpal,     md,       md_cons_slot_state, init_md_eur,  "Sega",   "Mega Drive (Europe, PAL)", MACHINE_SUPPORTS_SAVE )
-CONS( 1988, megadrij,     genesis,  0,      ms_megadriv,     md,       md_cons_slot_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
+CONS( 1988, megadrij,     genesis,  0,      ms_megadrivj,    md,       md_cons_slot_state, init_md_jpn,  "Sega",   "Mega Drive (Japan, NTSC)", MACHINE_SUPPORTS_SAVE )
 
 // 1990+ models had the TMSS security chip, leave this as a clone, it reduces compatibility and nothing more.
 CONS( 1990, genesis_tmss, genesis,  0,      genesis_tmss,    md,       md_cons_slot_state, init_genesis, "Sega",   "Genesis (USA, NTSC, with TMSS chip)",  MACHINE_SUPPORTS_SAVE )

--- a/src/mame/sega/mdconsole.h
+++ b/src/mame/sega/mdconsole.h
@@ -75,6 +75,7 @@ public:
 
 	void ms_megadpal(machine_config &config);
 	void ms_megadriv(machine_config &config);
+	void ms_megadrivj(machine_config &config);
 	void ms_megadriv2(machine_config &config);
 
 	void genesis_tmss(machine_config &config);


### PR DESCRIPTION
TLDR summary: Do not list non working (region locked) combinations of Megadrive/Genesis console and rom.

The megadriv.xml software list has now been updated to document the region locking of the various ROMs that implement this (https://github.com/mamedev/mame/pull/9688 and https://github.com/mamedev/mame/pull/9732, released in Mame version 0.245).

The code change in this PR would prevent listing a ROM which doesn't work on the regional variant of the Mega Drive / Genesis machine chosen.

Some Mega Drive/Genesis ROMs are region protected, when the game starts they either display a message (explaining the Cartridge is designed for a different region), or they hang (e.g. some Konami games); Either way they are not playable on a machine with an invalid region.

This enhancement filters on the softwarelist to use the optional "compatibility" value set to prevent invalid combinations of Console region and ROM region. It is based on how the 32x Mega Drive based Mame machines achieve this.

If compatibility region is not set for a ROM then it defaults to being listed as available for all 3 consoles (NTSC-U, NTSC-J and PAL) as before.

This PR is a replacement for https://github.com/mamedev/mame/pull/9620 given it has gone stale, and all the changes to directory structure and file naming since that PR was initially raised.