### PR TITLE
Fix PCI device initialization

### DIFF
--- a/src/devices/machine/pci.cpp
+++ b/src/devices/machine/pci.cpp
@@ -544,6 +544,10 @@ void pci_bridge_device::device_reset()
 	primary_bus = 0x00;
 	secondary_bus = 0x00;
 	subordinate_bus = 0x00;
+}
+
+void pci_bridge_device::interface_post_reset()
+{
 	regenerate_config_mapping();
 }
 
@@ -893,9 +897,14 @@ void pci_host_device::device_reset()
 {
 	pci_bridge_device::device_reset();
 	reset_all_mappings();
-	regenerate_mapping();
 
 	config_address = 0;
+}
+
+void pci_host_device::interface_post_reset()
+{
+	pci_bridge_device::interface_post_reset();
+	regenerate_mapping();
 }
 
 void pci_host_device::regenerate_mapping()

--- a/src/devices/machine/pci.h
+++ b/src/devices/machine/pci.h
@@ -205,6 +205,7 @@ protected:
 
 	virtual void device_start() override;
 	virtual void device_reset() override;
+	virtual void interface_post_reset() override;
 	virtual space_config_vector memory_space_config() const override;
 
 	virtual device_t *bus_root();
@@ -251,6 +252,7 @@ protected:
 
 	virtual void device_start() override;
 	virtual void device_reset() override;
+	virtual void interface_post_reset() override;
 
 	virtual device_t *bus_root() override;
 


### PR DESCRIPTION
This makes sure that PCI map_extra in device initialization is executed after complete reset of device is performed 