### PR TITLE
Update ymfm library to latest version (a78b567)

### DIFF
--- a/3rdparty/ymfm/src/ymfm.h
+++ b/3rdparty/ymfm/src/ymfm.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
  #define _CRT_SECURE_NO_WARNINGS
 #endif
 

--- a/3rdparty/ymfm/src/ymfm_adpcm.cpp
+++ b/3rdparty/ymfm/src/ymfm_adpcm.cpp
@@ -459,48 +459,60 @@ void adpcm_b_channel::clock()
 	if (position < 0x10000)
 		return;
 
-	// if playing from RAM/ROM, check the end address and process
-	if (m_regs.external())
+	// if we're about to process nibble 0, fetch sample
+	if (m_curnibble == 0)
 	{
-		// wrap at the limit address
-		if (at_limit())
-			m_curaddress = 0;
-
-		// handle the sample end, either repeating or stopping
-		if (at_end())
-		{
-			// if repeating, go back to the start
-			if (m_regs.repeat())
-				load_start();
-
-			// otherwise, done; set the EOS bit and return
-			else
-			{
-				m_accumulator = 0;
-				m_prev_accum = 0;
-				m_status = (m_status & ~STATUS_PLAYING) | STATUS_EOS;
-				debug::log_keyon("%s\n", "ADPCM EOS");
-				return;
-			}
-		}
-
-		// if we're about to process nibble 0, fetch and increment
-		if (m_curnibble == 0)
-		{
-			m_curbyte = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress++);
-			m_curaddress &= 0xffffff;
-		}
+		// playing from RAM/ROM
+		if (m_regs.external())
+			m_curbyte = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress);
 	}
 
 	// extract the nibble from our current byte
 	uint8_t data = uint8_t(m_curbyte << (4 * m_curnibble)) >> 4;
 	m_curnibble ^= 1;
 
-	// if CPU-driven and we just processed the last nibble, copy the next byte and request more
-	if (m_curnibble == 0 && !m_regs.external())
+	// we just processed the last nibble
+	if (m_curnibble == 0)
 	{
-		m_curbyte = m_regs.cpudata();
-		m_status |= STATUS_BRDY;
+		// if playing from RAM/ROM, check the end/limit address or advance
+		if (m_regs.external())
+		{
+			// handle the sample end, either repeating or stopping
+			if (at_end())
+			{
+				// if repeating, go back to the start
+				if (m_regs.repeat())
+					load_start();
+
+				// otherwise, done; set the EOS bit
+				else
+				{
+					m_accumulator = 0;
+					m_prev_accum = 0;
+					m_status = (m_status & ~STATUS_PLAYING) | STATUS_EOS;
+					debug::log_keyon("%s\n", "ADPCM EOS");
+					return;
+				}
+			}
+
+			// wrap at the limit address
+			else if (at_limit())
+				m_curaddress = 0;
+
+			// otherwise, advance the current address
+			else
+			{
+				m_curaddress++;
+				m_curaddress &= 0xffffff;
+			}
+		}
+
+		// if CPU-driven, copy the next byte and request more
+		else
+		{
+			m_curbyte = m_regs.cpudata();
+			m_status |= STATUS_BRDY;
+		}
 	}
 
 	// remember previous value for interpolation
@@ -564,18 +576,27 @@ uint8_t adpcm_b_channel::read(uint32_t regnum)
 			m_dummy_read--;
 		}
 
-		// did we hit the end? if so, signal EOS
-		if (at_end())
-		{
-			m_status = STATUS_EOS | STATUS_BRDY;
-			debug::log_keyon("%s\n", "ADPCM EOS");
-		}
-
-		// otherwise, write the data and signal ready
+		// read the data
 		else
 		{
+			// read from outside of the chip
 			result = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress++);
-			m_status = STATUS_BRDY;
+
+			// did we hit the end? if so, signal EOS
+			if (at_end())
+			{
+				m_status = STATUS_EOS | STATUS_BRDY;
+				debug::log_keyon("%s\n", "ADPCM EOS");
+			}
+			else
+			{
+				// signal ready
+				m_status = STATUS_BRDY;
+			}
+
+			// wrap at the limit address
+			if (at_limit())
+				m_curaddress = 0;
 		}
 	}
 	return result;

--- a/3rdparty/ymfm/src/ymfm_adpcm.h
+++ b/3rdparty/ymfm/src/ymfm_adpcm.h
@@ -341,11 +341,11 @@ private:
 	// load the start address
 	void load_start();
 
-	// limit checker
-	bool at_limit() const { return (m_curaddress >> address_shift()) >= m_regs.limit(); }
+	// limit checker; stops at the last byte of the chunk described by address_shift()
+	bool at_limit() const { return (m_curaddress == (((m_regs.limit() + 1) << address_shift()) - 1)); }
 
-	// end checker
-	bool at_end() const { return (m_curaddress >> address_shift()) > m_regs.end(); }
+	// end checker; stops at the last byte of the chunk described by address_shift()
+	bool at_end() const { return (m_curaddress == (((m_regs.end() + 1) << address_shift()) - 1)); }
 
 	// internal state
 	uint32_t const m_address_shift; // address bits shift-left

--- a/3rdparty/ymfm/src/ymfm_fm.h
+++ b/3rdparty/ymfm/src/ymfm_fm.h
@@ -162,8 +162,8 @@ template<class RegisterType> class fm_engine_base;
 template<class RegisterType>
 class fm_operator
 {
-	// "quiet" value, used to optimize when we can skip doing working
-	static constexpr uint32_t EG_QUIET = 0x200;
+	// "quiet" value, used to optimize when we can skip doing work
+	static constexpr uint32_t EG_QUIET = 0x380;
 
 public:
 	// constructor
@@ -206,6 +206,7 @@ public:
 	// simple getters for debugging
 	envelope_state debug_eg_state() const { return m_env_state; }
 	uint16_t debug_eg_attenuation() const { return m_env_attenuation; }
+	uint8_t debug_ssg_inverted() const { return m_ssg_inverted; }
 	opdata_cache &debug_cache() { return m_cache; }
 
 private:

--- a/3rdparty/ymfm/src/ymfm_opl.cpp
+++ b/3rdparty/ymfm/src/ymfm_opl.cpp
@@ -2035,8 +2035,8 @@ void opll_base::generate(output_data *output, uint32_t numsamples)
 
 		// final output is multiplexed; we don't simulate that here except
 		// to average over everything
-		output->data[0] = (output->data[0] << 7) / 9;
-		output->data[1] = (output->data[1] << 7) / 9;
+		output->data[0] = (output->data[0] * 128) / 9;
+		output->data[1] = (output->data[1] * 128) / 9;
 	}
 }
 

--- a/3rdparty/ymfm/src/ymfm_opm.cpp
+++ b/3rdparty/ymfm/src/ymfm_opm.cpp
@@ -74,6 +74,7 @@ opm_registers::opm_registers() :
 		m_lfo_waveform[2][index] = am | (pm << 8);
 
 		// waveform 3 is noise; it is filled in dynamically
+		m_lfo_waveform[3][index] = 0;
 	}
 }
 

--- a/3rdparty/ymfm/src/ymfm_opm.h
+++ b/3rdparty/ymfm/src/ymfm_opm.h
@@ -174,7 +174,7 @@ public:
 	// system-wide registers
 	uint32_t test() const                            { return byte(0x01, 0, 8); }
 	uint32_t lfo_reset() const                       { return byte(0x01, 1, 1); }
-	uint32_t noise_frequency() const                 { return byte(0x0f, 0, 5); }
+	uint32_t noise_frequency() const                 { return byte(0x0f, 0, 5) ^ 0x1f; }
 	uint32_t noise_enable() const                    { return byte(0x0f, 7, 1); }
 	uint32_t timer_a_value() const                   { return word(0x10, 0, 8, 0x11, 0, 2); }
 	uint32_t timer_b_value() const                   { return byte(0x12, 0, 8); }

--- a/3rdparty/ymfm/src/ymfm_opn.cpp
+++ b/3rdparty/ymfm/src/ymfm_opn.cpp
@@ -146,7 +146,10 @@ bool opn_registers_base<IsOpnA>::write(uint16_t index, uint8_t data, uint32_t &c
 	// borrow unused registers 0xb8-bf/0x1b8-bf as temporary holding locations
 	if ((index & 0xf0) == 0xa0)
 	{
-		uint32_t latchindex = 0xb8 | (bitfield(index, 3) << 2) | bitfield(index, 0, 2);
+		if (bitfield(index, 0, 2) == 3)
+			return false;
+
+		uint32_t latchindex = 0xb8 | bitfield(index, 3);
 		if (IsOpnA)
 			latchindex |= index & 0x100;
 
@@ -157,9 +160,16 @@ bool opn_registers_base<IsOpnA>::write(uint16_t index, uint8_t data, uint32_t &c
 		// writes to the lower half only commit if the latch is there
 		else if (bitfield(m_regdata[latchindex], 7))
 		{
+			m_regdata[index] = data;
 			m_regdata[index | 4] = m_regdata[latchindex] & 0x3f;
 			m_regdata[latchindex] = 0;
 		}
+		return false;
+	}
+	else if ((index & 0xf8) == 0xb8)
+	{
+		// registers 0xb8-0xbf are used internally
+		return false;
 	}
 
 	// everything else is normal
@@ -1094,7 +1104,7 @@ uint8_t ym2608::read_status_hi()
 uint8_t ym2608::read_data_hi()
 {
 	uint8_t result = 0;
-	if (m_address < 0x10)
+	if ((m_address & 0xff) < 0x10)
 	{
 		// 00-0F: Read from ADPCM-B
 		result = m_adpcm_b.read(m_address & 0x0f);
@@ -2398,8 +2408,8 @@ void ym2612::generate(output_data *output, uint32_t numsamples)
 		// a better sound mixer than we usually have, so just average over the six
 		// channels; also apply a 64/65 factor to account for the discontinuity
 		// adjustment above
-		output->data[0] = (output->data[0] << 7) * 64 / (6 * 65);
-		output->data[1] = (output->data[1] << 7) * 64 / (6 * 65);
+		output->data[0] = (output->data[0] * 128) * 64 / (6 * 65);
+		output->data[1] = (output->data[1] * 128) * 64 / (6 * 65);
 	}
 }
 
@@ -2432,8 +2442,8 @@ void ym3438::generate(output_data *output, uint32_t numsamples)
 
 		// YM3438 doesn't have the same DAC discontinuity, though its output is
 		// multiplexed like the YM2612
-		output->data[0] = (output->data[0] << 7) / 6;
-		output->data[1] = (output->data[1] << 7) / 6;
+		output->data[0] = (output->data[0] * 128) / 6;
+		output->data[1] = (output->data[1] * 128) / 6;
 	}
 }
 

--- a/3rdparty/ymfm/src/ymfm_opn.h
+++ b/3rdparty/ymfm/src/ymfm_opn.h
@@ -763,7 +763,7 @@ public:
 
 protected:
 	// simulate the DAC discontinuity
-	constexpr int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 2) : (value + 3); }
+	constexpr int32_t dac_discontinuity(int32_t value) const { return (value < 0) ? (value - 3) : (value + 4); }
 
 	// internal state
 	uint16_t m_address;              // address register

--- a/3rdparty/ymfm/src/ymfm_pcm.cpp
+++ b/3rdparty/ymfm/src/ymfm_pcm.cpp
@@ -433,6 +433,9 @@ void pcm_channel::load_wavetable()
 	m_owner.write(0xb0 + m_choffs, read_pcm(wavheader + 9));
 	m_owner.write(0xc8 + m_choffs, read_pcm(wavheader + 10));
 	m_owner.write(0xe0 + m_choffs, read_pcm(wavheader + 11));
+
+	// reset the envelope so we don't continue playing mid-sample from previous key ons
+	m_env_attenuation = 0x3ff;
 }
 
 

--- a/3rdparty/ymfm/src/ymfm_pcm.h
+++ b/3rdparty/ymfm/src/ymfm_pcm.h
@@ -38,6 +38,46 @@
 namespace ymfm
 {
 
+/*
+Note to self: Sega "Multi-PCM" is almost identical to this
+
+28 channels
+
+Writes:
+00 = data reg, causes write
+01 = target slot = data - (data / 8)
+02 = address (clamped to 7)
+
+Slot data (registers with ADSR/KSR seem to be inaccessible):
+0: xxxx---- panpot
+1: xxxxxxxx wavetable low
+2: xxxxxx-- pitch low
+   -------x wavetable high
+3: xxxx---- octave
+   ----xxxx pitch hi
+4: x------- key on
+5: xxxxxxx- total level
+   -------x level direct (0=interpolate)
+6: --xxx--- LFO frequency
+   -----xxx PM sensitivity
+7: -----xxx AM sensitivity
+
+Sample data:
++00: start hi
++01: start mid
++02: start low
++03: loop hi
++04: loop low
++05: -end hi
++06: -end low
++07: vibrato (reg 6)
++08: attack/decay
++09: sustain level/rate
++0A: ksr/release
++0B: LFO amplitude (reg 7)
+
+*/
+
 //*********************************************************
 //  INTERFACE CLASSES
 //*********************************************************

--- a/3rdparty/ymfm/src/ymfm_ssg.cpp
+++ b/3rdparty/ymfm/src/ymfm_ssg.cpp
@@ -201,14 +201,14 @@ void ssg_engine::output(output_data &output)
 	for (int chan = 0; chan < 3; chan++)
 	{
 		// noise depends on the noise state, which is the LSB of m_noise_state
-		uint32_t noise_on = m_regs.ch_noise_enable(chan) & m_noise_state;
+		uint32_t noise_on = m_regs.ch_noise_enable_n(chan) | m_noise_state;
 
 		// tone depends on the current tone state
-		uint32_t tone_on = m_regs.ch_tone_enable(chan) & m_tone_state[chan];
+		uint32_t tone_on = m_regs.ch_tone_enable_n(chan) | m_tone_state[chan];
 
 		// if neither tone nor noise enabled, return 0
 		uint32_t volume;
-		if ((noise_on | tone_on) == 0)
+		if ((noise_on & tone_on) == 0)
 			volume = 0;
 
 		// if the envelope is enabled, use its amplitude

--- a/3rdparty/ymfm/src/ymfm_ssg.h
+++ b/3rdparty/ymfm/src/ymfm_ssg.h
@@ -44,9 +44,8 @@ namespace ymfm
 
 // ======================> ssg_override
 
-// this class represents a built-in overridable SSG implementation; at this
-// time it is not implemented, so you will have to add your own, or else live
-// with no SSG audio
+// this class describes a simple interface to allow the internal SSG to be
+// overridden with another implementation
 class ssg_override
 {
 public:
@@ -131,8 +130,8 @@ public:
 	uint32_t io_b_data() const                          { return m_regdata[0x0f]; }
 
 	// per-channel registers
-	uint32_t ch_noise_enable(uint32_t choffs) const     { return bitfield(~m_regdata[0x07], 3 + choffs); }
-	uint32_t ch_tone_enable(uint32_t choffs) const      { return bitfield(~m_regdata[0x07], 0 + choffs); }
+	uint32_t ch_noise_enable_n(uint32_t choffs) const     { return bitfield(m_regdata[0x07], 3 + choffs); }
+	uint32_t ch_tone_enable_n(uint32_t choffs) const      { return bitfield(m_regdata[0x07], 0 + choffs); }
 	uint32_t ch_tone_period(uint32_t choffs) const      { return m_regdata[0x00 + 2 * choffs] | (bitfield(m_regdata[0x01 + 2 * choffs], 0, 4) << 8); }
 	uint32_t ch_envelope_enable(uint32_t choffs) const  { return bitfield(m_regdata[0x08 + choffs], 4); }
 	uint32_t ch_amplitude(uint32_t choffs) const        { return bitfield(m_regdata[0x08 + choffs], 0, 4); }


### PR DESCRIPTION
Update ymfm library to latest version (a78b567): [Aaron Giles, hyano]
 - Fix incorrect operator volumes in some cases for OPL (MT8108)
 - Fix PCM playback to cut off previous notes when new waveforms are selected (see dragnblz)
 - Fix reversed OPM noise frequency
 - Fix bug preventing CSM key ons from being noticed
 - Fix bug where SSG EG envelope could be left in inverted state
 - Fix SSG envelope handling when tone and noise are off
 - Increase strength of DAC discontinuity in YM2612
 - Improve latching logic for fnums in OPN
 - Increase envelope suppression threshold so some effects don't get prematurely muted
 - Improve ADPCM-B behavior at stop/limit addresses (more thorough rewrite here coming later)