### PR TITLE
n64.xml: Converted ROM sizes to hexadecimal.

### DIFF
--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -87,8 +87,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ngep-0.u1" size="12582912" crc="7425ae2d" sha1="63627dba22be2b357c0e370e68dc5af56eeb0a24" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ngep-0.u1" size="0xc00000" crc="7425ae2d" sha1="63627dba22be2b357c0e370e68dc5af56eeb0a24" />
 			</dataarea>
 		</part>
 	</software>
@@ -107,8 +107,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ngej-0.u1" size="12582912" crc="c26fed78" sha1="451b41b63d75677bd42db89a56679208808fcfd0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ngej-0.u1" size="0xc00000" crc="c26fed78" sha1="451b41b63d75677bd42db89a56679208808fcfd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -125,8 +125,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" /> <!-- Also with [CIC-NUS-6102A] -->
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" /> <!-- also found with NUS-USA/CAN-1 -->
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ngee-0.u1" size="12582912" crc="8b70cb5b" sha1="7dd376e996d77d108316ac7ced087125c5674fa4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ngee-0.u1" size="0xc00000" crc="8b70cb5b" sha1="7dd376e996d77d108316ac7ced087125c5674fa4" />
 			</dataarea>
 		</part>
 	</software>
@@ -143,8 +143,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-n07p-0.u1" size="33554432" crc="7f030d3a" sha1="441bdf924566e6475aa49bab7a199dc06d32a6d5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-n07p-0.u1" size="0x2000000" crc="7f030d3a" sha1="441bdf924566e6475aa49bab7a199dc06d32a6d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -159,8 +159,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-N07E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-n07e-0.u1" size="33554432" crc="34f0ee5b" sha1="e93005466ac84bc1d19b40673d0c50b604a8753c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-n07e-0.u1" size="0x2000000" crc="34f0ee5b" sha1="e93005466ac84bc1d19b40673d0c50b604a8753c" />
 			</dataarea>
 		</part>
 	</software>
@@ -170,8 +170,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2000</year>
 		<publisher>Electronic Arts</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="the world is not enough ver 21.bin" size="33554432" crc="ebf883ed" sha1="5b1fd70969dce39c215aab618d9da718351ce7e5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="the world is not enough ver 21.bin" size="0x2000000" crc="ebf883ed" sha1="5b1fd70969dce39c215aab618d9da718351ce7e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -190,8 +190,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntep-0.u1" size="16777216" crc="b0256101" sha1="da7bcb78cf78333d7515b77f676fd45473b5b506" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntep-0.u1" size="0x1000000" crc="b0256101" sha1="da7bcb78cf78333d7515b77f676fd45473b5b506" />
 			</dataarea>
 		</part>
 	</software>
@@ -212,8 +212,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntea-0.u1" size="16777216" crc="d1744951" sha1="5f837c13a2fb3c8cdfd6fb720bd4a963ab515632" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntea-0.u1" size="0x1000000" crc="d1744951" sha1="5f837c13a2fb3c8cdfd6fb720bd4a963ab515632" />
 			</dataarea>
 		</part>
 	</software>
@@ -248,8 +248,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u22" value="U22 32M FLASH MEMORY [empty]" />
 			<feature name="u23" value="U23 32M FLASH MEMORY [empty]" />
 			<feature name="batt1" value="BATT1 [CR2032]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="40 winks (europe) (en,es,it) (proto).bin" size="33554432" crc="366ed851" sha1="2ea62384321e12e2b9c33196ae662a77b2125ae4" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="40 winks (europe) (en,es,it) (proto).bin" size="0x2000000" crc="366ed851" sha1="2ea62384321e12e2b9c33196ae662a77b2125ae4" />
 			</dataarea>
 		</part>
 	</software>
@@ -266,8 +266,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NTWJ-0]" /> <!-- MX23L9602-35 -->
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="64 de hakken tamagotchi - minna de tamagotchi world (japan).bin" size="12582912" crc="c6400938" sha1="538ae3f3354c3fb96926d759e81cf64b827f2782" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="64 de hakken tamagotchi - minna de tamagotchi world (japan).bin" size="0xc00000" crc="c6400938" sha1="538ae3f3354c3fb96926d759e81cf64b827f2782" />
 			</dataarea>
 		</part>
 	</software>
@@ -286,8 +286,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nhfj-0.u1" size="8388608" crc="2b43006c" sha1="17d93494401aeadad114d8db66b85e75b714473c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nhfj-0.u1" size="0x800000" crc="2b43006c" sha1="17d93494401aeadad114d8db66b85e75b714473c" />
 			</dataarea>
 		</part>
 	</software>
@@ -306,8 +306,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nosj-0.u1" size="16777216" crc="a6dbf8ae" sha1="da4c60c6054c374a251a7e5e718f199a37946423" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nosj-0.u1" size="0x1000000" crc="a6dbf8ae" sha1="da4c60c6054c374a251a7e5e718f199a37946423" />
 			</dataarea>
 		</part>
 	</software>
@@ -326,8 +326,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-no2j-0.u1" size="16777216" crc="3cd5e271" sha1="1daa89ec3f5e63e131973bab03166e4f7fb60ee9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-no2j-0.u1" size="0x1000000" crc="3cd5e271" sha1="1daa89ec3f5e63e131973bab03166e4f7fb60ee9" />
 			</dataarea>
 		</part>
 	</software>
@@ -340,8 +340,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19980807"/>
 		<info name="alt_title" value="64トランプコレクション アリスのわくわくトランプワールド"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="64 trump collection - alice no wakuwaku trump world (japan).bin" size="12582912" crc="34bbb95d" sha1="769cb7028262871611acb8cd5788d477e7f6c12f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="64 trump collection - alice no wakuwaku trump world (japan).bin" size="0xc00000" crc="34bbb95d" sha1="769cb7028262871611acb8cd5788d477e7f6c12f" />
 			</dataarea>
 		</part>
 	</software>
@@ -352,8 +352,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Video System</publisher>
 		<info name="serial" value="NUS-NSAP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="aerofighters assault (europe) (en,fr,de).bin" size="12582912" crc="e493e46c" sha1="7849993e61d690dece9c5524ce2831d7b2340f34" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="aerofighters assault (europe) (en,fr,de).bin" size="0xc00000" crc="e493e46c" sha1="7849993e61d690dece9c5524ce2831d7b2340f34" />
 			</dataarea>
 		</part>
 	</software>
@@ -368,8 +368,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NERE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nu-nere-0.u1" size="8388608" crc="b08ef0b9" sha1="de542f002e4f08cfdac19dec57f5bbaea6edeafe" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nu-nere-0.u1" size="0x800000" crc="b08ef0b9" sha1="de542f002e4f08cfdac19dec57f5bbaea6edeafe" />
 			</dataarea>
 		</part>
 	</software>
@@ -386,8 +386,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nagp-0.u1" size="8388608" crc="d8ca6c8e" sha1="1645ccf3c77d41b70ba7f3a6c7155ec819728cf0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nagp-0.u1" size="0x800000" crc="d8ca6c8e" sha1="1645ccf3c77d41b70ba7f3a6c7155ec819728cf0" />
 			</dataarea>
 		</part>
 	</software>
@@ -397,8 +397,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>1997</year>
 		<publisher>ASCII Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="aerogauge (japan) (demo) (kiosk).bin" size="8388608" crc="4ba2a495" sha1="e6bb91d367911fdc7e858a7614560ffce1758aec" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="aerogauge (japan) (demo) (kiosk).bin" size="0x800000" crc="4ba2a495" sha1="e6bb91d367911fdc7e858a7614560ffce1758aec" />
 			</dataarea>
 		</part>
 	</software>
@@ -417,8 +417,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nagj-1.u1" size="8388608" crc="1a5f6c19" sha1="dfb171caa0091bd36526641d252839c0e72b616c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nagj-1.u1" size="0x800000" crc="1a5f6c19" sha1="dfb171caa0091bd36526641d252839c0e72b616c" />
 			</dataarea>
 		</part>
 	</software>
@@ -433,8 +433,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NAGE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nage-0.u1" size="8388608" crc="04038cb8" sha1="204df59cbd065e39cadccc23a68e08ae212546d0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nage-0.u1" size="0x800000" crc="04038cb8" sha1="204df59cbd065e39cadccc23a68e08ae212546d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -447,8 +447,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="AI将棋3"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="ai shougi 3 (japan).bin" size="8388608" crc="43022243" sha1="0acf1f83ba14dbe2edbae454eea04caf2cc0030a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="ai shougi 3 (japan).bin" size="0x800000" crc="43022243" sha1="0acf1f83ba14dbe2edbae454eea04caf2cc0030a" />
 			</dataarea>
 		</part>
 	</software>
@@ -459,8 +459,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NAYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="aidyn chronicles - the first mage (europe).bin" size="33554432" crc="9dc07fc0" sha1="dd8867a3b33c897fa9e7e1742c4bc0df1207cfa8" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="aidyn chronicles - the first mage (europe).bin" size="0x2000000" crc="9dc07fc0" sha1="dd8867a3b33c897fa9e7e1742c4bc0df1207cfa8" />
 			</dataarea>
 		</part>
 	</software>
@@ -476,8 +476,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-naye-1.u1" size="33554432" crc="276178df" sha1="c4d93da5205edcad44177a26e32532d98795fa3e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-naye-1.u1" size="0x2000000" crc="276178df" sha1="c4d93da5205edcad44177a26e32532d98795fa3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -492,8 +492,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NAYE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-naye-0.u1" size="33554432" crc="8da62304" sha1="32ef42e143b74cb957a88ddb9249af13b15b45e7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-naye-0.u1" size="0x2000000" crc="8da62304" sha1="32ef42e143b74cb957a88ddb9249af13b15b45e7" />
 			</dataarea>
 		</part>
 	</software>
@@ -503,8 +503,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2000</year>
 		<publisher>T*HQ</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="2000-02-10 n_aidyn150200.bin" size="33554432" crc="c46d84a0" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="2000-02-10 n_aidyn150200.bin" size="0x2000000" crc="c46d84a0" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -514,8 +514,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2000</year>
 		<publisher>T*HQ</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="2000-05-09 aidyn0509c.bin" size="33554432" crc="abd43f3f" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="2000-05-09 aidyn0509c.bin" size="0x2000000" crc="abd43f3f" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -526,8 +526,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Human Entertainment</publisher>
 		<info name="serial" value="NUS-NABP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="air boarder 64 (europe).bin" size="8388608" crc="92659837" sha1="e0a148ae2193e533947f52ba4ab029c2cd8b34d3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="air boarder 64 (europe).bin" size="0x800000" crc="92659837" sha1="e0a148ae2193e533947f52ba4ab029c2cd8b34d3" />
 			</dataarea>
 		</part>
 	</software>
@@ -540,8 +540,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19980327"/>
 		<info name="alt_title" value="エアーボーダー64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="air boarder 64 (japan).bin" size="8388608" crc="79f2df14" sha1="0ce4d812125f7c153795bbe3835cda6c29105724" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="air boarder 64 (japan).bin" size="0x800000" crc="79f2df14" sha1="0ce4d812125f7c153795bbe3835cda6c29105724" />
 			</dataarea>
 		</part>
 	</software>
@@ -560,8 +560,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nd3j-0.u1" size="12582912" crc="ca79d5a0" sha1="78629a527b6ec02825487e3c800aa81178768039" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nd3j-0.u1" size="0xc00000" crc="ca79d5a0" sha1="78629a527b6ec02825487e3c800aa81178768039" />
 			</dataarea>
 		</part>
 	</software>
@@ -580,8 +580,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nd4j-0.u1" size="16777216" crc="420ce37b" sha1="10b15a7ceb6d56720ddd7755dac6102832407110" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nd4j-0.u1" size="0x1000000" crc="420ce37b" sha1="10b15a7ceb6d56720ddd7755dac6102832407110" />
 			</dataarea>
 		</part>
 	</software>
@@ -592,8 +592,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NTNP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="all star tennis '99 (europe) (en,fr,de,es,it).bin" size="8388608" crc="e718347d" sha1="85d2b8ded8d2a6d9bbf1cf80c9a0422fb338fd63" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="all star tennis '99 (europe) (en,fr,de,es,it).bin" size="0x800000" crc="e718347d" sha1="85d2b8ded8d2a6d9bbf1cf80c9a0422fb338fd63" />
 			</dataarea>
 		</part>
 	</software>
@@ -608,8 +608,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NTNE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntne-0.u1" size="8388608" crc="7326e6c9" sha1="2655af06374c3ca9f8a40a76f7f9fc6e1044b576" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntne-0.u1" size="0x800000" crc="7326e6c9" sha1="2655af06374c3ca9f8a40a76f7f9fc6e1044b576" />
 			</dataarea>
 		</part>
 	</software>
@@ -620,8 +620,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NBSP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="all-star baseball '99 (europe).bin" size="12582912" crc="cecd29a6" sha1="47272c40a13e42e6400c6e1221173f6bd07205bd" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="all-star baseball '99 (europe).bin" size="0xc00000" crc="cecd29a6" sha1="47272c40a13e42e6400c6e1221173f6bd07205bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -636,8 +636,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBSE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbse-0.u1" size="12582912" crc="82b7e47d" sha1="6d01a4986311a4486b4b0be029658e8df63f4ee4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbse-0.u1" size="0xc00000" crc="82b7e47d" sha1="6d01a4986311a4486b4b0be029658e8df63f4ee4" />
 			</dataarea>
 		</part>
 	</software>
@@ -648,8 +648,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NBEP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="all-star baseball 2000 (europe).bin" size="16777216" crc="15f18cae" sha1="eff8ce1b3efd9c0ada98838715c10633f0e6f4f9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="all-star baseball 2000 (europe).bin" size="0x1000000" crc="15f18cae" sha1="eff8ce1b3efd9c0ada98838715c10633f0e6f4f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -665,8 +665,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbee-0.u1" size="16777216" crc="15063eac" sha1="c0d574af5c3523a4a804182b4d6465212fd9ee29" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbee-0.u1" size="0x1000000" crc="15063eac" sha1="c0d574af5c3523a4a804182b4d6465212fd9ee29" />
 			</dataarea>
 		</part>
 	</software>
@@ -683,8 +683,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nase-0.u1" size="16777216" crc="3e8be0e0" sha1="353ad679666287988a0e645851ee01eff2048449" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nase-0.u1" size="0x1000000" crc="3e8be0e0" sha1="353ad679666287988a0e645851ee01eff2048449" />
 			</dataarea>
 		</part>
 	</software>
@@ -695,8 +695,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NARP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="armorines - project s.w.a.r.m. (europe).bin" size="16777216" crc="33332c57" sha1="38e0cafcbecddd2f2cf46f1cdbb0be6f8582402f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="armorines - project s.w.a.r.m. (europe).bin" size="0x1000000" crc="33332c57" sha1="38e0cafcbecddd2f2cf46f1cdbb0be6f8582402f" />
 			</dataarea>
 		</part>
 	</software>
@@ -707,8 +707,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NARD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="armorines - project s.w.a.r.m. (germany).bin" size="16777216" crc="43a6829d" sha1="3479266909bcbfa928f67e967bdae789c20895e1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="armorines - project s.w.a.r.m. (germany).bin" size="0x1000000" crc="43a6829d" sha1="3479266909bcbfa928f67e967bdae789c20895e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -723,8 +723,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NARE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nare-0.u1" size="16777216" crc="950985f6" sha1="a9c1319c582668b9afc7807dcd59f68d09b5317e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nare-0.u1" size="0x1000000" crc="950985f6" sha1="a9c1319c582668b9afc7807dcd59f68d09b5317e" />
 			</dataarea>
 		</part>
 	</software>
@@ -739,8 +739,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NACE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nace-0.u1" size="8388608" crc="2355e4f3" sha1="52f4722cbf3ded8e55a62471fbc5a6cf07f4fd5d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nace-0.u1" size="0x800000" crc="2355e4f3" sha1="52f4722cbf3ded8e55a62471fbc5a6cf07f4fd5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -751,8 +751,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>3DO Company</publisher>
 		<info name="serial" value="NUS-NAMP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="army men - sarge's heroes (europe) (en,fr,de).bin" size="8388608" crc="b2b54cc1" sha1="c6470921ea8b5d3565383d94e98b6ff8b39f7c14" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="army men - sarge's heroes (europe) (en,fr,de).bin" size="0x800000" crc="b2b54cc1" sha1="c6470921ea8b5d3565383d94e98b6ff8b39f7c14" />
 			</dataarea>
 		</part>
 	</software>
@@ -767,8 +767,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NAME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-name-0.u1" size="8388608" crc="97bf6db2" sha1="82f8d41d16c9161ff21776a8b2531cb11857f410" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-name-0.u1" size="0x800000" crc="97bf6db2" sha1="82f8d41d16c9161ff21776a8b2531cb11857f410" />
 			</dataarea>
 		</part>
 	</software>
@@ -783,8 +783,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-N32E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-n32e-0.u1" size="8388608" crc="3e9d1c51" sha1="ff1a799c6c0aec45efa7e0f8d107d91e1bba5eea" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-n32e-0.u1" size="0x800000" crc="3e9d1c51" sha1="ff1a799c6c0aec45efa7e0f8d107d91e1bba5eea" />
 			</dataarea>
 		</part>
 	</software>
@@ -799,8 +799,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NAHE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nahe-0.u1" size="4194304" crc="fb982b44" sha1="6e1c4af8f765dee69b5308ec5a0b20bc7fb8d862" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nahe-0.u1" size="0x400000" crc="fb982b44" sha1="6e1c4af8f765dee69b5308ec5a0b20bc7fb8d862" />
 			</dataarea>
 		</part>
 	</software>
@@ -811,8 +811,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NLCP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="automobili lamborghini (europe).bin" size="4194304" crc="210f594e" sha1="3b03236c455c2fbfe76e13f0f44efb502b30acea" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="automobili lamborghini (europe).bin" size="0x400000" crc="210f594e" sha1="3b03236c455c2fbfe76e13f0f44efb502b30acea" />
 			</dataarea>
 		</part>
 	</software>
@@ -829,8 +829,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nlce-0.u1" size="4194304" crc="17932c62" sha1="022cde34610af501687baf6b33b76f9b6841044b" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nlce-0.u1" size="0x400000" crc="17932c62" sha1="022cde34610af501687baf6b33b76f9b6841044b" />
 			</dataarea>
 		</part>
 	</software>
@@ -843,8 +843,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19970926"/>
 		<info name="alt_title" value="ばく ボンバーマン"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="baku bomberman (japan).bin" size="8388608" crc="b9faa3e4" sha1="57b5b49e61afb44a368820997706c752545c677f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="baku bomberman (japan).bin" size="0x800000" crc="b9faa3e4" sha1="57b5b49e61afb44a368820997706c752545c677f" />
 			</dataarea>
 		</part>
 	</software>
@@ -857,8 +857,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="ばく ボンバーマン2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="baku bomberman 2 (japan).bin" size="16777216" crc="850675cc" sha1="c6188f3217e28cf820040b6fb1f57db655995b38" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="baku bomberman 2 (japan).bin" size="0x1000000" crc="850675cc" sha1="c6188f3217e28cf820040b6fb1f57db655995b38" />
 			</dataarea>
 		</part>
 	</software>
@@ -877,8 +877,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbnj-0.u1" size="12582912" crc="2a8ce2e1" sha1="38c6653a0c4e45f25f33c97ccd2a7f5af0b57784" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbnj-0.u1" size="0xc00000" crc="2a8ce2e1" sha1="38c6653a0c4e45f25f33c97ccd2a7f5af0b57784" />
 			</dataarea>
 		</part>
 	</software>
@@ -891,8 +891,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19981224"/>
 		<info name="alt_title" value="爆笑人生64 めざせ!リゾート王"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bakushou jinsei 64 - mezase resort ou (japan).bin" size="12582912" crc="5fd42464" sha1="353b62279f67634030cc66f43c4b82e516a6af28" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bakushou jinsei 64 - mezase resort ou (japan).bin" size="0xc00000" crc="5fd42464" sha1="353b62279f67634030cc66f43c4b82e516a6af28" />
 			</dataarea>
 		</part>
 	</software>
@@ -911,8 +911,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbkj-0.u1" size="16777216" crc="11ad432c" sha1="9379962839a6638f8ddcfb7d917216ec40a83edb"/>
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbkj-0.u1" size="0x1000000" crc="11ad432c" sha1="9379962839a6638f8ddcfb7d917216ec40a83edb"/>
 			</dataarea>
 		</part>
 	</software>
@@ -925,8 +925,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="20001127"/>
 		<info name="alt_title" value="バンジョーとカズーイの大冒険2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="banjo to kazooie no daibouken 2 (japan).bin" size="33554432" crc="8a3d8792" sha1="a6c8d06aa6462c1479639786eda455cd60ff6aa3" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="banjo to kazooie no daibouken 2 (japan).bin" size="0x2000000" crc="8a3d8792" sha1="a6c8d06aa6462c1479639786eda455cd60ff6aa3" />
 			</dataarea>
 		</part>
 	</software>
@@ -942,8 +942,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-7103]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbkp-0.u1" size="16777216" crc="4af7c16b" sha1="908469a0b4f4b7473e85d3c981520f32cf3e3c70" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbkp-0.u1" size="0x1000000" crc="4af7c16b" sha1="908469a0b4f4b7473e85d3c981520f32cf3e3c70" />
 			</dataarea>
 		</part>
 	</software>
@@ -954,8 +954,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NBKE-USA-1"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="banjo-kazooie (usa) (rev a).bin" size="16777216" crc="90b38651" sha1="93c5cfac5cca89e54c0f1d076625e2a4570994fd" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="banjo-kazooie (usa) (rev a).bin" size="0x1000000" crc="90b38651" sha1="93c5cfac5cca89e54c0f1d076625e2a4570994fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -972,8 +972,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbke-0.u1" size="16777216" crc="4fd43199" sha1="0ca5e28494b7d99e22ed27dfc914ec5b391cdb6b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbke-0.u1" size="0x1000000" crc="4fd43199" sha1="0ca5e28494b7d99e22ed27dfc914ec5b391cdb6b" />
 			</dataarea>
 		</part>
 	</software>
@@ -984,8 +984,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NB7U-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="banjo-tooie (australia).bin" size="33554432" crc="38ec4a6e" sha1="f3c391f7d04f9cbcddac1cf03b7b6c78d844f7b0" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="banjo-tooie (australia).bin" size="0x2000000" crc="38ec4a6e" sha1="f3c391f7d04f9cbcddac1cf03b7b6c78d844f7b0" />
 			</dataarea>
 		</part>
 	</software>
@@ -996,8 +996,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NB7P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="banjo-tooie (europe) (en,fr,de,es).bin" size="33554432" crc="5ee620fb" sha1="1e2ca48f786983c487a8d0e17c496fccf5411dfe" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="banjo-tooie (europe) (en,fr,de,es).bin" size="0x2000000" crc="5ee620fb" sha1="1e2ca48f786983c487a8d0e17c496fccf5411dfe" />
 			</dataarea>
 		</part>
 	</software>
@@ -1012,8 +1012,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NB7E-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nb7e-0.u1" size="33554432" crc="0e0dc5a5" sha1="139051ab7312fd5e1314ba6baf7d424ea5987eac" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nb7e-0.u1" size="0x2000000" crc="0e0dc5a5" sha1="139051ab7312fd5e1314ba6baf7d424ea5987eac" />
 			</dataarea>
 		</part>
 	</software>
@@ -1026,8 +1026,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="20000428"/>
 		<info name="alt_title" value="バスラッシュ〜ECOGEAR PowerWorm Championship〜"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="bass rush - ecogear powerworm championship (japan).bin" size="33554432" crc="0e388fae" sha1="06d9da5dfd1e16ed56fc2bd028fa3642b4905820" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="bass rush - ecogear powerworm championship (japan).bin" size="0x2000000" crc="0e388fae" sha1="06d9da5dfd1e16ed56fc2bd028fa3642b4905820" />
 			</dataarea>
 		</part>
 	</software>
@@ -1042,8 +1042,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NB4E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nb4e-0.u1" size="12582912" crc="8b7bd07e" sha1="747b3b6c49f27e3381d91e9df59d01dbee769a58" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nb4e-0.u1" size="0xc00000" crc="8b7bd07e" sha1="747b3b6c49f27e3381d91e9df59d01dbee769a58" />
 			</dataarea>
 		</part>
 	</software>
@@ -1058,8 +1058,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NJQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-njqe-0.u1" size="4194304" crc="d64e0a7b" sha1="a67cef8a1f06ce201e0486ad2b9507314398799f" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-njqe-0.u1" size="0x400000" crc="d64e0a7b" sha1="a67cef8a1f06ce201e0486ad2b9507314398799f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1070,8 +1070,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NJQP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="batman of the future - return of the joker (europe) (en,fr,de).bin" size="4194304" crc="86aa921c" sha1="16977e84fda45bbde7882a73a9685426fd4b458c" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="batman of the future - return of the joker (europe) (en,fr,de).bin" size="0x400000" crc="86aa921c" sha1="16977e84fda45bbde7882a73a9685426fd4b458c" />
 			</dataarea>
 		</part>
 	</software>
@@ -1086,8 +1086,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBXE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbxe-0.u1" size="8388608" crc="66123c8b" sha1="1daced29439e8f2605349e9f453e90155fea46f4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbxe-0.u1" size="0x800000" crc="66123c8b" sha1="1daced29439e8f2605349e9f453e90155fea46f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -1098,8 +1098,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>3DO Company</publisher>
 		<info name="serial" value="NUS-NBQP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="battletanx - global assault (europe) (en,fr,de).bin" size="8388608" crc="ec02c5ad" sha1="ec346910b30e5c5c91cf4394633d226ea604bb57" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="battletanx - global assault (europe) (en,fr,de).bin" size="0x800000" crc="ec02c5ad" sha1="ec346910b30e5c5c91cf4394633d226ea604bb57" />
 			</dataarea>
 		</part>
 	</software>
@@ -1114,8 +1114,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbqe-0.u1" size="8388608" crc="5819d423" sha1="08a9037488c47d1e26ce6f709955639e9f0f0bb8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbqe-0.u1" size="0x800000" crc="5819d423" sha1="08a9037488c47d1e26ce6f709955639e9f0f0bb8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1130,8 +1130,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NZOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nzoe-0.u1" size="16777216" crc="18ccccfd" sha1="cdd1d1dec9763ce6b7b1a70668effcead0a185a0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nzoe-0.u1" size="0x1000000" crc="18ccccfd" sha1="cdd1d1dec9763ce6b7b1a70668effcead0a185a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1142,8 +1142,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NNSP-NOE, NUS-NNSP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="beetle adventure racing (europe) (en,fr,de).bin" size="16777216" crc="e6f43f48" sha1="b185ed71668f9bd4f6aeef5edb31e03c1a119ae0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="beetle adventure racing (europe) (en,fr,de).bin" size="0x1000000" crc="e6f43f48" sha1="b185ed71668f9bd4f6aeef5edb31e03c1a119ae0" />
 			</dataarea>
 		</part>
 	</software>
@@ -1156,8 +1156,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19991126"/>
 		<info name="alt_title" value="ビートル アドベンチャーレーシング"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="beetle adventure racing (japan).bin" size="16777216" crc="4246acd8" sha1="196b70d4fd0bd361baabaee9719a5a3aa5a7f48f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="beetle adventure racing (japan).bin" size="0x1000000" crc="4246acd8" sha1="196b70d4fd0bd361baabaee9719a5a3aa5a7f48f" />
 			</dataarea>
 		</part>
 	</software>
@@ -1172,8 +1172,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NNSE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nnse-0.u1" size="16777216" crc="e3517fd8" sha1="52171429b655825a02864a94499816187d4014dc" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nnse-0.u1" size="0x1000000" crc="e3517fd8" sha1="52171429b655825a02864a94499816187d4014dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -1188,8 +1188,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NMUE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmue-0.u1" size="12582912" crc="ff44020c" sha1="cdc88d4ffa5883d34ffc426c552df200c4c65023" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmue-0.u1" size="0xc00000" crc="ff44020c" sha1="cdc88d4ffa5883d34ffc426c552df200c4c65023" />
 			</dataarea>
 		</part>
 	</software>
@@ -1200,8 +1200,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NBFP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="bio f.r.e.a.k.s. (europe).bin" size="16777216" crc="3ec67ad8" sha1="ef5546f288b39ca628907c05f8cbaada9e895026" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="bio f.r.e.a.k.s. (europe).bin" size="0x1000000" crc="3ec67ad8" sha1="ef5546f288b39ca628907c05f8cbaada9e895026" />
 			</dataarea>
 		</part>
 	</software>
@@ -1216,8 +1216,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbfe-0.u1" size="16777216" crc="52283865" sha1="7d0a70c4437fe985aaf4faf82ca1dc011b8ed4e1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbfe-0.u1" size="0x1000000" crc="52283865" sha1="7d0a70c4437fe985aaf4faf82ca1dc011b8ed4e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1239,9 +1239,9 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-nb5j-0 02.u1" size="33554432" crc="bab2006f" sha1="866989ca17afb6def592674a5707a2c8c44cd99c" offset="0x0000000" />
-				<rom name="nus-nb5j-0 12.u2" size="33554432" crc="95922d14" sha1="843ce2a4030b47fd5325e960ffa45fc962c6455b" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-nb5j-0 02.u1" size="0x2000000" crc="bab2006f" sha1="866989ca17afb6def592674a5707a2c8c44cd99c" offset="0x0000000" />
+				<rom name="nus-nb5j-0 12.u2" size="0x2000000" crc="95922d14" sha1="843ce2a4030b47fd5325e960ffa45fc962c6455b" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -1257,8 +1257,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbcp-0.u1" size="8388608" crc="2ff810cf" sha1="9d42be8a947e64d4862d8a7c1fae57e10c2257ee" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbcp-0.u1" size="0x800000" crc="2ff810cf" sha1="9d42be8a947e64d4862d8a7c1fae57e10c2257ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -1273,8 +1273,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBCE-1]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbce-1.u1" size="8388608" crc="23d415f8" sha1="80e5365bd5ee8388e38a04b23bf3db9b5e4bf06b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbce-1.u1" size="0x800000" crc="23d415f8" sha1="80e5365bd5ee8388e38a04b23bf3db9b5e4bf06b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1288,8 +1288,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBCE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbce-0.u1" size="8388608" crc="22ca221d" sha1="a6ad7fff57b10b782cede51d4558e19ad134f019" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbce-0.u1" size="0x800000" crc="22ca221d" sha1="a6ad7fff57b10b782cede51d4558e19ad134f019" />
 			</dataarea>
 		</part>
 	</software>
@@ -1306,8 +1306,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBCJ-0]" /> <!-- MX823L6402-35 -->
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="blastdozer (japan).bin" size="8388608" crc="4605759e" sha1="68c6d95af29c647b64d5dad90c02980b772d5faf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="blastdozer (japan).bin" size="0x800000" crc="4605759e" sha1="68c6d95af29c647b64d5dad90c02980b772d5faf" />
 			</dataarea>
 		</part>
 	</software>
@@ -1318,8 +1318,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NBPP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="blues brothers 2000 (europe) (en,fr,de,es,it,nl).bin" size="16777216" crc="56507793" sha1="a3e21ec8bf3de87d257f254ab68879981eaed4a9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="blues brothers 2000 (europe) (en,fr,de,es,it,nl).bin" size="0x1000000" crc="56507793" sha1="a3e21ec8bf3de87d257f254ab68879981eaed4a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -1334,8 +1334,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBPE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbpe-0.u1" size="16777216" crc="109907b5" sha1="62655484f77091f31fb6a8142af90ae58489e0e2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbpe-0.u1" size="0x1000000" crc="109907b5" sha1="62655484f77091f31fb6a8142af90ae58489e0e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -1346,8 +1346,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Gremlin Interactive</publisher>
 		<info name="serial" value="NUS-NBHP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="body harvest (europe) (en,fr,de).bin" size="12582912" crc="2761bdae" sha1="c366cec6dfe3b724648486f0940d9a2c091c5e14" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="body harvest (europe) (en,fr,de).bin" size="0xc00000" crc="2761bdae" sha1="c366cec6dfe3b724648486f0940d9a2c091c5e14" />
 			</dataarea>
 		</part>
 	</software>
@@ -1362,8 +1362,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBHE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbhe-0.u1" size="12582912" crc="7b878c56" sha1="f61c30bc6feaac9700578a865d552ae42079b0e5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbhe-0.u1" size="0xc00000" crc="7b878c56" sha1="f61c30bc6feaac9700578a865d552ae42079b0e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -1376,8 +1376,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19990205"/>
 		<info name="alt_title" value="牧場物語2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="bokujou monogatari 2 (japan) (rev b).bin" size="16777216" crc="36a97d01" sha1="756ef426dd81bec87c33dc981bc4a13c92ab0aab" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="bokujou monogatari 2 (japan) (rev b).bin" size="0x1000000" crc="36a97d01" sha1="756ef426dd81bec87c33dc981bc4a13c92ab0aab" />
 			</dataarea>
 		</part>
 	</software>
@@ -1390,8 +1390,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19990205"/>
 		<info name="alt_title" value="牧場物語2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="bokujou monogatari 2 (japan) (rev a).bin" size="16777216" crc="bcfc0724" sha1="4e7f4001dbead7bcb2bac1f5379f2c3e065f5411" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="bokujou monogatari 2 (japan) (rev a).bin" size="0x1000000" crc="bcfc0724" sha1="4e7f4001dbead7bcb2bac1f5379f2c3e065f5411" />
 			</dataarea>
 		</part>
 	</software>
@@ -1412,8 +1412,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nywj-0.u1" size="16777216" crc="0837b349" sha1="e12e5f2fce0f27c52be2c7454b21d9b538ea2ee5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nywj-0.u1" size="0x1000000" crc="0837b349" sha1="e12e5f2fce0f27c52be2c7454b21d9b538ea2ee5" />
 			</dataarea>
 		</part>
 	</software>
@@ -1424,8 +1424,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NBMP-AUS, NUS-NBMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="bomberman 64 (europe).bin" size="8388608" crc="d3657c19" sha1="2338fb84aa8c0a4a67e98c52da2fc7059c570509" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="bomberman 64 (europe).bin" size="0x800000" crc="d3657c19" sha1="2338fb84aa8c0a4a67e98c52da2fc7059c570509" />
 			</dataarea>
 		</part>
 	</software>
@@ -1444,8 +1444,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nhaj-0.u1" size="12582912" crc="7c532342" sha1="161639fd706dd2637fed2a14ccee73138e82fb2d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nhaj-0.u1" size="0xc00000" crc="7c532342" sha1="161639fd706dd2637fed2a14ccee73138e82fb2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1461,8 +1461,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbme-0.u1" size="8388608" crc="50a98bdf" sha1="df52caea78cc786f896cb14e532088ec9ca6bea6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbme-0.u1" size="0x800000" crc="50a98bdf" sha1="df52caea78cc786f896cb14e532088ec9ca6bea6" />
 			</dataarea>
 		</part>
 	</software>
@@ -1479,8 +1479,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbve-0.u1" size="16777216" crc="302b3135" sha1="5c2c59506aa4dfd83ce80e9e5e377f64f4f18c58" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbve-0.u1" size="0x1000000" crc="302b3135" sha1="5c2c59506aa4dfd83ce80e9e5e377f64f4f18c58" />
 			</dataarea>
 		</part>
 	</software>
@@ -1491,8 +1491,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NBDP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bomberman hero (europe).bin" size="12582912" crc="28dad01b" sha1="68cefa50957d6b6f2e7126851c6a3bdec8e3ad83" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bomberman hero (europe).bin" size="0xc00000" crc="28dad01b" sha1="68cefa50957d6b6f2e7126851c6a3bdec8e3ad83" />
 			</dataarea>
 		</part>
 	</software>
@@ -1507,8 +1507,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBDE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbde-0.u1" size="12582912" crc="3e73af1a" sha1="f4377bd43de34cc61e59ca5167109d4d6123272a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbde-0.u1" size="0xc00000" crc="3e73af1a" sha1="f4377bd43de34cc61e59ca5167109d4d6123272a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1521,8 +1521,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19980430"/>
 		<info name="alt_title" value="ボンバーマンヒーローミリアン王女を救え!"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bomberman hero - mirian oujo wo sukue (japan).bin" size="12582912" crc="f3a50116" sha1="c143fca315277496e0558c93701494a225ba4a37" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bomberman hero - mirian oujo wo sukue (japan).bin" size="0xc00000" crc="f3a50116" sha1="c143fca315277496e0558c93701494a225ba4a37" />
 			</dataarea>
 		</part>
 	</software>
@@ -1537,8 +1537,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nboe-0.u1" size="16777216" crc="0f016e17" sha1="a4d2e5afc511631d1cc5d8af6c4c705f17ea8ed6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nboe-0.u1" size="0x1000000" crc="0f016e17" sha1="a4d2e5afc511631d1cc5d8af6c4c705f17ea8ed6" />
 			</dataarea>
 		</part>
 	</software>
@@ -1553,8 +1553,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NOWE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nowe-0.u1" size="8388608" crc="3ac1bbae" sha1="578bef71585b2cc956a6847c682b123599be830a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nowe-0.u1" size="0x800000" crc="3ac1bbae" sha1="578bef71585b2cc956a6847c682b123599be830a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1565,8 +1565,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NBLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="buck bumble (europe) (en,fr,de,es,it).bin" size="12582912" crc="08433e0d" sha1="60305a61143bae5557672e2bdbb9d81ec2da5c20" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="buck bumble (europe) (en,fr,de,es,it).bin" size="0xc00000" crc="08433e0d" sha1="60305a61143bae5557672e2bdbb9d81ec2da5c20" />
 			</dataarea>
 		</part>
 	</software>
@@ -1579,8 +1579,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="バックバンブル"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="buck bumble (japan).bin" size="12582912" crc="24d1a591" sha1="60afbcc6afde1f22aa8031f98f9ad84b1529f848" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="buck bumble (japan).bin" size="0xc00000" crc="24d1a591" sha1="60afbcc6afde1f22aa8031f98f9ad84b1529f848" />
 			</dataarea>
 		</part>
 	</software>
@@ -1595,8 +1595,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBLE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nble-0.u1" size="12582912" crc="da2acd5e" sha1="9cf046e320e5437159a41c49694dc66d4d8e79bd" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nble-0.u1" size="0xc00000" crc="da2acd5e" sha1="9cf046e320e5437159a41c49694dc66d4d8e79bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -1607,8 +1607,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NBYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bug's life, a (europe).bin" size="12582912" crc="0d101756" sha1="ee0175cdf971bce250e174d5bc56cdb53104058e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bug's life, a (europe).bin" size="0xc00000" crc="0d101756" sha1="ee0175cdf971bce250e174d5bc56cdb53104058e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1619,8 +1619,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NBYF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bug's life, a (france).bin" size="12582912" crc="2420c6fd" sha1="ee71dbbb82cea124ab2d8a59aa7c24ac20e5979a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bug's life, a (france).bin" size="0xc00000" crc="2420c6fd" sha1="ee71dbbb82cea124ab2d8a59aa7c24ac20e5979a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1631,8 +1631,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NBYD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bug's life, a (germany).bin" size="12582912" crc="de6ce3ef" sha1="9bdc6d273262f6d1362565215566f6166aec6a07" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bug's life, a (germany).bin" size="0xc00000" crc="de6ce3ef" sha1="9bdc6d273262f6d1362565215566f6166aec6a07" />
 			</dataarea>
 		</part>
 	</software>
@@ -1643,8 +1643,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NBYI-ITA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="bug's life, a (italy).bin" size="12582912" crc="04244aac" sha1="59564546478ae885a39b4ed77f8fb3a6e7e9bc40" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="bug's life, a (italy).bin" size="0xc00000" crc="04244aac" sha1="59564546478ae885a39b4ed77f8fb3a6e7e9bc40" />
 			</dataarea>
 		</part>
 	</software>
@@ -1661,8 +1661,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbye-0.u1" size="12582912" crc="7c2f610d" sha1="e30e1b6bdcfd985b000757a8e611a419d1f38233" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbye-0.u1" size="0xc00000" crc="7c2f610d" sha1="e30e1b6bdcfd985b000757a8e611a419d1f38233" />
 			</dataarea>
 		</part>
 	</software>
@@ -1677,8 +1677,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NB3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nb3e-0.u1" size="8388608" crc="2a95290f" sha1="3561149ddff17a60210ec5752781c512b6f4e126" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nb3e-0.u1" size="0x800000" crc="2a95290f" sha1="3561149ddff17a60210ec5752781c512b6f4e126" />
 			</dataarea>
 		</part>
 	</software>
@@ -1689,8 +1689,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NBUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="bust-a-move 2 - arcade edition (europe).bin" size="8388608" crc="14f2cbe9" sha1="275a39083567c0e4ecf334b666ee6543962fb899" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="bust-a-move 2 - arcade edition (europe).bin" size="0x800000" crc="14f2cbe9" sha1="275a39083567c0e4ecf334b666ee6543962fb899" />
 			</dataarea>
 		</part>
 	</software>
@@ -1705,8 +1705,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NBUE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbue-0.u1" size="8388608" crc="47511877" sha1="9f7dcb8ee0a918eb9b257ac9f210f0d30f9f6430" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbue-0.u1" size="0x800000" crc="47511877" sha1="9f7dcb8ee0a918eb9b257ac9f210f0d30f9f6430" />
 			</dataarea>
 		</part>
 	</software>
@@ -1717,8 +1717,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NB3P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="bust-a-move 3 dx (europe).bin" size="8388608" crc="9f3f484b" sha1="20b2704b12298987bb6151ff432d616866dc00c1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="bust-a-move 3 dx (europe).bin" size="0x800000" crc="9f3f484b" sha1="20b2704b12298987bb6151ff432d616866dc00c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -1735,8 +1735,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ncle-0.u1" size="16777216" crc="387b0c4c" sha1="afe86aed561560bfcf1bc7130c8341252142269b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ncle-0.u1" size="0x1000000" crc="387b0c4c" sha1="afe86aed561560bfcf1bc7130c8341252142269b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1746,8 +1746,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>1999?</year>
 		<publisher>Midway</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="california speed (Europe, proto).bin" size="16777216" crc="8ef396fb" sha1="b9244f898e302ca06c04caf5d595f3a70d65fce5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="california speed (Europe, proto).bin" size="0x1000000" crc="8ef396fb" sha1="b9244f898e302ca06c04caf5d595f3a70d65fce5" />
 			</dataarea>
 		</part>
 	</software>
@@ -1758,8 +1758,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NUS-NCDX-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="carmageddon 64 (europe) (en,fr,de,es).bin" size="16777216" crc="d8d87dca" sha1="b8aa32d7d78e3119b05c19cd45aad102465ad254" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="carmageddon 64 (europe) (en,fr,de,es).bin" size="0x1000000" crc="d8d87dca" sha1="b8aa32d7d78e3119b05c19cd45aad102465ad254" />
 			</dataarea>
 		</part>
 	</software>
@@ -1770,8 +1770,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NUS-NCDY-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="carmageddon 64 (europe) (en,fr,es,it).bin" size="16777216" crc="17b07602" sha1="2e64e34dc8f3b6349cb71412f1bf2ca6a2fd5c2b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="carmageddon 64 (europe) (en,fr,es,it).bin" size="0x1000000" crc="17b07602" sha1="2e64e34dc8f3b6349cb71412f1bf2ca6a2fd5c2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -1786,8 +1786,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NCDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ncde-0.u1" size="16777216" crc="e78debb6" sha1="ab3a1a52754fed3dea98e587fb9cc4cd64973403" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ncde-0.u1" size="0x1000000" crc="e78debb6" sha1="ab3a1a52754fed3dea98e587fb9cc4cd64973403" />
 			</dataarea>
 		</part>
 	</software>
@@ -1797,8 +1797,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2000</year>
 		<publisher>Vatical Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="carnival [nsye].bin" size="67108864" crc="abb60a59" sha1="e942047db783437d0c8364d0b0d61aac2b0522f8" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="carnival [nsye].bin" size="0x4000000" crc="abb60a59" sha1="e942047db783437d0c8364d0b0d61aac2b0522f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1809,8 +1809,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-ND3E-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="castlevania (europe) (en,fr,de).bin" size="12582912" crc="d1d4d306" sha1="72fec07cdb52645e48126a154c9f72e32c2b1931" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="castlevania (europe) (en,fr,de).bin" size="0xc00000" crc="d1d4d306" sha1="72fec07cdb52645e48126a154c9f72e32c2b1931" />
 			</dataarea>
 		</part>
 	</software>
@@ -1821,8 +1821,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-ND3E-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="castlevania (usa) (rev b).bin" size="12582912" crc="7f50e637" sha1="c99a25022cc019ca8d3dd6b58552049b0ee0718c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="castlevania (usa) (rev b).bin" size="0xc00000" crc="7f50e637" sha1="c99a25022cc019ca8d3dd6b58552049b0ee0718c" />
 			</dataarea>
 		</part>
 	</software>
@@ -1833,8 +1833,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-ND3E-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="castlevania (usa) (rev a).bin" size="12582912" crc="bf911b10" sha1="f542a9d2134a7066676422376a129b1970865f5d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="castlevania (usa) (rev a).bin" size="0xc00000" crc="bf911b10" sha1="f542a9d2134a7066676422376a129b1970865f5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1849,8 +1849,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-ND3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nd3e-0.u1" size="12582912" crc="84e815f3" sha1="b9e2dd5ca9e38e3beb4c4c374e7dd9377e88d943" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nd3e-0.u1" size="0xc00000" crc="84e815f3" sha1="b9e2dd5ca9e38e3beb4c4c374e7dd9377e88d943" />
 			</dataarea>
 		</part>
 	</software>
@@ -1861,8 +1861,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-ND4P-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="castlevania - legacy of darkness (europe) (en,fr,de).bin" size="16777216" crc="a12bf3de" sha1="57ef17bd7450eb1e3c486e5c628aded23e884236" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="castlevania - legacy of darkness (europe) (en,fr,de).bin" size="0x1000000" crc="a12bf3de" sha1="57ef17bd7450eb1e3c486e5c628aded23e884236" />
 			</dataarea>
 		</part>
 	</software>
@@ -1877,8 +1877,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-ND4E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nd4e-0.u1" size="16777216" crc="1f147376" sha1="ab24feae782703886ee61069b930a2713b398c6d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nd4e-0.u1" size="0x1000000" crc="1f147376" sha1="ab24feae782703886ee61069b930a2713b398c6d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1889,8 +1889,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>BigBen Interactive</publisher>
 		<info name="serial" value="NUS-NTSP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="centre court tennis (europe).bin" size="12582912" crc="2573171a" sha1="18cc04521d0c7e9eba015b45cf7f3ab9930af28e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="centre court tennis (europe).bin" size="0xc00000" crc="2573171a" sha1="18cc04521d0c7e9eba015b45cf7f3ab9930af28e" />
 			</dataarea>
 		</part>
 	</software>
@@ -1901,8 +1901,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NUS-NCTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="chameleon twist (europe).bin" size="12582912" crc="2af50883" sha1="1c936c558066da54210deef28eba58520d264011" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="chameleon twist (europe).bin" size="0xc00000" crc="2af50883" sha1="1c936c558066da54210deef28eba58520d264011" />
 			</dataarea>
 		</part>
 	</software>
@@ -1915,8 +1915,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19971212"/>
 		<info name="alt_title" value="カメレオン ツイスト"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="chameleon twist (japan).bin" size="12582912" crc="a2dcf689" sha1="e6a1d9b94e83d1784ecaf0dec6f6a9e42feaa74d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="chameleon twist (japan).bin" size="0xc00000" crc="a2dcf689" sha1="e6a1d9b94e83d1784ecaf0dec6f6a9e42feaa74d" />
 			</dataarea>
 		</part>
 	</software>
@@ -1927,8 +1927,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NUS-NCTE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="chameleon twist (usa)(v1.1).bin" size="12582912" crc="c0345565" sha1="115cd6c1c75eb1f4b4e5debfcbace61e94647579" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="chameleon twist (usa)(v1.1).bin" size="0xc00000" crc="c0345565" sha1="115cd6c1c75eb1f4b4e5debfcbace61e94647579" />
 			</dataarea>
 		</part>
 	</software>
@@ -1943,8 +1943,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NCTE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ncte-0.u1" size="12582912" crc="4246ee14" sha1="2cabb61506bf5f74437bc813429c22325045393a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ncte-0.u1" size="0xc00000" crc="4246ee14" sha1="2cabb61506bf5f74437bc813429c22325045393a" />
 			</dataarea>
 		</part>
 	</software>
@@ -1955,8 +1955,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Sunsoft</publisher>
 		<info name="serial" value="NUS-NV2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="chameleon twist 2 (europe).bin" size="8388608" crc="35958f55" sha1="6ef1f9c84e73c9307b52a52635e4fe5e23d795d8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="chameleon twist 2 (europe).bin" size="0x800000" crc="35958f55" sha1="6ef1f9c84e73c9307b52a52635e4fe5e23d795d8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1969,8 +1969,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19981225"/>
 		<info name="alt_title" value="カメレオンツイスト2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="chameleon twist 2 (japan).bin" size="12582912" crc="f42bb75f" sha1="e659cd6059fd464ba1883a5bae8b839c14ba72f4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="chameleon twist 2 (japan).bin" size="0xc00000" crc="f42bb75f" sha1="e659cd6059fd464ba1883a5bae8b839c14ba72f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -1985,8 +1985,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-N2VE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-n2ve-0.u1" size="8388608" crc="356736c7" sha1="185141b800bf109367905f1a6b0ef6823f224ce8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-n2ve-0.u1" size="0x800000" crc="356736c7" sha1="185141b800bf109367905f1a6b0ef6823f224ce8" />
 			</dataarea>
 		</part>
 	</software>
@@ -1997,8 +1997,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NCBP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="charlie blast's territory (europe).bin" size="4194304" crc="831c5a55" sha1="43b30901befbc629e50f76edc7d96b393dcc5f0b" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="charlie blast's territory (europe).bin" size="0x400000" crc="831c5a55" sha1="43b30901befbc629e50f76edc7d96b393dcc5f0b" />
 			</dataarea>
 		</part>
 	</software>
@@ -2016,8 +2016,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-ncbe-0.u1" size="4194304" crc="928a2968" sha1="ca22fa616d00d6199513a52c7851cbee5cc52354" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-ncbe-0.u1" size="0x400000" crc="928a2968" sha1="ca22fa616d00d6199513a52c7851cbee5cc52354" />
 			</dataarea>
 		</part>
 	</software>
@@ -2028,8 +2028,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NCHP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="chopper attack (europe).bin" size="8388608" crc="30ca7dbe" sha1="9d0840380c468a8458a838c0ee06c4858dcd1c9a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="chopper attack (europe).bin" size="0x800000" crc="30ca7dbe" sha1="9d0840380c468a8458a838c0ee06c4858dcd1c9a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2044,8 +2044,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NCHE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nche-0.u1" size="8388608" crc="2c22147d" sha1="ce39f1afac5efc889cbe0ae03f0ccfa9a2e5b085" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nche-0.u1" size="0x800000" crc="2c22147d" sha1="ce39f1afac5efc889cbe0ae03f0ccfa9a2e5b085" />
 			</dataarea>
 		</part>
 	</software>
@@ -2058,8 +2058,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19980717"/>
 		<info name="alt_title" value="チョロQ 64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="choro q 64 (japan).bin" size="8388608" crc="c5722b49" sha1="c399149b3166ce310028184610aaf312af9ba75a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="choro q 64 (japan).bin" size="0x800000" crc="c5722b49" sha1="c399149b3166ce310028184610aaf312af9ba75a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2072,8 +2072,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="チョロQ64 2 ハチャメチャグランプリレース"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="choro q 64 ii - hacha mecha grand prix race (japan).bin" size="12582912" crc="42ae9174" sha1="edd177a68dd0c20dd6f939cdb7a74264132dd326" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="choro q 64 ii - hacha mecha grand prix race (japan).bin" size="0xc00000" crc="42ae9174" sha1="edd177a68dd0c20dd6f939cdb7a74264132dd326" />
 			</dataarea>
 		</part>
 	</software>
@@ -2086,8 +2086,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19961220"/>
 		<info name="alt_title" value="超空間ナイター プロ野球キング"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="chou kuukan nighter pro yakyuu king (japan).bin" size="8388608" crc="c73e336c" sha1="ea7e403a37ee386f6422f4b96d4450fcd5d816f0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="chou kuukan nighter pro yakyuu king (japan).bin" size="0x800000" crc="c73e336c" sha1="ea7e403a37ee386f6422f4b96d4450fcd5d816f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2100,8 +2100,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="超空間ナイター プロ野球キング2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="chou kuukan nighter pro yakyuu king 2 (japan).bin" size="16777216" crc="c0fc82c0" sha1="391e91ddbff9b42a0f5563187dc66f4d2842f598" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="chou kuukan nighter pro yakyuu king 2 (japan).bin" size="0x1000000" crc="c0fc82c0" sha1="391e91ddbff9b42a0f5563187dc66f4d2842f598" />
 			</dataarea>
 		</part>
 	</software>
@@ -2114,8 +2114,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19990219"/>
 		<info name="alt_title" value="超スノボキッズ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="chou snobo kids (japan).bin" size="16777216" crc="ab53586b" sha1="36df553351def16bf92de8cada7350e0a287fd0d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="chou snobo kids (japan).bin" size="0x1000000" crc="ab53586b" sha1="36df553351def16bf92de8cada7350e0a287fd0d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2128,8 +2128,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<info name="release" value="19981030"/>
 		<info name="alt_title" value="シティーツアーグランプリ〜全日本GT選手権〜"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="city-tour gp - zennihon gt senshuken (japan).bin" size="16777216" crc="7a59354b" sha1="fcad11bcdd2ad20e1c49cea89f1ed4697ddebd91" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="city-tour gp - zennihon gt senshuken (japan).bin" size="0x1000000" crc="7a59354b" sha1="fcad11bcdd2ad20e1c49cea89f1ed4697ddebd91" />
 			</dataarea>
 		</part>
 	</software>
@@ -2144,8 +2144,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NC2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nc2e-0.u1" size="16777216" crc="f59fd73e" sha1="99cc2fe3c4f7e8df185feca570281364bab987c6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nc2e-0.u1" size="0x1000000" crc="f59fd73e" sha1="99cc2fe3c4f7e8df185feca570281364bab987c6" />
 			</dataarea>
 		</part>
 	</software>
@@ -2156,8 +2156,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Interplay</publisher>
 		<info name="serial" value="NUS-NCFP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="clay fighter 63 1-3 (europe).bin" size="12582912" crc="dcccb22f" sha1="1cda578cad71abccecd3643197c76a3284caac3e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="clay fighter 63 1-3 (europe).bin" size="0xc00000" crc="dcccb22f" sha1="1cda578cad71abccecd3643197c76a3284caac3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2167,8 +2167,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>1997</year>
 		<publisher>Interplay</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="clay fighter 63 1-3 (usa) (beta).bin" size="12582912" crc="23139027" sha1="9c2009462315508119b991ba22d4b23bb50d0779" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="clay fighter 63 1-3 (usa) (beta).bin" size="0xc00000" crc="23139027" sha1="9c2009462315508119b991ba22d4b23bb50d0779" />
 			</dataarea>
 		</part>
 	</software>
@@ -2183,8 +2183,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u1" value="U1 [NUS-NCFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ncfe-0.u1" size="12582912" crc="e7c70f25" sha1="475e41f3e2ac43892657146170fd223d5d6557a9" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ncfe-0.u1" size="0xc00000" crc="e7c70f25" sha1="475e41f3e2ac43892657146170fd223d5d6557a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2201,8 +2201,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nccp-0.u1" size="33554432" crc="ce383b3e" sha1="5ea73072575eded3954abe4a9d44623b7847c820" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nccp-0.u1" size="0x2000000" crc="ce383b3e" sha1="5ea73072575eded3954abe4a9d44623b7847c820" />
 			</dataarea>
 		</part>
 	</software>
@@ -2213,8 +2213,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NCCD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="command &amp; conquer (germany).bin" size="33554432" crc="b312e838" sha1="662d03f3df3e1817330db94ce330f7915bd9a00c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="command &amp; conquer (germany).bin" size="0x2000000" crc="b312e838" sha1="662d03f3df3e1817330db94ce330f7915bd9a00c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2231,8 +2231,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ncce-0.u1" size="33554432" crc="8d23ba95" sha1="63bafa4615eb7488aec3c631021720e05376aa1c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ncce-0.u1" size="0x2000000" crc="8d23ba95" sha1="63bafa4615eb7488aec3c631021720e05376aa1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2243,8 +2243,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NFUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="conker's bad fur day (europe).bin" size="67108864" crc="96dba949" sha1="175a058e739762d49aff01b4eac8784db415c711" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="conker's bad fur day (europe).bin" size="0x4000000" crc="96dba949" sha1="175a058e739762d49aff01b4eac8784db415c711" />
 			</dataarea>
 		</part>
 	</software>
@@ -2261,9 +2261,9 @@ Info on N64 chip labels (from The Cart Scan Repository)
 			<feature name="u3" value="U3 [BU9850]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-nfue-0 02.u1" size="33554432" crc="8a6fc9ef" sha1="eb287d733de04ed895bf02578be4c7cfc54b2c72" offset="0x0000000" />
-				<rom name="nus-nfue-0 12.u2" size="33554432" crc="48f2e400" sha1="7abf8d669359b5f480982dc3e38d0635dc51cd45" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-nfue-0 02.u1" size="0x2000000" crc="8a6fc9ef" sha1="eb287d733de04ed895bf02578be4c7cfc54b2c72" offset="0x0000000" />
+				<rom name="nus-nfue-0 12.u2" size="0x2000000" crc="48f2e400" sha1="7abf8d669359b5f480982dc3e38d0635dc51cd45" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -2273,8 +2273,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2001?</year>
 		<publisher>Rare</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="conkers bfd debug_ec.bin" size="67108864" crc="8443ff39" sha1="8b0952b9d13d2f082badfb587a97f2762600cd14" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="conkers bfd debug_ec.bin" size="0x4000000" crc="8443ff39" sha1="8b0952b9d13d2f082badfb587a97f2762600cd14" />
 			</dataarea>
 		</part>
 	</software>
@@ -2284,8 +2284,8 @@ Info on N64 chip labels (from The Cart Scan Repository)
 		<year>2001?</year>
 		<publisher>Rare</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="conkers bfd ects demo_ec.bin" size="67108864" crc="99b3c27a" sha1="3bf1f052ce728ad77971efd4882ec8e18b7bf9a3" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="conkers bfd ects demo_ec.bin" size="0x4000000" crc="99b3c27a" sha1="3bf1f052ce728ad77971efd4882ec8e18b7bf9a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -2306,8 +2306,8 @@ patched out (+ a fix for internal checksum)
 		<year>2001?</year>
 		<publisher>Rare</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="bfd_ntsc_debug_dc.bin" size="67108864" crc="c9822f5c" sha1="6956bd77351a91cdd22af454a8d410a3b9c829f0" status="baddump" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="bfd_ntsc_debug_dc.bin" size="0x4000000" crc="c9822f5c" sha1="6956bd77351a91cdd22af454a8d410a3b9c829f0" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -2317,8 +2317,8 @@ patched out (+ a fix for internal checksum)
 		<year>2001?</year>
 		<publisher>Rare</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="conker_bfd_ects_dc.bin" size="67108864" crc="af9c5972" sha1="92575eed941324b9cd7d29df61e720b04d8b26cb" status="baddump" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="conker_bfd_ects_dc.bin" size="0x4000000" crc="af9c5972" sha1="92575eed941324b9cd7d29df61e720b04d8b26cb" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -2333,8 +2333,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NXOE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nxoe-0.u1" size="16777216" crc="20e7dbd7" sha1="130fed584a6eb820b69e90e8ac8ec9301d69c3c5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nxoe-0.u1" size="0x1000000" crc="20e7dbd7" sha1="130fed584a6eb820b69e90e8ac8ec9301d69c3c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2345,8 +2345,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NCUP-AUS, NUS-NCUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="cruis'n usa (europe).bin" size="8388608" crc="6767eca4" sha1="6cc846aedcc31597842645bbb6030272cd9a82f0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="cruis'n usa (europe).bin" size="0x800000" crc="6767eca4" sha1="6cc846aedcc31597842645bbb6030272cd9a82f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -2361,8 +2361,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NCUE-2]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ncue-2.u1" size="8388608" crc="e466c124" sha1="4e0af2979c573aaab84a60f42266ec0c3fa60b84" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ncue-2.u1" size="0x800000" crc="e466c124" sha1="4e0af2979c573aaab84a60f42266ec0c3fa60b84" />
 			</dataarea>
 		</part>
 	</software>
@@ -2379,8 +2379,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ncue-1.u1" size="8388608" crc="615ac9bc" sha1="da43a6443c22a608b76b6b73602c30b0c6038379" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ncue-1.u1" size="0x800000" crc="615ac9bc" sha1="da43a6443c22a608b76b6b73602c30b0c6038379" />
 			</dataarea>
 		</part>
 	</software>
@@ -2391,8 +2391,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NCUE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="cruis'n usa (usa).bin" size="8388608" crc="ee925406" sha1="aa8768945ff398b13b7ee9722a268e49424b6f26" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="cruis'n usa (usa).bin" size="0x800000" crc="ee925406" sha1="aa8768945ff398b13b7ee9722a268e49424b6f26" />
 			</dataarea>
 		</part>
 	</software>
@@ -2403,8 +2403,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NCWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="cruis'n world (europe).bin" size="12582912" crc="2a8b3094" sha1="e0efbb03b343cc9ace4e98306250436604054b6e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="cruis'n world (europe).bin" size="0xc00000" crc="2a8b3094" sha1="e0efbb03b343cc9ace4e98306250436604054b6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2415,8 +2415,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NCWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="cruis'n world (europe) (rev. 1).bin" size="12582912" crc="e962672d" sha1="48e4722765644ef98d46195d1abb1e79f99f7cfb" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="cruis'n world (europe) (rev. 1).bin" size="0xc00000" crc="e962672d" sha1="48e4722765644ef98d46195d1abb1e79f99f7cfb" />
 			</dataarea>
 		</part>
 	</software>
@@ -2433,8 +2433,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6106]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ncwe-0.u1" size="12582912" crc="41877d7d" sha1="a584735385485ee0b158e3206ce9b2e47feca830" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ncwe-0.u1" size="0xc00000" crc="41877d7d" sha1="a584735385485ee0b158e3206ce9b2e47feca830" />
 			</dataarea>
 		</part>
 	</software>
@@ -2453,8 +2453,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ncxj-0.u1" size="16777216" crc="30c84f36" sha1="9d462983d2f6c4417c328d97d430e0d62c5dac94" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ncxj-0.u1" size="0x1000000" crc="30c84f36" sha1="9d462983d2f6c4417c328d97d430e0d62c5dac94" />
 			</dataarea>
 		</part>
 	</software>
@@ -2473,8 +2473,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nczj-0.u1" size="16777216" crc="7bef9ecc" sha1="67ff98e6230470f0c3c209edb72869c715db2800" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nczj-0.u1" size="0x1000000" crc="7bef9ecc" sha1="67ff98e6230470f0c3c209edb72869c715db2800" />
 			</dataarea>
 		</part>
 	</software>
@@ -2485,8 +2485,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NT4P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="cybertiger (europe).bin" size="16777216" crc="bcf1071f" sha1="e68970895cc01b69b8a5a05eaf4d07b632544330" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="cybertiger (europe).bin" size="0x1000000" crc="bcf1071f" sha1="e68970895cc01b69b8a5a05eaf4d07b632544330" />
 			</dataarea>
 		</part>
 	</software>
@@ -2501,8 +2501,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NT4E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nt4e-0.u1" size="16777216" crc="f0f89bb9" sha1="afb3e9290730fd19106eca24cb305c1b55f2e864" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nt4e-0.u1" size="0x1000000" crc="f0f89bb9" sha1="afb3e9290730fd19106eca24cb305c1b55f2e864" />
 			</dataarea>
 		</part>
 	</software>
@@ -2513,8 +2513,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NDUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="daffy duck starring as duck dodgers (europe) (en,fr,de,es,it,nl).bin" size="16777216" crc="6cb4b600" sha1="456706f0e7a55b40715585f4a66a250a5654c02c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="daffy duck starring as duck dodgers (europe) (en,fr,de,es,it,nl).bin" size="0x1000000" crc="6cb4b600" sha1="456706f0e7a55b40715585f4a66a250a5654c02c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2527,8 +2527,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="20001130"/>
 		<info name="alt_title" value="ダンスダンスレボリューション ディズニーダンシングミュージアム"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="dance dance revolution - disney dancing museum (japan).bin" size="33554432" crc="e085afa0" sha1="b0931ecabc6d7c05a14c792f45bc6faac8722ab1" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="dance dance revolution - disney dancing museum (japan).bin" size="0x2000000" crc="e085afa0" sha1="b0931ecabc6d7c05a14c792f45bc6faac8722ab1" />
 			</dataarea>
 		</part>
 	</software>
@@ -2545,8 +2545,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndkp-0.u1" size="8388608" crc="375d8ffe" sha1="9c6701dd396a35649b0045c5be3dc0642c334c8c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndkp-0.u1" size="0x800000" crc="375d8ffe" sha1="9c6701dd396a35649b0045c5be3dc0642c334c8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2561,8 +2561,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndke-0.u1" size="8388608" crc="2afab93c" sha1="8e7ec39e0f4b0a1351cf15f12ad5e5afa337f5f4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndke-0.u1" size="0x800000" crc="2afab93c" sha1="8e7ec39e0f4b0a1351cf15f12ad5e5afa337f5f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2577,8 +2577,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NGAE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ngae-0.u1" size="12582912" crc="b4afbf51" sha1="f4c7b5f79cee09d263b8a75b683ffbdb453d88f4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ngae-0.u1" size="0xc00000" crc="b4afbf51" sha1="f4c7b5f79cee09d263b8a75b683ffbdb453d88f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -2589,8 +2589,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NUS-NMTF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="defi au tetris magique (france).bin" size="16777216" crc="eb304709" sha1="0f90ce8124a023f207c59ccbda17d10d13532d62" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="defi au tetris magique (france).bin" size="0x1000000" crc="eb304709" sha1="0f90ce8124a023f207c59ccbda17d10d13532d62" />
 			</dataarea>
 		</part>
 	</software>
@@ -2617,8 +2617,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nd6j-0.u1" size="33554432" crc="8f63474f" sha1="ad5b14c3c571db911b2896d6c80e200b12cafdcd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nd6j-0.u1" size="0x2000000" crc="8f63474f" sha1="ad5b14c3c571db911b2896d6c80e200b12cafdcd" />
 			</dataarea>
 		</part>
 	</software>
@@ -2628,8 +2628,8 @@ patched out (+ a fix for internal checksum)
 		<year>2001</year>
 		<publisher>Media Factory</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="derby stallion 64 (japan) (beta).bin" size="33554432" crc="418fa479" sha1="bca2db2b280261cd0e62b304ba3754a6c56351b5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="derby stallion 64 (japan) (beta).bin" size="0x2000000" crc="418fa479" sha1="bca2db2b280261cd0e62b304ba3754a6c56351b5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2642,8 +2642,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="20010810"/>
 		<info name="alt_title" value="ダービースタリオン64" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="derby stallion 64 (japan).bin" size="33554432" crc="922506ad" sha1="b404e2a26da5cf0ee2eecfd691ffb0385d08642a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="derby stallion 64 (japan).bin" size="0x2000000" crc="922506ad" sha1="b404e2a26da5cf0ee2eecfd691ffb0385d08642a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2654,8 +2654,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NDEP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="destruction derby 64 (europe) (en,fr,de).bin" size="16777216" crc="212a8000" sha1="e68747f46ab2eb21d56bd39f65232bdaad86bcf9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="destruction derby 64 (europe) (en,fr,de).bin" size="0x1000000" crc="212a8000" sha1="e68747f46ab2eb21d56bd39f65232bdaad86bcf9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2670,8 +2670,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDEE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ndee-0.u1" size="16777216" crc="ef680f71" sha1="31981b9b32814bbc3fe0c2a71c888858566352f9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ndee-0.u1" size="0x1000000" crc="ef680f71" sha1="31981b9b32814bbc3fe0c2a71c888858566352f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -2695,8 +2695,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 CR2032" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-cdzj-0.u1" size="16777216" crc="8ce25c68" sha1="7ca61515b13d927e905b59390dd300945b68d218" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-cdzj-0.u1" size="0x1000000" crc="8ce25c68" sha1="7ca61515b13d927e905b59390dd300945b68d218" />
 			</dataarea>
 		</part>
 	</software>
@@ -2707,8 +2707,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NDYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="diddy kong racing (europe) (en,fr,de) (rev a).bin" size="12582912" crc="f05d414f" sha1="fd57da7fe1d4dd471caaca419176a4c097ee7b90" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="diddy kong racing (europe) (en,fr,de) (rev a).bin" size="0xc00000" crc="f05d414f" sha1="fd57da7fe1d4dd471caaca419176a4c097ee7b90" />
 			</dataarea>
 		</part>
 	</software>
@@ -2719,8 +2719,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NDYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="diddy kong racing (europe) (en,fr,de).bin" size="12582912" crc="883df1ea" sha1="944ef38c40630573c16d7534109eb7d3c822eeec" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="diddy kong racing (europe) (en,fr,de).bin" size="0xc00000" crc="883df1ea" sha1="944ef38c40630573c16d7534109eb7d3c822eeec" />
 			</dataarea>
 		</part>
 	</software>
@@ -2739,8 +2739,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ndyj-0.u1" size="12582912" crc="95931356" sha1="a33962564640cd80e57f7cac895ca831f123afd5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ndyj-0.u1" size="0xc00000" crc="95931356" sha1="a33962564640cd80e57f7cac895ca831f123afd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2751,8 +2751,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NDYE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="diddy kong racing (usa) (en,fr) (rev a).bin" size="12582912" crc="96c32bb6" sha1="03f04dfe0c34e8bad370aa4b68f4bb8ed3429fde" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="diddy kong racing (usa) (en,fr) (rev a).bin" size="0xc00000" crc="96c32bb6" sha1="03f04dfe0c34e8bad370aa4b68f4bb8ed3429fde" />
 			</dataarea>
 		</part>
 	</software>
@@ -2769,8 +2769,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
 			<feature name="cart_model" value="NUS-006(USA)" /> <!-- Also with NUS-006(JPN) -->
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ndye-0.u1" size="12582912" crc="9d2935a1" sha1="812807d8dc23229e736d543c3bafc7ef28519ef5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ndye-0.u1" size="0xc00000" crc="9d2935a1" sha1="812807d8dc23229e736d543c3bafc7ef28519ef5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2780,8 +2780,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Fox Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="dh64-1.bin" size="33554432" crc="5e826037" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="dh64-1.bin" size="0x2000000" crc="5e826037" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46" />
 			</dataarea>
 		</part>
 	</software>
@@ -2791,8 +2791,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Fox Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="dh64-2.bin" size="33554432" crc="d1d593cf" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="dh64-2.bin" size="0x2000000" crc="d1d593cf" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e" />
 			</dataarea>
 		</part>
 	</software>
@@ -2802,8 +2802,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Fox Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="dh64-3.bin" size="33554432" crc="70943925" sha1="0971545144930f221a4350e98866c8cd1ee22af5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="dh64-3.bin" size="0x2000000" crc="70943925" sha1="0971545144930f221a4350e98866c8cd1ee22af5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2818,8 +2818,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="20971520">
-				<rom name="nus-ndqe-0.u1" size="20971520" crc="6d48b64e" sha1="2700f7534d477c7b673dcdee0fe19b93dc95ca89" />
+			<dataarea name="rom" size="0x1400000">
+				<rom name="nus-ndqe-0.u1" size="0x1400000" crc="6d48b64e" sha1="2700f7534d477c7b673dcdee0fe19b93dc95ca89" />
 			</dataarea>
 		</part>
 	</software>
@@ -2830,8 +2830,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NDQP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="20971520">
-				<rom name="donald duck - quack attack (europe) (en,fr,de,es,it).bin" size="20971520" crc="5f67a191" sha1="6c761e0668247a5b264e2deb502f1de992f83346" />
+			<dataarea name="rom" size="0x1400000">
+				<rom name="donald duck - quack attack (europe) (en,fr,de,es,it).bin" size="0x1400000" crc="5f67a191" sha1="6c761e0668247a5b264e2deb502f1de992f83346" />
 			</dataarea>
 		</part>
 	</software>
@@ -2846,8 +2846,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDOP-0]" />
 			<feature name="u2" value="U2 [BK16D 9851]" />
 			<feature name="u3" value="U3 [CIC-NUS-7105]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ndop-0.u1" size="33554432" crc="fc37b06a" sha1="29fa421e7732ab990178033bc8c979aeb8fe78d5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ndop-0.u1" size="0x2000000" crc="fc37b06a" sha1="29fa421e7732ab990178033bc8c979aeb8fe78d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -2866,8 +2866,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ndoj-0.u1" size="33554432" crc="fbd001b9" sha1="429e7ace2a68832345bfbb3bc3aadf3a7a505d7b" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ndoj-0.u1" size="0x2000000" crc="fbd001b9" sha1="429e7ace2a68832345bfbb3bc3aadf3a7a505d7b" />
 			</dataarea>
 		</part>
 	</software>
@@ -2884,8 +2884,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6105]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ndoe-0.u1" size="33554432" crc="96972d67" sha1="3ead7798284c0593d8c91e09923cde03e87c6b09" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ndoe-0.u1" size="0x2000000" crc="96972d67" sha1="3ead7798284c0593d8c91e09923cde03e87c6b09" />
 			</dataarea>
 		</part>
 	</software>
@@ -2902,8 +2902,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3" /> <!-- unknown -->
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ndpe-0.u1" size="33554432" crc="54bb87f6" sha1="69127a8b8a0848ceeccd3712f3752eab3f9143cd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ndpe-0.u1" size="0x2000000" crc="54bb87f6" sha1="69127a8b8a0848ceeccd3712f3752eab3f9143cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -2914,8 +2914,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NDMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="doom 64 (europe).bin" size="8388608" crc="0227db4b" sha1="1c863f00650fa5c4111f3cf0b972105edfc970ab" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="doom 64 (europe).bin" size="0x800000" crc="0227db4b" sha1="1c863f00650fa5c4111f3cf0b972105edfc970ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -2928,8 +2928,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19970801"/>
 		<info name="alt_title" value="ドゥーム64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="doom 64 (japan).bin" size="8388608" crc="95526f13" sha1="d7d8e5636839255fd1c324b9a27511917e3c454f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="doom 64 (japan).bin" size="0x800000" crc="95526f13" sha1="d7d8e5636839255fd1c324b9a27511917e3c454f" />
 			</dataarea>
 		</part>
 	</software>
@@ -2940,8 +2940,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NDME-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="doom 64 (usa) (rev a).bin" size="8388608" crc="0f080d06" sha1="07a7dac8084f1be8b102312fcd3ee65be095109c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="doom 64 (usa) (rev a).bin" size="0x800000" crc="0f080d06" sha1="07a7dac8084f1be8b102312fcd3ee65be095109c" />
 			</dataarea>
 		</part>
 	</software>
@@ -2957,8 +2957,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndme-0.u1" size="8388608" crc="4dfb7cb6" sha1="b30f2b1b1cf70dc4b398bff26f75eedff858540d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndme-0.u1" size="0x800000" crc="4dfb7cb6" sha1="b30f2b1b1cf70dc4b398bff26f75eedff858540d" />
 			</dataarea>
 		</part>
 	</software>
@@ -2975,8 +2975,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDRJ-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndrj-0.u1" size="8388608" crc="cad0a2c2" sha1="a35b06dc974429dbd6cbf0712a4c170fd099748a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndrj-0.u1" size="0x800000" crc="cad0a2c2" sha1="a35b06dc974429dbd6cbf0712a4c170fd099748a" />
 			</dataarea>
 		</part>
 	</software>
@@ -2989,8 +2989,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ドラえもん2 のび太と光の神殿"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="doraemon 2 - nobita to hikari no shinden (japan).bin" size="12582912" crc="2de1a873" sha1="00a02647de6760fa2cf1a2ffcaada43703a8a98d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="doraemon 2 - nobita to hikari no shinden (japan).bin" size="0xc00000" crc="2de1a873" sha1="00a02647de6760fa2cf1a2ffcaada43703a8a98d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3009,8 +3009,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-n3dj-0.u1" size="16777216" crc="0b3ad913" sha1="a567aa96860525963f9dafa256036c0df5f66909" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-n3dj-0.u1" size="0x1000000" crc="0b3ad913" sha1="a567aa96860525963f9dafa256036c0df5f66909" />
 			</dataarea>
 		</part>
 	</software>
@@ -3021,8 +3021,8 @@ patched out (+ a fix for internal checksum)
 		<year>200?</year>
 		<publisher>Marigul</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="doubutsu_banchou.bin" size="33554432" crc="7a2e1b99" sha1="15a22d0e2320d4aa3487ec57532110ea4390b849" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="doubutsu_banchou.bin" size="0x2000000" crc="7a2e1b99" sha1="15a22d0e2320d4aa3487ec57532110ea4390b849" />
 			</dataarea>
 		</part>
 	</software>
@@ -3045,8 +3045,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u4" value="U4 [74LV2416]" />
 			<feature name="u5" value="U5 [CIC_NUS-6102A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nafj-0.u1" size="16777216" crc="b9fcd0a6" sha1="648b978895bc20256d48f763a72a8686f5cf549d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nafj-0.u1" size="0x1000000" crc="b9fcd0a6" sha1="648b978895bc20256d48f763a72a8686f5cf549d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3061,8 +3061,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NN6E-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nn6e-0.u1" size="4194304" crc="f7c44b5b" sha1="188abdf9e879dd8c92e78a2e978284879a00a8bf" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nn6e-0.u1" size="0x400000" crc="f7c44b5b" sha1="188abdf9e879dd8c92e78a2e978284879a00a8bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -3076,7 +3076,7 @@ This cart features a RTC, currently unemulated
 				<!-- Original release, in .z64 format -->
 				<!-- rom name="dragonsword.n64" size="9448848" crc="dcea9210" sha1="efbdbcb499a3d8a37613ca1d94528016bdbf5735" /-->
 				<!-- .v64 version -->
-				<rom name="dragonsword.bin" size="9448848" crc="c16b220f" sha1="72e2c2261c7c4031b7b27137cb092d40a0e45e02" />
+				<rom name="dragonsword.bin" size="9448848" crc="c16b220f" sha1="72e2c2261c7c4031b7b27137cb092d40a0e45e02" status="baddump" /> <!-- allegedly from a dev cart, so this has been trimmed? -->
 			</dataarea>
 		</part>
 	</software>
@@ -3087,7 +3087,7 @@ This cart features a RTC, currently unemulated
 		<publisher>Interactive Studios / Blitzgames</publisher>
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="11891184">
-				<rom name="dragon sword ntsc.bin" size="11891184" crc="a568ca1b" sha1="e4b705fd31d33e214cbd5d95bb1e62e0a7829b01" />
+				<rom name="dragon sword ntsc.bin" size="11891184" crc="a568ca1b" sha1="e4b705fd31d33e214cbd5d95bb1e62e0a7829b01" status="baddump" /> <!-- dumper trimmed empty data, this should be 32MB -->
 			</dataarea>
 		</part>
 	</software>
@@ -3098,8 +3098,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Hudson Soft</publisher>
 		<info name="serial" value="NUS-NDHP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="dual heroes (europe).bin" size="12582912" crc="04064347" sha1="7703976c4bef912feeb5b553ff913e8ef0db8a60" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="dual heroes (europe).bin" size="0xc00000" crc="04064347" sha1="7703976c4bef912feeb5b553ff913e8ef0db8a60" />
 			</dataarea>
 		</part>
 	</software>
@@ -3112,8 +3112,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971205"/>
 		<info name="alt_title" value="デュアルヒーローズ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="dual heroes (japan).bin" size="12582912" crc="a3565ffc" sha1="b36e4d8a19a50711b0423469dd43b954084fe36a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="dual heroes (japan).bin" size="0xc00000" crc="a3565ffc" sha1="b36e4d8a19a50711b0423469dd43b954084fe36a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3128,8 +3128,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NDHE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ndhe-0.u1" size="12582912" crc="8968d989" sha1="ac48d0a10a26de691976618d1d0caebf402f9123" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ndhe-0.u1" size="0xc00000" crc="8968d989" sha1="ac48d0a10a26de691976618d1d0caebf402f9123" />
 			</dataarea>
 		</part>
 	</software>
@@ -3140,8 +3140,8 @@ This cart features a RTC, currently unemulated
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="20971520">
-				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="20971520" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" />
+			<dataarea name="rom" size="0x1400000">
+				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="0x1400000" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3156,8 +3156,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NDUE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ndue-0.u1" size="16777216" crc="b67bbc15" sha1="40ce11880a5e0603a42ae46b0518b95ae174556c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ndue-0.u1" size="0x1000000" crc="b67bbc15" sha1="40ce11880a5e0603a42ae46b0518b95ae174556c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3173,8 +3173,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndnp-0.u1" size="8388608" crc="9817b026" sha1="3da4e470dc928c62fd7e0c010b9ea413321c7824" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndnp-0.u1" size="0x800000" crc="9817b026" sha1="3da4e470dc928c62fd7e0c010b9ea413321c7824" />
 			</dataarea>
 		</part>
 	</software>
@@ -3198,8 +3198,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u11" value="U11 N64_EEPROM [BU9850]" />
 			<feature name="u12" value="U12 [17805]" />
 			<feature name="u13" value="U13" /> <!-- unknown -->
-			<dataarea name="rom" size="8388608">
-				<rom name="duke nukem 64 (europe) (beta).bin" size="8388608" crc="1ff97bad" sha1="f4adffeb61eccf5715e3f61a9d24b87ce2ae08c9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="duke nukem 64 (europe) (beta).bin" size="0x800000" crc="1ff97bad" sha1="f4adffeb61eccf5715e3f61a9d24b87ce2ae08c9" />
 			</dataarea>
 		</part>
 	</software>
@@ -3210,8 +3210,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NDNF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="duke nukem 64 (france).bin" size="8388608" crc="cbe8c78a" sha1="bf05f8ec1a1bb936f8cc4d32f0deada7355b16b1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="duke nukem 64 (france).bin" size="0x800000" crc="cbe8c78a" sha1="bf05f8ec1a1bb936f8cc4d32f0deada7355b16b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -3226,8 +3226,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NDNE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ndne-0.u1" size="8388608" crc="1bf948c3" sha1="72fcf260632323c2538a6d2feea7030b8da5bac8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ndne-0.u1" size="0x800000" crc="1bf948c3" sha1="72fcf260632323c2538a6d2feea7030b8da5bac8" />
 			</dataarea>
 		</part>
 	</software>
@@ -3238,8 +3238,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NDZP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="duke nukem - zero hour (europe).bin" size="33554432" crc="c2b3df4d" sha1="d90325d6ac785c94ed0a66469319f2164474a8a3" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="duke nukem - zero hour (europe).bin" size="0x2000000" crc="c2b3df4d" sha1="d90325d6ac785c94ed0a66469319f2164474a8a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3250,8 +3250,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NDZF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="duke nukem - zero hour (france).bin" size="33554432" crc="8fbf7447" sha1="1777e76dd3ff153373ae458e35a29188ed901082" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="duke nukem - zero hour (france).bin" size="0x2000000" crc="8fbf7447" sha1="1777e76dd3ff153373ae458e35a29188ed901082" />
 			</dataarea>
 		</part>
 	</software>
@@ -3267,8 +3267,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ndze-0.u1" size="33554432" crc="912f576f" sha1="18fc2f1d69b34b31588a0617e81abb794a9205ef" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ndze-0.u1" size="0x2000000" crc="912f576f" sha1="18fc2f1d69b34b31588a0617e81abb794a9205ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -3303,8 +3303,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u22" value="U22 32M FLASH MEMORY [empty]" />
 			<feature name="u23" value="U23 32M FLASH MEMORY [empty]" />
 			<feature name="batt1" value="BATT1 [CR2032]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="duke nukem - zero hour (usa).bin" size="33554432" crc="912f576f" sha1="18fc2f1d69b34b31588a0617e81abb794a9205ef" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="duke nukem - zero hour (usa).bin" size="0x2000000" crc="912f576f" sha1="18fc2f1d69b34b31588a0617e81abb794a9205ef" />
 			</dataarea>
 		</part>
 	</software>
@@ -3315,8 +3315,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Rockstar Games</publisher>
 		<info name="serial" value="NUS-NJMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="earthworm jim 3d (europe) (en,fr,de,es,it).bin" size="16777216" crc="20c3adab" sha1="c613b72369292bb8a16b395073f70c586e0fa65e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="earthworm jim 3d (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="20c3adab" sha1="c613b72369292bb8a16b395073f70c586e0fa65e" />
 			</dataarea>
 		</part>
 	</software>
@@ -3331,8 +3331,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NJME-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-njme-0.u1" size="16777216" crc="1017be14" sha1="1b0aa4d94194edc885d9a9c2a4f37000c963756a" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-njme-0.u1" size="0x1000000" crc="1017be14" sha1="1b0aa4d94194edc885d9a9c2a4f37000c963756a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3343,8 +3343,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NWIP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="ecw hardcore revolution (europe).bin" size="33554432" crc="2fac2c41" sha1="8718a6e6c75ba0db8d2266f5a2fb0361807ac988" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="ecw hardcore revolution (europe).bin" size="0x2000000" crc="2fac2c41" sha1="8718a6e6c75ba0db8d2266f5a2fb0361807ac988" />
 			</dataarea>
 		</part>
 	</software>
@@ -3354,8 +3354,8 @@ This cart features a RTC, currently unemulated
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="ecw hardcore revolution (germany).bin" size="33554432" crc="61503331" sha1="5747161ac3666fb5a5c876013207568253a2d279" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="ecw hardcore revolution (germany).bin" size="0x2000000" crc="61503331" sha1="5747161ac3666fb5a5c876013207568253a2d279" />
 			</dataarea>
 		</part>
 	</software>
@@ -3370,8 +3370,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NWIE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nwie-0.u1" size="33554432" crc="4ba40079" sha1="8bc52ec9d4a66f4c7a8dd2349c5da90aa2dd3684" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nwie-0.u1" size="0x2000000" crc="4ba40079" sha1="8bc52ec9d4a66f4c7a8dd2349c5da90aa2dd3684" />
 			</dataarea>
 		</part>
 	</software>
@@ -3388,8 +3388,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NSTJ-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="eikou no saint andrews (japan).bin" size="8388608" crc="ce55bb19" sha1="1a313d3b4b11a16b8280b0139a15e47791c8080a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="eikou no saint andrews (japan).bin" size="0x800000" crc="ce55bb19" sha1="1a313d3b4b11a16b8280b0139a15e47791c8080a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3404,8 +3404,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NELE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nele-0.u1" size="8388608" crc="710011fb" sha1="4c8e68cc1c5af546bc9ac26de423458141346e2c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nele-0.u1" size="0x800000" crc="710011fb" sha1="4c8e68cc1c5af546bc9ac26de423458141346e2c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3420,8 +3420,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NENE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nene-0.u1" size="8388608" crc="b7ad0f05" sha1="72419fd0a80cbdeea635f094d6b0d086ebbb2750" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nene-0.u1" size="0x800000" crc="b7ad0f05" sha1="72419fd0a80cbdeea635f094d6b0d086ebbb2750" />
 			</dataarea>
 		</part>
 	</software>
@@ -3440,8 +3440,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-netj-0.u1" size="16777216" crc="3541c4bb" sha1="36fc37e9eec7157961e8accd9e40da4134055669" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-netj-0.u1" size="0x1000000" crc="3541c4bb" sha1="36fc37e9eec7157961e8accd9e40da4134055669" />
 			</dataarea>
 		</part>
 	</software>
@@ -3452,8 +3452,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="excitebike 64 (europe).bin" size="16777216" crc="8feede6f" sha1="2579188d81bfbd26557ad7034a2931ccea72f84f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="excitebike 64 (europe).bin" size="0x1000000" crc="8feede6f" sha1="2579188d81bfbd26557ad7034a2931ccea72f84f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3466,8 +3466,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000623"/>
 		<info name="alt_title" value="エキサイトバイク64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="excitebike 64 (japan).bin" size="16777216" crc="9dfeb099" sha1="ad840fe563076bd600ad0ab3ad4433b3f1a72a4c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="excitebike 64 (japan).bin" size="0x1000000" crc="9dfeb099" sha1="ad840fe563076bd600ad0ab3ad4433b3f1a72a4c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3478,8 +3478,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DIS-NUS-NNXE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="excitebike 64 (usa) (demo) (kiosk).bin" size="16777216" crc="13157df7" sha1="7130fb444673842807a4c38d6f2e9505c8616a39" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="excitebike 64 (usa) (demo) (kiosk).bin" size="0x1000000" crc="13157df7" sha1="7130fb444673842807a4c38d6f2e9505c8616a39" />
 			</dataarea>
 		</part>
 	</software>
@@ -3490,8 +3490,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMXE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="excitebike 64 (usa) (v1.1).bin" size="16777216" crc="820a12db" sha1="88214240204ab3c01f31c0a19d74a4eafe53c027" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="excitebike 64 (usa) (v1.1).bin" size="0x1000000" crc="820a12db" sha1="88214240204ab3c01f31c0a19d74a4eafe53c027" />
 			</dataarea>
 		</part>
 	</software>
@@ -3508,8 +3508,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6103A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nmxe-0.u1" size="16777216" crc="ef78ed7e" sha1="3f65d89577ff12a47502a970a0c81b8e5bdb39e0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nmxe-0.u1" size="0x1000000" crc="ef78ed7e" sha1="3f65d89577ff12a47502a970a0c81b8e5bdb39e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3520,8 +3520,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NEGP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="extreme-g (europe) (en,fr,de,es,it).bin" size="8388608" crc="1be8e42b" sha1="cc28fd3b6eb8deff86ccca081ef78f93b63011f4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="extreme-g (europe) (en,fr,de,es,it).bin" size="0x800000" crc="1be8e42b" sha1="cc28fd3b6eb8deff86ccca081ef78f93b63011f4" />
 			</dataarea>
 		</part>
 	</software>
@@ -3534,8 +3534,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980529"/>
 		<info name="alt_title" value="エクストリームG"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="extreme-g (japan).bin" size="8388608" crc="856227bb" sha1="afb26291e828e049e6913f88fc11f28d097057bf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="extreme-g (japan).bin" size="0x800000" crc="856227bb" sha1="afb26291e828e049e6913f88fc11f28d097057bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -3550,8 +3550,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NEGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nege-0.u1" size="8388608" crc="a43a0b17" sha1="3544a3779af1b7bca0c03e2298aad0acbb3c0b2a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nege-0.u1" size="0x800000" crc="a43a0b17" sha1="3544a3779af1b7bca0c03e2298aad0acbb3c0b2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3562,8 +3562,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NG2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="extreme-g xg2 (europe) (en,fr,de,es,it).bin" size="12582912" crc="32fc980c" sha1="3076cd1e025aebc6168c0f33fcb215106f519dd3" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="extreme-g xg2 (europe) (en,fr,de,es,it).bin" size="0xc00000" crc="32fc980c" sha1="3076cd1e025aebc6168c0f33fcb215106f519dd3" />
 			</dataarea>
 		</part>
 	</software>
@@ -3576,8 +3576,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990910"/>
 		<info name="alt_title" value="エクストリームG2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="extreme-g xg2 (japan).bin" size="12582912" crc="62202d15" sha1="769e78efae2164ce03441dcdf5b2a2849f15f281" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="extreme-g xg2 (japan).bin" size="0xc00000" crc="62202d15" sha1="769e78efae2164ce03441dcdf5b2a2849f15f281" />
 			</dataarea>
 		</part>
 	</software>
@@ -3592,8 +3592,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NG2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ng2e-0.u1" size="12582912" crc="849c18ce" sha1="e27268a708b6d6a707b6e01af94d062ea9cbc26d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ng2e-0.u1" size="0xc00000" crc="849c18ce" sha1="e27268a708b6d6a707b6e01af94d062ea9cbc26d" />
 			</dataarea>
 		</part>
 	</software>
@@ -3603,8 +3603,8 @@ This cart features a RTC, currently unemulated
 		<year>1998</year>
 		<publisher>Video System</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="f-1 world grand prix (europe) (beta).bin" size="12582912" crc="338777bf" sha1="33ef8bedba32950b132e60b492b88a3683fc8ed5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="f-1 world grand prix (europe) (beta).bin" size="0xc00000" crc="338777bf" sha1="33ef8bedba32950b132e60b492b88a3683fc8ed5" />
 			</dataarea>
 		</part>
 	</software>
@@ -3621,8 +3621,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfwp-0.u1" size="12582912" crc="8c08a7a8" sha1="359e4b83246bca7f377ecfc97291f297012febcc" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfwp-0.u1" size="0xc00000" crc="8c08a7a8" sha1="359e4b83246bca7f377ecfc97291f297012febcc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3633,8 +3633,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Video System</publisher>
 		<info name="serial" value="NUS-NFWF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="f-1 world grand prix (france).bin" size="12582912" crc="02e9695d" sha1="40ca54db3858ad04b328f741a79caef2bbd02873" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="f-1 world grand prix (france).bin" size="0xc00000" crc="02e9695d" sha1="40ca54db3858ad04b328f741a79caef2bbd02873" />
 			</dataarea>
 		</part>
 	</software>
@@ -3645,8 +3645,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Video System</publisher>
 		<info name="serial" value="NUS-NFWD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="f-1 world grand prix (germany).bin" size="12582912" crc="7d8ddefb" sha1="ba7a94d3cece240276c294c2ff29ac93c59bd939" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="f-1 world grand prix (germany).bin" size="0xc00000" crc="7d8ddefb" sha1="ba7a94d3cece240276c294c2ff29ac93c59bd939" />
 			</dataarea>
 		</part>
 	</software>
@@ -3659,8 +3659,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981218"/>
 		<info name="alt_title" value="エフワン ワールド グランプリ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="f-1 world grand prix (japan).bin" size="12582912" crc="386e127d" sha1="932ca3ddd3a6b4e4c1f7a1a1f9a77e14a009a6c0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="f-1 world grand prix (japan).bin" size="0xc00000" crc="386e127d" sha1="932ca3ddd3a6b4e4c1f7a1a1f9a77e14a009a6c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -3675,8 +3675,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFWE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfwe-0.u1" size="12582912" crc="4d203242" sha1="ca05633242b31e3ec808945e9afeafc2fe4de652" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfwe-0.u1" size="0xc00000" crc="4d203242" sha1="ca05633242b31e3ec808945e9afeafc2fe4de652" />
 			</dataarea>
 		</part>
 	</software>
@@ -3687,8 +3687,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Video System</publisher>
 		<info name="serial" value="NUS-NF2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="f-1 world grand prix ii (europe) (en,fr,de,es).bin" size="12582912" crc="484c801d" sha1="e8e598ccd19011539e815c01131539649c3ea8da" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="f-1 world grand prix ii (europe) (en,fr,de,es).bin" size="0xc00000" crc="484c801d" sha1="e8e598ccd19011539e815c01131539649c3ea8da" />
 			</dataarea>
 		</part>
 	</software>
@@ -3706,8 +3706,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u4" value="U4 [CIC-NUS-7106]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-cfzp-0.u1" size="16777216" crc="3d95df80" sha1="6108dd6d6d65e1440535aad43caff99c2e886340" /> <!-- Also labelse NUS-NFZP-0 -->
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-cfzp-0.u1" size="0x1000000" crc="3d95df80" sha1="6108dd6d6d65e1440535aad43caff99c2e886340" /> <!-- Also labelse NUS-NFZP-0 -->
 			</dataarea>
 		</part>
 	</software>
@@ -3728,8 +3728,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-cfzj-0.u1" size="16777216" crc="927387b6" sha1="aad380ce474a19d3823aeaaad3594ab0edd47f97" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-cfzj-0.u1" size="0x1000000" crc="927387b6" sha1="aad380ce474a19d3823aeaaad3594ab0edd47f97" />
 			</dataarea>
 		</part>
 	</software>
@@ -3746,8 +3746,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [BU9803A]" />
 			<feature name="u4" value="U4 [CIC-NUS-6106]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-cfze-0.u1" size="16777216" crc="9408c2c1" sha1="c322c80a676604cda4b605558b5bd8aa6f1a2060" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-cfze-0.u1" size="0x1000000" crc="9408c2c1" sha1="c322c80a676604cda4b605558b5bd8aa6f1a2060" />
 			</dataarea>
 		</part>
 	</software>
@@ -3758,8 +3758,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NHGP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="f1 pole position 64 (europe) (en,fr,de).bin" size="8388608" crc="ec8b6db6" sha1="dfa0fac4e42e6426a8213101807ec445d752934f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="f1 pole position 64 (europe) (en,fr,de).bin" size="0x800000" crc="ec8b6db6" sha1="dfa0fac4e42e6426a8213101807ec445d752934f" />
 			</dataarea>
 		</part>
 	</software>
@@ -3774,8 +3774,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nhge-0.u1" size="8388608" crc="873bc45a" sha1="bbc6ca8fe4c5bdb77d9963696ba8bf8e46fb39a6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nhge-0.u1" size="0x800000" crc="873bc45a" sha1="bbc6ca8fe4c5bdb77d9963696ba8bf8e46fb39a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -3786,8 +3786,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NFRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="16777216" crc="0605e5ac" sha1="9c13ed6322a45772ea881be821c22f5157aa895a" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="f1 racing championship (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="0605e5ac" sha1="9c13ed6322a45772ea881be821c22f5157aa895a" />
 			</dataarea>
 		</part>
 	</software>
@@ -3797,8 +3797,8 @@ This cart features a RTC, currently unemulated
 		<year>2000</year>
 		<publisher>Gradiente</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="f1 racing championship (brazil).bin" size="16777216" crc="7ad98002" sha1="4fb7619af8d48b6dd8d8057ad9f6567b9e84f446" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="f1 racing championship (brazil).bin" size="0x1000000" crc="7ad98002" sha1="4fb7619af8d48b6dd8d8057ad9f6567b9e84f446" />
 			</dataarea>
 		</part>
 	</software>
@@ -3811,8 +3811,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971128"/>
 		<info name="alt_title" value="ファミスタ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="famista 64 (japan).bin" size="12582912" crc="51e0b88a" sha1="c14270956393834da8f670668155c41af34af7a9" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="famista 64 (japan).bin" size="0xc00000" crc="51e0b88a" sha1="c14270956393834da8f670668155c41af34af7a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -3828,8 +3828,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n8ip-0.u1" size="12582912" crc="2d49f99a" sha1="12a12c3b5aba1307d947ea7f72246497755b5482" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n8ip-0.u1" size="0xc00000" crc="2d49f99a" sha1="12a12c3b5aba1307d947ea7f72246497755b5482" />
 			</dataarea>
 		</part>
 	</software>
@@ -3842,8 +3842,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980424"/>
 		<info name="alt_title" value="FIFA Road to WORLD CUP 98 ワールドカップへの道"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="fifa - road to world cup 98 - world cup e no michi (japan).bin" size="12582912" crc="6ae6b8ed" sha1="83a86ce813e7dbb5c7d80b567f35fca7e742f8ba" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="fifa - road to world cup 98 - world cup e no michi (japan).bin" size="0xc00000" crc="6ae6b8ed" sha1="83a86ce813e7dbb5c7d80b567f35fca7e742f8ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -3861,8 +3861,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="n/a (NUS-006 clone)" />
 			<feature name="cart_back_label" value="" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n8ie-0.u1" size="12582912" crc="9504b3df" sha1="7deb782823b8d14496ce9843384281d07cc814fc" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n8ie-0.u1" size="0xc00000" crc="9504b3df" sha1="7deb782823b8d14496ce9843384281d07cc814fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -3873,8 +3873,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N9FP-ESP, NUS-N9FP-FRA, NUS-N9FP-NOE, NUS-N9FP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="fifa 99 (europe) (en,fr,de,es,it,nl,pt,sv).bin" size="16777216" crc="ce258860" sha1="eab12cc33bd12923c022d2336c3b8a1001132137" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="fifa 99 (europe) (en,fr,de,es,it,nl,pt,sv).bin" size="0x1000000" crc="ce258860" sha1="eab12cc33bd12923c022d2336c3b8a1001132137" />
 			</dataarea>
 		</part>
 	</software>
@@ -3889,8 +3889,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-N9FE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-n9fe-0.u1" size="16777216" crc="d69dd3d1" sha1="5a085f6d871fb697a672f56b4023cf3b822e4cf9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-n9fe-0.u1" size="0x1000000" crc="d69dd3d1" sha1="5a085f6d871fb697a672f56b4023cf3b822e4cf9" />
 			</dataarea>
 		</part>
 	</software>
@@ -3901,8 +3901,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N7IP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="fifa soccer 64 (europe) (en,fr,de).bin" size="8388608" crc="26f52456" sha1="6d2f25b4d87e8ddcd8af34831cd5952552b11f3c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="fifa soccer 64 (europe) (en,fr,de).bin" size="0x800000" crc="26f52456" sha1="6d2f25b4d87e8ddcd8af34831cd5952552b11f3c" />
 			</dataarea>
 		</part>
 	</software>
@@ -3917,8 +3917,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-N7IE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-n7ie-0.u1" size="8388608" crc="3b22f9f2" sha1="a27a2ba02bb02eaac999e60e3cedd67fb937b580" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-n7ie-0.u1" size="0x800000" crc="3b22f9f2" sha1="a27a2ba02bb02eaac999e60e3cedd67fb937b580" />
 			</dataarea>
 		</part>
 	</software>
@@ -3929,8 +3929,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NKAP-EUR, NUS-NKAP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="fighters destiny (europe).bin" size="12582912" crc="83f9299e" sha1="ad18a0144137ed61012363f7e810548e7ceaa934" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="fighters destiny (europe).bin" size="0xc00000" crc="83f9299e" sha1="ad18a0144137ed61012363f7e810548e7ceaa934" />
 			</dataarea>
 		</part>
 	</software>
@@ -3941,8 +3941,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NKAF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="fighters destiny (france).bin" size="12582912" crc="80d968b1" sha1="3ef0546bffc49807c4c00ac7c06ca72f5a787c29" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="fighters destiny (france).bin" size="0xc00000" crc="80d968b1" sha1="3ef0546bffc49807c4c00ac7c06ca72f5a787c29" />
 			</dataarea>
 		</part>
 	</software>
@@ -3953,8 +3953,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NKAD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="fighters destiny (germany).bin" size="12582912" crc="0a89ca02" sha1="4317a5cb4ada2d73d752fdc6c962ade147953cf6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="fighters destiny (germany).bin" size="0xc00000" crc="0a89ca02" sha1="4317a5cb4ada2d73d752fdc6c962ade147953cf6" />
 			</dataarea>
 		</part>
 	</software>
@@ -3969,8 +3969,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKAE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nkae-0.u1" size="12582912" crc="a625973f" sha1="2fba94ec3a6eac33e2680e1db661178c3e320bc4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nkae-0.u1" size="0xc00000" crc="a625973f" sha1="2fba94ec3a6eac33e2680e1db661178c3e320bc4" />
 			</dataarea>
 		</part>
 	</software>
@@ -3987,8 +3987,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nfge-0.u1" size="16777216" crc="7fc19103" sha1="55af6bfb78d58700d0b97a5ef390693817195051" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nfge-0.u1" size="0x1000000" crc="7fc19103" sha1="55af6bfb78d58700d0b97a5ef390693817195051" />
 			</dataarea>
 		</part>
 	</software>
@@ -4001,8 +4001,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981211"/>
 		<info name="alt_title" value="ファイティングカップ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="fighting cup (japan).bin" size="12582912" crc="a9740235" sha1="55f3e6e3c9fdcf0278fa494a798316600d9db4d4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="fighting cup (japan).bin" size="0xc00000" crc="a9740235" sha1="55f3e6e3c9fdcf0278fa494a798316600d9db4d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -4013,8 +4013,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NFFP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="fighting force 64 (europe).bin" size="16777216" crc="8d0cb2ff" sha1="0e55db7874b9259622f54aa9b36247db87373e58" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="fighting force 64 (europe).bin" size="0x1000000" crc="8d0cb2ff" sha1="0e55db7874b9259622f54aa9b36247db87373e58" />
 			</dataarea>
 		</part>
 	</software>
@@ -4029,8 +4029,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nffe-0.u1" size="16777216" crc="ade7dca4" sha1="3ce2ddafaa5101d3b2f49210ab6e6976994e5fbe" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nffe-0.u1" size="0x1000000" crc="ade7dca4" sha1="3ce2ddafaa5101d3b2f49210ab6e6976994e5fbe" />
 			</dataarea>
 		</part>
 	</software>
@@ -4041,8 +4041,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Natsume</publisher>
 		<info name="serial" value="NUS-NFDP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="flying dragon (europe).bin" size="12582912" crc="00fff973" sha1="fa71bada5055fcda27899d8f165224b737dc8449" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="flying dragon (europe).bin" size="0xc00000" crc="00fff973" sha1="fa71bada5055fcda27899d8f165224b737dc8449" />
 			</dataarea>
 		</part>
 	</software>
@@ -4057,8 +4057,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfde-0.u1" size="12582912" crc="87e4e352" sha1="25fd5cc411092d917d18c6d6ba3d7749b2f27f1a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfde-0.u1" size="0xc00000" crc="87e4e352" sha1="25fd5cc411092d917d18c6d6ba3d7749b2f27f1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4069,8 +4069,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NFOP-EUR, NUS-NFOP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="forsaken 64 (europe) (en,fr,es,it).bin" size="8388608" crc="6c65ef7a" sha1="5b6a661f75f9e3560238acf6dfcd4287e75586c0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="forsaken 64 (europe) (en,fr,es,it).bin" size="0x800000" crc="6c65ef7a" sha1="5b6a661f75f9e3560238acf6dfcd4287e75586c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -4081,8 +4081,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NFOD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="forsaken 64 (germany).bin" size="8388608" crc="c3fa1b8e" sha1="46e2a07b805f06e04fb4dc6934eaa0ebccc81f76" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="forsaken 64 (germany).bin" size="0x800000" crc="c3fa1b8e" sha1="46e2a07b805f06e04fb4dc6934eaa0ebccc81f76" />
 			</dataarea>
 		</part>
 	</software>
@@ -4097,8 +4097,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nfoe-0.u1" size="8388608" crc="f970e4a4" sha1="7741fa3cc164e7b51d79079e14c46edd5be205bf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nfoe-0.u1" size="0x800000" crc="f970e4a4" sha1="7741fa3cc164e7b51d79079e14c46edd5be205bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -4113,8 +4113,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NF9E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nf9e-0.u1" size="12582912" crc="fede3ef8" sha1="86d16b039abe70bc5b8b16805dd48483477fbdf6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nf9e-0.u1" size="0xc00000" crc="fede3ef8" sha1="86d16b039abe70bc5b8b16805dd48483477fbdf6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4149,8 +4149,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u22" value="U22 32M FLASH MEMORY [empty]" />
 			<feature name="u23" value="U23 32M FLASH MEMORY [empty]" />
 			<feature name="batt1" value="BATT1 [CR2032]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="frogger 2 (usa) (rev a) (proto).bin" size="33554432" crc="dc59ece7" sha1="f16b3d87c243f0e25c1f71eb8c388178757dcdf9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="frogger 2 (usa) (rev a) (proto).bin" size="0x2000000" crc="dc59ece7" sha1="f16b3d87c243f0e25c1f71eb8c388178757dcdf9" />
 			</dataarea>
 		</part>
 	</software>
@@ -4160,8 +4160,8 @@ This cart features a RTC, currently unemulated
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="frogger 2.bin" size="8388608" crc="8273bfa5" sha1="d2bc7a66d95510c7f51934823ef5ba2de76b6d9c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="frogger 2.bin" size="0x800000" crc="8273bfa5" sha1="d2bc7a66d95510c7f51934823ef5ba2de76b6d9c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4182,8 +4182,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nsij-0.u1" size="33554432" crc="af0a22ef" sha1="a50ef01ec653ed48a2b857fe2834d815cbd8e972" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nsij-0.u1" size="0x2000000" crc="af0a22ef" sha1="a50ef01ec653ed48a2b857fe2834d815cbd8e972" />
 			</dataarea>
 		</part>
 	</software>
@@ -4194,8 +4194,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NGAP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="g.a.s.p fighters' nextream (europe).bin" size="12582912" crc="b0d256b8" sha1="ff187a9a1f357796528ca98e0b15ec227df8a659" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="g.a.s.p fighters' nextream (europe).bin" size="0xc00000" crc="b0d256b8" sha1="ff187a9a1f357796528ca98e0b15ec227df8a659" />
 			</dataarea>
 		</part>
 	</software>
@@ -4208,8 +4208,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980326"/>
 		<info name="alt_title" value="ガスプ ファイターズ ネクストリーム"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="g.a.s.p fighters' nextream (japan).bin" size="12582912" crc="0e05ea3a" sha1="743673180188dfee89f36c76602c1a75df51716e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="g.a.s.p fighters' nextream (japan).bin" size="0xc00000" crc="0e05ea3a" sha1="743673180188dfee89f36c76602c1a75df51716e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4222,8 +4222,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981223"/>
 		<info name="alt_title" value="がんばれゴエモン でろでろ道中オバケてんこ盛り"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="ganbare goemon - dero dero douchuu obake tenkomori (japan).bin" size="16777216" crc="163c3c51" sha1="d8ee4e745bae3625826ff267da5404b42f36c3c2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="ganbare goemon - dero dero douchuu obake tenkomori (japan).bin" size="0x1000000" crc="163c3c51" sha1="d8ee4e745bae3625826ff267da5404b42f36c3c2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4240,8 +4240,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NG5J-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ng5j-0.u1" size="16777216" crc="69964858" sha1="b6386455c0b8f573e315976bbb47548cbafcedb3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ng5j-0.u1" size="0x1000000" crc="69964858" sha1="b6386455c0b8f573e315976bbb47548cbafcedb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4254,8 +4254,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000713"/>
 		<info name="alt_title" value="がんばれ!ニッポン!オリンピック2000"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="ganbare nippon olympics 2000 (japan).bin" size="12582912" crc="1c7e5d6e" sha1="ff7721bea55f0447e5eb84f5583bbb67de1348d3" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="ganbare nippon olympics 2000 (japan).bin" size="0xc00000" crc="1c7e5d6e" sha1="ff7721bea55f0447e5eb84f5583bbb67de1348d3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4266,8 +4266,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NGXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="gauntlet legends (europe).bin" size="16777216" crc="d9f765ad" sha1="e659120ebde6fe00da6815d0e10360d7a0652557" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="gauntlet legends (europe).bin" size="0x1000000" crc="d9f765ad" sha1="e659120ebde6fe00da6815d0e10360d7a0652557" />
 			</dataarea>
 		</part>
 	</software>
@@ -4280,8 +4280,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="ガントレット レジェンド"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="gauntlet legends (japan).bin" size="16777216" crc="1f3a1912" sha1="c7938e334f9fa10004355f7163d5a7f3b80d981d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="gauntlet legends (japan).bin" size="0x1000000" crc="1f3a1912" sha1="c7938e334f9fa10004355f7163d5a7f3b80d981d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4296,8 +4296,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NGXE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ngxe-0.u1" size="16777216" crc="7e90c0a8" sha1="5debf6cc5dc00b962b29079caf505cdf50914e1d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ngxe-0.u1" size="0x1000000" crc="7e90c0a8" sha1="5debf6cc5dc00b962b29079caf505cdf50914e1d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4316,8 +4316,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nglj-0.u1" size="12582912" crc="bbd2ae37" sha1="17507afa02aec34fe3af3077ef60a4a990626160" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nglj-0.u1" size="0xc00000" crc="bbd2ae37" sha1="17507afa02aec34fe3af3077ef60a4a990626160" />
 			</dataarea>
 		</part>
 	</software>
@@ -4328,8 +4328,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NX3P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="gex 3 - deep cover gecko (europe) (en,es,it).bin" size="33554432" crc="1110cc22" sha1="1071d9cde1dedd1f44aec60cab40703643094d33" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="gex 3 - deep cover gecko (europe) (en,es,it).bin" size="0x2000000" crc="1110cc22" sha1="1071d9cde1dedd1f44aec60cab40703643094d33" />
 			</dataarea>
 		</part>
 	</software>
@@ -4340,8 +4340,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NX3X-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="gex 3 - deep cover gecko (europe) (fr,de).bin" size="33554432" crc="d169e9f8" sha1="ee133817a0ac2d0be0f0ef8aa343f83e70704acc" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="gex 3 - deep cover gecko (europe) (fr,de).bin" size="0x2000000" crc="d169e9f8" sha1="ee133817a0ac2d0be0f0ef8aa343f83e70704acc" />
 			</dataarea>
 		</part>
 	</software>
@@ -4356,8 +4356,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NX3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nx3e-0.u1" size="33554432" crc="3571f3bd" sha1="4d26566ba00f6f633fb41384a01a4464a7371000" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nx3e-0.u1" size="0x2000000" crc="3571f3bd" sha1="4d26566ba00f6f633fb41384a01a4464a7371000" />
 			</dataarea>
 		</part>
 	</software>
@@ -4368,8 +4368,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NX2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="gex 64 - enter the gecko (europe).bin" size="16777216" crc="3e20eafd" sha1="b802dfc2015bd7f944a9633ac06c96f68001c0a8" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="gex 64 - enter the gecko (europe).bin" size="0x1000000" crc="3e20eafd" sha1="b802dfc2015bd7f944a9633ac06c96f68001c0a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -4384,8 +4384,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NX2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nx2e-0.u1" size="16777216" crc="3f90e7c2" sha1="8c10971d9052ef796973f4ce137858109a63a598" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nx2e-0.u1" size="0x1000000" crc="3f90e7c2" sha1="8c10971d9052ef796973f4ce137858109a63a598" />
 			</dataarea>
 		</part>
 	</software>
@@ -4402,8 +4402,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ngvp-0.u1" size="8388608" crc="93dae2a0" sha1="d61d03147a0f88136dd3fef4e934fa8c8bd96bc1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ngvp-0.u1" size="0x800000" crc="93dae2a0" sha1="d61d03147a0f88136dd3fef4e934fa8c8bd96bc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -4418,8 +4418,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NGVE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ngve-0.u1" size="8388608" crc="d024893a" sha1="ed756cae1582a4940ddb854b5376a0013f7f5634" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ngve-0.u1" size="0x800000" crc="d024893a" sha1="ed756cae1582a4940ddb854b5376a0013f7f5634" />
 			</dataarea>
 		</part>
 	</software>
@@ -4431,8 +4431,8 @@ This cart features a RTC, currently unemulated
 		<year>1998</year>
 		<publisher>Hasbro Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="glover (prototype).bin" size="67108864" crc="4c708e6d" sha1="72484ed65cc8cefe23e6536735d053b822bb7fbf"/>
+			<dataarea name="rom" size="0x4000000">
+				<rom name="glover (prototype).bin" size="0x4000000" crc="4c708e6d" sha1="72484ed65cc8cefe23e6536735d053b822bb7fbf"/>
 			</dataarea>
 		</part>
 	</software>
@@ -4442,8 +4442,8 @@ This cart features a RTC, currently unemulated
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="glover 2 - unreleased beta version (new build).bin" size="33554432" crc="57b71a9c" sha1="42ffaa752d2bdc27e524cb402f868c4dd36fc606" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="glover 2 - unreleased beta version (new build).bin" size="0x2000000" crc="57b71a9c" sha1="42ffaa752d2bdc27e524cb402f868c4dd36fc606" />
 			</dataarea>
 		</part>
 	</software>
@@ -4453,8 +4453,8 @@ This cart features a RTC, currently unemulated
 		<year>1999</year>
 		<publisher>Hasbro Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="glover 2 (unreleased beta version).bin" size="33554432" crc="40f45974" sha1="4ac11eb87de52e8e39b4cd404107ff7840e6e8e6" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="glover 2 (unreleased beta version).bin" size="0x2000000" crc="40f45974" sha1="4ac11eb87de52e8e39b4cd404107ff7840e6e8e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4467,8 +4467,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19991225"/>
 		<info name="alt_title" value="ゴエモン もののけ双六"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="goemon - mononoke sugoroku (japan).bin" size="16777216" crc="f6bacbac" sha1="fbb8c3d20023ab13dc8eb95a23f10d8e1063d86b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="goemon - mononoke sugoroku (japan).bin" size="0x1000000" crc="f6bacbac" sha1="fbb8c3d20023ab13dc8eb95a23f10d8e1063d86b" />
 			</dataarea>
 		</part>
 	</software>
@@ -4483,8 +4483,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NGME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ngme-0.u1" size="16777216" crc="e3c7a184" sha1="fb5f82d315ec99e5cd1ed5edda0d2f289231851e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ngme-0.u1" size="0x1000000" crc="e3c7a184" sha1="fb5f82d315ec99e5cd1ed5edda0d2f289231851e" />
 			</dataarea>
 		</part>
 	</software>
@@ -4501,8 +4501,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ngne-0.u1" size="8388608" crc="05a0db83" sha1="fe9d5a5ebd075b9030f23c0525cedda6fe790002" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ngne-0.u1" size="0x800000" crc="05a0db83" sha1="fe9d5a5ebd075b9030f23c0525cedda6fe790002" />
 			</dataarea>
 		</part>
 	</software>
@@ -4513,8 +4513,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NGCP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="gt64 - championship edition (europe) (en,fr,de).bin" size="12582912" crc="b06d0d85" sha1="a2016364dde65ec5746bab9710bd4fa72da25485" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="gt64 - championship edition (europe) (en,fr,de).bin" size="0xc00000" crc="b06d0d85" sha1="a2016364dde65ec5746bab9710bd4fa72da25485" />
 			</dataarea>
 		</part>
 	</software>
@@ -4529,8 +4529,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NGCE-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ngce-0.u1" size="12582912" crc="b6dc4cfd" sha1="bbf4039865fdcf30e403a45478dc6c8450944512" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ngce-0.u1" size="0xc00000" crc="b6dc4cfd" sha1="bbf4039865fdcf30e403a45478dc6c8450944512" />
 			</dataarea>
 		</part>
 	</software>
@@ -4557,8 +4557,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u14" value="U14 [LH52V246]" />
 			<feature name="sw1" value="SW1" /> <!-- .... -->
 			<feature name="batt" value="BATT [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="obs-ngce.bin" size="16777216" crc="db690612" sha1="026d2d02a103e3c1d5ddfafbc605e6110768cb14" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="obs-ngce.bin" size="0x1000000" crc="db690612" sha1="026d2d02a103e3c1d5ddfafbc605e6110768cb14" />
 			</dataarea>
 		</part>
 	</software>
@@ -4571,8 +4571,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20010406"/>
 		<info name="alt_title" value="ハムスター物語64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="hamster monogatari 64 (japan).bin" size="12582912" crc="689191c6" sha1="0460de6b25d40ca4f8d7c4af671c736f029812f6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="hamster monogatari 64 (japan).bin" size="0xc00000" crc="689191c6" sha1="0460de6b25d40ca4f8d7c4af671c736f029812f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -4585,8 +4585,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971226"/>
 		<info name="alt_title" value="マスターズ'98 〜遥かなるオーガスタ〜"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="harukanaru augusta - masters '98 (japan).bin" size="16777216" crc="ad4720e2" sha1="ca7bcae17e76880d3853c96e842db4ee0538630d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="harukanaru augusta - masters '98 (japan).bin" size="0x1000000" crc="ad4720e2" sha1="ca7bcae17e76880d3853c96e842db4ee0538630d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4603,8 +4603,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [74LV2416]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nywe-0.u1" size="16777216" crc="d2ee315f" sha1="7fcab48a10a9b3b7ba5834347ff180c74d7b932c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nywe-0.u1" size="0x1000000" crc="d2ee315f" sha1="7fcab48a10a9b3b7ba5834347ff180c74d7b932c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4617,8 +4617,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971128"/>
 		<info name="alt_title" value="HEIWA パチンコワールド64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="heiwa pachinko world 64 (japan).bin" size="8388608" crc="3acb817e" sha1="0143e37535187f5ff40eed1c0b7a41a195c0e724" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="heiwa pachinko world 64 (japan).bin" size="0x800000" crc="3acb817e" sha1="0143e37535187f5ff40eed1c0b7a41a195c0e724" />
 			</dataarea>
 		</part>
 	</software>
@@ -4629,8 +4629,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NHCP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="hercules - the legendary journeys (europe) (en,fr,de,es,it,nl).bin" size="16777216" crc="65517307" sha1="9fc6c63eb8641d957342aa5f31d35075bc5b9e8c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="hercules - the legendary journeys (europe) (en,fr,de,es,it,nl).bin" size="0x1000000" crc="65517307" sha1="9fc6c63eb8641d957342aa5f31d35075bc5b9e8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -4645,8 +4645,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHCE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nhce-0.u1" size="16777216" crc="cf90bc4a" sha1="09e56e035981831a2bb0b932774e4ebe34ea175f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nhce-0.u1" size="0x1000000" crc="cf90bc4a" sha1="09e56e035981831a2bb0b932774e4ebe34ea175f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4657,8 +4657,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NHXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="hexen (europe).bin" size="8388608" crc="ed939f94" sha1="3970a749e5b88e8130418cb06a28af84c54be40d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="hexen (europe).bin" size="0x800000" crc="ed939f94" sha1="3970a749e5b88e8130418cb06a28af84c54be40d" />
 			</dataarea>
 		</part>
 	</software>
@@ -4669,8 +4669,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NHXF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="hexen (france).bin" size="8388608" crc="4b3dc7fe" sha1="84da065c47e1d29155b9869970b9156428a1ae00" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="hexen (france).bin" size="0x800000" crc="4b3dc7fe" sha1="84da065c47e1d29155b9869970b9156428a1ae00" />
 			</dataarea>
 		</part>
 	</software>
@@ -4681,8 +4681,8 @@ This cart features a RTC, currently unemulated
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NHXD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="hexen (germany).bin" size="8388608" crc="176c6242" sha1="4c70006b724fc43a3283b8e2aae9941be6f67dea" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="hexen (germany).bin" size="0x800000" crc="176c6242" sha1="4c70006b724fc43a3283b8e2aae9941be6f67dea" />
 			</dataarea>
 		</part>
 	</software>
@@ -4695,8 +4695,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971218"/>
 		<info name="alt_title" value="ヘクセン"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="hexen (japan).bin" size="8388608" crc="3d157140" sha1="70adc890606315107d97adedc02d210ab7ae8a57" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="hexen (japan).bin" size="0x800000" crc="3d157140" sha1="70adc890606315107d97adedc02d210ab7ae8a57" />
 			</dataarea>
 		</part>
 	</software>
@@ -4711,8 +4711,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHXE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nhxe-0.u1" size="8388608" crc="d2b22343" sha1="5b58cc647fb10178c89d4dacc97cd25f5fbff2d0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nhxe-0.u1" size="0x800000" crc="d2b22343" sha1="5b58cc647fb10178c89d4dacc97cd25f5fbff2d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -4735,8 +4735,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NPGE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npge-0.u1" size="16777216" crc="0149e9f6" sha1="615835390e80921f37cb9c081d27fea42920fcce" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npge-0.u1" size="0x1000000" crc="0149e9f6" sha1="615835390e80921f37cb9c081d27fea42920fcce" />
 			</dataarea>
 		</part>
 	</software>
@@ -4753,8 +4753,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHKJ-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nhkj-0.u1" size="12582912" crc="4a07511c" sha1="bf68b9514a78040edd62863dfe15b75aed397cdb" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nhkj-0.u1" size="0xc00000" crc="4a07511c" sha1="bf68b9514a78040edd62863dfe15b75aed397cdb" />
 			</dataarea>
 		</part>
 	</software>
@@ -4770,8 +4770,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-netp-0.u1" size="16777216" crc="2f886030" sha1="4a5fad6564ffb69b874b1054b702e64aed197387" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-netp-0.u1" size="0x1000000" crc="2f886030" sha1="4a5fad6564ffb69b874b1054b702e64aed197387" />
 			</dataarea>
 		</part>
 	</software>
@@ -4782,8 +4782,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NETF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="holy magic century (france).bin" size="16777216" crc="cefc98aa" sha1="31f28c9a0c6b0ca00a6015496b377936e196d498" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="holy magic century (france).bin" size="0x1000000" crc="cefc98aa" sha1="31f28c9a0c6b0ca00a6015496b377936e196d498" />
 			</dataarea>
 		</part>
 	</software>
@@ -4794,8 +4794,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NETD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="holy magic century (germany).bin" size="16777216" crc="40796997" sha1="92dccc50ec31676ed983aa0bd5e4056137919ab2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="holy magic century (germany).bin" size="0x1000000" crc="40796997" sha1="92dccc50ec31676ed983aa0bd5e4056137919ab2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4808,8 +4808,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="星のカービィ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hoshi no kirby 64 (japan) (rev c).bin" size="33554432" crc="3dec34a5" sha1="95e28e31109a42e80a6a4afebb3157b8acc6b4ec" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hoshi no kirby 64 (japan) (rev c).bin" size="0x2000000" crc="3dec34a5" sha1="95e28e31109a42e80a6a4afebb3157b8acc6b4ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -4822,8 +4822,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="星のカービィ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hoshi no kirby 64 (japan) (rev b).bin" size="33554432" crc="32d2d11e" sha1="84e2597bc65a67e8c74e47b38614c89d42e3316f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hoshi no kirby 64 (japan) (rev b).bin" size="0x2000000" crc="32d2d11e" sha1="84e2597bc65a67e8c74e47b38614c89d42e3316f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4836,8 +4836,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="星のカービィ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hoshi no kirby 64 (japan) (rev a).bin" size="33554432" crc="e2fab230" sha1="e2fb9469e99ca6ed48fbe19b1f57f5fd653981a3" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hoshi no kirby 64 (japan) (rev a).bin" size="0x2000000" crc="e2fab230" sha1="e2fb9469e99ca6ed48fbe19b1f57f5fd653981a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -4850,8 +4850,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000324"/>
 		<info name="alt_title" value="星のカービィ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hoshi no kirby 64 (japan).bin" size="33554432" crc="fcacbe90" sha1="8861aacdf6c36b40ae2031a85798173d8d180c91" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hoshi no kirby 64 (japan).bin" size="0x2000000" crc="fcacbe90" sha1="8861aacdf6c36b40ae2031a85798173d8d180c91" />
 			</dataarea>
 		</part>
 	</software>
@@ -4862,8 +4862,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NHWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="hot wheels - turbo racing (europe) (en,fr,de).bin" size="16777216" crc="ef63c780" sha1="1bf92987c5531ae213ed1d721980c61f580436fa" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="hot wheels - turbo racing (europe) (en,fr,de).bin" size="0x1000000" crc="ef63c780" sha1="1bf92987c5531ae213ed1d721980c61f580436fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -4878,8 +4878,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHWE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nhwe-0.u1" size="12582912" crc="525e8f8f" sha1="477818165666648bfbe8452f2f89f42277add932" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nhwe-0.u1" size="0xc00000" crc="525e8f8f" sha1="477818165666648bfbe8452f2f89f42277add932" />
 			</dataarea>
 		</part>
 	</software>
@@ -4890,8 +4890,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NNSX-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="hsv adventure racing (australia).bin" size="16777216" crc="fb1294c3" sha1="066b18e04a5ae248db3b7041f73fe3e8e883de93" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="hsv adventure racing (australia).bin" size="0x1000000" crc="fb1294c3" sha1="066b18e04a5ae248db3b7041f73fe3e8e883de93" />
 			</dataarea>
 		</part>
 	</software>
@@ -4904,8 +4904,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970328"/>
 		<info name="alt_title" value="ヒューマングランプリザ・ニュージェネレーション"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="human grand prix - the new generation (japan).bin" size="8388608" crc="a3fc9aea" sha1="d7bc56c4ed710091bec56c3e1485adf1c533d1c5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="human grand prix - the new generation (japan).bin" size="0x800000" crc="a3fc9aea" sha1="d7bc56c4ed710091bec56c3e1485adf1c533d1c5" />
 			</dataarea>
 		</part>
 	</software>
@@ -4916,8 +4916,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NHVP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="hybrid heaven (europe) (en,fr,de).bin" size="16777216" crc="8696b2a2" sha1="3ed6d3b4127dc26fae32e88e1fd78bf95e1118e2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="hybrid heaven (europe) (en,fr,de).bin" size="0x1000000" crc="8696b2a2" sha1="3ed6d3b4127dc26fae32e88e1fd78bf95e1118e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -4930,8 +4930,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990805"/>
 		<info name="alt_title" value="ハイブリッドヘブン"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="hybrid heaven (japan).bin" size="16777216" crc="42e44701" sha1="6b755fc59f35f0f25c46f062471699533ab99da4" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="hybrid heaven (japan).bin" size="0x1000000" crc="42e44701" sha1="6b755fc59f35f0f25c46f062471699533ab99da4" />
 			</dataarea>
 		</part>
 	</software>
@@ -4946,8 +4946,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHVE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nhve-0.u1" size="16777216" crc="7ce3ea39" sha1="a0f6777dcecf8b956f12ff69ec5051a9be4c234f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nhve-0.u1" size="0x1000000" crc="7ce3ea39" sha1="a0f6777dcecf8b956f12ff69ec5051a9be4c234f" />
 			</dataarea>
 		</part>
 	</software>
@@ -4958,8 +4958,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NHTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hydro thunder (europe).bin" size="33554432" crc="b75696ae" sha1="6377afc193b7c8fa8ad3f8b3a41279d05702e43a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hydro thunder (europe).bin" size="0x2000000" crc="b75696ae" sha1="6377afc193b7c8fa8ad3f8b3a41279d05702e43a" />
 			</dataarea>
 		</part>
 	</software>
@@ -4970,8 +4970,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NHTF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="hydro thunder (france).bin" size="33554432" crc="c8cd9b5d" sha1="164c60c5966e4716f3a5aef6bf6eb023e4875d32" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="hydro thunder (france).bin" size="0x2000000" crc="c8cd9b5d" sha1="164c60c5966e4716f3a5aef6bf6eb023e4875d32" />
 			</dataarea>
 		</part>
 	</software>
@@ -4986,8 +4986,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NHTE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nhte-0.u1" size="33554432" crc="6b78c2c8" sha1="665e3d9773b0a6802814cd3e7b930cab62fc583d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nhte-0.u1" size="0x2000000" crc="6b78c2c8" sha1="665e3d9773b0a6802814cd3e7b930cab62fc583d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5004,8 +5004,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NH5J-0]" /> <!-- MX23L9602-35 -->
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="hyper olympics in nagano 64 (japan).bin" size="12582912" crc="f7c2bb67" sha1="51ea8af6b29fc99a9c61dd2242c3732b6cdf43dc" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="hyper olympics in nagano 64 (japan).bin" size="0xc00000" crc="f7c2bb67" sha1="51ea8af6b29fc99a9c61dd2242c3732b6cdf43dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -5024,8 +5024,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nimj-0.u1" size="12582912" crc="32003c85" sha1="278e45431689b52ce28955957b444ae4f8539199" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nimj-0.u1" size="0xc00000" crc="32003c85" sha1="278e45431689b52ce28955957b444ae4f8539199" />
 			</dataarea>
 		</part>
 	</software>
@@ -5036,8 +5036,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NWBP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="iggy's reckin' balls (europe).bin" size="4194304" crc="76530405" sha1="67c05c4056fe7e38d34fea26e4a87edf570910af" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="iggy's reckin' balls (europe).bin" size="0x400000" crc="76530405" sha1="67c05c4056fe7e38d34fea26e4a87edf570910af" />
 			</dataarea>
 		</part>
 	</software>
@@ -5052,8 +5052,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NWBE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nwbe-0.u1" size="4194304" crc="5953567e" sha1="289a26f3a0d656ff522252caabc0e005c760faca" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nwbe-0.u1" size="0x400000" crc="5953567e" sha1="289a26f3a0d656ff522252caabc0e005c760faca" />
 			</dataarea>
 		</part>
 	</software>
@@ -5066,8 +5066,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980828"/>
 		<info name="alt_title" value="イギーくんのぶら2ぽよん"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="iggy-kun no bura bura poyon (japan).bin" size="4194304" crc="e133064b" sha1="02542cfdc3734350403e4fb7cc139953436584d8" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="iggy-kun no bura bura poyon (japan).bin" size="0x400000" crc="e133064b" sha1="02542cfdc3734350403e4fb7cc139953436584d8" />
 			</dataarea>
 		</part>
 	</software>
@@ -5078,8 +5078,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Take Two Software</publisher>
 		<info name="serial" value="NUS-NFHP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="in-fisherman - bass hunter 64 (europe).bin" size="8388608" crc="930e6f44" sha1="3d09c3384069a4bcf959bfb05cf7a9f398c6ceb6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="in-fisherman - bass hunter 64 (europe).bin" size="0x800000" crc="930e6f44" sha1="3d09c3384069a4bcf959bfb05cf7a9f398c6ceb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5094,8 +5094,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFHE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nfhe-0.u1" size="8388608" crc="88279f19" sha1="39fde60d5447006cf864624860f3889c8b20ef27" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nfhe-0.u1" size="0x800000" crc="88279f19" sha1="39fde60d5447006cf864624860f3889c8b20ef27" />
 			</dataarea>
 		</part>
 	</software>
@@ -5105,8 +5105,8 @@ This cart features a RTC, currently unemulated
 		<year>2000</year>
 		<publisher>LucasArts</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="indiana jones and the infernal machine (unreleased pal).bin" size="33554432" crc="de726d5a" sha1="be6abe64badfae9dc5f24d564e6c32fdcc442af7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="indiana jones and the infernal machine (unreleased pal).bin" size="0x2000000" crc="de726d5a" sha1="be6abe64badfae9dc5f24d564e6c32fdcc442af7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5121,8 +5121,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NIJE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nije-0.u1" size="33554432" crc="a8f86eb6" sha1="9d326652e881d80742e49c51d60fa3ffea21207c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nije-0.u1" size="0x2000000" crc="a8f86eb6" sha1="9d326652e881d80742e49c51d60fa3ffea21207c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5137,8 +5137,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NICE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nice-0.u1" size="16777216" crc="1c622354" sha1="b8983fa34d9614af433fee6dfd331bf8793a4dd1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nice-0.u1" size="0x1000000" crc="1c622354" sha1="b8983fa34d9614af433fee6dfd331bf8793a4dd1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5154,8 +5154,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwsp-0.u1" size="12582912" crc="463fe8b7" sha1="4fc51fbe034f8572b4727756778de7a27b43c81a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwsp-0.u1" size="0xc00000" crc="463fe8b7" sha1="4fc51fbe034f8572b4727756778de7a27b43c81a" />
 			</dataarea>
 		</part>
 	</software>
@@ -5170,8 +5170,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NWSE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwse-0.u1" size="12582912" crc="d685f2ec" sha1="1ee4dd4d774fed61248513e0d2f5285918b98d73" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwse-0.u1" size="0xc00000" crc="d685f2ec" sha1="1ee4dd4d774fed61248513e0d2f5285918b98d73" />
 			</dataarea>
 		</part>
 	</software>
@@ -5188,8 +5188,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nisx-0.u1" size="16777216" crc="61799242" sha1="e6d2b8e25d3fcd9f38439ef07d71e9f8a48a4f99" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nisx-0.u1" size="0x1000000" crc="61799242" sha1="e6d2b8e25d3fcd9f38439ef07d71e9f8a48a4f99" />
 			</dataarea>
 		</part>
 	</software>
@@ -5200,8 +5200,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NISY-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="international superstar soccer 2000 (europe) (fr,it).bin" size="16777216" crc="7d7dcd46" sha1="640ec4bf4c838814b003add093b0f9642058fe04" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="international superstar soccer 2000 (europe) (fr,it).bin" size="0x1000000" crc="7d7dcd46" sha1="640ec4bf4c838814b003add093b0f9642058fe04" />
 			</dataarea>
 		</part>
 	</software>
@@ -5216,8 +5216,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NISE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nise-0.u1" size="16777216" crc="bb1824b8" sha1="d86386eeee1b5b32ce43bc9a4149314a23a6320b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nise-0.u1" size="0x1000000" crc="bb1824b8" sha1="d86386eeee1b5b32ce43bc9a4149314a23a6320b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5234,8 +5234,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nise-1.u1" size="16777216" crc="8b73672c" sha1="aa53928967839fcdd864b3f384f23fda435e3e5e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nise-1.u1" size="0x1000000" crc="8b73672c" sha1="aa53928967839fcdd864b3f384f23fda435e3e5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5246,8 +5246,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NJPP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="international superstar soccer 64 (europe).bin" size="8388608" crc="662da098" sha1="c19b5dd94ed7ec6799da5f41a14ec67f2493f119" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="international superstar soccer 64 (europe).bin" size="0x800000" crc="662da098" sha1="c19b5dd94ed7ec6799da5f41a14ec67f2493f119" />
 			</dataarea>
 		</part>
 	</software>
@@ -5262,8 +5262,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NJPE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-njpe-0.u1" size="8388608" crc="91cb6803" sha1="94d4969597596c9e990754aefdd506d3c75177ba" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-njpe-0.u1" size="0x800000" crc="91cb6803" sha1="94d4969597596c9e990754aefdd506d3c75177ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -5274,8 +5274,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-N3HP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="international track &amp; field - summer games (europe) (en,fr,de).bin" size="12582912" crc="73073ec2" sha1="e08b8e0eb424cb9044b53d5d903ab89cc82f0fb8" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="international track &amp; field - summer games (europe) (en,fr,de).bin" size="0xc00000" crc="73073ec2" sha1="e08b8e0eb424cb9044b53d5d903ab89cc82f0fb8" />
 			</dataarea>
 		</part>
 	</software>
@@ -5290,8 +5290,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-N3HE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n3he-0.u1" size="12582912" crc="f93868a3" sha1="d5b614b9a95086b2366c5470659fa5b89facec68" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n3he-0.u1" size="0xc00000" crc="f93868a3" sha1="d5b614b9a95086b2366c5470659fa5b89facec68" />
 			</dataarea>
 		</part>
 	</software>
@@ -5312,8 +5312,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nibj-0.u1" size="16777216" crc="5e9c3e4b" sha1="e9581337df0f93638ddaf328f84bfe92e5764474" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nibj-0.u1" size="0x1000000" crc="5e9c3e4b" sha1="e9581337df0f93638ddaf328f84bfe92e5764474" />
 			</dataarea>
 		</part>
 	</software>
@@ -5326,8 +5326,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970905"/>
 		<info name="alt_title" value="Jリーグダイナマイトサッカー64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="j.league dynamite soccer 64 (japan).bin" size="8388608" crc="67ec5f38" sha1="fbd0a8b7d405a06e3a955e6f897c667eac3f03a7" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="j.league dynamite soccer 64 (japan).bin" size="0x800000" crc="67ec5f38" sha1="fbd0a8b7d405a06e3a955e6f897c667eac3f03a7" />
 			</dataarea>
 		</part>
 	</software>
@@ -5340,8 +5340,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19971024"/>
 		<info name="alt_title" value="Jリーグ イレブンビート1997"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="j.league eleven beat 1997 (japan).bin" size="8388608" crc="b2d77747" sha1="c5d159bddc89da2224e1d32c695248998c4560bd" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="j.league eleven beat 1997 (japan).bin" size="0x800000" crc="b2d77747" sha1="c5d159bddc89da2224e1d32c695248998c4560bd" />
 			</dataarea>
 		</part>
 	</software>
@@ -5354,8 +5354,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970328"/>
 		<info name="alt_title" value="Jリーグライブ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="j.league live 64 (japan).bin" size="8388608" crc="8a48de94" sha1="563c4f5d0b7cbe2ec675153d52eefb2901e5b624" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="j.league live 64 (japan).bin" size="0x800000" crc="8a48de94" sha1="563c4f5d0b7cbe2ec675153d52eefb2901e5b624" />
 			</dataarea>
 		</part>
 	</software>
@@ -5368,8 +5368,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990115"/>
 		<info name="alt_title" value="Jリーグタクティクスサッカー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="j.league tactics soccer (japan) (rev a).bin" size="12582912" crc="71fa1d4d" sha1="bc3a2585e96e64e1f0d8cb7c2f7f38f0a6163319" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="j.league tactics soccer (japan) (rev a).bin" size="0xc00000" crc="71fa1d4d" sha1="bc3a2585e96e64e1f0d8cb7c2f7f38f0a6163319" />
 			</dataarea>
 		</part>
 	</software>
@@ -5382,8 +5382,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990115"/>
 		<info name="alt_title" value="Jリーグタクティクスサッカー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="j.league tactics soccer (japan).bin" size="12582912" crc="0b6c70ea" sha1="058e9ccd131199394e0d6e6f6ea04aeeb2946d59" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="j.league tactics soccer (japan).bin" size="0xc00000" crc="0b6c70ea" sha1="058e9ccd131199394e0d6e6f6ea04aeeb2946d59" />
 			</dataarea>
 		</part>
 	</software>
@@ -5396,8 +5396,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970725"/>
 		<info name="alt_title" value="雀豪シミュレーション 麻雀道64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="jangou simulation mahjong dou 64 (japan).bin" size="8388608" crc="27e9853c" sha1="d969105f2ec0d1116e35b66410acac4b207aaf3d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="jangou simulation mahjong dou 64 (japan).bin" size="0x800000" crc="27e9853c" sha1="d969105f2ec0d1116e35b66410acac4b207aaf3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5412,8 +5412,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NJOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-njoe-0.u1" size="4194304" crc="82b2ab69" sha1="6f22227ea9a64f16f4b8a5a8b84a30fac55fd84c" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-njoe-0.u1" size="0x400000" crc="82b2ab69" sha1="6f22227ea9a64f16f4b8a5a8b84a30fac55fd84c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5424,8 +5424,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NCOP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jeremy mcgrath supercross 2000 (europe).bin" size="16777216" crc="efe0b465" sha1="3e61ce15a20be752240c889c37be82270bdd423e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jeremy mcgrath supercross 2000 (europe).bin" size="0x1000000" crc="efe0b465" sha1="3e61ce15a20be752240c889c37be82270bdd423e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5436,8 +5436,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NCOE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jeremy mcgrath supercross 2000 (usa).bin" size="16777216" crc="67bf293b" sha1="1c0352bad4f56f1cf5d892e85f2d04d956edb49e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jeremy mcgrath supercross 2000 (usa).bin" size="0x1000000" crc="67bf293b" sha1="1c0352bad4f56f1cf5d892e85f2d04d956edb49e" />
 			</dataarea>
 		</part>
 	</software>
@@ -5454,8 +5454,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7105]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-njfp-0.u1" size="33554432" crc="fec297ef" sha1="3085a20258f3a554839d0007cb231bc9b96875bc" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-njfp-0.u1" size="0x2000000" crc="fec297ef" sha1="3085a20258f3a554839d0007cb231bc9b96875bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -5472,8 +5472,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6105]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-njfe-0.u1" size="33554432" crc="b5932174" sha1="aa7edc75952104f0b52bf1300df427835a128b01" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-njfe-0.u1" size="0x2000000" crc="b5932174" sha1="aa7edc75952104f0b52bf1300df427835a128b01" />
 			</dataarea>
 		</part>
 	</software>
@@ -5489,8 +5489,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6105]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-njde-0.u1" size="33554432" crc="6e75735b" sha1="4c1eedfac94ea2041a765e60caac00abf77a678d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-njde-0.u1" size="0x2000000" crc="6e75735b" sha1="4c1eedfac94ea2041a765e60caac00abf77a678d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5503,8 +5503,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="実況GIステイブル"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou g1 stable (japan) (rev a).bin" size="16777216" crc="142072bf" sha1="6da9b4181b3aec624d9b9ce507251c319313411f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou g1 stable (japan) (rev a).bin" size="0x1000000" crc="142072bf" sha1="6da9b4181b3aec624d9b9ce507251c319313411f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5517,8 +5517,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990428"/>
 		<info name="alt_title" value="実況GIステイブル"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou g1 stable (japan).bin" size="16777216" crc="97669431" sha1="076d1ef9af18a6456048a1699aad377aeab8772f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou g1 stable (japan).bin" size="0x1000000" crc="97669431" sha1="076d1ef9af18a6456048a1699aad377aeab8772f" />
 			</dataarea>
 		</part>
 	</software>
@@ -5535,8 +5535,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NJPJ-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-njpj-0.u1" size="8388608" crc="97e1bce2" sha1="260270b33f3add84c99b5f2e4aa6f7c3f2abe93b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-njpj-0.u1" size="0x800000" crc="97e1bce2" sha1="260270b33f3add84c99b5f2e4aa6f7c3f2abe93b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5549,8 +5549,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990729"/>
 		<info name="alt_title" value="実況J.LEAGUE1999 パーフェクトストライカー2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou j.league 1999 - perfect striker 2 (japan) (rev a).bin" size="16777216" crc="b4131606" sha1="5a3734b75495372b0c6d45f9dd4dfcf57bc75be8" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou j.league 1999 - perfect striker 2 (japan) (rev a).bin" size="0x1000000" crc="b4131606" sha1="5a3734b75495372b0c6d45f9dd4dfcf57bc75be8" />
 			</dataarea>
 		</part>
 	</software>
@@ -5563,8 +5563,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990729"/>
 		<info name="alt_title" value="実況J.LEAGUE1999 パーフェクトストライカー2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou j.league 1999 - perfect striker 2 (japan).bin" size="16777216" crc="8e2f8322" sha1="25033e8ebaa71316d108de450971180b544de315" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou j.league 1999 - perfect striker 2 (japan).bin" size="0x1000000" crc="8e2f8322" sha1="25033e8ebaa71316d108de450971180b544de315" />
 			</dataarea>
 		</part>
 	</software>
@@ -5577,8 +5577,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000429"/>
 		<info name="alt_title" value="実況パワフルプロ野球2000"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu 2000 (japan) (rev a).bin" size="16777216" crc="4e6faa43" sha1="6f32972fe2fdce0ac051787b8253950aa36487d1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu 2000 (japan) (rev a).bin" size="0x1000000" crc="4e6faa43" sha1="6f32972fe2fdce0ac051787b8253950aa36487d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5598,9 +5598,9 @@ This cart features a RTC, currently unemulated
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-np4j-0 02.u1" size="8388608" crc="1ac6624d" sha1="2cb0dca3f271a2cd6f1558727d9446acc44ec669" offset="0x000000" />
-				<rom name="nus-np4j-0 12.u2" size="4194304" crc="f5604b17" sha1="962c05e34019d19df88a6873e2dc8580173e036c" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-np4j-0 02.u1" size="0x800000" crc="1ac6624d" sha1="2cb0dca3f271a2cd6f1558727d9446acc44ec669" offset="0x000000" />
+				<rom name="nus-np4j-0 12.u2" size="0x400000" crc="f5604b17" sha1="962c05e34019d19df88a6873e2dc8580173e036c" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -5617,8 +5617,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NP4J-1]" /> <!-- MX23L9602-35 -->
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="jikkyou powerful pro yakyuu 4 (japan) (rev a).bin" size="12582912" crc="435126ae" sha1="44287562745c42662b61224ebfd9b483867eafee" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="jikkyou powerful pro yakyuu 4 (japan) (rev a).bin" size="0xc00000" crc="435126ae" sha1="44287562745c42662b61224ebfd9b483867eafee" />
 			</dataarea>
 		</part>
 	</software>
@@ -5631,8 +5631,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970314"/>
 		<info name="alt_title" value="実況パワフルプロ野球4"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="jikkyou powerful pro yakyuu 4 (japan).bin" size="12582912" crc="8d2540f1" sha1="73016b7c15bae869b0d868e62b433400503ef540" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="jikkyou powerful pro yakyuu 4 (japan).bin" size="0xc00000" crc="8d2540f1" sha1="73016b7c15bae869b0d868e62b433400503ef540" />
 			</dataarea>
 		</part>
 	</software>
@@ -5645,8 +5645,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980326"/>
 		<info name="alt_title" value="実況パワフルプロ野球5"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu 5 (japan) (rev b).bin" size="16777216" crc="5b39c8b2" sha1="6105e653e99e56b6e0edf80db35031bf0f0b1881" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu 5 (japan) (rev b).bin" size="0x1000000" crc="5b39c8b2" sha1="6105e653e99e56b6e0edf80db35031bf0f0b1881" />
 			</dataarea>
 		</part>
 	</software>
@@ -5667,8 +5667,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nj5j-1.u1" size="16777216" crc="a25d1427" sha1="483e455584f8fd4a4ad002d9718695d3a11cbfc6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nj5j-1.u1" size="0x1000000" crc="a25d1427" sha1="483e455584f8fd4a4ad002d9718695d3a11cbfc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5687,8 +5687,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [BU9803A]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu 5 (japan).bin" size="16777216" crc="94fa55ff" sha1="7822e0015e716ae540e95f50c32558eaa7865174" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu 5 (japan).bin" size="0x1000000" crc="94fa55ff" sha1="7822e0015e716ae540e95f50c32558eaa7865174" />
 			</dataarea>
 		</part>
 	</software>
@@ -5701,8 +5701,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="実況パワフルプロ野球6"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev b).bin" size="16777216" crc="e8d4a365" sha1="be9811a86db41f5b1f4844bc004aa34d1d4bc406" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev b).bin" size="0x1000000" crc="e8d4a365" sha1="be9811a86db41f5b1f4844bc004aa34d1d4bc406" />
 			</dataarea>
 		</part>
 	</software>
@@ -5715,8 +5715,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990325"/>
 		<info name="alt_title" value="実況パワフルプロ野球6"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev a).bin" size="16777216" crc="5b6351f1" sha1="713b5c8bf72d78b97df416923aad589ec3c8ec64" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu 6 (japan) (rev a).bin" size="0x1000000" crc="5b6351f1" sha1="713b5c8bf72d78b97df416923aad589ec3c8ec64" />
 			</dataarea>
 		</part>
 	</software>
@@ -5737,8 +5737,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-np6j-0.u1" size="16777216" crc="a54e4397" sha1="ae89aa2cd42aa841984c3e9ee2e3aada1148bf2d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-np6j-0.u1" size="0x1000000" crc="a54e4397" sha1="ae89aa2cd42aa841984c3e9ee2e3aada1148bf2d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5751,8 +5751,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20010329"/>
 		<info name="alt_title" value="実況パワフルプロ野球 Basic版2001"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan) (rev a).bin" size="16777216" crc="68d57df2" sha1="897d785332af3f7f055b23e7d848e60874003bd5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan) (rev a).bin" size="0x1000000" crc="68d57df2" sha1="897d785332af3f7f055b23e7d848e60874003bd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -5765,8 +5765,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20010329"/>
 		<info name="alt_title" value="実況パワフルプロ野球 Basic版2001"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan).bin" size="16777216" crc="4e102917" sha1="0f34cc6c6448cf4956dccdabeac0fbbd1f36dca1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou powerful pro yakyuu basic ban 2001 (japan).bin" size="0x1000000" crc="4e102917" sha1="0f34cc6c6448cf4956dccdabeac0fbbd1f36dca1" />
 			</dataarea>
 		</part>
 	</software>
@@ -5779,8 +5779,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980604"/>
 		<info name="alt_title" value="実況ワールドサッカーワールドカップ フランス'98"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou world soccer - world cup france '98 (japan) (rev b).bin" size="16777216" crc="55551947" sha1="b86cb29227a7173338b6a2245e760be5344379b6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou world soccer - world cup france '98 (japan) (rev b).bin" size="0x1000000" crc="55551947" sha1="b86cb29227a7173338b6a2245e760be5344379b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5793,8 +5793,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980604"/>
 		<info name="alt_title" value="実況ワールドサッカーワールドカップ フランス'98"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou world soccer - world cup france '98 (japan) (rev a).bin" size="16777216" crc="7576897d" sha1="cfbdeb8a9218b147b2cff8d087b3d3fb07e9cd37" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou world soccer - world cup france '98 (japan) (rev a).bin" size="0x1000000" crc="7576897d" sha1="cfbdeb8a9218b147b2cff8d087b3d3fb07e9cd37" />
 			</dataarea>
 		</part>
 	</software>
@@ -5807,8 +5807,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19980604"/>
 		<info name="alt_title" value="実況ワールドサッカーワールドカップ フランス'98"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jikkyou world soccer - world cup france '98 (japan).bin" size="16777216" crc="970a3c24" sha1="5ffd475d721c334ed82ca7bc99ed0e17c025d1e4" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jikkyou world soccer - world cup france '98 (japan).bin" size="0x1000000" crc="970a3c24" sha1="5ffd475d721c334ed82ca7bc99ed0e17c025d1e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -5825,8 +5825,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NJ3J-1]" /> <!-- MX23L6402-35 -->
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="jikkyou world soccer 3 (japan).bin" size="8388608" crc="8755de1f" sha1="e1c73256a92e98bcb79d2d4c56efce77f0ff158b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="jikkyou world soccer 3 (japan).bin" size="0x800000" crc="8755de1f" sha1="e1c73256a92e98bcb79d2d4c56efce77f0ff158b" />
 			</dataarea>
 		</part>
 	</software>
@@ -5839,8 +5839,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970530"/>
 		<info name="alt_title" value="時空戦士テュロック"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="jikuu senshi turok (japan).bin" size="8388608" crc="c3230021" sha1="182394e9772985ddd45e4459a58916fba9f386ad" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="jikuu senshi turok (japan).bin" size="0x800000" crc="c3230021" sha1="182394e9772985ddd45e4459a58916fba9f386ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -5853,8 +5853,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="人生ゲーム64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="jinsei game 64 (japan).bin" size="16777216" crc="888b4265" sha1="ce9931571e9d60cc3c92458f89fbdbed214ed833" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="jinsei game 64 (japan).bin" size="0x1000000" crc="888b4265" sha1="ce9931571e9d60cc3c92458f89fbdbed214ed833" />
 			</dataarea>
 		</part>
 	</software>
@@ -5865,8 +5865,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NDWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="john romero's daikatana (europe) (en,fr,de).bin" size="16777216" crc="48f3e888" sha1="0a9400897cb7984a0e927a47f912405664ab70ba" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="john romero's daikatana (europe) (en,fr,de).bin" size="0x1000000" crc="48f3e888" sha1="0a9400897cb7984a0e927a47f912405664ab70ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -5879,8 +5879,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="20000407"/>
 		<info name="alt_title" value="JOHN ROMERO'S 大刀 DAIKATANA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="john romero's daikatana (japan).bin" size="16777216" crc="befb1434" sha1="8bda39f1e1c39020ff259b1d4d1ccb2c87d1ee38" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="john romero's daikatana (japan).bin" size="0x1000000" crc="befb1434" sha1="8bda39f1e1c39020ff259b1d4d1ccb2c87d1ee38" />
 			</dataarea>
 		</part>
 	</software>
@@ -5895,8 +5895,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NDWE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ndwe-0.u1" size="16777216" crc="cb126ea9" sha1="c9f3d07af09adef1cc977bf263b899e005a5aab6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ndwe-0.u1" size="0x1000000" crc="cb126ea9" sha1="c9f3d07af09adef1cc977bf263b899e005a5aab6" />
 			</dataarea>
 		</part>
 	</software>
@@ -5909,8 +5909,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990827"/>
 		<info name="alt_title" value="格闘伝承 F-Cup Maniax"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="kakutou denshou - f-cup maniax (japan).bin" size="16777216" crc="1e967ac0" sha1="6e7116db2a7aabd5f8d6149f34b6e187bcaaec3c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="kakutou denshou - f-cup maniax (japan).bin" size="0x1000000" crc="1e967ac0" sha1="6e7116db2a7aabd5f8d6149f34b6e187bcaaec3c" />
 			</dataarea>
 		</part>
 	</software>
@@ -5925,8 +5925,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKJE-0]" />
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nkje-0.u1" size="16777216" crc="42d1ed42" sha1="ec8497ee9ebe1333032472b39206f9899c9213b3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nkje-0.u1" size="0x1000000" crc="42d1ed42" sha1="ec8497ee9ebe1333032472b39206f9899c9213b3" />
 			</dataarea>
 		</part>
 	</software>
@@ -5937,8 +5937,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NKIP-AUS, NUS-NKIP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="killer instinct gold (europe).bin" size="12582912" crc="19421ca7" sha1="a7a6428ee27e62b9e2d91280c71b29963e5f3b22" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="killer instinct gold (europe).bin" size="0xc00000" crc="19421ca7" sha1="a7a6428ee27e62b9e2d91280c71b29963e5f3b22" />
 			</dataarea>
 		</part>
 	</software>
@@ -5949,8 +5949,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NKIE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="killer instinct gold (usa) (rev b).bin" size="12582912" crc="8e1db3c2" sha1="291f62378dc3d378d443d649689cfcbf43382174" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="killer instinct gold (usa) (rev b).bin" size="0xc00000" crc="8e1db3c2" sha1="291f62378dc3d378d443d649689cfcbf43382174" />
 			</dataarea>
 		</part>
 	</software>
@@ -5961,8 +5961,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NKIE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="killer instinct gold (usa) (rev a).bin" size="12582912" crc="24ac459c" sha1="90b7d7e5a7372ca3abf059c0d24d499fad2e909d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="killer instinct gold (usa) (rev a).bin" size="0xc00000" crc="24ac459c" sha1="90b7d7e5a7372ca3abf059c0d24d499fad2e909d" />
 			</dataarea>
 		</part>
 	</software>
@@ -5978,9 +5978,9 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [NUS-NKIE-0 12]" />
 			<feature name="u3" value="U3 [BU9850]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nkie-0 02.u1" size="8388608" crc="3c6869da" sha1="c7b749502dd5db65d09febcc64a6efe96a348356" offset="0x000000" />
-				<rom name="nus-nkie-0 12.u2" size="4194304" crc="993640cb" sha1="58dd8ea2b34ddd6af8a8a5590cab291dedb7b8a1" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nkie-0 02.u1" size="0x800000" crc="3c6869da" sha1="c7b749502dd5db65d09febcc64a6efe96a348356" offset="0x000000" />
+				<rom name="nus-nkie-0 12.u2" size="0x400000" crc="993640cb" sha1="58dd8ea2b34ddd6af8a8a5590cab291dedb7b8a1" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -5993,8 +5993,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19991218"/>
 		<info name="alt_title" value="キングヒル64 エクストリームスノーボーディング"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="king hill 64 - extreme snowboarding (japan).bin" size="12582912" crc="bc5f8666" sha1="35df68d6c1be28ef72ed54ad7f19bf1504c43c2a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="king hill 64 - extreme snowboarding (japan).bin" size="0xc00000" crc="bc5f8666" sha1="35df68d6c1be28ef72ed54ad7f19bf1504c43c2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6013,8 +6013,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n64j-0.u1" size="12582912" crc="9fc8a30c" sha1="c6b8349a834853501397225e29d2a7decedd07f1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n64j-0.u1" size="0xc00000" crc="9fc8a30c" sha1="c6b8349a834853501397225e29d2a7decedd07f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -6025,8 +6025,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NK4P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="kirby 64 - the crystal shards (europe).bin" size="33554432" crc="f1eb0f93" sha1="47cd5958a26e9a118cf7d15b65d613db894fa8b7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="kirby 64 - the crystal shards (europe).bin" size="0x2000000" crc="f1eb0f93" sha1="47cd5958a26e9a118cf7d15b65d613db894fa8b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6041,8 +6041,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NK4E-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6103A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nk4e-0.u1" size="33554432" crc="8eb3565b" sha1="56d8a1c461a3ee38c5c1977d497686058b90df8a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nk4e-0.u1" size="0x2000000" crc="8eb3565b" sha1="56d8a1c461a3ee38c5c1977d497686058b90df8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6053,8 +6053,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NKEP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="knife edge - nose gunner (europe).bin" size="8388608" crc="35b61293" sha1="feaf0b775e71dd35d5a1fef72e3cf4ce6e06d230" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="knife edge - nose gunner (europe).bin" size="0x800000" crc="35b61293" sha1="feaf0b775e71dd35d5a1fef72e3cf4ce6e06d230" />
 			</dataarea>
 		</part>
 	</software>
@@ -6067,8 +6067,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ナイフエッジ ノーズガンナー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="knife edge - nose gunner (japan).bin" size="8388608" crc="2ff68ed9" sha1="5e1eceddb5fd98a08dd5f08ce85ff6f9dff34417" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="knife edge - nose gunner (japan).bin" size="0x800000" crc="2ff68ed9" sha1="5e1eceddb5fd98a08dd5f08ce85ff6f9dff34417" />
 			</dataarea>
 		</part>
 	</software>
@@ -6083,8 +6083,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKEE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nkee-0.u1" size="8388608" crc="cf204405" sha1="b6b92b53285d22967e2250b6d020350eafb72643" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nkee-0.u1" size="0x800000" crc="cf204405" sha1="b6b92b53285d22967e2250b6d020350eafb72643" />
 			</dataarea>
 		</part>
 	</software>
@@ -6095,8 +6095,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NKKP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="knockout kings 2000 (europe).bin" size="16777216" crc="3c38ba4a" sha1="f21eb0318863175c3ddc73757636383d824b7202" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="knockout kings 2000 (europe).bin" size="0x1000000" crc="3c38ba4a" sha1="f21eb0318863175c3ddc73757636383d824b7202" />
 			</dataarea>
 		</part>
 	</software>
@@ -6111,8 +6111,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nkke-0.u1" size="16777216" crc="a26533fc" sha1="2c8a091cb5ee9be6aaaf390d25642e12409330f8" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nkke-0.u1" size="0x1000000" crc="a26533fc" sha1="2c8a091cb5ee9be6aaaf390d25642e12409330f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -6129,8 +6129,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7103]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nnbp-0.u1" size="12582912" crc="5adef1c7" sha1="cab29e7b3d9c1993801e415b5823567b8fe2f682" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nnbp-0.u1" size="0xc00000" crc="5adef1c7" sha1="cab29e7b3d9c1993801e415b5823567b8fe2f682" />
 			</dataarea>
 		</part>
 	</software>
@@ -6145,8 +6145,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NNBE-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nnbe-0.u1" size="12582912" crc="0ff8c439" sha1="c17d414b741338fd2c079b1ac6238d4ed87b0675" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nnbe-0.u1" size="0xc00000" crc="0ff8c439" sha1="c17d414b741338fd2c079b1ac6238d4ed87b0675" />
 			</dataarea>
 		</part>
 	</software>
@@ -6159,8 +6159,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990528"/>
 		<info name="alt_title" value="ラストレジオンUX"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="last legion ux (japan).bin" size="12582912" crc="c3daf1aa" sha1="3d434df177270a319b83d99df74f0c2d59c8c370" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="last legion ux (japan).bin" size="0xc00000" crc="c3daf1aa" sha1="3d434df177270a319b83d99df74f0c2d59c8c370" />
 			</dataarea>
 		</part>
 	</software>
@@ -6171,8 +6171,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NZSP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - majora's mask (europe) (en,fr,de,es) (rev a).bin" size="33554432" crc="1d4d50b7" sha1="b02a477871bbb90e75f09e714bf30991fd2b8caf" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - majora's mask (europe) (en,fr,de,es) (rev a).bin" size="0x2000000" crc="1d4d50b7" sha1="b02a477871bbb90e75f09e714bf30991fd2b8caf" />
 			</dataarea>
 		</part>
 	</software>
@@ -6189,8 +6189,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7105A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nzsp-0.u1" size="33554432" crc="9267f4ba" sha1="8bf74834c614f6ccb7c659b82dfdc68ba61301a4" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nzsp-0.u1" size="0x2000000" crc="9267f4ba" sha1="8bf74834c614f6ccb7c659b82dfdc68ba61301a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6200,11 +6200,11 @@ This cart features a RTC, currently unemulated
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
+			<dataarea name="rom" size="0x4000000">
 				<!-- Original release, in .z64 format -->
-				<!-- rom name="mm_debug.rom" size="67108864" crc="687d8395" sha1="b38b71d2961dffb523020a67f4807a4b704e347a" /-->
+				<!-- rom name="mm_debug.rom" size="0x4000000" crc="687d8395" sha1="b38b71d2961dffb523020a67f4807a4b704e347a" /-->
 				<!-- .v64 version -->
-				<rom name="legend of zelda, the - majora's mask (europe) (en,fr,de,es) (debug edition).bin" size="67108864" crc="ea2e7abb" sha1="c790b3de31196645034c76e326640ccf3b8c91dd" />
+				<rom name="legend of zelda, the - majora's mask (europe) (en,fr,de,es) (debug edition).bin" size="0x4000000" crc="ea2e7abb" sha1="c790b3de31196645034c76e326640ccf3b8c91dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -6215,8 +6215,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="DIS-NUS-NZSE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - majora's mask (usa) (demo).bin" size="33554432" crc="f97c02ce" sha1="99d8b0e3000dceaf494ea18941d7c31e796bfc78" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - majora's mask (usa) (demo).bin" size="0x2000000" crc="f97c02ce" sha1="99d8b0e3000dceaf494ea18941d7c31e796bfc78" />
 			</dataarea>
 		</part>
 	</software>
@@ -6231,8 +6231,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NZSE-0]" />
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nzse-0.u1" size="33554432" crc="3ee3f2d1" sha1="22f8bfa1ab6c763013a3c2a568bb014395b12499" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nzse-0.u1" size="0x2000000" crc="3ee3f2d1" sha1="22f8bfa1ab6c763013a3c2a568bb014395b12499" />
 			</dataarea>
 		</part>
 	</software>
@@ -6243,8 +6243,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NZLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - ocarina of time (europe) (en,fr,de) (rev a).bin" size="33554432" crc="ab0ffbae" sha1="663c34f1b2c05a09e5beffe4d0dcd440f7d49dc7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - ocarina of time (europe) (en,fr,de) (rev a).bin" size="0x2000000" crc="ab0ffbae" sha1="663c34f1b2c05a09e5beffe4d0dcd440f7d49dc7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6263,8 +6263,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nzlp-0.u1" size="33554432" crc="9852a62f" sha1="d0bdc2eb320668b4ba6893b9aefe4040a73123ff" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nzlp-0.u1" size="0x2000000" crc="9852a62f" sha1="d0bdc2eb320668b4ba6893b9aefe4040a73123ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -6283,8 +6283,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czle-2.u1" size="33554432" crc="3c7dbf5b" sha1="3ac86253e0c0d55486d212e647350c1527b9c92d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czle-2.u1" size="0x2000000" crc="3c7dbf5b" sha1="3ac86253e0c0d55486d212e647350c1527b9c92d" />
 			</dataarea>
 		</part>
 	</software>
@@ -6303,8 +6303,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czle-1.u1" size="33554432" crc="aa07c8ba" sha1="18cd0eb65914a21d8fa08dfe71c29d865e9d728a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czle-1.u1" size="0x2000000" crc="aa07c8ba" sha1="18cd0eb65914a21d8fa08dfe71c29d865e9d728a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6323,8 +6323,8 @@ This cart features a RTC, currently unemulated
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" /> <!-- Also with NUS-006(-01)(JPN) -->
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" /> <!-- Also with NUS-HKG-1 -->
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czle-0.u1" size="33554432" crc="ec95702d" sha1="79a4f053d34018e59279e6d4b83c7daccd985c87" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czle-0.u1" size="0x2000000" crc="ec95702d" sha1="79a4f053d34018e59279e6d4b83c7daccd985c87" />
 			</dataarea>
 		</part>
 	</software>
@@ -6335,8 +6335,8 @@ This cart features a RTC, currently unemulated
 		<publisher>LEGO Media</publisher>
 		<info name="serial" value="NUS-NLGP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="lego racers (europe) (en,fr,de,es,it,nl,sv,no,da,fi).bin" size="16777216" crc="3d4679e5" sha1="c221abc794bb1c67da5499acea8c80222b200a90" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="lego racers (europe) (en,fr,de,es,it,nl,sv,no,da,fi).bin" size="0x1000000" crc="3d4679e5" sha1="c221abc794bb1c67da5499acea8c80222b200a90" />
 			</dataarea>
 		</part>
 	</software>
@@ -6351,8 +6351,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NLGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nlge-0.u1" size="16777216" crc="3339e557" sha1="9c5b574680a18fc87c74e7c1feea19aae87cc059" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nlge-0.u1" size="0x1000000" crc="3339e557" sha1="9c5b574680a18fc87c74e7c1feea19aae87cc059" />
 			</dataarea>
 		</part>
 	</software>
@@ -6365,8 +6365,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981009"/>
 		<info name="alt_title" value="Let's スマッシュ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="let's smash (japan).bin" size="12582912" crc="33543946" sha1="7dd60d27cc1cabf70a380fa2a567621ef8e69dcd" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="let's smash (japan).bin" size="0xc00000" crc="33543946" sha1="7dd60d27cc1cabf70a380fa2a567621ef8e69dcd" />
 			</dataarea>
 		</part>
 	</software>
@@ -6377,8 +6377,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NLRP-EUR, NUS-NLRP-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="lode runner 3-d (europe) (en,fr,de,es,it).bin" size="8388608" crc="78707cea" sha1="80c368da49a956756d14d4e5b313e3d64a772f36" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="lode runner 3-d (europe) (en,fr,de,es,it).bin" size="0x800000" crc="78707cea" sha1="80c368da49a956756d14d4e5b313e3d64a772f36" />
 			</dataarea>
 		</part>
 	</software>
@@ -6391,8 +6391,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990730"/>
 		<info name="alt_title" value="ロードランナー3D"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="lode runner 3-d (japan).bin" size="8388608" crc="8a1ae6a7" sha1="62c0d2599bb3ebbab3602f5e1cb5cfc2626506d4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="lode runner 3-d (japan).bin" size="0x800000" crc="8a1ae6a7" sha1="62c0d2599bb3ebbab3602f5e1cb5cfc2626506d4" />
 			</dataarea>
 		</part>
 	</software>
@@ -6407,8 +6407,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NLRE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nlre-0.u1" size="8388608" crc="5af38589" sha1="361ca0a284ce8de1b8e54716ed3952a179e0a148" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nlre-0.u1" size="0x800000" crc="5af38589" sha1="361ca0a284ce8de1b8e54716ed3952a179e0a148" />
 			</dataarea>
 		</part>
 	</software>
@@ -6419,8 +6419,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NFXU-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="lylat wars (australia) (en,fr,de).bin" size="12582912" crc="ed1249a5" sha1="9cbf5087d5684d3b5329630932eb2bfb29af8511" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="lylat wars (australia) (en,fr,de).bin" size="0xc00000" crc="ed1249a5" sha1="9cbf5087d5684d3b5329630932eb2bfb29af8511" />
 			</dataarea>
 		</part>
 	</software>
@@ -6437,8 +6437,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-7102]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfxp-0.u1" size="12582912" crc="94a1a16a" sha1="8de2942e59e31fea235ad672f6096294d8e7d12e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfxp-0.u1" size="0xc00000" crc="94a1a16a" sha1="8de2942e59e31fea235ad672f6096294d8e7d12e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6449,8 +6449,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NMEP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mace - the dark age (europe).bin" size="12582912" crc="4bdf2d6c" sha1="904ae518fd489ef94e0f379a4020d96a1771c2c0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mace - the dark age (europe).bin" size="0xc00000" crc="4bdf2d6c" sha1="904ae518fd489ef94e0f379a4020d96a1771c2c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -6465,8 +6465,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NMEE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmee-0.u1" size="12582912" crc="e49d603a" sha1="55d187b8ae20d2271f96fa9a8fb76fc11301a2eb" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmee-0.u1" size="0xc00000" crc="e49d603a" sha1="55d187b8ae20d2271f96fa9a8fb76fc11301a2eb" />
 			</dataarea>
 		</part>
 	</software>
@@ -6477,8 +6477,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N8MP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="madden football 64 (europe).bin" size="12582912" crc="c39f863d" sha1="711c709393cdc4d76ca9e3cc669504144f554bc5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="madden football 64 (europe).bin" size="0xc00000" crc="c39f863d" sha1="711c709393cdc4d76ca9e3cc669504144f554bc5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6493,8 +6493,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-N8ME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n8me-0.u1" size="12582912" crc="43b28179" sha1="65fdc159374e6161a0ce0ba8ed520a669512094f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n8me-0.u1" size="0xc00000" crc="43b28179" sha1="65fdc159374e6161a0ce0ba8ed520a669512094f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6509,8 +6509,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NMDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmde-0.u1" size="12582912" crc="f41b2332" sha1="a2a09dfde793bd42f5b3c11429628e48794091b1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmde-0.u1" size="0xc00000" crc="f41b2332" sha1="a2a09dfde793bd42f5b3c11429628e48794091b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -6525,8 +6525,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NFLE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfle-0.u1" size="12582912" crc="3b49ec33" sha1="fba3c676a8acd733f16ddf7ef9bf95811974f9f1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfle-0.u1" size="0xc00000" crc="3b49ec33" sha1="fba3c676a8acd733f16ddf7ef9bf95811974f9f1" />
 			</dataarea>
 		</part>
 	</software>
@@ -6541,8 +6541,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-N2ME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n2me-0.u1" size="12582912" crc="0c711dfe" sha1="df3f696131141b4e5bc9e71a72a9815fb24c9112" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n2me-0.u1" size="0xc00000" crc="0c711dfe" sha1="df3f696131141b4e5bc9e71a72a9815fb24c9112" />
 			</dataarea>
 		</part>
 	</software>
@@ -6553,8 +6553,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N9MP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="madden nfl 99 (europe).bin" size="12582912" crc="5dcad836" sha1="c6d88bbf811e3973ef6b9fb8a565424abf2c15b6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="madden nfl 99 (europe).bin" size="0xc00000" crc="5dcad836" sha1="c6d88bbf811e3973ef6b9fb8a565424abf2c15b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -6571,8 +6571,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n9me-0.u1" size="12582912" crc="ac21a5bf" sha1="fd5da6fef67461fb5d6767d933663dcfa6e0f054" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n9me-0.u1" size="0xc00000" crc="ac21a5bf" sha1="fd5da6fef67461fb5d6767d933663dcfa6e0f054" />
 			</dataarea>
 		</part>
 	</software>
@@ -6589,8 +6589,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n9me-1.u1" size="12582912" crc="e05b574d" sha1="c686a44e43df6b4e5ecd816d113a402ae9e1570b" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n9me-1.u1" size="0xc00000" crc="e05b574d" sha1="c686a44e43df6b4e5ecd816d113a402ae9e1570b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6600,8 +6600,8 @@ This cart features a RTC, currently unemulated
 		<year>1998</year>
 		<publisher>Electronic Arts</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="madden-99-n64-proto.bin" size="16777216" crc="e7f33cc8" sha1="4f38e57f5f6d0a0406b074d9b5473c3fe99a0f32" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="madden-99-n64-proto.bin" size="0x1000000" crc="e7f33cc8" sha1="4f38e57f5f6d0a0406b074d9b5473c3fe99a0f32" />
 			</dataarea>
 		</part>
 	</software>
@@ -6612,8 +6612,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NUS-NMTP-EUR, NUS-NMTP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="magical tetris challenge (europe).bin" size="16777216" crc="bf53bf3d" sha1="4885e3951584032fb0254cbbdba9961c45c3d10f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="magical tetris challenge (europe).bin" size="0x1000000" crc="bf53bf3d" sha1="4885e3951584032fb0254cbbdba9961c45c3d10f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6624,8 +6624,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Capcom</publisher>
 		<info name="serial" value="NUS-NMTD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="magical tetris challenge (germany).bin" size="16777216" crc="16995cf8" sha1="df058519cce4b5517b10c633f2a2dbd882018f47" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="magical tetris challenge (germany).bin" size="0x1000000" crc="16995cf8" sha1="df058519cce4b5517b10c633f2a2dbd882018f47" />
 			</dataarea>
 		</part>
 	</software>
@@ -6640,8 +6640,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NMTE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nmte-0.u1" size="16777216" crc="167c60e6" sha1="d0cbbe4e61af75b6bc41ae76881f81b499f1ae3e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nmte-0.u1" size="0x1000000" crc="167c60e6" sha1="d0cbbe4e61af75b6bc41ae76881f81b499f1ae3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6654,8 +6654,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19981120"/>
 		<info name="alt_title" value="マジカル TETRIS チャレンジ featuring ミッキー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="magical tetris challenge featuring mickey (japan).bin" size="16777216" crc="6d3eba8b" sha1="43848d4a70a0d33b4c94b340895f0a09561b6bbc" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="magical tetris challenge featuring mickey (japan).bin" size="0x1000000" crc="6d3eba8b" sha1="43848d4a70a0d33b4c94b340895f0a09561b6bbc" />
 			</dataarea>
 		</part>
 	</software>
@@ -6668,8 +6668,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970404"/>
 		<info name="alt_title" value="麻雀64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="mahjong 64 (japan).bin" size="8388608" crc="0fb9138c" sha1="3c9d98dfc27e9b5a8f085a2f189f42e2a77a970e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="mahjong 64 (japan).bin" size="0x800000" crc="0fb9138c" sha1="3c9d98dfc27e9b5a8f085a2f189f42e2a77a970e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6682,8 +6682,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19970801"/>
 		<info name="alt_title" value="麻雀放浪記 CLASSIC"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mahjong hourouki classic (japan).bin" size="12582912" crc="fd9ea0d5" sha1="dbb8e86f53953abc97fa015f50523264689d3331" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mahjong hourouki classic (japan).bin" size="0xc00000" crc="fd9ea0d5" sha1="dbb8e86f53953abc97fa015f50523264689d3331" />
 			</dataarea>
 		</part>
 	</software>
@@ -6696,8 +6696,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19961220"/>
 		<info name="alt_title" value="麻雀 MASTER"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="mahjong master (japan).bin" size="8388608" crc="db0b662a" sha1="734f5865d4e293a3fc28e167a0aaf79ddefe8837" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="mahjong master (japan).bin" size="0x800000" crc="db0b662a" sha1="734f5865d4e293a3fc28e167a0aaf79ddefe8837" />
 			</dataarea>
 		</part>
 	</software>
@@ -6708,8 +6708,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NKGP-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="major league baseball featuring ken griffey jr. (australia).bin" size="16777216" crc="10cc55ba" sha1="515a3b5c22938642d2929c84c1a62eae1702ad4f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="major league baseball featuring ken griffey jr. (australia).bin" size="0x1000000" crc="10cc55ba" sha1="515a3b5c22938642d2929c84c1a62eae1702ad4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6726,8 +6726,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [74LV2416]" />
 			<feature name="u4" value="U4 [CIC-NUS-6103]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nkge-0.u1" size="16777216" crc="7542d45d" sha1="ee0ab1e8af669712afbaf4b9bbcee62e8eb13a4a" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nkge-0.u1" size="0x1000000" crc="7542d45d" sha1="ee0ab1e8af669712afbaf4b9bbcee62e8eb13a4a" />
 			</dataarea>
 		</part>
 	</software>
@@ -6738,8 +6738,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMFP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario golf (europe).bin" size="33554432" crc="1ca3e8b6" sha1="b77c8a9f163feb9ae2f2253b6d9ec82d77b7088c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario golf (europe).bin" size="0x2000000" crc="1ca3e8b6" sha1="b77c8a9f163feb9ae2f2253b6d9ec82d77b7088c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6756,8 +6756,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [BU9811]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nmfe-0.u1" size="33554432" crc="ceb5b977" sha1="03db12b8a018eb10a31d3edcf693d92ab8676f1b" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nmfe-0.u1" size="0x2000000" crc="ceb5b977" sha1="03db12b8a018eb10a31d3edcf693d92ab8676f1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -6770,8 +6770,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990611"/>
 		<info name="alt_title" value="マリオゴルフ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario golf 64 (japan) (rev a).bin" size="33554432" crc="b2672604" sha1="c4399c37a0f63a18c6ac0d7a98e63b5c3483e4ad" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario golf 64 (japan) (rev a).bin" size="0x2000000" crc="b2672604" sha1="c4399c37a0f63a18c6ac0d7a98e63b5c3483e4ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -6784,8 +6784,8 @@ This cart features a RTC, currently unemulated
 		<info name="release" value="19990611"/>
 		<info name="alt_title" value="マリオゴルフ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario golf 64 (japan).bin" size="33554432" crc="889091fd" sha1="137b9591194489cfc33d29fa0b054d9954db4e1e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario golf 64 (japan).bin" size="0x2000000" crc="889091fd" sha1="137b9591194489cfc33d29fa0b054d9954db4e1e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6800,8 +6800,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKTP-1]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nktp-1.u1" size="12582912" crc="032625b0" sha1="f18317bfd7fbcaea6cfbfcb9c4ae3c7c7d1d66c7" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nktp-1.u1" size="0xc00000" crc="032625b0" sha1="f18317bfd7fbcaea6cfbfcb9c4ae3c7c7d1d66c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -6812,8 +6812,8 @@ This cart features a RTC, currently unemulated
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NKTP-AUS, NUS-NKTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mario kart 64 (europe).bin" size="12582912" crc="6787e212" sha1="f1324f0a316ed895a92097b949e3aa74aefedda5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mario kart 64 (europe).bin" size="0xc00000" crc="6787e212" sha1="f1324f0a316ed895a92097b949e3aa74aefedda5" />
 			</dataarea>
 		</part>
 	</software>
@@ -6832,8 +6832,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nktj-1.u1" size="12582912" crc="26450aab" sha1="42769bc9467df9a517a88e28f9ce2b6956a7a15f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nktj-1.u1" size="0xc00000" crc="26450aab" sha1="42769bc9467df9a517a88e28f9ce2b6956a7a15f" />
 			</dataarea>
 		</part>
 	</software>
@@ -6851,9 +6851,9 @@ This cart features a RTC, currently unemulated
 			<feature name="u2" value="U2 [NUS-NKTJ-0 12]" />
 			<feature name="u3" value="U3 [BU9850]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nktj-0 02.u1" size="8388608" crc="6575dcf7" sha1="9e5e99461236c56c640b3ef2bf11fb8636abc04c" offset="0x000000" />
-				<rom name="nus-nktj-0 12.u2" size="4194304" crc="9aed2500" sha1="879716e48c99699910702e0fa89c45895a798777" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nktj-0 02.u1" size="0x800000" crc="6575dcf7" sha1="9e5e99461236c56c640b3ef2bf11fb8636abc04c" offset="0x000000" />
+				<rom name="nus-nktj-0 12.u2" size="0x400000" crc="9aed2500" sha1="879716e48c99699910702e0fa89c45895a798777" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -6871,9 +6871,9 @@ This cart features a RTC, currently unemulated
 			<feature name="u4" value="CIC-NUS-6102" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nkte-0 02.u1" size="8388608" crc="895652e1" sha1="beb07f9d9909a22d273925a29c97ef7adc3c0b5d" offset="0x000000" />
-				<rom name="nus-nkte-0 12.u2" size="4194304" crc="673e021a" sha1="41a6f35a8a334b41b4346478b8043c2153f1d93e" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nkte-0 02.u1" size="0x800000" crc="895652e1" sha1="beb07f9d9909a22d273925a29c97ef7adc3c0b5d" offset="0x000000" />
+				<rom name="nus-nkte-0 12.u2" size="0x400000" crc="673e021a" sha1="41a6f35a8a334b41b4346478b8043c2153f1d93e" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -6888,8 +6888,8 @@ This cart features a RTC, currently unemulated
 			<feature name="u1" value="U1 [NUS-NKTE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nkte-0.u1" size="12582912" crc="434389c1" sha1="579c48e211ae952530ffc8738709f078d5dd215e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nkte-0.u1" size="0xc00000" crc="434389c1" sha1="579c48e211ae952530ffc8738709f078d5dd215e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6917,8 +6917,8 @@ Dumped Title                                                Japanese title      
 		<info name="release" value="19981202"/>
 		<info name="alt_title" value="マリオのふぉとぴー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mario no photopie (japan).bin" size="16777216" crc="49e24ae2" sha1="f8bba2635aade03fb700c1614f36aa5a605af85e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mario no photopie (japan).bin" size="0x1000000" crc="49e24ae2" sha1="f8bba2635aade03fb700c1614f36aa5a605af85e" />
 			</dataarea>
 		</part>
 	</software>
@@ -6929,8 +6929,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NLBP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party (europe) (en,fr,de).bin" size="33554432" crc="6973373f" sha1="2f8b0bf9861d10b4c1c5b9c0f0c47333c96dbe30" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party (europe) (en,fr,de).bin" size="0x2000000" crc="6973373f" sha1="2f8b0bf9861d10b4c1c5b9c0f0c47333c96dbe30" />
 			</dataarea>
 		</part>
 	</software>
@@ -6947,8 +6947,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-clbe-0.u1" size="33554432" crc="4717cd1b" sha1="08390db915dd689191906a13f4f736d419e2aff9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-clbe-0.u1" size="0x2000000" crc="4717cd1b" sha1="08390db915dd689191906a13f4f736d419e2aff9" />
 			</dataarea>
 		</part>
 	</software>
@@ -6965,8 +6965,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-CLBJ-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party (japan).bin" size="33554432" crc="7d387e37" sha1="82d03c229f37b7e8af72f4ee867022e4fa0f1f99" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party (japan).bin" size="0x2000000" crc="7d387e37" sha1="82d03c229f37b7e8af72f4ee867022e4fa0f1f99" />
 			</dataarea>
 		</part>
 	</software>
@@ -6977,8 +6977,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party 2 (europe) (en,fr,de,es,it).bin" size="33554432" crc="8c0c8bec" sha1="130bdc56fbe29fc27645e21959b27322c342728c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party 2 (europe) (en,fr,de,es,it).bin" size="0x2000000" crc="8c0c8bec" sha1="130bdc56fbe29fc27645e21959b27322c342728c" />
 			</dataarea>
 		</part>
 	</software>
@@ -6991,8 +6991,8 @@ Dumped Title                                                Japanese title      
 		<info name="release" value="19991217"/>
 		<info name="alt_title" value="マリオパーティ2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party 2 (japan).bin" size="33554432" crc="e19bf21c" sha1="fd523dff2f552a766993ebb5f056f15fcf52e17f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party 2 (japan).bin" size="0x2000000" crc="e19bf21c" sha1="fd523dff2f552a766993ebb5f056f15fcf52e17f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7007,8 +7007,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMWE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nmwe-0.u1" size="33554432" crc="3ba5471b" sha1="528ecd9e10233ea7ce372559a16196a8e9438763" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nmwe-0.u1" size="0x2000000" crc="3ba5471b" sha1="528ecd9e10233ea7ce372559a16196a8e9438763" />
 			</dataarea>
 		</part>
 	</software>
@@ -7019,8 +7019,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMVP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party 3 (europe) (en,fr,de,es).bin" size="33554432" crc="a5d78a36" sha1="e8ba773a4fd1251a78eefcf1f3cbe1f0054a8a38" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party 3 (europe) (en,fr,de,es).bin" size="0x2000000" crc="a5d78a36" sha1="e8ba773a4fd1251a78eefcf1f3cbe1f0054a8a38" />
 			</dataarea>
 		</part>
 	</software>
@@ -7033,8 +7033,8 @@ Dumped Title                                                Japanese title      
 		<info name="release" value="20001207"/>
 		<info name="alt_title" value="マリオパーティ3"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mario party 3 (japan).bin" size="33554432" crc="703586d1" sha1="89b91548c6c5943e95eebfb8a4df84fb98d3d905" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mario party 3 (japan).bin" size="0x2000000" crc="703586d1" sha1="89b91548c6c5943e95eebfb8a4df84fb98d3d905" />
 			</dataarea>
 		</part>
 	</software>
@@ -7049,8 +7049,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMVE-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nmve-0.u1" size="33554432" crc="a1bee3f8" sha1="58bd552b48bcec6aa39174de9796a7c093d64b67" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nmve-0.u1" size="0x2000000" crc="a1bee3f8" sha1="58bd552b48bcec6aa39174de9796a7c093d64b67" />
 			</dataarea>
 		</part>
 	</software>
@@ -7070,9 +7070,9 @@ Dumped Title                                                Japanese title      
 			<feature name="u4" value="U4 [CIC-NUS-6103A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="41943040">
-				<rom name="nus-nmqj-0 02.u1" size="33554432" crc="7eb4a9ad" sha1="7601a5ae522c855c7c4570adc5d43741c6b51d74" offset="0x0000000" />
-				<rom name="nus-nmqj-0 12.u2" size="8388608" crc="80b0f0d6" sha1="e94f4a80de1953877de0fbe3e83bbd0332d3e108" offset="0x2000000" />
+			<dataarea name="rom" size="0x2800000">
+				<rom name="nus-nmqj-0 02.u1" size="0x2000000" crc="7eb4a9ad" sha1="7601a5ae522c855c7c4570adc5d43741c6b51d74" offset="0x0000000" />
+				<rom name="nus-nmqj-0 12.u2" size="0x800000" crc="80b0f0d6" sha1="e94f4a80de1953877de0fbe3e83bbd0332d3e108" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -7083,8 +7083,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NM8P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mario tennis (europe).bin" size="16777216" crc="0f03ca6e" sha1="f7c4535ce92ca794c4b26e09e74072125ae97dab" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mario tennis (europe).bin" size="0x1000000" crc="0f03ca6e" sha1="f7c4535ce92ca794c4b26e09e74072125ae97dab" />
 			</dataarea>
 		</part>
 	</software>
@@ -7099,8 +7099,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NM8E-0]" />
 			<feature name="u2" value="U2 [BK16D]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nm8e-0.u1" size="16777216" crc="995c9f24" sha1="9bb2d4e8d1cc4e31bd75a588bd94eb085ff7d73e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nm8e-0.u1" size="0x1000000" crc="995c9f24" sha1="9bb2d4e8d1cc4e31bd75a588bd94eb085ff7d73e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7119,8 +7119,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nm8j-0.u1" size="16777216" crc="17c5515b" sha1="fb7f917aa3f40dbde33107f1c949301af8470c2e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nm8j-0.u1" size="0x1000000" crc="17c5515b" sha1="fb7f917aa3f40dbde33107f1c949301af8470c2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7136,8 +7136,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nm6e-0.u1" size="33554432" crc="b57dd0e4" sha1="c24b210f2fc297897940af1add23c1c19c191699" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nm6e-0.u1" size="0x2000000" crc="b57dd0e4" sha1="c24b210f2fc297897940af1add23c1c19c191699" />
 			</dataarea>
 		</part>
 	</software>
@@ -7147,8 +7147,8 @@ Dumped Title                                                Japanese title      
 		<year>2000</year>
 		<publisher>Capcom</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="mega man 64 (proto).bin" size="67108864" crc="421d2a09" sha1="4f37f66ac3adf8257162d3420fd558504334be0f" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="mega man 64 (proto).bin" size="0x4000000" crc="421d2a09" sha1="4f37f66ac3adf8257162d3420fd558504334be0f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7163,8 +7163,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NHME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nhme-0.u1" size="16777216" crc="3aa4bff5" sha1="656daa19bc199929ef2ed52f841487e3ffac7692" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nhme-0.u1" size="0x1000000" crc="3aa4bff5" sha1="656daa19bc199929ef2ed52f841487e3ffac7692" />
 			</dataarea>
 		</part>
 	</software>
@@ -7175,8 +7175,8 @@ Dumped Title                                                Japanese title      
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NWKX-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="michael owen's world league soccer 2000 (europe).bin" size="16777216" crc="faffef70" sha1="b2c6442f2e04fec284ac4c4f7439059fa2315700" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="michael owen's world league soccer 2000 (europe).bin" size="0x1000000" crc="faffef70" sha1="b2c6442f2e04fec284ac4c4f7439059fa2315700" />
 			</dataarea>
 		</part>
 	</software>
@@ -7189,8 +7189,8 @@ Dumped Title                                                Japanese title      
 		<info name="release" value="20010121"/>
 		<info name="alt_title" value="ミッキーのレーシングチャレンジUSA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mickey no racing challenge usa (japan).bin" size="33554432" crc="915a43ee" sha1="74b76cb5075663e568eebf9ac977e08cdba17ba9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mickey no racing challenge usa (japan).bin" size="0x2000000" crc="915a43ee" sha1="74b76cb5075663e568eebf9ac977e08cdba17ba9" />
 			</dataarea>
 		</part>
 	</software>
@@ -7201,8 +7201,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NMLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="mickey's speedway usa (europe) (en,fr,de,es,it).bin" size="33554432" crc="ddf28f6b" sha1="bf43fa4a34cefb537271dd71db8db47f5b4a29fd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="mickey's speedway usa (europe) (en,fr,de,es,it).bin" size="0x2000000" crc="ddf28f6b" sha1="bf43fa4a34cefb537271dd71db8db47f5b4a29fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -7217,8 +7217,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMLE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nmle-0.u1" size="33554432" crc="6e589c47" sha1="1156459d3da0cd1ac8da73f75aecdc23d093afff" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nmle-0.u1" size="0x2000000" crc="6e589c47" sha1="1156459d3da0cd1ac8da73f75aecdc23d093afff" />
 			</dataarea>
 		</part>
 	</software>
@@ -7229,8 +7229,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Codemasters</publisher>
 		<info name="serial" value="NUS-NV3P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="micro machines 64 turbo (europe) (en,fr,de,es,it).bin" size="12582912" crc="14030ff5" sha1="b8961f88210027ee0525623242f7ced6c139dedf" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="micro machines 64 turbo (europe) (en,fr,de,es,it).bin" size="0xc00000" crc="14030ff5" sha1="b8961f88210027ee0525623242f7ced6c139dedf" />
 			</dataarea>
 		</part>
 	</software>
@@ -7245,8 +7245,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NV3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nv3e-0.u1" size="12582912" crc="02790693" sha1="b62d18dcecad57852b21107d5b9c026237cbee6e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nv3e-0.u1" size="0xc00000" crc="02790693" sha1="b62d18dcecad57852b21107d5b9c026237cbee6e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7261,8 +7261,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NAIE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-naie-0.u1" size="4194304" crc="202a2718" sha1="db7cae68d2a73018ada2e9587e997ec8557f8a8a" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-naie-0.u1" size="0x400000" crc="202a2718" sha1="db7cae68d2a73018ada2e9587e997ec8557f8a8a" />
 			</dataarea>
 		</part>
 	</software>
@@ -7277,8 +7277,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMBE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmbe-0.u1" size="12582912" crc="9042cb8e" sha1="d333e7c755451f244f24ac56352a0c6294406016" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmbe-0.u1" size="0xc00000" crc="9042cb8e" sha1="d333e7c755451f244f24ac56352a0c6294406016" />
 			</dataarea>
 		</part>
 	</software>
@@ -7289,8 +7289,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NBRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="milo's astro lanes (europe).bin" size="4194304" crc="165d7bc2" sha1="5d5ab3e386b8970c3fd61e84187315c1e8297443" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="milo's astro lanes (europe).bin" size="0x400000" crc="165d7bc2" sha1="5d5ab3e386b8970c3fd61e84187315c1e8297443" />
 			</dataarea>
 		</part>
 	</software>
@@ -7305,8 +7305,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NBRE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nbre-0.u1" size="4194304" crc="dff1ba7e" sha1="fc5c26b0089b50624f330e9f769078d333754a5e" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nbre-0.u1" size="0x400000" crc="dff1ba7e" sha1="fc5c26b0089b50624f330e9f769078d333754a5e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7316,8 +7316,8 @@ Dumped Title                                                Japanese title      
 		<year>1999</year>
 		<publisher>Looking Glass Studios</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mini racers (unreleased).bin" size="16777216" crc="cf4c80b0" sha1="ac093f0bbec0893e942da322318f54268834c10b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mini racers (unreleased).bin" size="0x1000000" crc="cf4c80b0" sha1="ac093f0bbec0893e942da322318f54268834c10b" />
 			</dataarea>
 		</part>
 	</software>
@@ -7328,8 +7328,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NTMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="mischief makers (europe).bin" size="8388608" crc="12529953" sha1="a2805e1c825157a491850b0d25c84759ca76bbb6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="mischief makers (europe).bin" size="0x800000" crc="12529953" sha1="a2805e1c825157a491850b0d25c84759ca76bbb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7340,8 +7340,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NTME-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="mischief makers (usa) (rev a).bin" size="8388608" crc="c454e245" sha1="3a66a71240b34df5607c8bb84c679c44472a6da2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="mischief makers (usa) (rev a).bin" size="0x800000" crc="c454e245" sha1="3a66a71240b34df5607c8bb84c679c44472a6da2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7356,8 +7356,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NTME-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntme-0.u1" size="8388608" crc="af7b3820" sha1="fa7b20e6c4082d9068a59eda3713525f1b7d794e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntme-0.u1" size="0x800000" crc="af7b3820" sha1="fa7b20e6c4082d9068a59eda3713525f1b7d794e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7368,8 +7368,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NMIP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mission impossible (europe).bin" size="12582912" crc="c41a1ebe" sha1="3aa5b3b1a063ddb1f2d883ad95d04365d2c0a42a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mission impossible (europe).bin" size="0xc00000" crc="c41a1ebe" sha1="3aa5b3b1a063ddb1f2d883ad95d04365d2c0a42a" />
 			</dataarea>
 		</part>
 	</software>
@@ -7380,8 +7380,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NMIF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mission impossible (france).bin" size="12582912" crc="67895343" sha1="fc28edcae49ca1bd298258bb693c92cf39ed39b6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mission impossible (france).bin" size="0xc00000" crc="67895343" sha1="fc28edcae49ca1bd298258bb693c92cf39ed39b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7392,8 +7392,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NMID-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mission impossible (germany).bin" size="12582912" crc="20067768" sha1="a891aee53f10bd4e25973ce47a2e70b5cf4c90da" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mission impossible (germany).bin" size="0xc00000" crc="20067768" sha1="a891aee53f10bd4e25973ce47a2e70b5cf4c90da" />
 			</dataarea>
 		</part>
 	</software>
@@ -7410,8 +7410,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmii-0.u1" size="12582912" crc="ac5c1408" sha1="25b1ff3432465450b4b17bb26ce9f9289ebfe65c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmii-0.u1" size="0xc00000" crc="ac5c1408" sha1="25b1ff3432465450b4b17bb26ce9f9289ebfe65c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7428,8 +7428,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmis-0.u1" size="12582912" crc="e33b52f0" sha1="244711046f77e8059e677731c2d26d0c45996dda" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmis-0.u1" size="0xc00000" crc="e33b52f0" sha1="244711046f77e8059e677731c2d26d0c45996dda" />
 			</dataarea>
 		</part>
 	</software>
@@ -7446,8 +7446,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmis-1.u1" size="12582912" crc="ffd3f31e" sha1="816a3c905f28d43a9a0c4922951b90a48074626d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmis-1.u1" size="0xc00000" crc="ffd3f31e" sha1="816a3c905f28d43a9a0c4922951b90a48074626d" />
 			</dataarea>
 		</part>
 	</software>
@@ -7464,8 +7464,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmie-0.u1" size="12582912" crc="2dbd815d" sha1="c17c89f1a8485cfd481426800870f860c2ceae24" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmie-0.u1" size="0xc00000" crc="2dbd815d" sha1="c17c89f1a8485cfd481426800870f860c2ceae24" />
 			</dataarea>
 		</part>
 	</software>
@@ -7480,8 +7480,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMGE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nmge-0.u1" size="16777216" crc="30079403" sha1="75f401c150cd9210432a96cf6db411f6f46e0047" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nmge-0.u1" size="0x1000000" crc="30079403" sha1="75f401c150cd9210432a96cf6db411f6f46e0047" />
 			</dataarea>
 		</part>
 	</software>
@@ -7492,8 +7492,8 @@ Dumped Title                                                Japanese title      
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NMGP-FAH, NUS-NMGP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="monaco grand prix - racing simulation 2 (europe) (en,fr,es,it).bin" size="16777216" crc="0a54fdf0" sha1="bd25283c98fc1915c07f4ee9ce58820c1d4a44b2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="monaco grand prix - racing simulation 2 (europe) (en,fr,es,it).bin" size="0x1000000" crc="0a54fdf0" sha1="bd25283c98fc1915c07f4ee9ce58820c1d4a44b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -7508,8 +7508,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u1" value="U1 [NUS-NMOE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nmoe-0.u1" size="8388608" crc="416b1f8f" sha1="99d176b45784ced5f469c64e065f6ea3e1176188" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nmoe-0.u1" size="0x800000" crc="416b1f8f" sha1="99d176b45784ced5f469c64e065f6ea3e1176188" />
 			</dataarea>
 		</part>
 	</software>
@@ -7525,8 +7525,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nm3p-0.u1" size="8388608" crc="ce6779fb" sha1="42f1702360e5381b0c94912ae3b5bb092c04297c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nm3p-0.u1" size="0x800000" crc="ce6779fb" sha1="42f1702360e5381b0c94912ae3b5bb092c04297c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7543,8 +7543,8 @@ Dumped Title                                                Japanese title      
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nm3e-0.u1" size="8388608" crc="b8d03ffb" sha1="f7e66b1eb2905df6c6dfadf1593064fc6d592c17" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nm3e-0.u1" size="0x800000" crc="b8d03ffb" sha1="f7e66b1eb2905df6c6dfadf1593064fc6d592c17" />
 			</dataarea>
 		</part>
 	</software>
@@ -7569,8 +7569,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u6" value="U6 78L08T" />
 			<feature name="U7" value="U7 UPC358 [LM358]" />
 			<feature name="U8" value="U8 UPC3403 [MC3403D]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="morita shougi 64 (japan).bin" size="8388608" crc="377b7580" sha1="41b66663b6428c040579cebeda70db2fcd063b3e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="morita shougi 64 (japan).bin" size="0x800000" crc="377b7580" sha1="41b66663b6428c040579cebeda70db2fcd063b3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -7581,8 +7581,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NM4P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mortal kombat 4 (europe).bin" size="16777216" crc="70b72a07" sha1="c992254964774aaaea5fbde5bf4031c5096fb554" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mortal kombat 4 (europe).bin" size="0x1000000" crc="70b72a07" sha1="c992254964774aaaea5fbde5bf4031c5096fb554" />
 			</dataarea>
 		</part>
 	</software>
@@ -7599,8 +7599,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nm4e-0.u1" size="16777216" crc="aa865b66" sha1="5fb558a40f06365a1f759b4df718623f1f3ac3df" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nm4e-0.u1" size="0x1000000" crc="aa865b66" sha1="5fb558a40f06365a1f759b4df718623f1f3ac3df" />
 			</dataarea>
 		</part>
 	</software>
@@ -7611,8 +7611,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NMYP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mortal kombat mythologies - sub-zero (europe).bin" size="16777216" crc="1063da05" sha1="3fde66ec7640f79a10471cd159e6b5c6101742ee" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mortal kombat mythologies - sub-zero (europe).bin" size="0x1000000" crc="1063da05" sha1="3fde66ec7640f79a10471cd159e6b5c6101742ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -7627,8 +7627,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NMYE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nmye-0.u1" size="16777216" crc="f0f7d9e3" sha1="04b8029337afddf618d9b0f0998bd0692782048f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nmye-0.u1" size="0x1000000" crc="f0f7d9e3" sha1="04b8029337afddf618d9b0f0998bd0692782048f" />
 			</dataarea>
 		</part>
 	</software>
@@ -7639,8 +7639,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NMKP-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mortal kombat trilogy (europe).bin" size="12582912" crc="6a805380" sha1="75298d06adaf9814430c9dfde87dca3a9c59dab1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mortal kombat trilogy (europe).bin" size="0xc00000" crc="6a805380" sha1="75298d06adaf9814430c9dfde87dca3a9c59dab1" />
 			</dataarea>
 		</part>
 	</software>
@@ -7651,8 +7651,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NMKE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mortal kombat trilogy (usa) (rev b).bin" size="12582912" crc="e58597d7" sha1="4092a66080afc03d7bf9779aad047aff1a56ecb6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mortal kombat trilogy (usa) (rev b).bin" size="0xc00000" crc="e58597d7" sha1="4092a66080afc03d7bf9779aad047aff1a56ecb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7670,9 +7670,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmke-1 02.u1" size="8388608" crc="da3aae5d" sha1="d13322ee9998426cad9324c16c46191a360d1b92" offset="0x000000" />
-				<rom name="nus-nmke-1 12.u2" size="4194304" crc="822f4ccd" sha1="ca842ce91ea9bbc8f4ee6a31bea2a99a7e633543" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmke-1 02.u1" size="0x800000" crc="da3aae5d" sha1="d13322ee9998426cad9324c16c46191a360d1b92" offset="0x000000" />
+				<rom name="nus-nmke-1 12.u2" size="0x400000" crc="822f4ccd" sha1="ca842ce91ea9bbc8f4ee6a31bea2a99a7e633543" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -7688,9 +7688,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u2" value="U2 [NUS-NMKE-0 12]" />
 			<feature name="u3" value="U3 [empty]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmke-0 02.u1" size="8388608" crc="64f61706" sha1="2771d42bc093b0d30aef9b92d06ab09cfdebdea2" offset="0x000000" />
-				<rom name="nus-nmke-0 12.u2" size="4194304" crc="822f4ccd" sha1="ca842ce91ea9bbc8f4ee6a31bea2a99a7e633543" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmke-0 02.u1" size="0x800000" crc="64f61706" sha1="2771d42bc093b0d30aef9b92d06ab09cfdebdea2" offset="0x000000" />
+				<rom name="nus-nmke-0 12.u2" size="0x400000" crc="822f4ccd" sha1="ca842ce91ea9bbc8f4ee6a31bea2a99a7e633543" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -7700,8 +7700,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<year>1996</year>
 		<publisher>Midway</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mktril.bin" size="16777216" crc="eab22c06" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mktril.bin" size="0x1000000" crc="eab22c06" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7712,8 +7712,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NMRP-EUR, NUS-NMRP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mrc - multi racing championship (europe) (en,fr,de).bin" size="12582912" crc="9c7d29ec" sha1="6c00683512f99da0db25e22833b8369270a3a044" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mrc - multi racing championship (europe) (en,fr,de).bin" size="0xc00000" crc="9c7d29ec" sha1="6c00683512f99da0db25e22833b8369270a3a044" />
 			</dataarea>
 		</part>
 	</software>
@@ -7726,8 +7726,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19970718"/>
 		<info name="alt_title" value="マルチレーシングチャンピオンシップ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="mrc - multi racing championship (japan).bin" size="12582912" crc="4ca898e3" sha1="96b6966a12c0d3deb78a26e7273ecb5aed17d5e9" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="mrc - multi racing championship (japan).bin" size="0xc00000" crc="4ca898e3" sha1="96b6966a12c0d3deb78a26e7273ecb5aed17d5e9" />
 			</dataarea>
 		</part>
 	</software>
@@ -7742,8 +7742,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NMRE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmre-0.u1" size="12582912" crc="2f30b7fe" sha1="72009eba46cd9362cb7979d457eb1c7581b552da" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmre-0.u1" size="0xc00000" crc="2f30b7fe" sha1="72009eba46cd9362cb7979d457eb1c7581b552da" />
 			</dataarea>
 		</part>
 	</software>
@@ -7758,8 +7758,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NP9E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-np9e-0.u1" size="12582912" crc="d5017d76" sha1="b3924a297a03a0b10ff246a7c90f424c90e7ab64" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-np9e-0.u1" size="0xc00000" crc="d5017d76" sha1="b3924a297a03a0b10ff246a7c90f424c90e7ab64" />
 			</dataarea>
 		</part>
 	</software>
@@ -7770,8 +7770,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NGMP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mystical ninja 2 starring goemon (europe) (en,fr,de).bin" size="16777216" crc="6df2bda6" sha1="45bbfd1436d86055a82dba19869cb9d2038bfa18" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mystical ninja 2 starring goemon (europe) (en,fr,de).bin" size="0x1000000" crc="6df2bda6" sha1="45bbfd1436d86055a82dba19869cb9d2038bfa18" />
 			</dataarea>
 		</part>
 	</software>
@@ -7782,8 +7782,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NG5P-EUR, NUS-NG5P-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="mystical ninja starring goemon (europe).bin" size="16777216" crc="7dfe2e7a" sha1="3eb67f551791aa84ec2524c7a00b53dfd24b11ee" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="mystical ninja starring goemon (europe).bin" size="0x1000000" crc="7dfe2e7a" sha1="3eb67f551791aa84ec2524c7a00b53dfd24b11ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -7798,8 +7798,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NG5E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ng5e-0.u1" size="16777216" crc="81c10ad9" sha1="7a7cc41a47f0edbc96efa29d3f0f0e1c0d1e65af" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ng5e-0.u1" size="0x1000000" crc="81c10ad9" sha1="7a7cc41a47f0edbc96efa29d3f0f0e1c0d1e65af" />
 			</dataarea>
 		</part>
 	</software>
@@ -7810,8 +7810,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NH5P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nagano winter olympics '98 (europe).bin" size="12582912" crc="36d43f29" sha1="cb3ee16b5e45fef723af43bcf3e6f5ae07bc570a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nagano winter olympics '98 (europe).bin" size="0xc00000" crc="36d43f29" sha1="cb3ee16b5e45fef723af43bcf3e6f5ae07bc570a" />
 			</dataarea>
 		</part>
 	</software>
@@ -7826,8 +7826,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NH5E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nh5e-0.u1" size="12582912" crc="1f8d21fb" sha1="090d652498885ccfa841c1465e4b721d090d7b39" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nh5e-0.u1" size="0xc00000" crc="1f8d21fb" sha1="090d652498885ccfa841c1465e4b721d090d7b39" />
 			</dataarea>
 		</part>
 	</software>
@@ -7842,8 +7842,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NNME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nnme-0.u1" size="4194304" crc="03776764" sha1="8ff73b91e62abe925ad475b166ea65b1a698dae7" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nnme-0.u1" size="0x400000" crc="03776764" sha1="8ff73b91e62abe925ad475b166ea65b1a698dae7" />
 			</dataarea>
 		</part>
 	</software>
@@ -7858,8 +7858,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NN2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nn2e-0.u1" size="12582912" crc="d07ad471" sha1="d889b2f0e632cdc9d1ec6261a6841f7822a5d130" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nn2e-0.u1" size="0xc00000" crc="d07ad471" sha1="d889b2f0e632cdc9d1ec6261a6841f7822a5d130" />
 			</dataarea>
 		</part>
 	</software>
@@ -7870,8 +7870,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N9CP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nascar 99 (europe) (en,fr,de).bin" size="12582912" crc="5351acb5" sha1="84c515ab4ecf3cac306d1355b639d7e535845f42" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nascar 99 (europe) (en,fr,de).bin" size="0xc00000" crc="5351acb5" sha1="84c515ab4ecf3cac306d1355b639d7e535845f42" />
 			</dataarea>
 		</part>
 	</software>
@@ -7886,8 +7886,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-N9CE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n9ce-0.u1" size="12582912" crc="2d234fb7" sha1="c65ca3084221ccbd63a21cab179a50184a7fa798" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n9ce-0.u1" size="0xc00000" crc="2d234fb7" sha1="c65ca3084221ccbd63a21cab179a50184a7fa798" />
 			</dataarea>
 		</part>
 	</software>
@@ -7902,8 +7902,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NCKE-0]" />
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ncke-0.u1" size="16777216" crc="7a8fd7d3" sha1="63711be92268098bc69bec3168c09d0088db8ce6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ncke-0.u1" size="0x1000000" crc="7a8fd7d3" sha1="63711be92268098bc69bec3168c09d0088db8ce6" />
 			</dataarea>
 		</part>
 	</software>
@@ -7918,8 +7918,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NXGP-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nxgp-0.u1" size="12582912" crc="bf05fe53" sha1="004afe25ee5b70b915797ae799bfbf1d92c969a5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nxgp-0.u1" size="0xc00000" crc="bf05fe53" sha1="004afe25ee5b70b915797ae799bfbf1d92c969a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -7934,8 +7934,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NXGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nxge-0.u1" size="12582912" crc="72e2aca9" sha1="2a1ef108f5345e6ca80d7f73f4ca4557e7843594" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nxge-0.u1" size="0xc00000" crc="72e2aca9" sha1="2a1ef108f5345e6ca80d7f73f4ca4557e7843594" />
 			</dataarea>
 		</part>
 	</software>
@@ -7951,9 +7951,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u2" value="U2 [NUS-NXGE-0 12]" />
 			<feature name="u3" value="U3 [empty]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nxge-0 02.u1" size="8388608" crc="61a09164" sha1="771911da1aa2aabbf87b2a15ed14fa7909b0c593" offset="0x000000" />
-				<rom name="nus-nxge-0 12.u2" size="4194304" crc="6be5f4f3" sha1="9b909c40b72c519442f4c52f632f1b9fe0c8fe60" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nxge-0 02.u1" size="0x800000" crc="61a09164" sha1="771911da1aa2aabbf87b2a15ed14fa7909b0c593" offset="0x000000" />
+				<rom name="nus-nxge-0 12.u2" size="0x400000" crc="6be5f4f3" sha1="9b909c40b72c519442f4c52f632f1b9fe0c8fe60" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -7966,8 +7966,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19980129"/>
 		<info name="alt_title" value="NBA イン ザ ゾーン '98"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nba in the zone '98 (japan).bin" size="12582912" crc="58b2150d" sha1="4fc0a8392ece34f8a8c524640dce2a1255c66bfc" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nba in the zone '98 (japan).bin" size="0xc00000" crc="58b2150d" sha1="4fc0a8392ece34f8a8c524640dce2a1255c66bfc" />
 			</dataarea>
 		</part>
 	</software>
@@ -7982,8 +7982,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NBAE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nbae-0.u1" size="12582912" crc="2bb83c0e" sha1="b0e5d3a7fc83ec86027f9e7efdd876b7639e727c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nbae-0.u1" size="0xc00000" crc="2bb83c0e" sha1="b0e5d3a7fc83ec86027f9e7efdd876b7639e727c" />
 			</dataarea>
 		</part>
 	</software>
@@ -7998,8 +7998,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NB2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nb2e-0.u1" size="12582912" crc="c15afc69" sha1="be6b8fad67ece51e3dc09182ca7497652d92b241" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nb2e-0.u1" size="0xc00000" crc="c15afc69" sha1="be6b8fad67ece51e3dc09182ca7497652d92b241" />
 			</dataarea>
 		</part>
 	</software>
@@ -8012,8 +8012,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19990603"/>
 		<info name="alt_title" value="NBA イン ザ ゾーン 2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nba in the zone 2 (japan).bin" size="12582912" crc="f736d01a" sha1="c81bce72a48686b3966815915a579f2f5de733ec" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nba in the zone 2 (japan).bin" size="0xc00000" crc="f736d01a" sha1="c81bce72a48686b3966815915a579f2f5de733ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -8024,8 +8024,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NWZP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nba in the zone 2000 (europe).bin" size="16777216" crc="ad6cd2ae" sha1="29ecbf3dadb77c56051370897344839ebbd63130" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nba in the zone 2000 (europe).bin" size="0x1000000" crc="ad6cd2ae" sha1="29ecbf3dadb77c56051370897344839ebbd63130" />
 			</dataarea>
 		</part>
 	</software>
@@ -8040,8 +8040,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NWZE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nwze-0.u1" size="16777216" crc="d850cfa3" sha1="681d09e327e4faaa3ea53977047be5434aba1468" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nwze-0.u1" size="0x1000000" crc="d850cfa3" sha1="681d09e327e4faaa3ea53977047be5434aba1468" />
 			</dataarea>
 		</part>
 	</software>
@@ -8052,8 +8052,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NJAP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nba jam 2000 (europe).bin" size="16777216" crc="84deb3bd" sha1="4fc4d73eeb7669d9d54f8ae26908124cd8f9f618" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nba jam 2000 (europe).bin" size="0x1000000" crc="84deb3bd" sha1="4fc4d73eeb7669d9d54f8ae26908124cd8f9f618" />
 			</dataarea>
 		</part>
 	</software>
@@ -8068,8 +8068,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NJAE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-njae-0.u1" size="16777216" crc="65a3bd1c" sha1="58facec83666d3eba51986df97024229a087c78d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-njae-0.u1" size="0x1000000" crc="65a3bd1c" sha1="58facec83666d3eba51986df97024229a087c78d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8080,8 +8080,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NB9P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nba jam 99 (europe).bin" size="12582912" crc="8cce0ae4" sha1="07ea5c1767c0ede88d0cf231352f7389abcb2f2f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nba jam 99 (europe).bin" size="0xc00000" crc="8cce0ae4" sha1="07ea5c1767c0ede88d0cf231352f7389abcb2f2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8096,8 +8096,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NB9E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nb9e-0.u1" size="12582912" crc="f40c871a" sha1="5303a21d20bef75e6f77fbaedd120391cb4131d5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nb9e-0.u1" size="0xc00000" crc="f40c871a" sha1="5303a21d20bef75e6f77fbaedd120391cb4131d5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8108,8 +8108,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NNLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nba live 2000 (europe) (en,fr,de,es).bin" size="16777216" crc="4c7282d6" sha1="e2b90369cc88d6488d8ca307b7ab915cff8ed5d6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nba live 2000 (europe) (en,fr,de,es).bin" size="0x1000000" crc="4c7282d6" sha1="e2b90369cc88d6488d8ca307b7ab915cff8ed5d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -8125,8 +8125,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nnle-0.u1" size="16777216" crc="94fc12d3" sha1="61e5052589bfe9b7736b9e758125a8af11a11cb3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nnle-0.u1" size="0x1000000" crc="94fc12d3" sha1="61e5052589bfe9b7736b9e758125a8af11a11cb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8137,8 +8137,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N9BP-EUR, NUS-N9BP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nba live 99 (europe) (en,fr,de,es,it).bin" size="16777216" crc="086e322e" sha1="eea6e4ff34beb7d0eb5692d79f4c5a1ff757853e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nba live 99 (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="086e322e" sha1="eea6e4ff34beb7d0eb5692d79f4c5a1ff757853e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8155,8 +8155,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-n9be-0.u1" size="16777216" crc="74bc96be" sha1="c040aabd6a985052a6d2e9ab7b8d458233d0793f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-n9be-0.u1" size="0x1000000" crc="74bc96be" sha1="c040aabd6a985052a6d2e9ab7b8d458233d0793f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8167,8 +8167,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NBAP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nba pro 98 (europe).bin" size="12582912" crc="7fabf1ea" sha1="fd5131330c501858e6ad3128ee3d252c998a2eb5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nba pro 98 (europe).bin" size="0xc00000" crc="7fabf1ea" sha1="fd5131330c501858e6ad3128ee3d252c998a2eb5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8179,8 +8179,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NB2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nba pro 99 (europe).bin" size="12582912" crc="6ea32e08" sha1="fb369e088766095bc6466ad09b8c94caaf9a1df5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nba pro 99 (europe).bin" size="0xc00000" crc="6ea32e08" sha1="fb369e088766095bc6466ad09b8c94caaf9a1df5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8195,8 +8195,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NSOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nsoe-0.u1" size="16777216" crc="a9302dee" sha1="4857b02997b65aa86d2ada8e7364e62b5ff10356" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nsoe-0.u1" size="0x1000000" crc="a9302dee" sha1="4857b02997b65aa86d2ada8e7364e62b5ff10356" />
 			</dataarea>
 		</part>
 	</software>
@@ -8209,8 +8209,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19990625"/>
 		<info name="alt_title" value="新世紀エヴァンゲリオン"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="neon genesis evangelion (japan).bin" size="33554432" crc="4b8b23dc" sha1="bf10f76812ada36c304eb45ad5da794f02c560fe" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="neon genesis evangelion (japan).bin" size="0x2000000" crc="4b8b23dc" sha1="bf10f76812ada36c304eb45ad5da794f02c560fe" />
 			</dataarea>
 		</part>
 	</software>
@@ -8221,8 +8221,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NRIP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="new tetris, the (europe).bin" size="12582912" crc="88b774c4" sha1="99c7ff49cfd04569fb29514149be62f073a19bda" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="new tetris, the (europe).bin" size="0xc00000" crc="88b774c4" sha1="99c7ff49cfd04569fb29514149be62f073a19bda" />
 			</dataarea>
 		</part>
 	</software>
@@ -8239,8 +8239,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [BU9811]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrie-0.u1" size="12582912" crc="82a76dc9" sha1="cc88bfed8b77885cda6123c08e5d3b11451c6074" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrie-0.u1" size="0xc00000" crc="82a76dc9" sha1="cc88bfed8b77885cda6123c08e5d3b11451c6074" />
 			</dataarea>
 		</part>
 	</software>
@@ -8255,8 +8255,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NBZE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbze-0.u1" size="16777216" crc="5fa3455d" sha1="fa193a704b83f00cf3874d2f49275930168f0416" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbze-0.u1" size="0x1000000" crc="5fa3455d" sha1="fa193a704b83f00cf3874d2f49275930168f0416" />
 			</dataarea>
 		</part>
 	</software>
@@ -8271,8 +8271,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NSZE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nsze-0.u1" size="16777216" crc="3dd3eb64" sha1="2f64076b423a72f873a04910a40d3a3f5dddbb25" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nsze-0.u1" size="0x1000000" crc="3dd3eb64" sha1="2f64076b423a72f873a04910a40d3a3f5dddbb25" />
 			</dataarea>
 		</part>
 	</software>
@@ -8287,8 +8287,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NBIE-1]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbie-1.u1" size="16777216" crc="f77108c0" sha1="2041bc6ebc6bfd412640a14d236a279b07cae616" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbie-1.u1" size="0x1000000" crc="f77108c0" sha1="2041bc6ebc6bfd412640a14d236a279b07cae616" />
 			</dataarea>
 		</part>
 	</software>
@@ -8305,8 +8305,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nbie-0.u1" size="16777216" crc="e4b42e6a" sha1="0dc7a0b174c53d95cb8046538a1a4c4475d7209d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nbie-0.u1" size="0x1000000" crc="e4b42e6a" sha1="0dc7a0b174c53d95cb8046538a1a4c4475d7209d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8317,8 +8317,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NFBE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nfl blitz 2001 (usa).bin" size="16777216" crc="e18211e5" sha1="1305ea64fa5eb62b36e029c5646299c080daede9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nfl blitz 2001 (usa).bin" size="0x1000000" crc="e18211e5" sha1="1305ea64fa5eb62b36e029c5646299c080daede9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8329,8 +8329,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NQBP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nfl quarterback club 2000 (europe).bin" size="12582912" crc="11225980" sha1="9029e7b3ea19277e323337e5b41bb6ba83ee57ae" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nfl quarterback club 2000 (europe).bin" size="0xc00000" crc="11225980" sha1="9029e7b3ea19277e323337e5b41bb6ba83ee57ae" />
 			</dataarea>
 		</part>
 	</software>
@@ -8345,8 +8345,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NQBE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nqbe-0.u1" size="12582912" crc="b61d114a" sha1="63b52f8c4d8efaaabc87237938fd65975ec19bad" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nqbe-0.u1" size="0xc00000" crc="b61d114a" sha1="63b52f8c4d8efaaabc87237938fd65975ec19bad" />
 			</dataarea>
 		</part>
 	</software>
@@ -8361,8 +8361,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NQCE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nqce-0.u1" size="12582912" crc="2c0d748b" sha1="1b31a55a7c744f5de52f6198820c17bf25785ebf" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nqce-0.u1" size="0xc00000" crc="2c0d748b" sha1="1b31a55a7c744f5de52f6198820c17bf25785ebf" />
 			</dataarea>
 		</part>
 	</software>
@@ -8373,8 +8373,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NQ8P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="nfl quarterback club 98 (europe).bin" size="8388608" crc="129928ed" sha1="e73f59f51eff338da0feedfe018c6fb46c3638f3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nfl quarterback club 98 (europe).bin" size="0x800000" crc="129928ed" sha1="e73f59f51eff338da0feedfe018c6fb46c3638f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -8389,8 +8389,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NQ8E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nq8e-0.u1" size="8388608" crc="94368db1" sha1="afa0fa7b55931325426c46c3a04a1a5bec81f711" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nq8e-0.u1" size="0x800000" crc="94368db1" sha1="afa0fa7b55931325426c46c3a04a1a5bec81f711" />
 			</dataarea>
 		</part>
 	</software>
@@ -8401,8 +8401,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NQ9P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nfl quarterback club 99 (europe).bin" size="12582912" crc="8d95305f" sha1="32e5b34284b4ca3cf52fab86dc4a155624b4b64d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nfl quarterback club 99 (europe).bin" size="0xc00000" crc="8d95305f" sha1="32e5b34284b4ca3cf52fab86dc4a155624b4b64d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8417,8 +8417,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NQ9E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nq9e-0.u1" size="12582912" crc="ce525bc5" sha1="bb054fa24a084018995b68164560020de44c6c92" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nq9e-0.u1" size="0xc00000" crc="ce525bc5" sha1="bb054fa24a084018995b68164560020de44c6c92" />
 			</dataarea>
 		</part>
 	</software>
@@ -8429,8 +8429,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-N9HP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nhl 99 (europe) (en,de,sv,fi).bin" size="12582912" crc="5caabe5a" sha1="d6142f571bb72e4bc6ac9c665e666fcd927302a4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nhl 99 (europe) (en,de,sv,fi).bin" size="0xc00000" crc="5caabe5a" sha1="d6142f571bb72e4bc6ac9c665e666fcd927302a4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8445,8 +8445,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-N9HE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n9he-0.u1" size="12582912" crc="50f81f73" sha1="94b9957551bc31e5bfb49c72310155e376887757" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n9he-0.u1" size="0xc00000" crc="50f81f73" sha1="94b9957551bc31e5bfb49c72310155e376887757" />
 			</dataarea>
 		</part>
 	</software>
@@ -8461,8 +8461,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NHOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nhoe-0.u1" size="12582912" crc="5ef28cfb" sha1="176bde5f17295aeccea06c09c761add271a6931f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nhoe-0.u1" size="0xc00000" crc="5ef28cfb" sha1="176bde5f17295aeccea06c09c761add271a6931f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8473,8 +8473,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NHLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nhl breakaway 98 (europe).bin" size="12582912" crc="30b28491" sha1="7f3f234bb01b1128d954c3d98f2debad6eaa018f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nhl breakaway 98 (europe).bin" size="0xc00000" crc="30b28491" sha1="7f3f234bb01b1128d954c3d98f2debad6eaa018f" />
 			</dataarea>
 		</part>
 	</software>
@@ -8489,8 +8489,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NHLE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nhle-0.u1" size="12582912" crc="f59b082f" sha1="4ce6fa90bc8a92a73eafebb677ea6ddb90e93ecc" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nhle-0.u1" size="0xc00000" crc="f59b082f" sha1="4ce6fa90bc8a92a73eafebb677ea6ddb90e93ecc" />
 			</dataarea>
 		</part>
 	</software>
@@ -8501,8 +8501,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NH9P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nhl breakaway 99 (europe).bin" size="12582912" crc="b7e1618a" sha1="59a291a5f9887f8d569670a868e44c53cfb84475" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nhl breakaway 99 (europe).bin" size="0xc00000" crc="b7e1618a" sha1="59a291a5f9887f8d569670a868e44c53cfb84475" />
 			</dataarea>
 		</part>
 	</software>
@@ -8517,8 +8517,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NH9E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nh9e-0.u1" size="12582912" crc="9f774781" sha1="b026fb43057815b7d383f82170617ab5d59120f9" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nh9e-0.u1" size="0xc00000" crc="9f774781" sha1="b026fb43057815b7d383f82170617ab5d59120f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -8529,8 +8529,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NHOP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="nhl pro 99 (europe).bin" size="12582912" crc="36696571" sha1="c8b0d2c2fa2b221efe1fee05220581a68a6c3f9e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nhl pro 99 (europe).bin" size="0xc00000" crc="36696571" sha1="c8b0d2c2fa2b221efe1fee05220581a68a6c3f9e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8545,8 +8545,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NNCE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nnce-0.u1" size="16777216" crc="134c09da" sha1="1d01be47a805679d17bedc4f5294db20bbb2875d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nnce-0.u1" size="0x1000000" crc="134c09da" sha1="1d01be47a805679d17bedc4f5294db20bbb2875d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8565,8 +8565,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nhbj-0.u1" size="8388608" crc="2d96c091" sha1="0c2ee2266c67b5afa507f5b8ece88ab565fed63a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nhbj-0.u1" size="0x800000" crc="2d96c091" sha1="0c2ee2266c67b5afa507f5b8ece88ab565fed63a" />
 			</dataarea>
 		</part>
 	</software>
@@ -8587,8 +8587,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nalj-0.u1" size="16777216" crc="a2d1d0d1" sha1="42e5bab5d8c3b3ca3582e142094b50ecc7fea5e6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nalj-0.u1" size="0x1000000" crc="a2d1d0d1" sha1="42e5bab5d8c3b3ca3582e142094b50ecc7fea5e6" />
 			</dataarea>
 		</part>
 	</software>
@@ -8599,8 +8599,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NCEP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="nuclear strike 64 (europe) (en,fr).bin" size="33554432" crc="575fbfe5" sha1="c170b3a4032cfdf885068f6f3af9eb6cbf28484c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nuclear strike 64 (europe) (en,fr).bin" size="0x2000000" crc="575fbfe5" sha1="c170b3a4032cfdf885068f6f3af9eb6cbf28484c" />
 			</dataarea>
 		</part>
 	</software>
@@ -8611,8 +8611,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NCED-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="nuclear strike 64 (germany).bin" size="33554432" crc="2f575e61" sha1="7df3153f6fd24ba33255909225b481c3444a6fa7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nuclear strike 64 (germany).bin" size="0x2000000" crc="2f575e61" sha1="7df3153f6fd24ba33255909225b481c3444a6fa7" />
 			</dataarea>
 		</part>
 	</software>
@@ -8627,8 +8627,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NCEE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ncee-0.u1" size="33554432" crc="1a70d11a" sha1="ea1371d29cbdede166a69c77b2c4a77d6edab77d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ncee-0.u1" size="0x2000000" crc="1a70d11a" sha1="ea1371d29cbdede166a69c77b2c4a77d6edab77d" />
 			</dataarea>
 		</part>
 	</software>
@@ -8641,8 +8641,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ぬし釣り64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nushi tsuri 64 (japan) (rev a).bin" size="16777216" crc="df59e5f2" sha1="75caf0eda25d60a6e877573c3e16fb41e2d60209" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nushi tsuri 64 (japan) (rev a).bin" size="0x1000000" crc="df59e5f2" sha1="75caf0eda25d60a6e877573c3e16fb41e2d60209" />
 			</dataarea>
 		</part>
 	</software>
@@ -8655,8 +8655,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19981127"/>
 		<info name="alt_title" value="ぬし釣り64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="nushi tsuri 64 (japan).bin" size="16777216" crc="02ff4df5" sha1="0c6561db721d440c1e29fabb79a53b0422ac1903" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nushi tsuri 64 (japan).bin" size="0x1000000" crc="02ff4df5" sha1="0c6561db721d440c1e29fabb79a53b0422ac1903" />
 			</dataarea>
 		</part>
 	</software>
@@ -8669,8 +8669,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="20000526"/>
 		<info name="alt_title" value="ぬし釣り64 −潮風にのって−"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="nushi tsuri 64 - shiokaze ni notte (japan).bin" size="33554432" crc="6a81744d" sha1="5306827ffbf9bd51f52723d87083d68db240c890" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nushi tsuri 64 - shiokaze ni notte (japan).bin" size="0x2000000" crc="6a81744d" sha1="5306827ffbf9bd51f52723d87083d68db240c890" />
 			</dataarea>
 		</part>
 	</software>
@@ -8680,8 +8680,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="o.d.t. (europe) (en,fr,de,es,it) (proto).bin" size="16777216" crc="6e79473e" sha1="93dc2adb08c209fdc0bf2f007824fde79f79a638" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="o.d.t. (europe) (en,fr,de,es,it) (proto).bin" size="0x1000000" crc="6e79473e" sha1="93dc2adb08c209fdc0bf2f007824fde79f79a638" />
 			</dataarea>
 		</part>
 	</software>
@@ -8691,8 +8691,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<year>1999</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="o.d.t. (usa) (en,fr,es) (proto).bin" size="16777216" crc="ae7e3a9e" sha1="9d1e073f9aad18f4a7a52cb185a50f5045bfd656" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="o.d.t. (usa) (en,fr,es) (proto).bin" size="0x1000000" crc="ae7e3a9e" sha1="9d1e073f9aad18f4a7a52cb185a50f5045bfd656" />
 			</dataarea>
 		</part>
 	</software>
@@ -8703,8 +8703,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NOFP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="off road challenge (europe).bin" size="16777216" crc="e1938232" sha1="c15ebcdbe0532556e215cdb7ee35c4f25fe66884" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="off road challenge (europe).bin" size="0x1000000" crc="e1938232" sha1="c15ebcdbe0532556e215cdb7ee35c4f25fe66884" />
 			</dataarea>
 		</part>
 	</software>
@@ -8719,8 +8719,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NOFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nofe-0.u1" size="16777216" crc="129badcc" sha1="914239aa8172c91c44280a09e34b6e7ce046ca1b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nofe-0.u1" size="0x1000000" crc="129badcc" sha1="914239aa8172c91c44280a09e34b6e7ce046ca1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -8740,8 +8740,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u4" value="U4 BU9803 [LV2416]" />
 			<feature name="u5" value="U5 CIC-NUS [CIC6102A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="41943040">
-				<rom name="ogre battle 64 - person of lordly caliber (japan) (rev a).bin" size="41943040" crc="d52f01fd" sha1="771bb04c814fdb741351b37bc4ca2db00f3d2a43" />
+			<dataarea name="rom" size="0x2800000">
+				<rom name="ogre battle 64 - person of lordly caliber (japan) (rev a).bin" size="0x2800000" crc="d52f01fd" sha1="771bb04c814fdb741351b37bc4ca2db00f3d2a43" />
 			</dataarea>
 		</part>
 	</software>
@@ -8752,8 +8752,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Atlus</publisher>
 		<info name="serial" value="NUS-NOBE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="41943040">
-				<rom name="ogre battle 64 - person of lordly caliber (usa) (rev a).bin" size="41943040" crc="50c78d4c" sha1="6f3c590d1f3225cca9bf7e7dec8c20f91d61d645" />
+			<dataarea name="rom" size="0x2800000">
+				<rom name="ogre battle 64 - person of lordly caliber (usa) (rev a).bin" size="0x2800000" crc="50c78d4c" sha1="6f3c590d1f3225cca9bf7e7dec8c20f91d61d645" />
 			</dataarea>
 		</part>
 	</software>
@@ -8771,9 +8771,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u4" value="U4 BU9803 [LV2416]" />
 			<feature name="u5" value="U5 CIC-NUS [CIC6102A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="41943040">
-				<rom name="nus-nobe-0 02.u1" size="33554432" crc="15d593ec" sha1="974132ac52e57792ae4de674a2cd5396fa07ad9f" offset="0x0000000" />
-				<rom name="nus-nobe-0 12.u2" size="8388608" crc="13d20667" sha1="62872cffdf809a0b6616ad6369e1e45f1fd95722" offset="0x2000000" />
+			<dataarea name="rom" size="0x2800000">
+				<rom name="nus-nobe-0 02.u1" size="0x2000000" crc="15d593ec" sha1="974132ac52e57792ae4de674a2cd5396fa07ad9f" offset="0x0000000" />
+				<rom name="nus-nobe-0 12.u2" size="0x800000" crc="13d20667" sha1="62872cffdf809a0b6616ad6369e1e45f1fd95722" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -8784,8 +8784,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NHNP-NOE, NUS-NHNP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="olympic hockey nagano '98 (europe) (en,fr,de,es).bin" size="8388608" crc="1c7b9ed5" sha1="d72f932b0d12f19b9423a112664d0ccfc1526767" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="olympic hockey nagano '98 (europe) (en,fr,de,es).bin" size="0x800000" crc="1c7b9ed5" sha1="d72f932b0d12f19b9423a112664d0ccfc1526767" />
 			</dataarea>
 		</part>
 	</software>
@@ -8798,8 +8798,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19980716"/>
 		<info name="alt_title" value="オリンピックホッケーナガノ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="olympic hockey nagano '98 (japan).bin" size="8388608" crc="436cc625" sha1="df9d4743019fba3dd0725588f0d17d97cbb2c223" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="olympic hockey nagano '98 (japan).bin" size="0x800000" crc="436cc625" sha1="df9d4743019fba3dd0725588f0d17d97cbb2c223" />
 			</dataarea>
 		</part>
 	</software>
@@ -8810,8 +8810,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NHNE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="olympic hockey nagano '98 (usa).bin" size="8388608" crc="c57c7643" sha1="7e200f4f4d2a7eb0ddc2011bd55628b5a50788bf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="olympic hockey nagano '98 (usa).bin" size="0x800000" crc="c57c7643" sha1="7e200f4f4d2a7eb0ddc2011bd55628b5a50788bf" />
 			</dataarea>
 		</part>
 	</software>
@@ -8824,8 +8824,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19990409"/>
 		<info name="alt_title" value="おねがいモンスター"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="onegai monsters (japan).bin" size="16777216" crc="ff03ec8a" sha1="a352a6f95b414f7563503fa39e92c604f965a11e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="onegai monsters (japan).bin" size="0x1000000" crc="ff03ec8a" sha1="a352a6f95b414f7563503fa39e92c604f965a11e" />
 			</dataarea>
 		</part>
 	</software>
@@ -8836,8 +8836,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Koei</publisher>
 		<info name="serial" value="NUS-NWDP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="operation winback (europe) (en,fr,de,es,it).bin" size="16777216" crc="15f1c325" sha1="6ab5a9771f4bed7f96726c943a24215300c107e5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="operation winback (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="15f1c325" sha1="6ab5a9771f4bed7f96726c943a24215300c107e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8856,8 +8856,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-npcj-0.u1" size="12582912" crc="41363874" sha1="a14f8b56f1f40d982e3636b328911ccc96b58bd5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-npcj-0.u1" size="0xc00000" crc="41363874" sha1="a14f8b56f1f40d982e3636b328911ccc96b58bd5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8873,9 +8873,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u2" value="U2 [NUS-NMQP-0 12]" />
 			<feature name="u3" value="U3 [29L1100KC-15B0]" />
 			<feature name="u4" value="U4 [CIC-NUS-7103A]" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-nmqp-0 02.u1" size="33554432" crc="68f7101c" sha1="c82851bd21e31a59fd63ca3af19801816eebfde9" offset="0x0000000" />
-				<rom name="nus-nmqp-0 12.u1" size="16777216" crc="d5f2e57d" sha1="586217209dcd4de1448594eef6e3f51f785cfc14" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-nmqp-0 02.u1" size="0x2000000" crc="68f7101c" sha1="c82851bd21e31a59fd63ca3af19801816eebfde9" offset="0x0000000" />
+				<rom name="nus-nmqp-0 12.u1" size="0x1000000" crc="d5f2e57d" sha1="586217209dcd4de1448594eef6e3f51f785cfc14" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -8892,9 +8892,9 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [29L1100KC-15B0]" />
 			<feature name="u4" value="U4 [CIC-NUS-6103A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="41943040">
-				<rom name="nus-nmqe-0 02.u1" size="33554432" crc="de434d52" sha1="e8325ed8cba6c7f8c36acdf8f05e3abd9a759557" offset="0x0000000" />
-				<rom name="nus-nmqe-0 12.u2" size="8388608" crc="73e87a64" sha1="c01be0de303bfda35c47d0c7b70168a7af6f56c6" offset="0x2000000" />
+			<dataarea name="rom" size="0x2800000">
+				<rom name="nus-nmqe-0 02.u1" size="0x2000000" crc="de434d52" sha1="e8325ed8cba6c7f8c36acdf8f05e3abd9a759557" offset="0x0000000" />
+				<rom name="nus-nmqe-0 12.u2" size="0x800000" crc="73e87a64" sha1="c01be0de303bfda35c47d0c7b70168a7af6f56c6" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -8905,8 +8905,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NYPP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="paperboy (europe).bin" size="12582912" crc="d98c3f8b" sha1="da7da76570c4c5303475c30c18791ca83f8455c4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="paperboy (europe).bin" size="0xc00000" crc="d98c3f8b" sha1="da7da76570c4c5303475c30c18791ca83f8455c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -8921,8 +8921,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NYPE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nype-0.u1" size="12582912" crc="2fceeff6" sha1="0dccd178f9af55a2fcbc5b963b60e7a897e237ff" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nype-0.u1" size="0xc00000" crc="2fceeff6" sha1="0dccd178f9af55a2fcbc5b963b60e7a897e237ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -8935,8 +8935,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19990129"/>
 		<info name="alt_title" value="Parlor! PRO 64 パチンコ実機シミュレーション"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="parlor pro 64 - pachinko jikki simulation game (japan).bin" size="12582912" crc="66420991" sha1="2e1f15cbb6e4744d6b1c8efdc708349ab6c8982a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="parlor pro 64 - pachinko jikki simulation game (japan).bin" size="0xc00000" crc="66420991" sha1="2e1f15cbb6e4744d6b1c8efdc708349ab6c8982a" />
 			</dataarea>
 		</part>
 	</software>
@@ -8949,8 +8949,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="19990716"/>
 		<info name="alt_title" value="PDウルトラマンバトルコレクション64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pd ultraman battle collection 64 (japan).bin" size="33554432" crc="ab901b83" sha1="15a646c8e612f50a767055c352a1bef59aef49e5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pd ultraman battle collection 64 (japan).bin" size="0x2000000" crc="ab901b83" sha1="15a646c8e612f50a767055c352a1bef59aef49e5" />
 			</dataarea>
 		</part>
 	</software>
@@ -8961,8 +8961,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NCRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="penny racers (europe).bin" size="8388608" crc="decd5d16" sha1="d44053caed77de2c91de6527e1d4cd4441b231d8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="penny racers (europe).bin" size="0x800000" crc="decd5d16" sha1="d44053caed77de2c91de6527e1d4cd4441b231d8" />
 			</dataarea>
 		</part>
 	</software>
@@ -8977,8 +8977,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u1" value="U1 [NUS-NCRE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ncre-0.u1" size="8388608" crc="06beea3f" sha1="f8ca8a70653dbe488749fd3ea3e428fb9b1f72c8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ncre-0.u1" size="0x800000" crc="06beea3f" sha1="f8ca8a70653dbe488749fd3ea3e428fb9b1f72c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -8989,8 +8989,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPDP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="perfect dark (europe) (en,fr,de,es,it).bin" size="33554432" crc="c4639ed6" sha1="eb38780b7f7a0ea4c24369d03644b42ffe739e63" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="perfect dark (europe) (en,fr,de,es,it).bin" size="0x2000000" crc="c4639ed6" sha1="eb38780b7f7a0ea4c24369d03644b42ffe739e63" />
 			</dataarea>
 		</part>
 	</software>
@@ -9003,8 +9003,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<info name="release" value="20001021"/>
 		<info name="alt_title" value="パーフェクトダーク"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="perfect dark (japan).bin" size="33554432" crc="d76471db" sha1="e001af5a3069b374e0a08d1598b0833fe3128d82" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="perfect dark (japan).bin" size="0x2000000" crc="d76471db" sha1="e001af5a3069b374e0a08d1598b0833fe3128d82" />
 			</dataarea>
 		</part>
 	</software>
@@ -9021,8 +9021,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npde-1.u1" size="33554432" crc="f85a16f1" sha1="07e74d1b42aaadc6d95b171f6bd5f16e7c641284" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npde-1.u1" size="0x2000000" crc="f85a16f1" sha1="07e74d1b42aaadc6d95b171f6bd5f16e7c641284" />
 			</dataarea>
 		</part>
 	</software>
@@ -9033,8 +9033,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPDE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="perfect dark (usa).bin" size="33554432" crc="f0fe18f0" sha1="ea43d1f09b47107ae0d1b7472bca58d785e8573a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="perfect dark (usa).bin" size="0x2000000" crc="f0fe18f0" sha1="ea43d1f09b47107ae0d1b7472bca58d785e8573a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9045,8 +9045,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="perfect dark eur debug.bin" size="33554432" crc="5c6ac287" sha1="278cec1806eb39690cd2a3ae4838cfa8b8e630d2" status="baddump" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="perfect dark eur debug.bin" size="0x2000000" crc="5c6ac287" sha1="278cec1806eb39690cd2a3ae4838cfa8b8e630d2" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -9056,8 +9056,8 @@ This cart features a built-in RJ-42 Modem Connection port to play online, curren
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="perfect dark ntsc debug_ec.bin" size="67108864" crc="571ca36e" sha1="578eef928e7f93310288ea1e319dc1d00dee51fa" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="perfect dark ntsc debug_ec.bin" size="0x4000000" crc="571ca36e" sha1="578eef928e7f93310288ea1e319dc1d00dee51fa" />
 			</dataarea>
 		</part>
 	</software>
@@ -9074,8 +9074,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pd_ntsc_debug_dc.bin" size="33554432" crc="0ea2645f" sha1="40c60733840ee68ac60f0c951055c942a2573bfc" status="baddump" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pd_ntsc_debug_dc.bin" size="0x2000000" crc="0ea2645f" sha1="40c60733840ee68ac60f0c951055c942a2573bfc" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -9090,8 +9090,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NEAE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-neae-0.u1" size="16777216" crc="2b07f591" sha1="6417f608e7dd002dc1193641d8c846328c3faab2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-neae-0.u1" size="0x1000000" crc="2b07f591" sha1="6417f608e7dd002dc1193641d8c846328c3faab2" />
 			</dataarea>
 		</part>
 	</software>
@@ -9102,8 +9102,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NEAP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pga european tour golf (europe) (en,fr,de,es,it).bin" size="16777216" crc="07b0271e" sha1="20c442cf25951e2b09eb7b19e3e900b885231ffa" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pga european tour golf (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="07b0271e" sha1="20c442cf25951e2b09eb7b19e3e900b885231ffa" />
 			</dataarea>
 		</part>
 	</software>
@@ -9130,8 +9130,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="pikachuu genki de chuu (japan).bin" size="16777216" crc="2ae884cd" sha1="533ba7078e631bdcbf97776a151dbcab206fa991" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pikachuu genki de chuu (japan).bin" size="0x1000000" crc="2ae884cd" sha1="533ba7078e631bdcbf97776a151dbcab206fa991" />
 			</dataarea>
 		</part>
 	</software>
@@ -9142,8 +9142,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="pilotwings 64 (europe) (en,fr,de).bin" size="8388608" crc="334e88bf" sha1="7014b6ac0a6af8ab729e441ae9b5de08ef7b68dd" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="pilotwings 64 (europe) (en,fr,de).bin" size="0x800000" crc="334e88bf" sha1="7014b6ac0a6af8ab729e441ae9b5de08ef7b68dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -9162,8 +9162,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-npwj-0.u1" size="8388608" crc="001ee45b" sha1="e6e8a48e433dc7a4949756e70ab18d0165a1bc6f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-npwj-0.u1" size="0x800000" crc="001ee45b" sha1="e6e8a48e433dc7a4949756e70ab18d0165a1bc6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9178,8 +9178,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPWE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-npwe-0.u1" size="8388608" crc="c445f7e3" sha1="0576080dd468ff528d90cf2de6c4a7790e4923f3" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-npwe-0.u1" size="0x800000" crc="c445f7e3" sha1="0576080dd468ff528d90cf2de6c4a7790e4923f3" />
 			</dataarea>
 		</part>
 	</software>
@@ -9192,8 +9192,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990321"/>
 		<info name="alt_title" value="ポケモンスナップ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pocket monsters snap (japan).bin" size="16777216" crc="100aacc0" sha1="76ea033f8d76c3add4f76d7dc718834aa1d30615" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pocket monsters snap (japan).bin" size="0x1000000" crc="100aacc0" sha1="76ea033f8d76c3add4f76d7dc718834aa1d30615" />
 			</dataarea>
 		</part>
 	</software>
@@ -9206,8 +9206,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980801"/>
 		<info name="alt_title" value="ポケモンスタジアム"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pocket monsters stadium (japan).bin" size="16777216" crc="3b2a3f7a" sha1="d1796076f855bd2354ffc5019eaeb2c9d7676716" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pocket monsters stadium (japan).bin" size="0x1000000" crc="3b2a3f7a" sha1="d1796076f855bd2354ffc5019eaeb2c9d7676716" />
 			</dataarea>
 		</part>
 	</software>
@@ -9220,8 +9220,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990430"/>
 		<info name="alt_title" value="ポケモンスタジアム2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pocket monsters stadium 2 (japan).bin" size="33554432" crc="c876be9c" sha1="17a3552f251daeb475b359aac687bcee473c13f7" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pocket monsters stadium 2 (japan).bin" size="0x2000000" crc="c876be9c" sha1="17a3552f251daeb475b359aac687bcee473c13f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -9241,9 +9241,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u4" value="U4 [CIC-NUS-6103A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-np3j-0 12.u1" size="33554432" crc="a235a8fb" sha1="0de404dd6d8eb0fcff0d7455aea6e85e1fa2abf6" offset="0x0000000" />
-				<rom name="nus-np3j-0 02.u2" size="33554432" crc="0a4fab4f" sha1="6d97504363a344a6bb29868fd315332c86495207" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-np3j-0 12.u1" size="0x2000000" crc="a235a8fb" sha1="0de404dd6d8eb0fcff0d7455aea6e85e1fa2abf6" offset="0x0000000" />
+				<rom name="nus-np3j-0 02.u2" size="0x2000000" crc="0a4fab4f" sha1="6d97504363a344a6bb29868fd315332c86495207" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -9254,8 +9254,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPNP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon puzzle league (europe).bin" size="33554432" crc="443b309a" sha1="06eb1d4c92a7bab8267b6fa15be89f253dead96c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon puzzle league (europe).bin" size="0x2000000" crc="443b309a" sha1="06eb1d4c92a7bab8267b6fa15be89f253dead96c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9266,8 +9266,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPNF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon puzzle league (france).bin" size="33554432" crc="ee080ccd" sha1="838f4cdc5033a672afc8662700ecd8df1ef6b776" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon puzzle league (france).bin" size="0x2000000" crc="ee080ccd" sha1="838f4cdc5033a672afc8662700ecd8df1ef6b776" />
 			</dataarea>
 		</part>
 	</software>
@@ -9282,8 +9282,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPND-0]" />
 			<feature name="u2" value="U2 [29LL1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npnd-0.u1" size="33554432" crc="7d4c9859" sha1="656c86a50e4954e11c202ada31d2e2fd516b8f07" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npnd-0.u1" size="0x2000000" crc="7d4c9859" sha1="656c86a50e4954e11c202ada31d2e2fd516b8f07" />
 			</dataarea>
 		</part>
 	</software>
@@ -9298,8 +9298,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPNE-0]" />
 			<feature name="u2" value="U2 [29LL1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npne-0.u1" size="33554432" crc="281afb0d" sha1="e52af5a60ea9bd2dae34e4252d71bedaf496cdb3" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npne-0.u1" size="0x2000000" crc="281afb0d" sha1="e52af5a60ea9bd2dae34e4252d71bedaf496cdb3" />
 			</dataarea>
 		</part>
 	</software>
@@ -9310,8 +9310,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPFU-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pokemon snap (australia).bin" size="16777216" crc="8a8f6d5f" sha1="d6bdd376a1baeb863a14925bc96e2d1a73645e71" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pokemon snap (australia).bin" size="0x1000000" crc="8a8f6d5f" sha1="d6bdd376a1baeb863a14925bc96e2d1a73645e71" />
 			</dataarea>
 		</part>
 	</software>
@@ -9327,8 +9327,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [29LL1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npfp-0.u1" size="16777216" crc="e9100906" sha1="85ec6f75567d5676ee7317b4f20c8ec6caca03bb" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npfp-0.u1" size="0x1000000" crc="e9100906" sha1="85ec6f75567d5676ee7317b4f20c8ec6caca03bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -9339,8 +9339,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPFF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pokemon snap (france).bin" size="16777216" crc="116b2cac" sha1="5c1d6e2020eed2e012b722a98846db16fa7b1c9b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pokemon snap (france).bin" size="0x1000000" crc="116b2cac" sha1="5c1d6e2020eed2e012b722a98846db16fa7b1c9b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9358,8 +9358,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npfd-0.u1" size="16777216" crc="482a6d8d" sha1="d12d3ad66da97985f057d42dd7fbb9b9c1a0074e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npfd-0.u1" size="0x1000000" crc="482a6d8d" sha1="d12d3ad66da97985f057d42dd7fbb9b9c1a0074e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9376,8 +9376,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npfi-0.u1" size="16777216" crc="d3ae1d04" sha1="ab649b902b48271f628b614b43453c651592af4f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npfi-0.u1" size="0x1000000" crc="d3ae1d04" sha1="ab649b902b48271f628b614b43453c651592af4f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9394,8 +9394,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npfs-0.u1" size="16777216" crc="426a1919" sha1="e2276abf1cc2fe7bb5a8d05241214481b02580e1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npfs-0.u1" size="0x1000000" crc="426a1919" sha1="e2276abf1cc2fe7bb5a8d05241214481b02580e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -9412,8 +9412,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6103]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npfe-0.u1" size="16777216" crc="df387848" sha1="cfa6c20848651b686761f3bd72d5d97c3b83cca9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npfe-0.u1" size="0x1000000" crc="df387848" sha1="cfa6c20848651b686761f3bd72d5d97c3b83cca9" />
 			</dataarea>
 		</part>
 	</software>
@@ -9423,8 +9423,8 @@ patched out (+ a fix for internal checksum)
 		<year>1999</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="pokemon snap station (usa) (promo).bin" size="16777216" crc="9bef1033" sha1="7dfbe7f3e764a740d92d4c7195f1c638a0912452" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="pokemon snap station (usa) (promo).bin" size="0x1000000" crc="9bef1033" sha1="7dfbe7f3e764a740d92d4c7195f1c638a0912452" />
 			</dataarea>
 		</part>
 	</software>
@@ -9435,8 +9435,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPOP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon stadium (europe) (rev a).bin" size="33554432" crc="60f6be65" sha1="b34b5db300e0a7b9d283839b92a3a7040924130a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon stadium (europe) (rev a).bin" size="0x2000000" crc="60f6be65" sha1="b34b5db300e0a7b9d283839b92a3a7040924130a" />
 			</dataarea>
 		</part>
 	</software>
@@ -9452,8 +9452,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npop-0.u1" size="33554432" crc="7a8bf040" sha1="df6d958fdf04d598194ab5821dd77655da9d0c5d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npop-0.u1" size="0x2000000" crc="7a8bf040" sha1="df6d958fdf04d598194ab5821dd77655da9d0c5d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9464,8 +9464,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPOF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon stadium (france).bin" size="33554432" crc="476848f6" sha1="3f246d6357ab981db1e2c588c92b29b7dbe4051c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon stadium (france).bin" size="0x2000000" crc="476848f6" sha1="3f246d6357ab981db1e2c588c92b29b7dbe4051c" />
 			</dataarea>
 		</part>
 	</software>
@@ -9482,8 +9482,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npod-0.u1" size="33554432" crc="3243a2a7" sha1="20943b1e25af11ae2305d9680049dfa777b96ef0" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npod-0.u1" size="0x2000000" crc="3243a2a7" sha1="20943b1e25af11ae2305d9680049dfa777b96ef0" />
 			</dataarea>
 		</part>
 	</software>
@@ -9494,8 +9494,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPOI-ITA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon stadium (italy).bin" size="33554432" crc="77a59419" sha1="c205d6cef57d1fec51f13627f1d2957138814322" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon stadium (italy).bin" size="0x2000000" crc="77a59419" sha1="c205d6cef57d1fec51f13627f1d2957138814322" />
 			</dataarea>
 		</part>
 	</software>
@@ -9512,8 +9512,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npos-0.u1" size="33554432" crc="7adfb7e0" sha1="d8bce5fdd89654c37c74e64a39589466c6ed8c3d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npos-0.u1" size="0x2000000" crc="7adfb7e0" sha1="d8bce5fdd89654c37c74e64a39589466c6ed8c3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9524,8 +9524,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NPOE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="pokemon stadium (u) (v1.2).bin" size="33554432" crc="d2e2ec6d" sha1="f7b4e8fd76b97c34a81f448a7e016c38d7fdff0e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="pokemon stadium (u) (v1.2).bin" size="0x2000000" crc="d2e2ec6d" sha1="f7b4e8fd76b97c34a81f448a7e016c38d7fdff0e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9540,8 +9540,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPOE-1]" />
 			<feature name="u2" value="U2 [29LL1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6103A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npoe-1.u1" size="33554432" crc="7bb7489f" sha1="d5b479461cd45db31e896143519c85b7136cfe2e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npoe-1.u1" size="0x2000000" crc="7bb7489f" sha1="d5b479461cd45db31e896143519c85b7136cfe2e" />
 			</dataarea>
 		</part>
 	</software>
@@ -9558,8 +9558,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6103A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-npoe-0.u1" size="33554432" crc="3003e90c" sha1="59e8993202e6b8219a80855a400822417132cc81" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-npoe-0.u1" size="0x2000000" crc="3003e90c" sha1="59e8993202e6b8219a80855a400822417132cc81" />
 			</dataarea>
 		</part>
 	</software>
@@ -9577,9 +9577,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u4" value="U4 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-np3p-0 02.u1" size="33554432" crc="dbbcb75c" sha1="70c24226bac5114a9f24d4e97f1cad0137c6dd80" offset="0x0000000" />
-				<rom name="nus-np3p-0 12.u2" size="33554432" crc="e1fcdc93" sha1="4658ee0ce4fa97afb7909f6ce3156c25ee80a085" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-np3p-0 02.u1" size="0x2000000" crc="dbbcb75c" sha1="70c24226bac5114a9f24d4e97f1cad0137c6dd80" offset="0x0000000" />
+				<rom name="nus-np3p-0 12.u2" size="0x2000000" crc="e1fcdc93" sha1="4658ee0ce4fa97afb7909f6ce3156c25ee80a085" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -9590,8 +9590,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NP3F-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="pokemon stadium 2 (france).bin" size="67108864" crc="a72c55af" sha1="8b7d84bfce6e1cce565e3da13d1b70ac49972b4b" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="pokemon stadium 2 (france).bin" size="0x4000000" crc="a72c55af" sha1="8b7d84bfce6e1cce565e3da13d1b70ac49972b4b" />
 			</dataarea>
 		</part>
 	</software>
@@ -9609,9 +9609,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u4" value="U4 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-np3d-0 12.u1" size="33554432" crc="e12f9ac1" sha1="06d6b0c79991b6b546603ca9068ed94dce4867a9" offset="0x0000000" />
-				<rom name="nus-np3d-0 02.u2" size="33554432" crc="c2e53eea" sha1="f3a36667a91c8efb77efb375ca9e04c5f0dab377" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-np3d-0 12.u1" size="0x2000000" crc="e12f9ac1" sha1="06d6b0c79991b6b546603ca9068ed94dce4867a9" offset="0x0000000" />
+				<rom name="nus-np3d-0 02.u2" size="0x2000000" crc="c2e53eea" sha1="f3a36667a91c8efb77efb375ca9e04c5f0dab377" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -9622,8 +9622,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NP3I-ITA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="pokemon stadium 2 (italy).bin" size="67108864" crc="c849c481" sha1="55e9c0186a5c846b84315b1780587d31e8a9eb44" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="pokemon stadium 2 (italy).bin" size="0x4000000" crc="c849c481" sha1="55e9c0186a5c846b84315b1780587d31e8a9eb44" />
 			</dataarea>
 		</part>
 	</software>
@@ -9641,9 +9641,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u4" value="U4 [CIC-NUS-7103A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-np3s-0 02.u1" size="33554432" crc="8b4238b2" sha1="3e764dad17a6dd801931928852cfffb429a4b6d9" offset="0x0000000" />
-				<rom name="nus-np3s-0 12.u2" size="33554432" crc="a1a77dba" sha1="aff7f2eab9fb7093332c270af2c3ccf4114514f7" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-np3s-0 02.u1" size="0x2000000" crc="8b4238b2" sha1="3e764dad17a6dd801931928852cfffb429a4b6d9" offset="0x0000000" />
+				<rom name="nus-np3s-0 12.u2" size="0x2000000" crc="a1a77dba" sha1="aff7f2eab9fb7093332c270af2c3ccf4114514f7" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -9659,9 +9659,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [NUS-NP3E-0 12]" />
 			<feature name="u3" value="U3 [29L1100KC-15B0]" />
 			<feature name="u4" value="U4 [CIC-NUS-6103A]" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-np3e-0 02.u1" size="33554432" crc="940db20b" sha1="9c95c78f367ce95903ede7b8cb53070b4787483e" offset="0x0000000" />
-				<rom name="nus-np3e-0 12.u2" size="33554432" crc="e1fcdc93" sha1="4658ee0ce4fa97afb7909f6ce3156c25ee80a085" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-np3e-0 02.u1" size="0x2000000" crc="940db20b" sha1="9c95c78f367ce95903ede7b8cb53070b4787483e" offset="0x0000000" />
+				<rom name="nus-np3e-0 12.u2" size="0x2000000" crc="e1fcdc93" sha1="4658ee0ce4fa97afb7909f6ce3156c25ee80a085" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -9676,8 +9676,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPXE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-npxe-0.u1" size="12582912" crc="ba3ec852" sha1="2a9585e5819fa7984877848c58fbf9973380d624" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-npxe-0.u1" size="0xc00000" crc="ba3ec852" sha1="2a9585e5819fa7984877848c58fbf9973380d624" />
 			</dataarea>
 		</part>
 	</software>
@@ -9690,8 +9690,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19970808"/>
 		<info name="alt_title" value="パワーリーグ64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="power league 64 (japan).bin" size="8388608" crc="bc7e2494" sha1="97e55b2c39f4e0390ec280a6f6d6d2777669eb43" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="power league 64 (japan).bin" size="0x800000" crc="bc7e2494" sha1="97e55b2c39f4e0390ec280a6f6d6d2777669eb43" />
 			</dataarea>
 		</part>
 	</software>
@@ -9708,8 +9708,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-npup-0.u1" size="12582912" crc="88250ab1" sha1="c49ac782bc970a7ce1f76d7b60f7e741e915fbe2" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-npup-0.u1" size="0xc00000" crc="88250ab1" sha1="c49ac782bc970a7ce1f76d7b60f7e741e915fbe2" />
 			</dataarea>
 		</part>
 	</software>
@@ -9724,8 +9724,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPUE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-npue-0.u1" size="12582912" crc="eb8ce95b" sha1="a7523544e7e293f58207ecea9ca44f713e9deee2" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-npue-0.u1" size="0xc00000" crc="eb8ce95b" sha1="a7523544e7e293f58207ecea9ca44f713e9deee2" />
 			</dataarea>
 		</part>
 	</software>
@@ -9740,8 +9740,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-npqe-0.u1" size="8388608" crc="4ee7cd7e" sha1="8f982bab4f1857d6562113d120bce82bd316f78d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-npqe-0.u1" size="0x800000" crc="4ee7cd7e" sha1="8f982bab4f1857d6562113d120bce82bd316f78d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9752,8 +9752,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Gremlin Interactive</publisher>
 		<info name="serial" value="NUS-NPMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="premier manager 64 (europe).bin" size="16777216" crc="74a0c415" sha1="c379521c2bae36f37d93ddcd2781abc255ae4e14" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="premier manager 64 (europe).bin" size="0x1000000" crc="74a0c415" sha1="c379521c2bae36f37d93ddcd2781abc255ae4e14" />
 			</dataarea>
 		</part>
 	</software>
@@ -9766,8 +9766,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19971121"/>
 		<info name="alt_title" value="プロ麻雀 極64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="pro mahjong kiwame 64 (japan) (rev a).bin" size="8388608" crc="fb5fcd97" sha1="ac12b381eeb7d4616dc219c96f3d04b4b95c913f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="pro mahjong kiwame 64 (japan) (rev a).bin" size="0x800000" crc="fb5fcd97" sha1="ac12b381eeb7d4616dc219c96f3d04b4b95c913f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9780,8 +9780,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19971121"/>
 		<info name="alt_title" value="プロ麻雀 極64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="pro mahjong kiwame 64 (japan).bin" size="8388608" crc="01e83335" sha1="d58d1bd7184a69ab06f0104a0a94a1179ee7b208" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="pro mahjong kiwame 64 (japan).bin" size="0x800000" crc="01e83335" sha1="d58d1bd7184a69ab06f0104a0a94a1179ee7b208" />
 			</dataarea>
 		</part>
 	</software>
@@ -9794,8 +9794,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19991105"/>
 		<info name="alt_title" value="プロ麻雀 兵 64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="pro mahjong tsuwamono 64 - jansou battle ni chousen (japan).bin" size="8388608" crc="388da567" sha1="7c5565519bb9041ebd25a78ca174143faf872809" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="pro mahjong tsuwamono 64 - jansou battle ni chousen (japan).bin" size="0x800000" crc="388da567" sha1="7c5565519bb9041ebd25a78ca174143faf872809" />
 			</dataarea>
 		</part>
 	</software>
@@ -9808,8 +9808,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19991203"/>
 		<info name="alt_title" value="ぷよぷよ〜ん パーティー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="puyo puyo 4 - puyo puyon party (japan).bin" size="12582912" crc="9c32adeb" sha1="e02d3a92256a43c8aeaa6dabd2f53cd3769ef1f6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="puyo puyo 4 - puyo puyon party (japan).bin" size="0xc00000" crc="9c32adeb" sha1="e02d3a92256a43c8aeaa6dabd2f53cd3769ef1f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9828,8 +9828,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-npyj-0.u1" size="8388608" crc="c256544c" sha1="6ba3441890502ed5cdc27f29752f231490e49bf5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-npyj-0.u1" size="0x800000" crc="c256544c" sha1="6ba3441890502ed5cdc27f29752f231490e49bf5" />
 			</dataarea>
 		</part>
 	</software>
@@ -9842,8 +9842,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990305"/>
 		<info name="alt_title" value="パズルボブル64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="puzzle bobble 64 (japan).bin" size="8388608" crc="30238199" sha1="4e8b0bfb5a885919e63cb09618a0a3d938422301" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="puzzle bobble 64 (japan).bin" size="0x800000" crc="30238199" sha1="4e8b0bfb5a885919e63cb09618a0a3d938422301" />
 			</dataarea>
 		</part>
 	</software>
@@ -9854,8 +9854,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NQKP-EUR, NUS-NQKP-FRA, NUS-NQKP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="quake 64 (europe).bin" size="12582912" crc="6f79b0eb" sha1="8b9ff00fff48ef847794164111ec9415e5dccb31" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="quake 64 (europe).bin" size="0xc00000" crc="6f79b0eb" sha1="8b9ff00fff48ef847794164111ec9415e5dccb31" />
 			</dataarea>
 		</part>
 	</software>
@@ -9870,8 +9870,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NQKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nqke-0.u1" size="12582912" crc="06d5cdbb" sha1="4df581ebf44eb0e6060c331995febd39a04ccedd" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nqke-0.u1" size="0xc00000" crc="06d5cdbb" sha1="4df581ebf44eb0e6060c331995febd39a04ccedd" />
 			</dataarea>
 		</part>
 	</software>
@@ -9882,8 +9882,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NQ2P-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="quake ii (europe).bin" size="12582912" crc="7098df97" sha1="03f9a512c37e1351cb701a4ee5504ba6ea7d47ab" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="quake ii (europe).bin" size="0xc00000" crc="7098df97" sha1="03f9a512c37e1351cb701a4ee5504ba6ea7d47ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -9898,8 +9898,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NQ2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nq2e-0.u1" size="12582912" crc="5d880e55" sha1="24b792fef01fca18faf73a1b980e9c738822298f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nq2e-0.u1" size="0xc00000" crc="5d880e55" sha1="24b792fef01fca18faf73a1b980e9c738822298f" />
 			</dataarea>
 		</part>
 	</software>
@@ -9916,8 +9916,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nete-0.u1" size="16777216" crc="e90856e8" sha1="738f11572a72bea06cc5c6d9c0a341a288f29457" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nete-0.u1" size="0x1000000" crc="e90856e8" sha1="738f11572a72bea06cc5c6d9c0a341a288f29457" />
 			</dataarea>
 		</part>
 	</software>
@@ -9928,8 +9928,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NMGD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="racing simulation 2 (germany).bin" size="16777216" crc="d660a56f" sha1="2cd2004b2e349773f3457dc8ae2f174f0e6fa0c0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="racing simulation 2 (germany).bin" size="0x1000000" crc="d660a56f" sha1="2cd2004b2e349773f3457dc8ae2f174f0e6fa0c0" />
 			</dataarea>
 		</part>
 	</software>
@@ -9940,8 +9940,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Konami</publisher>
 		<info name="serial" value="NUS-NKRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rakuga kids (europe).bin" size="12582912" crc="2146409a" sha1="f6e08506ba7f53312767c0033d1ef8d393c0457d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rakuga kids (europe).bin" size="0xc00000" crc="2146409a" sha1="f6e08506ba7f53312767c0033d1ef8d393c0457d" />
 			</dataarea>
 		</part>
 	</software>
@@ -9960,8 +9960,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nkrj-0.u1" size="12582912" crc="4c07c266" sha1="9cb434635987e947f25d0ebd0e1a0f500e63adc6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nkrj-0.u1" size="0xc00000" crc="4c07c266" sha1="9cb434635987e947f25d0ebd0e1a0f500e63adc6" />
 			</dataarea>
 		</part>
 	</software>
@@ -9974,8 +9974,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990806"/>
 		<info name="alt_title" value="ラリー'99"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="rally '99 (japan).bin" size="8388608" crc="a1c36245" sha1="920113a96dfb15e3e8ed991c42e28734efa26599" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="rally '99 (japan).bin" size="0x800000" crc="a1c36245" sha1="920113a96dfb15e3e8ed991c42e28734efa26599" />
 			</dataarea>
 		</part>
 	</software>
@@ -9992,8 +9992,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwqe-0.u1" size="12582912" crc="faf5c3b6" sha1="ecd309fc0826467f7b0e197743abf1c51c48910d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwqe-0.u1" size="0xc00000" crc="faf5c3b6" sha1="ecd309fc0826467f7b0e197743abf1c51c48910d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10004,8 +10004,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NRPP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rampage - world tour (europe).bin" size="12582912" crc="dfba19d6" sha1="742b440371e2b27bff9267041cebbd1358b105ed" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rampage - world tour (europe).bin" size="0xc00000" crc="dfba19d6" sha1="742b440371e2b27bff9267041cebbd1358b105ed" />
 			</dataarea>
 		</part>
 	</software>
@@ -10020,8 +10020,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRPE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrpe-0.u1" size="12582912" crc="6fe4da23" sha1="5dd821436db22ce9b4168088189ee5788270d044" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrpe-0.u1" size="0xc00000" crc="6fe4da23" sha1="5dd821436db22ce9b4168088189ee5788270d044" />
 			</dataarea>
 		</part>
 	</software>
@@ -10032,8 +10032,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-N2PP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rampage 2 - universal tour (europe).bin" size="12582912" crc="0d4654a8" sha1="52583ee2ceb4606f86c01fe8a3498971a104d987" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rampage 2 - universal tour (europe).bin" size="0xc00000" crc="0d4654a8" sha1="52583ee2ceb4606f86c01fe8a3498971a104d987" />
 			</dataarea>
 		</part>
 	</software>
@@ -10048,8 +10048,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-N2PE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n2pe-0.u1" size="12582912" crc="75e8c2ad" sha1="bb3af2fc085e58befa528051b7a91a54f9f38e8f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n2pe-0.u1" size="0xc00000" crc="75e8c2ad" sha1="bb3af2fc085e58befa528051b7a91a54f9f38e8f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10060,8 +10060,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Mindscape</publisher>
 		<info name="serial" value="NUS-NRTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="rat attack (europe) (en,fr,de,es,it,nl).bin" size="8388608" crc="c3909721" sha1="8115f19aade05147db633266a4dd7bec82cdd735" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="rat attack (europe) (en,fr,de,es,it,nl).bin" size="0x800000" crc="c3909721" sha1="8115f19aade05147db633266a4dd7bec82cdd735" />
 			</dataarea>
 		</part>
 	</software>
@@ -10076,8 +10076,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRTE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nrte-0.u1" size="8388608" crc="78f6ffa2" sha1="6814ee444c67f1289f11a9f7decacb75176bf634" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nrte-0.u1" size="0x800000" crc="78f6ffa2" sha1="6814ee444c67f1289f11a9f7decacb75176bf634" />
 			</dataarea>
 		</part>
 	</software>
@@ -10088,8 +10088,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NY2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="rayman 2 - the great escape (europe) (en,fr,de,es,it).bin" size="33554432" crc="b7e10177" sha1="a422b3be224814c7f01512d778becfa0bdffafc8" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="rayman 2 - the great escape (europe) (en,fr,de,es,it).bin" size="0x2000000" crc="b7e10177" sha1="a422b3be224814c7f01512d778becfa0bdffafc8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10104,8 +10104,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NY2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ny2e-0.u1" size="33554432" crc="72ee54b2" sha1="4d7a58f7a87928e592416b75b364e3563bbeed2f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ny2e-0.u1" size="0x2000000" crc="72ee54b2" sha1="4d7a58f7a87928e592416b75b364e3563bbeed2f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10116,8 +10116,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NRGF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="razmoket, les - la chasse aux tresors (france).bin" size="16777216" crc="d6c8d961" sha1="1f697bbe34dcce3a74605f13d50d0cbbe4510085" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="razmoket, les - la chasse aux tresors (france).bin" size="0x1000000" crc="d6c8d961" sha1="1f697bbe34dcce3a74605f13d50d0cbbe4510085" />
 			</dataarea>
 		</part>
 	</software>
@@ -10132,8 +10132,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NFQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nfqe-0.u1" size="8388608" crc="208350c5" sha1="8af56990d73f7eae9212c44cd9f417b27ed78649" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nfqe-0.u1" size="0x800000" crc="208350c5" sha1="8af56990d73f7eae9212c44cd9f417b27ed78649" />
 			</dataarea>
 		</part>
 	</software>
@@ -10144,8 +10144,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NRVP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="re-volt (europe) (en,fr,de,es).bin" size="12582912" crc="194bb8a1" sha1="31d1b888bda70d2d5b1c7ecd95f8f2d83ac35d36" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="re-volt (europe) (en,fr,de,es).bin" size="0xc00000" crc="194bb8a1" sha1="31d1b888bda70d2d5b1c7ecd95f8f2d83ac35d36" />
 			</dataarea>
 		</part>
 	</software>
@@ -10160,8 +10160,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRVE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrve-0.u1" size="12582912" crc="9366c53c" sha1="bffc68e662338cdf03b619b3a62ef880f1db025d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrve-0.u1" size="0xc00000" crc="9366c53c" sha1="bffc68e662338cdf03b619b3a62ef880f1db025d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10172,8 +10172,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NRDP-EUR, NUS-NRDP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="ready 2 rumble boxing (europe) (en,fr,de).bin" size="33554432" crc="f2fe85ad" sha1="8a2bd9ceb91bc753cbeebd4cb0d47819361e4bea" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="ready 2 rumble boxing (europe) (en,fr,de).bin" size="0x2000000" crc="f2fe85ad" sha1="8a2bd9ceb91bc753cbeebd4cb0d47819361e4bea" />
 			</dataarea>
 		</part>
 	</software>
@@ -10188,8 +10188,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nrde-0.u1" size="33554432" crc="e8d926f3" sha1="667083f0dbbd428216475ddcad1883ad04207cfd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nrde-0.u1" size="0x2000000" crc="e8d926f3" sha1="667083f0dbbd428216475ddcad1883ad04207cfd" />
 			</dataarea>
 		</part>
 	</software>
@@ -10204,8 +10204,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-N22E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-n22e-0.u1" size="33554432" crc="a64fdf28" sha1="3e6b280a6b8925c0528c63add72f0861156d07d6" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-n22e-0.u1" size="0x2000000" crc="a64fdf28" sha1="3e6b280a6b8925c0528c63add72f0861156d07d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10216,8 +10216,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Virgin Interactive</publisher>
 		<info name="serial" value="NUS-NREP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="resident evil 2 (europe) (en,fr).bin" size="67108864" crc="a9936cec" sha1="c82e3c253e438c0f742882f26e8006fdf9c99346" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="resident evil 2 (europe) (en,fr).bin" size="0x4000000" crc="a9936cec" sha1="c82e3c253e438c0f742882f26e8006fdf9c99346" />
 			</dataarea>
 		</part>
 	</software>
@@ -10237,9 +10237,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-nree-1 02.u1" size="33554432" crc="e6f9f955" sha1="e44abf4c2ef0640369ec0a25648b2c151a5a8c5a" offset="0x0000000" />
-				<rom name="nus-nree-1 12.u2" size="33554432" crc="622ed12d" sha1="f226fd097c594c3d3171b81934c8e2931b5561c7" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-nree-1 02.u1" size="0x2000000" crc="e6f9f955" sha1="e44abf4c2ef0640369ec0a25648b2c151a5a8c5a" offset="0x0000000" />
+				<rom name="nus-nree-1 12.u2" size="0x2000000" crc="622ed12d" sha1="f226fd097c594c3d3171b81934c8e2931b5561c7" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -10259,9 +10259,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="67108864">
-				<rom name="nus-nree-0 02.u1" size="33554432" crc="66495606" sha1="125ded805b134633b6778bc1d4c4e7955a4c9e93" offset="0x0000000" />
-				<rom name="nus-nree-0 12.u2" size="33554432" crc="7e2efb88" sha1="03bb6eb43b1ec888300250d45011d89ca1ec4e57" offset="0x2000000" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="nus-nree-0 02.u1" size="0x2000000" crc="66495606" sha1="125ded805b134633b6778bc1d4c4e7955a4c9e93" offset="0x0000000" />
+				<rom name="nus-nree-0 12.u2" size="0x2000000" crc="7e2efb88" sha1="03bb6eb43b1ec888300250d45011d89ca1ec4e57" offset="0x2000000" />
 			</dataarea>
 		</part>
 	</software>
@@ -10272,8 +10272,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NROP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="road rash 64 (europe).bin" size="33554432" crc="e3bc7725" sha1="273c72f8c9f9d194b98375e3076972bfd7fdf64d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="road rash 64 (europe).bin" size="0x2000000" crc="e3bc7725" sha1="273c72f8c9f9d194b98375e3076972bfd7fdf64d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10288,8 +10288,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NROE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nroe-0.u1" size="33554432" crc="2da44585" sha1="4990b922e946aa0ee45fd8355e447dedc92ec352" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nroe-0.u1" size="0x2000000" crc="2da44585" sha1="4990b922e946aa0ee45fd8355e447dedc92ec352" />
 			</dataarea>
 		</part>
 	</software>
@@ -10300,8 +10300,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NRRP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="roadsters trophy (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="c2d2f16b" sha1="bde57b268b6bffe2e60cca0e3d9500a35506a81c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="roadsters trophy (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="c2d2f16b" sha1="bde57b268b6bffe2e60cca0e3d9500a35506a81c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10316,8 +10316,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRRE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrre-0.u1" size="12582912" crc="f68d139e" sha1="e2827c55874a4883c5d969eb34944324d639af06" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrre-0.u1" size="0xc00000" crc="f68d139e" sha1="e2827c55874a4883c5d969eb34944324d639af06" />
 			</dataarea>
 		</part>
 	</software>
@@ -10330,8 +10330,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19991224"/>
 		<info name="alt_title" value="ロボットポンコッツ64 七つの海のカラメル"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="robot ponkottsu 64 - 7tsu no umi no caramel (japan).bin" size="33554432" crc="49bb7dde" sha1="27bfaff7a8d2a3cef081af67a5e89290c6b59550" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="robot ponkottsu 64 - 7tsu no umi no caramel (japan).bin" size="0x2000000" crc="49bb7dde" sha1="27bfaff7a8d2a3cef081af67a5e89290c6b59550" />
 			</dataarea>
 		</part>
 	</software>
@@ -10341,8 +10341,8 @@ patched out (+ a fix for internal checksum)
 		<year>1998</year>
 		<publisher>GameTek</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="robotech - crystal dreams (prototype).n64" size="16777216" crc="4d6016ab" sha1="b86a1567becb47c30be79370c85706c103b063a9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="robotech - crystal dreams (prototype).n64" size="0x1000000" crc="4d6016ab" sha1="b86a1567becb47c30be79370c85706c103b063a9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10353,8 +10353,8 @@ patched out (+ a fix for internal checksum)
 		<year>1998</year>
 		<publisher>GameTek</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="robotech - crystal dreams (usa) (proto).bin" size="12582912" crc="3a711f12" sha1="5ea71103d323530c73e1668cc47a1c287d07e99b" status="baddump" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="robotech - crystal dreams (usa) (proto).bin" size="0xc00000" crc="3a711f12" sha1="5ea71103d323530c73e1668cc47a1c287d07e99b" status="baddump" />
 			</dataarea>
 		</part>
 	</software>
@@ -10365,8 +10365,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NRXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="robotron 64 (europe).bin" size="8388608" crc="862acd20" sha1="a12c93ac2c4e70a3b19bcb07a62b7b6b9ce83db9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="robotron 64 (europe).bin" size="0x800000" crc="862acd20" sha1="a12c93ac2c4e70a3b19bcb07a62b7b6b9ce83db9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10377,8 +10377,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NRXE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="robotron 64 (usa).bin" size="8388608" crc="123d44cc" sha1="9dacd6239f2256e8efac6d1c6acf8e5ea53040bb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="robotron 64 (usa).bin" size="0x800000" crc="123d44cc" sha1="9dacd6239f2256e8efac6d1c6acf8e5ea53040bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -10389,8 +10389,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NSUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rocket - robot on wheels (europe) (en,fr,de).bin" size="12582912" crc="2960ff8b" sha1="fce3a9b4cc94e44d0c2f58b7669140447f9bf0ec" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rocket - robot on wheels (europe) (en,fr,de).bin" size="0xc00000" crc="2960ff8b" sha1="fce3a9b4cc94e44d0c2f58b7669140447f9bf0ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -10405,8 +10405,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSUE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nsue-0.u1" size="12582912" crc="b0f36d79" sha1="5dfcd4cdb0a2ea1412fa5d92236d0a066231d9ac" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nsue-0.u1" size="0xc00000" crc="b0f36d79" sha1="5dfcd4cdb0a2ea1412fa5d92236d0a066231d9ac" />
 			</dataarea>
 		</part>
 	</software>
@@ -10419,8 +10419,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="20001122"/>
 		<info name="alt_title" value="ロックマンDASH 鋼の冒険心"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="rockman dash - hagane no boukenshin (japan).bin" size="33554432" crc="e1919c66" sha1="cd8c73a181a137dc8a4ac24e9f26ccc2518dc35f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="rockman dash - hagane no boukenshin (japan).bin" size="0x2000000" crc="e1919c66" sha1="cd8c73a181a137dc8a4ac24e9f26ccc2518dc35f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10435,8 +10435,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="[epoxy]" />
 			<feature name="u2" value="[epoxy]" />
 			<feature name="u3" value="[S-A 629]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="epoxy" size="8388608" crc="19380e04" sha1="dfd37b71df3f22c4f65ee1477fd5e1bb07049537" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="epoxy" size="0x800000" crc="19380e04" sha1="dfd37b71df3f22c4f65ee1477fd5e1bb07049537" />
 			</dataarea>
 		</part>
 	</software>
@@ -10447,8 +10447,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NRZP-AUS, NUS-NRZP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="rr64 - ridge racer 64 (europe).bin" size="33554432" crc="170f63b2" sha1="7543e17585ef4af0b3b1de8004b6cd4d92ec214d" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="rr64 - ridge racer 64 (europe).bin" size="0x2000000" crc="170f63b2" sha1="7543e17585ef4af0b3b1de8004b6cd4d92ec214d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10463,8 +10463,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRZE-0]" />
 			<feature name="u2" value="U2 [BK16DA]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nrze-0.u1" size="33554432" crc="7ccb9749" sha1="79db18ac171142f287a45271ef3a7cf6341a17f8" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nrze-0.u1" size="0x2000000" crc="7ccb9749" sha1="79db18ac171142f287a45271ef3a7cf6341a17f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10475,8 +10475,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>South Peak</publisher>
 		<info name="serial" value="NUS-NWKD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="rtl world league soccer 2000 (germany).bin" size="16777216" crc="4e3c9433" sha1="ef2e9dbb16c798df3315a925231314e1660a2f03" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="rtl world league soccer 2000 (germany).bin" size="0x1000000" crc="4e3c9433" sha1="ef2e9dbb16c798df3315a925231314e1660a2f03" />
 			</dataarea>
 		</part>
 	</software>
@@ -10491,8 +10491,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nrge-0.u1" size="16777216" crc="ea79ad0a" sha1="f69a4a88bc2374fea96dfb06a42dbb5b9a5eb6b1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nrge-0.u1" size="0x1000000" crc="ea79ad0a" sha1="f69a4a88bc2374fea96dfb06a42dbb5b9a5eb6b1" />
 			</dataarea>
 		</part>
 	</software>
@@ -10503,8 +10503,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NRGP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="rugrats - treasure hunt (europe).bin" size="16777216" crc="65ede901" sha1="a86b2faed29727496dd3f0b0367293e16b324568" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="rugrats - treasure hunt (europe).bin" size="0x1000000" crc="65ede901" sha1="a86b2faed29727496dd3f0b0367293e16b324568" />
 			</dataarea>
 		</part>
 	</software>
@@ -10520,8 +10520,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nrgd-0.u1" size="16777216" crc="e1d7919f" sha1="7840bdfe801fa2d8e34e120f66af59a140d3c1c3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nrgd-0.u1" size="0x1000000" crc="e1d7919f" sha1="7840bdfe801fa2d8e34e120f66af59a140d3c1c3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10532,8 +10532,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NRKP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="rugrats in paris - the movie (europe).bin" size="16777216" crc="17bd7518" sha1="0212c18e1fe5c637c5b88124f053cf08f048efc4" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="rugrats in paris - the movie (europe).bin" size="0x1000000" crc="17bd7518" sha1="0212c18e1fe5c637c5b88124f053cf08f048efc4" />
 			</dataarea>
 		</part>
 	</software>
@@ -10548,8 +10548,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nrke-0.u1" size="16777216" crc="8f09af37" sha1="42fba753590296b288537162437357741b7f5596" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nrke-0.u1" size="0x1000000" crc="8f09af37" sha1="42fba753590296b288537162437357741b7f5596" />
 			</dataarea>
 		</part>
 	</software>
@@ -10560,8 +10560,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>GT Interactive</publisher>
 		<info name="serial" value="NUS-NR2P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rush 2 - extreme racing usa (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="9b364df7" sha1="fc590418f82bd5e360ff4530100d72cea2a97d99" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rush 2 - extreme racing usa (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="9b364df7" sha1="fc590418f82bd5e360ff4530100d72cea2a97d99" />
 			</dataarea>
 		</part>
 	</software>
@@ -10572,8 +10572,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NR2E-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="rush 2 - extreme racing usa (usa).bin" size="12582912" crc="5412916b" sha1="94685e4a27114175946cdf2084079c9bf2e69ef3" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="rush 2 - extreme racing usa (usa).bin" size="0xc00000" crc="5412916b" sha1="94685e4a27114175946cdf2084079c9bf2e69ef3" />
 			</dataarea>
 		</part>
 	</software>
@@ -10584,8 +10584,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NCSP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="s.c.a.r.s. (europe) (en,fr,de).bin" size="8388608" crc="da47d3c9" sha1="ef5834f25a44931cc9339dd22b6e8f9955736076" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="s.c.a.r.s. (europe) (en,fr,de).bin" size="0x800000" crc="da47d3c9" sha1="ef5834f25a44931cc9339dd22b6e8f9955736076" />
 			</dataarea>
 		</part>
 	</software>
@@ -10600,8 +10600,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NCSE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ncse-0.u1" size="8388608" crc="6594b593" sha1="8fef439b4649fe6c52f722f6158c67cade7841cd" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ncse-0.u1" size="0x800000" crc="6594b593" sha1="8fef439b4649fe6c52f722f6158c67cade7841cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -10618,8 +10618,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NCHJ-0]" /> <!-- MX23L6402-35 -->
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="saikyou habu shougi (japan).bin" size="8388608" crc="e8d0810b" sha1="8a06e7a7d15e5586ff5ce5fed235e0357096c827" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="saikyou habu shougi (japan).bin" size="0x800000" crc="e8d0810b" sha1="8a06e7a7d15e5586ff5ce5fed235e0357096c827" />
 			</dataarea>
 		</part>
 	</software>
@@ -10630,8 +10630,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NSFP-EUR, NUS-NSFP-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="san francisco rush - extreme racing (europe) (en,fr,de).bin" size="8388608" crc="78cd03c9" sha1="9339cce34d9eac2626ba14fa55f558bd7c827cc9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="san francisco rush - extreme racing (europe) (en,fr,de).bin" size="0x800000" crc="78cd03c9" sha1="9339cce34d9eac2626ba14fa55f558bd7c827cc9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10642,8 +10642,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NSFE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="san francisco rush extreme racing v1.1 - usa.bin" size="8388608" crc="ba05b83f" sha1="867c475e65844a421d51af3a75414d46899b404c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="san francisco rush extreme racing v1.1 - usa.bin" size="0x800000" crc="ba05b83f" sha1="867c475e65844a421d51af3a75414d46899b404c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10658,8 +10658,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsfe-0.u1" size="8388608" crc="32e250ba" sha1="8980d1e967d63cb13f794ee5de15bef299b93935" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsfe-0.u1" size="0x800000" crc="32e250ba" sha1="8980d1e967d63cb13f794ee5de15bef299b93935" />
 			</dataarea>
 		</part>
 	</software>
@@ -10670,8 +10670,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NRUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="san francisco rush 2049 (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="df85fdc3" sha1="c722fdc039489e1c0e604eed8b81e29da75cb0be" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="san francisco rush 2049 (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="df85fdc3" sha1="c722fdc039489e1c0e604eed8b81e29da75cb0be" />
 			</dataarea>
 		</part>
 	</software>
@@ -10686,8 +10686,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NRUE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrue-0.u1" size="12582912" crc="1a03b9de" sha1="f79223f8060a530d0dc8683a923c3c60615aa0a0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrue-0.u1" size="0xc00000" crc="1a03b9de" sha1="f79223f8060a530d0dc8683a923c3c60615aa0a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10698,8 +10698,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NSYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="scooby-doo - classic creep capers (europe).bin" size="16777216" crc="81cdd595" sha1="ad7148b91845113a10a297da25f7110eddeb8758" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="scooby-doo - classic creep capers (europe).bin" size="0x1000000" crc="81cdd595" sha1="ad7148b91845113a10a297da25f7110eddeb8758" />
 			</dataarea>
 		</part>
 	</software>
@@ -10710,8 +10710,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NSYE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="scooby-doo - classic creep capers (usa) (rev. a).bin" size="16777216" crc="91cc1ed6" sha1="bbc12b280c38de870a89877809cfd5bda009aa98" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="scooby-doo - classic creep capers (usa) (rev. a).bin" size="0x1000000" crc="91cc1ed6" sha1="bbc12b280c38de870a89877809cfd5bda009aa98" />
 			</dataarea>
 		</part>
 	</software>
@@ -10726,8 +10726,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSYE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nsye-0.u1" size="16777216" crc="e3a2f1e7" sha1="41c8454775e0e555b354537f3efd916fd5f058d6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nsye-0.u1" size="0x1000000" crc="e3a2f1e7" sha1="41c8454775e0e555b354537f3efd916fd5f058d6" />
 			</dataarea>
 		</part>
 	</software>
@@ -10740,8 +10740,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990129"/>
 		<info name="alt_title" value="SD飛龍の拳伝説"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="sd hiryuu no ken densetsu (japan).bin" size="12582912" crc="adf81b90" sha1="da0d9331c5a9688b674e6c72d4206fb05f1c2ee0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="sd hiryuu no ken densetsu (japan).bin" size="0xc00000" crc="adf81b90" sha1="da0d9331c5a9688b674e6c72d4206fb05f1c2ee0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10752,8 +10752,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NSDP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="shadow man (europe) (en,es,it).bin" size="33554432" crc="0cd66c1f" sha1="7bcd7d9a05363b20f338b092081c2fae4d8c1f64" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="shadow man (europe) (en,es,it).bin" size="0x2000000" crc="0cd66c1f" sha1="7bcd7d9a05363b20f338b092081c2fae4d8c1f64" />
 			</dataarea>
 		</part>
 	</software>
@@ -10764,8 +10764,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NSDF-FAH"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="shadow man (france).bin" size="33554432" crc="cb221562" sha1="9fd09639dbf2a9b11f7d1c2cccb40529febedb2a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="shadow man (france).bin" size="0x2000000" crc="cb221562" sha1="9fd09639dbf2a9b11f7d1c2cccb40529febedb2a" />
 			</dataarea>
 		</part>
 	</software>
@@ -10776,8 +10776,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NSDD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="shadow man (germany).bin" size="33554432" crc="1f171a3f" sha1="01d453d23e8e089c071f41a2bdcb78a3c695a72a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="shadow man (germany).bin" size="0x2000000" crc="1f171a3f" sha1="01d453d23e8e089c071f41a2bdcb78a3c695a72a" />
 			</dataarea>
 		</part>
 	</software>
@@ -10792,8 +10792,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nsde-0.u1" size="33554432" crc="47e05128" sha1="f3791231dc17af77056e5320c59081d3e8459a7f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nsde-0.u1" size="0x2000000" crc="47e05128" sha1="f3791231dc17af77056e5320c59081d3e8459a7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -10803,8 +10803,8 @@ patched out (+ a fix for internal checksum)
 		<year>1999</year>
 		<publisher>Gradiente ~ Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="shadow man (brazil).bin" size="33554432" crc="679487b0" sha1="e7b05eab4b8d78ca338499eb8af503669e4a18bc" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="shadow man (brazil).bin" size="0x2000000" crc="679487b0" sha1="e7b05eab4b8d78ca338499eb8af503669e4a18bc" />
 			</dataarea>
 		</part>
 	</software>
@@ -10815,8 +10815,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NSGY-ITA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="shadowgate 64 - trials of the four towers (europe) (es,it).bin" size="16777216" crc="d49b5065" sha1="ec3ed3d0a854c726c2355bcd8ab23799fc1630ca" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="shadowgate 64 - trials of the four towers (europe) (es,it).bin" size="0x1000000" crc="d49b5065" sha1="ec3ed3d0a854c726c2355bcd8ab23799fc1630ca" />
 			</dataarea>
 		</part>
 	</software>
@@ -10827,8 +10827,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NSGX-FAH"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="shadowgate 64 - trials of the four towers (europe) (fr,de,nl).bin" size="16777216" crc="dc3ed03e" sha1="b8ec5c7f833b7a4aabcd243804ecc824d51e506c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="shadowgate 64 - trials of the four towers (europe) (fr,de,nl).bin" size="0x1000000" crc="dc3ed03e" sha1="b8ec5c7f833b7a4aabcd243804ecc824d51e506c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10839,8 +10839,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NSGP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="shadowgate 64 - trials of the four towers (europe).bin" size="16777216" crc="abb08bc3" sha1="e879093c0243ebbc0c9e392de4141cd65fc9b85d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="shadowgate 64 - trials of the four towers (europe).bin" size="0x1000000" crc="abb08bc3" sha1="e879093c0243ebbc0c9e392de4141cd65fc9b85d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10853,8 +10853,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990813"/>
 		<info name="alt_title" value="シャドウゲイト64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="shadowgate 64 - trials of the four towers (japan).bin" size="16777216" crc="f2665afd" sha1="94295ac2b5e44ad299ded088a8d43ef7a168c59d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="shadowgate 64 - trials of the four towers (japan).bin" size="0x1000000" crc="f2665afd" sha1="94295ac2b5e44ad299ded088a8d43ef7a168c59d" />
 			</dataarea>
 		</part>
 	</software>
@@ -10869,8 +10869,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nsge-0.u1" size="16777216" crc="1e9986e5" sha1="5c22f49bda1332d1c060a576c3e8cebeeee6e7a0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nsge-0.u1" size="0x1000000" crc="1e9986e5" sha1="5c22f49bda1332d1c060a576c3e8cebeeee6e7a0" />
 			</dataarea>
 		</part>
 	</software>
@@ -10889,8 +10889,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntoj-0.u1" size="12582912" crc="62c99de2" sha1="4da682946b4a6f586f4d525f0649d7a1e36357d9" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntoj-0.u1" size="0xc00000" crc="62c99de2" sha1="4da682946b4a6f586f4d525f0649d7a1e36357d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -10911,8 +10911,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nt3j-0.u1" size="33554432" crc="be0fc7e8" sha1="15b9c28584a26b60e5a2a231e5ba2897e831e8f8" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nt3j-0.u1" size="0x2000000" crc="be0fc7e8" sha1="15b9c28584a26b60e5a2a231e5ba2897e831e8f8" />
 			</dataarea>
 		</part>
 	</software>
@@ -10925,8 +10925,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980130"/>
 		<info name="alt_title" value="シムシティ2000"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="sim city 2000 (japan).bin" size="12582912" crc="f7a96b81" sha1="2a5b25809a5470b85db9cc0a1e6c5c44f225747b" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="sim city 2000 (japan).bin" size="0xc00000" crc="f7a96b81" sha1="2a5b25809a5470b85db9cc0a1e6c5c44f225747b" />
 			</dataarea>
 		</part>
 	</software>
@@ -10939,8 +10939,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19971212"/>
 		<info name="alt_title" value="スノボキッズ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="snobo kids (japan).bin" size="8388608" crc="9b691df4" sha1="739ab70a45cca33e8bf884c35be338ff4ce66f11" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="snobo kids (japan).bin" size="0x800000" crc="9b691df4" sha1="739ab70a45cca33e8bf884c35be338ff4ce66f11" />
 			</dataarea>
 		</part>
 	</software>
@@ -10953,8 +10953,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19981226"/>
 		<info name="alt_title" value="スノースピーダー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="snow speeder (japan).bin" size="12582912" crc="5c98f900" sha1="2ef8591e9750066e248075dc940ec4fc080ef905" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="snow speeder (japan).bin" size="0xc00000" crc="5c98f900" sha1="2ef8591e9750066e248075dc940ec4fc080ef905" />
 			</dataarea>
 		</part>
 	</software>
@@ -10965,8 +10965,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Atlus</publisher>
 		<info name="serial" value="NUS-NSKP-AUS, NUS-NSKP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="snowboard kids (europe).bin" size="8388608" crc="4f2415f3" sha1="fd4ca5dc092da70996af699c8a4591faef58ec0c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="snowboard kids (europe).bin" size="0x800000" crc="4f2415f3" sha1="fd4ca5dc092da70996af699c8a4591faef58ec0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10981,8 +10981,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nkse-0.u1" size="8388608" crc="540c190b" sha1="584277aa4190d23f7db8a6e225735d934022e58c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nkse-0.u1" size="0x800000" crc="540c190b" sha1="584277aa4190d23f7db8a6e225735d934022e58c" />
 			</dataarea>
 		</part>
 	</software>
@@ -10993,8 +10993,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Atlus</publisher>
 		<info name="serial" value="NUS-NK2P-AUS"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="snowboard kids 2 (australia).bin" size="16777216" crc="43afb227" sha1="35c1a9af8ae9abe09b50b6529b73c53b80395b66" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="snowboard kids 2 (australia).bin" size="0x1000000" crc="43afb227" sha1="35c1a9af8ae9abe09b50b6529b73c53b80395b66" />
 			</dataarea>
 		</part>
 	</software>
@@ -11009,8 +11009,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NK2E-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nk2e-0.u1" size="16777216" crc="ca84aace" sha1="7a195b4d0d03ce1c7c4fd0d13b1be2e97d20000c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nk2e-0.u1" size="0x1000000" crc="ca84aace" sha1="7a195b4d0d03ce1c7c4fd0d13b1be2e97d20000c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11023,8 +11023,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980319"/>
 		<info name="alt_title" value="ソニックウイングス アサルト"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="sonic wings assault (japan).bin" size="8388608" crc="1d8f9d5e" sha1="fb3e2be4927cf3fb39cce031004ff3420023eec5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="sonic wings assault (japan).bin" size="0x800000" crc="1d8f9d5e" sha1="fb3e2be4927cf3fb39cce031004ff3420023eec5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11035,8 +11035,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NDTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="south park (europe) (en,fr,es).bin" size="16777216" crc="acd74f7f" sha1="b1905fa89677f770a8b57876488d96bff4c4b278" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="south park (europe) (en,fr,es).bin" size="0x1000000" crc="acd74f7f" sha1="b1905fa89677f770a8b57876488d96bff4c4b278" />
 			</dataarea>
 		</part>
 	</software>
@@ -11047,8 +11047,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NDTD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="south park (germany).bin" size="16777216" crc="3445c078" sha1="c9f78f00f1749ec36d06d43693552ee33647d54b" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="south park (germany).bin" size="0x1000000" crc="3445c078" sha1="c9f78f00f1749ec36d06d43693552ee33647d54b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11063,8 +11063,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NDTE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ndte-0.u1" size="16777216" crc="faae9aa3" sha1="5133b87061172b467424170672c3321de6c78494" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ndte-0.u1" size="0x1000000" crc="faae9aa3" sha1="5133b87061172b467424170672c3321de6c78494" />
 			</dataarea>
 		</part>
 	</software>
@@ -11074,8 +11074,8 @@ patched out (+ a fix for internal checksum)
 		<year>1998</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="south park (brazil).bin" size="16777216" crc="40ac4211" sha1="def6ce5c26bb8acf51cb57002bea707bcdf0ec15" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="south park (brazil).bin" size="0x1000000" crc="40ac4211" sha1="def6ce5c26bb8acf51cb57002bea707bcdf0ec15" />
 			</dataarea>
 		</part>
 	</software>
@@ -11086,8 +11086,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NCYP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="south park - chef's luv shack (europe).bin" size="16777216" crc="ed36fa49" sha1="1fcdc805db0b026db04730fb385b30721ce74a21" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="south park - chef's luv shack (europe).bin" size="0x1000000" crc="ed36fa49" sha1="1fcdc805db0b026db04730fb385b30721ce74a21" />
 			</dataarea>
 		</part>
 	</software>
@@ -11102,8 +11102,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NCYE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ncye-0.u1" size="16777216" crc="67d38382" sha1="54fb22142f3a02c9c15e412d7e900a963698bbda" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ncye-0.u1" size="0x1000000" crc="67d38382" sha1="54fb22142f3a02c9c15e412d7e900a963698bbda" />
 			</dataarea>
 		</part>
 	</software>
@@ -11114,8 +11114,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NPRP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="south park rally (europe).bin" size="16777216" crc="de023e0a" sha1="63f95579b1f2a5e41e78343b59105ef08a290bf3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="south park rally (europe).bin" size="0x1000000" crc="de023e0a" sha1="63f95579b1f2a5e41e78343b59105ef08a290bf3" />
 			</dataarea>
 		</part>
 	</software>
@@ -11130,8 +11130,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NPRE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-npre-0.u1" size="16777216" crc="2c1f0859" sha1="0309df340d098f014c6673ec7cad60eace1bf166" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-npre-0.u1" size="0x1000000" crc="2c1f0859" sha1="0309df340d098f014c6673ec7cad60eace1bf166" />
 			</dataarea>
 		</part>
 	</software>
@@ -11144,8 +11144,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980327"/>
 		<info name="alt_title" value="スペースダイナマイツ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="space dynamites (japan).bin" size="8388608" crc="803f78ac" sha1="9b0776e967cbc97f832799ca8b16535efabc1cdf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="space dynamites (japan).bin" size="0x800000" crc="803f78ac" sha1="9b0776e967cbc97f832799ca8b16535efabc1cdf" />
 			</dataarea>
 		</part>
 	</software>
@@ -11160,8 +11160,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NIVE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nive-0.u1" size="8388608" crc="62e6deff" sha1="1ed83dd9637d5b6e7323480e74bf151542665a1b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nive-0.u1" size="0x800000" crc="62e6deff" sha1="1ed83dd9637d5b6e7323480e74bf151542665a1b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11172,8 +11172,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Take Two Interactive</publisher>
 		<info name="serial" value="NUS-NSVP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="spacestation silicon valley (europe) (en,fr,de,es,it,nl,pt).bin" size="8388608" crc="6148b598" sha1="065085d8e956e75980baed473754fe539ee843d9" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="spacestation silicon valley (europe) (en,fr,de,es,it,nl,pt).bin" size="0x800000" crc="6148b598" sha1="065085d8e956e75980baed473754fe539ee843d9" />
 			</dataarea>
 		</part>
 	</software>
@@ -11183,8 +11183,8 @@ patched out (+ a fix for internal checksum)
 		<year>1998</year>
 		<publisher>Take Two Interactive</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="spacestation silicon valley (japan) (proto).bin" size="8388608" crc="7abf7f2c" sha1="f9b2a71ada850509e27225a41e6fe8e271051a99" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="spacestation silicon valley (japan) (proto).bin" size="0x800000" crc="7abf7f2c" sha1="f9b2a71ada850509e27225a41e6fe8e271051a99" />
 			</dataarea>
 		</part>
 	</software>
@@ -11199,8 +11199,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSVE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsve-0.u1" size="8388608" crc="76db1da1" sha1="8ae14d65342f5a1ff8d0f09251ef46e24c29ff2b" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsve-0.u1" size="0x800000" crc="76db1da1" sha1="8ae14d65342f5a1ff8d0f09251ef46e24c29ff2b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11217,8 +11217,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsve-1.u1" size="8388608" crc="0bcf3f2e" sha1="9d826f67dd8b6567de9c9259e795e97f9a02e3f5" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsve-1.u1" size="0x800000" crc="0bcf3f2e" sha1="9d826f67dd8b6567de9c9259e795e97f9a02e3f5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11233,8 +11233,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSLE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nsle-0.u1" size="33554432" crc="a2866a6e" sha1="2ae97b0581bec355c4a7a2dc7a12df46cf4c91ab" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nsle-0.u1" size="0x2000000" crc="a2866a6e" sha1="2ae97b0581bec355c4a7a2dc7a12df46cf4c91ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -11253,8 +11253,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6101]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfxj-0.u1" size="12582912" crc="879edb89" sha1="86629def8edbcfd1c6a3de1c5172b14d1bf2f020" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfxj-0.u1" size="0xc00000" crc="879edb89" sha1="86629def8edbcfd1c6a3de1c5172b14d1bf2f020" />
 			</dataarea>
 		</part>
 	</software>
@@ -11265,8 +11265,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NFXE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="star fox 64 (usa) (rev a).bin" size="12582912" crc="d71902b0" sha1="7d6b2d10decd487a172fc4c49e44c4f71ab0d703" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="star fox 64 (usa) (rev a).bin" size="0xc00000" crc="d71902b0" sha1="7d6b2d10decd487a172fc4c49e44c4f71ab0d703" />
 			</dataarea>
 		</part>
 	</software>
@@ -11283,8 +11283,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6101]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nfxe-0.u1" size="12582912" crc="363e7ee8" sha1="cff7fb46e79d35f727e4e20cc4c13492ecd2a2d7" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nfxe-0.u1" size="0xc00000" crc="363e7ee8" sha1="cff7fb46e79d35f727e4e20cc4c13492ecd2a2d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -11297,8 +11297,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980710"/>
 		<info name="alt_title" value="スターソルジャー バニシングアース"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="star soldier - vanishing earth (japan).bin" size="12582912" crc="f51d4c7c" sha1="f075eeb6890065ce827a900df99e95f02f19098c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="star soldier - vanishing earth (japan).bin" size="0xc00000" crc="f51d4c7c" sha1="f075eeb6890065ce827a900df99e95f02f19098c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11313,8 +11313,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NS6E-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ns6e-0.u1" size="12582912" crc="052945e7" sha1="a1a7ee7f86485c854f81dec66462ca83abc8edd2" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ns6e-0.u1" size="0xc00000" crc="052945e7" sha1="a1a7ee7f86485c854f81dec66462ca83abc8edd2" />
 			</dataarea>
 		</part>
 	</software>
@@ -11327,8 +11327,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19991201"/>
 		<info name="alt_title" value="スターツインズ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="star twins (japan).bin" size="33554432" crc="c7bfb542" sha1="8f1a670d89c1252326d0979126deff532452f333" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="star twins (japan).bin" size="0x2000000" crc="c7bfb542" sha1="8f1a670d89c1252326d0979126deff532452f333" />
 			</dataarea>
 		</part>
 	</software>
@@ -11339,8 +11339,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NRSP-AUS, NUS-NRSP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="star wars - rogue squadron (europe) (en,fr,de) (rev a).bin" size="16777216" crc="a6e336ce" sha1="d8b0aafc759f6bee328cc5d447250e3bc1d0905f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="star wars - rogue squadron (europe) (en,fr,de) (rev a).bin" size="0x1000000" crc="a6e336ce" sha1="d8b0aafc759f6bee328cc5d447250e3bc1d0905f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11356,8 +11356,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nrsp-0.u1" size="16777216" crc="13cc4ca4" sha1="e09ff328184b25f6a9170901fac2d0a7158ce7b9" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nrsp-0.u1" size="0x1000000" crc="13cc4ca4" sha1="e09ff328184b25f6a9170901fac2d0a7158ce7b9" />
 			</dataarea>
 		</part>
 	</software>
@@ -11374,8 +11374,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nrse-1.u1" size="16777216" crc="4a479574" sha1="95b9042bfe4cca5ba801fefb47ca2d7e79f4c76d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nrse-1.u1" size="0x1000000" crc="4a479574" sha1="95b9042bfe4cca5ba801fefb47ca2d7e79f4c76d" />
 			</dataarea>
 		</part>
 	</software>
@@ -11386,8 +11386,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>LucasArts</publisher>
 		<info name="serial" value="NUS-NRSE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="star wars - rogue squadron (usa).bin" size="16777216" crc="2d6fa165" sha1="ffe16de53b845c7687808ea78bb664498738f8ce" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="star wars - rogue squadron (usa).bin" size="0x1000000" crc="2d6fa165" sha1="ffe16de53b845c7687808ea78bb664498738f8ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -11398,8 +11398,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NSWP-AUS, NUS-NSWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="star wars - shadows of the empire (europe).bin" size="12582912" crc="675d15b2" sha1="c0f55dea0bb07d0a8cb25f633db3f86630b4c639" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="star wars - shadows of the empire (europe).bin" size="0xc00000" crc="675d15b2" sha1="c0f55dea0bb07d0a8cb25f633db3f86630b4c639" />
 			</dataarea>
 		</part>
 	</software>
@@ -11409,8 +11409,8 @@ patched out (+ a fix for internal checksum)
 		<year>1996</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="star wars - shadows of the empire (prototype).bin" size="12582912" crc="448228ce" sha1="3509758f8920fcb653b7239580ea036d395a3c73" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="star wars - shadows of the empire (prototype).bin" size="0xc00000" crc="448228ce" sha1="3509758f8920fcb653b7239580ea036d395a3c73" />
 			</dataarea>
 		</part>
 	</software>
@@ -11425,8 +11425,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSWE-2]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nswe-2.u1" size="12582912" crc="f4e546d1" sha1="f3ab96424b567417722d95790f4efe30333b23f6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nswe-2.u1" size="0xc00000" crc="f4e546d1" sha1="f3ab96424b567417722d95790f4efe30333b23f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -11444,9 +11444,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nswe-1 02.u1" size="8388608" crc="170180b2" sha1="1c7b0e71a908c77d5c516c94ca88e85a3584fa55" offset="0x000000" />
-				<rom name="nus-nswe-1 12.u2" size="4194304" crc="c3b0b9a3" sha1="d1acc51a79a04b0a48f7e5e02d3df12a287964d1" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nswe-1 02.u1" size="0x800000" crc="170180b2" sha1="1c7b0e71a908c77d5c516c94ca88e85a3584fa55" offset="0x000000" />
+				<rom name="nus-nswe-1 12.u2" size="0x400000" crc="c3b0b9a3" sha1="d1acc51a79a04b0a48f7e5e02d3df12a287964d1" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -11462,9 +11462,9 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [NUS-NSWE-0 12]" />
 			<feature name="u3" value="U3 [BU9850]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nswe-0 02.u1" size="8388608" crc="cfd53ca8" sha1="00191182504a864828910cb76e7652635d2f18b0" offset="0x000000" />
-				<rom name="nus-nswe-0 12.u2" size="4194304" crc="b509d2cb" sha1="bde74d9a98a9a89fab73ccbb32705e75421ff590" offset="0x800000" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nswe-0 02.u1" size="0x800000" crc="cfd53ca8" sha1="00191182504a864828910cb76e7652635d2f18b0" offset="0x000000" />
+				<rom name="nus-nswe-0 12.u2" size="0x400000" crc="b509d2cb" sha1="bde74d9a98a9a89fab73ccbb32705e75421ff590" offset="0x800000" />
 			</dataarea>
 		</part>
 	</software>
@@ -11477,8 +11477,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990827"/>
 		<info name="alt_title" value="スター・ウォーズ [出撃!ローグ中隊]"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="star wars - shutsugeki rogue chuutai (japan).bin" size="16777216" crc="de90ade4" sha1="184a06d1967921e5bc9451d1337a529754b55c50" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="star wars - shutsugeki rogue chuutai (japan).bin" size="0x1000000" crc="de90ade4" sha1="184a06d1967921e5bc9451d1337a529754b55c50" />
 			</dataarea>
 		</part>
 	</software>
@@ -11491,8 +11491,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19970614"/>
 		<info name="alt_title" value="スター・ウォーズ 帝国の影"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="star wars - teikoku no kage (japan).bin" size="12582912" crc="54f66bb9" sha1="5ae92acb3035de0b62164787940f3d8272bb2708" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="star wars - teikoku no kage (japan).bin" size="0xc00000" crc="54f66bb9" sha1="5ae92acb3035de0b62164787940f3d8272bb2708" />
 			</dataarea>
 		</part>
 	</software>
@@ -11503,8 +11503,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NNAP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="star wars episode i - battle for naboo (europe).bin" size="33554432" crc="f6b20484" sha1="7a22d9bdce8067a9dc800017e5a01823d1514293" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="star wars episode i - battle for naboo (europe).bin" size="0x2000000" crc="f6b20484" sha1="7a22d9bdce8067a9dc800017e5a01823d1514293" />
 			</dataarea>
 		</part>
 	</software>
@@ -11519,8 +11519,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NNAE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nnae-0.u1" size="33554432" crc="97ebbea8" sha1="9f2782c314f7a8f481e6515fcd19c5431c6d5347" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nnae-0.u1" size="0x2000000" crc="97ebbea8" sha1="9f2782c314f7a8f481e6515fcd19c5431c6d5347" />
 			</dataarea>
 		</part>
 	</software>
@@ -11537,8 +11537,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nepp-0.u1" size="33554432" crc="ede47e8a" sha1="d4968ce06b93705ed40ff4433279f587f62e3c26" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nepp-0.u1" size="0x2000000" crc="ede47e8a" sha1="d4968ce06b93705ed40ff4433279f587f62e3c26" />
 			</dataarea>
 		</part>
 	</software>
@@ -11551,8 +11551,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990721"/>
 		<info name="alt_title" value="スター・ウォーズ エピソード1 レーサー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="star wars episode i - racer (japan).bin" size="33554432" crc="794412bf" sha1="4760072bb254bb7abfbf19d7664238b2cf5a6bd3" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="star wars episode i - racer (japan).bin" size="0x2000000" crc="794412bf" sha1="4760072bb254bb7abfbf19d7664238b2cf5a6bd3" />
 			</dataarea>
 		</part>
 	</software>
@@ -11569,8 +11569,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nepe-0.u1" size="33554432" crc="494c667a" sha1="f7f84332057e3fde3168c34d781b8c2b8c312e57" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nepe-0.u1" size="0x2000000" crc="494c667a" sha1="f7f84332057e3fde3168c34d781b8c2b8c312e57" />
 			</dataarea>
 		</part>
 	</software>
@@ -11587,8 +11587,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nsqp-0.u1" size="33554432" crc="d42fcfe1" sha1="0e4ae4d13bc78cea021a1f7d1534e9b82bdb0cdd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nsqp-0.u1" size="0x2000000" crc="d42fcfe1" sha1="0e4ae4d13bc78cea021a1f7d1534e9b82bdb0cdd" />
 			</dataarea>
 		</part>
 	</software>
@@ -11598,8 +11598,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="starcraft 64 (germany).bin" size="33554432" crc="35f8c03c" sha1="499c53f3d54293edb6889b6953b6e752e94322de" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="starcraft 64 (germany).bin" size="0x2000000" crc="35f8c03c" sha1="499c53f3d54293edb6889b6953b6e752e94322de" />
 			</dataarea>
 		</part>
 	</software>
@@ -11616,8 +11616,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nsqe-0.u1" size="33554432" crc="14c77369" sha1="3466ce39800b160ab8157ba1505ada238ed10d4a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nsqe-0.u1" size="0x2000000" crc="14c77369" sha1="3466ce39800b160ab8157ba1505ada238ed10d4a" />
 			</dataarea>
 		</part>
 	</software>
@@ -11627,8 +11627,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="starcraft 64 (usa) (beta).bin" size="33554432" crc="0dab69e2" sha1="1c58ebc31a5a7d750c980d8730ea4b2a98b6e1d0" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="starcraft 64 (usa) (beta).bin" size="0x2000000" crc="0dab69e2" sha1="1c58ebc31a5a7d750c980d8730ea4b2a98b6e1d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11639,8 +11639,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NSCP-FRA, NUS-NSCP-SCN"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="starshot - space circus fever (europe) (en,fr,de).bin" size="12582912" crc="171b80e1" sha1="4cccf890424728ba500db1046984edcbae280beb" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="starshot - space circus fever (europe) (en,fr,de).bin" size="0xc00000" crc="171b80e1" sha1="4cccf890424728ba500db1046984edcbae280beb" />
 			</dataarea>
 		</part>
 	</software>
@@ -11655,8 +11655,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSCE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nsce-0.u1" size="12582912" crc="64370749" sha1="1a4b81c3bd09d24dbbfed6aae66cb6761429817b" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nsce-0.u1" size="0xc00000" crc="64370749" sha1="1a4b81c3bd09d24dbbfed6aae66cb6761429817b" />
 			</dataarea>
 		</part>
 	</software>
@@ -11671,8 +11671,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NR3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nr3e-0.u1" size="12582912" crc="f60613de" sha1="69d2ccb020f710886e76f28288fea2846e341527" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nr3e-0.u1" size="0xc00000" crc="f60613de" sha1="69d2ccb020f710886e76f28288fea2846e341527" />
 			</dataarea>
 		</part>
 	</software>
@@ -11685,8 +11685,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980724"/>
 		<info name="alt_title" value="スーパービーダマン バトルフェニックス64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="super b-daman - battle phoenix 64 (japan).bin" size="12582912" crc="0be4f736" sha1="e5f4934bd4b4dc553a9a42c37a09dc24156941c4" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="super b-daman - battle phoenix 64 (japan).bin" size="0xc00000" crc="0be4f736" sha1="e5f4934bd4b4dc553a9a42c37a09dc24156941c4" />
 			</dataarea>
 		</part>
 	</software>
@@ -11699,8 +11699,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19990326"/>
 		<info name="alt_title" value="スーパーボウリング"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="super bowling (japan).bin" size="8388608" crc="be01964b" sha1="8c9a5a424f3fd5c3165835bc240102f1a8bb67ad" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="super bowling (japan).bin" size="0x800000" crc="be01964b" sha1="8c9a5a424f3fd5c3165835bc240102f1a8bb67ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -11715,8 +11715,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NBWE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nbwe-0.u1" size="8388608" crc="e651cbaa" sha1="876973c2e83d4f915f65d7231cbf9051a2cf03aa" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nbwe-0.u1" size="0x800000" crc="e651cbaa" sha1="876973c2e83d4f915f65d7231cbf9051a2cf03aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -11733,8 +11733,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsmp-0.u1" size="8388608" crc="11fb579b" sha1="d80ee9eeb6454d53a96ceb6ed0aca3ffde045091" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsmp-0.u1" size="0x800000" crc="11fb579b" sha1="d80ee9eeb6454d53a96ceb6ed0aca3ffde045091" />
 			</dataarea>
 		</part>
 	</software>
@@ -11747,8 +11747,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19970718"/>
 		<info name="alt_title" value="スーパーマリオ64 振動パック対応, スーパーマリオ64 (振動パック対応バージョン) (box)"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="super mario 64 (japan) (rev a) (shindou edition).bin" size="8388608" crc="bc9ff5f2" sha1="2a2b85e94581545ca3c05b8f864b488b141a8a1f" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="super mario 64 (japan) (rev a) (shindou edition).bin" size="0x800000" crc="bc9ff5f2" sha1="2a2b85e94581545ca3c05b8f864b488b141a8a1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11767,8 +11767,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsmj-0.u1" size="8388608" crc="5cf7952a" sha1="1d2579dd5fb1d8263a4bcc063a651a64acc88921" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsmj-0.u1" size="0x800000" crc="5cf7952a" sha1="1d2579dd5fb1d8263a4bcc063a651a64acc88921" />
 			</dataarea>
 		</part>
 	</software>
@@ -11785,8 +11785,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" /> <!-- Also with [CIC-NUS-6102A] -->
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN, NUS-HKG" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nsme-0.u1" size="8388608" crc="42c43204" sha1="1002dd7b56aa0a59a9103f1fb3d57d6b161f8da7" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nsme-0.u1" size="0x800000" crc="42c43204" sha1="1002dd7b56aa0a59a9103f1fb3d57d6b161f8da7" />
 			</dataarea>
 		</part>
 	</software>
@@ -11805,8 +11805,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nssj-0.u1" size="16777216" crc="dab52b89" sha1="f7b7e507b7210e637ccfd2f788a95ef5c7970ec0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nssj-0.u1" size="0x1000000" crc="dab52b89" sha1="f7b7e507b7210e637ccfd2f788a95ef5c7970ec0" />
 			</dataarea>
 		</part>
 	</software>
@@ -11819,8 +11819,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19991029"/>
 		<info name="alt_title" value="スーパーロボット大戦64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="super robot taisen 64 (japan).bin" size="33554432" crc="70fbc3b8" sha1="5ba9e915c1494fa6d9e8b0d4d32f312469963777" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="super robot taisen 64 (japan).bin" size="0x2000000" crc="70fbc3b8" sha1="5ba9e915c1494fa6d9e8b0d4d32f312469963777" />
 			</dataarea>
 		</part>
 	</software>
@@ -11837,8 +11837,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [74LV2416]" />
 			<feature name="u4" value="U4 [CIC-NUS-7103A]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nalu-0.u1" size="16777216" crc="b2f04090" sha1="e6f5167eee80c2c92358a195fb88c6207ab0f9f6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nalu-0.u1" size="0x1000000" crc="b2f04090" sha1="e6f5167eee80c2c92358a195fb88c6207ab0f9f6" />
 			</dataarea>
 		</part>
 	</software>
@@ -11857,8 +11857,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nalp-0.u1" size="33554432" crc="7976248c" sha1="a582522c0a09816bf904109e014a970625c06d3c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nalp-0.u1" size="0x2000000" crc="7976248c" sha1="a582522c0a09816bf904109e014a970625c06d3c" />
 			</dataarea>
 		</part>
 	</software>
@@ -11877,8 +11877,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nale-0.u1" size="16777216" crc="dd2df6d9" sha1="0fd35ae9976b4fe68ece1c6f2d9156d913ccf076" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nale-0.u1" size="0x1000000" crc="dd2df6d9" sha1="0fd35ae9976b4fe68ece1c6f2d9156d913ccf076" />
 			</dataarea>
 		</part>
 	</software>
@@ -11891,8 +11891,8 @@ patched out (+ a fix for internal checksum)
 		<info name="release" value="19980529"/>
 		<info name="alt_title" value="スーパースピードレース64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="super speed race 64 (japan).bin" size="4194304" crc="d96b76c3" sha1="e2e885786198a0f44ae740ba8c5dd59eac14b207" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="super speed race 64 (japan).bin" size="0x400000" crc="d96b76c3" sha1="e2e885786198a0f44ae740ba8c5dd59eac14b207" />
 			</dataarea>
 		</part>
 	</software>
@@ -11903,8 +11903,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NSXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="supercross 2000 (europe) (en,fr,de).bin" size="16777216" crc="0a6377ee" sha1="ee0802389002a907410a0e3f826fdcefa572e6c1" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="supercross 2000 (europe) (en,fr,de).bin" size="0x1000000" crc="0a6377ee" sha1="ee0802389002a907410a0e3f826fdcefa572e6c1" />
 			</dataarea>
 		</part>
 	</software>
@@ -11919,8 +11919,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSXE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nsxe-0.u1" size="16777216" crc="5a8a721d" sha1="03cbbfb4f57e2813cbe9050401d6144724b84d6f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nsxe-0.u1" size="0x1000000" crc="5a8a721d" sha1="03cbbfb4f57e2813cbe9050401d6144724b84d6f" />
 			</dataarea>
 		</part>
 	</software>
@@ -11931,8 +11931,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NSPP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="superman (europe) (en,fr,de,es,it,nl).bin" size="8388608" crc="9cef1753" sha1="660cbd7f4808d928f8c3dada9851267b6058fa80" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="superman (europe) (en,fr,de,es,it,nl).bin" size="0x800000" crc="9cef1753" sha1="660cbd7f4808d928f8c3dada9851267b6058fa80" />
 			</dataarea>
 		</part>
 	</software>
@@ -11942,8 +11942,8 @@ patched out (+ a fix for internal checksum)
 		<year>1999</year>
 		<publisher>Titus</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="superman64_prototype_raw.bin" size="33554432" crc="fea2232b" sha1="af23cee64673738145f1fec9203cbc1ddadb3ef5" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="superman64_prototype_raw.bin" size="0x2000000" crc="fea2232b" sha1="af23cee64673738145f1fec9203cbc1ddadb3ef5" />
 			</dataarea>
 		</part>
 	</software>
@@ -11958,8 +11958,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NSPE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nspe-0.u1" size="8388608" crc="f10d66f0" sha1="25fdc20ff0c55f6223c12058f7eab2df893ce9e4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nspe-0.u1" size="0x800000" crc="f10d66f0" sha1="25fdc20ff0c55f6223c12058f7eab2df893ce9e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -11978,8 +11978,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-npzj-0.u1" size="8388608" crc="dc83bcd3" sha1="abd8ecdbfc3676488c4cb961439f13ef8dc7c0c7" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-npzj-0.u1" size="0x800000" crc="dc83bcd3" sha1="abd8ecdbfc3676488c4cb961439f13ef8dc7c0c7" />
 			</dataarea>
 		</part>
 	</software>
@@ -11989,8 +11989,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="syd2k (eur).bin" size="33554432" crc="cb366589" sha1="f1ada6fbedf08754db14983678220cbf411da0b6" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="syd2k (eur).bin" size="0x2000000" crc="cb366589" sha1="f1ada6fbedf08754db14983678220cbf411da0b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12000,8 +12000,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000</year>
 		<publisher>Eidos</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="syd2k (usa).bin" size="33554432" crc="9b7b6f51" sha1="b9def914d6395b794418f0ccd846cbee123b27ff" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="syd2k (usa).bin" size="0x2000000" crc="9b7b6f51" sha1="b9def914d6395b794418f0ccd846cbee123b27ff" />
 			</dataarea>
 		</part>
 	</software>
@@ -12011,8 +12011,8 @@ patched out (+ a fix for internal checksum)
 		<year>1999</year>
 		<publisher>Looking Glass Studios</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tamiya racing 64 (unreleased).bin" size="16777216" crc="7ea56078" sha1="6d8551c846dec2a732732d988078731e047a82a5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tamiya racing 64 (unreleased).bin" size="0x1000000" crc="7ea56078" sha1="6d8551c846dec2a732732d988078731e047a82a5" />
 			</dataarea>
 		</part>
 	</software>
@@ -12023,8 +12023,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTAP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tarzan (europe).bin" size="16777216" crc="5fa14035" sha1="a489e4e47de9b59083f7bebafd260c8dcbb56f5f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tarzan (europe).bin" size="0x1000000" crc="5fa14035" sha1="a489e4e47de9b59083f7bebafd260c8dcbb56f5f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12035,8 +12035,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTAF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tarzan (france).bin" size="16777216" crc="c1176831" sha1="f3193b0eb2a2ddd2735d51c1adc4170bf2ed0252" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tarzan (france).bin" size="0x1000000" crc="c1176831" sha1="f3193b0eb2a2ddd2735d51c1adc4170bf2ed0252" />
 			</dataarea>
 		</part>
 	</software>
@@ -12047,8 +12047,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTAD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tarzan (germany).bin" size="16777216" crc="67dbec0b" sha1="04e6c0a8c6b19b78e1b124d8d758813559716809" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tarzan (germany).bin" size="0x1000000" crc="67dbec0b" sha1="04e6c0a8c6b19b78e1b124d8d758813559716809" />
 			</dataarea>
 		</part>
 	</software>
@@ -12063,8 +12063,8 @@ patched out (+ a fix for internal checksum)
 			<feature name="u1" value="U1 [NUS-NTAE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntae-0.u1" size="16777216" crc="2b59490b" sha1="64c186549f71134872fe1279a0440a95a2a60866" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntae-0.u1" size="0x1000000" crc="2b59490b" sha1="64c186549f71134872fe1279a0440a95a2a60866" />
 			</dataarea>
 		</part>
 	</software>
@@ -12075,8 +12075,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NTXP-NOE, NUS-NTXP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="taz express (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="85382541" sha1="fa61bd39f2a02bdf65fbe0b5730ff7c01f239b18" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="taz express (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="85382541" sha1="fa61bd39f2a02bdf65fbe0b5730ff7c01f239b18" />
 			</dataarea>
 		</part>
 	</software>
@@ -12086,8 +12086,8 @@ patched out (+ a fix for internal checksum)
 		<year>2000?</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="taz express (usa, proto).bin" size="33554432" crc="9e9b2ed5" sha1="285e448d8ccd707cfb401dd6496834e2e2bcb567" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="taz express (usa, proto).bin" size="0x2000000" crc="9e9b2ed5" sha1="285e448d8ccd707cfb401dd6496834e2e2bcb567" />
 			</dataarea>
 		</part>
 	</software>
@@ -12098,8 +12098,8 @@ patched out (+ a fix for internal checksum)
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NWKF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="telefoot soccer 2000 (france).bin" size="16777216" crc="fad893ea" sha1="d8f7d0557319b7b24de2f9ef864a1a46f84f1dd8" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="telefoot soccer 2000 (france).bin" size="0x1000000" crc="fad893ea" sha1="d8f7d0557319b7b24de2f9ef864a1a46f84f1dd8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12117,8 +12117,8 @@ clips onto the player's ear.
 		<info name="release" value="19981113"/>
 		<info name="alt_title" value="テトリス64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="tetris 64 (japan).bin" size="8388608" crc="08b4ca1b" sha1="95d42d3b33569fc2f47ac30c7de277470cb79462" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="tetris 64 (japan).bin" size="0x800000" crc="08b4ca1b" sha1="95d42d3b33569fc2f47ac30c7de277470cb79462" />
 			</dataarea>
 		</part>
 	</software>
@@ -12129,8 +12129,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NTPP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="tetrisphere (europe).bin" size="8388608" crc="2e953131" sha1="4486f5bdb049f170f7525e72d14bcf61f159b0bb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="tetrisphere (europe).bin" size="0x800000" crc="2e953131" sha1="4486f5bdb049f170f7525e72d14bcf61f159b0bb" />
 			</dataarea>
 		</part>
 	</software>
@@ -12145,8 +12145,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTPE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntpe-0.u1" size="8388608" crc="5db18578" sha1="81ffbb3912aae46bf358fe03a96a090a9997ddb0" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntpe-0.u1" size="0x800000" crc="5db18578" sha1="81ffbb3912aae46bf358fe03a96a090a9997ddb0" />
 			</dataarea>
 		</part>
 	</software>
@@ -12162,8 +12162,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nl2x-0.u1" size="12582912" crc="b5e8a1df" sha1="77baf3dd7b20c2c7faae4944d1f9d30476a25aac" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nl2x-0.u1" size="0xc00000" crc="b5e8a1df" sha1="77baf3dd7b20c2c7faae4944d1f9d30476a25aac" />
 			</dataarea>
 		</part>
 	</software>
@@ -12174,8 +12174,8 @@ clips onto the player's ear.
 		<publisher>NewKidCo</publisher>
 		<info name="serial" value="NUS-NT9P-EUR, NUS-NT9P-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tigger's honey hunt (europe) (en,fr,de,es,it,nl,da).bin" size="16777216" crc="cf7aa5ef" sha1="92362bf5c1cf95b726fb9b05735bbeb00c0751e0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tigger's honey hunt (europe) (en,fr,de,es,it,nl,da).bin" size="0x1000000" crc="cf7aa5ef" sha1="92362bf5c1cf95b726fb9b05735bbeb00c0751e0" />
 			</dataarea>
 		</part>
 	</software>
@@ -12190,8 +12190,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NT9E-0]" />
 			<feature name="u2" value="U2 [29L1100KC-15B0]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nt9e-0.u1" size="16777216" crc="79f8bf3b" sha1="5b48828607cfcecaaf3450ee369e5d0cabbafd7c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nt9e-0.u1" size="0x1000000" crc="79f8bf3b" sha1="5b48828607cfcecaaf3450ee369e5d0cabbafd7c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12202,8 +12202,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NTJP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="tom and jerry in fists of furry (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="b030a574" sha1="c4ff73733c284cc927f06be23551e73b14844984" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="tom and jerry in fists of furry (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="b030a574" sha1="c4ff73733c284cc927f06be23551e73b14844984" />
 			</dataarea>
 		</part>
 	</software>
@@ -12218,8 +12218,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTJE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntje-0.u1" size="12582912" crc="f0bfc6ab" sha1="66c59eef4370edd573b3aead79e1c805ca768e1f" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntje-0.u1" size="0xc00000" crc="f0bfc6ab" sha1="66c59eef4370edd573b3aead79e1c805ca768e1f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12230,8 +12230,8 @@ clips onto the player's ear.
 		<publisher>Red Storm Entertainment</publisher>
 		<info name="serial" value="NUS-NR6P-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tom clancy's rainbow six (europe).bin" size="16777216" crc="b430ba47" sha1="ce2cb1bdd42e0e7450b82df3c238a3c0b58667b2" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tom clancy's rainbow six (europe).bin" size="0x1000000" crc="b430ba47" sha1="ce2cb1bdd42e0e7450b82df3c238a3c0b58667b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12242,8 +12242,8 @@ clips onto the player's ear.
 		<publisher>Red Storm Entertainment</publisher>
 		<info name="serial" value="NUS-NR6F-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tom clancy's rainbow six (france).bin" size="16777216" crc="31bc7b49" sha1="ed7356fb54fb6f24eaf76bec971c5dad72252e74" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tom clancy's rainbow six (france).bin" size="0x1000000" crc="31bc7b49" sha1="ed7356fb54fb6f24eaf76bec971c5dad72252e74" />
 			</dataarea>
 		</part>
 	</software>
@@ -12254,8 +12254,8 @@ clips onto the player's ear.
 		<publisher>Red Storm Entertainment</publisher>
 		<info name="serial" value="NUS-NR6D-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tom clancy's rainbow six (germany).bin" size="16777216" crc="1f872c4a" sha1="0e79ad6f283903a9e408c6dd3c80541b920cb3fc" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tom clancy's rainbow six (germany).bin" size="0x1000000" crc="1f872c4a" sha1="0e79ad6f283903a9e408c6dd3c80541b920cb3fc" />
 			</dataarea>
 		</part>
 	</software>
@@ -12270,8 +12270,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NR6E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nr6e-0.u1" size="16777216" crc="67f3d120" sha1="1effa41aeaf6ebf626ea8e26093e0609015e1007" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nr6e-0.u1" size="0x1000000" crc="67f3d120" sha1="1effa41aeaf6ebf626ea8e26093e0609015e1007" />
 			</dataarea>
 		</part>
 	</software>
@@ -12281,8 +12281,8 @@ clips onto the player's ear.
 		<year>1997</year>
 		<publisher>Player 1</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="tommy thunder (usa) (proto).bin" size="8388608" crc="e5bc76d8" sha1="9ffb0084e560395e788dcc18d6fa3d238f0e9853" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="tommy thunder (usa) (proto).bin" size="0x800000" crc="e5bc76d8" sha1="9ffb0084e560395e788dcc18d6fa3d238f0e9853" />
 			</dataarea>
 		</part>
 	</software>
@@ -12293,8 +12293,8 @@ clips onto the player's ear.
 		<publisher>Ubi Soft</publisher>
 		<info name="serial" value="NUS-NTTP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="tonic trouble (europe) (en,fr,de,es,it).bin" size="16777216" crc="a10b0009" sha1="84e6c54c9dd3f18eba2c741e5f1cfd1be04855cc" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="tonic trouble (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="a10b0009" sha1="84e6c54c9dd3f18eba2c741e5f1cfd1be04855cc" />
 			</dataarea>
 		</part>
 	</software>
@@ -12309,8 +12309,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTTE-1]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntte-1.u1" size="16777216" crc="0ecd289a" sha1="88f9ace09f949a43253d37896e75472bc9ae6d12" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntte-1.u1" size="0x1000000" crc="0ecd289a" sha1="88f9ace09f949a43253d37896e75472bc9ae6d12" />
 			</dataarea>
 		</part>
 	</software>
@@ -12321,8 +12321,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTFE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="tony hawk's pro skater (usa) (rev a).bin" size="12582912" crc="1be278c1" sha1="8f6b113675cf437fa0686e35683ebdc8aaf11d39" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="tony hawk's pro skater (usa) (rev a).bin" size="0xc00000" crc="1be278c1" sha1="8f6b113675cf437fa0686e35683ebdc8aaf11d39" />
 			</dataarea>
 		</part>
 	</software>
@@ -12337,8 +12337,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntfe-0.u1" size="12582912" crc="ee2c9008" sha1="7523d5e43ee18fc1298e8ce6656effcdb7b0c1b7" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntfe-0.u1" size="0xc00000" crc="ee2c9008" sha1="7523d5e43ee18fc1298e8ce6656effcdb7b0c1b7" />
 			</dataarea>
 		</part>
 	</software>
@@ -12353,8 +12353,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTQP-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntqp-0.u1.bin" size="16777216" crc="dc703b1e" sha1="28b9c785bdc0a54f1675d6180a092c300f514633" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntqp-0.u1.bin" size="0x1000000" crc="dc703b1e" sha1="28b9c785bdc0a54f1675d6180a092c300f514633" />
 			</dataarea>
 		</part>
 	</software>
@@ -12369,8 +12369,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTQE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ntqe-0.u1" size="16777216" crc="6df2d58e" sha1="6c2d313aea3724f5638738923a58c0e765bddcfa" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ntqe-0.u1" size="0x1000000" crc="6df2d58e" sha1="6c2d313aea3724f5638738923a58c0e765bddcfa" />
 			</dataarea>
 		</part>
 	</software>
@@ -12385,8 +12385,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-N3TE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nt3e-0.u1" size="16777216" crc="ed73272e" sha1="63ecbb3d07b8ac20ed096af0735704ef715bd398" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nt3e-0.u1" size="0x1000000" crc="ed73272e" sha1="63ecbb3d07b8ac20ed096af0735704ef715bd398" />
 			</dataarea>
 		</part>
 	</software>
@@ -12397,8 +12397,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTFP-AUS, NUS-NTFP-NOE, NUS-NTFP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="tony hawk's skateboarding (europe).bin" size="12582912" crc="93a26129" sha1="9dc473f35cea9ba531590de833ebf32e25a6a9d1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="tony hawk's skateboarding (europe).bin" size="0xc00000" crc="93a26129" sha1="9dc473f35cea9ba531590de833ebf32e25a6a9d1" />
 			</dataarea>
 		</part>
 	</software>
@@ -12408,8 +12408,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Bottom Up</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="toon panic (japan) (proto).bin" size="12582912" crc="55c88f04" sha1="56a59924c9a4125f7ca7cc1cf51c06ac383e3d7c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="toon panic (japan) (proto).bin" size="0xc00000" crc="55c88f04" sha1="56a59924c9a4125f7ca7cc1cf51c06ac383e3d7c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12420,8 +12420,8 @@ clips onto the player's ear.
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NGBP-EUR, NUS-NGBP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="top gear hyper-bike (europe).bin" size="16777216" crc="dc687ad1" sha1="29573e3a4016adcdfd2ee318d7700ad423eb369f" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="top gear hyper-bike (europe).bin" size="0x1000000" crc="dc687ad1" sha1="29573e3a4016adcdfd2ee318d7700ad423eb369f" />
 			</dataarea>
 		</part>
 	</software>
@@ -12434,8 +12434,8 @@ clips onto the player's ear.
 		<info name="release" value="20000317"/>
 		<info name="alt_title" value="トップギア・ハイパーバイク"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="top gear hyper-bike (japan).bin" size="16777216" crc="d9af869c" sha1="0b97dbee843094ed6320d4b795b64f7fac908dae" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="top gear hyper-bike (japan).bin" size="0x1000000" crc="d9af869c" sha1="0b97dbee843094ed6320d4b795b64f7fac908dae" />
 			</dataarea>
 		</part>
 	</software>
@@ -12450,8 +12450,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NGBE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-ngbe-0.u1" size="16777216" crc="3e9ce2af" sha1="4a146c7a53fb979bceedd79cc1719bd6130698a3" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-ngbe-0.u1" size="0x1000000" crc="3e9ce2af" sha1="4a146c7a53fb979bceedd79cc1719bd6130698a3" />
 			</dataarea>
 		</part>
 	</software>
@@ -12461,8 +12461,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="top gear hyper-bike (2000)(kemco)(beta).bin" size="33554432" crc="00c0278a" sha1="d3ae07e2c4360ec4eb06a70c6e48d848eec532dd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="top gear hyper-bike (2000)(kemco)(beta).bin" size="0x2000000" crc="00c0278a" sha1="d3ae07e2c4360ec4eb06a70c6e48d848eec532dd" />
 			</dataarea>
 		</part>
 	</software>
@@ -12473,8 +12473,8 @@ clips onto the player's ear.
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NRCP-EUR, NUS-NRCP-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="top gear overdrive (europe).bin" size="12582912" crc="52d39097" sha1="37013dffc9e8a61f3b40eb100133cd40f2ae523d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="top gear overdrive (europe).bin" size="0xc00000" crc="52d39097" sha1="37013dffc9e8a61f3b40eb100133cd40f2ae523d" />
 			</dataarea>
 		</part>
 	</software>
@@ -12487,8 +12487,8 @@ clips onto the player's ear.
 		<info name="release" value="19990319"/>
 		<info name="alt_title" value="トップギア オーバードライブ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="top gear overdrive (japan).bin" size="12582912" crc="e680b138" sha1="7a92260252f5e823f1b3b4adedc85908a0cadbb5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="top gear overdrive (japan).bin" size="0xc00000" crc="e680b138" sha1="7a92260252f5e823f1b3b4adedc85908a0cadbb5" />
 			</dataarea>
 		</part>
 	</software>
@@ -12503,8 +12503,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NRCE-0]" />
 			<feature name="u2" value="U2 [BK4D-NUS]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nrce-0.u1" size="12582912" crc="b5b23053" sha1="2b79d74949bc631e74379720265e8633806290af" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nrce-0.u1" size="0xc00000" crc="b5b23053" sha1="2b79d74949bc631e74379720265e8633806290af" />
 			</dataarea>
 		</part>
 	</software>
@@ -12515,8 +12515,8 @@ clips onto the player's ear.
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NTRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="top gear rally (europe).bin" size="8388608" crc="83b04584" sha1="42f8c45ace108ade7ffdcdf5d8475c2e1702954c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="top gear rally (europe).bin" size="0x800000" crc="83b04584" sha1="42f8c45ace108ade7ffdcdf5d8475c2e1702954c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12529,8 +12529,8 @@ clips onto the player's ear.
 		<info name="release" value="19971205"/>
 		<info name="alt_title" value="トップギア・ラリー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="top gear rally (japan).bin" size="8388608" crc="d8e793f5" sha1="3c29783dd963b8594d2fd41e296b2c7d9dc318f2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="top gear rally (japan).bin" size="0x800000" crc="d8e793f5" sha1="3c29783dd963b8594d2fd41e296b2c7d9dc318f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -12545,8 +12545,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NGRE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ngre-0.u1" size="8388608" crc="a04f1cc0" sha1="0dde80bae97b82fa56496360fc6b1bbfeaca6999" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ngre-0.u1" size="0x800000" crc="a04f1cc0" sha1="0dde80bae97b82fa56496360fc6b1bbfeaca6999" />
 			</dataarea>
 		</part>
 	</software>
@@ -12563,8 +12563,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-ASM" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ngrx-0.u1" size="8388608" crc="c85372cf" sha1="7339e97dcc7fca10788fb29f100c8d2316b7305e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ngrx-0.u1" size="0x800000" crc="c85372cf" sha1="7339e97dcc7fca10788fb29f100c8d2316b7305e" />
 			</dataarea>
 		</part>
 	</software>
@@ -12575,8 +12575,8 @@ clips onto the player's ear.
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NL2P-EUR, NUS-NL2P-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="top gear rally 2 (europe).bin" size="12582912" crc="88c8a6ea" sha1="cdeba42c305995a7fb66b26c8daf4e135152abec" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="top gear rally 2 (europe).bin" size="0xc00000" crc="88c8a6ea" sha1="cdeba42c305995a7fb66b26c8daf4e135152abec" />
 			</dataarea>
 		</part>
 	</software>
@@ -12589,8 +12589,8 @@ clips onto the player's ear.
 		<info name="release" value="20000204"/>
 		<info name="alt_title" value="トップギア・ラリー2"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="top gear rally 2 (japan).bin" size="12582912" crc="ccd50a05" sha1="6c342e8e47baa3b9ee8a0a35721ec3a123b94243" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="top gear rally 2 (japan).bin" size="0xc00000" crc="ccd50a05" sha1="6c342e8e47baa3b9ee8a0a35721ec3a123b94243" />
 			</dataarea>
 		</part>
 	</software>
@@ -12605,8 +12605,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NL2E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nl2e-0.u1" size="12582912" crc="7e4e181c" sha1="2c51ef2ca9b738daa5f70b8199a64cd765a44243" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nl2e-0.u1" size="0xc00000" crc="7e4e181c" sha1="2c51ef2ca9b738daa5f70b8199a64cd765a44243" />
 			</dataarea>
 		</part>
 	</software>
@@ -12616,8 +12616,8 @@ clips onto the player's ear.
 		<year>1999</year>
 		<publisher>Kemco</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="top gear rally 2 rev 19990831 (1999)(kemco)(beta).bin" size="16777216" crc="3c77c5d6" sha1="168dd383edd88a921d25cf7eaeb18b2da29c744a" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="top gear rally 2 rev 19990831 (1999)(kemco)(beta).bin" size="0x1000000" crc="3c77c5d6" sha1="168dd383edd88a921d25cf7eaeb18b2da29c744a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12628,8 +12628,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTHP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="toy story 2 (europe).bin" size="12582912" crc="c1c5b460" sha1="e201405104e9c4275edc2671e1bd99d13ccc40a8" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="toy story 2 (europe).bin" size="0xc00000" crc="c1c5b460" sha1="e201405104e9c4275edc2671e1bd99d13ccc40a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12640,8 +12640,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTHF-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="toy story 2 (france).bin" size="12582912" crc="2af45190" sha1="4f08a4d02fc14e99bd13789895f7a447381e0c8c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="toy story 2 (france).bin" size="0xc00000" crc="2af45190" sha1="4f08a4d02fc14e99bd13789895f7a447381e0c8c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12657,8 +12657,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nthd-1.u1" size="12582912" crc="1878086f" sha1="9786f138231509156bf23b1e9f1c327acec89b41" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nthd-1.u1" size="0xc00000" crc="1878086f" sha1="9786f138231509156bf23b1e9f1c327acec89b41" />
 			</dataarea>
 		</part>
 	</software>
@@ -12669,8 +12669,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTHD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="toy story 2 (germany).bin" size="12582912" crc="33fd1561" sha1="24cb3c7f89640a9ab542aabc55bc32561fd9218a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="toy story 2 (germany).bin" size="0xc00000" crc="33fd1561" sha1="24cb3c7f89640a9ab542aabc55bc32561fd9218a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12686,8 +12686,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nthe-1.u1" size="12582912" crc="a11f0f8e" sha1="e0cd3699fd9f5443d3dfa2333726eaea724d892d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nthe-1.u1" size="0xc00000" crc="a11f0f8e" sha1="e0cd3699fd9f5443d3dfa2333726eaea724d892d" />
 			</dataarea>
 		</part>
 	</software>
@@ -12698,8 +12698,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NTHE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="toy story 2 (usa).bin" size="12582912" crc="f7a72276" sha1="2196b226f1a75a917bfd1dcf22f02cd96ff39007" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="toy story 2 (usa).bin" size="0xc00000" crc="f7a72276" sha1="2196b226f1a75a917bfd1dcf22f02cd96ff39007" />
 			</dataarea>
 		</part>
 	</software>
@@ -12718,8 +12718,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntbj-0.u1" size="12582912" crc="5e972b7d" sha1="da8e453dbbd57ac3b207b44b4621ea8897141bb6" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntbj-0.u1" size="0xc00000" crc="5e972b7d" sha1="da8e453dbbd57ac3b207b44b4621ea8897141bb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12734,8 +12734,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NOHE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nohe-0.u1" size="16777216" crc="14c6b5e3" sha1="423e5388f643bbfda1f893382f1f91849be4dd99" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nohe-0.u1" size="0x1000000" crc="14c6b5e3" sha1="423e5388f643bbfda1f893382f1f91849be4dd99" />
 			</dataarea>
 		</part>
 	</software>
@@ -12750,8 +12750,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-N3PE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-n3pe-0.u1" size="16777216" crc="bfb124fc" sha1="e604aa2d812dfc73d20e3fc8c81cbb73439db88a" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-n3pe-0.u1" size="0x1000000" crc="bfb124fc" sha1="e604aa2d812dfc73d20e3fc8c81cbb73439db88a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12764,8 +12764,8 @@ clips onto the player's ear.
 		<info name="release" value="20001121"/>
 		<info name="alt_title" value="罪と罰～地球の継承者～"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="tsumi to batsu - hoshi no keishousha (japan).bin" size="33554432" crc="c0891399" sha1="4c9ae28811f8688a9016d293c5f67681da53cad9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="tsumi to batsu - hoshi no keishousha (japan).bin" size="0x2000000" crc="c0891399" sha1="4c9ae28811f8688a9016d293c5f67681da53cad9" />
 			</dataarea>
 		</part>
 	</software>
@@ -12776,8 +12776,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTUP-EUR-1"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - dinosaur hunter (europe) (rev b).bin" size="8388608" crc="03d8ca48" sha1="bfcf4fb8c268eb07eb4921712e0c8fb9ef0702ce" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - dinosaur hunter (europe) (rev b).bin" size="0x800000" crc="03d8ca48" sha1="bfcf4fb8c268eb07eb4921712e0c8fb9ef0702ce" />
 			</dataarea>
 		</part>
 	</software>
@@ -12788,8 +12788,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTUP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - dinosaur hunter (europe) (rev a).bin" size="8388608" crc="5ed8ab71" sha1="81a389040f3a284766bd31a7b65529b939241689" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - dinosaur hunter (europe) (rev a).bin" size="0x800000" crc="5ed8ab71" sha1="81a389040f3a284766bd31a7b65529b939241689" />
 			</dataarea>
 		</part>
 	</software>
@@ -12805,8 +12805,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntup-0.u1" size="8388608" crc="019a0c30" sha1="0ccdbfa032ae5f48c47489468b5da23cf98f6d84" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntup-0.u1" size="0x800000" crc="019a0c30" sha1="0ccdbfa032ae5f48c47489468b5da23cf98f6d84" />
 			</dataarea>
 		</part>
 	</software>
@@ -12822,8 +12822,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntud-2.u1" size="8388608" crc="01f632f6" sha1="90b11d34f7dd13aea195f98ecb40f869bcefbce4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntud-2.u1" size="0x800000" crc="01f632f6" sha1="90b11d34f7dd13aea195f98ecb40f869bcefbce4" />
 			</dataarea>
 		</part>
 	</software>
@@ -12839,8 +12839,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntud-1.u1" size="8388608" crc="5a345522" sha1="e6418a4823751f78977dbc392f24f098b2e42c1a" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntud-1.u1" size="0x800000" crc="5a345522" sha1="e6418a4823751f78977dbc392f24f098b2e42c1a" />
 			</dataarea>
 		</part>
 	</software>
@@ -12851,8 +12851,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTUD-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - dinosaur hunter (germany).bin" size="8388608" crc="70398790" sha1="d82536e69ff05ce4829588cec79b96dc51e2beb6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - dinosaur hunter (germany).bin" size="0x800000" crc="70398790" sha1="d82536e69ff05ce4829588cec79b96dc51e2beb6" />
 			</dataarea>
 		</part>
 	</software>
@@ -12863,8 +12863,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTUE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - dinosaur hunter (usa) (rev b).bin" size="8388608" crc="af6ea1b8" sha1="e5f7580f2909b79c623b93491af2bca5a64127c8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - dinosaur hunter (usa) (rev b).bin" size="0x800000" crc="af6ea1b8" sha1="e5f7580f2909b79c623b93491af2bca5a64127c8" />
 			</dataarea>
 		</part>
 	</software>
@@ -12875,8 +12875,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTUE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - dinosaur hunter (usa) (rev a).bin" size="8388608" crc="f26ec081" sha1="9a2e1db319aec3eada430053fb79d150bade79ad" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - dinosaur hunter (usa) (rev a).bin" size="0x800000" crc="f26ec081" sha1="9a2e1db319aec3eada430053fb79d150bade79ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -12892,8 +12892,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntue-0.u1" size="8388608" crc="777d75e6" sha1="8a5d29e062f6893af4e817b90afd5f941968df6d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntue-0.u1" size="0x800000" crc="777d75e6" sha1="8a5d29e062f6893af4e817b90afd5f941968df6d" />
 			</dataarea>
 		</part>
 	</software>
@@ -12912,8 +12912,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nrwd-0.u1" size="8388608" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nrwd-0.u1" size="0x800000" crc="a2754ca4" sha1="51792351f4fd61c11f4b3b755a5eb8b9ea725b72" />
 			</dataarea>
 		</part>
 	</software>
@@ -12924,8 +12924,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NRWX-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - rage wars (europe) (en,fr,it).bin" size="8388608" crc="6331b573" sha1="a0173d69a2dfd793b8a23092d7edc79fa5a61c0c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - rage wars (europe) (en,fr,it).bin" size="0x800000" crc="6331b573" sha1="a0173d69a2dfd793b8a23092d7edc79fa5a61c0c" />
 			</dataarea>
 		</part>
 	</software>
@@ -12936,8 +12936,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NRWP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="turok - rage wars (europe).bin" size="8388608" crc="6c391585" sha1="1dcd7b6a18e395872392e8f718d8eb8ed6f5d29d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="turok - rage wars (europe).bin" size="0x800000" crc="6c391585" sha1="1dcd7b6a18e395872392e8f718d8eb8ed6f5d29d" />
 			</dataarea>
 		</part>
 	</software>
@@ -12953,8 +12953,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nrwe-1.u1" size="8388608" crc="282319a0" sha1="c94f093486f2ba2030f077254d0b6ce26372e684" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nrwe-1.u1" size="0x800000" crc="282319a0" sha1="c94f093486f2ba2030f077254d0b6ce26372e684" />
 			</dataarea>
 		</part>
 	</software>
@@ -12970,8 +12970,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nrwe-0.u1" size="8388608" crc="416474d8" sha1="11c2dd51ffcecc5d8134cec96ffcf9c44b15db48" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nrwe-0.u1" size="0x800000" crc="416474d8" sha1="11c2dd51ffcecc5d8134cec96ffcf9c44b15db48" />
 			</dataarea>
 		</part>
 	</software>
@@ -12988,8 +12988,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntyp-0.u1" size="12582912" crc="38b017d5" sha1="4d47eabe2740d6327207539cd229d7c9a27b51f0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntyp-0.u1" size="0xc00000" crc="38b017d5" sha1="4d47eabe2740d6327207539cd229d7c9a27b51f0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13000,8 +13000,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NT2P-EUR, NUS-NT2P-UKV" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 2 - seeds of evil (europe).bin" size="33554432" crc="9791b9cf" sha1="54fd5142f25a5fa058bdd2eb9f47ee1dfdd93b10" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 2 - seeds of evil (europe).bin" size="0x2000000" crc="9791b9cf" sha1="54fd5142f25a5fa058bdd2eb9f47ee1dfdd93b10" />
 			</dataarea>
 		</part>
 	</software>
@@ -13012,8 +13012,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NT2X-EUR" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 2 - seeds of evil (europe) (en,fr,es,it).bin" size="33554432" crc="a309d9d3" sha1="b7d0dd6908acbc7bc7a2588eedbdcdfab8c210be" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 2 - seeds of evil (europe) (en,fr,es,it).bin" size="0x2000000" crc="a309d9d3" sha1="b7d0dd6908acbc7bc7a2588eedbdcdfab8c210be" />
 			</dataarea>
 		</part>
 	</software>
@@ -13030,8 +13030,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nt2d-0.u1" size="33554432" crc="fbe927cc" sha1="1a46b9ca32625bd20c7c8e02ad62ae3273b8790a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nt2d-0.u1" size="0x2000000" crc="fbe927cc" sha1="1a46b9ca32625bd20c7c8e02ad62ae3273b8790a" />
 			</dataarea>
 		</part>
 	</software>
@@ -13048,8 +13048,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-ntye-0.u1" size="12582912" crc="46175228" sha1="e9c274dd10c65fc4e0b07c1896eb884eef78c41c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-ntye-0.u1" size="0xc00000" crc="46175228" sha1="e9c274dd10c65fc4e0b07c1896eb884eef78c41c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13064,8 +13064,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NT2E-1]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nt2e-1.u1" size="33554432" crc="adec745f" sha1="bf56fe227f6e1936e7ae54390ee09ec2f9500160" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nt2e-1.u1" size="0x2000000" crc="adec745f" sha1="bf56fe227f6e1936e7ae54390ee09ec2f9500160" />
 			</dataarea>
 		</part>
 	</software>
@@ -13082,8 +13082,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nt2e-0.u1" size="33554432" crc="fe3527ae" sha1="2ca5d6ba9529a57d822661ef770001276e7beb92" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nt2e-0.u1" size="0x2000000" crc="fe3527ae" sha1="2ca5d6ba9529a57d822661ef770001276e7beb92" />
 			</dataarea>
 		</part>
 	</software>
@@ -13094,8 +13094,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTKP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 3 - shadow of oblivion (europe).bin" size="33554432" crc="3113283e" sha1="10df040ef5d6b2e9e72a1bfa2bde5c0d74f68a7f" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 3 - shadow of oblivion (europe).bin" size="0x2000000" crc="3113283e" sha1="10df040ef5d6b2e9e72a1bfa2bde5c0d74f68a7f" />
 			</dataarea>
 		</part>
 	</software>
@@ -13105,8 +13105,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 3 - shadow of oblivion (usa) (beta).bin" size="33554432" crc="a53de25f" sha1="ab268d630c5f206b36f0db0605be8762cd2b96da" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 3 - shadow of oblivion (usa) (beta).bin" size="0x2000000" crc="a53de25f" sha1="ab268d630c5f206b36f0db0605be8762cd2b96da" />
 			</dataarea>
 		</part>
 	</software>
@@ -13116,8 +13116,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 3 - shadow of oblivion (usa) (2000-05-31) (beta).bin" size="33554432" crc="505e9066" sha1="12a22310e653b2389110e7708831634e3f9f18db" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 3 - shadow of oblivion (usa) (2000-05-31) (beta).bin" size="0x2000000" crc="505e9066" sha1="12a22310e653b2389110e7708831634e3f9f18db" />
 			</dataarea>
 		</part>
 	</software>
@@ -13127,8 +13127,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Acclaim Entertainment</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="turok 3 - shadow of oblivion (2000)(acclaim)(beta).bin" size="33554432" crc="bf082a47" sha1="26f6558d5c824d17174782ec9a3bed4689828a76" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="turok 3 - shadow of oblivion (2000)(acclaim)(beta).bin" size="0x2000000" crc="bf082a47" sha1="26f6558d5c824d17174782ec9a3bed4689828a76" />
 			</dataarea>
 		</part>
 	</software>
@@ -13143,8 +13143,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTKE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ntke-0.u1" size="33554432" crc="e0d0d902" sha1="0176e990fa8145dbba9b1781b44a121ea014cda4" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ntke-0.u1" size="0x2000000" crc="e0d0d902" sha1="0176e990fa8145dbba9b1781b44a121ea014cda4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13155,8 +13155,8 @@ clips onto the player's ear.
 		<publisher>Kemco</publisher>
 		<info name="serial" value="NUS-NSBP-HOL, NUS-NSBP-NOE, NUS-NSBP-UKV" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="twisted edge - extreme snowboarding (europe).bin" size="12582912" crc="394bdd25" sha1="e5bae263e692121a080308e6fdb2e42d20b1b347" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="twisted edge - extreme snowboarding (europe).bin" size="0xc00000" crc="394bdd25" sha1="e5bae263e692121a080308e6fdb2e42d20b1b347" />
 			</dataarea>
 		</part>
 	</software>
@@ -13171,8 +13171,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NSBE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nsbe-0.u1" size="12582912" crc="3a572b23" sha1="0b737f0e48b4bfc80a78fe18e7e0530050f70fc0" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nsbe-0.u1" size="0xc00000" crc="3a572b23" sha1="0b737f0e48b4bfc80a78fe18e7e0530050f70fc0" />
 			</dataarea>
 		</part>
 	</software>
@@ -13191,8 +13191,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nirj-0.u1" size="8388608" crc="cb8c642b" sha1="9099c31fa07c8bfdd5dc94efebb9054144a1e34c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nirj-0.u1" size="0x800000" crc="cb8c642b" sha1="9099c31fa07c8bfdd5dc94efebb9054144a1e34c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13203,8 +13203,8 @@ clips onto the player's ear.
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NVLP-EUR, NUS-NVLP-EUU" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="v-rally edition 99 (europe) (en,fr,de).bin" size="12582912" crc="d200f779" sha1="d55b29cee570d6bd7e8b5a4f817d987a8c08b32e" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="v-rally edition 99 (europe) (en,fr,de).bin" size="0xc00000" crc="d200f779" sha1="d55b29cee570d6bd7e8b5a4f817d987a8c08b32e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13217,8 +13217,8 @@ clips onto the player's ear.
 		<info name="release" value="19991014"/>
 		<info name="alt_title" value="V-RALLY EDITION 99"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="v-rally edition 99 (japan).bin" size="8388608" crc="7aab7e2a" sha1="04bac1690879d0178f646e04c935dac7ae72e16d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="v-rally edition 99 (japan).bin" size="0x800000" crc="7aab7e2a" sha1="04bac1690879d0178f646e04c935dac7ae72e16d" />
 			</dataarea>
 		</part>
 	</software>
@@ -13233,8 +13233,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NVLE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="vnus-nvle-0.u1" size="8388608" crc="bfef13e9" sha1="7fc14b6683a5cbf1597211eb2375e5ad0e16c756" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="vnus-nvle-0.u1" size="0x800000" crc="bfef13e9" sha1="7fc14b6683a5cbf1597211eb2375e5ad0e16c756" />
 			</dataarea>
 		</part>
 	</software>
@@ -13245,8 +13245,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NV8P-UKV" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="vigilante 8 (europe).bin" size="8388608" crc="959ecce7" sha1="49f44e03dcc432784ed4251d4a52490f734a30a8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="vigilante 8 (europe).bin" size="0x800000" crc="959ecce7" sha1="49f44e03dcc432784ed4251d4a52490f734a30a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -13257,8 +13257,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NV8F-FRA" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="vigilante 8 (france).bin" size="8388608" crc="c178ea87" sha1="53446583aee4c693c9a9b5ed50a4d9bae1d284b2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="vigilante 8 (france).bin" size="0x800000" crc="c178ea87" sha1="53446583aee4c693c9a9b5ed50a4d9bae1d284b2" />
 			</dataarea>
 		</part>
 	</software>
@@ -13269,8 +13269,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NV8D-NOE" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="vigilante 8 (germany).bin" size="8388608" crc="179eec29" sha1="7e6e6630f419c25efc18adc9af884ab25eef42b6" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="vigilante 8 (germany).bin" size="0x800000" crc="179eec29" sha1="7e6e6630f419c25efc18adc9af884ab25eef42b6" />
 			</dataarea>
 		</part>
 	</software>
@@ -13287,8 +13287,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nv8e-0.u1" size="8388608" crc="b445edcd" sha1="588807afb3acda05955b6362c21ca24a5f2e70a2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nv8e-0.u1" size="0x800000" crc="b445edcd" sha1="588807afb3acda05955b6362c21ca24a5f2e70a2" />
 			</dataarea>
 		</part>
 	</software>
@@ -13299,8 +13299,8 @@ clips onto the player's ear.
 		<publisher>Activision</publisher>
 		<info name="serial" value="NUS-NVGP-FRA, NUS-NVGP-NOE, NUS-NVGP-UKV" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="vigilante 8 - 2nd offense (europe).bin" size="12582912" crc="763d501e" sha1="ad3f8cc2e2ead6e713621e25f5f6f02534a81ad5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="vigilante 8 - 2nd offense (europe).bin" size="0xc00000" crc="763d501e" sha1="ad3f8cc2e2ead6e713621e25f5f6f02534a81ad5" />
 			</dataarea>
 		</part>
 	</software>
@@ -13315,8 +13315,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NVGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nvge-0.u1" size="12582912" crc="764abdb3" sha1="2da6a5a3fa61077949582154597a4717bcf51e3a" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nvge-0.u1" size="0xc00000" crc="764abdb3" sha1="2da6a5a3fa61077949582154597a4717bcf51e3a" />
 			</dataarea>
 		</part>
 	</software>
@@ -13329,8 +13329,8 @@ clips onto the player's ear.
 		<info name="release" value="19990618"/>
 		<info name="alt_title" value="バイオレンスキラーTUROK NEW GENERATION"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="violence killer - turok new generation (japan).bin" size="33554432" crc="65785622" sha1="873b8520fc44db2b3910dd5f11b9aec63f17645c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="violence killer - turok new generation (japan).bin" size="0x2000000" crc="65785622" sha1="873b8520fc44db2b3910dd5f11b9aec63f17645c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13341,8 +13341,8 @@ clips onto the player's ear.
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NVCP-EUR" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="virtual chess 64 (europe) (en,fr,de,es,it,nl).bin" size="4194304" crc="d20f855c" sha1="47b211d0f2cb0c5f53bfbb52649caf6a616cf24c" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="virtual chess 64 (europe) (en,fr,de,es,it,nl).bin" size="0x400000" crc="d20f855c" sha1="47b211d0f2cb0c5f53bfbb52649caf6a616cf24c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13357,8 +13357,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NVCE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nvce-0.u1" size="4194304" crc="3cd894c4" sha1="9f57ec795e3c62d88ea823a5866a7b1012b731db" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nvce-0.u1" size="0x400000" crc="3cd894c4" sha1="9f57ec795e3c62d88ea823a5866a7b1012b731db" />
 			</dataarea>
 		</part>
 	</software>
@@ -13368,8 +13368,8 @@ clips onto the player's ear.
 		<year>1999</year>
 		<publisher>Sammy</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="Viewpoint2064.z64" size="16777216" crc="93a630cb" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="Viewpoint2064.z64" size="0x1000000" crc="93a630cb" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454" />
 			</dataarea>
 		</part>
 	</software>
@@ -13380,8 +13380,8 @@ clips onto the player's ear.
 		<publisher>Crave Entertainment</publisher>
 		<info name="serial" value="NUS-NVRP-EUR" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="4194304">
-				<rom name="virtual pool 64 (europe).bin" size="4194304" crc="f8498bd2" sha1="92994b5289c95951a566b745e2d9a80d62c711ee" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="virtual pool 64 (europe).bin" size="0x400000" crc="f8498bd2" sha1="92994b5289c95951a566b745e2d9a80d62c711ee" />
 			</dataarea>
 		</part>
 	</software>
@@ -13396,8 +13396,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NVRE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nvre-0.u1" size="4194304" crc="584b2a5f" sha1="5aa70fe4e2bf875ba089afd53d1fef27a59bb3f9" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nvre-0.u1" size="0x400000" crc="584b2a5f" sha1="5aa70fe4e2bf875ba089afd53d1fef27a59bb3f9" />
 			</dataarea>
 		</part>
 	</software>
@@ -13418,8 +13418,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-na2j-0.u1" size="33554432" crc="8e33c3af" sha1="d6e4980ee08519a0af60bed5c40a71e284b1e178" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-na2j-0.u1" size="0x2000000" crc="8e33c3af" sha1="d6e4980ee08519a0af60bed5c40a71e284b1e178" />
 			</dataarea>
 		</part>
 	</software>
@@ -13440,8 +13440,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nvpj-0.u1" size="16777216" crc="2b4b9bef" sha1="a98df45b6fdeb368fb906a2a1fb257658739cefe" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nvpj-0.u1" size="0x1000000" crc="2b4b9bef" sha1="a98df45b6fdeb368fb906a2a1fb257658739cefe" />
 			</dataarea>
 		</part>
 	</software>
@@ -13452,8 +13452,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NWLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="waialae country club - true golf classics (europe) (rev a).bin" size="16777216" crc="53a68628" sha1="57cbfa043a2d86c11b35b49855115641184097d7" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="waialae country club - true golf classics (europe) (rev a).bin" size="0x1000000" crc="53a68628" sha1="57cbfa043a2d86c11b35b49855115641184097d7" />
 			</dataarea>
 		</part>
 	</software>
@@ -13464,8 +13464,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NWLP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="waialae country club - true golf classics (europe).bin" size="16777216" crc="8e6f987b" sha1="b7542c7fc1566d4a9d72b85e3c6d57642614ee29" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="waialae country club - true golf classics (europe).bin" size="0x1000000" crc="8e6f987b" sha1="b7542c7fc1566d4a9d72b85e3c6d57642614ee29" />
 			</dataarea>
 		</part>
 	</software>
@@ -13476,8 +13476,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NWLE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="waialae country club - true golf classics (usa) (rev a).bin" size="16777216" crc="76ebdb18" sha1="305e4a9fa345cf74000f7f05aec2483f4c7bdf3e" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="waialae country club - true golf classics (usa) (rev a).bin" size="0x1000000" crc="76ebdb18" sha1="305e4a9fa345cf74000f7f05aec2483f4c7bdf3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13494,8 +13494,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [BU9803A]" />
 			<feature name="u4" value="U4 [CIC-NUS-6102]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nwle-0.u1" size="16777216" crc="cb760261" sha1="f0a57d923159f5940528ead63c1f34d129dca866" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nwle-0.u1" size="0x1000000" crc="cb760261" sha1="f0a57d923159f5940528ead63c1f34d129dca866" />
 			</dataarea>
 		</part>
 	</software>
@@ -13506,8 +13506,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NWAP-EUR, NUS-NWAP-FRA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="war gods (europe).bin" size="12582912" crc="fd10aaa6" sha1="fc77e3d872220dafc41147ba79188a04e21f3805" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="war gods (europe).bin" size="0xc00000" crc="fd10aaa6" sha1="fc77e3d872220dafc41147ba79188a04e21f3805" />
 			</dataarea>
 		</part>
 	</software>
@@ -13522,8 +13522,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWAE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwae-0.u1" size="12582912" crc="10635b27" sha1="3ff5c88420221f95eb27a65519c6fe558618bfc7" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwae-0.u1" size="0xc00000" crc="10635b27" sha1="3ff5c88420221f95eb27a65519c6fe558618bfc7" />
 			</dataarea>
 		</part>
 	</software>
@@ -13534,8 +13534,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NWRP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wave race 64 (europe) (en,de).bin" size="8388608" crc="d74117b0" sha1="7ffdd44890b1a00e0c13868a18b482fbf8c752f7" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wave race 64 (europe) (en,de).bin" size="0x800000" crc="d74117b0" sha1="7ffdd44890b1a00e0c13868a18b482fbf8c752f7" />
 			</dataarea>
 		</part>
 	</software>
@@ -13548,8 +13548,8 @@ clips onto the player's ear.
 		<info name="release" value="19960927"/>
 		<info name="alt_title" value="ウエーブレース64"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wave race 64 (japan) (rev a).bin" size="8388608" crc="a977cc81" sha1="79cb03859a973d8b65b39c0ace3100034d70eafa" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wave race 64 (japan) (rev a).bin" size="0x800000" crc="a977cc81" sha1="79cb03859a973d8b65b39c0ace3100034d70eafa" />
 			</dataarea>
 		</part>
 	</software>
@@ -13562,8 +13562,8 @@ clips onto the player's ear.
 		<info name="release" value="19970718"/>
 		<info name="alt_title" value="ウエーブレース64 振動パック対応, ウエーブレース64 (振動パック対応バージョン) (box)"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wave race 64 (japan) (rev b) (shindou edition).bin" size="8388608" crc="d3610a02" sha1="443e3c3476568de9c36582184104f2dd09b59407" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wave race 64 (japan) (rev b) (shindou edition).bin" size="0x800000" crc="d3610a02" sha1="443e3c3476568de9c36582184104f2dd09b59407" />
 			</dataarea>
 		</part>
 	</software>
@@ -13582,8 +13582,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nwrj-0.u1" size="8388608" crc="0580eee7" sha1="b1b4435b15627830f7c932eb40df862eea2b38e4" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nwrj-0.u1" size="0x800000" crc="0580eee7" sha1="b1b4435b15627830f7c932eb40df862eea2b38e4" />
 			</dataarea>
 		</part>
 	</software>
@@ -13599,8 +13599,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nwre-1.u1" size="8388608" crc="dd2bb7b6" sha1="d37f82b15669502487b3e5790e76e3ed33ef9831" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nwre-1.u1" size="0x800000" crc="dd2bb7b6" sha1="d37f82b15669502487b3e5790e76e3ed33ef9831" />
 			</dataarea>
 		</part>
 	</software>
@@ -13611,8 +13611,8 @@ clips onto the player's ear.
 		<publisher>Nintendo</publisher>
 		<info name="serial" value="NUS-NWRE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wave race 64 (usa).bin" size="8388608" crc="9ef814cd" sha1="8baccf6a8a298609bff1fe489845f2136fd03cf1" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wave race 64 (usa).bin" size="0x800000" crc="9ef814cd" sha1="8baccf6a8a298609bff1fe489845f2136fd03cf1" />
 			</dataarea>
 		</part>
 	</software>
@@ -13623,8 +13623,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NW8P-FRA, NUS-NW8P-NOE, NUS-NW8P-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wayne gretzky's 3d hockey '98 (europe) (en,fr,de,es).bin" size="8388608" crc="53751331" sha1="2f1462118b4aff3ded4ae5afd3952f2189b43a27" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wayne gretzky's 3d hockey '98 (europe) (en,fr,de,es).bin" size="0x800000" crc="53751331" sha1="2f1462118b4aff3ded4ae5afd3952f2189b43a27" />
 			</dataarea>
 		</part>
 	</software>
@@ -13639,8 +13639,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NW8E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nw8e-0.u1" size="8388608" crc="5c593e2e" sha1="d561eba53bed8b399635298233a073fffaf0eede" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nw8e-0.u1" size="0x800000" crc="5c593e2e" sha1="d561eba53bed8b399635298233a073fffaf0eede" />
 			</dataarea>
 		</part>
 	</software>
@@ -13651,8 +13651,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NWGP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wayne gretzky's 3d hockey (europe) (en,fr,de,es).bin" size="8388608" crc="0eff3f94" sha1="bfa32477ea99c93c156e51fdf14107a6beeb31aa" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wayne gretzky's 3d hockey (europe) (en,fr,de,es).bin" size="0x800000" crc="0eff3f94" sha1="bfa32477ea99c93c156e51fdf14107a6beeb31aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -13665,8 +13665,8 @@ clips onto the player's ear.
 		<info name="release" value="19980228"/>
 		<info name="alt_title" value="ウェイン・グレツキー・3Dホッケー"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wayne gretzky's 3d hockey (japan).bin" size="8388608" crc="694b3b0b" sha1="0a7890d52130cfa7f6076545735c510586c230ba" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wayne gretzky's 3d hockey (japan).bin" size="0x800000" crc="694b3b0b" sha1="0a7890d52130cfa7f6076545735c510586c230ba" />
 			</dataarea>
 		</part>
 	</software>
@@ -13677,8 +13677,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NWGE-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wayne gretzky's 3d hockey (usa) (rev a).bin" size="8388608" crc="6e5a30ed" sha1="073b4e9cd8d93a58145625ffef9b1fc642eb31a8" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wayne gretzky's 3d hockey (usa) (rev a).bin" size="0x800000" crc="6e5a30ed" sha1="073b4e9cd8d93a58145625ffef9b1fc642eb31a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -13693,8 +13693,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWGE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nwge-0.u1" size="8388608" crc="2462389e" sha1="2cb103fecada5da8de2a6384f13e004098f4e724" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nwge-0.u1" size="0x800000" crc="2462389e" sha1="2cb103fecada5da8de2a6384f13e004098f4e724" />
 			</dataarea>
 		</part>
 	</software>
@@ -13709,8 +13709,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWVE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nwve-0.u1" size="33554432" crc="d3a9f234" sha1="f31e03752c7502e99a201bf86ffb453ac260d426" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nwve-0.u1" size="0x2000000" crc="d3a9f234" sha1="f31e03752c7502e99a201bf86ffb453ac260d426" />
 			</dataarea>
 		</part>
 	</software>
@@ -13721,8 +13721,8 @@ clips onto the player's ear.
 		<publisher>Electronic Arts</publisher>
 		<info name="serial" value="NUS-NWMP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="wcw mayhem (europe).bin" size="16777216" crc="e56874ee" sha1="e52d1e83bc9283a7ba7b99372a83d4d6ecf57347" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="wcw mayhem (europe).bin" size="0x1000000" crc="e56874ee" sha1="e52d1e83bc9283a7ba7b99372a83d4d6ecf57347" />
 			</dataarea>
 		</part>
 	</software>
@@ -13737,8 +13737,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWME-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nwme-0.u1" size="16777216" crc="a1911368" sha1="0b848a7747c97286d42764f9237d9ef05b39becd" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nwme-0.u1" size="0x1000000" crc="a1911368" sha1="0b848a7747c97286d42764f9237d9ef05b39becd" />
 			</dataarea>
 		</part>
 	</software>
@@ -13753,8 +13753,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NW3E-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nw3e-0.u1" size="12582912" crc="ac1909a9" sha1="f4c03ae1ccc3eac5b0f8b37b0293db44daa6397c" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nw3e-0.u1" size="0xc00000" crc="ac1909a9" sha1="f4c03ae1ccc3eac5b0f8b37b0293db44daa6397c" />
 			</dataarea>
 		</part>
 	</software>
@@ -13765,8 +13765,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NWNP-EUR, NUS-NWNP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="wcw vs. nwo - world tour (europe).bin" size="12582912" crc="b3a472a3" sha1="dd07a3434ee38ac03f5d3e45bfb0b3f956ebdab5" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="wcw vs. nwo - world tour (europe).bin" size="0xc00000" crc="b3a472a3" sha1="dd07a3434ee38ac03f5d3e45bfb0b3f956ebdab5" />
 			</dataarea>
 		</part>
 	</software>
@@ -13783,8 +13783,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwne-1.u1" size="12582912" crc="85e0c097" sha1="6ecedd03908627b4a76c3e1cc46d3567e755591d" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwne-1.u1" size="0xc00000" crc="85e0c097" sha1="6ecedd03908627b4a76c3e1cc46d3567e755591d" />
 			</dataarea>
 		</part>
 	</software>
@@ -13801,8 +13801,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwne-0.u1" size="12582912" crc="ad6fe55f" sha1="050a85a8fb5146d0a5dd0a67d1004695f83cea36" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwne-0.u1" size="0xc00000" crc="ad6fe55f" sha1="050a85a8fb5146d0a5dd0a67d1004695f83cea36" />
 			</dataarea>
 		</part>
 	</software>
@@ -13813,8 +13813,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NW2P-EUR, NUS-NW2P-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="wcw-nwo revenge (europe).bin" size="16777216" crc="0abbe702" sha1="12c5ccbbb9744226517e6eecfba0ff103e83b905" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="wcw-nwo revenge (europe).bin" size="0x1000000" crc="0abbe702" sha1="12c5ccbbb9744226517e6eecfba0ff103e83b905" />
 			</dataarea>
 		</part>
 	</software>
@@ -13833,8 +13833,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nw2e-0.u1" size="16777216" crc="2257fd02" sha1="ef6cd4df563c3dbbf8e7afd890a6c4a3e0704ff6" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nw2e-0.u1" size="0x1000000" crc="2257fd02" sha1="ef6cd4df563c3dbbf8e7afd890a6c4a3e0704ff6" />
 			</dataarea>
 		</part>
 	</software>
@@ -13845,8 +13845,8 @@ clips onto the player's ear.
 		<publisher>Ocean</publisher>
 		<info name="serial" value="NUS-NWTP-EUR, NUS-NWTP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wetrix (europe) (en,fr,de,es,it,nl).bin" size="8388608" crc="e26cff31" sha1="8967cd465fbcc1151f8794f0c58181da1040c2ec" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wetrix (europe) (en,fr,de,es,it,nl).bin" size="0x800000" crc="e26cff31" sha1="8967cd465fbcc1151f8794f0c58181da1040c2ec" />
 			</dataarea>
 		</part>
 	</software>
@@ -13865,8 +13865,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nwtj-0.u1" size="4194304" crc="aebafd6d" sha1="a8d2970eb0313bdf925be994f04508373715f771" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nwtj-0.u1" size="0x400000" crc="aebafd6d" sha1="a8d2970eb0313bdf925be994f04508373715f771" />
 			</dataarea>
 		</part>
 	</software>
@@ -13883,8 +13883,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nwte-0.u1" size="8388608" crc="4eda94c1" sha1="80cc6c54cc9517a33e90ccf0cc9f2c03d1f050ad" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nwte-0.u1" size="0x800000" crc="4eda94c1" sha1="80cc6c54cc9517a33e90ccf0cc9f2c03d1f050ad" />
 			</dataarea>
 		</part>
 	</software>
@@ -13899,8 +13899,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="4194304">
-				<rom name="nus-nwfe-0.u1" size="4194304" crc="c2571693" sha1="a40d8dae6bfe2c0abdf1fd6b1eb219f4da988bd2" />
+			<dataarea name="rom" size="0x400000">
+				<rom name="nus-nwfe-0.u1" size="0x400000" crc="c2571693" sha1="a40d8dae6bfe2c0abdf1fd6b1eb219f4da988bd2" />
 			</dataarea>
 		</part>
 	</software>
@@ -13910,8 +13910,8 @@ clips onto the player's ear.
 		<year>2000</year>
 		<publisher>Looking Glass Studios</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="wildwaters (usa).bin" size="16777216" crc="ecb6780c" sha1="ecb137225f46a8eec882aea0d52b213e9402581d" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="wildwaters (usa).bin" size="0x1000000" crc="ecb6780c" sha1="ecb137225f46a8eec882aea0d52b213e9402581d" />
 			</dataarea>
 		</part>
 	</software>
@@ -13924,8 +13924,8 @@ clips onto the player's ear.
 		<info name="release" value="19971128"/>
 		<info name="alt_title" value="ワイルドチョッパーズ"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wild choppers (japan).bin" size="8388608" crc="fed21f49" sha1="e9794038f75ddadd6f57b0981b4e077766dcca3e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wild choppers (japan).bin" size="0x800000" crc="fed21f49" sha1="e9794038f75ddadd6f57b0981b4e077766dcca3e" />
 			</dataarea>
 		</part>
 	</software>
@@ -13938,8 +13938,8 @@ clips onto the player's ear.
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="ウィン バック"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="winback (japan) (rev a).bin" size="16777216" crc="9fbd5973" sha1="5018f33d561edd38cf6234e68a4e86dc3edfd3dc" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="winback (japan) (rev a).bin" size="0x1000000" crc="9fbd5973" sha1="5018f33d561edd38cf6234e68a4e86dc3edfd3dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -13952,8 +13952,8 @@ clips onto the player's ear.
 		<info name="release" value="19990923"/>
 		<info name="alt_title" value="ウィン バック"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="winback (japan).bin" size="16777216" crc="a5364d80" sha1="e66e96813bb9a7d4e9c6b4ff39695adcc10b7ed5" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="winback (japan).bin" size="0x1000000" crc="a5364d80" sha1="e66e96813bb9a7d4e9c6b4ff39695adcc10b7ed5" />
 			</dataarea>
 		</part>
 	</software>
@@ -13968,8 +13968,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWDE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nwde-0.u1" size="16777216" crc="1a6334d0" sha1="b0fafa4570b27f42428dffa3bac2ba582b99fe21" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nwde-0.u1" size="0x1000000" crc="1a6334d0" sha1="b0fafa4570b27f42428dffa3bac2ba582b99fe21" />
 			</dataarea>
 		</part>
 	</software>
@@ -13980,8 +13980,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NWPP-EUR, NUS-NWPP-EUU"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="wipeout 64 (europe).bin" size="8388608" crc="0c3497e4" sha1="ccab769b06290671adbc81b09440049b487adbab" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="wipeout 64 (europe).bin" size="0x800000" crc="0c3497e4" sha1="ccab769b06290671adbc81b09440049b487adbab" />
 			</dataarea>
 		</part>
 	</software>
@@ -13998,8 +13998,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nwpe-0.u1" size="8388608" crc="3e8cce96" sha1="4b9d19e3010756d3106f8b20b2b90daddb80bc1c" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nwpe-0.u1" size="0x800000" crc="3e8cce96" sha1="4b9d19e3010756d3106f8b20b2b90daddb80bc1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -14023,8 +14023,8 @@ clips onto the player's ear.
 			<feature name="u11" value="U11 N64_EEPROM [BU9850]" />
 			<feature name="u12" value="U12 [17805]" />
 			<feature name="u13" value="U13" /> <!-- unknown -->
-			<dataarea name="rom" size="16777216">
-				<rom name="wipeout 64 (europe) (proto).bin" size="16777216" crc="944b258f" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="wipeout 64 (europe) (proto).bin" size="0x1000000" crc="944b258f" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14043,8 +14043,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-nj2j-0.u1" size="8388608" crc="8aaf74a3" sha1="585b62b5ca10a5e296a7dd0065dccb91bb620ed2" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-nj2j-0.u1" size="0x800000" crc="8aaf74a3" sha1="585b62b5ca10a5e296a7dd0065dccb91bb620ed2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14060,8 +14060,8 @@ clips onto the player's ear.
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-7101]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n8wp-0.u1" size="12582912" crc="163481d0" sha1="5e115692c924ccd0ca6afa4c4777077f97a7d9c2" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n8wp-0.u1" size="0xc00000" crc="163481d0" sha1="5e115692c924ccd0ca6afa4c4777077f97a7d9c2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14076,8 +14076,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-N8WE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-n8we-0.u1" size="12582912" crc="b875cd94" sha1="8eca8b866a0f746e9bd7a6fc1b8dff6bd7b2f210" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-n8we-0.u1" size="0xc00000" crc="b875cd94" sha1="8eca8b866a0f746e9bd7a6fc1b8dff6bd7b2f210" />
 			</dataarea>
 		</part>
 	</software>
@@ -14088,8 +14088,8 @@ clips onto the player's ear.
 		<publisher>Midway</publisher>
 		<info name="serial" value="NUS-NWOP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="world driver championship (europe) (en,fr,de,es,it).bin" size="16777216" crc="74fad5aa" sha1="dbe027955669e25e6cecafa6e07bed9890c8995c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="world driver championship (europe) (en,fr,de,es,it).bin" size="0x1000000" crc="74fad5aa" sha1="dbe027955669e25e6cecafa6e07bed9890c8995c" />
 			</dataarea>
 		</part>
 	</software>
@@ -14104,8 +14104,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWOE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nwoe-0.u1" size="16777216" crc="dcd9d2d2" sha1="b5a329e477febc75a0b73a7466c48bbfd1320bff" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nwoe-0.u1" size="0x1000000" crc="dcd9d2d2" sha1="b5a329e477febc75a0b73a7466c48bbfd1320bff" />
 			</dataarea>
 		</part>
 	</software>
@@ -14116,8 +14116,8 @@ clips onto the player's ear.
 		<publisher>Infogrames</publisher>
 		<info name="serial" value="NUS-NWUP-NOE, NUS-NWUP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="worms armageddon (europe) (en,fr,de,es,it,nl).bin" size="12582912" crc="4862ebbd" sha1="ec23bb5489c76933eff1a2ba17658c7ebd116328" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="worms armageddon (europe) (en,fr,de,es,it,nl).bin" size="0xc00000" crc="4862ebbd" sha1="ec23bb5489c76933eff1a2ba17658c7ebd116328" />
 			</dataarea>
 		</part>
 	</software>
@@ -14132,8 +14132,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NADE-0]" />
 			<feature name="u2" value="U2 [BU9850]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nade-0.u1" size="12582912" crc="556268b7" sha1="04d60d848a5cb9923eb95b016eebb6af829296f2" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nade-0.u1" size="0xc00000" crc="556268b7" sha1="04d60d848a5cb9923eb95b016eebb6af829296f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14144,8 +14144,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTIP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf attitude (europe).bin" size="33554432" crc="69cf2fe6" sha1="4135d3346be4eb657c6779ce7b2ca89d5d94a0db" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf attitude (europe).bin" size="0x2000000" crc="69cf2fe6" sha1="4135d3346be4eb657c6779ce7b2ca89d5d94a0db" />
 			</dataarea>
 		</part>
 	</software>
@@ -14156,8 +14156,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NTID-NOE"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf attitude (germany).bin" size="33554432" crc="f1f22e20" sha1="53fc14dfc7ccbb4498aecb2d0dbcb3bb1a569b0a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf attitude (germany).bin" size="0x2000000" crc="f1f22e20" sha1="53fc14dfc7ccbb4498aecb2d0dbcb3bb1a569b0a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14172,8 +14172,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NTIE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-ntie-0.u1" size="33554432" crc="f694db1e" sha1="9519c9a7e9f370e565545fa5f5a21077f585310b" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-ntie-0.u1" size="0x2000000" crc="f694db1e" sha1="9519c9a7e9f370e565545fa5f5a21077f585310b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14184,8 +14184,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NW4P-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf no mercy (europe) (rev a).bin" size="33554432" crc="1a6f82e4" sha1="f49217cb9039212d2d779acb00222fb73c454f56" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf no mercy (europe) (rev a).bin" size="0x2000000" crc="1a6f82e4" sha1="f49217cb9039212d2d779acb00222fb73c454f56" />
 			</dataarea>
 		</part>
 	</software>
@@ -14202,8 +14202,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-7101A]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nw4p-0.u1" size="33554432" crc="eeb166b4" sha1="cadbcd5361dffaf2aa17f0cb4c4cc799bdc8350a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nw4p-0.u1" size="0x2000000" crc="eeb166b4" sha1="cadbcd5361dffaf2aa17f0cb4c4cc799bdc8350a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14214,8 +14214,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NW4E-USA"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf no mercy (usa) (rev a).bin" size="33554432" crc="afbc514e" sha1="159ecd53e5fd9b0f607cb39042057f55f07d18a6" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf no mercy (usa) (rev a).bin" size="0x2000000" crc="afbc514e" sha1="159ecd53e5fd9b0f607cb39042057f55f07d18a6" />
 			</dataarea>
 		</part>
 	</software>
@@ -14230,8 +14230,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NW4E-0]" />
 			<feature name="u2" value="U2 [NUS MN63F81MPN]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nw4e-0.u1" size="33554432" crc="ee8c16c1" sha1="3a902129bd2221c4411d05c642ef7f79aefb1720" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nw4e-0.u1" size="0x2000000" crc="ee8c16c1" sha1="3a902129bd2221c4411d05c642ef7f79aefb1720" />
 			</dataarea>
 		</part>
 	</software>
@@ -14242,8 +14242,8 @@ clips onto the player's ear.
 		<publisher>Acclaim Entertainment</publisher>
 		<info name="serial" value="NUS-NWWP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="wwf war zone (europe).bin" size="12582912" crc="58062c02" sha1="4685430fbc7bb719ea2a277c4eb8616011925546" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="wwf war zone (europe).bin" size="0xc00000" crc="58062c02" sha1="4685430fbc7bb719ea2a277c4eb8616011925546" />
 			</dataarea>
 		</part>
 	</software>
@@ -14258,8 +14258,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NWWE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nwwe-0.u1" size="12582912" crc="6cfe13a8" sha1="852a6d39fc61c82bf13e852978924f8c7db8d039" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nwwe-0.u1" size="0xc00000" crc="6cfe13a8" sha1="852a6d39fc61c82bf13e852978924f8c7db8d039" />
 			</dataarea>
 		</part>
 	</software>
@@ -14270,8 +14270,8 @@ clips onto the player's ear.
 		<publisher>T*HQ</publisher>
 		<info name="serial" value="NUS-NWXP-EUR"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf wrestlemania 2000 (europe).bin" size="33554432" crc="acb7ba1b" sha1="a5923994a65ffd425ed094fb9ff8ccafd5abc10a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf wrestlemania 2000 (europe).bin" size="0x2000000" crc="acb7ba1b" sha1="a5923994a65ffd425ed094fb9ff8ccafd5abc10a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14284,8 +14284,8 @@ clips onto the player's ear.
 		<info name="release" value="20000915"/>
 		<info name="alt_title" value="WWF レッスルマニア2000"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="wwf wrestlemania 2000 (japan).bin" size="33554432" crc="e4e3b9a3" sha1="4128e150bc7e1291a3d388a210a50bd423e5d3e2" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="wwf wrestlemania 2000 (japan).bin" size="0x2000000" crc="e4e3b9a3" sha1="4128e150bc7e1291a3d388a210a50bd423e5d3e2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14304,8 +14304,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(-01)(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nwxe-0.u1" size="33554432" crc="d514e83c" sha1="d8cf547eb81c72c748be87b6ce6b2f66c2699bd0" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nwxe-0.u1" size="0x2000000" crc="d514e83c" sha1="d8cf547eb81c72c748be87b6ce6b2f66c2699bd0" />
 			</dataarea>
 		</part>
 	</software>
@@ -14316,8 +14316,8 @@ clips onto the player's ear.
 		<publisher>Titus</publisher>
 		<info name="serial" value="NUS-NXFP-UKV"/>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="12582912">
-				<rom name="xena - warrior princess - the talisman of fate (europe).bin" size="12582912" crc="2bb18eb6" sha1="b900a33736f7ab68648d274b76bbd4a8f6e4af33" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="xena - warrior princess - the talisman of fate (europe).bin" size="0xc00000" crc="2bb18eb6" sha1="b900a33736f7ab68648d274b76bbd4a8f6e4af33" />
 			</dataarea>
 		</part>
 	</software>
@@ -14332,8 +14332,8 @@ clips onto the player's ear.
 			<feature name="u1" value="U1 [NUS-NXFE-0]" />
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nxfe-0.u1" size="12582912" crc="7cb26725" sha1="91a1e7c709d7cd8065c38cd23910d19c5bf991e1" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nxfe-0.u1" size="0xc00000" crc="7cb26725" sha1="91a1e7c709d7cd8065c38cd23910d19c5bf991e1" />
 			</dataarea>
 		</part>
 	</software>
@@ -14345,8 +14345,8 @@ clips onto the player's ear.
 		<publisher>Microids</publisher>
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-16F32SB-B" /> <!-- label on cartridge shell -->
-			<dataarea name="rom" size="25165824">
-				<rom name="xtremeroller.bin" size="25165824" crc="9a47af0f" sha1="238efed4c5f4d6c3aba98774299bf7ea2cb0d021" />
+			<dataarea name="rom" size="0x1800000">
+				<rom name="xtremeroller.bin" size="0x1800000" crc="9a47af0f" sha1="238efed4c5f4d6c3aba98774299bf7ea2cb0d021" />
 			</dataarea>
 		</part>
 	</software>
@@ -14365,8 +14365,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nykj-0.u1" size="33554432" crc="5c97c412" sha1="e4035072f682fe16e189e57bf6a9a35706d3028a" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nykj-0.u1" size="0x2000000" crc="5c97c412" sha1="e4035072f682fe16e189e57bf6a9a35706d3028a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14385,8 +14385,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6106]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" /> <!-- Also with NUS-USA/CAN-1 -->
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nysj-0.u1" size="16777216" crc="feac925c" sha1="325a1487c4be295837728dbe7809a31823ad2554" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nysj-0.u1" size="0x1000000" crc="feac925c" sha1="325a1487c4be295837728dbe7809a31823ad2554" />
 			</dataarea>
 		</part>
 	</software>
@@ -14403,8 +14403,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-7106]" />
 			<feature name="cart_model" value="NUS-006(EUR)" />
 			<feature name="cart_back_label" value="NUS-EUR-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nysp-0.u1" size="16777216" crc="21a5f264" sha1="0a480425baecc4d4fd236275384d9ee67285e8fd" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nysp-0.u1" size="0x1000000" crc="21a5f264" sha1="0a480425baecc4d4fd236275384d9ee67285e8fd" />
 			</dataarea>
 		</part>
 	</software>
@@ -14421,8 +14421,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6106]" />
 			<feature name="cart_model" value="NUS-006(USA)" />
 			<feature name="cart_back_label" value="NUS-USA/CAN-1" />
-			<dataarea name="rom" size="16777216">
-				<rom name="nus-nyse-0.u1" size="16777216" crc="01a4b1e9" sha1="2263c34ff25cce79a51693ebba109c76f6246d01" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="nus-nyse-0.u1" size="0x1000000" crc="01a4b1e9" sha1="2263c34ff25cce79a51693ebba109c76f6246d01" />
 			</dataarea>
 		</part>
 	</software>
@@ -14441,8 +14441,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN" />
-			<dataarea name="rom" size="8388608">
-				<rom name="nus-ntmj-0.u1" size="8388608" crc="f8bb860c" sha1="6807ebe5f95c30baee18f5da6c170396d6b8764e" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="nus-ntmj-0.u1" size="0x800000" crc="f8bb860c" sha1="6807ebe5f95c30baee18f5da6c170396d6b8764e" />
 			</dataarea>
 		</part>
 	</software>
@@ -14461,8 +14461,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6105A]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nzsj-1.u1" size="33554432" crc="2de56c55" sha1="666fad106735135c1a3471ef1b967c396f949ad9" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nzsj-1.u1" size="0x2000000" crc="2de56c55" sha1="666fad106735135c1a3471ef1b967c396f949ad9" />
 			</dataarea>
 		</part>
 	</software>
@@ -14481,8 +14481,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6105]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-nzsj-0.u1" size="33554432" crc="3361b649" sha1="9afda65b3ae7d3714066dbccf820158c3286f423" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-nzsj-0.u1" size="0x2000000" crc="3361b649" sha1="9afda65b3ae7d3714066dbccf820158c3286f423" />
 			</dataarea>
 		</part>
 	</software>
@@ -14501,8 +14501,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [74LV2416]" />
 			<feature name="u4" value="U4 [CIC-NUS-6105]" />
 			<feature name="bt1" value="BT1 [CR2032]" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czlj-2.u1" size="33554432" crc="656657cd" sha1="2d8fb7140a9c5d11ce614561e5a36ffef0c17540" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czlj-2.u1" size="0x2000000" crc="656657cd" sha1="2d8fb7140a9c5d11ce614561e5a36ffef0c17540" />
 			</dataarea>
 		</part>
 	</software>
@@ -14523,8 +14523,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czlj-1.u1" size="33554432" crc="f31c202c" sha1="1181034d5f9533f53ebe8e1c781badbee115f5aa" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czlj-1.u1" size="0x2000000" crc="f31c202c" sha1="1181034d5f9533f53ebe8e1c781badbee115f5aa" />
 			</dataarea>
 		</part>
 	</software>
@@ -14545,8 +14545,8 @@ clips onto the player's ear.
 			<feature name="bt1" value="BT1 [CR2032]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="33554432">
-				<rom name="nus-czlj-0.u1" size="33554432" crc="b58e98bb" sha1="f9e2b6840b9103e9707ea390089a7b6943592a98" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="nus-czlj-0.u1" size="0x2000000" crc="b58e98bb" sha1="f9e2b6840b9103e9707ea390089a7b6943592a98" />
 			</dataarea>
 		</part>
 	</software>
@@ -14565,8 +14565,8 @@ clips onto the player's ear.
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<feature name="cart_model" value="NUS-006(JPN)" />
 			<feature name="cart_back_label" value="NUS-JPN-1" />
-			<dataarea name="rom" size="12582912">
-				<rom name="nus-nmzj-0.u1" size="12582912" crc="84428431" sha1="def9f1d097cef5857449827ae2b1291ba346c2a8" />
+			<dataarea name="rom" size="0xc00000">
+				<rom name="nus-nmzj-0.u1" size="0xc00000" crc="84428431" sha1="def9f1d097cef5857449827ae2b1291ba346c2a8" />
 			</dataarea>
 		</part>
 	</software>
@@ -14578,8 +14578,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="67108864">
-				<rom name="legend of zelda, the - ocarina of time - master quest (usa) (debug edition).bin" size="67108864" crc="2ee3e247" sha1="973bc6fe56010a8d646166a1182a81b4f13b8cf9" />
+			<dataarea name="rom" size="0x4000000">
+				<rom name="legend of zelda, the - ocarina of time - master quest (usa) (debug edition).bin" size="0x4000000" crc="2ee3e247" sha1="973bc6fe56010a8d646166a1182a81b4f13b8cf9" />
 			</dataarea>
 		</part>
 	</software>
@@ -14589,8 +14589,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - ocarina of time - master quest (usa)(2003)(nintendo)(ntsc)[gamecube version].bin" size="33554432" crc="7b89b13f" sha1="e1d070ad7b017de9f992b362164dcd9d7f820f7e" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - ocarina of time - master quest (usa)(2003)(nintendo)(ntsc)[gamecube version].bin" size="0x2000000" crc="7b89b13f" sha1="e1d070ad7b017de9f992b362164dcd9d7f820f7e" />
 			</dataarea>
 		</part>
 	</software>
@@ -14600,8 +14600,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - ocarina of time - master quest (europe)(2003)(nintendo)(pal)[gamecube version].bin" size="33554432" crc="177fa73a" sha1="8ebf2e29313f44f2d49e5b4191971d09919e8e48" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - ocarina of time - master quest (europe)(2003)(nintendo)(pal)[gamecube version].bin" size="0x2000000" crc="177fa73a" sha1="8ebf2e29313f44f2d49e5b4191971d09919e8e48" />
 			</dataarea>
 		</part>
 	</software>
@@ -14611,8 +14611,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="zelda no densetsu - toki no ocarina ura (japan)(2003)(nintendo)(ntsc)[gamecube version].bin" size="33554432" crc="d97c20ba" sha1="06c3c098f0e14ed61811dfaf0e8e4519d7d7a826" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="zelda no densetsu - toki no ocarina ura (japan)(2003)(nintendo)(ntsc)[gamecube version].bin" size="0x2000000" crc="d97c20ba" sha1="06c3c098f0e14ed61811dfaf0e8e4519d7d7a826" />
 			</dataarea>
 		</part>
 	</software>
@@ -14622,8 +14622,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - ocarina of time (usa)(2003)(nintendo)(ntsc)[gamecube version].bin" size="33554432" crc="84bbc39f" sha1="44c75962911e13bdfdc31b35e0b8e3be6a6a49ab" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - ocarina of time (usa)(2003)(nintendo)(ntsc)[gamecube version].bin" size="0x2000000" crc="84bbc39f" sha1="44c75962911e13bdfdc31b35e0b8e3be6a6a49ab" />
 			</dataarea>
 		</part>
 	</software>
@@ -14633,8 +14633,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - ocarina of time (europe)(2003)(nintendo)(pal)[gamecube version].bin" size="33554432" crc="6e658036" sha1="580dd0bd1b6d2c51cc20a764eece84dba558964c" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - ocarina of time (europe)(2003)(nintendo)(pal)[gamecube version].bin" size="0x2000000" crc="6e658036" sha1="580dd0bd1b6d2c51cc20a764eece84dba558964c" />
 			</dataarea>
 		</part>
 	</software>
@@ -14644,8 +14644,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="zelda no densetsu - toki no ocarina (japan)(2003)(nintendo)(ntsc)[gamecube version].bin" size="33554432" crc="0ac22de8" sha1="245410280d152f28d5b1c0c0fc37f384db0020cd" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="zelda no densetsu - toki no ocarina (japan)(2003)(nintendo)(ntsc)[gamecube version].bin" size="0x2000000" crc="0ac22de8" sha1="245410280d152f28d5b1c0c0fc37f384db0020cd" />
 			</dataarea>
 		</part>
 	</software>
@@ -14655,8 +14655,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - majora's mask (2003)(nintendo)(us)[gamecube version].bin" size="33554432" crc="52245acb" sha1="8c378b87c83b3f4de20b14accf91e7590399f5dc" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - majora's mask (2003)(nintendo)(us)[gamecube version].bin" size="0x2000000" crc="52245acb" sha1="8c378b87c83b3f4de20b14accf91e7590399f5dc" />
 			</dataarea>
 		</part>
 	</software>
@@ -14666,8 +14666,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="legend of zelda, the - majora's mask (2003)(nintendo)(europe)[gamecube version].bin" size="33554432" crc="19139e89" sha1="f4b0bedafc45c78c4428882036d46d691b650d8b" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="legend of zelda, the - majora's mask (2003)(nintendo)(europe)[gamecube version].bin" size="0x2000000" crc="19139e89" sha1="f4b0bedafc45c78c4428882036d46d691b650d8b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14677,8 +14677,8 @@ clips onto the player's ear.
 		<year>2003</year>
 		<publisher>Nintendo</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="33554432">
-				<rom name="zelda no densetsu - mujura no kamen (2003)(nintendo)(japan)[gamecube version].bin" size="33554432" crc="766ebdeb" sha1="7beadea493f24f77b5be85bf2c1dbd813481549b" />
+			<dataarea name="rom" size="0x2000000">
+				<rom name="zelda no densetsu - mujura no kamen (2003)(nintendo)(japan)[gamecube version].bin" size="0x2000000" crc="766ebdeb" sha1="7beadea493f24f77b5be85bf2c1dbd813481549b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14690,8 +14690,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="action replay pro 64 (europe) (v3.0) (unl).bin" size="262144" crc="c992dfb4" sha1="d5e4e8c875d6bda0afafb1b2513b16b1cb88dfc1" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="action replay pro 64 (europe) (v3.0) (unl).bin" size="0x40000" crc="c992dfb4" sha1="d5e4e8c875d6bda0afafb1b2513b16b1cb88dfc1" />
 			</dataarea>
 		</part>
 	</software>
@@ -14701,8 +14701,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="action replay pro 64 (europe) (v3.3) (unl).bin" size="262144" crc="9fbabfda" sha1="c3426114f5da1fb7abde15a766d362698ad07166" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="action replay pro 64 (europe) (v3.3) (unl).bin" size="0x40000" crc="9fbabfda" sha1="c3426114f5da1fb7abde15a766d362698ad07166" />
 			</dataarea>
 		</part>
 	</software>
@@ -14712,8 +14712,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="gamebooster 64 (europe) (v1.1) (unl).bin" size="262144" crc="35b99bd9" sha1="d79ee0482443c046b9e865a78f3d4507b7478af4" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gamebooster 64 (europe) (v1.1) (unl).bin" size="0x40000" crc="35b99bd9" sha1="d79ee0482443c046b9e865a78f3d4507b7478af4" />
 			</dataarea>
 		</part>
 	</software>
@@ -14723,8 +14723,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="gamebooster 64 (usa) (v1.1) (unl).bin" size="262144" crc="e0b8edae" sha1="5d0f244584d6cc0b0ced714409412f61de181e57" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gamebooster 64 (usa) (v1.1) (unl).bin" size="0x40000" crc="e0b8edae" sha1="5d0f244584d6cc0b0ced714409412f61de181e57" />
 			</dataarea>
 		</part>
 	</software>
@@ -14734,8 +14734,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="gameshark pro (usa) (v2.0) (unl).bin" size="262144" crc="ef9edf87" sha1="19148a009ef8e1013ab35c8141781184b141699f" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gameshark pro (usa) (v2.0) (unl).bin" size="0x40000" crc="ef9edf87" sha1="19148a009ef8e1013ab35c8141781184b141699f" />
 			</dataarea>
 		</part>
 	</software>
@@ -14745,8 +14745,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="gameshark pro (usa) (v3.3) (unl).bin" size="262144" crc="7cc07bbc" sha1="3b5046ae8129fd226eb7b02bc2c26cc7548fe6f2" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="gameshark pro (usa) (v3.3) (unl).bin" size="0x40000" crc="7cc07bbc" sha1="3b5046ae8129fd226eb7b02bc2c26cc7548fe6f2" />
 			</dataarea>
 		</part>
 	</software>
@@ -14759,8 +14759,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>Datel</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="PowerFlash (Europe) (Unl).bin" size="262144" crc="0e15b8a4" sha1="22169ccc5be0d3bf481056f4a004ee6959e0409b" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="PowerFlash (Europe) (Unl).bin" size="0x40000" crc="0e15b8a4" sha1="22169ccc5be0d3bf481056f4a004ee6959e0409b" />
 			</dataarea>
 		</part>
 	</software>
@@ -14770,8 +14770,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="262144">
-				<rom name="xplorer 64 (germany) (v1.067) (unl).bin" size="262144" crc="656acdf5" sha1="3a13b42074c2b6948f55f22d3e4fe44fbf2cde6a" />
+			<dataarea name="rom" size="0x40000">
+				<rom name="xplorer 64 (germany) (v1.067) (unl).bin" size="0x40000" crc="656acdf5" sha1="3a13b42074c2b6948f55f22d3e4fe44fbf2cde6a" />
 			</dataarea>
 		</part>
 	</software>
@@ -14781,8 +14781,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="cntr64_checker_64mbit.bin" size="8388608" crc="063e0a52" sha1="6cd924266e64be7bdba0017e38004d56d96c22cb" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="cntr64_checker_64mbit.bin" size="0x800000" crc="063e0a52" sha1="6cd924266e64be7bdba0017e38004d56d96c22cb" />
 			</dataarea>
 		</part>
 	</software>
@@ -14792,8 +14792,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="cntpak64.bin" size="16777216" crc="bbaaa427" sha1="b2e7432086b1ebc82c713f68e1a3a93abdcebd1c" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="cntpak64.bin" size="0x1000000" crc="bbaaa427" sha1="b2e7432086b1ebc82c713f68e1a3a93abdcebd1c" />
 			</dataarea>
 		</part>
 	</software>
@@ -14805,8 +14805,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="64gb checker v1.05.bin" size="8388608" crc="049924fd" sha1="caee91a7a1059ae7c6fd299138745f0cd284de3d" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="64gb checker v1.05.bin" size="0x800000" crc="049924fd" sha1="caee91a7a1059ae7c6fd299138745f0cd284de3d" />
 			</dataarea>
 		</part>
 	</software>
@@ -14816,8 +14816,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="photo viewer.bin" size="8388608" crc="6d3897e0" sha1="a05946880d590aa0696e2fcf3a1b6727e5229d52" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="photo viewer.bin" size="0x800000" crc="6d3897e0" sha1="a05946880d590aa0696e2fcf3a1b6727e5229d52" />
 			</dataarea>
 		</part>
 	</software>
@@ -14827,8 +14827,8 @@ clips onto the player's ear.
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="16777216">
-				<rom name="u64 demo.bin" size="16777216" crc="c07f24ee" sha1="4b8aa22dc0422402afeed682727fe9b22a5daf42" />
+			<dataarea name="rom" size="0x1000000">
+				<rom name="u64 demo.bin" size="0x1000000" crc="c07f24ee" sha1="4b8aa22dc0422402afeed682727fe9b22a5daf42" />
 			</dataarea>
 		</part>
 	</software>
@@ -14839,8 +14839,8 @@ clips onto the player's ear.
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="alt_title" value="ドルフィン・コントローラー・テスト" />
 		<part name="cart" interface="n64_cart">
-			<dataarea name="rom" size="8388608">
-				<rom name="unknown test.bin" size="8388608" crc="cba61bc8" sha1="b1d514c8b50aa05c688b20121783dff6069087bf" />
+			<dataarea name="rom" size="0x800000">
+				<rom name="unknown test.bin" size="0x800000" crc="cba61bc8" sha1="b1d514c8b50aa05c688b20121783dff6069087bf" />
 			</dataarea>
 		</part>
 	</software>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -3140,7 +3140,7 @@ This cart features a RTC, currently unemulated
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1400000">
-				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="0x1400000" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" status="baddump" /> <!-- Supposedly comes from a prototype cart. First 16MB match the final USA release. Is this possibly just an overdump or an underdump from a 32MB dev cart? -->
+				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="0x1400000" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" status="baddump" /> <!-- Supposedly comes from a prototype cart. First 16MB match the final USA release. Is this possibly just an overdump, or is it an underdump from a 32MB dev cart? -->
 			</dataarea>
 		</part>
 	</software>

--- a/hash/n64.xml
+++ b/hash/n64.xml
@@ -2819,7 +2819,7 @@ patched out (+ a fix for internal checksum)
 			<feature name="u2" value="U2 [empty]" />
 			<feature name="u3" value="U3 [CIC-NUS-6102]" />
 			<dataarea name="rom" size="0x1400000">
-				<rom name="nus-ndqe-0.u1" size="0x1400000" crc="6d48b64e" sha1="2700f7534d477c7b673dcdee0fe19b93dc95ca89" />
+				<rom name="nus-ndqe-0.u1" size="0x1400000" crc="6d48b64e" sha1="2700f7534d477c7b673dcdee0fe19b93dc95ca89" status="baddump" /> <!-- Underdump that should be 32MB -->
 			</dataarea>
 		</part>
 	</software>
@@ -2831,7 +2831,7 @@ patched out (+ a fix for internal checksum)
 		<info name="serial" value="NUS-NDQP-EUR"/>
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1400000">
-				<rom name="donald duck - quack attack (europe) (en,fr,de,es,it).bin" size="0x1400000" crc="5f67a191" sha1="6c761e0668247a5b264e2deb502f1de992f83346" />
+				<rom name="donald duck - quack attack (europe) (en,fr,de,es,it).bin" size="0x1400000" crc="5f67a191" sha1="6c761e0668247a5b264e2deb502f1de992f83346" status="baddump" /> <!-- Underdump that should be 32MB -->
 			</dataarea>
 		</part>
 	</software>
@@ -3134,14 +3134,13 @@ This cart features a RTC, currently unemulated
 		</part>
 	</software>
 
-	<!-- Possibly an overdump -->
 	<software name="duckdodgub" cloneof="duckdodg">
 		<description>Duck Dodgers Starring Daffy Duck (USA, final prototype)</description>
 		<year>2000</year>
 		<publisher>Infogrames</publisher>
 		<part name="cart" interface="n64_cart">
 			<dataarea name="rom" size="0x1400000">
-				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="0x1400000" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" />
+				<rom name="duck dodgers starring daffy duck (usa) (en,fr,es) (beta).bin" size="0x1400000" crc="0829b87a" sha1="10cd84ceadd50dd7c5a06652bb1c203677644fb0" status="baddump" /> <!-- Supposedly comes from a prototype cart. First 16MB match the final USA release. Is this possibly just an overdump or an underdump from a 32MB dev cart? -->
 			</dataarea>
 		</part>
 	</software>
@@ -14346,7 +14345,7 @@ clips onto the player's ear.
 		<part name="cart" interface="n64_cart">
 			<feature name="pcb" value="NUS-16F32SB-B" /> <!-- label on cartridge shell -->
 			<dataarea name="rom" size="0x1800000">
-				<rom name="xtremeroller.bin" size="0x1800000" crc="9a47af0f" sha1="238efed4c5f4d6c3aba98774299bf7ea2cb0d021" />
+				<rom name="xtremeroller.bin" size="0x1800000" crc="9a47af0f" sha1="238efed4c5f4d6c3aba98774299bf7ea2cb0d021" status="baddump" /> <!-- Should be 32MB, probably just missing padding -->
 			</dataarea>
 		</part>
 	</software>


### PR DESCRIPTION
- Marked Dragon Sword prototypes as bad dumps and noted incorrect sizes.