### PR TITLE
vectrex: Pass the new value with the timer param, so it ends up in the y integrator.

### DIFF
--- a/src/mame/miltonbradley/vectrex_m.cpp
+++ b/src/mame/miltonbradley/vectrex_m.cpp
@@ -50,7 +50,7 @@ TIMER_CALLBACK_MEMBER(vectrex_base_state::update_analog)
 {
 	update_vector();
 	if (param & 0x100)
-		m_analog[param&0xff] = param>>9;
+		m_analog[param&0xff] = param >> 9;
 	else
 		m_analog[param] = m_via_out[PORTA];
 }

--- a/src/mame/miltonbradley/vectrex_m.cpp
+++ b/src/mame/miltonbradley/vectrex_m.cpp
@@ -49,7 +49,10 @@ static const double unknown_game_angles[3] = {0,0.16666666, 0.33333333};
 TIMER_CALLBACK_MEMBER(vectrex_base_state::update_analog)
 {
 	update_vector();
-	m_analog[param] = m_via_out[PORTA];
+	if (param & 0x100)
+		m_analog[param&0xff] = param>>9;
+	else
+		m_analog[param] = m_via_out[PORTA];
 }
 
 TIMER_CALLBACK_MEMBER(vectrex_base_state::update_blank)

--- a/src/mame/miltonbradley/vectrex_m.cpp
+++ b/src/mame/miltonbradley/vectrex_m.cpp
@@ -50,7 +50,7 @@ TIMER_CALLBACK_MEMBER(vectrex_base_state::update_analog)
 {
 	update_vector();
 	if (param & 0x100)
-		m_analog[param&0xff] = param >> 9;
+		m_analog[param & 0xff] = param >> 9;
 	else
 		m_analog[param] = m_via_out[PORTA];
 }

--- a/src/mame/miltonbradley/vectrex_v.cpp
+++ b/src/mame/miltonbradley/vectrex_v.cpp
@@ -275,7 +275,7 @@ void vectrex_state::video_start()
 
 void vectrex_base_state::multiplexer(int mux)
 {
-	machine().scheduler().timer_set(attotime::from_nsec(ANALOG_DELAY), timer_expired_delegate(FUNC(vectrex_base_state::update_analog), this), mux);
+	machine().scheduler().timer_set(attotime::from_nsec(ANALOG_DELAY), timer_expired_delegate(FUNC(vectrex_base_state::update_analog), this), m_via_out[PORTA]<<9|0x100|mux);
 
 	if (mux == A_AUDIO)
 		m_dac->write(m_via_out[PORTA] ^ 0x80); // not gate shown on schematic

--- a/src/mame/miltonbradley/vectrex_v.cpp
+++ b/src/mame/miltonbradley/vectrex_v.cpp
@@ -275,7 +275,7 @@ void vectrex_state::video_start()
 
 void vectrex_base_state::multiplexer(int mux)
 {
-	machine().scheduler().timer_set(attotime::from_nsec(ANALOG_DELAY), timer_expired_delegate(FUNC(vectrex_base_state::update_analog), this), m_via_out[PORTA]<<9|0x100|mux);
+	machine().scheduler().timer_set(attotime::from_nsec(ANALOG_DELAY), timer_expired_delegate(FUNC(vectrex_base_state::update_analog), this), m_via_out[PORTA] << 9 | 0x100 | mux);
 
 	if (mux == A_AUDIO)
 		m_dac->write(m_via_out[PORTA] ^ 0x80); // not gate shown on schematic


### PR DESCRIPTION
In commits ca79d71af4b and then 1efbdbf8055, `mame/machine/vectrex.cpp` and `mame/video/vectrex.cpp` changed how the value from via PORTA reaches the mux output with the requisite 8.5us delay.
An unwanted result is that the value _currently_ on PORTA at the time the delay expires is what ends up in the destination, rather than the value that had been in place when the delay started. The effect is that in some circumstances the Y integrator operates with the current X value, to produce output in the game Thrust like [this,](https://drive.google.com/file/d/1jNNX95YxQ2b_LjT31GElsjEAC7HlVa9X/view?usp=sharing) whereas it should look like [this](https://drive.google.com/file/d/1iyoltPLEq-q8JLcpEuIoam3EiTKnEZsS/view?usp=sharing).
