### PR TITLE
nld_dm9314.cpp: add RS mode to netlist 9314

### DIFF
--- a/src/lib/netlist/devices/nld_dm9314.cpp
+++ b/src/lib/netlist/devices/nld_dm9314.cpp
@@ -64,7 +64,19 @@ namespace netlist::devices {
 					if (m_SQ[i]())
 					{
 						/* R-S Mode */
-						// FIXME: R-S mode is not yet implemented!
+						// RS mode is just an "extension of regular D mode"
+						// The way RS mode works is that D and S bar go high (keeps old value)
+						// S bar going low sets output high
+						// D going low and S bar high sets output low
+						// S bar going low AND D going low sets output low (D takes precedence)
+						if (!m_EQ())
+						{
+							if (!m_D[i]())  // if D low and SQ high we clear the bit
+							{
+								m_last_Q &= ~(1 << i);
+								m_Q[i].push((m_last_Q & (1<<i))>>i, delay);
+							}
+						}
 					}
 					else
 					{


### PR DESCRIPTION
In working on the gtrak10, the score will count up to 8 and won't go up to 10, I believe because the 9314 doesn't have RS mode enabled.  With this fix, the score works and the zeroes propagate upwards from QA to QB to QC to QD since the output bits are hooked up to the next stage Data in (Q0 -> D1, Q1-> D2, Q2->D3)

S Bar is high, Data goes low -> supposed to clear the bit