### PR TITLE
genie: Explicitly set LinkSupportCircularDependencies for NetBSD

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -1264,6 +1264,10 @@ configuration { "linux-*" }
 		end
 
 
+configuration { "netbsd" }
+		flags {
+			"LinkSupportCircularDependencies",
+		}
 
 configuration { "osx*" }
 		links {


### PR DESCRIPTION
Fixes #10011 following a suggestion by @cuavas.