### PR TITLE
ps2.cpp: Turn from skeleton driver into not working driver

### DIFF
--- a/scripts/src/bus.lua
+++ b/scripts/src/bus.lua
@@ -1872,7 +1872,50 @@ end
 
 ---------------------------------------------------
 --
---@src/devices/bus/msx/slot/slot.h,BUSES["MSX_SLOT"] = true
+--@src/devices/bus/mca/mca.h,BUSES["MCA"] = true
+---------------------------------------------------
+if (BUSES["MCA"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/bus/mca/3c523.cpp",
+		MAME_DIR .. "src/devices/bus/mca/3c523.h",
+		MAME_DIR .. "src/devices/bus/mca/adlib.cpp",
+		MAME_DIR .. "src/devices/bus/mca/adlib.h",
+		MAME_DIR .. "src/devices/bus/mca/c1000.cpp",
+		MAME_DIR .. "src/devices/bus/mca/c1000.h",	
+		MAME_DIR .. "src/devices/bus/mca/curam.cpp",
+		MAME_DIR .. "src/devices/bus/mca/curam.h",
+		MAME_DIR .. "src/devices/bus/mca/ibm72x8299.cpp",
+		MAME_DIR .. "src/devices/bus/mca/ibm72x8299.h",
+		MAME_DIR .. "src/devices/bus/mca/ibm_dual_async.cpp",
+		MAME_DIR .. "src/devices/bus/mca/ibm_dual_async.h",
+		MAME_DIR .. "src/devices/bus/mca/ibm_memory_exp_16.cpp",	
+		MAME_DIR .. "src/devices/bus/mca/ibm_memory_exp_16.h",
+		MAME_DIR .. "src/devices/bus/mca/ibm_memory_exp_32.cpp",	
+		MAME_DIR .. "src/devices/bus/mca/ibm_memory_exp_32.h",
+		MAME_DIR .. "src/devices/bus/mca/ibm_svga.cpp",	
+		MAME_DIR .. "src/devices/bus/mca/ibm_svga.h",
+		MAME_DIR .. "src/devices/bus/mca/macpa.cpp",
+		MAME_DIR .. "src/devices/bus/mca/macpa.h",
+		MAME_DIR .. "src/devices/bus/mca/mca.cpp",
+		MAME_DIR .. "src/devices/bus/mca/mca.h",
+		MAME_DIR .. "src/devices/bus/mca/mca_cards.cpp",
+		MAME_DIR .. "src/devices/bus/mca/mca_cards.h",
+		MAME_DIR .. "src/devices/bus/mca/planar_fdc.cpp",
+		MAME_DIR .. "src/devices/bus/mca/planar_fdc.h",	
+		MAME_DIR .. "src/devices/bus/mca/planar_lpt.cpp",
+		MAME_DIR .. "src/devices/bus/mca/planar_lpt.h",		
+		MAME_DIR .. "src/devices/bus/mca/planar_uart.cpp",
+		MAME_DIR .. "src/devices/bus/mca/planar_uart.h",
+		MAME_DIR .. "src/devices/bus/mca/planar_vga.cpp",
+		MAME_DIR .. "src/devices/bus/mca/planar_vga.h",
+		MAME_DIR .. "src/devices/bus/mca/snark_barker.cpp",
+		MAME_DIR .. "src/devices/bus/mca/snark_barker.h",	
+	}
+end
+
+---------------------------------------------------
+--
+--@src/devices/bus/msx_slot/slot.h,BUSES["MSX_SLOT"] = true
 ---------------------------------------------------
 
 if (BUSES["MSX_SLOT"]~=null) then

--- a/scripts/src/machine.lua
+++ b/scripts/src/machine.lua
@@ -1790,6 +1790,18 @@ end
 
 ---------------------------------------------------
 --
+--@src/devices/machine/ibm72x7377.h,MACHINES["IBM72X7377"] = true
+---------------------------------------------------
+
+if (MACHINES["IBM72X7377"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/machine/ibm72x7377.cpp",
+		MAME_DIR .. "src/devices/machine/ibm72x7377.h",
+	}
+end
+
+---------------------------------------------------
+--
 --@src/devices/machine/idectrl.h,MACHINES["IDECTRL"] = true
 --@src/devices/machine/vt83c461.h,MACHINES["IDECTRL"] = true
 ---------------------------------------------------
@@ -5178,6 +5190,17 @@ if (MACHINES["NMK112"]~=null) then
 	files {
 		MAME_DIR .. "src/devices/machine/nmk112.cpp",
 		MAME_DIR .. "src/devices/machine/nmk112.h",
+	}
+end
+
+---------------------------------------------------
+--
+--@src/devices/machine/ibmps2.h,MACHINES["PS2_MB"] = true
+---------------------------------------------------
+if (MACHINES["PS2_MB"]~=null) then
+	files {
+		MAME_DIR .. "src/devices/machine/ibmps2.cpp",
+		MAME_DIR .. "src/devices/machine/ibmps2.h",
 	}
 end
 

--- a/src/devices/bus/isa/sblaster.cpp
+++ b/src/devices/bus/isa/sblaster.cpp
@@ -31,6 +31,14 @@
 #define IRQ_MPU     0x04
 #define IRQ_ALL     0xff
 
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
 
 /*
   adlib (YM3812/OPL2 chip), part of many many soundcards (soundblaster)
@@ -248,7 +256,10 @@ void sb_device::dsp_data_w(offs_t offset, uint8_t data)
 //    printf("%02x to DSP data @ %x\n", data, offset);
 	if(offset)
 		return;
-	logerror("Soundblaster DSP data port undocumented write\n");
+	
+	LOG("%s: SB DSP port write O:%02X D:%02X\n", FUNCNAME, offset, data);
+
+	//logerror("Soundblaster DSP data port undocumented write\n");
 }
 
 uint8_t sb_device::dsp_rbuf_status_r(offs_t offset)

--- a/src/devices/bus/mca/3c523.cpp
+++ b/src/devices/bus/mca/3c523.cpp
@@ -1,0 +1,418 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    3COM 3C523 EtherLink/MC 
+	MCA ID @6042
+
+    i82586-based LAN card.
+
+    POS options:
+    - POS 0
+    -- bit 0: Enable/Disable
+    --- XXXXXXX0b Disable	- When disabled, 82586 is held in Reset.
+    --- XXXXXXX1b Enable
+    -- bits 2-1: I/O ports
+    --- XXXXX00Xb 0300h-0307h
+    --- XXXXX01Xb 1300h-1307h
+    --- XXXXX10Xb 2300h-2307h
+    --- XXXXX11Xb 3300h-3307h
+    -- bits 4-3: MMIO base - 16K of packet buffer SRAM and 8K of ROM, if present.
+    --- XXX00XXXb C0000h-C5FFFh
+    --- XXX01XXXb C8000h-CDFFFh
+    --- XXX10XXXb D0000h-D5FFFh
+    --- XXX11XXXb D8000h-DDFFFh
+    -- bit 5: Transceiver Type
+    --- XX0XXXXXb On-Board (BNC or RJ45)
+    --- XX1XXXXXb External (AUI)
+	-- bit 6-7: IRQ selection (read-only)
+	--- 00XXXXXXb IRQ 12
+	--- 01XXXXXXb IRQ 7
+	--- 10XXXXXXb IRQ 3
+	--- 11XXXXXXb IRQ 9
+    
+    - POS 1
+    -- bits 3-0: IRQ
+    --- XXXX0100b IRQ 3
+    --- XXXX0010b IRQ 7
+    --- XXXX1000b IRQ 9
+    --- XXXX0001b IRQ 12
+
+	https://ardent-tool.com/NIC/3c523_Technical_Reference.pdf
+
+***************************************************************************/
+
+#include "emu.h"
+#include "3c523.h"
+
+
+//#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_3C523, mca16_3c523_device, "mca_3c523", "3COM EtherLink/MC (@6042)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_3c523_device::device_add_mconfig(machine_config &config)
+{
+	I82586(config, m_net, 20_MHz_XTAL/2);
+	m_net->set_addrmap(0, &mca16_3c523_device::map_main);
+	m_net->out_irq_cb().set(FUNC(mca16_3c523_device::irq_w));
+
+    RAM(config, m_ram);
+	m_ram->set_default_size("16KiB");
+}
+
+void mca16_3c523_device::map_main(address_map &map)
+{
+	// i82586 upper 8 address lines are ignored
+	map.global_mask(0x00ffff);
+
+	// suppress logging when sizing RAM
+	map(0xc000, 0xffff).rw(FUNC(mca16_3c523_device::packet_buffer_r), FUNC(mca16_3c523_device::packet_buffer_w));
+}
+
+//-------------------------------------------------
+//  mca16_3c523_device - constructor
+//-------------------------------------------------
+
+mca16_3c523_device::mca16_3c523_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_3c523_device(mconfig, MCA16_3C523, tag, owner, clock)
+{
+}
+
+mca16_3c523_device::mca16_3c523_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x6042),
+    m_net(*this, "net"),
+	m_ram(*this, "ram")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_3c523_device::device_start()
+{
+	set_mca_device();
+	m_is_mapped = 0;
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_3c523_device::device_reset()
+{
+	reset_option_select();	// manual: RESET clears POS registers and host register
+
+	if(m_is_mapped) unmap();
+    m_is_mapped = 0;
+
+	m_cur_io_base = 0;
+	m_cur_irq = 0;
+	m_cur_mem_base = 0;
+
+	m_reset = 0;
+	m_channel_attention = 0;
+	m_loopback_enabled = 0;
+	m_interrupt_flag = 0;
+	m_interrupt_fired = 0;
+	m_interrupts_enabled = 0;
+	m_ram_bank = 0;
+
+}
+
+void mca16_3c523_device::unmap()
+{
+	m_mca->unmap_device(m_cur_io_base, m_cur_io_base+0xf);
+	m_mca->unmap_readwrite(m_cur_mem_base, m_cur_mem_base+0x3fff);
+	
+	m_is_mapped = false;
+}
+
+void mca16_3c523_device::remap()
+{
+	if(BIT(m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], 0) == 0)
+	{
+		// do not map
+		LOG("%s: disabled via POS, not mapping\n", FUNCNAME);
+		return;
+	}
+
+	uint16_t pos_io_base = get_pos_io_base();
+	uint8_t pos_irq = get_pos_irq();
+	offs_t pos_mem_base = get_pos_mem_base();
+
+	LOG("%s: %02X %02X Installing to %04Xh IRQ%d memory %06X\n", FUNCNAME, 
+		m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], m_option_select[MCABus::POS::OPTION_SELECT_DATA_2],
+	 	pos_io_base, pos_irq, pos_mem_base);
+
+	LOG("%s: Installing I/O\n", FUNCNAME);
+	m_mca->install_device(pos_io_base, pos_io_base+0xf,
+		read8sm_delegate(*this, FUNC(mca16_3c523_device::io8_r)), write8sm_delegate(*this, FUNC(mca16_3c523_device::io8_w)));
+	LOG("%s: Installing MMIO space\n", FUNCNAME);
+	m_mca->install_memory(pos_mem_base, pos_mem_base+0x3fff,
+			read8sm_delegate(*this, FUNC(mca16_3c523_device::shared_ram_r)), write8sm_delegate(*this, FUNC(mca16_3c523_device::shared_ram_w)));
+
+	m_cur_io_base = pos_io_base;
+	m_cur_irq = pos_irq;
+	m_cur_mem_base = pos_mem_base;
+
+	LOG("%s: Updating POS DATA 1 for new IRQ\n", FUNCNAME);
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] &= 0x3f;
+	switch(m_cur_irq)
+	{
+		case 12: 	m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= 0b00000000; break;
+		case 7:		m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= 0b01000000; break;
+		case 3:		m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= 0b10000000; break;
+		case 9:		m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= 0b11000000; break;
+	}	
+
+	m_is_mapped = true;
+}
+
+uint8_t mca16_3c523_device::get_pos_irq()
+{
+	LOG("%s: OPTION_SELECT_DATA_2 %02X\n", FUNCNAME, m_option_select[MCABus::POS::OPTION_SELECT_DATA_2]);
+	switch(m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0x0F)
+	{
+		case 1: return 12;
+		case 2: return 7;
+		case 4: return 3;
+		case 8: return 9;
+		default: return 0; // invalid
+	}
+}
+
+offs_t mca16_3c523_device::get_pos_mem_base()
+{
+	return 0xC0000 + (0x8000 * ((m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] >> 3) & 3));
+}
+
+uint16_t mca16_3c523_device::get_pos_io_base()
+{
+	return 0x300 + (0x1000 * ((m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] >> 1) & 3));
+}
+
+bool mca16_3c523_device::map_has_changed()
+{
+	uint16_t pos_io_base = get_pos_io_base();
+	uint8_t pos_irq = get_pos_irq();
+	offs_t pos_mem_base = get_pos_mem_base();
+
+	return (pos_io_base != m_cur_io_base) || (pos_irq != m_cur_irq) || (pos_mem_base != m_cur_mem_base);
+}
+
+void mca16_3c523_device::update_pos_data_1(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] &= 0xc0;
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= (data & 0x3f); // bits 6 and 7 are read-only
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+
+	update_reset();
+}
+
+void mca16_3c523_device::update_pos_data_2(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+}
+
+void mca16_3c523_device::update_pos_data_3(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = data;
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+}
+
+void mca16_3c523_device::update_pos_data_4(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] = data;
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+}
+
+/* 3C523 I/O registers */
+
+/* 
+	Control Register
+	b7: /RST	Reset, active low. When asserted, the 82586 is in Reset. Set to 0 on power-up.
+	b6: CA		Channel Attention. The 82586 responds when this goes from high to low.
+	b5: LBK		Loopback Enable, sets the encoder to loopback mode for testing.
+	b4: always 0
+	b3: INT		Current interrupt state. Not latched, so always reflects the IRQ line.
+	b2: INTE	Assert to enable interrupts. Should always be 1.
+	b1: BS1	 	\ RAM Bank Select, always set both bits to 1 for a 16K card
+	b0: BS0		/
+*/
+
+uint8_t mca16_3c523_device::control_register_r()
+{
+	uint8_t data = 0;
+
+	data |= (m_reset 				? 0x80 : 0x00);
+	data |= (m_channel_attention 	? 0x40 : 0x00);
+	data |= (m_loopback_enabled 	? 0x20 : 0x00);
+	data |= (m_interrupt_flag 		? 0x08 : 0x00);
+	data |= (m_interrupts_enabled 	? 0x04 : 0x00);
+	data |= m_ram_bank;				// 0-3 are all valid values
+
+	return data;
+}
+
+void mca16_3c523_device::control_register_w(uint8_t data)
+{
+	LOG("%s: writing %02X\n", FUNCNAME, data);
+
+	m_reset 				= BIT(data, 7);
+	m_channel_attention 	= BIT(data, 6);
+	m_loopback_enabled		= BIT(data, 5);
+	// INT is r/o
+	m_interrupts_enabled 	= BIT(data, 2);
+	m_ram_bank 				= data & 0x03;
+
+	m_net->ca(m_channel_attention);
+	update_reset();
+}
+
+void mca16_3c523_device::update_reset()
+{
+	// The controller is held in reset if POS[0].0 is 0 or the control register's reset bit is 0.
+	bool is_in_reset = (BIT(m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], 0) == 0) || (m_reset == 0);
+	LOG("%s: 82586 reset line %d. POS reset = %d, ctrl reg reset = %d\n", FUNCNAME, is_in_reset, BIT(m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], 0), m_reset);
+	m_net->reset_w(is_in_reset);
+}
+
+uint8_t mca16_3c523_device::io8_r(offs_t offset)
+{
+	// The adapter uses 8 I/O ports.
+	// Ports 0-5 are read-only and contain the MAC address.
+	// Port 6 is the actual control register.
+	// Port 7 is a revision register.
+
+	LOG("%s: O:%02X\n", FUNCNAME, offset);
+
+	switch(offset)
+	{
+		case 0: return 0x00;	// MAC 0
+		case 1: return 0xc0;	// MAC 1
+		case 2: return 0x75;	// MAC 2
+		case 3: return 0x72;	// MAC 3
+		case 4: return 0xb8;	// MAC 4
+		case 5: return 0x9e;	// MAC 5
+		case 6: return control_register_r();
+		case 7: return 0x0f;	// revision
+		default: return 0xff;
+	}
+}
+
+void mca16_3c523_device::io8_w(offs_t offset, uint8_t data)
+{
+	LOG("%s: O:%02X\n", FUNCNAME, offset);
+
+	// All other registers are read-only.
+	if(offset == 6) control_register_w(data);
+}
+
+WRITE_LINE_MEMBER(mca16_3c523_device::irq_w)
+{
+	bool asserting_now = (m_interrupt_flag == 0) && (state == 1);
+	m_interrupt_flag = state; // This flag is not affected by the INTE bit.
+
+	if(m_interrupt_fired && asserting_now)
+	{
+		LOG("%s: *** Still waiting for IRQ ack...\n", FUNCNAME);
+	}
+
+	LOG("%s: state %d, ints enabled %d, int flag %d\n", FUNCNAME, state, m_interrupts_enabled, m_interrupts_enabled);
+	if(state && !m_interrupt_fired)
+	{
+		if(m_interrupts_enabled)
+		{
+			LOG("%s: firing IRQ %d\n", FUNCNAME, m_cur_irq);
+			// Going from cleared to asserted with interrupts enabled, trigger the IRQ.
+			switch(m_cur_irq)
+			{
+				case 3: 	m_mca->ireq_w<3>(state); break;
+				case 7: 	m_mca->ireq_w<7>(state); break;
+				case 9:	 	m_mca->ireq_w<9>(state); break;
+				case 12: 	m_mca->ireq_w<12>(state); break;
+				default: break;
+			}
+			m_interrupt_fired = true;	// An interrupt is actually in progress.
+		}
+		// Going from cleared to asserted with interrupts disabled, do nothing.
+	}
+	else if(!state)
+	{
+		// Going from asserted to cleared. Clear in all cases.
+		switch(m_cur_irq)
+		{
+			case 3: 	m_mca->ireq_w<3>(state); break;
+			case 7: 	m_mca->ireq_w<7>(state); break;
+			case 9:	 	m_mca->ireq_w<9>(state); break;
+			case 12: 	m_mca->ireq_w<12>(state); break;
+			default: break;
+		}
+		m_interrupt_fired = false;		// An interrupt is not actually in progress.
+	}
+}
+
+uint8_t mca16_3c523_device::shared_ram_r(offs_t offset)
+{
+	uint8_t data = m_ram->read(offset);
+	return data;
+}
+
+void mca16_3c523_device::shared_ram_w(offs_t offset, uint8_t data)
+{
+	//LOG("%s O:%02X D:%02X\n", FUNCNAME, offset, data);
+	m_ram->write(offset, data);
+}
+
+uint16_t mca16_3c523_device::packet_buffer_r(offs_t offset)
+{
+	// All 82586 memory cycles are 16-bit on the 3C523.
+	uint16_t data = (m_ram->read(offset*2)) | (m_ram->read((offset*2) + 1) << 8);
+
+	//LOG("packet_buffer_r O:%04X (P:%06X) D:%04X\n", offset, (offset*2)+0xC0000, data);
+
+	return data;
+}
+
+void mca16_3c523_device::packet_buffer_w(offs_t offset, uint16_t data)
+{
+	//LOG("packet_buffer_w O:%04X (P:%06X) D:%04X\n", offset, (offset*2)+0xC0000, data);
+
+	// All 82586 memory cycles are 16-bit on the 3C523.
+	m_ram->write((offset*2), data & 0xFF);
+	m_ram->write((offset*2)+1, (data & 0xFF00) >> 8);
+}

--- a/src/devices/bus/mca/3c523.cpp
+++ b/src/devices/bus/mca/3c523.cpp
@@ -342,7 +342,7 @@ void mca16_3c523_device::io8_w(offs_t offset, uint8_t data)
 	if(offset == 6) control_register_w(data);
 }
 
-WRITE_LINE_MEMBER(mca16_3c523_device::irq_w)
+void mca16_3c523_device::irq_w(int state)
 {
 	bool asserting_now = (m_interrupt_flag == 0) && (state == 1);
 	m_interrupt_flag = state; // This flag is not affected by the INTE bit.

--- a/src/devices/bus/mca/3c523.h
+++ b/src/devices/bus/mca/3c523.h
@@ -66,7 +66,7 @@ protected:
 	required_device<i82586_device> m_net;
 	required_device<ram_device> m_ram;
 
-	DECLARE_WRITE_LINE_MEMBER(irq_w);
+	void irq_w(int state);
 
 private:
 	uint8_t 	control_register_r();

--- a/src/devices/bus/mca/3c523.h
+++ b/src/devices/bus/mca/3c523.h
@@ -1,0 +1,97 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    3COM 3C523 EtherLink/MC
+
+    i82586-based LAN card.
+	Skeleton.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_3C523_H
+#define MAME_BUS_MCA_3C523_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/i82586.h"
+#include "machine/ram.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> isa8_com_device
+
+class mca16_3c523_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_3c523_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void remap() override;
+	virtual void unmap() override;
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+	uint8_t shared_ram_r(offs_t offset);
+	void shared_ram_w(offs_t offset, uint8_t data);
+
+protected:
+	mca16_3c523_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+    void map_main(address_map &map);
+
+	bool map_has_changed() override;
+
+	void update_pos_data_1(uint8_t data) override;
+	void update_pos_data_2(uint8_t data) override;
+	void update_pos_data_3(uint8_t data) override;
+	void update_pos_data_4(uint8_t data) override;
+
+	uint16_t packet_buffer_r(offs_t offset);
+	void packet_buffer_w(offs_t offset, uint16_t data);
+
+	required_device<i82586_device> m_net;
+	required_device<ram_device> m_ram;
+
+	DECLARE_WRITE_LINE_MEMBER(irq_w);
+
+private:
+	uint8_t 	control_register_r();
+	void 		control_register_w(uint8_t data);
+
+	void		update_reset();
+
+	uint16_t	get_pos_io_base();
+	uint8_t 	get_pos_irq();
+	offs_t 		get_pos_mem_base();
+
+	uint16_t 	m_cur_io_base;
+	uint8_t 	m_cur_irq;
+	offs_t		m_cur_mem_base;
+
+	bool		m_reset;
+	bool		m_channel_attention;
+	bool		m_loopback_enabled;
+	bool		m_interrupt_flag;		// Not affected by INTE.
+	bool		m_interrupt_fired;		// Is an IRQ *actually* fired?
+	bool		m_interrupts_enabled;
+	uint8_t		m_ram_bank;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_3C523, mca16_3c523_device)
+
+#endif

--- a/src/devices/bus/mca/adlib.cpp
+++ b/src/devices/bus/mca/adlib.cpp
@@ -1,0 +1,151 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+  	Ad Lib MCA
+	MCA ID @70D7
+
+    - Not configurable. Always at 388h.
+    pos[0]=0000000Xb 
+    pos[1]=11000XXXb
+
+***************************************************************************/
+
+#include "emu.h"
+#include "adlib.h"
+
+#include "sound/spkrdev.h"
+#include "speaker.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_ADLIB, mca16_adlib_device, "mca16_adlib_device", "Ad Lib Music Synthesis Card (@70D7)");
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_adlib_device::device_add_mconfig(machine_config &config)
+{
+	SPEAKER(config, "mono").front_center();
+	YM3812(config, m_ym3812, 3'579'545_Hz_XTAL).add_route(ALL_OUTPUTS, "mono", 3.00);
+}
+
+//-------------------------------------------------
+//  mca16_adlib_device - constructor
+//-------------------------------------------------
+
+mca16_adlib_device::mca16_adlib_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_adlib_device(mconfig, MCA16_ADLIB, tag, owner, clock)
+{
+}
+
+mca16_adlib_device::mca16_adlib_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x70d7),
+    m_ym3812(*this, "ym3812")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_adlib_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_adlib_device::device_reset()
+{
+	reset_option_select();
+	if(m_is_mapped) unmap();
+    m_is_mapped = 0;
+}
+
+void mca16_adlib_device::remap()
+{
+    // The only valid setting is I/O base 0388h.
+	m_mca->install_device(0x388, 0x389,
+		read8sm_delegate(*this, FUNC(mca16_adlib_device::io8_r)), write8sm_delegate(*this, FUNC(mca16_adlib_device::io8_w)));
+    m_is_mapped = true;
+}
+
+void mca16_adlib_device::unmap()
+{
+    // The only valid setting is I/O base 0388h.
+	m_mca->unmap_device(0x388, 0x389);
+    m_is_mapped = false;
+}
+
+uint8_t mca16_adlib_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+
+	switch(offset)
+	{
+		case 0: 	return m_ym3812->status_r();
+		default: 	return 0xff;
+	}
+}
+
+void mca16_adlib_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+
+    switch(offset)
+	{
+		case 0 : m_ym3812->address_w(data); break;
+		case 1 : m_ym3812->data_w(data); break;
+	}
+}
+
+bool mca16_adlib_device::map_has_changed()
+{
+	// This is the only valid setting.
+    if(((m_option_select[0] & 0b11111110) == 0) && ((m_option_select[1] & 0b11111000) == 0b11000000))
+    {
+		// Needs to be mapped if not already mapped.
+        return (m_is_mapped ? false : true);
+	}
+	else
+	{
+		// If mapped, we need to unmap it.
+		return (m_is_mapped ? true : false);
+	}
+}
+
+void mca16_adlib_device::update_pos_data_1(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] = data;
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+}
+
+void mca16_adlib_device::update_pos_data_2(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	if(map_has_changed())
+	{
+		if(m_is_mapped) unmap();
+		remap();
+	}
+}

--- a/src/devices/bus/mca/adlib.h
+++ b/src/devices/bus/mca/adlib.h
@@ -1,0 +1,59 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    Ad Lib MCA
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_ADLIB_H
+#define MAME_BUS_MCA_ADLIB_H
+
+#pragma once
+
+#include "mca.h"
+#include "sound/ymopl.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_adlib_device
+
+class mca16_adlib_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_adlib_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void remap() override;
+	virtual void unmap() override;
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+protected:
+	mca16_adlib_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	virtual bool map_has_changed() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+private:
+	void update_pos_data_1(uint8_t data) override;
+	void update_pos_data_2(uint8_t data) override;
+
+	required_device<ym3812_device> m_ym3812;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_ADLIB, mca16_adlib_device)
+
+#endif

--- a/src/devices/bus/mca/c1000.cpp
+++ b/src/devices/bus/mca/c1000.cpp
@@ -1,0 +1,360 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+	Custom Computer Systems C1000
+    MCA ID @6213
+    MCA IDE adapter
+
+    POS configuration:
+    - POS 0 bit 7: I/O port
+    -- 0 = 11F0h-11F7h (primary)
+    -- 1 = 1170h-117Fh (secondary)
+
+    - POS 0 bits 3-6: option ROM base
+    -- X1111XXX = DC000h-DFFFFh
+    -- X1101XXX = D8000h-DBFFFh
+    -- X1011XXX = D4000h-D7FFFh
+    -- X1001XXX = D0000h-D3FFFh
+    -- X0111XXX = CC000h-CFFFFh
+    -- X0011XXX = C8000h-CBFFFh
+
+    - POS 1 bits 0-6: IRQ line
+    -- XX001001 = IRQ 10 
+    -- XX001011 = IRQ 15
+
+    - POS 2 bits 6-7: CO-RESIDENT INSTALLATION
+    -- 00XXXXXX = no
+    -- 01XXXXXX = yes
+
+    - POS 2 bits 0-3: Drive 0 Type Selection
+    -- XXXX0001 = "Identify and Translate"
+    -- XXXX0010 = "Identify and Truncate"
+    -- XXXX0000 = "Not Installed"
+
+    - POS 2 bits 7-4: Drive 0 Type Selection
+    -- 0001XXXX = "Identify and Translate"
+    -- 0010XXXX = "Identify and Truncate"
+    -- 0000XXXX = "Not Installed"
+
+***************************************************************************/
+
+#include "emu.h"
+#include "c1000.h"
+
+#include "bus/ata/atadev.h"
+#include "imagedev/harddriv.h"
+
+//#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_C1000_IDE, mca16_c1000_ide_device, "mca_c1000_ide", "CCS C1000 IDE Adapter (@6213)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_c1000_ide_device::device_add_mconfig(machine_config &config)
+{
+	ATA_INTERFACE(config, m_ata).options(ata_devices, "hdd", nullptr, false);
+	m_ata->irq_handler().set(FUNC(mca16_c1000_ide_device::ide_interrupt));
+}
+
+//-------------------------------------------------
+//  isa8_com_device - constructor
+//-------------------------------------------------
+
+mca16_c1000_ide_device::mca16_c1000_ide_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_c1000_ide_device(mconfig, MCA16_C1000_IDE, tag, owner, clock)
+{
+}
+
+mca16_c1000_ide_device::mca16_c1000_ide_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x6213),
+    m_is_primary(true),
+	m_ata(*this, "ata")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_c1000_ide_device::device_start()
+{
+	set_mca_device();
+    m_is_mapped = false;
+    m_is_latched = false;
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_c1000_ide_device::device_reset()
+{
+    if(m_is_mapped) unmap();
+
+    reset_option_select();
+    m_is_mapped = false;
+}
+
+void mca16_c1000_ide_device::map(address_map &map)
+{
+	map(0x0, 0x7).rw("ide", FUNC(ide_controller_device::cs0_r), FUNC(ide_controller_device::cs0_w));
+}
+
+void mca16_c1000_ide_device::unmap()
+{
+    LOG("%s: Unmapping MCA card\n", FUNCNAME);
+    m_mca->unmap_device(m_cur_io_start, m_cur_io_end);
+    m_mca->unmap_device(m_cur_io_start+0xc, m_cur_io_start+0xf);
+
+    offs_t cur_rom_base = rom_base();
+    if(cur_rom_base != 0) m_mca->unmap_rom(cur_rom_base, cur_rom_base+0x3fff);
+    m_is_mapped = false;
+}
+
+void mca16_c1000_ide_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+            update_pos_data_1(data);
+			break;
+		case 3:
+			// Option Select Data 2
+            update_pos_data_2(data);
+			break;
+		case 4:
+			// Option Select Data 3
+            update_pos_data_3(data);
+			break;
+		case 5:
+			// Option Select Data 4
+            // not used
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}
+
+void mca16_c1000_ide_device::update_pos_data_1(uint8_t data)
+{
+    // POS 0 controls the I/O mapping and option ROM base address.
+
+    LOG("%s: C1000 POS data 1 write %02X\n", FUNCNAME, data);
+    
+    // Unmap the I/O ports and option ROM.
+    if(m_is_mapped) unmap();
+
+    // Remap the I/O ports.
+    if(BIT(data, 7)) 
+    {
+        // Secondary
+        m_cur_io_start = 0x1170;
+        m_cur_io_end = 0x1177;
+        m_is_primary = false;
+    }
+    else
+    {
+        // Primary
+        m_cur_io_start = 0x11f0;
+        m_cur_io_end = 0x11f7;
+        m_is_primary = true;
+    }
+
+    LOG("%s: Mapping MCA card to %04Xh-%04Xh\n", FUNCNAME, m_cur_io_start, m_cur_io_end);
+    m_mca->install_device(m_cur_io_start, m_cur_io_end, 
+            read8sm_delegate(*this, FUNC(mca16_c1000_ide_device::io8_r)),
+            write8sm_delegate(*this, FUNC(mca16_c1000_ide_device::io8_w)));
+    m_mca->install_device(m_cur_io_start+0xc, m_cur_io_start+0xf,
+            read8sm_delegate(*this, FUNC(mca16_c1000_ide_device::alt_r)),
+            write8sm_delegate(*this, FUNC(mca16_c1000_ide_device::alt_w)));       
+
+    // So rom_base() picks up the new address.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] = data;
+
+    // Apply the updated ROM base address.
+    offs_t cur_rom_base = rom_base();
+    if(cur_rom_base != 0)
+    {
+        m_mca->install_rom(this, cur_rom_base, cur_rom_base+0x3fff, "option");
+    }
+
+    m_is_mapped = true;
+}
+
+uint8_t mca16_c1000_ide_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+    uint8_t data;
+
+    // 0 does a 16-bit read. 1 is latched to the other data byte.
+    switch(offset)
+    {
+        case 0:
+            m_ata_data_latch = m_ata->cs0_r(offset, 0xffff);
+            data = m_ata_data_latch & 0xff;
+            m_is_latched = true;
+            break;
+        case 1:
+            if(m_is_latched)
+            {
+                data = m_ata_data_latch >> 8;
+                m_is_latched = false;
+            }
+            else
+            {
+                data = m_ata->cs0_r(1, 0xff);
+            }
+            break;
+        default: 
+            data = m_ata->cs0_r(offset, 0xff);
+            break;
+    }
+
+    LOG("IDE CS0 R %02X %02X\n", offset, data);
+    return data;
+}
+
+void mca16_c1000_ide_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+
+    switch(offset)
+    {
+        case 0:
+            // The BIOS writes 0 then 1, so latch 0 then write 1?
+            m_ata_data_latch = data;
+            m_is_latched = true;
+            break;
+        case 1:
+            if(m_is_latched)
+            {
+                m_ata_data_latch |= ((uint16_t)data) << 8;
+                m_ata->cs0_w(0, m_ata_data_latch, 0xffff);
+                m_is_latched = false;
+                break;
+            }
+            else
+            {
+                m_ata->cs0_w(1, data, 0xff);
+                break;
+            }
+        default: 
+            m_ata->cs0_w(offset, data, 0xff);
+            break;
+    }
+
+    LOG("IDE CS0 W %02X %02X\n", offset, data);
+}
+
+uint8_t mca16_c1000_ide_device::alt_r(offs_t offset)
+{
+    assert_card_feedback();
+    uint8_t data;
+
+    switch(offset)
+    {
+        case 0: data = m_ata->cs1_r(7, 0xff); break;
+        case 2: data = m_ata->cs1_r(6, 0xff); break;
+        default: data = 0xff;
+    }
+
+    LOG("IDE ALT R %02X %02X\n", offset, data);
+
+    return data;
+}
+
+void mca16_c1000_ide_device::alt_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+
+    LOG("IDE ALT W %02X %02X\n", offset, data);
+    switch(offset)
+    {
+        case 0: m_ata->cs1_w(7, data, 0xff); return;
+        case 2: m_ata->cs1_w(6, data, 0xff); return;
+        default: return;
+    }
+}
+
+void mca16_c1000_ide_device::update_pos_data_2(uint8_t data)
+{
+    // IRQ is handled by ide_interrupt callback, just set the bits correctly.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+}
+
+void mca16_c1000_ide_device::update_pos_data_3(uint8_t data)
+{
+    // Adapter-specific stuff. Not sure what this does in hardware if anything.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = data;
+}
+
+WRITE_LINE_MEMBER(mca16_c1000_ide_device::ide_interrupt)
+{
+    switch(m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0x3f)
+    {
+        case 0b001001: m_mca->ireq_w<10>(state); break;
+        case 0b001011: m_mca->ireq_w<15>(state); break;
+        default:
+            LOG("%s: IDE interrupt with invalid POS 1 selection %02X\n", FUNCNAME, m_option_select[MCABus::POS::OPTION_SELECT_DATA_2]);
+            break;
+    }
+}
+
+offs_t mca16_c1000_ide_device::rom_base()
+{
+    offs_t base = 0;
+    switch(pos_r(MCABus::POS::OPTION_SELECT_DATA_1) & 0b01111000)
+    {
+        case 0b01111000: base = 0xdc000; break;
+        case 0b01101000: base = 0xd8000; break;
+        case 0b01011000: base = 0xd4000; break;
+        case 0b01001000: base = 0xd0000; break;
+        case 0b00111000: base = 0xcc000; break;
+        case 0b00011000: base = 0xc8000; break;
+        default: base = 0;
+    }
+
+    LOG("%s: ROM base is %06Xh\n", FUNCNAME, base);
+
+    return base;
+}
+
+ROM_START( c1000 )
+	ROM_REGION( 0xc8000, "option", 0 )
+	ROM_LOAD( "c1000.bin", 0x0000, 0x4000, CRC(e805b055) SHA1(3434fe34d982c54a68d225d4f50fa0aec96470d1) )
+ROM_END
+
+const tiny_rom_entry *mca16_c1000_ide_device::device_rom_region() const
+{
+	return ROM_NAME( c1000 );
+}
+

--- a/src/devices/bus/mca/c1000.cpp
+++ b/src/devices/bus/mca/c1000.cpp
@@ -317,7 +317,7 @@ void mca16_c1000_ide_device::update_pos_data_3(uint8_t data)
     m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = data;
 }
 
-WRITE_LINE_MEMBER(mca16_c1000_ide_device::ide_interrupt)
+void mca16_c1000_ide_device::ide_interrupt(int state)
 {
     switch(m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0x3f)
     {

--- a/src/devices/bus/mca/c1000.h
+++ b/src/devices/bus/mca/c1000.h
@@ -1,0 +1,83 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    Custom Computer Systems C1000 IDE Adapter
+
+    A whole bunch of TTL, an option ROM, and an IDE port.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_C1000_H
+#define MAME_BUS_MCA_C1000_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/idectrl.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> isa8_com_device
+
+class mca16_c1000_ide_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_c1000_ide_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual uint16_t get_card_id() override { return 0x6213; }
+
+protected:
+	mca16_c1000_ide_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+	uint8_t alt_r(offs_t offset);
+	void alt_w(offs_t offset, uint8_t data);
+
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+	virtual void unmap() override;
+	virtual void remap() override {};
+
+    virtual const tiny_rom_entry *device_rom_region() const override;
+    
+private:
+    DECLARE_WRITE_LINE_MEMBER(ide_interrupt);
+
+    void update_pos_data_1(uint8_t data) override;
+    void update_pos_data_2(uint8_t data) override;
+    void update_pos_data_3(uint8_t data) override;
+
+	void map(address_map &map);    
+
+	offs_t rom_base();
+
+    bool m_is_primary;
+	uint8_t m_is_mapped;
+
+    required_device<ata_interface_device> m_ata;
+
+    offs_t  m_cur_io_start, m_cur_io_end;
+    uint8_t m_cur_irq;
+    uint16_t m_ata_data_latch;
+    bool    m_is_latched;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_C1000_IDE, mca16_c1000_ide_device)
+
+#endif

--- a/src/devices/bus/mca/c1000.h
+++ b/src/devices/bus/mca/c1000.h
@@ -56,7 +56,7 @@ protected:
     virtual const tiny_rom_entry *device_rom_region() const override;
     
 private:
-    DECLARE_WRITE_LINE_MEMBER(ide_interrupt);
+    void ide_interrupt(int state);
 
     void update_pos_data_1(uint8_t data) override;
     void update_pos_data_2(uint8_t data) override;

--- a/src/devices/bus/mca/curam.cpp
+++ b/src/devices/bus/mca/curam.cpp
@@ -1,0 +1,386 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    Cumulus CuRAM-16 Plus Memory Multifunction Adapter
+    MCA ID @6025
+
+***************************************************************************/
+
+#include "emu.h"
+#include "curam.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_CURAM16_PLUS, mca16_curam16_plus_device, "mca_curam16_plus", "Cumulus CuRAM-16 Plus Memory Multifunction Adapter (@6025)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_curam16_plus_device::device_add_mconfig(machine_config &config)
+{
+	RAM(config, RAM_TAG).set_default_size("12M");
+}
+
+//-------------------------------------------------
+//  mca16_curam16_plus_device - constructor
+//-------------------------------------------------
+
+mca16_curam16_plus_device::mca16_curam16_plus_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_curam16_plus_device(mconfig, MCA16_CURAM16_PLUS, tag, owner, clock)
+{
+}
+
+mca16_curam16_plus_device::mca16_curam16_plus_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x6025),
+	m_ram(*this, RAM_TAG)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_curam16_plus_device::device_start()
+{
+    m_is_mapped = 0;
+    m_xms_start = 0;
+    m_xms_end = 0;
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_curam16_plus_device::device_reset()
+{
+    remap();
+}
+
+uint8_t mca16_curam16_plus_device::ems_200_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    uint8_t data = m_ems_regs_200h[offset];
+    return data;
+}
+
+uint8_t mca16_curam16_plus_device::ems_4200_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    uint8_t data = m_ems_regs_4200h[offset];
+    return data;
+}
+
+uint8_t mca16_curam16_plus_device::ems_8200_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    uint8_t data = m_ems_regs_8200h[offset];
+    return data;
+}
+
+uint8_t mca16_curam16_plus_device::ems_c200_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    uint8_t data = m_ems_regs_c200h[offset];
+    return data;
+}
+
+void mca16_curam16_plus_device::ems_200_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_ems_regs_200h[offset] = data;
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+void mca16_curam16_plus_device::ems_4200_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_ems_regs_4200h[offset] = data;    
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+void mca16_curam16_plus_device::ems_8200_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_ems_regs_8200h[offset] = data;
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+void mca16_curam16_plus_device::ems_c200_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_ems_regs_c200h[offset] = data;
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+uint8_t mca16_curam16_plus_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    return 0x00;
+}
+
+void mca16_curam16_plus_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+uint8_t mca16_curam16_plus_device::pos_r(offs_t offset)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+			return get_card_id() & 0xFF;
+		case 1:
+			// Adapter Identification b8-b15
+			return (get_card_id() & 0xFF00) >> 8;
+		case 2:
+			// Option Select Data 1
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_1];
+			break;
+		case 3:
+			// Option Select Data 2
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_2];
+			break;
+		case 4:
+			// Option Select Data 3
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_3];
+			break;
+		case 5:
+			// Option Select Data 4
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_4];
+			break;
+		case 6:
+			// Subaddress Extension Low
+			return 0xff;
+			break;
+		case 7:
+			// Subaddress Extension High
+			return 0xff;
+			break;
+		default:
+			break;
+	}
+
+	return 0xFF;
+}
+
+void mca16_curam16_plus_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+            update_pos_data_1(data);
+			break;
+		case 3:
+			// Option Select Data 2
+            update_pos_data_2(data);
+			break;
+		case 4:
+			// Option Select Data 3
+            update_pos_data_3(data);
+			break;
+		case 5:
+			// Option Select Data 4
+            update_pos_data_4(data);
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}
+
+void mca16_curam16_plus_device::unmap()
+{
+    if(m_xms_start != 0) m_mca->unmap_readwrite(m_xms_start+0x60000, m_xms_end+0x60000);
+
+	m_is_mapped = false;
+}
+
+offs_t mca16_curam16_plus_device::calculate_xms_start_address()
+{
+    // XMS disabled?
+    if((m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] & 0b11100000) == 0b11100000)
+    {
+        return 0; // Disabled.
+    }
+
+    // XMS enabled, so where's it start?
+    uint8_t pos4 = m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] & 0b11111100;
+    uint8_t pos2 = m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0b01111000;
+
+    // TODO: Table
+    if(pos4 == 0b11011100 && pos2 == 0b00000000) return 0x100000;
+    else if(pos4 == 0b11011100 && pos2 == 0b01000000) return 0x200000;
+    else if(pos4 == 0b11011000 && pos2 == 0b00001000) return 0x300000;
+    else if(pos4 == 0b11011000 && pos2 == 0b01001000) return 0x400000;
+    else if(pos4 == 0b11010100 && pos2 == 0b00010000) return 0x500000;
+    else if(pos4 == 0b11010100 && pos2 == 0b01010000) return 0x600000;
+    else if(pos4 == 0b11010000 && pos2 == 0b00011000) return 0x700000;
+    else if(pos4 == 0b11010000 && pos2 == 0b01011000) return 0x800000;
+    else if(pos4 == 0b11001100 && pos2 == 0b00100000) return 0x900000;
+    else if(pos4 == 0b11001100 && pos2 == 0b01100000) return 0xa00000;
+    else if(pos4 == 0b11001000 && pos2 == 0b00101000) return 0xb00000;
+    else if(pos4 == 0b11001000 && pos2 == 0b01101000) return 0xc00000;
+    else if(pos4 == 0b11000100 && pos2 == 0b00110000) return 0xd00000;
+    else if(pos4 == 0b11000100 && pos2 == 0b01110000) return 0xe00000;
+
+    return 0; // ?
+}
+
+offs_t mca16_curam16_plus_device::calculate_xms_end_address()
+{
+    switch(m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0b01000111)
+    {
+        case 0b00000001: return 0x300000-1;
+        case 0b01000001: return 0x400000-1;
+        case 0b00000010: return 0x500000-1;
+        case 0b01000010: return 0x600000-1;
+        case 0b00000011: return 0x700000-1;
+        case 0b01000011: return 0x800000-1;
+        case 0b00000100: return 0x900000-1;
+        case 0b01000100: return 0xa00000-1;
+        case 0b00000101: return 0xb00000-1;
+        case 0b01000101: return 0xc00000-1;
+        case 0b00000110: return 0xd00000-1;
+        case 0b01000110: return 0xe00000-1;
+        case 0b00000111: return 0xf00000-1;
+        case 0b01000000: return 0xf80000-1;
+    }
+
+    return 0;
+}
+
+offs_t mca16_curam16_plus_device::calculate_ems_ports()
+{
+    return 0x200 + (((m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] & 0b01111110) >> 1) * 0x10);
+}
+
+void mca16_curam16_plus_device::remap()
+{
+    if(m_is_mapped) unmap();
+
+    m_xms_start = calculate_xms_start_address();
+    m_xms_end = calculate_xms_end_address();
+
+    LOG("%s: XMS mapping %06X-%06X\n", FUNCNAME, m_xms_start, m_xms_end);
+
+    // This is a 16-bit card that only works with 286 models that map the high 384K to 100000h.
+    if(m_xms_start != 0 && m_xms_end != 0)
+    {
+        // This is not the right behavior but I don't know what is.
+        m_mca->install_memory(m_xms_start+0x60000, m_xms_end+0x60000,
+            read8sm_delegate(*m_ram, FUNC(ram_device::read)), write8sm_delegate(*m_ram, FUNC(ram_device::write)));
+        m_is_mapped = true;
+    }
+
+    offs_t ems_base = calculate_ems_ports();
+    LOG("%s: installing EMS at %04X\n", FUNCNAME, ems_base);
+
+    m_mca->install_device(ems_base, ems_base+0xf, 
+        read8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_200_r)),
+        write8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_200_w)));
+    m_mca->install_device(ems_base+0x4000, ems_base+0x400f, 
+        read8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_4200_r)),
+        write8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_4200_w)));
+    m_mca->install_device(ems_base+0x8000, ems_base+0x800f, 
+        read8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_8200_r)),
+        write8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_8200_w)));
+    m_mca->install_device(ems_base+0xc000, ems_base+0xc00f, 
+        read8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_c200_r)),
+        write8sm_delegate(*this, FUNC(mca16_curam16_plus_device::ems_c200_w)));
+}
+
+bool mca16_curam16_plus_device::map_has_changed()
+{
+    // EMS mapping
+    // TODO: Set up EMS.
+    
+    // XMS mapping
+    offs_t calculated_xms_start = calculate_xms_start_address();
+    offs_t calculated_xms_end = calculate_xms_end_address();
+
+    return (calculated_xms_start != m_xms_start || calculated_xms_end != m_xms_end);
+}
+
+void mca16_curam16_plus_device::update_pos_data_1(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] = data;
+	//if(map_has_changed()) remap();
+}
+
+void mca16_curam16_plus_device::update_pos_data_2(uint8_t data)
+{
+    // POS 0 and POS 2 together control the mapping.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	//if(map_has_changed()) remap();
+}
+
+void mca16_curam16_plus_device::update_pos_data_3(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = data;
+    //if(map_has_changed()) remap();
+}
+
+void mca16_curam16_plus_device::update_pos_data_4(uint8_t data)
+{
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] = data;
+    if(map_has_changed()) remap();
+}
+
+uint8_t mca16_curam16_plus_device::ems_r(offs_t offset)
+{
+    // figure out paging...
+
+    /*
+        I think the mapping is something like:
+        register offset 01: select first 64K page
+        register offset 03: select second 64K page
+        register offset 05: select third 64K page
+        register offset 07: select fourth 64K page
+    */ 
+
+    uint8_t page = m_ems_regs_200h[1];
+    return m_ram->read(0x400000 + (page * 65536) + offset);
+}
+
+void mca16_curam16_plus_device::ems_w(offs_t offset, uint8_t data)
+{
+    uint8_t page = m_ems_regs_200h[1];
+    return m_ram->write(0x400000 + (page * 65536) + offset, data);
+}

--- a/src/devices/bus/mca/curam.h
+++ b/src/devices/bus/mca/curam.h
@@ -1,0 +1,92 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    Cumulus CuRAM-16 Plus Memory Multifunction Adapter
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_CURAM_H
+#define MAME_BUS_MCA_CURAM_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/ram.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_curam16_plus_device
+
+class mca16_curam16_plus_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_curam16_plus_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+    virtual uint16_t get_card_id() override { return 0x6025; }
+
+	virtual void remap() override;
+	virtual void unmap() override;
+	
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+	virtual uint8_t pos_r(offs_t offset) override;
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+    virtual void update_pos_data_1(uint8_t data) override;
+    virtual void update_pos_data_2(uint8_t data) override;
+    virtual void update_pos_data_3(uint8_t data) override;
+	virtual void update_pos_data_4(uint8_t data) override;
+
+	uint8_t ems_200_r(offs_t offset);
+	uint8_t ems_4200_r(offs_t offset);
+	uint8_t ems_8200_r(offs_t offset);
+	uint8_t ems_c200_r(offs_t offset);
+
+	void ems_200_w(offs_t offset, uint8_t data);
+	void ems_4200_w(offs_t offset, uint8_t data);
+	void ems_8200_w(offs_t offset, uint8_t data);
+	void ems_c200_w(offs_t offset, uint8_t data);
+
+	uint8_t ems_r(offs_t offset);
+	void ems_w(offs_t offset, uint8_t data);
+
+protected:
+	mca16_curam16_plus_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual bool map_has_changed() override;
+	
+	required_device<ram_device> m_ram;
+private:
+    offs_t  calculate_xms_start_address();
+    offs_t  calculate_xms_end_address();
+
+	offs_t	calculate_ems_ports();
+
+	bool 	m_is_mapped;
+
+    offs_t  m_xms_start, m_xms_end;
+
+	uint8_t m_ems_regs_200h[16];
+	uint8_t m_ems_regs_4200h[16];
+	uint8_t m_ems_regs_8200h[16];
+	uint8_t m_ems_regs_c200h[16];
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_CURAM16_PLUS, mca16_curam16_plus_device)
+
+#endif

--- a/src/devices/bus/mca/ibm72x8299.cpp
+++ b/src/devices/bus/mca/ibm72x8299.cpp
@@ -1,0 +1,387 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM 72X8299 I/O controller
+    Provides the interface between the Micro Channel bus and planar peripherals.
+	Effectively the southbridge chip, controlling the onboard peripherals.
+
+	From the perspective of the BIOS, the 72X8299 is an MCA device, in charge
+	of the System Board device.
+	
+	Controls:
+	- One 16550 UART
+	- One 72X8287 VGA controller
+	- One Centronics parallel port
+	- One uPD72065 FDC
+	- Two PITs, AT-compatible
+
+***************************************************************************/
+
+#include "emu.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/mca_cards.h"
+#include "bus/mca/planar_uart.h"
+#include "bus/mca/planar_lpt.h"
+#include "bus/mca/planar_fdc.h"
+#include "bus/mca/planar_vga.h"
+#include "bus/mca/ibm72x8299.h"
+#include "machine/ibmps2.h"
+
+#define LOG_PORT80  0
+
+#define LOG_SYSPORTS    (1U <<  2)
+#define LOG_NVRAM       (1U <<  3)
+#define LOG_TIMERS      (1U <<  4)
+#define LOG_POST        (1U <<  5)
+#define LOG_POS         (1U <<  6)
+
+#define VERBOSE (LOG_SYSPORTS|LOG_NVRAM|LOG_TIMERS|LOG_POST|LOG_POS)
+#include "logmacro.h"
+
+#define LOGSYSPORTS(...)    LOGMASKED(LOG_SYSPORTS, __VA_ARGS__)
+#define LOGNVRAM(...)       LOGMASKED(LOG_NVRAM, __VA_ARGS__)
+#define LOGTIMERS(...)      LOGMASKED(LOG_TIMERS, __VA_ARGS__)
+#define LOGPOST(...)        LOGMASKED(LOG_POST, __VA_ARGS__)
+#define LOGPOS(...)         LOGMASKED(LOG_POS, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+#define XTAL_U153   25.175_MHz_XTAL
+
+DEFINE_DEVICE_TYPE(IBM72X8299, ibm72x8299_device, "ibm72x8299", "IBM 72X8299 Micro Channel I/O Controller")
+
+ibm72x8299_device::ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, ps2_mb_device *planar)
+	: ibm72x8299_device(mconfig, tag, owner, clock)
+{
+	m_planar = planar;
+	m_planar_id = planar->get_planar_id();
+}
+
+ibm72x8299_device::ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, IBM72X8299, tag, owner, clock)
+	, device_mca16_card_interface(mconfig, *this, m_planar_id)
+    , m_planar_vga(*this, "planar_vga")
+    , m_planar_fdc(*this, "planar_fdc")
+    , m_planar_uart(*this, "planar_uart")
+    , m_planar_lpt(*this, "planar_lpt")
+    , m_pit(*this, "pit")
+    , m_pit_ch_cb(*this)
+{
+}
+
+void ibm72x8299_device::device_start()
+{
+    m_system_board_io_enable = 0;
+    m_system_board_setup = 0xff;
+}
+
+void ibm72x8299_device::device_reset()
+{
+    m_system_board_io_enable = 0;
+    m_system_board_setup = 0xff;        // page 2-32: resets to 0xFF
+    m_adapter_setup = 0;
+    
+    m_cd_sfdbk = 0;
+}
+
+void ibm72x8299_device::device_add_mconfig(machine_config &config)
+{
+	// TODO: get rid of this absolute tag
+   	MCA16_SLOT(config, m_planar_vga,    0, ":mb:mcabus", pc_mca16_cards, "planar_vga", true);
+	MCA16_SLOT(config, m_planar_fdc,    0, ":mb:mcabus", pc_mca16_cards, "planar_fdc", true);
+	MCA16_SLOT(config, m_planar_uart,   0, ":mb:mcabus", pc_mca16_cards, "planar_uart", true);
+	MCA16_SLOT(config, m_planar_lpt,    0, ":mb:mcabus", pc_mca16_cards, "planar_lpt", true);
+
+    PS2_PIT(config, m_pit);
+    m_pit->set_clk<0>(XTAL_U153 / 21); /* heartbeat IRQ */
+	m_pit->out_handler<0>().set(FUNC(ibm72x8299_device::pit_ch0_w));
+	m_pit->set_clk<1>(XTAL_U153 / 21); /* dram refresh */
+	m_pit->set_clk<2>(XTAL_U153 / 21); /* pio port c pin 4 and speaker polling */
+	m_pit->out_handler<2>().set(FUNC(ibm72x8299_device::pit_ch2_w));
+	// CH 3 behavior: IRQ0 asserted enables the gate.
+	// CLK IN 3 is tied to ~(CLK OUT 0).
+	// If CLK OUT 3 is high, the NMI is asserted.
+	// Effectively, it asserts NMI when IRQ 0 is active for more than one CH 0 tick.
+	m_pit->ch3_out_handler().set(FUNC(ibm72x8299_device::pit_ch3_w));
+}
+
+void ibm72x8299_device::device_config_complete()
+{
+
+}
+
+void ibm72x8299_device::device_resolve_objects()
+{
+	// resolve callbacks
+	m_pit_ch_cb.resolve_all_safe();
+}
+
+
+/* PIT write lines and gates */
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch0_w)
+{
+    m_pit_ch_cb[0](state);
+}
+
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch2_w)
+{
+    m_pit_ch_cb[2](state);
+}
+
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch3_w)
+{
+    m_pit_ch_cb[3](state);
+}
+
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch2_gate_w)
+{
+    m_pit->write_gate2(state);
+}
+
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch3_gate_w)
+{
+    m_pit->write_gate3(state);
+}
+
+WRITE_LINE_MEMBER(ibm72x8299_device::pit_ch3_clk_w)
+{
+    m_pit->write_clk3(state);
+}
+
+// POS
+
+uint8_t ibm72x8299_device::adapter_pos_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s: %02X\n", FUNCNAME, m_adapter_setup | 0x70);
+	return m_adapter_setup | 0x70; // Always OR with $70 when reading this.
+}
+
+void ibm72x8299_device::adapter_pos_w(uint8_t data)
+{
+	LOGPOS("%s: %02X\n", FUNCNAME, data);
+	if(BIT(data, 3))
+	{
+		LOGPOS("%s: Selected channel %d for setup\n", FUNCNAME, (data & 7) + 1);
+	}
+	if(BIT(data, 7))
+	{
+		LOGPOS("%s: Channel reset asserted\n", FUNCNAME);
+	}
+
+	m_adapter_setup = data;
+}
+
+
+uint8_t ibm72x8299_device::system_board_pos_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s: %02X\n", FUNCNAME, m_system_board_setup);
+	return m_system_board_setup;
+}
+
+void ibm72x8299_device::system_board_pos_w(uint8_t data)
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s: %02X\n", FUNCNAME, data);
+	m_system_board_setup = data;
+}
+
+std::string posreg_name(offs_t offset)
+{
+	switch(offset)
+	{
+		case 0: return "ADAPTER_ID_LO";
+		case 1: return "ADAPTER_ID_HI";
+		case 2: return "OPTION_SELECT_DATA_1";
+		case 3: return "OPTION_SELECT_DATA_2";
+		case 4: return "OPTION_SELECT_DATA_3";
+		case 5: return "OPTION_SELECT_DATA_4";
+		case 6: return "SUBADDRESS_EXT_LO";
+		case 7:	return "SUBADDRESS_EXT_HI";
+		default: return "(error)";
+	}
+}
+
+uint8_t ibm72x8299_device::pos_registers_r(offs_t offset)
+{
+	// Programmable Option Select registers.
+	// 100: adapter identification low
+	// 101: adapter identification high
+	// 102: option select data 1
+	// 103: option select data 2
+	// 104: option select data 3
+	// 105: option select data 4
+	// 106: subaddress extension low
+	// 107: subaddress extension high
+
+	// Special case: Reading the planar VGA's registers.
+	if(BIT(m_system_board_setup, 5) == 0)
+	{
+		if(!machine().side_effects_disabled()) LOGPOS("%s: reading VGA POS register %s\n", FUNCNAME, posreg_name(offset));
+
+		// VGA I/O byte.
+		if(offset == MCABus::POS::OPTION_SELECT_DATA_1)
+			return dynamic_cast<mca16_planar_vga_device *>(m_planar_vga->get_card_device())->sleep_r();
+		else return 0xFF;
+	}
+	// Special case: Reading the planar's registers rather than an adapter.
+	if(!BIT(m_system_board_setup, 7))
+	{
+		if(!machine().side_effects_disabled()) LOGPOS("%s: reading planar POS register %s\n", FUNCNAME, posreg_name(offset));
+		return m_planar->planar_pos_r(offset);
+	}
+
+	if(m_planar->get_mca_slot(m_adapter_setup & 7) != NULL)
+	{
+		auto card = dynamic_cast<device_mca16_card_interface *>(m_planar->get_mca_slot(m_adapter_setup & 7)->get_card_device());
+		if(card)
+		{
+			uint8_t value = (card ? card->pos_r(offset) : 0xFF);
+			LOGPOS("%s: reading adapter %d POS register %s: %02X\n", FUNCNAME, (m_adapter_setup & 7) + 1, posreg_name(offset), value);
+			return value;
+		}
+		else
+		{
+			LOGPOS("%s: no card in slot %d\n", FUNCNAME, (m_adapter_setup & 7) + 1);
+			return 0xFF;
+		}
+	}
+	else return 0xFF;
+}
+
+void ibm72x8299_device::pos_registers_w(offs_t offset, uint8_t data)
+{
+
+	if(BIT(m_system_board_setup, 5) == 0)
+	{
+		if(!machine().side_effects_disabled()) LOGPOS("%s: writing VGA POS register %s: %02X\n", FUNCNAME, posreg_name(offset), data);
+
+		// VGA I/O byte.
+		if(offset == MCABus::POS::OPTION_SELECT_DATA_1)
+			dynamic_cast<mca16_planar_vga_device *>(m_planar_vga->get_card_device())->sleep_w(data);
+		return;
+	}
+
+	if(BIT(m_system_board_setup, 7) == 0)
+	{
+		if(!machine().side_effects_disabled()) LOGPOS("%s: writing planar POS register %s: %02X\n", FUNCNAME, posreg_name(offset), data);
+
+		m_planar->planar_pos_w(offset, data);
+		return;
+	}
+
+	if(m_planar->get_mca_slot(m_adapter_setup & 7) != NULL)
+	{
+		auto card = dynamic_cast<device_mca16_card_interface *>(m_planar->get_mca_slot(m_adapter_setup & 7)->get_card_device());
+
+		if(card)
+		{
+			LOGPOS("%s: writing adapter %d POS register %s: %02X\n", FUNCNAME, (m_adapter_setup & 7) + 1, posreg_name(offset), data);
+			card->pos_w(offset, data);
+		}
+		else
+		{
+			LOGPOS("%s: no card in slot %d\n", FUNCNAME, (m_adapter_setup & 7) + 1);
+		}
+	}
+}
+
+void ibm72x8299_device::system_board_io_w(uint8_t data)
+{
+	LOGPOS("%s\n", FUNCNAME);
+
+	m_system_board_io_enable = data;
+
+	// Bit 7: Parallel port is bidirectional when asserted.
+
+	// Bits 5-6: LPT1/LPT2/LPT3?
+	uint8_t lpt_select = (data & 0x60) >> 5;
+	switch(lpt_select)
+	{
+		case 0:
+			LOGPOS("%s: reassigning planar UART %p to LPT1\n", FUNCNAME, m_planar_lpt->get_card_device());
+			dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->planar_remap(AS_IO, 0x3BC, 0x3BF);
+			break;
+		case 1:
+			LOGPOS("%s: reassigning planar UART %p to LPT2\n", FUNCNAME, m_planar_lpt->get_card_device());
+			dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->planar_remap(AS_IO, 0x378, 0x37B);
+			break;
+		case 2:
+			LOGPOS("%s: reassigning planar UART %p to LPT3\n", FUNCNAME, m_planar_lpt->get_card_device());
+			dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->planar_remap(AS_IO, 0x278, 0x27B);
+			break;
+		default:
+			break;
+	}
+
+	// Bit 4: Parallel port enabled when asserted.
+	if(BIT(m_system_board_io_enable, 4))
+	{
+		dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->enable();
+	}
+	else
+	{
+		dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->disable();
+	}
+
+	// Bit 3: COM1 or COM2?
+	if(BIT(m_system_board_io_enable, 3) == 1)
+	{
+		LOGPOS("%s: reassigning planar UART %p to COM1\n", FUNCNAME, m_planar_uart->get_card_device());
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->planar_remap(AS_IO, 0x3F8, 0x3F8+7);
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->planar_remap_irq(4);
+	}
+	else
+	{
+		LOGPOS("%s: reassigning planar UART %p to COM2\n", FUNCNAME, m_planar_uart->get_card_device());
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->planar_remap(AS_IO, 0x2F8, 0x2F8+7);
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->planar_remap_irq(3);
+	}
+
+	// Bit 2: Serial port enabled when asserted.
+	if(BIT(m_system_board_io_enable, 2))
+	{
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->enable();
+	}
+	else
+	{
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->disable();
+	}
+
+	// Bit 1: Floppy drive enabled when asserted.
+	if(BIT(m_system_board_io_enable, 1))
+	{
+		LOGPOS("FDC enabled\n");
+		dynamic_cast<mca16_planar_fdc_device *>(m_planar_fdc->get_card_device())->enable();
+	}
+	else
+	{
+		LOGPOS("FDC disabled\n");
+		dynamic_cast<mca16_planar_fdc_device *>(m_planar_fdc->get_card_device())->disable();
+	}
+
+	// Bit 0: If cleared, all devices disabled.
+	if(!BIT(m_system_board_io_enable, 0))
+	{
+		dynamic_cast<mca16_planar_fdc_device *>(m_planar_fdc->get_card_device())->disable();
+		dynamic_cast<mca16_planar_uart_device *>(m_planar_uart->get_card_device())->disable();
+		dynamic_cast<mca16_planar_lpt_device *>(m_planar_lpt->get_card_device())->disable();
+	}
+}
+
+WRITE_LINE_MEMBER( ibm72x8299_device::cd_sfdbk_w )
+{
+	// An MCA adapter asserts this on any I/O access.
+	if(state) m_cd_sfdbk = true;
+}
+
+uint8_t ibm72x8299_device::card_select_feedback_r(offs_t offset)
+{
+	// Reading automatically resets the feedback bit.
+	uint8_t feedback = m_cd_sfdbk;
+	m_cd_sfdbk = 0;
+	return feedback; // Return state as bit 0.
+}

--- a/src/devices/bus/mca/ibm72x8299.cpp
+++ b/src/devices/bus/mca/ibm72x8299.cpp
@@ -59,7 +59,7 @@ ibm72x8299_device::ibm72x8299_device(const machine_config &mconfig, const char *
 	: ibm72x8299_device(mconfig, tag, owner, clock)
 {
 	m_planar = planar;
-	m_mca = bus;
+	m_mca = planar->get_mca_bus();
 	m_planar_id = planar->get_planar_id();
 }
 
@@ -92,13 +92,12 @@ void ibm72x8299_device::device_reset()
 
 void ibm72x8299_device::device_add_mconfig(machine_config &config)
 {
-   	MCA16_SLOT(config, m_planar_vga,    0, *m_mca, pc_mca16_cards, "planar_vga", true);
-	MCA16_SLOT(config, m_planar_fdc,    0, *m_mca, pc_mca16_cards, "planar_fdc", true);
-	MCA16_SLOT(config, m_planar_uart,   0, *m_mca, pc_mca16_cards, "planar_uart", true);
-	MCA16_SLOT(config, m_planar_lpt,    0, *m_mca, pc_mca16_cards, "planar_lpt", true);
+   	MCA16_SLOT(config, m_planar_vga,    0, ":mb:mcabus", pc_mca16_cards, "planar_vga", true);
+	MCA16_SLOT(config, m_planar_fdc,    0, ":mb:mcabus", pc_mca16_cards, "planar_fdc", true);
+	MCA16_SLOT(config, m_planar_uart,   0, ":mb:mcabus", pc_mca16_cards, "planar_uart", true);
+	MCA16_SLOT(config, m_planar_lpt,    0, ":mb:mcabus", pc_mca16_cards, "planar_lpt", true);
 
 	m_mca->cs_feedback_callback().set(*this, FUNC(ibm72x8299_device::cd_sfdbk_w));
-	printf("assert card feedback r %p\n", m_mca);
 
     PS2_PIT(config, m_pit);
     m_pit->set_clk<0>(XTAL_U153 / 21); /* heartbeat IRQ */

--- a/src/devices/bus/mca/ibm72x8299.h
+++ b/src/devices/bus/mca/ibm72x8299.h
@@ -1,0 +1,79 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+#ifndef MAME_BUS_MCA_IBM72X8299_H
+#define MAME_BUS_MCA_IBM72X8299_H
+
+#pragma once
+
+#include "bus/mca/mca.h"
+#include "machine/pit8253.h"
+
+class ps2_mb_device;
+
+class ibm72x8299_device : public device_t, public device_mca16_card_interface
+{
+public:
+	ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, ps2_mb_device *planar);
+    ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// outputs to host
+	template<std::size_t Line> auto pit_ch_callback() { return m_pit_ch_cb[Line].bind(); }
+
+    uint8_t pit_r(offs_t offset) { return m_pit->read(offset); };
+    void pit_w(offs_t offset, uint8_t data) { m_pit->write(offset, data); }
+
+    void    system_board_io_w(uint8_t data);
+    uint8_t system_board_io_r() { return m_system_board_io_enable; }
+
+    uint8_t system_board_pos_r();
+    void    system_board_pos_w(uint8_t data);
+
+    uint8_t pos_registers_r(offs_t offset);
+    void    pos_registers_w(offs_t offset, uint8_t data);
+
+    uint8_t adapter_pos_r();
+    void    adapter_pos_w(uint8_t data);
+
+    void    set_planar(ps2_mb_device *planar) { m_planar = planar; }
+
+    uint8_t card_select_feedback_r(offs_t offset);
+
+    DECLARE_WRITE_LINE_MEMBER(pit_ch2_gate_w);
+    DECLARE_WRITE_LINE_MEMBER(pit_ch3_gate_w);
+    DECLARE_WRITE_LINE_MEMBER(pit_ch3_clk_w);
+    
+    DECLARE_WRITE_LINE_MEMBER(cd_sfdbk_w);
+
+protected:
+	void device_start() override;
+	void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+    virtual void device_resolve_objects() override;
+    virtual void device_config_complete() override;
+
+	required_device<mca16_slot_device> m_planar_vga;
+    required_device<mca16_slot_device> m_planar_fdc;
+	required_device<mca16_slot_device> m_planar_uart;
+	required_device<mca16_slot_device> m_planar_lpt;
+
+private:
+    required_device<ps2_pit_device> m_pit;
+
+    DECLARE_WRITE_LINE_MEMBER(pit_ch0_w);
+    DECLARE_WRITE_LINE_MEMBER(pit_ch2_w);
+    DECLARE_WRITE_LINE_MEMBER(pit_ch3_w);
+    
+	devcb_write_line::array<4> m_pit_ch_cb;
+
+    uint8_t m_system_board_io_enable;
+    uint8_t m_system_board_setup;
+    uint8_t m_adapter_setup;
+   	bool m_cd_sfdbk;
+
+    ps2_mb_device *m_planar;
+    uint16_t m_planar_id;
+};
+
+DECLARE_DEVICE_TYPE(IBM72X8299, ibm72x8299_device)
+
+#endif

--- a/src/devices/bus/mca/ibm72x8299.h
+++ b/src/devices/bus/mca/ibm72x8299.h
@@ -13,7 +13,7 @@ class ps2_mb_device;
 class ibm72x8299_device : public device_t, public device_mca16_card_interface
 {
 public:
-	ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, ps2_mb_device *planar);
+	ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, ps2_mb_device *planar, mca16_device *bus);
     ibm72x8299_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// outputs to host
@@ -38,11 +38,11 @@ public:
 
     uint8_t card_select_feedback_r(offs_t offset);
 
-    DECLARE_WRITE_LINE_MEMBER(pit_ch2_gate_w);
-    DECLARE_WRITE_LINE_MEMBER(pit_ch3_gate_w);
-    DECLARE_WRITE_LINE_MEMBER(pit_ch3_clk_w);
+    void pit_ch2_gate_w(int state);
+    void pit_ch3_gate_w(int state);
+    void pit_ch3_clk_w(int state);
     
-    DECLARE_WRITE_LINE_MEMBER(cd_sfdbk_w);
+    void cd_sfdbk_w(int state);
 
 protected:
 	void device_start() override;
@@ -59,9 +59,9 @@ protected:
 private:
     required_device<ps2_pit_device> m_pit;
 
-    DECLARE_WRITE_LINE_MEMBER(pit_ch0_w);
-    DECLARE_WRITE_LINE_MEMBER(pit_ch2_w);
-    DECLARE_WRITE_LINE_MEMBER(pit_ch3_w);
+    void pit_ch0_w(int state);
+    void pit_ch2_w(int state);
+    void pit_ch3_w(int state);
     
 	devcb_write_line::array<4> m_pit_ch_cb;
 

--- a/src/devices/bus/mca/ibm_dual_async.cpp
+++ b/src/devices/bus/mca/ibm_dual_async.cpp
@@ -1,0 +1,431 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+	MCA 16-bit Dual Asynchronous Communication Card
+
+	Configuration info from the ADF:
+	
+	Connector 1:
+		choice "SERIAL_1"  pos[0]=XXXX000Xb  io 03f8h-03ffh  int 4
+		choice "SERIAL_2"  pos[0]=XXXX001Xb  io 02f8h-02ffh  int 3
+		choice "SERIAL_3"  pos[0]=XXXX010Xb  io 3220h-3227h  int 3
+		choice "SERIAL_4"  pos[0]=XXXX011Xb  io 3228h-322fh  int 3
+		choice "SERIAL_5"  pos[0]=XXXX100Xb  io 4220h-4227h  int 3
+		choice "SERIAL_6"  pos[0]=XXXX101Xb  io 4228h-422fh  int 3
+		choice "SERIAL_7"  pos[0]=XXXX110Xb  io 5220h-5227h  int 3
+		choice "SERIAL_8"  pos[0]=XXXX111Xb  io 5228h-522fh  int 3
+
+	Connector 2:
+		choice "SERIAL_1"  pos[0]=1000XXXXb  io 03f8h-03ffh  int 4
+		choice "SERIAL_2"  pos[0]=1001XXXXb  io 02f8h-02ffh  int 3
+		choice "SERIAL_3"  pos[0]=1010XXXXb  io 3220h-3227h  int 3
+		choice "SERIAL_4"  pos[0]=1011XXXXb  io 3228h-322fh  int 3
+		choice "SERIAL_5"  pos[0]=1100XXXXb  io 4220h-4227h  int 3
+		choice "SERIAL_6"  pos[0]=1101XXXXb  io 4228h-422fh  int 3
+		choice "SERIAL_7"  pos[0]=1110XXXXb  io 5220h-5227h  int 3
+		choice "SERIAL_8"  pos[0]=1111XXXXb  io 5228h-522fh  int 3
+
+***************************************************************************/
+
+#include "emu.h"
+#include "ibm_dual_async.h"
+
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+#include "machine/ins8250.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+enum io_assignments
+{
+	SERIAL_1 = 0x3F8,
+	SERIAL_2 = 0x2F8,
+	SERIAL_3 = 0x3220,
+	SERIAL_4 = 0x3228,
+	SERIAL_5 = 0x4220,
+	SERIAL_6 = 0x4228,
+	SERIAL_7 = 0x5220,
+	SERIAL_8 = 0x5228
+};
+
+static void isa_com(device_slot_interface &device)
+{
+	device.option_add("microsoft_mouse", MSFT_HLE_SERIAL_MOUSE);
+	device.option_add("logitech_mouse", LOGITECH_HLE_SERIAL_MOUSE);
+	device.option_add("wheel_mouse", WHEEL_HLE_SERIAL_MOUSE);
+	device.option_add("msystems_mouse", MSYSTEMS_HLE_SERIAL_MOUSE);
+	device.option_add("rotatable_mouse", ROTATABLE_HLE_SERIAL_MOUSE);
+	device.option_add("terminal", SERIAL_TERMINAL);
+	device.option_add("null_modem", NULL_MODEM);
+	device.option_add("sun_kbd", SUN_KBD_ADAPTOR);
+}
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_IBM_DUAL_ASYNC, mca16_ibm_dual_async_device, "mca_ibm_dual_async", "IBM Dual Async Adapter (@EEFF)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_ibm_dual_async_device::device_add_mconfig(machine_config &config)
+{
+	NS16550(config, m_uart1, XTAL(1'843'200));
+	m_uart1->out_tx_callback().set("serport0", FUNC(rs232_port_device::write_txd));
+	m_uart1->out_dtr_callback().set("serport0", FUNC(rs232_port_device::write_dtr));
+	m_uart1->out_rts_callback().set("serport0", FUNC(rs232_port_device::write_rts));
+	m_uart1->out_int_callback().set(FUNC(mca16_ibm_dual_async_device::pc_com_interrupt_1));
+	NS16550(config, m_uart2, XTAL(1'843'200));
+	m_uart2->out_tx_callback().set("serport1", FUNC(rs232_port_device::write_txd));
+	m_uart2->out_dtr_callback().set("serport1", FUNC(rs232_port_device::write_dtr));
+	m_uart2->out_rts_callback().set("serport1", FUNC(rs232_port_device::write_rts));
+	m_uart2->out_int_callback().set(FUNC(mca16_ibm_dual_async_device::pc_com_interrupt_2));
+
+	rs232_port_device &serport0(RS232_PORT(config, "serport0", isa_com, nullptr));
+	serport0.rxd_handler().set(m_uart1, FUNC(ins8250_uart_device::rx_w));
+	serport0.dcd_handler().set(m_uart1, FUNC(ins8250_uart_device::dcd_w));
+	serport0.dsr_handler().set(m_uart1, FUNC(ins8250_uart_device::dsr_w));
+	serport0.ri_handler().set(m_uart1, FUNC(ins8250_uart_device::ri_w));
+	serport0.cts_handler().set(m_uart1, FUNC(ins8250_uart_device::cts_w));
+
+	rs232_port_device &serport1(RS232_PORT(config, "serport1", isa_com, nullptr));
+	serport1.rxd_handler().set(m_uart2, FUNC(ins8250_uart_device::rx_w));
+	serport1.dcd_handler().set(m_uart2, FUNC(ins8250_uart_device::dcd_w));
+	serport1.dsr_handler().set(m_uart2, FUNC(ins8250_uart_device::dsr_w));
+	serport1.ri_handler().set(m_uart2, FUNC(ins8250_uart_device::ri_w));
+	serport1.cts_handler().set(m_uart2, FUNC(ins8250_uart_device::cts_w));
+}
+
+//-------------------------------------------------
+//  isa8_com_device - constructor
+//-------------------------------------------------
+
+mca16_ibm_dual_async_device::mca16_ibm_dual_async_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_ibm_dual_async_device(mconfig, MCA16_IBM_DUAL_ASYNC, tag, owner, clock)
+{
+}
+
+mca16_ibm_dual_async_device::mca16_ibm_dual_async_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xeeff),
+	m_uart1(*this, "uart1"),
+	m_uart2(*this, "uart2")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_ibm_dual_async_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_ibm_dual_async_device::device_reset()
+{
+}
+
+uint8_t mca16_ibm_dual_async_device::pos_r(offs_t offset)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+			return get_card_id() & 0xFF;
+		case 1:
+			// Adapter Identification b8-b15
+			return (get_card_id() & 0xFF00) >> 8;
+		case 2:
+			// Option Select Data 1
+			break;
+		case 3:
+			// Option Select Data 2
+			break;
+		case 4:
+			// Option Select Data 3
+			break;
+		case 5:
+			// Option Select Data 4
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+
+	return 0xFF;
+}
+
+void mca16_ibm_dual_async_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+			m_option_select[0] = data;
+			remap();
+			break;
+		case 3:
+			// Option Select Data 2
+			break;
+		case 4:
+			// Option Select Data 3
+			break;
+		case 5:
+			// Option Select Data 4
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}
+
+uint8_t mca16_ibm_dual_async_device::uart1_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_uart1->ins8250_r(offset);
+}
+
+void mca16_ibm_dual_async_device::uart1_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_uart1->ins8250_w(offset, data);
+}
+
+uint8_t mca16_ibm_dual_async_device::uart2_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_uart2->ins8250_r(offset);
+}
+
+void mca16_ibm_dual_async_device::uart2_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_uart2->ins8250_w(offset, data);
+}
+
+void mca16_ibm_dual_async_device::unmap()
+{
+	
+}
+
+void mca16_ibm_dual_async_device::remap()
+{
+	update_serial_assignment(m_option_select[0]);
+}
+
+void mca16_ibm_dual_async_device::update_serial_assignment(uint8_t pos)
+{
+	uint8_t uart1_assignment = pos & 7;
+	uint8_t uart2_assignment = (pos >> 4) & 7;
+
+	uint8_t old_uart1_assignment = m_serial_assignment & 7;
+	uint8_t old_uart2_assignment = (m_serial_assignment >> 4) & 7;
+
+	if(m_is_mapped)
+	{
+		switch(old_uart1_assignment)
+		{
+			case 0: m_mca->unmap_device(SERIAL_1, SERIAL_1+7); break;
+			case 1: m_mca->unmap_device(SERIAL_2, SERIAL_2+7); break;
+			case 2: m_mca->unmap_device(SERIAL_3, SERIAL_3+7); break;
+			case 3: m_mca->unmap_device(SERIAL_4, SERIAL_4+7); break;
+			case 4: m_mca->unmap_device(SERIAL_5, SERIAL_5+7); break;
+			case 5: m_mca->unmap_device(SERIAL_6, SERIAL_6+7); break;
+			case 6: m_mca->unmap_device(SERIAL_7, SERIAL_7+7); break;
+			case 7: m_mca->unmap_device(SERIAL_8, SERIAL_8+7); break;
+			default: break;
+		}
+
+		switch(old_uart2_assignment)
+		{
+			case 0: m_mca->unmap_device(SERIAL_1, SERIAL_1+7); break;
+			case 1: m_mca->unmap_device(SERIAL_2, SERIAL_2+7); break;
+			case 2: m_mca->unmap_device(SERIAL_3, SERIAL_3+7); break;
+			case 3: m_mca->unmap_device(SERIAL_4, SERIAL_4+7); break;
+			case 4: m_mca->unmap_device(SERIAL_5, SERIAL_5+7); break;
+			case 5: m_mca->unmap_device(SERIAL_6, SERIAL_6+7); break;
+			case 6: m_mca->unmap_device(SERIAL_7, SERIAL_7+7); break;
+			case 7: m_mca->unmap_device(SERIAL_8, SERIAL_8+7); break;
+			default: break;
+		}
+	}
+
+	switch(uart1_assignment)
+	{
+		case 0: 
+		{ 
+			m_mca->install_device(SERIAL_1, SERIAL_1+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 4;
+			break;
+		}
+		case 1:
+		{
+			m_mca->install_device(SERIAL_2, SERIAL_2+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;
+			break;
+		}
+		case 2: 
+		{ 
+			m_mca->install_device(SERIAL_3, SERIAL_3+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;	
+			break;	
+		}
+		case 3: 
+		{
+			m_mca->install_device(SERIAL_4, SERIAL_4+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;	
+			break;	
+		}
+		case 4: 
+		{
+			m_mca->install_device(SERIAL_5, SERIAL_5+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;
+			break;		
+		} 
+		case 5: 
+		{ 
+			m_mca->install_device(SERIAL_6, SERIAL_6+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;
+			break;		
+		}
+		case 6: 
+		{
+			m_mca->install_device(SERIAL_7, SERIAL_7+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;
+			break;			
+		}
+		case 7:
+		{
+			m_mca->install_device(SERIAL_8, SERIAL_8+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart1_w)));
+			m_cur_irq_uart1 = 3;
+			break;
+		}
+		default: break;
+	}
+
+	switch(uart2_assignment)
+	{
+		case 0: 
+		{ 
+			m_mca->install_device(SERIAL_1, SERIAL_1+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 4;
+			break;
+		}
+		case 1:
+		{
+			m_mca->install_device(SERIAL_2, SERIAL_2+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;
+			break;
+		}
+		case 2: 
+		{ 
+			m_mca->install_device(SERIAL_3, SERIAL_3+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;	
+			break;	
+		}
+		case 3: 
+		{
+			m_mca->install_device(SERIAL_4, SERIAL_4+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;	
+			break;	
+		}
+		case 4: 
+		{
+			m_mca->install_device(SERIAL_5, SERIAL_5+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;	
+			break;	
+		} 
+		case 5: 
+		{ 
+			m_mca->install_device(SERIAL_6, SERIAL_6+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;		
+			break;
+		}
+		case 6: 
+		{
+			m_mca->install_device(SERIAL_7, SERIAL_7+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;
+			break;		
+		}
+		case 7:
+		{
+			m_mca->install_device(SERIAL_8, SERIAL_8+7, 
+				read8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_r)),
+				write8sm_delegate(*this, FUNC(mca16_ibm_dual_async_device::uart2_w)));
+			m_cur_irq_uart2 = 3;
+			break;
+		}
+		default: break;
+	}
+
+	old_uart1_assignment = uart1_assignment;
+	old_uart2_assignment = uart2_assignment;
+}

--- a/src/devices/bus/mca/ibm_dual_async.h
+++ b/src/devices/bus/mca/ibm_dual_async.h
@@ -31,8 +31,8 @@ public:
 	// construction/destruction
 	mca16_ibm_dual_async_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_1) { if(m_cur_irq_uart1 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
-	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_2) { if(m_cur_irq_uart2 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
+	void pc_com_interrupt_1(int state) { if(m_cur_irq_uart1 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
+	void pc_com_interrupt_2(int state) { if(m_cur_irq_uart2 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
 
 	virtual void unmap() override;
 	virtual void remap() override;

--- a/src/devices/bus/mca/ibm_dual_async.h
+++ b/src/devices/bus/mca/ibm_dual_async.h
@@ -1,0 +1,76 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM Dual Asynchronous Adapter 
+    FRU 90X9229
+
+    16-bit MCA card with two 16550 UARTs.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_DUALASYNC_H
+#define MAME_BUS_MCA_DUALASYNC_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/ins8250.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> isa8_com_device
+
+class mca16_ibm_dual_async_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_ibm_dual_async_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_1) { if(m_cur_irq_uart1 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
+	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_2) { if(m_cur_irq_uart2 == 4) m_mca->ireq_w<4>(state); else m_mca->ireq_w<3>(state); }
+
+	virtual void unmap() override;
+	virtual void remap() override;
+
+	uint8_t uart1_r(offs_t offset);
+	void uart1_w(offs_t offset, uint8_t data);
+
+	uint8_t uart2_r(offs_t offset);
+	void uart2_w(offs_t offset, uint8_t data);
+
+protected:
+	mca16_ibm_dual_async_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual uint8_t pos_r(offs_t offset) override;
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+	required_device<ns16550_device> m_uart1;
+	required_device<ns16550_device> m_uart2;
+
+private:
+	void update_serial_assignment(uint8_t pos);
+
+	uint8_t m_serial_assignment;
+
+	uint8_t m_cur_irq_uart1;
+	uint8_t m_cur_irq_uart2;
+	
+	uint8_t m_is_mapped;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_IBM_DUAL_ASYNC, mca16_ibm_dual_async_device)
+
+#endif

--- a/src/devices/bus/mca/ibm_memory_exp_16.cpp
+++ b/src/devices/bus/mca/ibm_memory_exp_16.cpp
@@ -1,0 +1,324 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM 2-8MB Memory Expansion Adapter
+    FRU 15F8292
+	MCA ID $F7F7
+
+    16-bit memory expansion card. 4 72-pin SIMM slots, 8MB max capacity.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "ibm_memory_exp_16.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_IBM_MEMORY_EXP, mca16_ibm_memory_exp_device, "mca_f7f7", "IBM 2-8MB Memory Expansion Adapter, 16-bit (@F7F7)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_ibm_memory_exp_device::device_add_mconfig(machine_config &config)
+{
+	RAM(config, m_expansion_ram).set_default_size("2M");
+}
+
+//-------------------------------------------------
+//  mca16_planar_lpt_device - constructor
+//-------------------------------------------------
+
+mca16_ibm_memory_exp_device::mca16_ibm_memory_exp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_ibm_memory_exp_device(mconfig, MCA16_IBM_MEMORY_EXP, tag, owner, clock)
+{
+}
+
+mca16_ibm_memory_exp_device::mca16_ibm_memory_exp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xf7f7),
+	m_expansion_ram(*this, "expansion_ram")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_ibm_memory_exp_device::device_start()
+{
+    m_is_mapped = false;
+    m_rom_base = 0;
+    m_rom_enabled = false;
+    m_ram_enabled = false;
+
+    m_consecutive_reads = 0;
+
+	// POS data 3 is the memory present bits, see https://github.com/86Box/86Box/commit/8e6497f01dcf1abe72aea1f317bbba6165e7d026
+	set_mca_device();
+
+    // TODO: POS
+    m_mca->install_rom(this, 0xda000, 0xda000+0x1fff, "option");
+
+    // What are these for, exactly?
+    m_mca->install_device(0x31a0, 0x31a5, 
+        read16sm_delegate(*this, FUNC(mca16_ibm_memory_exp_device::io_31a0_r)),
+        write16sm_delegate(*this, FUNC(mca16_ibm_memory_exp_device::io_31a0_w)));
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_ibm_memory_exp_device::device_reset()
+{
+    LOG("%s\n", FUNCNAME);
+
+	if(m_is_mapped) unmap();
+
+	reset_option_select();
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = 0x00;
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = 0b00000001;  // low 4 bits are RAM presence detect?
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] = 0x00;
+
+    m_in_mode_e = false;
+}
+
+void mca16_ibm_memory_exp_device::remap()
+{
+    LOG("%s: %02X %02X %02X %02X\n", FUNCNAME,
+        m_option_select[MCABus::POS::OPTION_SELECT_DATA_1],
+        m_option_select[MCABus::POS::OPTION_SELECT_DATA_2],
+        m_option_select[MCABus::POS::OPTION_SELECT_DATA_3],
+        m_option_select[MCABus::POS::OPTION_SELECT_DATA_4]);
+
+    bool rom_enabled = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] & 0b00100000) == 0b00100000;
+    bool ram_enabled = BIT(m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], 0);
+    
+    offs_t multiplier = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] & 0b11110000) >> 4;
+    offs_t rom_base = 0xc0000 + (0x2000 * multiplier);
+
+    LOG("%s: rom_enabled %d ram_enabled %d multiplier %d\n", FUNCNAME, rom_enabled, ram_enabled, multiplier);
+
+    if(multiplier >= 4 && multiplier <= 15)
+    {
+        if(rom_enabled)
+        {
+            m_mca->install_rom(this, rom_base, rom_base+0x1fff, "option");
+            m_is_mapped = true;
+
+            m_rom_base = rom_base;
+            m_rom_enabled = rom_enabled;
+        }
+
+        if(ram_enabled)
+        {
+            // TODO: What tells the RAM expansion card how much system memory is present?
+            m_mca->install_memory(0x160000, 0x15ffff+0x800000,
+                read8sm_delegate(*m_expansion_ram, FUNC(ram_device::read)), write8sm_delegate(*m_expansion_ram, FUNC(ram_device::write)));
+        }
+    }
+}
+
+void mca16_ibm_memory_exp_device::unmap()
+{
+    m_mca->unmap_rom(m_rom_base, m_rom_base+0x1fff);
+
+    if(m_ram_enabled)
+    {
+        m_mca->unmap_readwrite(0x160000, 0x15ffff+0x800000);
+    }
+
+	m_is_mapped = false;
+}
+
+bool mca16_ibm_memory_exp_device::map_has_changed()
+{
+    bool rom_enabled = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] & 0b00100110) == 0b00100000;
+    
+    offs_t multiplier = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] & 0b11110000) >> 4;
+    offs_t rom_base = 0xc0000 + (0x2000 * multiplier);
+
+    bool ram_enabled = BIT(m_option_select[MCABus::POS::OPTION_SELECT_DATA_1], 0);
+
+    return (m_rom_enabled != rom_enabled) || (rom_base != m_rom_base) || (ram_enabled != m_ram_enabled);
+}
+
+void mca16_ibm_memory_exp_device::update_pos_data_1(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] &= ~(0x3f);
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] |= data & 0x3f;
+	if(map_has_changed())
+    {
+        if(m_is_mapped) unmap();
+        remap();
+    }
+}
+
+void mca16_ibm_memory_exp_device::update_pos_data_2(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	if(map_has_changed())
+    {
+        if(m_is_mapped) unmap();
+        remap();
+    }
+}
+
+void mca16_ibm_memory_exp_device::update_pos_data_3(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] &= 0x0f;
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] |= (data & 0xf0);
+	if(map_has_changed())
+    {
+        if(m_is_mapped) unmap();
+        remap();
+    }
+}   
+
+void mca16_ibm_memory_exp_device::update_pos_data_4(uint8_t data)
+{
+	// What do the bits do, exactly? 0x3F means enable, I think.
+
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] &= ~0xc0;
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] = data & 0xc0;
+	LOG("%s: D:%02X\n", FUNCNAME, data);
+	if(map_has_changed())
+    {
+        if(m_is_mapped) unmap();
+        remap();
+    }
+}
+
+void mca16_ibm_memory_exp_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+            break;
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+            update_pos_data_1(data);
+			break;
+		case 3:
+			// Option Select Data 2
+            update_pos_data_2(data);
+			break;
+		case 4:
+			// Option Select Data 3
+            update_pos_data_3(data);
+			break;
+		case 5:
+			// Option Select Data 4
+            update_pos_data_4(data);
+			break;
+		case 6:
+			// Subaddress Extension Low
+            m_option_select[MCABus::POS::SUBADDRESS_EXT_LO] = data;
+			break;
+		case 7:
+			// Subaddress Extension High
+            m_option_select[MCABus::POS::SUBADDRESS_EXT_HI] = data;
+			break;
+		default:
+			break;
+	}
+}
+
+
+
+uint16_t mca16_ibm_memory_exp_device::io_31a0_r(offs_t offset)
+{
+    uint16_t *ram = (uint16_t *)m_expansion_ram->pointer();
+    uint16_t data = 0xffff;
+
+    switch(offset)
+    {
+        case 0:     // address word 0?
+        {
+            data = m_address_register & 0x0000FFFF;
+            break;
+        }
+        case 1:     
+        {
+            if(m_in_mode_e)
+            {
+                data = ram[m_address_register];
+            }
+            else
+            {
+                data = (m_address_register & 0xFFFF0000) >> 16; break;              // address word 1?
+            }
+            break;
+        }
+        case 2:     // data word?   
+        {
+            if(m_address_register < 0x800000) data = ram[m_address_register];
+            m_address_register++;
+            m_consecutive_reads++;
+            if(m_consecutive_reads == 3 && m_command == 0xE)
+            {
+                m_address_register = 0;
+                m_command = 0;
+                m_in_mode_e = true;
+            }
+            break;
+        }
+        default:    data = 0xffff; break;
+    }
+
+    LOG("%s: O:%02X D:%04X %08X\n", FUNCNAME, offset, data, m_address_register);
+
+    return data;
+}
+
+void mca16_ibm_memory_exp_device::io_31a0_w(offs_t offset, uint16_t data)
+{
+    uint16_t *ram = (uint16_t *)m_expansion_ram->pointer();
+
+    LOG("%s: O:%02X D:%04X %08X\n", FUNCNAME, offset, data, m_address_register);
+
+    switch(offset)
+    {
+        case 0: 
+        {
+            m_command = data;
+            
+            m_address_register &= 0xFFFF0000; 
+            m_address_register |= data;
+            break;
+        }
+        case 1: m_address_register &= 0x0000FFFF; m_address_register |= (((uint32_t)data) << 16); break;
+        case 2: if(m_address_register < 0x800000) ram[m_address_register] = data; m_address_register++; break;
+    }
+
+    return;
+}
+
+ROM_START( ibm_f7f7 )
+	ROM_REGION( 0xc0000, "option", 0 )
+	ROM_LOAD( "57f2905.bin", 0x0000, 0x2000, CRC(e805b055) SHA1(3434fe34d982c54a68d225d4f50fa0aec96470d1) )
+ROM_END
+
+const tiny_rom_entry *mca16_ibm_memory_exp_device::device_rom_region() const
+{
+	return ROM_NAME( ibm_f7f7 );
+}

--- a/src/devices/bus/mca/ibm_memory_exp_16.h
+++ b/src/devices/bus/mca/ibm_memory_exp_16.h
@@ -1,0 +1,80 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM 2-8MB Memory Expansion Adapter
+    FRU 90X9556
+
+    32-bit memory expansion card. 4 72-pin SIMM slots, 8MB max capacity.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA16_IBM_MEMORY_EXP_H
+#define MAME_BUS_MCA16_IBM_MEMORY_EXP_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/ram.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_ibm_memory_exp_device
+
+class mca16_ibm_memory_exp_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_ibm_memory_exp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void unmap() override;
+    virtual void remap() override;
+
+    virtual void update_pos_data_1(uint8_t data) override;
+	virtual void update_pos_data_2(uint8_t data) override;
+	virtual void update_pos_data_3(uint8_t data) override;
+	virtual void update_pos_data_4(uint8_t data) override;
+
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+protected:
+	mca16_ibm_memory_exp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+    virtual const tiny_rom_entry *device_rom_region() const override;
+
+	virtual bool map_has_changed() override;
+
+	uint16_t 	io_31a0_r(offs_t offset);
+	void 		io_31a0_w(offs_t offset, uint16_t data);
+
+	required_device<ram_device> m_expansion_ram;
+private:
+	bool		m_ram_enabled;
+
+	bool		m_rom_enabled;
+	offs_t		m_rom_base;
+	bool 		m_is_mapped;
+
+	uint8_t 	m_consecutive_reads;
+	uint8_t		m_command;
+	
+	offs_t 		m_address_register;
+
+	bool		m_in_mode_e;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_IBM_MEMORY_EXP, mca16_ibm_memory_exp_device)
+
+#endif

--- a/src/devices/bus/mca/ibm_memory_exp_32.cpp
+++ b/src/devices/bus/mca/ibm_memory_exp_32.cpp
@@ -1,0 +1,153 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM 2-8MB Memory Expansion Adapter
+    FRU 90X9556
+	MCA ID $FCFF
+
+    32-bit memory expansion card. 4 72-pin SIMM slots, 8MB max capacity.
+
+	The ADP entry point is at 064220h linear, the function parameters are at 05FFD8h
+
+***************************************************************************/
+
+#include "emu.h"
+#include "ibm_memory_exp_32.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA32_IBM_MEMORY_EXP, mca32_ibm_memory_exp_device, "mca32_ibm_memory_exp", "IBM 2-8MB Memory Expansion Adapter (@FCFF)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca32_ibm_memory_exp_device::device_add_mconfig(machine_config &config)
+{
+	RAM(config, m_expansion_ram).set_default_size("8M");
+}
+
+//-------------------------------------------------
+//  mca32_planar_lpt_device - constructor
+//-------------------------------------------------
+
+mca32_ibm_memory_exp_device::mca32_ibm_memory_exp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca32_ibm_memory_exp_device(mconfig, MCA32_IBM_MEMORY_EXP, tag, owner, clock)
+{
+}
+
+mca32_ibm_memory_exp_device::mca32_ibm_memory_exp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca32_card_interface(mconfig, *this, 0xfcff),
+	m_expansion_ram(*this, "expansion_ram")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca32_ibm_memory_exp_device::device_start()
+{
+    m_is_mapped = 0;
+
+	// POS data 3 is the memory present bits, see https://github.com/86Box/86Box/commit/8e6497f01dcf1abe72aea1f317bbba6165e7d026
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca32_ibm_memory_exp_device::device_reset()
+{
+    m_is_mapped = 0;
+	if(m_is_mapped) unmap();
+
+	reset_option_select();
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = 0xaa;	// 8MB present
+}
+
+void mca32_ibm_memory_exp_device::remap()
+{
+    // LOG("%s\n", FUNCNAME);
+}
+
+void mca32_ibm_memory_exp_device::unmap()
+{
+	//m_is_mapped = false;
+}
+
+bool mca32_ibm_memory_exp_device::map_has_changed()
+{
+	//if(m_is_mapped) unmap();
+
+	// TODO: What do the bits in option select data 4 mean, exactly?
+
+	LOG("%s: Updating map. XMS base = %06X\n", FUNCNAME, m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] * 0x100000);
+
+	offs_t xms_base = m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] * 0x100000;
+
+	if((m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] & 0x3f) == 0x3f)
+	{
+		if(xms_base > 0)
+		{
+			LOG("%s: Enabling XMS card\n", FUNCNAME);
+		
+			m_mca->install_memory(xms_base, xms_base+0x7fffff,
+				read8sm_delegate(*m_expansion_ram, FUNC(ram_device::read)), write8sm_delegate(*m_expansion_ram, FUNC(ram_device::write)));
+				m_is_mapped = true;
+		}
+		else
+		{
+			LOG("%s: XMS base not set, not enabling card\n", FUNCNAME);
+		}
+
+	}
+	else
+	{
+		unmap();
+	}
+	
+	return false;
+}
+
+void mca32_ibm_memory_exp_device::update_pos_data_1(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] = data;
+	map_has_changed();
+}
+
+void mca32_ibm_memory_exp_device::update_pos_data_2(uint8_t data)
+{
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	map_has_changed();
+}
+
+void mca32_ibm_memory_exp_device::update_pos_data_3(uint8_t data)
+{
+	// I think this one's read-only, it shows the memory present.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_3] = data;
+	map_has_changed();
+}
+
+void mca32_ibm_memory_exp_device::update_pos_data_4(uint8_t data)
+{
+	// What do the bits do, exactly? 0x3F means enable, I think.
+
+	m_option_select[MCABus::POS::OPTION_SELECT_DATA_4] = data;
+	LOG("%s: D:%02X\n", FUNCNAME, data);
+	map_has_changed();
+}

--- a/src/devices/bus/mca/ibm_memory_exp_32.h
+++ b/src/devices/bus/mca/ibm_memory_exp_32.h
@@ -1,0 +1,64 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM 2-8MB Memory Expansion Adapter
+    FRU 90X9556
+
+    32-bit memory expansion card. 4 72-pin SIMM slots, 8MB max capacity.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA32_IBM_MEMORY_EXP_H
+#define MAME_BUS_MCA32_IBM_MEMORY_EXP_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/ram.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca32_ibm_memory_exp_device
+
+class mca32_ibm_memory_exp_device :
+		public device_t,
+		public device_mca32_card_interface
+{
+public:
+	// construction/destruction
+	mca32_ibm_memory_exp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void unmap() override;
+    virtual void remap() override;
+
+    virtual void update_pos_data_1(uint8_t data) override;
+	virtual void update_pos_data_2(uint8_t data) override;
+	virtual void update_pos_data_3(uint8_t data) override;
+	virtual void update_pos_data_4(uint8_t data) override;
+
+protected:
+	mca32_ibm_memory_exp_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual bool map_has_changed() override;
+
+	required_device<ram_device> m_expansion_ram;
+private:
+	uint8_t m_subaddress_hi, m_subaddress_lo;
+
+	bool 	m_is_mapped;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA32_IBM_MEMORY_EXP, mca32_ibm_memory_exp_device)
+
+#endif

--- a/src/devices/bus/mca/ibm_svga.cpp
+++ b/src/devices/bus/mca/ibm_svga.cpp
@@ -1,0 +1,227 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM SVGA Adapter
+    MCA ID @917B
+
+    Basic GD5428-based video card with 1MB of DRAM.
+    Fits in a 16-bit slot with AVE.
+    Will conflict with any onboard VGA.
+
+    No POS configuration - the VGA BIOS is always at C000-C7FFh.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "ibm_svga.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+#define MCA_CARD_ID 0x917b
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_IBM_SVGA, mca16_ibm_svga_device, "mca_ibm_svga", "IBM SVGA Adapter (@917B)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_ibm_svga_device::device_add_mconfig(machine_config &config)
+{
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	screen.set_raw(25.1748_MHz_XTAL, 900, 0, 640, 526, 0, 480);
+	screen.set_screen_update("vga", FUNC(cirrus_gd5428_device::screen_update));
+
+	cirrus_gd5428_device &vga(CIRRUS_GD5428(config, "vga", 0));
+	vga.set_screen("screen");
+	vga.set_vram_size(0x100000);
+}
+
+//-------------------------------------------------
+//  mca16_template_device - constructor
+//-------------------------------------------------
+
+mca16_ibm_svga_device::mca16_ibm_svga_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_ibm_svga_device(mconfig, MCA16_IBM_SVGA, tag, owner, clock)
+{
+}
+
+mca16_ibm_svga_device::mca16_ibm_svga_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, MCA_CARD_ID),
+    m_svga(*this, "svga")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_ibm_svga_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_ibm_svga_device::device_reset()
+{
+    if(m_is_mapped) unmap();
+    m_svga->reset();
+}
+
+void mca16_ibm_svga_device::unmap()
+{
+    // All standard VGA.
+    m_mca->unmap_readwrite(0xa0000, 0xbffff);   // VGA memory
+    m_mca->unmap_rom(0xc0000, 0xc7fff);         // VGA BIOS
+    m_mca->unmap_device(0x3b0, 0x3ba);          // I/O
+    m_mca->unmap_device(0x3c0, 0x3cf);          // I/O
+    m_mca->unmap_device(0x3d0, 0x3df);          // I/O
+}
+
+void mca16_ibm_svga_device::remap()
+{
+    m_mca->install_memory(0xa0000, 0xbffff, read8sm_delegate(*m_svga, FUNC(cirrus_gd5428_device::mem_r)), write8sm_delegate(*m_svga, FUNC(cirrus_gd5428_device::mem_w)));
+    m_mca->install_rom(this, 0xc0000, 0xc7fff, "option");                   // VGA BIOS is always at C0000-C7FFF.
+    // Need local trampolines to assert channel feedback
+    m_mca->install_device(0x3b0, 0x3ba, 
+        read8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03b0_r)),
+        write8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03b0_w)));
+    m_mca->install_device(0x3c0, 0x3cf, 
+        read8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03c0_r)),
+        write8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03c0_w)));
+    m_mca->install_device(0x3d0, 0x3df, 
+        read8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03d0_r)),
+        write8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03d0_w)));
+}
+
+uint8_t mca16_ibm_svga_device::port_03b0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_svga->port_03b0_r(offset);
+}
+
+void mca16_ibm_svga_device::port_03b0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_svga->port_03b0_w(offset, data);
+}
+
+uint8_t mca16_ibm_svga_device::port_03c0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_svga->port_03c0_r(offset);
+}
+
+void mca16_ibm_svga_device::port_03c0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_svga->port_03c0_w(offset, data);
+}
+
+uint8_t mca16_ibm_svga_device::port_03d0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_svga->port_03d0_r(offset);
+}
+
+void mca16_ibm_svga_device::port_03d0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_svga->port_03d0_w(offset, data);
+}
+
+ROM_START( ibm_svga )
+	ROM_REGION( 0xc0000, "option", 0 )
+	ROM_LOAD( "06h6915.bin", 0x0000, 0x8000, CRC(39d4566d) SHA1(d275193a870250f212dc29768d4e68fb43770e95) )
+ROM_END
+
+const tiny_rom_entry *mca16_ibm_svga_device::device_rom_region() const
+{
+	return ROM_NAME( ibm_svga );
+}
+
+uint8_t mca16_ibm_svga_device::pos_r(offs_t offset)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+			return get_card_id() & 0xFF;
+		case 1:
+			// Adapter Identification b8-b15
+			return (get_card_id() & 0xFF00) >> 8;
+		case 2:
+			// Option Select Data 1
+			break;
+		case 3:
+			// Option Select Data 2
+			break;
+		case 4:
+			// Option Select Data 3
+			break;
+		case 5:
+			// Option Select Data 4
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+
+	return 0xFF;
+}
+
+void mca16_ibm_svga_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+			break;
+		case 3:
+			// Option Select Data 2
+			break;
+		case 4:
+			// Option Select Data 3
+			break;
+		case 5:
+			// Option Select Data 4
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}

--- a/src/devices/bus/mca/ibm_svga.cpp
+++ b/src/devices/bus/mca/ibm_svga.cpp
@@ -97,6 +97,7 @@ void mca16_ibm_svga_device::remap()
 {
     m_mca->install_memory(0xa0000, 0xbffff, read8sm_delegate(*m_svga, FUNC(cirrus_gd5428_device::mem_r)), write8sm_delegate(*m_svga, FUNC(cirrus_gd5428_device::mem_w)));
     m_mca->install_rom(this, 0xc0000, 0xc7fff, "option");                   // VGA BIOS is always at C0000-C7FFF.
+
     // Need local trampolines to assert channel feedback
     m_mca->install_device(0x3b0, 0x3ba, 
         read8sm_delegate(*this, FUNC(mca16_ibm_svga_device::port_03b0_r)),
@@ -112,37 +113,37 @@ void mca16_ibm_svga_device::remap()
 uint8_t mca16_ibm_svga_device::port_03b0_r(offs_t offset)
 {
     assert_card_feedback();
-    return m_svga->port_03b0_r(offset);
+    return 0; //m_svga->port_03b0_r(offset);
 }
 
 void mca16_ibm_svga_device::port_03b0_w(offs_t offset, uint8_t data)
 {
     assert_card_feedback();
-    m_svga->port_03b0_w(offset, data);
+    //m_svga->port_03b0_w(offset, data);
 }
 
 uint8_t mca16_ibm_svga_device::port_03c0_r(offs_t offset)
 {
     assert_card_feedback();
-    return m_svga->port_03c0_r(offset);
+    return 0; //m_svga->port_03c0_r(offset);
 }
 
 void mca16_ibm_svga_device::port_03c0_w(offs_t offset, uint8_t data)
 {
     assert_card_feedback();
-    m_svga->port_03c0_w(offset, data);
+    //m_svga->port_03c0_w(offset, data);
 }
 
 uint8_t mca16_ibm_svga_device::port_03d0_r(offs_t offset)
 {
     assert_card_feedback();
-    return m_svga->port_03d0_r(offset);
+    return 0; //m_svga->port_03d0_r(offset);
 }
 
 void mca16_ibm_svga_device::port_03d0_w(offs_t offset, uint8_t data)
 {
     assert_card_feedback();
-    m_svga->port_03d0_w(offset, data);
+    //m_svga->port_03d0_w(offset, data);
 }
 
 ROM_START( ibm_svga )

--- a/src/devices/bus/mca/ibm_svga.h
+++ b/src/devices/bus/mca/ibm_svga.h
@@ -1,0 +1,67 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    MCA card template
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_IBM_SVGA_H
+#define MAME_BUS_MCA_IBM_SVGA_H
+
+#pragma once
+
+#include "mca.h"
+#include "video/clgd542x.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_ibm_svga_device
+
+class mca16_ibm_svga_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_ibm_svga_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void unmap() override;
+	virtual void remap() override;
+
+protected:
+	mca16_ibm_svga_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+	virtual uint8_t pos_r(offs_t offset) override;
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+    void map_main(address_map &map);
+
+	uint8_t port_03b0_r(offs_t offset);
+    uint8_t port_03c0_r(offs_t offset);
+    uint8_t port_03d0_r(offs_t offset);
+
+    void port_03b0_w(offs_t offset, uint8_t data);
+    void port_03c0_w(offs_t offset, uint8_t data);
+    void port_03d0_w(offs_t offset, uint8_t data);
+
+private:
+	bool m_is_mapped;
+
+	required_device<cirrus_gd5428_device> m_svga;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_IBM_SVGA, mca16_ibm_svga_device)
+
+#endif

--- a/src/devices/bus/mca/ibm_svga.h
+++ b/src/devices/bus/mca/ibm_svga.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "mca.h"
-#include "video/clgd542x.h"
+#include "video/pc_vga_cirrus.h"
 
 //**************************************************************************
 //  TYPE DEFINITIONS

--- a/src/devices/bus/mca/macpa.cpp
+++ b/src/devices/bus/mca/macpa.cpp
@@ -1,0 +1,692 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    M-Audio Capture and Playback Adapter/A
+    MCA ID @6E6C
+
+    Oscillator test microcode is at 0x24700 into ACPADIAG.EXE
+
+***************************************************************************/
+
+#include "emu.h"
+#include "macpa.h"
+#include "speaker.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_MACPA, mca16_macpa_device, "mca16_macpa", "M-Audio Capture and Playback Adapter/A (@6E6C)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_macpa_device::device_add_mconfig(machine_config &config)
+{
+	TMS32025(config, m_dsp, XTAL(40'000'000));
+	m_dsp->set_addrmap(AS_PROGRAM, &mca16_macpa_device::DSP_map_program);
+	m_dsp->set_addrmap(AS_DATA, &mca16_macpa_device::DSP_map_data);
+    m_dsp->set_addrmap(AS_IO, &mca16_macpa_device::DSP_map_io);
+	m_dsp->hold_in_cb().set(FUNC(mca16_macpa_device::tms_reset_r));
+	// m_dsp->hold_ack_out_cb().set(FUNC(mca16_macpa_device::dsp_HOLDA_signal_w));
+
+	SPEAKER(config, "lspeaker").front_left();
+	SPEAKER(config, "rspeaker").front_right();
+	DAC_16BIT_R2R(config, m_ldac, 0).add_route(ALL_OUTPUTS, "lspeaker", 1.0); // uPD6355
+	DAC_16BIT_R2R(config, m_rdac, 0).add_route(ALL_OUTPUTS, "rspeaker", 1.0); // uPD6355
+}
+
+//-------------------------------------------------
+//  isa8_com_device - constructor
+//-------------------------------------------------
+
+mca16_macpa_device::mca16_macpa_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_macpa_device(mconfig, MCA16_MACPA, tag, owner, clock)
+{
+}
+
+mca16_macpa_device::mca16_macpa_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x6e6c),
+    m_dsp(*this, "dsp"),
+    m_ldac(*this, "ldac"),
+    m_rdac(*this, "rdac")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_macpa_device::device_start()
+{
+	set_mca_device();
+    m_shared_ram = std::make_unique<uint16_t[]>(0x2000);
+    m_sample_ram = std::make_unique<uint16_t[]>(0x800);
+    m_board_is_mapped = 0;
+    m_tms_reset = 0;
+    m_sample_playback_int_pending = 0;
+    
+    m_sample_ptrs.adc = 0;
+    m_sample_ptrs.dac_l = 0;
+    m_sample_ptrs.dac_r = 0;
+    m_sample_ptrs.scr = 0;
+
+    m_dacl_enabled = 0;
+    m_dacr_enabled = 0;
+
+    m_dacl_int_pending = 0;
+    m_dacr_int_pending = 0;
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_macpa_device::device_reset()
+{
+    m_host_to_dsp_int_pending = 0; // Reset condition, page 6-12
+    m_dsp_to_host_int_pending = 0; // Reset condition
+    m_sample_playback_int_pending = 0; // Reset condition
+
+    m_sample_ptrs.adc = 0;
+    m_sample_ptrs.dac_l = 0;
+    m_sample_ptrs.dac_r = 0;
+    m_sample_ptrs.scr = 0;
+
+    dacl_enable(false);
+    dacr_enable(false);
+
+    m_dacl_int_pending = 0;
+    m_dacr_int_pending = 0;
+
+    if(m_board_is_mapped) unmap();
+}
+
+uint8_t mca16_macpa_device::shared_ram_read8_hi(offs_t address)
+{
+    LOG("%s: O:%04X\n", FUNCNAME, address);
+
+    // address is in 16-bit words, same as the shared ptr.
+    return (m_shared_ram[address % 0x2000] & 0xff00) >> 8;
+}
+
+uint8_t mca16_macpa_device::shared_ram_read8_lo(offs_t address)
+{
+    LOG("%s: O:%04X\n", FUNCNAME, address);
+
+    // address is in 16-bit words, same as the shared ptr.
+    return m_shared_ram[address % 0x2000] & 0xff;
+}
+
+void mca16_macpa_device::shared_ram_write8_hi(offs_t address, uint8_t data)
+{
+    LOG("%s: O:%04X D:%02X\n", FUNCNAME, address, data);
+
+    // address is in 16-bit words, same as the shared ptr.
+    m_shared_ram[address % 0x2000] &= 0x00ff;
+    m_shared_ram[address % 0x2000] |= (((uint16_t)data) << 8);
+}
+
+void mca16_macpa_device::shared_ram_write8_lo(offs_t address, uint8_t data)
+{
+    LOG("%s: O:%04X D:%02X\n", FUNCNAME, address, data);
+
+    // address is in 16-bit words, same as the shared ptr.
+    m_shared_ram[address % 0x2000] &= 0xff00;
+    m_shared_ram[address % 0x2000] |= data;
+}
+
+uint8_t mca16_macpa_device::status_register_r()
+{
+    // bit 7 - reserved
+    // bit 6-5-4: IRQ line configuration, not present on MCA version of the card (handled through POS)
+    // bit 3 - reserved
+    // bit 2 - reserved
+    // bit 1 - HST REQ: 1 if DSP->Host interrupt is pending. reset to 0 on power-up
+    // bit 0 - TMS INT: 0 if Host->DSP interrupt is pending. reset to 1 on power-up
+
+    uint8_t data = 0;
+
+    if(m_dsp_to_host_int_pending) data |= 2;
+    if(!m_host_to_dsp_int_pending) data |= 1;
+
+    LOG("%s: Host is reading status, %02X\n", FUNCNAME, data);
+
+    return data;    
+}
+
+void mca16_macpa_device::command_register_w(uint8_t data)
+{
+    LOG("%s: D:%04X\n", FUNCNAME, data);
+
+    /*
+        Write-only register.
+
+        bit 7 - reserved
+        bit 6 - reserved
+        bit 5 - reserved
+        bit 4 - SPKR EN - Speaker Enable. Latched bit.
+            - 1: Speaker enabled.
+            - 0: Speaker disabled. Power-up condition.
+        bit 3 - TMS INT - TMS Interrupt. Strobed bit.
+            - 0: Host->DSP interrupt when 0 is written to this bit.
+        bit 2 - HINTENA - Host Interrupt Enable. Latched bit.
+            - 1: TMS requests to the host cause a host interrupt.
+            - 0: TMS requests to the host do not cause a host interrupt. Power-up condition.
+        bit 1 - HREQACK - Host Request Acknowledge. Strobed bit.
+            - 0: Clears the DSP->Host interrupt when 0 is written to this bit.
+        bit 0 - TMS RES - Resets the TMS320C35. Latched bit.
+            - 1: TMS320C35 is in operating state.
+            - 0: TMS320C25 is in reset state. Power-up condition.
+     */
+
+    m_tms_reset = BIT(data, 0);
+
+    if(m_tms_reset == 0)
+    {
+        // We're in reset condition. Ignore everything. Reset everything.
+        m_host_to_dsp_int_pending = false;
+        m_dsp_to_host_int_pending = false;
+    }
+    else
+    {
+        if(BIT(data, 4)) LOG("%s: Motherboard speaker enabled\n", FUNCNAME);
+        if(BIT(data, 3) == 0) tms_int_w();
+        m_hintena = BIT(data, 2);
+        if(BIT(data, 1) == 0) hreqack_w();
+    }
+}
+
+void mca16_macpa_device::hreqack_w()
+{
+    LOG("%s: Clearing DSP->Host interrupt\n", FUNCNAME);
+
+    m_dsp_to_host_int_pending = false;
+
+    switch(m_mapped_irq)
+    {
+        case 2: m_mca->ireq_w<2>(m_dsp_to_host_int_pending); break;
+        case 3: m_mca->ireq_w<3>(m_dsp_to_host_int_pending); break;
+        case 4: m_mca->ireq_w<4>(m_dsp_to_host_int_pending); break;
+        case 5: m_mca->ireq_w<5>(m_dsp_to_host_int_pending); break;
+        case 6: m_mca->ireq_w<6>(m_dsp_to_host_int_pending); break;
+        case 10: m_mca->ireq_w<10>(m_dsp_to_host_int_pending); break;
+        case 11: m_mca->ireq_w<11>(m_dsp_to_host_int_pending); break;
+        case 12: m_mca->ireq_w<12>(m_dsp_to_host_int_pending); break;
+    }
+}
+
+void mca16_macpa_device::tms_int_w()
+{
+    // TMS INT strobed.
+    LOG("%s: Asserting Host->DSP interrupt\n", FUNCNAME);
+
+    m_host_to_dsp_int_pending = true;
+    m_dsp->set_input_line(TMS32025_INT1, m_host_to_dsp_int_pending);
+}
+
+uint16_t mca16_macpa_device::tms_reset_r()
+{    
+	return !m_tms_reset;
+}
+
+uint8_t mca16_macpa_device::io8_r(offs_t offset)
+{
+	LOG("%s: O:%02X\n", FUNCNAME, offset);
+    uint8_t data = 0;
+	assert_card_feedback();
+
+    switch(offset)
+    {
+        // Data - Low Byte
+        case 0: data = shared_ram_read8_lo(m_address_latch); break;
+        
+        // Data - High Byte. Advances address latch by one word.
+        case 1: data = shared_ram_read8_hi(m_address_latch); m_address_latch++; break;
+        
+        // 2, 3, 4, 5 not used
+        case 2: data = 0xff; break;
+        case 3: data = 0xff; break;
+        case 4: data = 0xff; break;
+        case 5: data = 0xff; break;
+
+        // Host - Status Register
+        case 6: data = status_register_r(); break;
+        
+        // ACPA-ID, always return 0x6C.
+        case 7: data = 0x6c; break;
+    }
+
+	return data;
+}
+
+void mca16_macpa_device::io8_w(offs_t offset, uint8_t data)
+{
+	LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+	assert_card_feedback();
+
+    switch(offset)
+    {
+        // Data - Low Byte
+        case 0: shared_ram_write8_lo(m_address_latch, data); break;
+        // Data - High Byte. Advances address latch by one word.
+        case 1: shared_ram_write8_hi(m_address_latch, data); m_address_latch++; m_address_latch = m_address_latch % 0x2000; break;
+        
+        // 2, 3 not used
+        case 2: break;
+        case 3: break;
+
+        // Address - Low Byte
+        case 4: m_address_latch &= 0xff00; m_address_latch |= data; break;
+        // Address - High Byte
+        case 5: m_address_latch &= 0x00ff; m_address_latch |= ((uint16_t)data << 8); break;
+
+        // Host - Command Register
+        case 6: command_register_w(data); break;
+        
+        // not used
+        case 7: break;
+    }
+}
+
+uint8_t mca16_macpa_device::pos_r(offs_t offset)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+			return get_card_id() & 0xFF;
+		case 1:
+			// Adapter Identification b8-b15
+			return (get_card_id() & 0xFF00) >> 8;
+		case 2:
+			// Option Select Data 1
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_1];
+			break;
+		case 3:
+			// Option Select Data 2
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_2];
+			break;
+		case 4:
+			// Option Select Data 3
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_3];
+			break;
+		case 5:
+			// Option Select Data 4
+            return m_option_select[MCABus::POS::OPTION_SELECT_DATA_4];
+			break;
+		case 6:
+			// Subaddress Extension Low
+			return 0xff;
+			break;
+		case 7:
+			// Subaddress Extension High
+			return 0xff;
+			break;
+		default:
+			break;
+	}
+
+	return 0xFF;
+}
+
+void mca16_macpa_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+            update_pos(data);
+			break;
+		case 3:
+			// Option Select Data 2 - not used
+			break;
+		case 4:
+			// Option Select Data 3 - not used
+			break;
+		case 5:
+			// Option Select Data 4 - not used
+			break;
+		case 6:
+			// Subaddress Extension Low - not used
+			break;
+		case 7:
+			// Subaddress Extension High - not used
+			break;
+		default:
+			break;
+	}
+}
+
+void mca16_macpa_device::update_pos(uint8_t data)
+{
+    // This card only uses one POS register.
+    // b7-b6: reserved
+    // b5-b3: IR2/IR1/IR0
+    // b2-b1: AS1/AS0
+    // b0: BDEN
+
+    uint8_t irq;
+    uint16_t io_base;
+    bool board_enable = m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] & 1;
+
+    switch((m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] & 0b00000110) >> 1)
+    {
+        case 0: io_base = 0xfdc0; break;
+        case 1: io_base = 0xfdc8; break;
+        case 2: io_base = 0xfdd0; break;
+        case 3: io_base = 0xfdd8; break;
+    };
+
+    switch((m_option_select[MCABus::POS::OPTION_SELECT_DATA_1] & 0b00111000) >> 3)
+    {
+        case 0: irq = 3; break;
+        case 1: irq = 4; break;
+        case 2: irq = 5; break;
+        case 3: irq = 6; break;
+        case 4: irq = 2; break;
+        case 5: irq = 10; break;
+        case 6: irq = 11; break;
+        case 7: irq = 12; break;
+    }
+
+    if(m_board_is_mapped) unmap();
+    m_mapped_io = io_base;
+    m_mapped_irq = irq;
+    if(board_enable) remap();
+}
+
+void mca16_macpa_device::remap()
+{
+    m_mca->install_device(m_mapped_io, m_mapped_io+7,
+        read8sm_delegate(*this, FUNC(mca16_macpa_device::io8_r)),
+        write8sm_delegate(*this, FUNC(mca16_macpa_device::io8_w)));
+}
+
+void mca16_macpa_device::unmap()
+{
+    m_mca->unmap_device(m_mapped_io, m_mapped_io+7);    
+}
+
+//
+// DSP
+//
+
+// Memory decoding is really, really weird.
+// There's also internal on-chip memory in here somewhere.
+
+void mca16_macpa_device::DSP_map_io(address_map &map)
+{
+    // Page 6-20 of ACPA_Techref.pdf
+
+    // All I/O address space points to one register.
+    map(0x0000, 0xffff).rw(FUNC(mca16_macpa_device::dsp_status_register_r), FUNC(mca16_macpa_device::dsp_command_register_w));
+}
+
+void mca16_macpa_device::DSP_map_program(address_map &map)
+{
+    // Page 6-20 of ACPA_Techref.pdf
+    // Program space contains:
+    // - 8 blocks of Shared Memory (A through H)
+
+    map(0x0000, 0x1fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x2000, 0x3fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x4000, 0x5fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x6000, 0x7fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x8000, 0x9fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0xa000, 0xbfff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0xc000, 0xdfff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0xe000, 0xffff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+}
+void mca16_macpa_device::DSP_map_data(address_map &map)
+{
+    // Page 6-20 of ACPA_Techref.pdf
+    // Data space contains:
+    // - 4 blocks of Shared Memory (A through D)
+    // - 16 blocks of Sample Memory (A through P)
+
+    map(0x0000, 0x1fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x2000, 0x3fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0x4000, 0x47ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x4800, 0x4fff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x5000, 0x57ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x5800, 0x5fff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x6000, 0x67ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x6800, 0x6fff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x7000, 0x77ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x7800, 0x7fff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0x8000, 0x9fff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0xa000, 0xbfff).rw(FUNC(mca16_macpa_device::shared_ram_r), FUNC(mca16_macpa_device::shared_ram_w));
+    map(0xc000, 0xc7ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xc800, 0xcfff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xd000, 0xd7ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xd800, 0xdfff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xe000, 0xe7ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xe800, 0xefff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xf000, 0xf7ff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+    map(0xf800, 0xffff).rw(FUNC(mca16_macpa_device::sample_ram_r), FUNC(mca16_macpa_device::sample_ram_w));
+}
+
+u16 mca16_macpa_device::shared_ram_r(offs_t offset)
+{
+	return m_shared_ram[offset];
+}
+
+void mca16_macpa_device::shared_ram_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	if (ACCESSING_BITS_8_15 && ACCESSING_BITS_0_7)
+		m_shared_ram[offset] = data;
+}
+
+u16 mca16_macpa_device::sample_ram_r(offs_t offset)
+{
+	return m_sample_ram[offset];
+}
+
+void mca16_macpa_device::sample_ram_w(offs_t offset, u16 data, u16 mem_mask)
+{
+	if (ACCESSING_BITS_8_15 && ACCESSING_BITS_0_7)
+		m_sample_ram[offset] = data;
+}
+
+// These are local registers that only the DSP can see.    
+uint16_t mca16_macpa_device::dsp_status_register_r(offs_t offset)
+{
+    // Any DSP I/O space read will go to the status register.
+
+    /*
+        bit 7 - reserved
+        bit 6 - reserved
+        bit 5 - reserved
+        bit 4 - reserved
+        bit 3 - HST REQ     - Host->DSP interrupt.
+            1: Interrupt pending.
+            0: No interrupt pending, power-up condition.
+        bit 2 - ADC INT     - ADC->DSP interrupt.
+            1: Interrupt pending.
+            0: No interrupt pending, power-up condition.
+        bit 1 - DACL INT    - DAC Left->DSP interrupt.
+            1: Interrupt pending.
+            0: No interrupt pending, power-up condition.
+        bit 0 - DACR INT    - DAC Right->DSP interrupt.
+            1: Interrupt pending.
+            0: No interrupt pending, power-up condition.
+    */
+
+    uint16_t data = 0;
+
+    if(m_tms_reset == 0)
+    {
+        // We're in the reset condition. All interrupts disabled.
+        data = 0;
+    }
+    else
+    {
+        if(m_host_to_dsp_int_pending) data |= (1 << 3);
+        if(m_dacl_int_pending) data |= (1 << 1);
+        if(m_dacr_int_pending) data |= (1 << 0);
+    }
+
+    LOG("%s: D:%04X\n", FUNCNAME, data);
+
+    return data;
+}
+
+void mca16_macpa_device::dsp_command_register_w(offs_t offset, uint16_t data)
+{
+    // Any DSP I/O space write will go to the command register.
+
+    LOG("%s: D:%04X\n", FUNCNAME, data);
+
+    /*
+        bit 9 - MIKE GAIN   - Select microphone gain amount.
+            1: +33dB
+            0: +45dB, power-up condition.
+        bit 8 - AD CHAN     - Select the right channel sampled at 88.2KHz or stereo at 44.1KHz.
+            1: Right and left channels sampled at 44.1KHz each.
+            0: Right channel sampled at 88.2KHz, power-up condition.
+        bit 7 - BLK RST     - Forces sample memory to the first location of block 0. Strobed bit.
+            0: When written, resets sample memory to the first location of block 0.
+        bit 6 - HST REQ     - Raises a DSP->Host interrupt. Strobed bit.
+            0: Requests service from the host, if HINTENA is asserted.
+        bit 5 - TMS IAK     - Acknowledges a Host->DSP interrupt. Strobed bit.
+            0: Clears the Host->DSP interrupt latch.
+        bit 4 - SPB IAK     - Acknowledges a sample playback request interrupt.
+            0: Clears the sample playback interrupt latch.
+        bit 3 - INP SEL     - Select Right input source.
+            1: Line selected
+            0: Mike selected, power-up condition.
+        bit 2 - ADC EN      - Enable the ADC.
+            1: ADC enabled
+            0: ADC disabled, power-up condition.
+        bit 1 - DACL EN     - Enable the left DAC.
+            1: DACL enabled
+            0: DACL disabled, power-up condition.
+        bit 0 - DACR EN     - Enable the right DAC.
+            1: DACR enabled
+            0: DACL disabled, power-up condition.
+    */
+
+    if(m_tms_reset == 0)
+    {
+        // We're in the reset condition.
+
+        // Disable ADC.
+        // Disable both DACs.
+        // Input is Mike.
+        // Right channel is sampled at 88.2KHz.
+        // Mike Gain is +45dB.
+    }
+    else
+    {
+        if(!BIT(data, 7))
+        {
+            m_sample_ptrs.adc = 0;
+            m_sample_ptrs.dac_l = 0;
+            m_sample_ptrs.dac_r = 0;
+            m_sample_ptrs.scr = 0;            
+        }
+
+        if(!BIT(data, 6))
+        {
+            if(m_hintena)
+            {
+                LOG("%s: Raising DSP->Host interrupt, IRQ %d\n", FUNCNAME, m_mapped_irq);
+                m_dsp_to_host_int_pending = true;
+                
+                switch(m_mapped_irq)
+                {
+                    case 2: m_mca->ireq_w<2>(m_dsp_to_host_int_pending); break;
+                    case 3: m_mca->ireq_w<3>(m_dsp_to_host_int_pending); break;
+                    case 4: m_mca->ireq_w<4>(m_dsp_to_host_int_pending); break;
+                    case 5: m_mca->ireq_w<5>(m_dsp_to_host_int_pending); break;
+                    case 6: m_mca->ireq_w<6>(m_dsp_to_host_int_pending); break;
+                    case 10: m_mca->ireq_w<10>(m_dsp_to_host_int_pending); break;
+                    case 11: m_mca->ireq_w<11>(m_dsp_to_host_int_pending); break;
+                    case 12: m_mca->ireq_w<12>(m_dsp_to_host_int_pending); break;
+                }
+            }
+            else
+            {
+                LOG("%s: DSP->Host IRQ is masked, not raising.\n", FUNCNAME);
+            }
+        }
+
+        if(!BIT(data, 5))
+        {
+            LOG("%s: Clearing Host->DSP interrupt\n", FUNCNAME);
+            m_host_to_dsp_int_pending = false;
+            m_dsp->set_input_line(TMS32025_INT1, m_host_to_dsp_int_pending);
+        }
+
+        if(!BIT(data, 4))
+        {
+            m_dacl_int_pending = false;
+            m_dacr_int_pending = false;
+            m_dsp->set_input_line(TMS32025_INT0, false);
+        }
+
+        LOG("%s: DAC L/R now %d/%d. ADC now %d\n", FUNCNAME, BIT(data, 1), BIT(data, 0), BIT(data, 2));
+
+        // Page 6-24 of the ACPA manual to see how to hook up the DAC.
+        // Sample Memory is divided up into 256-word blocks. Each peripheral has two blocks used as a ring buffer.
+        // - The DSP fills block 0 for the appropriate peripheral.
+        // - When the Enable bit is asserted, the DAC will immediately receive an INT0 from the peripheral.
+        // - The status register will show which peripheral sent the interrupt.
+        // - Each time the peripheral reaches the end of its 256-word block, INT0 is asserted.
+        // - The BIO pin shows which block is being used by the peripheral.
+        // - BIO 0 = The peripheral is using Block 0, the DSP must write Block 1.
+        // - BIO 1 = The peripheral is using Block 1, the DSP must write Block 0.
+        // - The INT0 is cleared by strobing 0 into the SPB IAK bit of the DSP command register.
+
+        dacr_enable(BIT(data, 0));
+        dacl_enable(BIT(data, 1));
+
+        // Assert INT0 if required.
+        m_dsp->set_input_line(TMS32025_INT0, m_dacr_int_pending || m_dacl_int_pending);
+    }
+}
+
+void mca16_macpa_device::dacr_enable(bool enable)
+{
+    if(m_dacr_enabled && enable) return;    // already enabled
+    if(!m_dacr_enabled && !enable) return;  // already disabled
+    
+    if(!m_dacr_enabled && enable)           // off -> on transition
+    {        
+        // What is the timing source for the DAC?
+        m_dacr_int_pending = true;
+        m_dacr_enabled = true;
+    }
+    else if(m_dacr_enabled && !enable)      // on -> off transition
+    {
+        m_dacr_int_pending = false;
+        m_dacr_enabled = false;        
+    }
+}
+
+void mca16_macpa_device::dacl_enable(bool enable)
+{
+    if(m_dacl_enabled && enable) return; // already enabled
+}

--- a/src/devices/bus/mca/macpa.h
+++ b/src/devices/bus/mca/macpa.h
@@ -1,0 +1,132 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    M-Audio Capture and Playback Adapter/A
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_MACPA_H
+#define MAME_BUS_MCA_MACPA_H
+
+#pragma once
+
+#include "mca.h"
+#include "cpu/tms32025/tms32025.h"
+#include "machine/ram.h"
+#include "sound/dac.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_macpa_device
+
+class mca16_macpa_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_macpa_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+    virtual uint8_t pos_r(offs_t offset) override;
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+protected:
+	mca16_macpa_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+    virtual void unmap() override;
+    virtual void remap() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+    void DSP_map_data(address_map &map);
+    void DSP_map_program(address_map &map);
+    void DSP_map_io(address_map &map);
+
+    uint16_t shared_ram_r(offs_t offset);
+    void shared_ram_w(offs_t offset, u16 data, u16 mem_mask);
+
+    uint16_t sample_ram_r(offs_t offset);
+    void sample_ram_w(offs_t offset, u16 data, u16 mem_mask);
+
+    required_device<tms32025_device> m_dsp;
+	required_device<dac_word_interface> m_ldac;
+	required_device<dac_word_interface> m_rdac;
+	std::unique_ptr<uint16_t[]> m_sample_ram; // 2Kx16
+    std::unique_ptr<uint16_t[]> m_shared_ram; // 8Kx16
+
+private:
+    uint16_t program_r(offs_t offset);
+    void program_w(offs_t offset, uint16_t data);
+
+    uint16_t data_r(offs_t offset);
+    void data_w(offs_t offset, uint16_t data);
+
+    void update_pos(uint8_t data);
+
+    uint8_t shared_ram_read8_hi(offs_t offset);
+    uint8_t shared_ram_read8_lo(offs_t offset);
+
+    void shared_ram_write8_hi(offs_t offset, uint8_t data);
+    void shared_ram_write8_lo(offs_t offset, uint8_t data);
+
+    uint16_t tms_reset_r();
+    void tms_int_w();
+    void hreqack_w();
+
+    uint16_t dsp_status_register_r(offs_t offset);
+    void dsp_command_register_w(offs_t offset, uint16_t data);
+
+    // Host control registers
+    uint16_t m_data_latch;
+    uint16_t m_address_latch;
+
+    bool m_host_to_dsp_int_pending;         // Flag for Host->DSP interrupt (DSP INT1).
+    bool m_dsp_to_host_int_pending;         // Flag for DSP->Host interrupt (host IRQ).
+    bool m_sample_playback_int_pending;     // Flag for sample playback interrupt (DSP INT0).
+    bool m_hintena;                         // Gates interrupts to the host.
+    bool m_tms_reset;                       // Hold the DSP, reset all flags to power-up condition.
+
+    uint8_t status_register_r();
+    void command_register_w(uint8_t data);
+
+    // The sample playback position. The address the DACs are currently reading from?
+    typedef struct {
+        uint16_t adc;
+        uint16_t scr;
+        uint16_t dac_r;
+        uint16_t dac_l;
+    } SAMPLE_MEMORY_POINTERS;
+
+    bool m_dacl_enabled;
+    bool m_dacr_enabled;
+
+    bool m_dacl_int_pending;
+    bool m_dacr_int_pending;
+
+    void dacl_enable(bool enable);
+    void dacr_enable(bool enable);
+
+    SAMPLE_MEMORY_POINTERS m_sample_ptrs;
+
+    // MCA bus setup
+    uint16_t m_mapped_io;
+    uint8_t m_mapped_irq;
+    bool m_board_enable;
+    bool m_board_is_mapped;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_MACPA, mca16_macpa_device)
+
+#endif

--- a/src/devices/bus/mca/mca.cpp
+++ b/src/devices/bus/mca/mca.cpp
@@ -169,15 +169,7 @@ void mca16_device::device_config_complete()
 
 void mca16_device::device_resolve_objects()
 {
-	// resolve callbacks
-	m_write_iochrdy.resolve_safe();
-	m_write_iochck.resolve_safe();
-
-	m_out_irq_cb.resolve_all_safe();
-	m_out_drq_cb.resolve_all_safe();
-
-	m_cs_feedback.resolve_safe();
-
+	
 	m_iowidth = m_iospace->data_width();
 	m_memwidth = m_memspace->data_width();
 }
@@ -197,8 +189,8 @@ void mca16_device::device_start()
 
 void mca16_device::device_reset()
 {
+	
 }
-
 
 template <typename R, typename W> void mca16_device::install_space(int spacenum, offs_t start, offs_t end, R rhandler, W whandler)
 {

--- a/src/devices/bus/mca/mca.cpp
+++ b/src/devices/bus/mca/mca.cpp
@@ -68,7 +68,7 @@ void mca16_slot_device::device_start()
 {
 	device_mca16_card_interface *const dev = dynamic_cast<device_mca16_card_interface *>(get_card_device());
 
-	if (dev) dev->set_mcabus(m_mca_bus);
+	if (dev) dev->set_host_bus(m_mca_bus);
 
 	// tell MCA bus that there is one slot with the specified tag
 	downcast<mca16_device &>(*m_mca_bus).add_slot(tag());
@@ -589,7 +589,7 @@ void mca32_slot_device::device_start()
 {
 	device_mca32_card_interface *const dev = dynamic_cast<device_mca32_card_interface *>(get_card_device());
 
-	if (dev) dev->set_mcabus(m_mca_bus);
+	if (dev) dev->set_host_bus(m_mca_bus);
 
 	// tell MCA bus that there is one slot with the specified tag
 	downcast<mca32_device &>(*m_mca_bus).add_slot(tag());

--- a/src/devices/bus/mca/mca.cpp
+++ b/src/devices/bus/mca/mca.cpp
@@ -1,0 +1,704 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM's Micro Channel bus, the PC version.
+	Supports 16-bit and 32-bit cards.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "mca.h"
+
+#define LOG_GENERIC		(1U <<	0)
+#define LOG_SYSPORTS    (1U <<  2)
+#define LOG_NVRAM       (1U <<  3)
+#define LOG_TIMERS      (1U <<  4)
+#define LOG_POST        (1U <<  5)
+#define LOG_POS         (1U <<  6)
+
+#define VERBOSE (LOG_GENERIC|LOG_SYSPORTS|LOG_NVRAM|LOG_TIMERS|LOG_POST|LOG_POS)
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+#define LOGGENERIC(...)    	LOGMASKED(LOG_GENERIC, __VA_ARGS__)
+#define LOGSYSPORTS(...)    LOGMASKED(LOG_SYSPORTS, __VA_ARGS__)
+#define LOGNVRAM(...)       LOGMASKED(LOG_NVRAM, __VA_ARGS__)
+#define LOGTIMERS(...)      LOGMASKED(LOG_TIMERS, __VA_ARGS__)
+#define LOGPOST(...)        LOGMASKED(LOG_POST, __VA_ARGS__)
+#define LOGPOS(...)         LOGMASKED(LOG_POS, __VA_ARGS__)
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_SLOT, mca16_slot_device, "mca16_slot", "16-bit MCA slot")
+DEFINE_DEVICE_TYPE(MCA32_SLOT, mca32_slot_device, "mca32_slot", "32-bit MCA slot")
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  mca16_slot_device - constructor
+//-------------------------------------------------
+mca16_slot_device::mca16_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_slot_device(mconfig, MCA16_SLOT, tag, owner, clock)
+{
+}
+
+mca16_slot_device::mca16_slot_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_slot_interface(mconfig, *this),
+	m_mca_bus(*this, finder_base::DUMMY_TAG)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_slot_device::device_start()
+{
+	device_mca16_card_interface *const dev = dynamic_cast<device_mca16_card_interface *>(get_card_device());
+
+	if (dev) dev->set_mcabus(m_mca_bus);
+
+	// tell MCA bus that there is one slot with the specified tag
+	downcast<mca16_device &>(*m_mca_bus).add_slot(tag());
+}
+
+/***************************
+ * 16-bit MCA bus
+ ***************************/
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16, mca16_device, "mca16", "16-bit MCA bus")
+DEFINE_DEVICE_TYPE(MCA32, mca32_device, "mca32", "32-bit MCA bus")
+
+//**************************************************************************
+//  LIVE DEVICE
+//**************************************************************************
+
+//-------------------------------------------------
+//  mca16_device - constructor
+//-------------------------------------------------
+
+mca16_device::mca16_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_device(mconfig, MCA16, tag, owner, clock)
+{
+}
+
+mca16_device::mca16_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_memory_interface(mconfig, *this),
+	m_mem16_config("mem16", ENDIANNESS_LITTLE, 16, 24, 0, address_map_constructor()),
+	m_io16_config("io16", ENDIANNESS_LITTLE, 16, 24, 0, address_map_constructor()),
+	m_memspace(*this, finder_base::DUMMY_TAG, -1),
+	m_iospace(*this, finder_base::DUMMY_TAG, -1),
+	m_memwidth(0),
+	m_iowidth(0),
+	m_allocspaces(false),
+	m_out_irq_cb(*this),
+	m_out_drq_cb(*this),
+	m_write_iochrdy(*this),
+	m_write_iochck(*this),
+	m_cs_feedback(*this)
+{
+	std::fill(std::begin(m_dma_device), std::end(m_dma_device), nullptr);
+	std::fill(std::begin(m_dma_eop), std::end(m_dma_eop), false);
+}
+
+device_memory_interface::space_config_vector mca16_device::memory_space_config() const
+{
+	return space_config_vector {
+		std::make_pair(AS_MCA_MEM16,  &m_mem16_config),
+		std::make_pair(AS_MCA_IO16,   &m_io16_config),	
+	};
+}
+
+void mca16_device::set_dma_channel(uint8_t channel, device_mca16_card_interface *dev, bool do_eop)
+{
+	m_dma_device[channel] = dev;
+	m_dma_eop[channel] = do_eop;
+}
+
+void mca16_device::unset_dma_channel(uint8_t channel)
+{
+	m_dma_device[channel] = NULL;
+}
+
+void mca16_device::add_slot(const char *tag)
+{
+	device_t *dev = subdevice(tag);
+	add_slot(dynamic_cast<device_slot_interface *>(dev));
+}
+
+void mca16_device::add_slot(device_slot_interface *slot)
+{
+	m_slot_list.push_front(slot);
+}
+
+//-------------------------------------------------
+//  device_config_complete - - perform any
+//  operations now that the configuration is
+//  complete
+//-------------------------------------------------
+
+void mca16_device::device_config_complete()
+{
+	printf("FIXME: MCA16 is not using its internal address space in device_config_complete\n");
+	m_memspace.set_tag(*this, ":maincpu", AS_PROGRAM);
+	m_iospace.set_tag(*this, ":maincpu", AS_IO);
+}
+
+//-------------------------------------------------
+//  device_resolve_objects - resolve objects that
+//  may be needed for other devices to set
+//  initial conditions at start time
+//-------------------------------------------------
+
+void mca16_device::device_resolve_objects()
+{
+	// resolve callbacks
+	m_write_iochrdy.resolve_safe();
+	m_write_iochck.resolve_safe();
+
+	m_out_irq_cb.resolve_all_safe();
+	m_out_drq_cb.resolve_all_safe();
+
+	m_cs_feedback.resolve_safe();
+
+	m_iowidth = m_iospace->data_width();
+	m_memwidth = m_memspace->data_width();
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_device::device_start()
+{
+	
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_device::device_reset()
+{
+}
+
+
+template <typename R, typename W> void mca16_device::install_space(int spacenum, offs_t start, offs_t end, R rhandler, W whandler)
+{
+	LOG("%s\n", FUNCNAME);
+
+	int buswidth;
+	address_space *space;
+
+	if (spacenum == AS_MCA_IO16)
+	{
+		space = m_iospace.target();
+		buswidth = m_iowidth;
+	}
+	else if (spacenum == AS_MCA_MEM16)
+	{
+		space = m_memspace.target();
+		buswidth = m_memwidth;
+	}
+	else
+	{
+		fatalerror("Unknown space passed to mca16_device::install_space!\n");
+	}
+
+	switch (buswidth)
+	{
+		case 8:
+			space->install_read_handler(start, end, rhandler, 0);
+			space->install_write_handler(start, end, whandler, 0);
+			break;
+		case 16:
+			space->install_read_handler(start, end, rhandler, 0xffff);
+			space->install_write_handler(start, end, whandler, 0xffff);
+			break;
+		case 32:
+			if ((start % 4) == 0)
+			{
+				if ((end - start) == 1)
+				{
+					space->install_read_handler(start, end + 2, rhandler, 0x0000ffff);
+					space->install_write_handler(start, end + 2, whandler, 0x0000ffff);
+				}
+				else
+				{
+					space->install_read_handler(start, end, rhandler, 0xffffffff);
+					space->install_write_handler(start, end, whandler, 0xffffffff);
+				}
+			}
+			else
+			{
+				// we handle just misaligned by 2
+				space->install_read_handler(start - 2, end, rhandler, 0xffff0000);
+				space->install_write_handler(start - 2, end, whandler, 0xffff0000);
+			}
+			break;
+		default:
+			fatalerror("MCA16: Bus width %d not supported\n", buswidth);
+	}
+}
+
+template void mca16_device::install_space<read8_delegate,    write8_delegate   >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8_delegate whandler);
+template void mca16_device::install_space<read8_delegate,    write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8m_delegate whandler);
+template void mca16_device::install_space<read8_delegate,    write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8s_delegate whandler);
+template void mca16_device::install_space<read8_delegate,    write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8sm_delegate whandler);
+template void mca16_device::install_space<read8_delegate,    write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8mo_delegate whandler);
+template void mca16_device::install_space<read8_delegate,    write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8smo_delegate whandler);
+
+template void mca16_device::install_space<read8m_delegate,   write8_delegate   >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8_delegate whandler);
+template void mca16_device::install_space<read8m_delegate,   write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8m_delegate whandler);
+template void mca16_device::install_space<read8m_delegate,   write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8s_delegate whandler);
+template void mca16_device::install_space<read8m_delegate,   write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8sm_delegate whandler);
+template void mca16_device::install_space<read8m_delegate,   write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8mo_delegate whandler);
+template void mca16_device::install_space<read8m_delegate,   write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8smo_delegate whandler);
+
+template void mca16_device::install_space<read8s_delegate,   write8_delegate   >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8_delegate whandler);
+template void mca16_device::install_space<read8s_delegate,   write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8m_delegate whandler);
+template void mca16_device::install_space<read8s_delegate,   write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8s_delegate whandler);
+template void mca16_device::install_space<read8s_delegate,   write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8sm_delegate whandler);
+template void mca16_device::install_space<read8s_delegate,   write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8mo_delegate whandler);
+template void mca16_device::install_space<read8s_delegate,   write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8smo_delegate whandler);
+
+template void mca16_device::install_space<read8sm_delegate,  write8_delegate   >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8_delegate whandler);
+template void mca16_device::install_space<read8sm_delegate,  write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8m_delegate whandler);
+template void mca16_device::install_space<read8sm_delegate,  write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8s_delegate whandler);
+template void mca16_device::install_space<read8sm_delegate,  write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8sm_delegate whandler);
+template void mca16_device::install_space<read8sm_delegate,  write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8mo_delegate whandler);
+template void mca16_device::install_space<read8sm_delegate,  write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8smo_delegate whandler);
+
+template void mca16_device::install_space<read8mo_delegate,  write8_delegate   >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8_delegate whandler);
+template void mca16_device::install_space<read8mo_delegate,  write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8m_delegate whandler);
+template void mca16_device::install_space<read8mo_delegate,  write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8s_delegate whandler);
+template void mca16_device::install_space<read8mo_delegate,  write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8sm_delegate whandler);
+template void mca16_device::install_space<read8mo_delegate,  write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8mo_delegate whandler);
+template void mca16_device::install_space<read8mo_delegate,  write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8smo_delegate whandler);
+
+template void mca16_device::install_space<read8smo_delegate, write8_delegate   >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8_delegate whandler);
+template void mca16_device::install_space<read8smo_delegate, write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8m_delegate whandler);
+template void mca16_device::install_space<read8smo_delegate, write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8s_delegate whandler);
+template void mca16_device::install_space<read8smo_delegate, write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8sm_delegate whandler);
+template void mca16_device::install_space<read8smo_delegate, write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8mo_delegate whandler);
+template void mca16_device::install_space<read8smo_delegate, write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8smo_delegate whandler);
+
+template void mca16_device::install_space<read16sm_delegate, write16sm_delegate >(int spacenum, offs_t start, offs_t end, read16sm_delegate rhandler,  write16sm_delegate whandler);
+
+void mca16_device::install_bank(offs_t start, offs_t end, uint8_t *data)
+{
+	m_memspace->install_ram(start, end, data);
+}
+
+void mca16_device::install_bank(offs_t start, offs_t end, memory_bank *bank)
+{
+	m_memspace->install_readwrite_bank(start, end, bank);
+}
+
+void mca16_device::unmap_bank(offs_t start, offs_t end)
+{
+	m_memspace->unmap_readwrite(start, end);
+}
+
+void mca16_device::install_rom(device_t *dev, offs_t start, offs_t end, const char *region)
+{
+	if (machine().root_device().memregion("mca")) {
+		uint8_t *src = dev->memregion(region)->base();
+		uint8_t *dest = machine().root_device().memregion("mca")->base() + start - 0xc0000;
+		memcpy(dest,src, end - start + 1);
+	} else {
+		m_memspace->install_rom(start, end, machine().root_device().memregion(dev->subtag(region).c_str())->base());
+		m_memspace->unmap_write(start, end);
+	}
+}
+
+void mca16_device::unmap_rom(offs_t start, offs_t end)
+{
+	m_memspace->unmap_read(start, end);
+}
+
+bool mca16_device::is_option_rom_space_available(offs_t start, int size)
+{
+	for(int i = 0; i < size; i += 4096) // 4KB granularity
+		if(m_memspace->get_read_ptr(start + i)) return false;
+	return true;
+}
+
+void mca16_device::unmap_readwrite(offs_t start, offs_t end)
+{
+	m_memspace->unmap_readwrite(start, end);
+}
+
+uint8_t mca16_device::dack_r(int line)
+{
+	//LOG("MCA DACK R %d\n", line);
+
+	if (m_dma_device[line])
+		return m_dma_device[line]->dack_r(line);
+	return 0xff;
+}
+
+void mca16_device::dack_w(int line, uint8_t data)
+{
+	//LOG("MCA DACK W %d\n", line);
+
+	if (m_dma_device[line])
+		return m_dma_device[line]->dack_w(line,data);
+}
+
+void mca16_device::dack_line_w(int line, int state)
+{
+	//LOG("MCA DACK line w %d\n", line);
+
+	if (m_dma_device[line])
+		m_dma_device[line]->dack_line_w(line, state);
+}
+
+void mca16_device::eop_w(int channel, int state)
+{
+	//LOG("MCA EOP ch %d %d\n", channel, state);
+
+	if (m_dma_eop[channel] && m_dma_device[channel])
+		m_dma_device[channel]->eop_w(state);
+}
+
+void mca16_device::set_ready(int state)
+{
+	m_write_iochrdy(state);
+}
+
+void mca16_device::nmi()
+{
+	// active low pulse
+	m_write_iochck(0);
+	m_write_iochck(1);
+}
+
+//**************************************************************************
+//  DEVICE CONFIG MCA16 CARD INTERFACE
+//**************************************************************************
+
+
+//**************************************************************************
+//  DEVICE MCA16 CARD INTERFACE
+//**************************************************************************
+
+//-------------------------------------------------
+//  device_mca16_card_interface - constructor
+//-------------------------------------------------
+
+device_mca16_card_interface::device_mca16_card_interface(const machine_config &mconfig, device_t &device, uint16_t card_id)
+	: device_interface(device, "mca"),
+		m_card_id(card_id), m_mca(nullptr), m_mca_dev(nullptr), m_next(nullptr)
+{
+
+}
+
+//-------------------------------------------------
+//  ~device_mca16_card_interface - destructor
+//-------------------------------------------------
+
+device_mca16_card_interface::~device_mca16_card_interface()
+{
+}
+
+/// @brief Read a POS register from an MCA card
+///
+/// Reads one of the Peripheral Option Select registers from the
+/// MCA card device. Bytes 0 and 1 are always the card ID.
+/// Anything further must be implemented in the card device.
+/// @param [in] offset The POS register to read.
+/// @return The data byte read from POS.
+uint8_t device_mca16_card_interface::pos_r(offs_t offset)
+{
+	uint8_t data = 0xff;
+
+	switch(offset)
+		{
+			case 0:
+				// Adapter Identification b0-b7
+				data = m_card_id & 0xff; break;
+			case 1:
+				// Adapter Identification b8-b15
+				data = (m_card_id >> 8) & 0xff; break;
+			case 2:
+				// Option Select Data 1
+				data = m_option_select[MCABus::POS::OPTION_SELECT_DATA_1]; break;
+			case 3:
+				// Option Select Data 2
+				data = m_option_select[MCABus::POS::OPTION_SELECT_DATA_2]; break;
+			case 4:
+				// Option Select Data 3
+				data = m_option_select[MCABus::POS::OPTION_SELECT_DATA_3]; break;
+			case 5:
+				// Option Select Data 4
+				data = m_option_select[MCABus::POS::OPTION_SELECT_DATA_4]; break;
+			case 6:
+				// Subaddress Extension Low - most devices don't implement this
+				data = m_option_select[MCABus::POS::SUBADDRESS_EXT_LO]; break;
+			case 7:
+				// Subaddress Extension High - most devices don't implement this
+				data = m_option_select[MCABus::POS::SUBADDRESS_EXT_HI]; break;
+		}
+	return data; // out of range? driver setup error
+}
+
+/// @brief Write a POS register to an MCA card.
+///
+/// Writes one of the Peripheral Option Select registers in the
+/// MCA card device. This typically changes resource assignment.
+/// @param [in] offset The POS register to write.
+/// @param [in] data The byte to write to the POS register.
+void device_mca16_card_interface::pos_w(offs_t offset, uint8_t data)
+{
+	// Generic POS implementation that will call inherited write members.
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+            update_pos_data_1(data);
+			break;
+		case 3:
+			// Option Select Data 2
+            update_pos_data_2(data);
+			break;
+		case 4:
+			// Option Select Data 3
+			update_pos_data_3(data);
+			break;
+		case 5:
+			// Option Select Data 4
+			update_pos_data_4(data);
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}
+
+uint16_t device_mca16_card_interface::io16_r(offs_t offset)
+{
+	// If no special 16-bit handler, perform two 8-bit reads.
+	uint16_t lo = io8_r(offset);
+	uint16_t hi = io8_r(offset+1);
+
+	return (hi << 8) | lo;
+}
+
+void device_mca16_card_interface::io16_w(offs_t offset, uint16_t data)
+{
+	io8_w(offset, data & 0xFF);
+	io8_w(offset, (data & 0xFF00) >> 8);
+}
+
+uint16_t mca16_device::dack16_r(int line)
+{
+	if (m_dma_device[line])
+		return dynamic_cast<device_mca16_card_interface *>(m_dma_device[line])->dack_r(line);
+	return 0xffff;
+}
+
+void mca16_device::dack16_w(int line, uint16_t data)
+{
+	if (m_dma_device[line])
+		return dynamic_cast<device_mca16_card_interface *>(m_dma_device[line])->dack_w(line,data);
+}
+
+//-------------------------------------------------
+//  32-bit MCA bus
+//-------------------------------------------------
+
+mca32_device::mca32_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca32_device(mconfig, MCA32, tag, owner, clock)
+{
+}
+
+mca32_device::mca32_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_device(mconfig, type, tag, owner, clock),
+	m_mem32_config("mem32", ENDIANNESS_LITTLE, 32, 32, 0, address_map_constructor()),
+	m_io32_config("io32", ENDIANNESS_LITTLE, 32, 16, 0, address_map_constructor())
+{
+	std::fill(std::begin(m_dma_device), std::end(m_dma_device), nullptr);
+	std::fill(std::begin(m_dma_eop), std::end(m_dma_eop), false);
+}
+
+device_memory_interface::space_config_vector mca32_device::memory_space_config() const
+{
+	return space_config_vector {
+		std::make_pair(AS_MCA_MEM32,  &m_mem32_config),
+		std::make_pair(AS_MCA_IO32,   &m_io32_config),	
+	};
+}
+
+void mca32_device::device_config_complete()
+{
+	printf("FIXME: MCA32 is not using its internal address space in device_config_complete\n");
+	m_memspace.set_tag(*this, ":maincpu", AS_PROGRAM);
+	m_iospace.set_tag(*this, ":maincpu", AS_IO);
+}
+
+/***********************************************
+ * MCA 32-bit card device
+ ***********************************************/
+
+device_mca32_card_interface::device_mca32_card_interface(const machine_config &mconfig, device_t &device, uint16_t card_id)
+	: device_mca16_card_interface(mconfig, device, card_id)
+{
+}
+
+void device_mca32_card_interface::set_mca_device()
+{
+	m_mca = dynamic_cast<mca32_device *>(m_mca_dev);
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+mca32_slot_device::mca32_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca32_slot_device(mconfig, MCA32_SLOT, tag, owner, clock)
+{
+}
+
+mca32_slot_device::mca32_slot_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_slot_device(mconfig, type, tag, owner, clock)
+{
+}
+
+void mca32_slot_device::device_start()
+{
+	device_mca32_card_interface *const dev = dynamic_cast<device_mca32_card_interface *>(get_card_device());
+
+	if (dev) dev->set_mcabus(m_mca_bus);
+
+	// tell MCA bus that there is one slot with the specified tag
+	downcast<mca32_device &>(*m_mca_bus).add_slot(tag());
+}
+
+template <typename R, typename W> void mca32_device::install_space(int spacenum, offs_t start, offs_t end, R rhandler, W whandler)
+{
+	LOG("%s\n", FUNCNAME);
+
+	int buswidth;
+	address_space *space;
+
+	if (spacenum == AS_MCA_IO32)
+	{
+		space = m_iospace.target();
+		buswidth = m_iowidth;
+	}
+	else if (spacenum == AS_MCA_MEM32)
+	{
+		space = m_memspace.target();
+		buswidth = m_memwidth;
+	}
+	else
+	{
+		fatalerror("Unknown space passed to mca32_device::install_space!\n");
+	}
+
+	switch (buswidth)
+	{
+		case 8:
+			space->install_read_handler(start, end, rhandler, 0);
+			space->install_write_handler(start, end, whandler, 0);
+			break;
+		case 16:
+			space->install_read_handler(start, end, rhandler, 0xffff);
+			space->install_write_handler(start, end, whandler, 0xffff);
+			break;
+		case 32:
+			if ((start % 4) == 0)
+			{
+				if ((end - start) == 1)
+				{
+					space->install_read_handler(start, end + 2, rhandler, 0x0000ffff);
+					space->install_write_handler(start, end + 2, whandler, 0x0000ffff);
+				}
+				else
+				{
+					space->install_read_handler(start, end, rhandler, 0xffffffff);
+					space->install_write_handler(start, end, whandler, 0xffffffff);
+				}
+			}
+			else
+			{
+				// we handle just misaligned by 2
+				space->install_read_handler(start - 2, end, rhandler, 0xffff0000);
+				space->install_write_handler(start - 2, end, whandler, 0xffff0000);
+			}
+			break;
+		default:
+			fatalerror("MCA16: Bus width %d not supported\n", buswidth);
+	}
+}
+
+template void mca32_device::install_space<read8_delegate,    write8_delegate   >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8_delegate whandler);
+template void mca32_device::install_space<read8_delegate,    write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8m_delegate whandler);
+template void mca32_device::install_space<read8_delegate,    write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8s_delegate whandler);
+template void mca32_device::install_space<read8_delegate,    write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8sm_delegate whandler);
+template void mca32_device::install_space<read8_delegate,    write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8mo_delegate whandler);
+template void mca32_device::install_space<read8_delegate,    write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8_delegate rhandler,    write8smo_delegate whandler);
+
+template void mca32_device::install_space<read8m_delegate,   write8_delegate   >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8_delegate whandler);
+template void mca32_device::install_space<read8m_delegate,   write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8m_delegate whandler);
+template void mca32_device::install_space<read8m_delegate,   write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8s_delegate whandler);
+template void mca32_device::install_space<read8m_delegate,   write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8sm_delegate whandler);
+template void mca32_device::install_space<read8m_delegate,   write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8mo_delegate whandler);
+template void mca32_device::install_space<read8m_delegate,   write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8m_delegate rhandler,   write8smo_delegate whandler);
+
+template void mca32_device::install_space<read8s_delegate,   write8_delegate   >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8_delegate whandler);
+template void mca32_device::install_space<read8s_delegate,   write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8m_delegate whandler);
+template void mca32_device::install_space<read8s_delegate,   write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8s_delegate whandler);
+template void mca32_device::install_space<read8s_delegate,   write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8sm_delegate whandler);
+template void mca32_device::install_space<read8s_delegate,   write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8mo_delegate whandler);
+template void mca32_device::install_space<read8s_delegate,   write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8s_delegate rhandler,   write8smo_delegate whandler);
+
+template void mca32_device::install_space<read8sm_delegate,  write8_delegate   >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8_delegate whandler);
+template void mca32_device::install_space<read8sm_delegate,  write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8m_delegate whandler);
+template void mca32_device::install_space<read8sm_delegate,  write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8s_delegate whandler);
+template void mca32_device::install_space<read8sm_delegate,  write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8sm_delegate whandler);
+template void mca32_device::install_space<read8sm_delegate,  write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8mo_delegate whandler);
+template void mca32_device::install_space<read8sm_delegate,  write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8sm_delegate rhandler,  write8smo_delegate whandler);
+
+template void mca32_device::install_space<read8mo_delegate,  write8_delegate   >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8_delegate whandler);
+template void mca32_device::install_space<read8mo_delegate,  write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8m_delegate whandler);
+template void mca32_device::install_space<read8mo_delegate,  write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8s_delegate whandler);
+template void mca32_device::install_space<read8mo_delegate,  write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8sm_delegate whandler);
+template void mca32_device::install_space<read8mo_delegate,  write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8mo_delegate whandler);
+template void mca32_device::install_space<read8mo_delegate,  write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8mo_delegate rhandler,  write8smo_delegate whandler);
+
+template void mca32_device::install_space<read8smo_delegate, write8_delegate   >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8_delegate whandler);
+template void mca32_device::install_space<read8smo_delegate, write8m_delegate  >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8m_delegate whandler);
+template void mca32_device::install_space<read8smo_delegate, write8s_delegate  >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8s_delegate whandler);
+template void mca32_device::install_space<read8smo_delegate, write8sm_delegate >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8sm_delegate whandler);
+template void mca32_device::install_space<read8smo_delegate, write8mo_delegate >(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8mo_delegate whandler);
+template void mca32_device::install_space<read8smo_delegate, write8smo_delegate>(int spacenum, offs_t start, offs_t end, read8smo_delegate rhandler, write8smo_delegate whandler);

--- a/src/devices/bus/mca/mca.h
+++ b/src/devices/bus/mca/mca.h
@@ -1,0 +1,362 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***********************************************************************************************************
+
+    IBM Micro Channel Architecture
+
+    16-bit works
+	32-bit is a skeleton
+    
+***********************************************************************************************************/
+
+#ifndef MAME_BUS_MCA_MCA_H
+#define MAME_BUS_MCA_MCA_H
+
+#pragma once
+
+#include <forward_list>
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+class mca16_device;
+
+namespace MCABus
+{
+	typedef enum
+	{
+		ADAPTER_ID_LO = 0,
+		ADAPTER_ID_HI = 1,
+		OPTION_SELECT_DATA_1 = 2,
+		OPTION_SELECT_DATA_2 = 3,
+		OPTION_SELECT_DATA_3 = 4,
+		OPTION_SELECT_DATA_4 = 5,
+		SUBADDRESS_EXT_LO = 6,
+		SUBADDRESS_EXT_HI = 7,
+	} POS;
+
+	const uint16_t CARD_NOT_PRESENT = 0xffff;
+};
+
+class mca16_slot_device : public device_t, public device_slot_interface
+{
+public:
+	// construction/destruction
+	template <typename T, typename U>
+	mca16_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&mca_tag, U &&opts, const char *dflt, bool fixed)
+		: mca16_slot_device(mconfig, tag, owner, clock)
+	{
+		option_reset();
+		opts(*this);
+		set_default_option(dflt);
+		set_fixed(fixed);
+		m_mca_bus.set_tag(std::forward<T>(mca_tag));
+	}
+	mca16_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	mca16_slot_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+
+	// configuration
+	required_device<device_t> m_mca_bus;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_SLOT, mca16_slot_device)
+
+class device_mca16_card_interface;
+// ======================> mca16_device
+class mca16_device : public device_t,
+					public device_memory_interface
+{
+public:
+	enum
+	{
+		AS_MCA_MEM16   	= 0,
+		AS_MCA_IO16    	= 1
+	};
+
+	// construction/destruction
+	mca16_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	// inline configuration
+	template<int Line> DECLARE_WRITE_LINE_MEMBER( dreq_w )
+	{
+		m_out_drq_cb[Line](state);
+	}
+	template<int Line> DECLARE_WRITE_LINE_MEMBER( ireq_w )
+	{
+		m_out_irq_cb[Line](state);
+	};
+
+	template <typename T> void set_memspace(T &&tag, int spacenum) { m_memspace.set_tag(std::forward<T>(tag), spacenum); }
+	template <typename T> void set_iospace(T &&tag, int spacenum) { m_iospace.set_tag(std::forward<T>(tag), spacenum); }
+	auto iochrdy_callback() { return m_write_iochrdy.bind(); }
+	auto iochck_callback() { return m_write_iochck.bind(); }
+	auto cs_feedback_callback() { return m_cs_feedback.bind(); }
+
+	template<int Line> auto irq_callback() { return m_out_irq_cb[Line].bind(); }
+	template<int Line> auto drq_callback() { return m_out_drq_cb[Line].bind(); }
+
+	// include this in a driver to have MCA allocate its own address spaces (e.g. non-x86)
+	void set_custom_spaces() { m_allocspaces = true; }
+	virtual space_config_vector memory_space_config() const override;
+
+	template<typename R, typename W> void install_device(offs_t start, offs_t end, R rhandler, W whandler)
+	{
+		install_space(AS_MCA_IO16, start, end, rhandler, whandler);
+	}
+	template<typename T> void install_device(offs_t addrstart, offs_t addrend, T &device, void (T::*map)(class address_map &map), uint64_t unitmask = ~u64(0))
+	{
+		m_iospace->install_device(addrstart, addrend, device, map, unitmask);
+	}
+	void install_bank(offs_t start, offs_t end, uint8_t *data);
+	void install_bank(offs_t start, offs_t end, memory_bank *bank);
+	void install_rom(device_t *dev, offs_t start, offs_t end, const char *region);
+	template<typename R, typename W> void install_memory(offs_t start, offs_t end, R rhandler, W whandler)
+	{
+		install_space(AS_MCA_MEM16, start, end, rhandler, whandler);
+	}
+
+	void unmap_device(offs_t start, offs_t end) const { m_iospace->unmap_readwrite(start, end); }
+	void unmap_bank(offs_t start, offs_t end);
+	void unmap_rom(offs_t start, offs_t end);
+	void unmap_readwrite(offs_t start, offs_t end);
+	bool is_option_rom_space_available(offs_t start, int size);
+
+	uint8_t dack_r(int line);
+	void dack_w(int line, uint8_t data);
+	void dack_line_w(int line, int state);
+	void eop_w(int channels, int state);
+
+	uint16_t dack16_r(int line);
+	void dack16_w(int line, uint16_t data);
+
+	void set_ready(int state);
+	void nmi();
+
+	virtual void set_dma_channel(uint8_t channel, device_mca16_card_interface *dev, bool do_eop);
+	virtual void unset_dma_channel(uint8_t channel);
+
+	void add_slot(const char *tag);
+	void add_slot(device_slot_interface *slot);
+	virtual void remap(int space_id, offs_t start, offs_t end) {};
+
+	const address_space_config m_mem16_config, m_io16_config;
+
+protected:
+	mca16_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	template<typename R, typename W> void install_space(int spacenum, offs_t start, offs_t end, R rhandler, W whandler);
+
+	// device-level overrides
+	virtual void device_config_complete() override;
+	virtual void device_resolve_objects() override;
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// address spaces
+	required_address_space m_memspace, m_iospace;
+	int m_memwidth, m_iowidth;
+	bool m_allocspaces;
+
+	device_mca16_card_interface *m_dma_device[8];
+	bool                        m_dma_eop[8];
+	std::forward_list<device_slot_interface *> m_slot_list;
+
+	void irq_request(unsigned line, bool state);
+	void dma_request(int channel, bool state);
+
+	devcb_write_line::array<16> m_out_irq_cb;
+	devcb_write_line::array<8> m_out_drq_cb;
+
+private:
+	devcb_write_line m_write_iochrdy;
+	devcb_write_line m_write_iochck;
+	devcb_write_line m_cs_feedback;
+};
+
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16, mca16_device)
+
+// ======================> device_mca16_card_interface
+
+// class representing interface-specific live mca16 card
+class device_mca16_card_interface : public device_interface
+{
+	friend class mca16_device;
+	template <class ElementType> friend class simple_list;
+public:
+	// construction/destruction
+	virtual ~device_mca16_card_interface();
+
+	virtual uint16_t get_card_id() { return m_card_id; }
+
+	// DMA signals
+	virtual uint8_t dack_r(int line) { return 0xff; };
+	virtual void dack_w(int line, uint8_t data) {};
+	virtual void dack_line_w(int line, int state) {};
+	virtual void eop_w(int state) {};
+
+	/// @brief Unmap MCA resources
+	///
+	/// Unmaps any resources that the MCA device is currently using.
+	/// This includes I/O ports, IRQ lines, DMA request lines, memory allocation.
+	virtual void unmap() { fatalerror("unmap() not defined for MCA card %04X", m_card_id); }
+
+	/// @brief Remap MCA resources
+	///
+	/// Installs all resources that the MCA device is currently using,
+	/// according to the current configuration in the POS registers.
+	/// This includes I/O ports, IRQ lines, DMA request lines, memory allocation.
+	virtual void remap() { fatalerror("remap() not defined for MCA card %04X", m_card_id); }
+
+	// map_has_changed will recalculate the resources specified in POS versus the
+	// resources in the IO/IRQ/DMA/memory range variables.
+	// Returns true if the card needs to be remapped, false if the card does not.
+	/// @brief Check for if the resource map has changed since the last remap().
+	///
+	/// Reads the device's POS data, checking what resources it is assigned to
+	/// through POS. If the resource map is different from the current assigned
+	/// resources, returns true and the caller should follow it up with an
+	/// unmap/remap cycle to update the assignment.
+	virtual bool map_has_changed() { fatalerror("remap() not defined for MCA card %04X", m_card_id); }
+
+	/// @brief 8-bit I/O port read.
+	/// @param offset The offset into the I/O mapping.
+	/// @return The value read from the MCA card device.
+	virtual uint8_t io8_r(offs_t offset) { return 0xFF; }
+
+	/// @brief 8-bit I/O port write.
+	/// @param offset The offset into the I/O mapping.
+	/// @return The value written to the MCA card device.
+	virtual void io8_w(offs_t offset, uint8_t data) {}
+
+	/// @brief 16-bit I/O port read.
+	/// @param offset The offset into the I/O mapping.
+	/// @return The value read from the MCA card device.	
+	virtual uint16_t io16_r(offs_t offset);
+
+	/// @brief 16-bit I/O port write.
+	/// @param offset The offset into the I/O mapping.
+	/// @return The value written to the MCA card device.
+	virtual void io16_w(offs_t offset, uint16_t data);
+
+	// Stuff for in-band configuation.
+	virtual uint8_t pos_r(offs_t offset);
+	virtual void pos_w(offs_t offset, uint8_t data);
+
+	virtual void update_pos_data_1(uint8_t data) {}
+	virtual void update_pos_data_2(uint8_t data) {}
+	virtual void update_pos_data_3(uint8_t data) {}
+	virtual void update_pos_data_4(uint8_t data) {}
+
+	// Stuff for out-of-band bus/card device configuration.
+	void set_mcabus(device_t *mca_device) { m_mca_dev = mca_device; }
+	virtual void set_mca_device() { m_mca = dynamic_cast<mca16_device *>(m_mca_dev); }
+
+	device_mca16_card_interface *next() const { return m_next; }
+
+	bool m_is_mapped;
+
+protected:
+	/// @brief Assert /CD_SFDBK
+	///
+	/// Asserts the Card Selected Feedback line, which informs the bus
+	/// that a device is present at a particular I/O address.
+	/// Asserted by the receiving device, not the transmitting device.
+	/// If no device is present, the line is never asserted.
+	virtual void assert_card_feedback() { m_mca->cs_feedback_callback(); }
+	virtual void reset_option_select() { memset(m_option_select, 0, 8);  }
+		
+	uint8_t 	m_option_select[8];
+	uint16_t 	m_card_id;
+public:
+	device_mca16_card_interface(const machine_config &mconfig, device_t &device, uint16_t card_id);
+
+	mca16_device	*m_mca;
+	device_t    	*m_mca_dev;
+
+private:
+	device_mca16_card_interface *m_next;
+};
+
+////////////////////////////
+class device_mca32_card_interface;
+
+class mca32_device : public mca16_device
+{
+public:
+	mca32_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	enum
+	{
+		AS_MCA_MEM32   	= 0,
+		AS_MCA_IO32    	= 1
+	};
+
+	const address_space_config m_mem32_config, m_io32_config;
+		
+	virtual space_config_vector memory_space_config() const override;
+
+	template<typename R, typename W> void install_memory(offs_t start, offs_t end, R rhandler, W whandler)
+	{
+		install_space(AS_MCA_MEM32, start, end, rhandler, whandler);
+	}
+
+	template<typename R, typename W> void install_space(int spacenum, offs_t start, offs_t end, R rhandler, W whandler);
+
+	uint8_t io8_r(offs_t offset) { return m_iospace->read_byte(offset); }
+	void io8_w(offs_t offset, uint8_t data) { return m_iospace->write_byte(offset, data); }
+
+protected:
+	mca32_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void device_config_complete() override;
+};
+
+DECLARE_DEVICE_TYPE(MCA32, mca32_device);
+
+class mca32_slot_device : public mca16_slot_device
+{
+public:
+	// construction/destruction
+	template <typename T, typename U>
+	mca32_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, T &&mca_tag, U &&opts, const char *dflt, bool fixed)
+		: mca32_slot_device(mconfig, tag, owner, clock)
+	{
+		option_reset();
+		opts(*this);
+		set_default_option(dflt);
+		set_fixed(fixed);
+		m_mca_bus.set_tag(std::forward<T>(mca_tag));
+	}
+	mca32_slot_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+protected:
+	mca32_slot_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+};
+
+class device_mca32_card_interface : public device_mca16_card_interface
+{
+	friend class mca32_device;
+
+	public:
+	device_mca32_card_interface(const machine_config &mconfig, device_t &device, uint16_t card_id);
+
+	virtual void set_mca_device() override;
+
+	mca32_device	*m_mca;
+};
+
+DECLARE_DEVICE_TYPE(MCA32_SLOT, mca32_slot_device)
+
+#endif // MAME_BUS_MCA_MCA_H

--- a/src/devices/bus/mca/mca.h
+++ b/src/devices/bus/mca/mca.h
@@ -84,11 +84,11 @@ public:
 	mca16_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
 	// inline configuration
-	template<int Line> DECLARE_WRITE_LINE_MEMBER( dreq_w )
+	template<int Line> void dreq_w(int state)
 	{
 		m_out_drq_cb[Line](state);
 	}
-	template<int Line> DECLARE_WRITE_LINE_MEMBER( ireq_w )
+	template<int Line> void ireq_w(int state)
 	{
 		m_out_irq_cb[Line](state);
 	};
@@ -114,6 +114,7 @@ public:
 	{
 		m_iospace->install_device(addrstart, addrend, device, map, unitmask);
 	}
+	
 	void install_bank(offs_t start, offs_t end, uint8_t *data);
 	void install_bank(offs_t start, offs_t end, memory_bank *bank);
 	void install_rom(device_t *dev, offs_t start, offs_t end, const char *region);
@@ -147,6 +148,8 @@ public:
 	virtual void remap(int space_id, offs_t start, offs_t end) {};
 
 	const address_space_config m_mem16_config, m_io16_config;
+
+	required_address_space get_iospace() { return m_iospace; }
 
 protected:
 	mca16_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
@@ -271,7 +274,7 @@ protected:
 	/// that a device is present at a particular I/O address.
 	/// Asserted by the receiving device, not the transmitting device.
 	/// If no device is present, the line is never asserted.
-	virtual void assert_card_feedback() { m_mca->cs_feedback_callback(); }
+	virtual void assert_card_feedback() { printf("assert_card_feedback %p\n", this); m_mca->cs_feedback_callback(); }
 	virtual void reset_option_select() { memset(m_option_select, 0, 8);  }
 		
 	uint8_t 	m_option_select[8];

--- a/src/devices/bus/mca/mca.h
+++ b/src/devices/bus/mca/mca.h
@@ -39,6 +39,7 @@ namespace MCABus
 	const uint16_t CARD_NOT_PRESENT = 0xffff;
 };
 
+// The class that represents a 16-bit MCA slot.
 class mca16_slot_device : public device_t, public device_slot_interface
 {
 public:
@@ -69,7 +70,8 @@ protected:
 DECLARE_DEVICE_TYPE(MCA16_SLOT, mca16_slot_device)
 
 class device_mca16_card_interface;
-// ======================> mca16_device
+
+// Class representing the 16-bit MCA bus.
 class mca16_device : public device_t,
 					public device_memory_interface
 {
@@ -97,7 +99,7 @@ public:
 	template <typename T> void set_iospace(T &&tag, int spacenum) { m_iospace.set_tag(std::forward<T>(tag), spacenum); }
 	auto iochrdy_callback() { return m_write_iochrdy.bind(); }
 	auto iochck_callback() { return m_write_iochck.bind(); }
-	auto cs_feedback_callback() { return m_cs_feedback.bind(); }
+	auto cs_feedback_callback() { printf("cs_feedback_callback %p\n", this); return m_cs_feedback.bind(); }
 
 	template<int Line> auto irq_callback() { return m_out_irq_cb[Line].bind(); }
 	template<int Line> auto drq_callback() { return m_out_drq_cb[Line].bind(); }
@@ -189,7 +191,7 @@ DECLARE_DEVICE_TYPE(MCA16, mca16_device)
 
 // ======================> device_mca16_card_interface
 
-// class representing interface-specific live mca16 card
+// The class representing a card with a 16-bit MCA interface.
 class device_mca16_card_interface : public device_interface
 {
 	friend class mca16_device;
@@ -260,7 +262,7 @@ public:
 	virtual void update_pos_data_4(uint8_t data) {}
 
 	// Stuff for out-of-band bus/card device configuration.
-	void set_mcabus(device_t *mca_device) { m_mca_dev = mca_device; }
+	void set_host_bus(device_t *mca_device) { m_mca_dev = mca_device; }
 	virtual void set_mca_device() { m_mca = dynamic_cast<mca16_device *>(m_mca_dev); }
 
 	device_mca16_card_interface *next() const { return m_next; }
@@ -274,7 +276,7 @@ protected:
 	/// that a device is present at a particular I/O address.
 	/// Asserted by the receiving device, not the transmitting device.
 	/// If no device is present, the line is never asserted.
-	virtual void assert_card_feedback() { printf("assert_card_feedback %p\n", this); m_mca->cs_feedback_callback(); }
+	virtual void assert_card_feedback() { } //printf("16-bit card interface: assert card feedback %p\n", m_mca); m_mca->cs_feedback_callback(); }
 	virtual void reset_option_select() { memset(m_option_select, 0, 8);  }
 		
 	uint8_t 	m_option_select[8];
@@ -292,6 +294,7 @@ private:
 ////////////////////////////
 class device_mca32_card_interface;
 
+// The class representing the 32-bit MCA bus.
 class mca32_device : public mca16_device
 {
 public:
@@ -325,6 +328,7 @@ protected:
 
 DECLARE_DEVICE_TYPE(MCA32, mca32_device);
 
+// The class that represents a 32-bit MCA slot.
 class mca32_slot_device : public mca16_slot_device
 {
 public:
@@ -348,6 +352,7 @@ protected:
 	virtual void device_start() override;
 };
 
+// The class that represents a 32-bit MCA card.
 class device_mca32_card_interface : public device_mca16_card_interface
 {
 	friend class mca32_device;

--- a/src/devices/bus/mca/mca_cards.cpp
+++ b/src/devices/bus/mca/mca_cards.cpp
@@ -1,0 +1,72 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/**********************************************************************
+
+    MCA cards
+
+**********************************************************************/
+
+#include "emu.h"
+#include "mca_cards.h"
+
+// Communications
+#include "3c523.h"
+#include "ibm_dual_async.h"
+#include "planar_lpt.h"
+#include "planar_uart.h"
+
+// Memory
+#include "curam.h"
+#include "ibm_memory_exp_16.h"
+#include "ibm_memory_exp_32.h"
+
+// Multimedia
+#include "adlib.h"
+#include "macpa.h"
+#include "snark_barker.h"
+
+// Storage
+#include "c1000.h"
+#include "planar_fdc.h"
+
+// Video
+#include "ibm_svga.h"
+#include "planar_vga.h"
+
+// Template, not a real card - remove before submitting
+#include "template.h"
+
+// 16-bit MCA cards go here.
+void pc_mca16_cards(device_slot_interface &device)
+{
+    // Communications
+    device.option_add("3c523", MCA16_3C523);                        //  @6042
+    device.option_add("ibm_dual_async", MCA16_IBM_DUAL_ASYNC);      //  @EEFF
+    device.option_add("planar_lpt", MCA16_PLANAR_LPT);              //  (planar device)
+    device.option_add("planar_uart", MCA16_PLANAR_UART);            //  (planar device)
+
+    // Memory
+    device.option_add("curam", MCA16_CURAM16_PLUS);                 //  @6025
+    device.option_add("ibm_memory_exp_16", MCA16_IBM_MEMORY_EXP);   //  @F7F7
+
+    // Multimedia
+    device.option_add("adlib", MCA16_ADLIB);                        //  @70D7
+    device.option_add("macpa", MCA16_MACPA);                        //  @6E6C
+    device.option_add("snark_barker", MCA16_SNARK_BARKER);          //  @5085
+
+    // Storage
+    device.option_add("c1000", MCA16_C1000_IDE);                    //  @6213
+    device.option_add("planar_fdc", MCA16_PLANAR_FDC);              //  (planar device)
+
+    // Video
+    device.option_add("ibm_svga", MCA16_IBM_SVGA);                  //  @917B
+    device.option_add("planar_vga", MCA16_PLANAR_VGA);              //  (planar device)
+}
+
+// 32-bit MCA cards go here.
+void pc_mca32_cards(device_slot_interface &device)
+{
+    pc_mca16_cards(device); // They're compatible.
+
+    device.option_add("ibm_memory_exp_32", MCA32_IBM_MEMORY_EXP);   //  @FCFF
+}

--- a/src/devices/bus/mca/mca_cards.h
+++ b/src/devices/bus/mca/mca_cards.h
@@ -1,0 +1,18 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/**********************************************************************
+
+    MCA cards
+
+**********************************************************************/
+
+#ifndef MAME_BUS_MCA_MCA_CARDS_H
+#define MAME_BUS_MCA_MCA_CARDS_H
+
+#pragma once
+
+// supported devices
+void pc_mca16_cards(device_slot_interface &device);
+void pc_mca32_cards(device_slot_interface &device);
+
+#endif // MAME_BUS_MCA_MCA_CARDS_H

--- a/src/devices/bus/mca/planar_fdc.cpp
+++ b/src/devices/bus/mca/planar_fdc.cpp
@@ -1,0 +1,174 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+  IBM PS/2 Planar FDC.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "planar_fdc.h"
+#include "formats/pc_dsk.h"
+#include "formats/naslite_dsk.h"
+#include "formats/ibmxdf_dsk.h"
+
+//#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_PLANAR_FDC, mca16_planar_fdc_device, "mca16_planar_fdc", "IBM PS/2 Planar FDC")
+
+void mca16_planar_fdc_device::floppy_formats(format_registration &fr)
+{
+	fr.add_pc_formats();
+	fr.add(FLOPPY_NASLITE_FORMAT);
+	fr.add(FLOPPY_IBMXDF_FORMAT);
+}
+
+static void pc_hd_floppies(device_slot_interface &device)
+{
+	device.option_add("525hd", FLOPPY_525_HD);
+	device.option_add("35hd", FLOPPY_35_HD);
+	device.option_add("525dd", FLOPPY_525_DD);
+	device.option_add("35dd", FLOPPY_35_DD);
+}
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_planar_fdc_device::device_add_mconfig(machine_config &config)
+{
+	N82077AA(config, m_fdc, 24'000'000);
+	m_fdc->set_mode(n82077aa_device::mode_t::PS2);
+	m_fdc->intrq_wr_callback().set(FUNC(mca16_planar_fdc_device::irq_w));
+	m_fdc->drq_wr_callback().set(FUNC(mca16_planar_fdc_device::drq_w));
+	FLOPPY_CONNECTOR(config, "fdc:0", pc_hd_floppies, "35hd", mca16_planar_fdc_device::floppy_formats).enable_sound(true);
+	FLOPPY_CONNECTOR(config, "fdc:1", pc_hd_floppies, "35hd", mca16_planar_fdc_device::floppy_formats).enable_sound(true);
+}
+
+//-------------------------------------------------
+//  isa8_com_device - constructor
+//-------------------------------------------------
+
+mca16_planar_fdc_device::mca16_planar_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_planar_fdc_device(mconfig, MCA16_PLANAR_FDC, tag, owner, clock)
+{
+}
+
+mca16_planar_fdc_device::mca16_planar_fdc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xffff),
+	m_fdc(*this, "fdc")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_planar_fdc_device::device_start()
+{
+	set_mca_device();
+
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_planar_fdc_device::device_reset()
+{
+	m_fdc->reset();
+}
+
+void mca16_planar_fdc_device::enable()
+{
+	m_mca->install_device(0x3f0, 0x3f7,
+		read8sm_delegate(*this, FUNC(mca16_planar_fdc_device::io8_r)),
+    	write8sm_delegate(*this, FUNC(mca16_planar_fdc_device::io8_w)));
+	m_mca->set_dma_channel(2, this, true);
+}
+
+void mca16_planar_fdc_device::disable()
+{
+	m_mca->unmap_device(0x3f0, 0x3f7);
+}
+
+WRITE_LINE_MEMBER( mca16_planar_fdc_device::irq_w )
+{
+	LOG("%s: FDC: IRQ 6 now %d\n", FUNCNAME, state);
+	m_mca->ireq_w<6>(state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+WRITE_LINE_MEMBER( mca16_planar_fdc_device::drq_w )
+{
+	LOG("%s: FDC: DMA 2 now %d\n", FUNCNAME, state);
+	m_mca->dreq_w<2>(state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+uint8_t mca16_planar_fdc_device::dack_r(int line)
+{
+	LOG("%s: line %d\n", FUNCNAME, line);
+	return m_fdc->dma_r();
+}
+
+void mca16_planar_fdc_device::dack_w(int line, uint8_t data)
+{
+	LOG("%s: line %d\n", FUNCNAME, line);
+	return m_fdc->dma_w(data);
+}
+
+void mca16_planar_fdc_device::eop_w(int state)
+{
+	LOG("%s: FDC: terminal count %d\n", FUNCNAME, state);
+	m_fdc->tc_w(state ? ASSERT_LINE : CLEAR_LINE);
+}
+
+uint8_t mca16_planar_fdc_device::io8_r(offs_t offset)
+{
+	assert_card_feedback();
+	uint8_t data;
+	
+	switch(offset)
+	{
+		case 0: data = m_fdc->sra_r(); break;
+		case 1: data = m_fdc->srb_r(); break;
+		case 2: data = m_fdc->dor_r(); break;
+		case 3: data = m_fdc->tdr_r(); break;
+		case 4: data = m_fdc->msr_r(); break;
+		case 5: data = m_fdc->fifo_r(); break;
+		case 7: data = m_fdc->dir_r(); break;
+		default: data = 0xFF; break;
+	}
+
+	//LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+
+	return data;
+}
+
+void mca16_planar_fdc_device::io8_w(offs_t offset, uint8_t data)
+{
+	//LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+
+	assert_card_feedback();
+	
+	switch(offset)
+	{
+		case 2: m_fdc->dor_w(data); break;
+		case 3: m_fdc->tdr_w(data); break;
+		case 4: m_fdc->dsr_w(data); break;
+		case 5: m_fdc->fifo_w(data); break;
+		case 7: m_fdc->ccr_w(data); break;
+		default: break;
+	}
+}

--- a/src/devices/bus/mca/planar_fdc.cpp
+++ b/src/devices/bus/mca/planar_fdc.cpp
@@ -136,7 +136,7 @@ void mca16_planar_fdc_device::eop_w(int state)
 
 uint8_t mca16_planar_fdc_device::io8_r(offs_t offset)
 {
-	assert_card_feedback();
+	//assert_card_feedback();
 	uint8_t data;
 	
 	switch(offset)
@@ -160,7 +160,7 @@ void mca16_planar_fdc_device::io8_w(offs_t offset, uint8_t data)
 {
 	//LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
 
-	assert_card_feedback();
+	//assert_card_feedback();
 	
 	switch(offset)
 	{

--- a/src/devices/bus/mca/planar_fdc.cpp
+++ b/src/devices/bus/mca/planar_fdc.cpp
@@ -104,13 +104,13 @@ void mca16_planar_fdc_device::disable()
 	m_mca->unmap_device(0x3f0, 0x3f7);
 }
 
-WRITE_LINE_MEMBER( mca16_planar_fdc_device::irq_w )
+void mca16_planar_fdc_device::irq_w(int state)
 {
 	LOG("%s: FDC: IRQ 6 now %d\n", FUNCNAME, state);
 	m_mca->ireq_w<6>(state ? ASSERT_LINE : CLEAR_LINE);
 }
 
-WRITE_LINE_MEMBER( mca16_planar_fdc_device::drq_w )
+void mca16_planar_fdc_device::drq_w(int state)
 {
 	LOG("%s: FDC: DMA 2 now %d\n", FUNCNAME, state);
 	m_mca->dreq_w<2>(state ? ASSERT_LINE : CLEAR_LINE);

--- a/src/devices/bus/mca/planar_fdc.h
+++ b/src/devices/bus/mca/planar_fdc.h
@@ -30,8 +30,8 @@ public:
 	// construction/destruction
 	mca16_planar_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
 
-	DECLARE_WRITE_LINE_MEMBER( irq_w );
-	DECLARE_WRITE_LINE_MEMBER( drq_w );
+	void irq_w(int state);
+	void drq_w(int state);
 	static void floppy_formats(format_registration &fr);
 
 	virtual uint8_t io8_r(offs_t offset) override;
@@ -64,8 +64,8 @@ protected:
 
 	required_device<n82077aa_device> m_fdc;
 
-	DECLARE_WRITE_LINE_MEMBER( fdc_irq_w );
-	DECLARE_WRITE_LINE_MEMBER( fdc_drq_w );
+	void fdc_irq_w(int state);
+	void fdc_drq_w(int state);
 };
 
 // device type definition

--- a/src/devices/bus/mca/planar_fdc.h
+++ b/src/devices/bus/mca/planar_fdc.h
@@ -1,0 +1,74 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar FDC.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_PLANARFDC_H
+#define MAME_BUS_MCA_PLANARFDC_H
+
+#pragma once
+
+#include "mca.h"
+#include "imagedev/floppy.h"
+#include "machine/upd765.h"
+
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_planar_fdc_device
+
+class mca16_planar_fdc_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_planar_fdc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	DECLARE_WRITE_LINE_MEMBER( irq_w );
+	DECLARE_WRITE_LINE_MEMBER( drq_w );
+	static void floppy_formats(format_registration &fr);
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+	void enable();
+	void disable();
+
+	virtual void unmap() override {};
+	virtual void remap() override {};
+
+protected:
+	mca16_planar_fdc_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual uint8_t dack_r(int line) override;
+	virtual void dack_w(int line, uint8_t data) override;
+	virtual void eop_w(int state) override;
+
+	uint8_t dor_r();
+	void dor_w(uint8_t data);
+	uint8_t dir_r();
+	void ccr_w(uint8_t data);
+
+	required_device<n82077aa_device> m_fdc;
+
+	DECLARE_WRITE_LINE_MEMBER( fdc_irq_w );
+	DECLARE_WRITE_LINE_MEMBER( fdc_drq_w );
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_PLANAR_FDC, mca16_planar_fdc_device)
+
+#endif

--- a/src/devices/bus/mca/planar_lpt.cpp
+++ b/src/devices/bus/mca/planar_lpt.cpp
@@ -134,12 +134,16 @@ void mca16_planar_lpt_device::planar_remap_irq(uint8_t new_irq)
 
 uint8_t mca16_planar_lpt_device::io8_r(offs_t offset)
 {
-    assert_card_feedback();
+	printf("assert card feedback r %p\n", m_mca);
+	assert_card_feedback();
+	printf("ok\n");
     return m_lpt->read(offset);
 }
 
 void mca16_planar_lpt_device::io8_w(offs_t offset, uint8_t data)
 {
-    assert_card_feedback();
+	printf("assert card feedback w %p\n", m_mca);
+	assert_card_feedback();
+	printf("ok\n");
     m_lpt->write(offset, data);
 }

--- a/src/devices/bus/mca/planar_lpt.cpp
+++ b/src/devices/bus/mca/planar_lpt.cpp
@@ -134,16 +134,16 @@ void mca16_planar_lpt_device::planar_remap_irq(uint8_t new_irq)
 
 uint8_t mca16_planar_lpt_device::io8_r(offs_t offset)
 {
-	printf("assert card feedback r %p\n", m_mca);
-	assert_card_feedback();
-	printf("ok\n");
+	// printf("planar lpt interface: assert card feedback r %p\n", m_mca);
+	// assert_card_feedback();
+	// printf("ok\n");
     return m_lpt->read(offset);
 }
 
 void mca16_planar_lpt_device::io8_w(offs_t offset, uint8_t data)
 {
-	printf("assert card feedback w %p\n", m_mca);
-	assert_card_feedback();
-	printf("ok\n");
+	// printf("planar lpt interface: assert card feedback w %p\n", m_mca);
+	// assert_card_feedback();
+	// printf("ok\n");
     m_lpt->write(offset, data);
 }

--- a/src/devices/bus/mca/planar_lpt.cpp
+++ b/src/devices/bus/mca/planar_lpt.cpp
@@ -1,0 +1,145 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar LPT.
+
+    Bidirectional SPP parallel port.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "planar_lpt.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_PLANAR_LPT, mca16_planar_lpt_device, "mca16_planar_lpt", "IBM PS/2 Planar LPT")
+
+// static void mca_com(device_slot_interface &device)
+// {
+
+// }
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_planar_lpt_device::device_add_mconfig(machine_config &config)
+{
+	PC_LPT(config, m_lpt);
+    m_lpt->irq_handler().set([this] (int state)
+	{
+        if (m_is_mapped)
+        {
+            if (m_cur_irq == 7) m_mca->ireq_w<7>(state);
+        }
+	});
+}
+
+//-------------------------------------------------
+//  mca16_planar_lpt_device - constructor
+//-------------------------------------------------
+
+mca16_planar_lpt_device::mca16_planar_lpt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_planar_lpt_device(mconfig, MCA16_PLANAR_LPT, tag, owner, clock)
+{
+}
+
+mca16_planar_lpt_device::mca16_planar_lpt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xffff),
+	m_lpt(*this, "lpt")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_planar_lpt_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_planar_lpt_device::device_reset()
+{
+	m_cur_io_start = m_cur_io_end = 0;
+    m_cur_irq = 0;
+    m_is_mapped = 0;
+}
+
+void mca16_planar_lpt_device::enable()
+{
+    // LOG("%s\n", FUNCNAME);
+
+    planar_remap(AS_IO, m_cur_io_start, m_cur_io_end);
+    m_is_mapped = 1;
+}
+
+void mca16_planar_lpt_device::disable()
+{
+    // LOG("%s\n", FUNCNAME);
+
+    m_mca->unmap_device(m_cur_io_start, m_cur_io_end);
+    m_is_mapped = 0;
+}
+
+void mca16_planar_lpt_device::planar_remap(int space_id, offs_t start, offs_t end)
+{
+    // LOG("%s\n", FUNCNAME);
+
+    if(space_id == AS_IO)
+    {
+        // LOG("%s mapped to %04X-%04X\n", FUNCNAME, start, end);
+        if(m_is_mapped) m_mca->unmap_device(m_cur_io_start, m_cur_io_end);
+        m_mca->install_device(start, end, 
+            read8sm_delegate(*this, FUNC(mca16_planar_lpt_device::io8_r)),
+            write8sm_delegate(*this, FUNC(mca16_planar_lpt_device::io8_w)));
+        m_cur_io_start = start;
+        m_cur_io_end = end;
+        m_is_mapped = true;
+    }
+    else
+    {
+        fatalerror("Tried to unmap I/O device from RAM space\n");
+    }
+}
+
+void mca16_planar_lpt_device::planar_remap_irq(uint8_t new_irq)
+{
+    // LOG("%s\n", FUNCNAME);
+    m_cur_irq = new_irq;
+}
+
+uint8_t mca16_planar_lpt_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_lpt->read(offset);
+}
+
+void mca16_planar_lpt_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_lpt->write(offset, data);
+}

--- a/src/devices/bus/mca/planar_lpt.h
+++ b/src/devices/bus/mca/planar_lpt.h
@@ -1,0 +1,64 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar LPT.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_PLANAR_LPT_H
+#define MAME_BUS_MCA_PLANAR_LPT_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/pc_lpt.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_planar_lpt_device
+
+class mca16_planar_lpt_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_planar_lpt_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+    void enable();
+    void disable();
+
+	virtual void unmap() override {};
+	virtual void remap() override {};
+
+    void planar_remap(int space_id, offs_t start, offs_t end);
+	void planar_remap_irq(uint8_t line);
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+protected:
+	mca16_planar_lpt_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	required_device<pc_lpt_device> m_lpt;
+
+private:
+	bool 	m_is_mapped;
+    offs_t  m_cur_io_start, m_cur_io_end;
+    uint8_t m_cur_irq;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_PLANAR_LPT, mca16_planar_lpt_device)
+
+#endif

--- a/src/devices/bus/mca/planar_uart.cpp
+++ b/src/devices/bus/mca/planar_uart.cpp
@@ -1,0 +1,163 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+  IBM PS/2 Planar UART.
+
+  16550 UART. Can be remapped to COM1/COM2 or disabled entirely.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "planar_uart.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_PLANAR_UART, mca16_planar_uart_device, "mca16_planar_uart", "IBM PS/2 Planar UART")
+
+static void mca_com(device_slot_interface &device)
+{
+    device.option_add("microsoft_mouse", MSFT_HLE_SERIAL_MOUSE);
+	device.option_add("logitech_mouse", LOGITECH_HLE_SERIAL_MOUSE);
+	device.option_add("wheel_mouse", WHEEL_HLE_SERIAL_MOUSE);
+	device.option_add("msystems_mouse", MSYSTEMS_HLE_SERIAL_MOUSE);
+	device.option_add("rotatable_mouse", ROTATABLE_HLE_SERIAL_MOUSE);
+	device.option_add("terminal", SERIAL_TERMINAL);
+	device.option_add("null_modem", NULL_MODEM);
+}
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_planar_uart_device::device_add_mconfig(machine_config &config)
+{
+	NS16550(config, m_uart, XTAL(1'843'200));
+	m_uart->out_tx_callback().set("serport0", FUNC(rs232_port_device::write_txd));
+	m_uart->out_dtr_callback().set("serport0", FUNC(rs232_port_device::write_dtr));
+	m_uart->out_rts_callback().set("serport0", FUNC(rs232_port_device::write_rts));
+    m_uart->out_int_callback().set([this] (int state)
+	{
+        if (m_is_mapped)
+        {
+            if (m_cur_irq == 3) m_mca->ireq_w<3>(state);
+            if (m_cur_irq == 4) m_mca->ireq_w<4>(state);
+        }
+	});
+
+	rs232_port_device &serport0(RS232_PORT(config, "serport0", mca_com, nullptr));
+	serport0.rxd_handler().set(m_uart, FUNC(ins8250_uart_device::rx_w));
+	serport0.dcd_handler().set(m_uart, FUNC(ins8250_uart_device::dcd_w));
+	serport0.dsr_handler().set(m_uart, FUNC(ins8250_uart_device::dsr_w));
+	serport0.ri_handler().set(m_uart, FUNC(ins8250_uart_device::ri_w));
+	serport0.cts_handler().set(m_uart, FUNC(ins8250_uart_device::cts_w));
+}
+
+//-------------------------------------------------
+//  mca16_planar_uart_device - constructor
+//-------------------------------------------------
+
+mca16_planar_uart_device::mca16_planar_uart_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_planar_uart_device(mconfig, MCA16_PLANAR_UART, tag, owner, clock)
+{
+}
+
+mca16_planar_uart_device::mca16_planar_uart_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xffff),
+	m_uart(*this, "uart")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_planar_uart_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_planar_uart_device::device_reset()
+{
+	m_cur_io_start = m_cur_io_end = 0;
+    m_cur_irq = 0;
+    m_is_mapped = 0;
+}
+
+void mca16_planar_uart_device::enable()
+{
+    LOG("%s\n", FUNCNAME);
+
+    planar_remap(AS_IO, m_cur_io_start, m_cur_io_end);
+    m_is_mapped = 1;
+}
+
+void mca16_planar_uart_device::disable()
+{
+    LOG("%s\n", FUNCNAME);
+
+    m_mca->unmap_device(m_cur_io_start, m_cur_io_end);
+    m_is_mapped = 0;
+}
+
+uint8_t mca16_planar_uart_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_uart->ins8250_r(offset);
+}
+
+void mca16_planar_uart_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_uart->ins8250_w(offset, data);
+}
+
+void mca16_planar_uart_device::planar_remap(int space_id, offs_t start, offs_t end)
+{
+    // LOG("%s\n", FUNCNAME);
+
+    if(space_id == AS_IO)
+    {
+        LOG("%s mapped to %04X-%04X\n", FUNCNAME, start, end);
+        if(m_is_mapped) m_mca->unmap_device(m_cur_io_start, m_cur_io_end);
+        
+        m_mca->install_device(start, end, 
+            read8sm_delegate(*this, FUNC(mca16_planar_uart_device::io8_r)),
+            write8sm_delegate(*this, FUNC(mca16_planar_uart_device::io8_w)));
+        m_cur_io_start = start;
+        m_cur_io_end = end;
+        m_is_mapped = true;
+    }
+    else
+    {
+            fatalerror("Tried to unmap I/O device from RAM space\n");
+    }
+}
+
+void mca16_planar_uart_device::planar_remap_irq(uint8_t new_irq)
+{
+    LOG("%s\n", FUNCNAME);
+    m_cur_irq = new_irq;
+}

--- a/src/devices/bus/mca/planar_uart.cpp
+++ b/src/devices/bus/mca/planar_uart.cpp
@@ -124,13 +124,13 @@ void mca16_planar_uart_device::disable()
 
 uint8_t mca16_planar_uart_device::io8_r(offs_t offset)
 {
-    assert_card_feedback();
+    //assert_card_feedback();
     return m_uart->ins8250_r(offset);
 }
 
 void mca16_planar_uart_device::io8_w(offs_t offset, uint8_t data)
 {
-    assert_card_feedback();
+    //assert_card_feedback();
     m_uart->ins8250_w(offset, data);
 }
 

--- a/src/devices/bus/mca/planar_uart.h
+++ b/src/devices/bus/mca/planar_uart.h
@@ -57,8 +57,8 @@ private:
     offs_t  m_cur_io_start, m_cur_io_end;
     uint8_t m_cur_irq;
 
-	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_3) { m_mca->ireq_w<3>(state); }
-	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_4) { m_mca->ireq_w<4>(state); }
+	void pc_com_interrupt_3(int state) { m_mca->ireq_w<3>(state); }
+	void pc_com_interrupt_4(int state) { m_mca->ireq_w<4>(state); }
 };
 
 // device type definition

--- a/src/devices/bus/mca/planar_uart.h
+++ b/src/devices/bus/mca/planar_uart.h
@@ -1,0 +1,67 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar UART.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_PLANAR_UART_H
+#define MAME_BUS_MCA_PLANAR_UART_H
+
+#pragma once
+
+#include "mca.h"
+#include "machine/ins8250.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_planar_uart_device
+
+class mca16_planar_uart_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_planar_uart_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+    void enable();
+    void disable();
+
+	virtual void unmap() override {};
+	virtual void remap() override {};
+
+    void planar_remap(int space_id, offs_t start, offs_t end);
+	void planar_remap_irq(uint8_t line);
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+protected:
+	mca16_planar_uart_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	required_device<ns16550_device> m_uart;
+
+private:
+	bool 	m_is_mapped;
+    offs_t  m_cur_io_start, m_cur_io_end;
+    uint8_t m_cur_irq;
+
+	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_3) { m_mca->ireq_w<3>(state); }
+	DECLARE_WRITE_LINE_MEMBER(pc_com_interrupt_4) { m_mca->ireq_w<4>(state); }
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_PLANAR_UART, mca16_planar_uart_device)
+
+#endif

--- a/src/devices/bus/mca/planar_vga.cpp
+++ b/src/devices/bus/mca/planar_vga.cpp
@@ -1,0 +1,163 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar VGA.
+
+***************************************************************************/
+
+#include "emu.h"
+#include "planar_vga.h"
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+#define XTAL_U155 	28.322_MHz_XTAL
+#define XTAL_U156 	25.175_MHz_XTAL
+
+DEFINE_DEVICE_TYPE(MCA16_PLANAR_VGA, mca16_planar_vga_device, "mca16_planar_vga", "IBM PS/2 Planar VGA")
+
+// static void mca_com(device_slot_interface &device)
+// {
+
+// }
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_planar_vga_device::device_add_mconfig(machine_config &config)
+{
+	// Onboard VGA
+	screen_device &screen(SCREEN(config, "screen", SCREEN_TYPE_RASTER));
+	screen.set_raw(XTAL_U155, 800, 0, 640, 524, 0, 480);
+	screen.set_screen_update(m_vga, FUNC(vga_device::screen_update));
+
+	VGA(config, m_vga, 0);
+	m_vga->set_screen("screen");
+	m_vga->set_vram_size(0x40000); // 256K of VRAM
+}
+
+//-------------------------------------------------
+//  mca16_planar_vga_device - constructor
+//-------------------------------------------------
+
+mca16_planar_vga_device::mca16_planar_vga_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_planar_vga_device(mconfig, MCA16_PLANAR_VGA, tag, owner, clock)
+{
+}
+
+mca16_planar_vga_device::mca16_planar_vga_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0xffff),
+    m_vga(*this, "vga"),
+    m_mcabus(*this, ":mb:mcabus")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_planar_vga_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_planar_vga_device::device_reset()
+{
+    m_is_mapped = 0;
+}
+
+void mca16_planar_vga_device::enable()
+{
+    LOG("%s\n", FUNCNAME);
+
+    m_mcabus->install_memory(0xa0000, 0xbffff, read8sm_delegate(*m_vga, FUNC(vga_device::mem_r)), write8sm_delegate(*m_vga, FUNC(vga_device::mem_w)));
+    m_mcabus->install_device(0x3b0, 0x3ba, 
+        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03b0_r)),
+        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03b0_w)));
+    m_mcabus->install_device(0x3c0, 0x3cf, 
+        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03c0_r)),
+        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03c0_w)));
+    m_mcabus->install_device(0x3d0, 0x3df, 
+        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03d0_r)),
+        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03d0_w)));
+    m_is_mapped = 1;
+}
+
+void mca16_planar_vga_device::disable()
+{
+    LOG("%s\n", FUNCNAME);
+    m_mcabus->unmap_readwrite(0xA0000, 0xBFFFF);
+    m_mcabus->unmap_device(0x3b0, 0x3ba);
+    m_mcabus->unmap_device(0x3c0, 0x3cf);
+    m_mcabus->unmap_device(0x3d0, 0x3df);
+    m_is_mapped = 0;
+}
+
+void mca16_planar_vga_device::planar_remap(int space_id, offs_t start, offs_t end)
+{  
+    // Can't be remapped.
+}
+
+void mca16_planar_vga_device::planar_remap_irq(uint8_t new_irq)
+{
+    // Always IRQ 2/9.
+}
+
+uint8_t mca16_planar_vga_device::port_03b0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_vga->port_03b0_r(offset);
+}
+
+void mca16_planar_vga_device::port_03b0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_vga->port_03b0_w(offset, data);
+}
+
+uint8_t mca16_planar_vga_device::port_03c0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_vga->port_03c0_r(offset);
+}
+
+void mca16_planar_vga_device::port_03c0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_vga->port_03c0_w(offset, data);
+}
+
+uint8_t mca16_planar_vga_device::port_03d0_r(offs_t offset)
+{
+    assert_card_feedback();
+    return m_vga->port_03d0_r(offset);
+}
+
+void mca16_planar_vga_device::port_03d0_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    m_vga->port_03d0_w(offset, data);
+}
+
+void mca16_planar_vga_device::sleep_w(uint8_t data)
+{
+    m_sleep = data & 0x01;
+    m_sleep ? enable() : disable();
+}

--- a/src/devices/bus/mca/planar_vga.cpp
+++ b/src/devices/bus/mca/planar_vga.cpp
@@ -88,15 +88,12 @@ void mca16_planar_vga_device::enable()
     LOG("%s\n", FUNCNAME);
 
     m_mcabus->install_memory(0xa0000, 0xbffff, read8sm_delegate(*m_vga, FUNC(vga_device::mem_r)), write8sm_delegate(*m_vga, FUNC(vga_device::mem_w)));
-    m_mcabus->install_device(0x3b0, 0x3ba, 
-        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03b0_r)),
-        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03b0_w)));
-    m_mcabus->install_device(0x3c0, 0x3cf, 
-        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03c0_r)),
-        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03c0_w)));
-    m_mcabus->install_device(0x3d0, 0x3df, 
-        read8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03d0_r)),
-        write8sm_delegate(*this, FUNC(mca16_planar_vga_device::port_03d0_w)));
+    m_mcabus->install_device(0x03b0, 0x03df, *m_vga, &vga_device::io_map);
+
+    m_mcabus->get_iospace()->install_readwrite_tap(0x03b0, 0x03bb, "card_feedback_tap", 
+        [this] (offs_t, u32& data, u32){ if(!machine().side_effects_disabled()) assert_card_feedback(); },
+        [this] (offs_t, u32& data, u32){ if(!machine().side_effects_disabled()) assert_card_feedback(); });
+
     m_is_mapped = 1;
 }
 
@@ -120,41 +117,41 @@ void mca16_planar_vga_device::planar_remap_irq(uint8_t new_irq)
     // Always IRQ 2/9.
 }
 
-uint8_t mca16_planar_vga_device::port_03b0_r(offs_t offset)
-{
-    assert_card_feedback();
-    return m_vga->port_03b0_r(offset);
-}
+// uint8_t mca16_planar_vga_device::port_03b0_r(offs_t offset)
+// {
+//     assert_card_feedback();
+//     return m_vga->port_03b0_r(offset);
+// }
 
-void mca16_planar_vga_device::port_03b0_w(offs_t offset, uint8_t data)
-{
-    assert_card_feedback();
-    m_vga->port_03b0_w(offset, data);
-}
+// void mca16_planar_vga_device::port_03b0_w(offs_t offset, uint8_t data)
+// {
+//     assert_card_feedback();
+//     m_vga->port_03b0_w(offset, data);
+// }
 
-uint8_t mca16_planar_vga_device::port_03c0_r(offs_t offset)
-{
-    assert_card_feedback();
-    return m_vga->port_03c0_r(offset);
-}
+// uint8_t mca16_planar_vga_device::port_03c0_r(offs_t offset)
+// {
+//     assert_card_feedback();
+//     return m_vga->port_03c0_r(offset);
+// }
 
-void mca16_planar_vga_device::port_03c0_w(offs_t offset, uint8_t data)
-{
-    assert_card_feedback();
-    m_vga->port_03c0_w(offset, data);
-}
+// void mca16_planar_vga_device::port_03c0_w(offs_t offset, uint8_t data)
+// {
+//     assert_card_feedback();
+//     m_vga->port_03c0_w(offset, data);
+// }
 
-uint8_t mca16_planar_vga_device::port_03d0_r(offs_t offset)
-{
-    assert_card_feedback();
-    return m_vga->port_03d0_r(offset);
-}
+// uint8_t mca16_planar_vga_device::port_03d0_r(offs_t offset)
+// {
+//     assert_card_feedback();
+//     return m_vga->port_03d0_r(offset);
+// }
 
-void mca16_planar_vga_device::port_03d0_w(offs_t offset, uint8_t data)
-{
-    assert_card_feedback();
-    m_vga->port_03d0_w(offset, data);
-}
+// void mca16_planar_vga_device::port_03d0_w(offs_t offset, uint8_t data)
+// {
+//     assert_card_feedback();
+//     m_vga->port_03d0_w(offset, data);
+// }
 
 void mca16_planar_vga_device::sleep_w(uint8_t data)
 {

--- a/src/devices/bus/mca/planar_vga.h
+++ b/src/devices/bus/mca/planar_vga.h
@@ -37,13 +37,13 @@ public:
     virtual void planar_remap(int space_id, offs_t start, offs_t end);
 	virtual void planar_remap_irq(uint8_t line);
 
-	uint8_t port_03b0_r(offs_t offset);
-    uint8_t port_03c0_r(offs_t offset);
-    uint8_t port_03d0_r(offs_t offset);
+	// uint8_t port_03b0_r(offs_t offset);
+    // uint8_t port_03c0_r(offs_t offset);
+    // uint8_t port_03d0_r(offs_t offset);
 
-    void port_03b0_w(offs_t offset, uint8_t data);
-    void port_03c0_w(offs_t offset, uint8_t data);
-    void port_03d0_w(offs_t offset, uint8_t data);
+    // void port_03b0_w(offs_t offset, uint8_t data);
+    // void port_03c0_w(offs_t offset, uint8_t data);
+    // void port_03d0_w(offs_t offset, uint8_t data);
 
 	void sleep_w(uint8_t data);
 	uint8_t sleep_r() { return m_sleep; }
@@ -65,7 +65,7 @@ private:
 	bool m_is_mapped;
 	bool m_sleep;		// VGA does not respond to any data when cleared.
 
-	DECLARE_WRITE_LINE_MEMBER(retrace_interrupt_w) { m_mcabus->ireq_w<2>(state); }
+	void retrace_interrupt_w(int state) { m_mcabus->ireq_w<2>(state); }
 
 };
 

--- a/src/devices/bus/mca/planar_vga.h
+++ b/src/devices/bus/mca/planar_vga.h
@@ -1,0 +1,75 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    IBM PS/2 Planar VGA.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_PLANAR_VGA_H
+#define MAME_BUS_MCA_PLANAR_VGA_H
+
+#pragma once
+
+#include "mca.h"
+#include "video/pc_vga.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_planar_vga_device
+
+class mca16_planar_vga_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_planar_vga_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+    virtual void enable();
+    virtual void disable();
+
+	virtual void unmap() override {};
+	virtual void remap() override {};
+
+    virtual void planar_remap(int space_id, offs_t start, offs_t end);
+	virtual void planar_remap_irq(uint8_t line);
+
+	uint8_t port_03b0_r(offs_t offset);
+    uint8_t port_03c0_r(offs_t offset);
+    uint8_t port_03d0_r(offs_t offset);
+
+    void port_03b0_w(offs_t offset, uint8_t data);
+    void port_03c0_w(offs_t offset, uint8_t data);
+    void port_03d0_w(offs_t offset, uint8_t data);
+
+	void sleep_w(uint8_t data);
+	uint8_t sleep_r() { return m_sleep; }
+
+protected:
+	mca16_planar_vga_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+    required_device<vga_device> m_vga;
+    required_device<mca16_device> m_mcabus;
+
+private:
+	bool m_is_mapped;
+	bool m_sleep;		// VGA does not respond to any data when cleared.
+
+	DECLARE_WRITE_LINE_MEMBER(retrace_interrupt_w) { m_mcabus->ireq_w<2>(state); }
+
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_PLANAR_VGA, mca16_planar_vga_device)
+
+#endif

--- a/src/devices/bus/mca/snark_barker.cpp
+++ b/src/devices/bus/mca/snark_barker.cpp
@@ -1,0 +1,542 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    Snark Barker MCA
+	MCA ID @5085
+	Using Sound Blaster DSP code 2.02
+
+	https://github.com/schlae/sb-firmware/blob/master/sbv202.asm
+
+	MCU code breakpoints:
+	0x446: received a command
+	0x44D: A <- command number
+
+	0x4D7: cmdg_setup_e
+	0x764: cmd_dac_dma
+
+***************************************************************************/
+
+#include "emu.h"
+#include "snark_barker.h"
+
+//#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+#define ym3812_StdClock XTAL(3'579'545)
+#define ymf262_StdClock XTAL(14'318'181)
+#define XTAL_DSP XTAL(12'000'000)	// XTL1
+
+DEFINE_DEVICE_TYPE(MCA16_SNARK_BARKER, mca16_snark_barker_device, "mca_snark_barker", "TubeTime Snark Barker MCA (@5085)")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_snark_barker_device::device_add_mconfig(machine_config &config)
+{
+	I80C51(config, m_dsp, XTAL_DSP); // XTL1
+	m_dsp->set_addrmap(AS_PROGRAM, &mca16_snark_barker_device::map_dsp_program);
+	m_dsp->set_addrmap(AS_IO, &mca16_snark_barker_device::map_dsp_io);
+
+	m_dsp->port_in_cb<0>().set(FUNC(mca16_snark_barker_device::dsp_port0_r));
+	// No inputs on port 1
+	m_dsp->port_in_cb<2>().set(FUNC(mca16_snark_barker_device::dsp_port2_r));
+	m_dsp->port_in_cb<3>().set(FUNC(mca16_snark_barker_device::dsp_port3_r));
+	m_dsp->port_out_cb<0>().set(FUNC(mca16_snark_barker_device::dsp_port0_w));
+	m_dsp->port_out_cb<1>().set(m_dac, FUNC(dac_byte_interface::data_w));				// DSP port 1 is hooked right up to the DAC.
+	m_dsp->port_out_cb<2>().set(FUNC(mca16_snark_barker_device::dsp_port2_w));
+	m_dsp->port_out_cb<3>().set(FUNC(mca16_snark_barker_device::dsp_port3_w));
+
+	PC_JOY(config, m_joy);
+
+	SPEAKER(config, m_speaker).front_center();
+	MC1408(config, m_dac, 0).add_route(ALL_OUTPUTS, m_speaker, 0.5);
+
+	YM3812(config, m_ym3812, ym3812_StdClock);
+	m_ym3812->add_route(ALL_OUTPUTS, m_speaker, 1.0);
+	/* no CM/S support (empty sockets) */
+}
+
+//-------------------------------------------------
+//  mca16_planar_lpt_device - constructor
+//-------------------------------------------------
+
+mca16_snark_barker_device::mca16_snark_barker_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_snark_barker_device(mconfig, MCA16_SNARK_BARKER, tag, owner, clock)
+{
+}
+
+mca16_snark_barker_device::mca16_snark_barker_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, 0x5085),
+	m_dsp(*this, "dsp"),
+	m_joy(*this, "pc_joy"),
+	m_ym3812(*this, "ym3812"),
+	m_dac(*this, "dac"),
+	m_speaker(*this, "speaker")
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_snark_barker_device::device_start()
+{
+    m_is_mapped = 0;
+	set_mca_device();
+
+	m_mca->install_device(0x0200, 0x0207, read8smo_delegate(*subdevice<pc_joy_device>("pc_joy"), FUNC(pc_joy_device::joy_port_r)), write8smo_delegate(*subdevice<pc_joy_device>("pc_joy"), FUNC(pc_joy_device::joy_port_w)));
+	m_mca->install_device(0x0226, 0x0227, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_reset_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_reset_w)));
+	m_mca->install_device(0x022a, 0x022b, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_data_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_data_w)));
+	m_mca->install_device(0x022c, 0x022d, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_wbuf_status_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_cmd_w)));
+	m_mca->install_device(0x022e, 0x022f, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_rbuf_status_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::dsp_rbuf_status_w)));
+
+	m_mca->install_device(0x0388, 0x0389, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::ym3812_16_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::ym3812_16_w)));
+	m_mca->install_device(0x0228, 0x0229, read8sm_delegate(*this, FUNC(mca16_snark_barker_device::ym3812_16_r)), write8sm_delegate(*this, FUNC(mca16_snark_barker_device::ym3812_16_w)));
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_snark_barker_device::device_reset()
+{
+	if(m_is_mapped) unmap();
+	m_is_mapped = 0;
+
+	m_irq_in_flag = false;
+	m_irequest = true;
+	m_drequest = false;
+
+	m_cur_dma_line = -1;
+	m_cur_irq_line = -1;
+
+	dsp_reset_w(0, 0);
+
+	m_irq_raised = false;
+	m_dma_raised = false;
+}
+
+uint8_t mca16_snark_barker_device::io8_r(offs_t offset)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X\n", FUNCNAME, offset);
+    return 0x00;
+}
+
+void mca16_snark_barker_device::io8_w(offs_t offset, uint8_t data)
+{
+    assert_card_feedback();
+    LOG("%s: O:%02X D:%02X\n", FUNCNAME, offset, data);
+}
+
+void mca16_snark_barker_device::pos_w(offs_t offset, uint8_t data)
+{
+	LOG("%s\n", FUNCNAME);
+
+	switch(offset)
+	{
+		case 0:
+			// Adapter Identification b0-b7
+		case 1:
+			// Adapter Identification b8-b15
+			break;
+		case 2:
+			// Option Select Data 1
+			break;
+		case 3:
+			update_pos(data);
+			// Option Select Data 2
+			break;
+		case 4:
+			// Option Select Data 3
+			break;
+		case 5:
+			// Option Select Data 4
+			break;
+		case 6:
+			// Subaddress Extension Low
+			break;
+		case 7:
+			// Subaddress Extension High
+			break;
+		default:
+			break;
+	}
+}
+
+uint8_t mca16_snark_barker_device::get_pos_irq()
+{
+	uint8_t pos_irq = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0b00011000) >> 3;
+
+	switch(pos_irq)
+	{
+		case 0: pos_irq = 2; break;
+		case 1:	pos_irq = 3; break;
+		case 2: pos_irq = 5; break;
+		case 3: pos_irq = 7; break;
+		default: pos_irq = -1; break;
+	}
+
+	return pos_irq;
+}
+
+uint8_t mca16_snark_barker_device::get_pos_dma()
+{
+	uint8_t pos_dma = (m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] & 0b01100000) >> 5;
+
+	switch(pos_dma)
+	{
+		case 0: pos_dma = 0; break;
+		case 1: pos_dma = 1; break;
+		case 2:	pos_dma = 3; break;
+		default: pos_dma = -1; break;
+	}
+
+	return pos_dma;
+}
+
+void mca16_snark_barker_device::remap()
+{
+	// TODO: remap I/O addresses. IRQ line is handled separately.
+	m_cur_dma_line = get_pos_dma();
+	m_cur_irq_line = get_pos_irq();
+
+	if(m_cur_dma_line != -1) m_mca->set_dma_channel(m_cur_dma_line, this, true);
+
+	m_is_mapped = true;
+}
+
+void mca16_snark_barker_device::unmap()
+{
+	m_is_mapped = false;
+	//m_mca->unset_dma_channel(m_cur_dma_line);
+}
+
+bool mca16_snark_barker_device::map_has_changed()
+{
+	uint8_t pos_irq = get_pos_irq();
+	uint8_t pos_dma = get_pos_dma();
+
+	return (pos_irq != m_cur_irq_line || pos_dma != m_cur_dma_line);
+}
+
+void mca16_snark_barker_device::update_pos(uint8_t data)
+{
+    // Only uses one POS byte.
+    m_option_select[MCABus::POS::OPTION_SELECT_DATA_2] = data;
+	if(map_has_changed())
+	{
+		unmap();
+		remap();
+	}
+}
+
+uint8_t mca16_snark_barker_device::ym3812_16_r(offs_t offset)
+{
+	uint8_t retVal = 0xff;
+	switch(offset)
+	{
+		case 0 : retVal = m_ym3812->status_r(); break;
+	}
+	return retVal;
+}
+
+void mca16_snark_barker_device::ym3812_16_w(offs_t offset, uint8_t data)
+{
+	switch(offset)
+	{
+		case 0 : m_ym3812->address_w(data); break;
+		case 1 : m_ym3812->data_w(data); break;
+	}
+}
+
+uint8_t mca16_snark_barker_device::dack_r(int line)
+{
+	// Shouldn't happen.
+
+	LOG("*** %s: line %d\n", FUNCNAME, line);
+	return dsp_data_r(0);
+}
+
+void mca16_snark_barker_device::dack_w(int line, uint8_t data)
+{
+	// Incoming DMA data!
+	LOG("%s: line %d data %d\n", FUNCNAME, line, data);
+	
+	lower_dma();			// Acknowledge clears the DMA request.
+	dsp_cmd_w(0, data);		// Write the byte to the data latch.
+}
+
+/* The DSP */
+
+uint8_t mca16_snark_barker_device::dsp_port0_r()
+{
+	LOG("%s\n", FUNCNAME);
+	return 0;
+}
+void mca16_snark_barker_device::dsp_port0_w(uint8_t data)
+{
+	LOG("%s D:%02X\n", FUNCNAME, data);
+}
+
+uint8_t mca16_snark_barker_device::dsp_port2_r()
+{
+	/*
+		Bit 5: MIC_COMP:	1 = Mic <- DAC. 0 = Mic -> DAC.
+		Bit 6: DAV_PC:		1 = Data waiting in buffer for host PC to read it.
+		Bit 7: DAV_DSP: 	1 = Data waiting in buffer for DSP to read it.
+	 */
+
+	uint8_t data = 0;
+
+	data |= (m_dav_dsp ? (1 << 7) : 0);
+	data |= (m_dav_pc  ? (1 << 6) : 0);
+
+	//LOG("%s: D:%02X\n", FUNCNAME, data);
+
+	return data;
+}
+void mca16_snark_barker_device::dsp_port2_w(uint8_t data)
+{
+	// Bit 0 is the only output, which mutes audio output when pulled high.
+	LOG("%s D:%02X\n", FUNCNAME, data);
+}
+
+uint8_t mca16_snark_barker_device::dsp_port3_r()
+{
+	/*
+		Bit 0: MIDI RX:		MIDI receive data in.
+	 */
+
+	LOG("%s\n", FUNCNAME);
+
+	uint8_t data = 0;
+
+	if(m_dma_en) data |= (1 << 4);
+	if(m_drequest) data |= (1 << 5);
+
+	return 0 | data; // latched bits
+}
+void mca16_snark_barker_device::dsp_port3_w(uint8_t data)
+{
+	/*
+		Bit 1: MIDI TX		MIDI transmit data out.
+		Bit 2: IREQUEST		Strobe low to send IRQ to host PC.
+		Bit 3: DSP_BUSY		Set high to tell PC we are busy.
+		Bit 4: DMA_EN#		Set low to enable DMA requests.
+		Bit 5: DREQUEST		Strobe high to set DRQ.
+		Bit 6: DSP_WRITE#	Strobe low to write a byte to the PC.
+		Bit 7: DSP_READ#	Strobe low to read a byte from the PC.
+	 */
+
+	m_dma_en = BIT(data, 4); // active low
+
+	if(!BIT(data, 2) && m_irequest) // Strobed high -> low
+	{
+		raise_irq();
+	}
+
+	if(BIT(data, 5))
+	{
+		if(m_dma_en == false && m_drequest == false)
+		{
+			raise_dma();
+		} 
+	}
+
+	if(!BIT(data, 6))
+	{
+		m_dav_pc = true;
+	}
+
+	if(!BIT(data, 7))
+	{
+		m_dav_dsp = true;
+	}
+
+	m_irequest = BIT(data, 2);
+	m_drequest = BIT(data, 5);
+
+	LOG("%s D:%02X\n", FUNCNAME, data);
+}
+
+uint8_t mca16_snark_barker_device::dsp_reset_r(offs_t offset)
+{
+	// NOP
+	LOG("%s\n", FUNCNAME);
+	return 0;
+}
+
+void mca16_snark_barker_device::dsp_reset_w(offs_t offset, uint8_t data)
+{
+	LOG("%s D:%02X\n", FUNCNAME, data);
+
+	// Reset DSP.
+	m_dsp->reset();
+
+	// Clear all flags.
+	m_irq_in_flag = false;
+	m_dav_dsp = false;
+	m_dav_pc = false;
+	m_irequest = true; 	// active low
+	m_drequest = false;	// active high
+
+	lower_irq();
+	lower_dma();
+}
+
+uint8_t mca16_snark_barker_device::dsp_rbuf_status_r(offs_t offset)
+{
+	// 0x22E
+	lower_irq();						// Reading this bit clears the IRQ.
+	return (m_dav_pc ? 0x80 : 0x00);	// Return the data waiting flag in bit 7.
+}
+
+void mca16_snark_barker_device::dsp_rbuf_status_w(offs_t offset, uint8_t data)
+{
+	// NOP
+}
+
+uint8_t mca16_snark_barker_device::dsp_wbuf_status_r(offs_t offset)
+{
+	// 0x22C
+	return (m_dav_dsp ? 0x80 : 0x00);
+}
+
+// From the perspective of the MCA bus.
+uint8_t mca16_snark_barker_device::dsp_data_r(offs_t offset)
+{
+	uint8_t data = m_dsp_to_host_latch;		// PC retrieves the latched byte.
+	LOG("%s D:%02X\n", FUNCNAME, data);
+	m_dav_pc = false;						// Clear the PC has data flag.
+	m_dsp_to_host_latch = 0; 				// Clear the latch.
+
+	return data;
+}
+
+void mca16_snark_barker_device::dsp_data_w(offs_t offset, uint8_t data)
+{
+	LOG("%s: This port does not exist\n", FUNCNAME);
+}
+
+void mca16_snark_barker_device::dsp_cmd_w(offs_t offset, uint8_t data)
+{
+	LOG("%s O:%02X D:%02X\n", FUNCNAME, offset, data);
+	
+	m_host_to_dsp_latch = data;
+	m_dav_dsp = true; 	// DSP has a byte waiting.
+}
+
+// From the perspective of the DSP.
+uint8_t mca16_snark_barker_device::dsp_latch_r(offs_t offset)
+{
+	uint8_t data = m_host_to_dsp_latch;					// DSP retrieves the latched byte.
+	m_host_to_dsp_latch = 0x00;							// Clear the latch.
+	LOG("%s O:%02X D:%02X\n", FUNCNAME, offset, data);
+	m_dav_dsp = false;									// Clear the DSP has data flag.
+	return data;
+}
+
+void mca16_snark_barker_device::dsp_latch_w(offs_t offset, uint8_t data)
+{
+	LOG("%s O:%02X D:%02X\n", FUNCNAME, offset, data);
+	m_dsp_to_host_latch = data;
+	m_dav_pc = true;	// PC has a byte waiting.
+}
+
+void mca16_snark_barker_device::map_dsp_program(address_map &map)
+{
+	map(0x000, 0xfff).rom().region("dsp", 0);
+}
+
+void mca16_snark_barker_device::map_dsp_io(address_map &map)
+{
+	map(0x0000, 0xffff).rw(FUNC(mca16_snark_barker_device::dsp_latch_r), FUNC(mca16_snark_barker_device::dsp_latch_w));
+}
+
+ROM_START(mca_snark_barker)
+	ROM_REGION(0x1000, "dsp", 0)
+	ROM_LOAD("ct1351v202.bin", 0x0000, 0x1000, CRC(bb2dd936) SHA1(2b5b75f2c9e923f0b44a454bdb06d9612ff4a8bb))
+ROM_END
+
+const tiny_rom_entry *mca16_snark_barker_device::device_rom_region() const
+{
+	return ROM_NAME(mca_snark_barker);
+}
+
+void mca16_snark_barker_device::raise_dma()
+{
+	LOG("SB raising DMA %d\n", m_cur_dma_line);
+
+	switch(m_cur_dma_line)
+	{
+		case 0: m_mca->dreq_w<0>(ASSERT_LINE); break;
+		case 1: m_mca->dreq_w<1>(ASSERT_LINE); break;
+		case 3: m_mca->dreq_w<3>(ASSERT_LINE); break;
+	}
+}
+
+void mca16_snark_barker_device::lower_dma()
+{
+	LOG("SB lowering DMA %d\n", m_cur_dma_line);
+
+	switch(m_cur_dma_line)
+	{
+		case 0: m_mca->dreq_w<0>(CLEAR_LINE); break;
+		case 1: m_mca->dreq_w<1>(CLEAR_LINE); break;
+		case 3: m_mca->dreq_w<3>(CLEAR_LINE); break;
+	}
+}
+
+void mca16_snark_barker_device::raise_irq()
+{
+	if(!m_irq_raised)
+	{
+		LOG("SB raising IRQ %d\n", m_cur_irq_line);
+
+		switch(m_cur_irq_line)
+		{
+			case 2: m_mca->ireq_w<2>(ASSERT_LINE); break;
+			case 3: m_mca->ireq_w<3>(ASSERT_LINE); break;
+			case 5: m_mca->ireq_w<5>(ASSERT_LINE); break;
+			case 7: m_mca->ireq_w<7>(ASSERT_LINE); break;
+		}
+		m_irq_raised = true;
+	}
+	else
+	{
+		LOG("SB already raising IRQ %d\n", m_cur_irq_line);
+	}
+
+}
+
+void mca16_snark_barker_device::lower_irq()
+{
+	if(m_irq_raised)
+	{
+		LOG("SB lowering IRQ %d\n", m_cur_irq_line);
+
+		switch(m_cur_irq_line)
+		{
+			case 2: m_mca->ireq_w<2>(CLEAR_LINE); break;
+			case 3: m_mca->ireq_w<3>(CLEAR_LINE); break;
+			case 5: m_mca->ireq_w<5>(CLEAR_LINE); break;
+			case 7: m_mca->ireq_w<7>(CLEAR_LINE); break;
+		}
+		m_irq_raised = false;
+	}	
+}

--- a/src/devices/bus/mca/snark_barker.h
+++ b/src/devices/bus/mca/snark_barker.h
@@ -1,0 +1,131 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+ 
+    TexElec Snark Barker New Wave MCA
+    OPL3-based Sound Blaster 2.0 clone.
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_SNARK_BARKER_H
+#define MAME_BUS_MCA_SNARK_BARKER_H
+
+#pragma once
+
+#include "mca.h"
+#include "bus/pc_joy/pc_joy.h"
+#include "cpu/mcs51/mcs51.h"
+#include "sound/dac.h"
+#include "sound/ymopl.h"
+#include "sound/spkrdev.h"
+#include "speaker.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_snark_barker_device
+
+class mca16_snark_barker_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_snark_barker_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void unmap() override;
+    virtual void remap() override;
+
+	virtual uint8_t io8_r(offs_t offset) override;
+	virtual void io8_w(offs_t offset, uint8_t data) override;
+
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+    void update_pos(uint8_t data);
+
+	uint8_t ym3812_16_r(offs_t offset);
+	void ym3812_16_w(offs_t offset, uint8_t data);
+
+	uint8_t dsp_reset_r(offs_t offset);
+	uint8_t dsp_data_r(offs_t offset);
+	uint8_t dsp_wbuf_status_r(offs_t offset);
+	uint8_t dsp_rbuf_status_r(offs_t offset);
+
+	void dsp_reset_w(offs_t offset, uint8_t data);
+	void dsp_data_w(offs_t offset, uint8_t data);
+	void dsp_cmd_w(offs_t offset, uint8_t data);
+	void dsp_rbuf_status_w(offs_t offset, uint8_t data);
+
+	void map_dsp_program(address_map &map);
+	void map_dsp_io(address_map &map);
+
+protected:
+	mca16_snark_barker_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual const tiny_rom_entry *device_rom_region() const override;
+
+	virtual bool map_has_changed() override;
+
+	virtual uint8_t dack_r(int line) override;
+	virtual void dack_w(int line, uint8_t data) override;
+
+	uint8_t dsp_latch_r(offs_t offset);
+	void dsp_latch_w(offs_t offset, uint8_t data);
+
+	required_device<i80c51_device> m_dsp;
+	required_device<pc_joy_device> m_joy;
+    required_device<ym3812_device> m_ym3812;
+	required_device<mc1408_device> m_dac;
+	required_device<speaker_device> m_speaker;
+
+private:
+	uint8_t dsp_port0_r();
+	uint8_t dsp_port2_r();
+	uint8_t dsp_port3_r();
+	void dsp_port0_w(uint8_t data);
+	void dsp_port1_w(uint8_t data);
+	void dsp_port2_w(uint8_t data);
+	void dsp_port3_w(uint8_t data);
+
+	void raise_irq();
+	void lower_irq();
+	void raise_dma();
+	void lower_dma();
+
+	uint8_t get_pos_irq();
+	uint8_t get_pos_dma();
+
+	bool 		m_is_mapped;
+
+	uint8_t		m_cur_dma_line;
+	uint8_t		m_cur_irq_line;
+
+	uint16_t 	m_setup_io_port;
+
+	bool m_irq_in_flag;
+	bool m_dav_pc;
+	bool m_dav_dsp;
+	bool m_dma_en;
+
+	bool m_irequest;
+	bool m_drequest;
+
+	uint8_t m_host_to_dsp_latch;
+	uint8_t m_dsp_to_host_latch;
+
+	bool m_irq_raised;
+	bool m_dma_raised;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_SNARK_BARKER, mca16_snark_barker_device)
+
+#endif

--- a/src/devices/bus/mca/template.cpp
+++ b/src/devices/bus/mca/template.cpp
@@ -1,0 +1,79 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    MCA card template
+
+***************************************************************************/
+
+#include "emu.h"
+#include "template.h"
+
+
+#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+#define MCA_CARD_ID 0xffff
+
+//**************************************************************************
+//  GLOBAL VARIABLES
+//**************************************************************************
+
+DEFINE_DEVICE_TYPE(MCA16_TEMPLATE, mca16_template_device, "mca_template", "MCA Card Template")
+
+//-------------------------------------------------
+//  device_add_mconfig - add device configuration
+//-------------------------------------------------
+
+void mca16_template_device::device_add_mconfig(machine_config &config)
+{
+
+}
+
+//-------------------------------------------------
+//  mca16_template_device - constructor
+//-------------------------------------------------
+
+mca16_template_device::mca16_template_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	mca16_template_device(mconfig, MCA16_TEMPLATE, tag, owner, clock)
+{
+}
+
+mca16_template_device::mca16_template_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, type, tag, owner, clock),
+	device_mca16_card_interface(mconfig, *this, MCA_CARD_ID)
+{
+}
+
+//-------------------------------------------------
+//  device_start - device-specific startup
+//-------------------------------------------------
+
+void mca16_template_device::device_start()
+{
+	set_mca_device();
+}
+
+//-------------------------------------------------
+//  device_reset - device-specific reset
+//-------------------------------------------------
+
+void mca16_template_device::device_reset()
+{
+}
+
+void mca16_template_device::unmap()
+{
+	
+}
+
+void mca16_template_device::remap()
+{
+
+}

--- a/src/devices/bus/mca/template.h
+++ b/src/devices/bus/mca/template.h
@@ -1,0 +1,55 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/***************************************************************************
+
+    MCA card template
+
+***************************************************************************/
+
+#ifndef MAME_BUS_MCA_TEMPLATE_H
+#define MAME_BUS_MCA_TEMPLATE_H
+
+#pragma once
+
+#include "mca.h"
+
+//**************************************************************************
+//  TYPE DEFINITIONS
+//**************************************************************************
+
+// ======================> mca16_template_device
+
+class mca16_template_device :
+		public device_t,
+		public device_mca16_card_interface
+{
+public:
+	// construction/destruction
+	mca16_template_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void unmap() override;
+	virtual void remap() override;
+
+protected:
+	mca16_template_device(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, uint32_t clock);
+
+	// device-level overrides
+	virtual void device_start() override;
+	virtual void device_reset() override;
+
+	// optional information overrides
+	virtual void device_add_mconfig(machine_config &config) override;
+
+	virtual uint8_t pos_r(offs_t offset) override;
+	virtual void pos_w(offs_t offset, uint8_t data) override;
+
+    void map_main(address_map &map);
+
+private:
+	uint8_t m_is_mapped;
+};
+
+// device type definition
+DECLARE_DEVICE_TYPE(MCA16_TEMPLATE, mca16_template_device)
+
+#endif

--- a/src/devices/bus/pc_kbd/hle_mouse.cpp
+++ b/src/devices/bus/pc_kbd/hle_mouse.cpp
@@ -42,7 +42,7 @@
 #define LOG_REPORT  (1U << 3)
 #define LOG_STATE   (1U << 4)
 
-//#define VERBOSE (LOG_COMMAND)
+//#define VERBOSE (LOG_GENERAL|LOG_COMMAND|LOG_RXTX|LOG_REPORT|LOG_STATE)
 
 #include "logmacro.h"
 
@@ -64,7 +64,8 @@ INPUT_PORTS_START(hle_ps2_mouse_device)
 	PORT_BIT(0xf8, IP_ACTIVE_HIGH, IPT_UNUSED)
 INPUT_PORTS_END
 
-static constexpr attotime serial_cycle = attotime::from_usec(25);
+// IBM documentation: serial cycle is between 30-50usec, 40usec makes the emulated PS/2 controller happy 
+static constexpr attotime serial_cycle = attotime::from_usec(40);
 
 hle_ps2_mouse_device::hle_ps2_mouse_device(const machine_config &mconfig, const char *tag, device_t *owner, u32 clock)
 	: device_t(mconfig, HLE_PS2_MOUSE, tag, owner, clock)
@@ -329,6 +330,8 @@ void hle_ps2_mouse_device::serial(s32 param)
 
 void hle_ps2_mouse_device::command(u8 const command)
 {
+	LOGMASKED(LOG_COMMAND, "got cmd %02X\n", command);
+
 	// consume the command byte
 	m_rx_len--;
 

--- a/src/devices/bus/pc_kbd/keyboards.cpp
+++ b/src/devices/bus/pc_kbd/keyboards.cpp
@@ -34,6 +34,11 @@ void pc_at_keyboards(device_slot_interface &device)
 	device.option_add(STR_KBD_CHERRY_G80_1500, CHERRY_G80_1500);
 }
 
+void pc_ps2_keyboards(device_slot_interface &device)
+{
+	device.option_add(STR_KBD_MICROSOFT_NATURAL, PC_KBD_MICROSOFT_NATURAL);
+}
+
 void ps2_mice(device_slot_interface &device)
 {
 	device.option_add(STR_HLE_PS2_MOUSE, HLE_PS2_MOUSE);

--- a/src/devices/bus/pc_kbd/keyboards.h
+++ b/src/devices/bus/pc_kbd/keyboards.h
@@ -31,6 +31,7 @@ void pc_xt_keyboards(device_slot_interface &device);
 #define STR_KBD_CHERRY_G80_1500     "g80_1500"
 
 void pc_at_keyboards(device_slot_interface &device);
+void pc_ps2_keyboards(device_slot_interface &device);
 
 // PS/2 protocol mice
 #define STR_HLE_PS2_MOUSE           "hle_ps2_mouse"

--- a/src/devices/imagedev/floppy.h
+++ b/src/devices/imagedev/floppy.h
@@ -125,6 +125,7 @@ public:
 	int idx_r() { return idx; }
 	int mon_r() { return mon; }
 	bool ss_r() { return ss; }
+	bool ds_r() { return ds; }
 	bool twosid_r();
 
 	virtual bool writing_disabled() const;

--- a/src/devices/machine/am9517a.h
+++ b/src/devices/machine/am9517a.h
@@ -238,10 +238,28 @@ private:
 	u8 m_ext_mode[4];
 };
 
+class ps2_dma_device : public am9517a_device
+{
+public:
+	ps2_dma_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	protected:
+	virtual void device_start() override;
+
+	public:
+	// Extended function support.
+	template <unsigned Channel> u32 get_address() { return m_channel[Channel].m_address; }
+	template <unsigned Channel> u16 get_count() { return m_channel[Channel].m_count; }
+
+	template <unsigned Channel> void set_address(u32 addr) { m_channel[Channel].m_address = addr; m_channel[Channel].m_base_address = addr; }
+	template <unsigned Channel> void set_count(u16 count) { m_channel[Channel].m_count = count; m_channel[Channel].m_base_count = count; }
+};
+
 // device type definition
-DECLARE_DEVICE_TYPE(AM9517A,      am9517a_device)
-DECLARE_DEVICE_TYPE(V5X_DMAU,     v5x_dmau_device)
-DECLARE_DEVICE_TYPE(PCXPORT_DMAC, pcxport_dmac_device)
-DECLARE_DEVICE_TYPE(EISA_DMA,     eisa_dma_device)
+DECLARE_DEVICE_TYPE(AM9517A,      		am9517a_device)
+DECLARE_DEVICE_TYPE(V5X_DMAU,     		v5x_dmau_device)
+DECLARE_DEVICE_TYPE(PCXPORT_DMAC, 		pcxport_dmac_device)
+DECLARE_DEVICE_TYPE(EISA_DMA,     		eisa_dma_device)
+DECLARE_DEVICE_TYPE(PS2_DMA, 			ps2_dma_device)
 
 #endif // MAME_MACHINE_AM9517_H

--- a/src/devices/machine/ibm72x7377.cpp
+++ b/src/devices/machine/ibm72x7377.cpp
@@ -1,0 +1,578 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/*************************************************************
+
+  IBM 72X7377
+  PS/2 Type 1 DMA Controller
+
+**************************************************************/
+
+#include "emu.h"
+#include "ibm72x7377.h"
+
+//#define VERBOSE 1
+#include "logmacro.h"
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+DEFINE_DEVICE_TYPE(IBM72X7377, ibm72x7377_device, "ibm72x7377", "IBM 72X7377 PS/2 DMA Controller")
+
+ibm72x7377_device::ibm72x7377_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: device_t(mconfig, IBM72X7377, tag, owner, clock),
+    m_maincpu(*this, ":maincpu"),
+    m_mcabus(*this, ":mb:mcabus"),
+    m_dma8237_1(*this, "dma8237_1"),
+	m_dma8237_2(*this, "dma8237_2")
+{
+}
+
+void ibm72x7377_device::device_start()
+{
+	m_arbus_ch0 = 0;
+	m_arbus_ch4 = 0;
+
+    m_dma_high_byte = 0;
+    m_dma_channel = -1;
+    m_cur_eop = false;
+	m_cur_eop2 = false;
+
+    m_byte_pointer = 0;
+	m_extended_function = 0;
+
+}
+
+void ibm72x7377_device::device_reset()
+{
+	m_arbus_ch0 = 0;
+	m_arbus_ch4 = 0;
+
+    m_dma_high_byte = 0;
+    m_dma_channel = -1;
+    m_cur_eop = false;
+	m_cur_eop2 = false;
+
+    m_byte_pointer = 0;
+	m_extended_function = 0;
+}
+
+void ibm72x7377_device::device_config_complete()
+{
+
+}
+
+void ibm72x7377_device::device_add_mconfig(machine_config &config)
+{
+    PS2_DMA(config, m_dma8237_1, 14.318181_MHz_XTAL / 3);
+	m_dma8237_1->out_hreq_callback().set(m_dma8237_2, FUNC(am9517a_device::dreq0_w));
+	m_dma8237_1->out_eop_callback().set(FUNC(ibm72x7377_device::dma8237_1_out_eop));
+	m_dma8237_1->in_memr_callback().set(FUNC(ibm72x7377_device::dma_read_byte));
+	m_dma8237_1->out_memw_callback().set(FUNC(ibm72x7377_device::dma_write_byte));
+	m_dma8237_1->in_ior_callback<0>().set(FUNC(ibm72x7377_device::dma8237_0_dack_r));
+	m_dma8237_1->in_ior_callback<1>().set(FUNC(ibm72x7377_device::dma8237_1_dack_r));
+	m_dma8237_1->in_ior_callback<2>().set(FUNC(ibm72x7377_device::dma8237_2_dack_r));
+	m_dma8237_1->in_ior_callback<3>().set(FUNC(ibm72x7377_device::dma8237_3_dack_r));
+	m_dma8237_1->out_iow_callback<0>().set(FUNC(ibm72x7377_device::dma8237_0_dack_w));
+	m_dma8237_1->out_iow_callback<1>().set(FUNC(ibm72x7377_device::dma8237_1_dack_w));
+	m_dma8237_1->out_iow_callback<2>().set(FUNC(ibm72x7377_device::dma8237_2_dack_w));
+	m_dma8237_1->out_iow_callback<3>().set(FUNC(ibm72x7377_device::dma8237_3_dack_w));
+	m_dma8237_1->out_dack_callback<0>().set(FUNC(ibm72x7377_device::dack0_w));
+	m_dma8237_1->out_dack_callback<1>().set(FUNC(ibm72x7377_device::dack1_w));
+	m_dma8237_1->out_dack_callback<2>().set(FUNC(ibm72x7377_device::dack2_w));
+	m_dma8237_1->out_dack_callback<3>().set(FUNC(ibm72x7377_device::dack3_w));
+
+	PS2_DMA(config, m_dma8237_2, 14.318181_MHz_XTAL / 3);
+	m_dma8237_2->out_hreq_callback().set(FUNC(ibm72x7377_device::dma_hrq_changed));
+	m_dma8237_2->out_eop_callback().set(FUNC(ibm72x7377_device::dma8237_2_out_eop));
+	m_dma8237_2->in_memr_callback().set(FUNC(ibm72x7377_device::dma_read_word));
+	m_dma8237_2->out_memw_callback().set(FUNC(ibm72x7377_device::dma_write_word));
+	m_dma8237_2->in_ior_callback<1>().set(FUNC(ibm72x7377_device::dma8237_5_dack_r));
+	m_dma8237_2->in_ior_callback<2>().set(FUNC(ibm72x7377_device::dma8237_6_dack_r));
+	m_dma8237_2->in_ior_callback<3>().set(FUNC(ibm72x7377_device::dma8237_7_dack_r));
+	m_dma8237_2->out_iow_callback<1>().set(FUNC(ibm72x7377_device::dma8237_5_dack_w));
+	m_dma8237_2->out_iow_callback<2>().set(FUNC(ibm72x7377_device::dma8237_6_dack_w));
+	m_dma8237_2->out_iow_callback<3>().set(FUNC(ibm72x7377_device::dma8237_7_dack_w));
+	m_dma8237_2->out_dack_callback<0>().set(FUNC(ibm72x7377_device::dack4_w));
+	m_dma8237_2->out_dack_callback<1>().set(FUNC(ibm72x7377_device::dack5_w));
+	m_dma8237_2->out_dack_callback<2>().set(FUNC(ibm72x7377_device::dack6_w));
+	m_dma8237_2->out_dack_callback<3>().set(FUNC(ibm72x7377_device::dack7_w));
+}
+
+uint8_t ibm72x7377_device::dma8237_0_dack_r() { return m_mcabus->dack_r(0); }
+uint8_t ibm72x7377_device::dma8237_1_dack_r() { return m_mcabus->dack_r(1); }
+uint8_t ibm72x7377_device::dma8237_2_dack_r() { return m_mcabus->dack_r(2); }
+uint8_t ibm72x7377_device::dma8237_3_dack_r() { return m_mcabus->dack_r(3); }
+uint8_t ibm72x7377_device::dma8237_5_dack_r() { uint16_t ret = m_mcabus->dack16_r(5); m_dma_high_byte = ret & 0xff00; return ret; }
+uint8_t ibm72x7377_device::dma8237_6_dack_r() { uint16_t ret = m_mcabus->dack16_r(6); m_dma_high_byte = ret & 0xff00; return ret; }
+uint8_t ibm72x7377_device::dma8237_7_dack_r() { uint16_t ret = m_mcabus->dack16_r(7); m_dma_high_byte = ret & 0xff00; return ret; }
+
+void ibm72x7377_device::dma8237_0_dack_w(uint8_t data) { m_mcabus->dack_w(0, data); }
+void ibm72x7377_device::dma8237_1_dack_w(uint8_t data) { m_mcabus->dack_w(1, data); }
+void ibm72x7377_device::dma8237_2_dack_w(uint8_t data) { m_mcabus->dack_w(2, data); }
+void ibm72x7377_device::dma8237_3_dack_w(uint8_t data) { m_mcabus->dack_w(3, data); }
+void ibm72x7377_device::dma8237_5_dack_w(uint8_t data) { m_mcabus->dack16_w(5, m_dma_high_byte | data); }
+void ibm72x7377_device::dma8237_6_dack_w(uint8_t data) { m_mcabus->dack16_w(6, m_dma_high_byte | data); }
+void ibm72x7377_device::dma8237_7_dack_w(uint8_t data) { m_mcabus->dack16_w(7, m_dma_high_byte | data); }
+
+WRITE_LINE_MEMBER( ibm72x7377_device::dack0_w ) { set_dma_channel(0, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack1_w ) { set_dma_channel(1, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack2_w ) { set_dma_channel(2, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack3_w ) { set_dma_channel(3, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack4_w ) { m_dma8237_1->hack_w(state ? 0 : 1); } // it's inverted
+WRITE_LINE_MEMBER( ibm72x7377_device::dack5_w ) { set_dma_channel(5, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack6_w ) { set_dma_channel(6, state); }
+WRITE_LINE_MEMBER( ibm72x7377_device::dack7_w ) { set_dma_channel(7, state); }
+
+void ibm72x7377_device::dma_request(int channel, bool state)
+{
+	// Bounce this to the correct DMA controller.
+
+	LOG("%s: ch:%d state:%d\n", FUNCNAME, channel, state);
+
+	switch(channel)
+	{
+		case 0: m_dma8237_1->dreq0_w(state); break;
+		case 1: m_dma8237_1->dreq1_w(state); break;
+		case 2: m_dma8237_1->dreq2_w(state); break;
+		case 3: m_dma8237_1->dreq3_w(state); break;
+		case 4: m_dma8237_2->dreq0_w(state); break;
+		case 5: m_dma8237_2->dreq1_w(state); break;
+		case 6: m_dma8237_2->dreq2_w(state); break;
+		case 7: m_dma8237_2->dreq3_w(state); break;
+	}
+}
+
+uint8_t ibm72x7377_device::dma_read_byte(offs_t offset)
+{
+	address_space& prog_space = m_maincpu->space(AS_PROGRAM); // get the right address space
+	if(m_dma_channel == -1)
+		return 0xff;
+	uint8_t result;
+	offs_t page_offset = ((offs_t) m_dma_offset[0][m_dma_channel]) << 16;
+
+	LOG("%s %06X\n", FUNCNAME, offset+page_offset);
+
+	result = prog_space.read_byte(page_offset + offset);
+	return result;
+}
+
+void ibm72x7377_device::dma_write_byte(offs_t offset, uint8_t data)
+{
+	address_space& prog_space = m_maincpu->space(AS_PROGRAM); // get the right address space
+	if(m_dma_channel == -1)
+		return;
+	offs_t page_offset = ((offs_t) m_dma_offset[0][m_dma_channel]) << 16;
+
+	LOG("%s %06X %02X\n", FUNCNAME, offset, data);
+
+	prog_space.write_byte(page_offset + offset, data);
+}
+
+
+uint8_t ibm72x7377_device::dma_read_word(offs_t offset)
+{
+	LOG("%s %d\n", FUNCNAME, offset);
+
+	address_space& prog_space = m_maincpu->space(AS_PROGRAM); // get the right address space
+	if(m_dma_channel == -1)
+		return 0xff;
+	uint16_t result;
+	offs_t page_offset = ((offs_t) m_dma_offset[1][m_dma_channel & 3]) << 16;
+
+	result = prog_space.read_word((page_offset & 0xfe0000) | (offset << 1));
+	m_dma_high_byte = result & 0xff00;
+
+	return result & 0xff;
+}
+
+
+void ibm72x7377_device::dma_write_word(offs_t offset, uint8_t data)
+{
+	LOG("%s %d %d\n", FUNCNAME, offset, data);
+
+	address_space& prog_space = m_maincpu->space(AS_PROGRAM); // get the right address space
+	if(m_dma_channel == -1)
+		return;
+	offs_t page_offset = ((offs_t) m_dma_offset[1][m_dma_channel & 3]) << 16;
+
+	prog_space.write_word((page_offset & 0xfe0000) | (offset << 1), m_dma_high_byte | data);
+}
+
+WRITE_LINE_MEMBER( ibm72x7377_device::dma_hrq_changed )
+{
+	LOG("%s %d\n", FUNCNAME, state);
+
+	m_maincpu->set_input_line(INPUT_LINE_HALT, state ? ASSERT_LINE : CLEAR_LINE);
+
+	/* Assert HLDA */
+	m_dma8237_2->hack_w(state);
+}
+
+WRITE_LINE_MEMBER( ibm72x7377_device::dma8237_1_out_eop )
+{
+	m_cur_eop = state == ASSERT_LINE;
+
+	LOG("DMA1 EOP channel %d\n", m_dma_channel);
+
+	if(m_dma_channel != -1)
+	{
+		m_mcabus->eop_w(m_dma_channel, m_cur_eop ? ASSERT_LINE : CLEAR_LINE );
+		
+	}
+		
+}
+
+WRITE_LINE_MEMBER( ibm72x7377_device::dma8237_2_out_eop )
+{
+	m_cur_eop2 = state == ASSERT_LINE;
+
+	LOG("DMA2 EOP channel %d\n", m_dma_channel);
+
+	if(m_dma_channel != -1)
+		m_mcabus->eop_w(m_dma_channel, m_cur_eop2 ? ASSERT_LINE : CLEAR_LINE );
+}
+
+void ibm72x7377_device::set_dma_channel(int channel, int state)
+{
+	LOG("%s %d %d\n", FUNCNAME, channel, state);
+
+	if(!state) {
+		m_dma_channel = channel;
+		if(m_cur_eop)
+			m_mcabus->eop_w(channel, ASSERT_LINE );
+	} else if(m_dma_channel == channel) {
+		m_dma_channel = -1;
+		if(m_cur_eop)
+			m_mcabus->eop_w(channel, CLEAR_LINE );
+	}
+}
+
+uint8_t ibm72x7377_device::page8_r(offs_t offset)
+{
+	uint8_t data = m_at_pages[offset % 0x10];
+
+	switch(offset % 8)
+	{
+	case 1:
+		data = m_dma_offset[BIT(offset, 3)][2];
+		break;
+	case 2:
+		data = m_dma_offset[BIT(offset, 3)][3];
+		break;
+	case 3:
+		data = m_dma_offset[BIT(offset, 3)][1];
+		break;
+	case 7:
+		data = m_dma_offset[BIT(offset, 3)][0];
+		break;
+	}
+
+	LOG("%s o:%02X d:%02X\n", FUNCNAME, offset, data);
+
+	return data;
+}
+
+
+void ibm72x7377_device::page8_w(offs_t offset, uint8_t data)
+{
+	uint8_t dma_channel = -1;
+
+	m_at_pages[offset % 0x10] = data;
+
+	switch(offset % 8)
+	{
+	case 1:
+		dma_channel = (BIT(offset, 3) ? 4 : 0) + 2;
+		m_dma_offset[BIT(offset, 3)][2] = data; // channel 2 or 6
+		break;
+	case 2:
+		dma_channel = (BIT(offset, 3) ? 4 : 0) + 3;
+		m_dma_offset[BIT(offset, 3)][3] = data;	// channel 3 or 7
+		break;
+	case 3:
+		dma_channel = (BIT(offset, 3) ? 4 : 0) + 1;
+		m_dma_offset[BIT(offset, 3)][1] = data;	// channel 1 or 5
+		break;
+	case 7:
+		dma_channel = (BIT(offset, 3) ? 4 : 0) + 0;
+		m_dma_offset[BIT(offset, 3)][0] = data;	// channel 0 or 4
+		break;
+	}
+	
+	if(dma_channel != 4) LOG("%s o:%02X d:%02X (ch:%d)\n", FUNCNAME, offset, data, dma_channel);
+}
+
+uint8_t ibm72x7377_device::extended_function_register_r(offs_t offset)
+{
+	LOG("%s o:%02X\n", FUNCNAME, offset);
+
+	return 0xFF; // write-only register
+}
+
+void ibm72x7377_device::extended_function_register_w(offs_t offset, uint8_t data)
+{
+	// All OUTs to this register reset the byte pointer.
+	m_byte_pointer = 0;
+	m_extended_function = data;
+
+	LOG("PS/2 DMA: ext function %d channel %d\n", (data & 0xF0) >> 4, data & 0x07);
+}
+
+u32 ibm72x7377_device::get_address(uint8_t channel)
+{
+	offs_t address;
+	
+	switch(channel)
+	{
+		case 0: address = m_dma8237_1->get_address<0>(); break;
+		case 1: address = m_dma8237_1->get_address<1>(); break;
+		case 2: address = m_dma8237_1->get_address<2>(); break;
+		case 3: address = m_dma8237_1->get_address<3>(); break;
+		case 4: address = m_dma8237_2->get_address<0>(); break;
+		case 5: address = m_dma8237_2->get_address<1>(); break;
+		case 6: address = m_dma8237_2->get_address<2>(); break;
+		case 7: address = m_dma8237_2->get_address<3>(); break;
+		default: address = 0xFF; break; // Invalid channel?
+	}
+
+	return address;
+}
+
+u32 ibm72x7377_device::get_count(uint8_t channel)
+{
+	u32 count;
+	
+	switch(channel)
+	{
+		case 0: count = m_dma8237_1->get_count<0>(); break;
+		case 1: count = m_dma8237_1->get_count<1>(); break;
+		case 2: count = m_dma8237_1->get_count<2>(); break;
+		case 3: count = m_dma8237_1->get_count<3>(); break;
+		case 4: count = m_dma8237_2->get_count<0>(); break;
+		case 5: count = m_dma8237_2->get_count<1>(); break;
+		case 6: count = m_dma8237_2->get_count<2>(); break;
+		case 7: count = m_dma8237_2->get_count<3>(); break;
+		default: count = 0xFF; break; // Invalid channel?
+	}
+
+	return count;
+}
+
+void ibm72x7377_device::set_address(uint8_t channel, uint8_t data, uint8_t byte_pointer)
+{
+	// Get the current address.
+
+	u32 shifted_data = data;
+	shifted_data = data << (8 * byte_pointer);
+
+	u32 address = get_address(channel);
+	switch(byte_pointer)
+	{
+		case 0: address = (address & 0x00FFFF00) | shifted_data; break;
+		case 1: address = (address & 0x00FF00FF) | shifted_data; break;
+		case 2: address = (address & 0x0000FFFF) | shifted_data; break;
+		default: LOG("%s: Illegal byte pointer %d\n", FUNCNAME, byte_pointer);
+	}
+
+	switch(channel)
+	{
+		case 0: m_dma8237_1->set_address<0>(address); break;
+		case 1: m_dma8237_1->set_address<1>(address); break;
+		case 2: m_dma8237_1->set_address<2>(address); break;
+		case 3: m_dma8237_1->set_address<3>(address); break;
+		case 4: m_dma8237_2->set_address<0>(address); break;
+		case 5: m_dma8237_2->set_address<1>(address); break;
+		case 6: m_dma8237_2->set_address<2>(address); break;
+		case 7: m_dma8237_2->set_address<3>(address); break;
+	}	
+}
+
+void ibm72x7377_device::set_count(uint8_t channel, uint8_t data, uint8_t byte_pointer)
+{
+	// Get the current count, shift our data into it, rewrite it.
+
+	u32 shifted_data = data;
+	shifted_data = data << (8 * byte_pointer);
+
+	u32 count = get_count(channel);
+	switch(byte_pointer)
+	{
+		case 0: count = (count & 0x0000FF00) | shifted_data; break;
+		case 1: count = (count & 0x000000FF) | shifted_data; break;
+		default: LOG("%s: Illegal byte pointer %d\n", FUNCNAME, byte_pointer);
+	}
+
+	switch(channel)
+	{
+		case 0: m_dma8237_1->set_count<0>(count); break;
+		case 1: m_dma8237_1->set_count<1>(count); break;
+		case 2: m_dma8237_1->set_count<2>(count); break;
+		case 3: m_dma8237_1->set_count<3>(count); break;
+		case 4: m_dma8237_2->set_count<0>(count); break;
+		case 5: m_dma8237_2->set_count<1>(count); break;
+		case 6: m_dma8237_2->set_count<2>(count); break;
+		case 7: m_dma8237_2->set_count<3>(count); break;
+	}
+}
+
+uint8_t ibm72x7377_device::extended_function_execute_r(offs_t offset)
+{
+	if(machine().side_effects_disabled()) return 0xFF;
+
+	LOG("%s o:%02X\n", FUNCNAME, offset);
+
+	// Extended Mode read.
+	uint8_t func = (m_extended_function & 0xF0) >> 4;
+	uint8_t channel = m_extended_function & 0x07;
+	uint8_t retval = 0xFF;
+
+	switch(func)
+	{
+		case 0:
+			break;
+		case 1:
+			break;
+		case 2:
+			{
+				retval = (get_address(channel) >> (m_byte_pointer * 8)) & 0xFF;
+				m_byte_pointer++;
+				break;
+			}
+		case 3:
+		case 4:
+			{
+				retval = (get_count(channel) >> (m_byte_pointer * 8)) & 0xFF;
+				m_byte_pointer++;
+				break;
+			}
+			break;
+		case 5:
+			break;
+		case 6:
+			break;
+		case 7:
+			break;
+		case 8:
+			switch(channel)
+			{
+				case 0: retval = m_arbus_ch0; break;
+				case 4: retval = m_arbus_ch4; break;
+				default: LOG("DMA Arbus read invalid channel %02X\n", channel);
+			}
+		case 9:
+			break;
+		case 10:
+			break;
+		case 11:
+			break;
+		case 12:
+			break;
+		case 13:
+			break;	
+		case 14:
+			break;
+		case 15:
+			break;
+		default:
+			LOG("Unhandled DMA Extended Function Read %02X\n", m_extended_function);
+	}
+
+	LOG("%s returning %02X\n", FUNCNAME, retval);
+
+	return retval;
+}
+void ibm72x7377_device::extended_function_execute_w(offs_t offset, uint8_t data)
+{
+	// Extended Mode write.
+	LOG("%s o:%02X\n", FUNCNAME, offset);
+
+	uint8_t func = (m_extended_function & 0xF0) >> 4;
+	uint8_t channel = m_extended_function & 0x07;
+
+	switch(func)
+	{
+		case 0:
+			break;
+		case 1:
+			break;
+		case 2:
+			set_address(channel, data, m_byte_pointer);
+			m_byte_pointer++;
+			break;
+		case 3:
+			break;
+		case 4:
+			set_count(channel, data, m_byte_pointer);
+			m_byte_pointer++;
+			break;
+		case 5:
+			break;
+		case 6:	
+			break;
+		case 7:
+			break;
+		case 8:
+			switch(channel)
+			{
+				case 0: m_arbus_ch0 = data; break;
+				case 4: m_arbus_ch4 = data; break;
+				default: break;
+			}
+		case 9:
+			break;
+		case 10:
+			break;
+		case 11:
+			break;
+		case 12:
+			break;
+		case 13:
+			break;
+		case 14:
+			break;
+		case 15:
+			break;
+		default:
+			LOG("Unhandled DMA Extended Function Write %02X\n", m_extended_function);
+			break;
+	}
+}
+
+uint8_t ibm72x7377_device::dma_arbiter_r(offs_t offset)
+{
+	//LOG("%s o:%02X\n", FUNCNAME, offset);
+	return 0xFF;
+}
+
+void ibm72x7377_device::dma_arbiter_w(offs_t offset, uint8_t data)
+{
+	//LOG("%s o:%02X d:%02X\n", FUNCNAME, offset, data);
+}
+
+void ibm72x7377_device::dma_feedback_w(offs_t offset, uint8_t data)
+{
+	//LOG("%s o:%02X d:%02X\n", FUNCNAME, offset, data);
+}
+
+uint8_t ibm72x7377_device::dmac1_r(offs_t offset)
+{
+	return m_dma8237_1->read(offset);
+}
+
+void ibm72x7377_device::dmac1_w(offs_t offset, uint8_t data)
+{
+	m_dma8237_1->write(offset, data);
+}
+
+uint8_t ibm72x7377_device::dmac2_r(offs_t offset)
+{
+	return m_dma8237_2->read(offset);
+}
+
+void ibm72x7377_device::dmac2_w(offs_t offset, uint8_t data)
+{
+	m_dma8237_2->write(offset, data);
+}

--- a/src/devices/machine/ibm72x7377.cpp
+++ b/src/devices/machine/ibm72x7377.cpp
@@ -117,14 +117,14 @@ void ibm72x7377_device::dma8237_5_dack_w(uint8_t data) { m_mcabus->dack16_w(5, m
 void ibm72x7377_device::dma8237_6_dack_w(uint8_t data) { m_mcabus->dack16_w(6, m_dma_high_byte | data); }
 void ibm72x7377_device::dma8237_7_dack_w(uint8_t data) { m_mcabus->dack16_w(7, m_dma_high_byte | data); }
 
-WRITE_LINE_MEMBER( ibm72x7377_device::dack0_w ) { set_dma_channel(0, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack1_w ) { set_dma_channel(1, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack2_w ) { set_dma_channel(2, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack3_w ) { set_dma_channel(3, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack4_w ) { m_dma8237_1->hack_w(state ? 0 : 1); } // it's inverted
-WRITE_LINE_MEMBER( ibm72x7377_device::dack5_w ) { set_dma_channel(5, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack6_w ) { set_dma_channel(6, state); }
-WRITE_LINE_MEMBER( ibm72x7377_device::dack7_w ) { set_dma_channel(7, state); }
+void ibm72x7377_device::dack0_w(int state) { set_dma_channel(0, state); }
+void ibm72x7377_device::dack1_w(int state) { set_dma_channel(1, state); }
+void ibm72x7377_device::dack2_w(int state) { set_dma_channel(2, state); }
+void ibm72x7377_device::dack3_w(int state) { set_dma_channel(3, state); }
+void ibm72x7377_device::dack4_w(int state) { m_dma8237_1->hack_w(state ? 0 : 1); } // it's inverted
+void ibm72x7377_device::dack5_w(int state) { set_dma_channel(5, state); }
+void ibm72x7377_device::dack6_w(int state) { set_dma_channel(6, state); }
+void ibm72x7377_device::dack7_w(int state) { set_dma_channel(7, state); }
 
 void ibm72x7377_device::dma_request(int channel, bool state)
 {
@@ -201,7 +201,7 @@ void ibm72x7377_device::dma_write_word(offs_t offset, uint8_t data)
 	prog_space.write_word((page_offset & 0xfe0000) | (offset << 1), m_dma_high_byte | data);
 }
 
-WRITE_LINE_MEMBER( ibm72x7377_device::dma_hrq_changed )
+void ibm72x7377_device::dma_hrq_changed(int state)
 {
 	LOG("%s %d\n", FUNCNAME, state);
 
@@ -211,7 +211,7 @@ WRITE_LINE_MEMBER( ibm72x7377_device::dma_hrq_changed )
 	m_dma8237_2->hack_w(state);
 }
 
-WRITE_LINE_MEMBER( ibm72x7377_device::dma8237_1_out_eop )
+void ibm72x7377_device::dma8237_1_out_eop(int state)
 {
 	m_cur_eop = state == ASSERT_LINE;
 
@@ -225,7 +225,7 @@ WRITE_LINE_MEMBER( ibm72x7377_device::dma8237_1_out_eop )
 		
 }
 
-WRITE_LINE_MEMBER( ibm72x7377_device::dma8237_2_out_eop )
+void ibm72x7377_device::dma8237_2_out_eop(int state)
 {
 	m_cur_eop2 = state == ASSERT_LINE;
 

--- a/src/devices/machine/ibm72x7377.h
+++ b/src/devices/machine/ibm72x7377.h
@@ -39,7 +39,7 @@ public:
 	void dma_arbiter_w(offs_t offset, uint8_t data);
 	void dma_feedback_w(offs_t offset, uint8_t data);
 
-	template <unsigned C> DECLARE_WRITE_LINE_MEMBER( dreq_w ) { dma_request(C, state); }
+	template <unsigned C> void dreq_w(int state) { dma_request(C, state); }
 
 protected:
 	void device_start() override;
@@ -55,8 +55,8 @@ private:
 
 	void dma_request(int channel, bool state);
 
-	DECLARE_WRITE_LINE_MEMBER(dma8237_1_out_eop);
-	DECLARE_WRITE_LINE_MEMBER(dma8237_2_out_eop);
+	void dma8237_1_out_eop(int state);
+	void dma8237_2_out_eop(int state);
 	uint8_t dma8237_0_dack_r();
 	uint8_t dma8237_1_dack_r();
 	uint8_t dma8237_2_dack_r();
@@ -71,16 +71,16 @@ private:
 	void dma8237_5_dack_w(uint8_t data);
 	void dma8237_6_dack_w(uint8_t data);
 	void dma8237_7_dack_w(uint8_t data);
-	DECLARE_WRITE_LINE_MEMBER(dack0_w);
-	DECLARE_WRITE_LINE_MEMBER(dack1_w);
-	DECLARE_WRITE_LINE_MEMBER(dack2_w);
-	DECLARE_WRITE_LINE_MEMBER(dack3_w);
-	DECLARE_WRITE_LINE_MEMBER(dack4_w);
-	DECLARE_WRITE_LINE_MEMBER(dack5_w);
-	DECLARE_WRITE_LINE_MEMBER(dack6_w);
-	DECLARE_WRITE_LINE_MEMBER(dack7_w);
+	void dack0_w(int state);
+	void dack1_w(int state);
+	void dack2_w(int state);
+	void dack3_w(int state);
+	void dack4_w(int state);
+	void dack5_w(int state);
+	void dack6_w(int state);
+	void dack7_w(int state);
 
-	DECLARE_WRITE_LINE_MEMBER(dma_hrq_changed);
+	void dma_hrq_changed(int state);
 	void set_dma_channel(int channel, int state);
 
     uint8_t dma_read_byte(offs_t offset);

--- a/src/devices/machine/ibm72x7377.h
+++ b/src/devices/machine/ibm72x7377.h
@@ -1,0 +1,114 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+/*************************************************************
+
+  IBM 72X7377
+  PS/2 Type 1 DMA Controller
+
+**************************************************************/
+
+#ifndef MAME_MACHINE_IBM72X7377_H
+#define MAME_MACHINE_IBM72X7377_H
+
+#pragma once
+
+#include "machine/am9517a.h"
+#include "bus/mca/mca.h"
+
+class ibm72x7377_device : public device_t
+{
+public:
+	ibm72x7377_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	uint8_t dmac1_r(offs_t offset);
+	void dmac1_w(offs_t offset, uint8_t data);
+
+	uint8_t dmac2_r(offs_t offset);
+	void dmac2_w(offs_t offset, uint8_t data);
+
+    uint8_t page8_r(offs_t offset);
+	void page8_w(offs_t offset, uint8_t data);
+
+	uint8_t extended_function_register_r(offs_t offset);
+	void extended_function_register_w(offs_t offset, uint8_t data);
+
+	uint8_t extended_function_execute_r(offs_t offset);
+	void extended_function_execute_w(offs_t offset, uint8_t data);
+
+	uint8_t dma_arbiter_r(offs_t offset);
+	void dma_arbiter_w(offs_t offset, uint8_t data);
+	void dma_feedback_w(offs_t offset, uint8_t data);
+
+	template <unsigned C> DECLARE_WRITE_LINE_MEMBER( dreq_w ) { dma_request(C, state); }
+
+protected:
+	void device_start() override;
+	void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+    virtual void device_config_complete() override;
+
+private:
+    required_device<cpu_device> m_maincpu;
+    required_device<mca16_device> m_mcabus;
+	required_device<ps2_dma_device> m_dma8237_1;
+	required_device<ps2_dma_device> m_dma8237_2;
+
+	void dma_request(int channel, bool state);
+
+	DECLARE_WRITE_LINE_MEMBER(dma8237_1_out_eop);
+	DECLARE_WRITE_LINE_MEMBER(dma8237_2_out_eop);
+	uint8_t dma8237_0_dack_r();
+	uint8_t dma8237_1_dack_r();
+	uint8_t dma8237_2_dack_r();
+	uint8_t dma8237_3_dack_r();
+	uint8_t dma8237_5_dack_r();
+	uint8_t dma8237_6_dack_r();
+	uint8_t dma8237_7_dack_r();
+	void dma8237_0_dack_w(uint8_t data);
+	void dma8237_1_dack_w(uint8_t data);
+	void dma8237_2_dack_w(uint8_t data);
+	void dma8237_3_dack_w(uint8_t data);
+	void dma8237_5_dack_w(uint8_t data);
+	void dma8237_6_dack_w(uint8_t data);
+	void dma8237_7_dack_w(uint8_t data);
+	DECLARE_WRITE_LINE_MEMBER(dack0_w);
+	DECLARE_WRITE_LINE_MEMBER(dack1_w);
+	DECLARE_WRITE_LINE_MEMBER(dack2_w);
+	DECLARE_WRITE_LINE_MEMBER(dack3_w);
+	DECLARE_WRITE_LINE_MEMBER(dack4_w);
+	DECLARE_WRITE_LINE_MEMBER(dack5_w);
+	DECLARE_WRITE_LINE_MEMBER(dack6_w);
+	DECLARE_WRITE_LINE_MEMBER(dack7_w);
+
+	DECLARE_WRITE_LINE_MEMBER(dma_hrq_changed);
+	void set_dma_channel(int channel, int state);
+
+    uint8_t dma_read_byte(offs_t offset);
+	void dma_write_byte(offs_t offset, uint8_t data);
+	uint8_t dma_read_word(offs_t offset);
+	void dma_write_word(offs_t offset, uint8_t data);
+
+	u32 get_address(uint8_t channel);
+	u32 get_count(uint8_t channel);
+
+	void set_address(uint8_t channel, u8 address, uint8_t byte_pointer);
+	void set_count(uint8_t channel, u8 count, uint8_t byte_pointer);
+
+	// DMA ARBUS registers. TODO: Combine into an array.
+	uint8_t m_arbus_ch0;
+	uint8_t m_arbus_ch4;
+
+	uint8_t m_at_pages[0x10]{};
+    uint16_t m_dma_high_byte = 0;
+    int m_dma_channel = 0;
+    uint8_t m_dma_offset[2][4]{};
+    bool m_cur_eop = false, m_cur_eop2 = false;
+
+    uint8_t m_byte_pointer;
+	uint8_t m_extended_function;
+
+};
+
+DECLARE_DEVICE_TYPE(IBM72X7377, ibm72x7377_device)
+
+#endif

--- a/src/devices/machine/ibmps2.cpp
+++ b/src/devices/machine/ibmps2.cpp
@@ -1,0 +1,608 @@
+// license:BSD-3-Clause
+// copyright-holders:Wilbert Pol, Miodrag Milanovic, Carl
+/***************************************************************************
+
+    IBM PS2 Compatibles
+
+***************************************************************************/
+
+#include "emu.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/mca_cards.h"
+#include "bus/mca/planar_uart.h"
+#include "bus/mca/planar_lpt.h"
+#include "bus/mca/planar_fdc.h"
+#include "bus/mca/planar_vga.h"
+#include "imagedev/floppy.h"
+#include "machine/ibmps2.h"
+#include "cpu/i86/i286.h"
+#include "cpu/i386/i386.h"
+#include "formats/pc_dsk.h"
+#include "speaker.h"
+#include "xtal.h"
+
+#define LOG_PORT80  0
+
+#define LOG_SYSPORTS    (1U <<  2)
+#define LOG_NVRAM       (1U <<  3)
+#define LOG_TIMERS      (1U <<  4)
+#define LOG_POST        (1U <<  5)
+#define LOG_POS         (1U <<  6)
+#define LOG_IRQ			(1U <<	7)
+
+#define VERBOSE (LOG_SYSPORTS|LOG_NVRAM|LOG_TIMERS|LOG_POST|LOG_POS|LOG_IRQ)
+#include "logmacro.h"
+
+#define LOGSYSPORTS(...)    LOGMASKED(LOG_SYSPORTS, __VA_ARGS__)
+#define LOGNVRAM(...)       LOGMASKED(LOG_NVRAM, __VA_ARGS__)
+#define LOGTIMERS(...)      LOGMASKED(LOG_TIMERS, __VA_ARGS__)
+#define LOGPOST(...)        LOGMASKED(LOG_POST, __VA_ARGS__)
+#define LOGPOS(...)         LOGMASKED(LOG_POS, __VA_ARGS__)
+#define LOGIRQ(...)			LOGMASKED(LOG_IRQ, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+#define XTAL_U153   25.175_MHz_XTAL
+#define XTAL_U155   25.175_MHz_XTAL
+#define XTAL_U156   28.322_MHz_XTAL
+#define XTAL_U159   32_MHz_XTAL
+#define XTAL_IO     14.318181_MHz_XTAL
+
+DEFINE_DEVICE_TYPE(PS2_MB,          ps2_mb_device,          "ps2_mb",           "Generic PS/2 Planar")
+
+ps2_mb_device::ps2_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
+	device_t(mconfig, PS2_MB, tag, owner, clock),
+	m_maincpu(*this, ":maincpu"),
+	m_ram(*this, ":ram"),
+	m_nvram(*this, "nvram"),
+	m_mcabus(*this, "mcabus"),
+	m_pic8259_master(*this, "pic8259_master"),
+	m_pic8259_slave(*this, "pic8259_slave"),
+	m_dmac(*this, "dmac"),
+	m_speaker(*this, "speaker"),
+	m_mc146818(*this, "rtc"),
+	m_keybc(*this, "keybc"),
+	m_ps2_con(*this, "ps2_con"),
+	m_aux_con(*this, "aux_con"),
+	m_timer_slow_refresh(*this, "timer_slow_refresh"),
+	m_timer_fast_refresh(*this, "timer_fast_refresh"),
+	m_io_controller(*this, "io_ctrlr"),
+	m_mcaslot(*this, "mca%u", 0U),
+	m_bios(*this, ":bios")
+{
+}
+
+void ps2_mb_device::device_reset()
+{
+	m_at_spkrdata = 0;
+	m_pit_out2 = 1;
+
+	m_refresh_bit = 0;
+
+	if(m_timer_fast_refresh != NULL) m_timer_fast_refresh->enable(0);
+	m_timer_slow_refresh->enable(1);
+
+	irq0_latch_reset();
+}
+
+void ps2_mb_device::device_start()
+{
+	m_nvram_index = 0;
+
+	m_at_speaker = 0;
+	m_at_spkrdata = 0;
+
+	m_channel_check = 0;
+	m_nmi_enabled = 0;
+	m_parity_check_enabled = 0;
+	m_channel_check_enabled = 0;
+	m_memory_control = 0;
+	m_gate_a20 = 0;
+	m_nmi_flag = 0;
+	m_alt_hot_reset = 0;
+
+	m_pit_out2 = 1;
+
+	m_refresh_bit = 0;
+	m_refresh_state = 0;
+}
+
+void ps2_mb_device::device_config_complete()
+{
+
+}
+
+void ps2_mb_device::ps2_32_map(address_map& map)
+{
+	map.unmap_value_high();
+	map(0x00000000, 0x0009ffff).bankrw(":bank10");
+	map(0x000e0000, 0x000fffff).rom().region(":bios", 0);
+	map(0xfffe0000, 0xffffffff).rom().region(":bios", 0);
+}
+
+void ps2_mb_device::ps2_32_io(address_map& map)
+{
+	map.unmap_value_high();
+	map(0x0000, 0xffff).m(*this, FUNC(ps2_mb_device::map));
+}
+
+
+void ps2_mb_device::ps2_16_map(address_map& map)
+{
+	map.unmap_value_high();
+	map(0x000000, 0x09ffff).bankrw(":bank10");
+	map(0x0e0000, 0x0fffff).rom().region(":bios", 0);
+	map(0xfe0000, 0xffffff).rom().region(":bios", 0);
+}
+
+void ps2_mb_device::ps2_16_io(address_map& map)
+{
+	map.unmap_value_high();
+	map(0x0000, 0xffff).m(*this, FUNC(ps2_mb_device::map));
+}
+
+void ps2_mb_device::add_mca_common(machine_config &config)
+{
+	m_mcabus->iochck_callback().set(FUNC(ps2_mb_device::iochck_w));
+
+	// IRQs
+	m_mcabus->irq_callback<2>().set(m_pic8259_slave, FUNC(pic8259_device::ir1_w)); 	// AT compatibility: IRQ 2 cascades to IRQ 9
+	m_mcabus->irq_callback<3>().set(m_pic8259_master, FUNC(pic8259_device::ir3_w));
+	m_mcabus->irq_callback<4>().set(m_pic8259_master, FUNC(pic8259_device::ir4_w));
+	m_mcabus->irq_callback<5>().set(m_pic8259_master, FUNC(pic8259_device::ir5_w));
+	m_mcabus->irq_callback<6>().set(m_pic8259_master, FUNC(pic8259_device::ir6_w));
+	m_mcabus->irq_callback<7>().set(m_pic8259_master, FUNC(pic8259_device::ir7_w));
+	// IRQ 8 doesn't use the 8259.
+	// IRQ 9 is cascade.
+	m_mcabus->irq_callback<10>().set(m_pic8259_slave, FUNC(pic8259_device::ir2_w));
+	m_mcabus->irq_callback<11>().set(m_pic8259_slave, FUNC(pic8259_device::ir3_w));
+	m_mcabus->irq_callback<12>().set(m_pic8259_slave, FUNC(pic8259_device::ir4_w));
+	// IRQ 13 doesn't use the 8259.
+	m_mcabus->irq_callback<14>().set(m_pic8259_slave, FUNC(pic8259_device::ir6_w));
+	m_mcabus->irq_callback<15>().set(m_pic8259_slave, FUNC(pic8259_device::ir7_w));
+}
+
+void ps2_mb_device::add_mca16(machine_config &config)
+{
+	MCA16(config, m_mcabus, 0);
+	m_mcabus->set_addrmap(0, &ps2_mb_device::ps2_16_map);
+	m_mcabus->set_addrmap(1, &ps2_mb_device::ps2_16_io);
+
+	m_mcabus->cs_feedback_callback().set(m_io_controller, FUNC(ibm72x8299_device::cd_sfdbk_w));
+
+	add_mca_common(config);
+}
+
+void ps2_mb_device::add_mca32(machine_config &config)
+{
+	MCA32(config, m_mcabus, 0);
+	m_mcabus->set_addrmap(0, &ps2_mb_device::ps2_32_map);
+	m_mcabus->set_addrmap(1, &ps2_mb_device::ps2_32_io);
+
+	m_mcabus->cs_feedback_callback().set(m_io_controller, FUNC(ibm72x8299_device::cd_sfdbk_w));
+
+	add_mca_common(config);
+}
+
+void ps2_mb_device::device_add_mconfig(machine_config &config)
+{
+	// Common AT-class hardware.
+
+	if(m_sram_size != 0) NVRAM(config, m_nvram);
+
+	PIC8259(config, m_pic8259_master, 0);
+	m_pic8259_master->out_int_callback().set_inputline(m_maincpu, 0);
+	m_pic8259_master->in_sp_callback().set_constant(1);
+	m_pic8259_master->read_slave_ack_callback().set(FUNC(ps2_mb_device::get_slave_ack));
+
+	PIC8259(config, m_pic8259_slave, 0);
+	m_pic8259_slave->out_int_callback().set(m_pic8259_master, FUNC(pic8259_device::ir2_w));
+	m_pic8259_slave->in_sp_callback().set_constant(0);
+
+	MC146818(config, m_mc146818, 32.768_kHz_XTAL);
+	m_mc146818->irq().set(m_pic8259_slave, FUNC(pic8259_device::ir0_w));
+	m_mc146818->set_century_index(0x37);
+
+	/* sound hardware */
+	SPEAKER(config, "mono").front_center();
+	SPEAKER_SOUND(config, m_speaker).add_route(ALL_OUTPUTS, "mono", 0.50);
+
+	PC_KBDC(config, m_ps2_con, pc_ps2_keyboards, STR_KBD_MICROSOFT_NATURAL);
+	m_ps2_con->out_clock_cb().set(m_keybc, FUNC(ps2_keyboard_controller_device::kbd_clk_w));
+	m_ps2_con->out_data_cb().set(m_keybc, FUNC(ps2_keyboard_controller_device::kbd_data_w));
+
+	PC_KBDC(config, m_aux_con, ps2_mice, STR_HLE_PS2_MOUSE);
+	m_aux_con->out_clock_cb().set(m_keybc, FUNC(ps2_keyboard_controller_device::aux_clk_w));
+	m_aux_con->out_data_cb().set(m_keybc, FUNC(ps2_keyboard_controller_device::aux_data_w));
+
+	PS2_KEYBOARD_CONTROLLER(config, m_keybc, 40_MHz_XTAL / 4); // operates at 10 MHz
+	m_keybc->set_default_bios_tag("ibm");
+	m_keybc->hot_res().set(FUNC(ps2_mb_device::hot_reset_w));
+	m_keybc->gate_a20().set(FUNC(ps2_mb_device::gate_a20_w));
+	m_keybc->kbd_irq().set(m_pic8259_master, FUNC(pic8259_device::ir1_w)); 	// IRQ 1
+	m_keybc->kbd_clk().set(m_ps2_con, FUNC(pc_kbdc_device::clock_write_from_mb));
+	m_keybc->kbd_data().set(m_ps2_con, FUNC(pc_kbdc_device::data_write_from_mb));
+	m_keybc->aux_irq().set(m_pic8259_slave, FUNC(pic8259_device::ir4_w));	// IRQ 12
+	m_keybc->aux_clk().set(m_aux_con, FUNC(pc_kbdc_device::clock_write_from_mb));
+	m_keybc->aux_data().set(m_aux_con, FUNC(pc_kbdc_device::data_write_from_mb));
+
+	// memory refresh timer
+	TIMER(config, m_timer_slow_refresh).configure_periodic(FUNC(ps2_mb_device::refresh_cb), attotime::from_hz(66137));
+	if(m_supports_fast_refresh)
+	{
+		timer_device &m_timer_fast_refresh(TIMER(config, "timer_fast_refresh"));
+		m_timer_fast_refresh.configure_periodic(FUNC(ps2_mb_device::refresh_cb), attotime::from_hz(1250000));
+	}	
+}
+
+/* Common PS/2 devices. */
+void ps2_mb_device::add_southbridge_72x8299(machine_config &config)
+{
+	ibm72x8299_device &m_io_controller(IBM72X8299(config, "io_ctrlr", 0, this));
+	
+	m_io_controller.pit_ch_callback<0>().set(FUNC(ps2_mb_device::irq0_w));
+	m_io_controller.pit_ch_callback<2>().set(FUNC(ps2_mb_device::pit8254_out2_changed));
+	m_io_controller.pit_ch_callback<3>().set(FUNC(ps2_mb_device::watchdog_w));
+
+	m_mcabus->cs_feedback_callback().set(m_io_controller, FUNC(ibm72x8299_device::cd_sfdbk_w));
+}
+
+void ps2_mb_device::add_dmac_72x7377(machine_config &config)
+{
+	ibm72x7377_device &m_dmac(IBM72X7377(config, "dmac", 14.318181_MHz_XTAL / 3));
+
+	// DMA channels
+	m_mcabus->drq_callback<0>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<0>));
+	m_mcabus->drq_callback<1>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<1>));
+	m_mcabus->drq_callback<2>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<2>));
+	m_mcabus->drq_callback<3>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<3>));
+	// DMA 4 doesn't exist
+	m_mcabus->drq_callback<5>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<5>));
+	m_mcabus->drq_callback<6>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<6>));
+	m_mcabus->drq_callback<7>().set(m_dmac, FUNC(ibm72x7377_device::dreq_w<7>));
+}
+
+TIMER_DEVICE_CALLBACK_MEMBER(ps2_mb_device::refresh_cb)
+{
+	m_refresh_bit = !m_refresh_bit;
+}
+
+void ps2_mb_device::hot_reset_w(int state)
+{
+	m_maincpu->set_input_line(INPUT_LINE_RESET, state);
+	if(state) m_dmac->reset();
+}
+
+void ps2_mb_device::map(address_map &map)
+{
+	// TODO: Take into account the presence/absence of the IBM ASICs.
+
+	map(0x0000, 0x001f).rw(m_dmac, FUNC(ibm72x7377_device::dmac1_r), FUNC(ibm72x7377_device::dmac1_w)).umask16(0xffff);
+	map(0x0018, 0x0018).rw(m_dmac, FUNC(ibm72x7377_device::extended_function_register_r), FUNC(ibm72x7377_device::extended_function_register_w)).umask16(0x00ff);
+	map(0x001a, 0x001a).rw(m_dmac, FUNC(ibm72x7377_device::extended_function_execute_r), FUNC(ibm72x7377_device::extended_function_execute_w)).umask16(0x00ff);
+	map(0x0020, 0x0021).rw(m_pic8259_master, FUNC(pic8259_device::read), FUNC(pic8259_device::write)).umask16(0xffff);
+	map(0x0040, 0x0047).rw(m_io_controller, FUNC(ibm72x8299_device::pit_r), FUNC(ibm72x8299_device::pit_w)).umask16(0xffff);
+	map(0x0060, 0x0060).r(FUNC(ps2_mb_device::keybc_data_r)).w(m_keybc, FUNC(ps2_keyboard_controller_device::data_w));
+	map(0x0061, 0x0061).rw(FUNC(ps2_mb_device::portb_r), FUNC(ps2_mb_device::portb_w));
+	map(0x0064, 0x0064).rw(m_keybc, FUNC(ps2_keyboard_controller_device::status_r), FUNC(ps2_keyboard_controller_device::command_w));
+	map(0x0070, 0x0071).r("rtc", FUNC(mc146818_device::read)).umask16(0xffff).w(FUNC(ps2_mb_device::write_rtc)).umask16(0xffff);
+	if(m_sram_size != 0) map(0x0074, 0x0076).rw(FUNC(ps2_mb_device::nvram_r), FUNC(ps2_mb_device::nvram_w));
+	map(0x0080, 0x008f).rw(m_dmac, FUNC(ibm72x7377_device::page8_r), FUNC(ibm72x7377_device::page8_w)).umask16(0xffff);
+	map(0x0090, 0x0090).rw(m_dmac, FUNC(ibm72x7377_device::dma_arbiter_r), FUNC(ibm72x7377_device::dma_arbiter_w));
+	map(0x0091, 0x0091).r(m_io_controller, FUNC(ibm72x8299_device::card_select_feedback_r)).w(m_dmac, FUNC(ibm72x7377_device::dma_feedback_w));
+	map(0x0092, 0x0092).rw(FUNC(ps2_mb_device::porta_r), FUNC(ps2_mb_device::porta_w));
+	map(0x0094, 0x0094).rw(m_io_controller, FUNC(ibm72x8299_device::system_board_pos_r), FUNC(ibm72x8299_device::system_board_pos_w));
+	map(0x0096, 0x0096).rw(m_io_controller, FUNC(ibm72x8299_device::adapter_pos_r), FUNC(ibm72x8299_device::adapter_pos_w));
+	map(0x00a0, 0x00a1).rw(m_pic8259_slave, FUNC(pic8259_device::read), FUNC(pic8259_device::write)).umask16(0xffff);
+	map(0x00c0, 0x00df).rw(m_dmac, FUNC(ibm72x7377_device::dmac2_r), FUNC(ibm72x7377_device::dmac2_w)).umask16(0x00ff);
+	map(0x0100, 0x0107).rw(m_io_controller, FUNC(ibm72x8299_device::pos_registers_r), FUNC(ibm72x8299_device::pos_registers_w));
+	// 0x1F0 - Fixed Disk
+	map(0x0680, 0x0681).w(FUNC(ps2_mb_device::post_debug_w));
+}
+
+/*************************************************************
+ *
+ * pic8259 configuration
+ *
+ *************************************************************/
+IRQ_CALLBACK_MEMBER(ps2_mb_device::inta_cb)
+{
+	// Clear the latch on IRQ0, then pass the ack onto the PIC.
+	//LOGIRQ("%s: acknowledging interrupt %02Xh\n", FUNCNAME, irqline);
+	if(irqline == INPUT_LINE_IRQ0) { irq0_latch_reset(); }
+	return m_pic8259_master->inta_cb(device, irqline);
+}
+
+uint8_t ps2_mb_device::get_slave_ack(offs_t offset)
+{
+	if (offset==2) // IRQ = 2
+		return m_pic8259_slave->acknowledge();
+
+	return 0x00;
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::keybc_irq_latch_w )
+{
+	// Latches on IRQ 1, reset by a read to 0x60.
+	if(state == ASSERT_LINE) m_pic8259_master->ir1_w(state);
+}
+
+uint8_t ps2_mb_device::keybc_data_r()
+{
+	m_pic8259_master->ir1_w(CLEAR_LINE); // clears the latch on read
+	return m_keybc->data_r();
+}
+
+/*************************************************************************
+ *
+ *      PC Speaker related
+ *
+ *************************************************************************/
+
+void ps2_mb_device::speaker_set_spkrdata(uint8_t data)
+{
+	m_at_spkrdata = data ? 1 : 0;
+	m_speaker->level_w(m_at_spkrdata & m_pit_out2);
+}
+
+/*************************************************************
+ *
+ * pit8254 configuration
+ *
+ *************************************************************/
+
+WRITE_LINE_MEMBER( ps2_mb_device::pit8254_out2_changed )
+{
+	m_pit_out2 = state ? 1 : 0;
+	m_speaker->level_w(m_at_spkrdata & m_pit_out2);
+}
+
+/*************************************************************************
+ *
+ * NVRAM and RTC
+ *
+ *************************************************************************/
+
+
+void ps2_mb_device::write_rtc(offs_t offset, uint8_t data)
+{
+	if (offset==0) {
+		m_nmi_enabled = BIT(data,7);
+		if (!m_nmi_enabled)
+			m_maincpu->set_input_line(INPUT_LINE_NMI, CLEAR_LINE);
+		m_mc146818->write(0,data);
+	}
+	else {
+		m_mc146818->write(offset,data);
+	}
+}
+
+uint8_t ps2_mb_device::nvram_r(offs_t offset)
+{
+	switch(offset)
+	{
+		case 0:
+			return (m_nvram_index & 0x00FF);
+		case 1:
+			return (m_nvram_index & 0x0700) >> 8;
+		case 2:
+			if(m_nvram_index > m_sram_size)
+			{
+				LOGNVRAM("NVRAM read out of range: %04X\n", m_nvram_index);
+				return 0xFF;
+			}
+			if (!machine().side_effects_disabled())
+				LOGNVRAM("reading NVRAM at %04X: %02X\n", m_nvram_index, m_sram[m_nvram_index]);
+			return m_sram[m_nvram_index];
+		default:
+			fatalerror("nvram_r out of range");
+	}
+}
+
+void ps2_mb_device::nvram_w(offs_t offset, uint8_t data)
+{
+	switch(offset)
+	{
+		case 0:
+			m_nvram_index = (m_nvram_index & 0x0700) | data;
+			break;
+		case 1:
+			m_nvram_index = (m_nvram_index & 0x00FF) | (data << 8);
+			break;
+		case 2:
+			if(m_nvram_index > m_sram_size)
+			{
+				LOGNVRAM("NVRAM write out of range: %04X %02X\n", m_nvram_index, data);
+				return;
+			}
+			if (!machine().side_effects_disabled())
+				LOGNVRAM("Writing NVRAM at %04X: %02X\n", m_nvram_index, data);
+			m_sram[m_nvram_index] = data;
+			break;
+		default:
+			fatalerror("nvram_w out of range");
+	}
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::shutdown )
+{
+	if(state)
+		m_maincpu->reset();
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::irq0_w )
+{
+	// IRQ0 is latched, the PIT channel 3 lines are not.
+	if(state) m_pic8259_master->ir0_w(state);
+	m_io_controller->pit_ch3_gate_w(state);
+	m_io_controller->pit_ch3_clk_w(!state);
+}
+
+void ps2_mb_device::irq0_latch_reset()
+{
+	m_pic8259_master->ir0_w(false);
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::watchdog_w )
+{
+	if(state)
+	{
+		LOGTIMERS("watchdog timeout, asserting NMI\n");
+		m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
+	}
+}
+
+uint8_t ps2_mb_device::portb_r()
+{
+	// 0x80 = status of parity check latch
+	// 0x40 = status of channel check latch
+	// 0x20 = timer 2 output bit
+	// 0x10 = DRAM refresh line
+	// 0x08 = channel check enabled
+	// 0x04 = parity check enabled
+	// 0x02 = speaker gate enabled
+	// 0x01 = timer 2 gate enabled
+
+	uint8_t data = 0;
+
+	// no parity check.
+	data |= m_channel_check ? 0x40 : 0;
+	data |= m_pit_out2 ? 0x20 : 0;
+
+	/*
+	 *  Bit 1 of MCR controls refresh rate.
+	 *  1: rate is 0.8uS
+	 *  0: rate is 15.12uS
+	 */
+	data |= m_refresh_bit ? 0x10 : 0;
+	data |= m_channel_check_enabled ? 0x08 : 0;
+	data |= m_parity_check_enabled ? 0x04 : 0;
+	data |= m_at_speaker ? 0x02 : 0;
+	data |= m_write_gate_2 ? 0x01 : 0;
+
+	return data;
+}
+
+void ps2_mb_device::portb_w(uint8_t data)
+{
+	// 0x80 = reset IRQ 0
+	// 0x08 = enable channel check
+	// 0x04 = enable parity check
+	// 0x02 = enable speaker gate
+	// 0x01 = enable timer 2 gate
+
+	m_at_speaker = data;
+	if(BIT(data, 7)) { irq0_latch_reset(); }
+	m_channel_check_enabled = BIT(data, 3);
+	m_parity_check_enabled = BIT(data, 2);
+	speaker_set_spkrdata(BIT(data, 1));
+	m_write_gate_2 = BIT(data, 0);
+	m_io_controller->pit_ch2_gate_w(m_write_gate_2);
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::iochck_w )
+{
+	if (!state && m_nmi_enabled && !m_channel_check)
+		m_maincpu->set_input_line(INPUT_LINE_NMI, ASSERT_LINE);
+}
+
+WRITE_LINE_MEMBER( ps2_mb_device::gate_a20_w )
+{
+	m_gate_a20 = state;
+	m_maincpu->set_input_line(INPUT_LINE_A20, m_gate_a20);
+}
+
+uint8_t ps2_mb_device::porta_r()
+{
+	uint8_t data = 0;
+
+	data |= m_nmi_flag ? 0x10 : 0;
+	data |= m_gate_a20 ? 0x02 : 0;
+	data |= m_alt_hot_reset ? 0x01 : 0;
+
+	return data;
+}
+
+void ps2_mb_device::porta_w(uint8_t data)
+{
+	//LOGSYSPORTS("%s d:%02X\n", FUNCNAME, data);
+
+	m_nmi_flag = BIT(data, 4);
+	gate_a20_w(BIT(data, 1));
+
+	// Bit 0 is latched so POST can read whether this is a cold boot or the system dropping to real mode.
+	if(!m_alt_hot_reset && BIT(data, 0))
+	{
+		// 0 to 1 transition: Hot reset.
+		m_alt_hot_reset = true;
+		// page 4-196 of the Model 80 manual: pulse the reset line for 100-125ns
+		m_maincpu->pulse_input_line(INPUT_LINE_RESET, attotime::from_nsec(100));
+	}
+	else if(m_alt_hot_reset && !BIT(data,0))
+	{
+		// 1 to 0 transition: Clear the latch.
+		m_alt_hot_reset = false;
+	}
+	// 1 to 1: Do nothing.
+	// 0 to 0: Do nothing.
+}
+
+/************************************************************/
+void ps2_mb_device::post_debug_w(offs_t offset, uint8_t data)
+{
+	if(offset == 0) LOGPOST("POST checkpoint: %02X\n", data);
+	else LOGPOST("POST detail: %02X\n", data);
+}
+
+/* PS/2 POS registers */
+
+uint8_t ps2_mb_device::planar_pos_r(offs_t offset)
+{
+	LOGPOS("%s: O:%02X\n", FUNCNAME, offset);
+
+	switch(offset)
+	{
+		case MCABus::POS::ADAPTER_ID_LO: return m_planar_id & 0xFF;
+		case MCABus::POS::ADAPTER_ID_HI: return (m_planar_id & 0xFF00) >> 8;
+		case MCABus::POS::OPTION_SELECT_DATA_1: return m_io_controller->system_board_io_r();
+		case MCABus::POS::OPTION_SELECT_DATA_2: return 0b00001010;
+		default: return 0xFF;
+	}
+}
+
+void ps2_mb_device::planar_pos_w(offs_t offset, uint8_t data)
+{
+	if(offset == 2)
+	{
+		// System Board I/O Byte.
+		LOGPOS("PS/2 system board I/O enable bits now %02X\n", data);
+		m_io_controller->system_board_io_w(data);
+	}
+}
+
+uint8_t ps2_mb_device::memory_control_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s\n", FUNCNAME);
+	return m_memory_control;
+}
+
+void ps2_mb_device::memory_control_w(uint8_t data)
+{
+	LOGPOS("*** %s %02X\n", FUNCNAME, data);
+	m_memory_control = data;
+}
+
+#define SYS_IOEN_BOARD  1
+#define SYS_IOEN_FDC    2
+#define SYS_IOEN_UART   4
+#define SYS_IOEN_COM1   8

--- a/src/devices/machine/ibmps2.cpp
+++ b/src/devices/machine/ibmps2.cpp
@@ -177,9 +177,6 @@ void ps2_mb_device::add_mca16(machine_config &config)
 	MCA16(config, m_mcabus, 0);
 	m_mcabus->set_addrmap(0, &ps2_mb_device::ps2_16_map);
 	m_mcabus->set_addrmap(1, &ps2_mb_device::ps2_16_io);
-
-	m_mcabus->cs_feedback_callback().set(m_io_controller, FUNC(ibm72x8299_device::cd_sfdbk_w));
-
 	add_mca_common(config);
 }
 
@@ -188,9 +185,6 @@ void ps2_mb_device::add_mca32(machine_config &config)
 	MCA32(config, m_mcabus, 0);
 	m_mcabus->set_addrmap(0, &ps2_mb_device::ps2_32_map);
 	m_mcabus->set_addrmap(1, &ps2_mb_device::ps2_32_io);
-
-	m_mcabus->cs_feedback_callback().set(m_io_controller, FUNC(ibm72x8299_device::cd_sfdbk_w));
-
 	add_mca_common(config);
 }
 

--- a/src/devices/machine/ibmps2.h
+++ b/src/devices/machine/ibmps2.h
@@ -65,8 +65,8 @@ public:
 	template <typename T> void set_cpu_tag(T &&tag) { m_maincpu.set_tag(std::forward<T>(tag)); }
 	template <typename T> void set_ram_tag(T &&tag) { m_ram.set_tag(std::forward<T>(tag)); }
 
-	DECLARE_WRITE_LINE_MEMBER(iochck_w);
-	DECLARE_WRITE_LINE_MEMBER(shutdown);
+	void iochck_w(int state);
+	void shutdown(int state);
 
 	virtual IRQ_CALLBACK_MEMBER(inta_cb);
 
@@ -146,12 +146,12 @@ protected:
 	bool m_refresh_state;
 	bool m_supports_fast_refresh;
 
-	DECLARE_WRITE_LINE_MEMBER(pit8254_out2_changed);
-	DECLARE_WRITE_LINE_MEMBER(irq0_w);
-	DECLARE_WRITE_LINE_MEMBER(watchdog_w);
-	DECLARE_WRITE_LINE_MEMBER(gate_a20_w);
-	DECLARE_WRITE_LINE_MEMBER(hot_reset_w);	
-	DECLARE_WRITE_LINE_MEMBER(keybc_irq_latch_w);
+	void pit8254_out2_changed(int state);
+	void irq0_w(int state);
+	void watchdog_w(int state);
+	void gate_a20_w(int state);
+	void hot_reset_w(int state);
+	void keybc_irq_latch_w(int state);
 
 	TIMER_DEVICE_CALLBACK_MEMBER(refresh_cb);
 };

--- a/src/devices/machine/ibmps2.h
+++ b/src/devices/machine/ibmps2.h
@@ -1,0 +1,159 @@
+// license:BSD-3-Clause
+// copyright-holders:Wilbert Pol, Miodrag Milanovic, Carl
+#ifndef MAME_MACHINE_PS2_H
+#define MAME_MACHINE_PS2_H
+
+#include "machine/timer.h"
+#include "machine/am9517a.h"
+#include "machine/at_keybc.h"
+#include "machine/ins8250.h"
+#include "machine/mc146818.h"
+#include "machine/nvram.h"
+#include "machine/pic8259.h"
+#include "machine/pit8253.h"
+#include "machine/ram.h"
+#include "machine/upd765.h"
+#include "machine/pc_lpt.h"
+#include "machine/ibm72x7377.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/ibm72x8299.h"
+#include "bus/pc_kbd/keyboards.h"
+#include "bus/pc_kbd/pc_kbdc.h"
+#include "sound/spkrdev.h"
+
+class ps2_mb_device : public device_t
+{
+public:
+	ps2_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock,
+		uint16_t sram_size, uint16_t planar_id, bool supports_fast_refresh)
+		: ps2_mb_device(mconfig, tag, owner, clock)
+	{
+		m_sram_size = sram_size;
+		m_planar_id = planar_id;
+		m_supports_fast_refresh = supports_fast_refresh;
+	}
+	ps2_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
+
+	virtual void map(address_map &map);
+
+	// Keyboard Controller
+	auto 	kbd_clk() { return subdevice<ps2_keyboard_controller_device>("keybc")->kbd_clk(); }
+	auto 	kbd_data() { return subdevice<ps2_keyboard_controller_device>("keybc")->kbd_data(); }
+	void 	write_rtc(offs_t offset, uint8_t data);
+	
+    void    post_debug_w(offs_t offset, uint8_t data);
+
+    uint8_t memory_control_r();
+    void    memory_control_w(uint8_t data);
+
+    uint8_t nvram_r(offs_t offset);
+    void    nvram_w(offs_t offset, uint8_t data);
+
+	virtual uint8_t 	planar_pos_r(offs_t offset);
+	virtual void 		planar_pos_w(offs_t offset, uint8_t data);
+
+	mca16_device * get_mca_bus() { return m_mcabus; }
+	mca16_slot_device * get_mca_slot(uint8_t slotnum) { return m_mcaslot[slotnum]; }
+
+	uint16_t get_planar_id() { return m_planar_id; }
+
+	template<typename R, typename W> void install_memory(offs_t start, offs_t end, R rhandler, W whandler)
+	{
+		m_mcabus->install_memory(start, end, rhandler, whandler);
+	}
+
+	template <typename T> void set_cpu_tag(T &&tag) { m_maincpu.set_tag(std::forward<T>(tag)); }
+	template <typename T> void set_ram_tag(T &&tag) { m_ram.set_tag(std::forward<T>(tag)); }
+
+	DECLARE_WRITE_LINE_MEMBER(iochck_w);
+	DECLARE_WRITE_LINE_MEMBER(shutdown);
+
+	virtual IRQ_CALLBACK_MEMBER(inta_cb);
+
+protected:
+	required_device<cpu_device> m_maincpu;
+    required_device<ram_device> m_ram;
+	optional_device<nvram_device> m_nvram;
+	required_device<mca16_device> m_mcabus;
+	required_device<pic8259_device> m_pic8259_master;
+	required_device<pic8259_device> m_pic8259_slave;
+	optional_device<ibm72x7377_device> m_dmac;
+	required_device<speaker_sound_device> m_speaker;
+	required_device<mc146818_device> m_mc146818;
+	required_device<ps2_keyboard_controller_device> m_keybc;
+    required_device<pc_kbdc_device> m_ps2_con;
+	required_device<pc_kbdc_device> m_aux_con;
+	required_device<timer_device> m_timer_slow_refresh;
+	optional_device<timer_device> m_timer_fast_refresh;
+	optional_device<ibm72x8299_device> m_io_controller;
+
+	optional_device_array<mca16_slot_device, 8> m_mcaslot;
+
+	required_memory_region m_bios;
+
+	void add_southbridge_72x8299(machine_config &config);
+	void add_dmac_72x7377(machine_config &config);
+
+	void ps2_32_map(address_map& map);
+	void ps2_32_io(address_map& map);
+
+	void ps2_16_map(address_map& map);
+	void ps2_16_io(address_map& map);
+
+	void device_start() override;
+	void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+    virtual void device_config_complete() override;
+
+	void add_mca_common(machine_config &config);
+	void add_mca16(machine_config &config);
+	void add_mca32(machine_config &config);
+
+	void speaker_set_spkrdata(uint8_t data);
+
+	uint8_t get_slave_ack(offs_t offset);
+	uint8_t keybc_data_r();
+
+	// System Control Ports A and B
+	uint8_t	porta_r();
+	void	porta_w(uint8_t data);
+
+	virtual uint8_t portb_r();
+	virtual void portb_w(uint8_t data);
+
+	virtual void irq0_latch_reset();
+
+	uint16_t m_sram_size;
+	uint16_t m_planar_id;
+
+	std::unique_ptr<uint8_t[]> m_sram;
+    uint16_t m_nvram_index;
+
+	uint8_t m_at_spkrdata;
+	uint8_t m_pit_out2;
+	bool m_write_gate_2;
+	
+	uint8_t m_at_speaker;
+	uint8_t m_channel_check;
+	uint8_t m_nmi_enabled;
+	uint8_t m_parity_check_enabled;
+	uint8_t m_channel_check_enabled;
+	uint8_t m_memory_control;
+	bool m_gate_a20;
+	bool m_nmi_flag;
+	bool m_alt_hot_reset;
+	bool m_refresh_bit;
+	bool m_refresh_state;
+	bool m_supports_fast_refresh;
+
+	DECLARE_WRITE_LINE_MEMBER(pit8254_out2_changed);
+	DECLARE_WRITE_LINE_MEMBER(irq0_w);
+	DECLARE_WRITE_LINE_MEMBER(watchdog_w);
+	DECLARE_WRITE_LINE_MEMBER(gate_a20_w);
+	DECLARE_WRITE_LINE_MEMBER(hot_reset_w);	
+	DECLARE_WRITE_LINE_MEMBER(keybc_irq_latch_w);
+
+	TIMER_DEVICE_CALLBACK_MEMBER(refresh_cb);
+};
+
+#endif // MAME_MACHINE_PS2_H

--- a/src/devices/machine/pit8253.cpp
+++ b/src/devices/machine/pit8253.cpp
@@ -122,7 +122,6 @@ void ps2_pit_device::device_resolve_objects()
 {
 	pit8253_device::device_resolve_objects();
 
-	m_ch3_out_handler.resolve_safe();
 	m_ch3_counter->m_index = 3;
 	m_ch3_counter->m_clockin = m_ch3_clk;
 	m_ch3_counter->m_clock_period = (m_ch3_clk != 0) ? attotime::from_hz(m_ch3_clk) : attotime::never;

--- a/src/devices/machine/pit8253.h
+++ b/src/devices/machine/pit8253.h
@@ -194,8 +194,11 @@ public:
 	virtual uint8_t read(offs_t offset) override;
 	virtual void write(offs_t offset, uint8_t data) override;
 
-	WRITE_LINE_MEMBER(write_gate3) { m_ch3_counter->gate_w(state); }
-	WRITE_LINE_MEMBER(write_clk3) { m_ch3_counter->set_clock_signal(state); }
+	// WRITE_LINE_MEMBER(write_gate3) { m_ch3_counter->gate_w(state); }
+	// WRITE_LINE_MEMBER(write_clk3) { m_ch3_counter->set_clock_signal(state); }
+
+	void write_gate3(int state) { m_ch3_counter->gate_w(state); }
+	void write_clk3(int state)	{ m_ch3_counter->set_clock_signal(state); }
 
 	auto ch3_out_handler() { return m_ch3_out_handler.bind(); }
 

--- a/src/mame/mame.lst
+++ b/src/mame/mame.lst
@@ -35507,16 +35507,6 @@ tetriskr                        // (c) 1988? bootleg
 @source:pc/poisk1.cpp
 poisk1                          //
 
-@source:pc/ps2.cpp
-i8530286                        // IBM PS/2 Model 30-286
-i8530h31                        // IBM PS/2 8530-H31 (Model 30/286)
-i8535043                        // IBM PS/2 8535-043 (Model 35)
-i8550021                        // IBM PS/2 8550-021 (Model 50)
-i8550061                        // IBM PS/2 8550-061 (Model 50Z)
-i8555081                        // IBM PS/2 8550-081 (Model 55SX)
-i8580071                        // IBM PS/2 8580-071 (Model 80)
-i8580111                        // IBM PS/2 8580-111 (Model 80)
-
 @source:pc/quakeat.cpp
 quake                           // (c) 19?? Lazer-Tron / iD Software
 
@@ -36497,6 +36487,1050 @@ theraid                         //
 theraida                        // (c) 1984 Playmatic / EFOSA
 trailer                         //
 ufo_x                           //
+
+@source:misc/playcenter.cpp
+plycntrchtr                     // (c) 2000 Recreativos Presas / Undergaming
+
+@source:nintendo/playch10.cpp
+pc_1942                         // (c) 1985 Capcom
+pc_bball                        // (c) 1984 Nintendo of America
+pc_bfght                        // (c) 1984 Nintendo
+pc_bload                        // (c) 1990 Jaleco (Nintendo of America license)
+pc_bstar                        // (c) 1989 SNK (Nintendo of America license)
+pc_cntra                        // (c) 1988 Konami (Nintendo of America license)
+pc_cshwk                        // (c) 1989 Rare (Nintendo of America license)
+pc_cvnia                        // (c) 1987 Konami (Nintendo of America license)
+pc_dbldr                        // (c) 1987 Konami (Nintendo of America license)
+pc_ddrgn                        // (c) 1988 Technos
+pc_drmro                        // (c) 1990 Nintendo
+pc_duckh                        // (c) 1984 Nintendo
+pc_ebike                        // (c) 1984 Nintendo
+pc_ftqst                        // (c) 1989 Sunsoft (Nintendo of America license)
+pc_gntlt                        // (c) 1985 Atari/Tengen (Nintendo of America license)
+pc_golf                         // (c) 1984 Nintendo
+pc_goons                        // (c) 1986 Konami
+pc_grdue                        // (c) 1986 Konami
+pc_grdus                        // (c) 1986 Konami
+pc_hgaly                        // (c) 1984 Nintendo
+pc_kngfu                        // (c) 1984 Irem (Nintendo license)
+pc_mario                        // (c) 1983 Nintendo
+pc_miket                        // (c) 1987 Nintendo
+pc_mman3                        // (c) 1990 Capcom USA (Nintendo of America license)
+pc_moglf                        // (c) 1991 Nintendo
+pc_mtoid                        // (c) 1986 Nintendo
+pc_ngai2                        // (c) 1990 Tecmo (Nintendo of America license)
+pc_ngai3                        // (c) 1991 Tecmo (Nintendo of America license)
+pc_ttoon                        //
+pc_ngaid                        // (c) 1989 Tecmo (Nintendo of America license)
+pc_pinbt                        // (c) 1988 Rare (Nintendo of America license)
+pc_pwbld                        // (c) 1991 Taito (Nintendo of America license)
+pc_pwrst                        // (c) 1986 Nintendo
+pc_radr2                        // (c) 1990 Square (Nintendo of America license)
+pc_radrc                        // (c) 1987 Square
+pc_rcpam                        // (c) 1987 Rare
+pc_rkats                        // (c) 1991 Atlus (Nintendo of America license)
+pc_rnatk                        // (c) 1987 Konami (Nintendo of America license)
+pc_rrngr                        // (c) Capcom USA (Nintendo of America license)
+pc_rygar                        // (c) 1987 Tecmo (Nintendo of America license)
+pc_sjetm                        // (c) 1990 Rare
+pc_smb                          // (c) 1985 Nintendo
+pc_smb2                         // (c) 1988 Nintendo
+pc_smb3                         // (c) 1988 Nintendo
+pc_suprc                        // (c) 1990 Konami (Nintendo of America license)
+pc_tbowl                        // (c) 1989 Tecmo (Nintendo of America license)
+pc_tenis                        // (c) 1983 Nintendo
+pc_tkfld                        // (c) 1987 Konami (Nintendo of America license)
+pc_tmnt                         // (c) 1989 Konami (Nintendo of America license)
+pc_tmnt2                        // (c) 1990 Konami (Nintendo of America license)
+pc_trjan                        // (c) 1986 Capcom USA (Nintendo of America license)
+pc_vball                        // (c) 1986 Nintendo
+pc_virus                        // (c) 1990 Nintendo
+pc_wcup                         // (c) 1990 Technos (Nintendo license)
+pc_wgnmn                        // (c) 1984 Nintendo
+pc_ynoid                        // (c) 1990 Capcom USA (Nintendo of America license)
+playch10                        //
+
+@source:playmark/playmark.cpp
+bigtwin                         // (c) 1995
+bigtwinb                        // (c) 1995
+excelsr                         // (c) 1995
+excelsra                        // (c) 1995
+hotmind                         // (c) 1995
+hrdtimes                        // (c) 1994
+hrdtimesa                       // (c) 1994
+luckboomh                       // (c) 1995
+wbeachvl                        // (c) 1995
+wbeachvl2                       // (c) 1995
+wbeachvl3                       // (c) 1995
+wbeachvla                       // (c) 1995
+
+@source:misc/plsonic4.cpp
+plsonic4                        //
+
+@source:commodore/plus4.cpp
+c116                            //
+c16                             //
+c16_hu                          //
+c16p                            //
+c232                            //
+c264                            //
+plus4                           //
+plus4p                          //
+v364                            //
+
+@source:jpm/pluto5.cpp
+hb_bar7                         // Bar Seven (Fairgames)
+hb_bar7a                        //
+hb_bigx                         // Big X (JPM)
+hb_bigxa                        //
+hb_bigxb                        //
+hb_bigxc                        //
+hb_bigxd                        //
+hb_cashc                        // Cash Crusade (Qps)
+hb_cashca                       //
+hb_cashcb                       //
+hb_cashx                        // Cash X (Fairgames)
+hb_cashxa                       //
+hb_ccow                         // Cash Cow (Qps)
+hb_ccowa                        //
+hb_ccowb                        //
+hb_cr                           // Cash Raker (QPS)
+hb_cra                          //
+hb_crb                          //
+hb_cwf                          // Cherry Win Falls (Fairgames)
+hb_cwfa                         //
+hb_dac                          // Dough & Arrow Club (Qps) [c]
+hb_daca                         //
+hb_dacb                         //
+hb_dacc                         //
+hb_dacd                         //
+hb_dace                         //
+hb_dacf                         //
+hb_dacg                         //
+hb_dacz                         //
+hb_frtcl                        // Fruitopia Club (Qps) [c]
+hb_frtcla                       //
+hb_frtclb                       //
+hb_frtclc                       //
+hb_frtcld                       //
+hb_frtcle                       //
+hb_frtclf                       //
+hb_frtclg                       //
+hb_frtclh                       //
+hb_frtcli                       //
+hb_frtclj                       //
+hb_frtclk                       //
+hb_frtcll                       //
+hb_frtclm                       //
+hb_frtcln                       //
+hb_gldpl                        // Golden Palace (Mazooma)
+hb_gldpla                       //
+hb_gldwn                        // Golden Winner (Fairgames)
+hb_gldwna                       //
+hb_gpal                         // G' Palace (Qps)
+hb_gpala                        //
+hb_gpalb                        //
+hb_gpalc                        //
+hb_gpald                        //
+hb_gpale                        //
+hb_gpalf                        //
+hb_gpalg                        //
+hb_gpalh                        //
+hb_gpali                        //
+hb_hotst                        // Hot Stuff??
+hb_hotsta                       //
+hb_hotstb                       //
+hb_hotstc                       //
+hb_hotstd                       //
+hb_hotste                       //
+hb_hotstf                       //
+hb_hotstg                       //
+hb_hotsth                       //
+hb_jailb                        // Jail Break (Qps)
+hb_jailba                       //
+hb_jkrwl                        // Jokers Wild (Fairgames)
+hb_jkrwla                       //
+hb_junglet                      // Jungle Treasures (Sega)
+hb_medal                        // Medallion Job (Qps)
+hb_mrmon                        // Mr. Money (Qps)
+hb_mrmona                       //
+hb_mrmonb                       //
+hb_mrmonc                       //
+hb_rckrl                        // Rock 'n' Roll (Qps)
+hb_rckrla                       //
+hb_rckrlb                       //
+hb_rckrlc                       //
+hb_rckrld                       //
+hb_rckrle                       //
+hb_rckrlf                       //
+hb_rckrlg                       //
+hb_rhv                          // Red Hot Voucher (Qps)
+hb_rhva                         //
+hb_ringb                        // Ring A Bell (JPM)
+hb_ringba                       //
+hb_ringbb                       //
+hb_ringbc                       //
+hb_ringbd                       //
+hb_ringbe                       //
+hb_ydd                          // Yabba-Dabba-Dough (Qps)
+hb_ydda                         //
+
+@source:konami/plygonet.cpp
+plygonet                        // GX305 (c) 1993
+polynetw                        // GX305 too? (c) 1993
+
+@source:skeleton/pm68k.cpp
+pm68k                           //
+
+@source:misc/pmc.cpp
+unkpmc
+
+@source:tesla/pmd85.cpp
+alfa                            // Alfa (PMD-85.1 clone)
+c2717                           // Consul 2717 (PMD-85.2 clone)
+c2717pmd                        // Consul 2717 with PMD-32
+mato                            // Mato (PMD-85.2 clone)
+pmd851                          // PMD-85.1
+pmd852                          // PMD-85.2
+pmd852a                         // PMD-85.2A
+pmd852b                         // PMD-85.2B
+pmd853                          // PMD-85.3
+
+@source:tesla/pmi80.cpp
+pmi80                           //
+
+@source:misc/pntnpuzl.cpp
+pntnpuzl                        // Century?
+
+@source:sharp/pocketc.cpp
+pc1245                          // Pocket Computer 1245
+pc1250                          // Pocket Computer 1250
+pc1251                          // Pocket Computer 1251
+pc1255                          // Pocket Computer 1255
+pc1260                          // Pocket Computer 1260
+pc1261                          // Pocket Computer 1261
+pc1350                          // Pocket Computer 1350
+pc1360                          // Pocket Computer 1360
+pc1401                          // Pocket Computer 1401
+pc1402                          // Pocket Computer 1402
+pc1403                          // Pocket Computer 1403
+pc1403h                         // Pocket Computer 1403H
+pc1450                          // Pocket Computer 1450
+trs80pc3                        // Tandy TRS80 PC-3
+
+@source:skeleton/pockchal.cpp
+pockchal
+
+@source:sony/pockstat.cpp
+pockstat                        // 1999 Sony PocketStation
+
+@source:atari/pofo.cpp
+pofo                            //
+
+@source:pc/poisk1.cpp
+poisk1                          //
+
+@source:dgrm/pokechmp.cpp
+billlist                        //
+pokechmp                        // Korean hack of Pocket Gal
+pokechmpa                       //
+
+@source:nintendo/pokemini.cpp
+pokemini                        // Nintendo Pokemon Mini
+
+@source:misc/poker72.cpp
+poker72                         //
+
+@source:misc/pokerout.cpp
+pokerout                        // 19??, unknown
+
+@source:namco/polepos.cpp
+grally                          // bootleg
+polepos                         // (c) 1982
+polepos2                        // (c) 1983
+polepos2a                       // 136014   (c) 1983 + Atari license
+polepos2b                       // bootleg
+polepos2bi                      // bootleg
+polepos2bs                      // 1984, BCN Internacional S.A. (bootleg)
+poleposa1                       // 136014   (c) 1982 Atari
+poleposa2                       // 136014   (c) 1982 + Atari license
+poleposj                        // (c) 1982
+ppspeed                         // bootleg
+topracer                        // bootleg
+topracera                       // bootleg
+topracern                       // bootleg
+
+@source:misc/policetr.cpp
+policetr                        // (c) 1996 P&P Marketing
+policetr10                      // (c) 1996 P&P Marketing
+policetr11                      // (c) 1996 P&P Marketing
+policetr13                      // (c) 1996 P&P Marketing
+policetr13a                     // (c) 1996 P&P Marketing
+policetr13b                     // (c) 1996 P&P Marketing
+sshooter                        // (c) 1998 P&P Marketing
+sshooter11                      // (c) 1998 P&P Marketing
+sshooter12                      // (c) 1998 P&P Marketing
+sshooter17                      // (c) 1998 P&P Marketing
+
+@source:ausnz/poly.cpp
+poly1                           // Poly 1
+poly1e                          // Poly 1 (early)
+poly2                           // Poly 2
+polydev                         // Poly Development
+
+@source:poly88/poly88.cpp
+poly88                          //
+poly8813                        //
+
+@source:korg/poly800.cpp
+poly800                         //
+poly800ii                       //
+poly800mdk                      //
+
+@source:ddr/poly880.cpp
+poly880                         //
+poly880s                        //
+
+@source:ddr/polyplay.cpp
+polyplay                        //
+polyplay2                       //
+polyplay2c                      //
+
+@source:korg/polysix.cpp
+polysix                         //
+poly61                          //
+
+@source:atari/pong.cpp
+breakout                        // (c) 1976 Atari
+pong                            // (c) 1972 Atari
+pongd                           // (c) 1973 Atari
+rebound                         //
+
+@source:atari/poolshrk.cpp
+poolshrk                        // 006281           1977/06 [6800]
+
+@source:konami/pooyan.cpp
+pootan                          // bootleg
+pooyan                          // GX320 (c) 1982
+pooyans                         // GX320 (c) 1982 Stern
+
+@source:nintendo/popeye.cpp
+popeye                          // (c) 1982
+popeyehs
+popeyebl                        // bootleg
+popeyeb2                        // bootleg
+popeyeb3                        // bootleg
+popeyef                         // (c) 1982
+popeyeu                         // (c) 1982
+popeyej                         //
+popeyejo                        //
+skyskipr                        // (c) 1981
+
+@source:bmc/popobear.cpp
+popobear                        // (c) 2000 BMC
+
+@source:omori/popper.cpp
+popper                          // (c) 1983 Omori Electric Co., Ltd.
+
+@source:positron/positron.cpp
+positron                        // 1982 Positron 9000
+
+@source:olympia/portrait.cpp
+portrait                        // (c) 1983 Olympia
+portraita                       // (c) 1983 Olympia
+
+@source:misc/potgoldu.cpp
+potgoldu                        // (c) 200? U.S. Games
+potgoldu580                     // (c) 200? U.S. Games
+
+@source:playmark/powerbal.cpp
+atombjt                         // bootleg
+hotminda                        // (c) 1995
+magicstk                        // (c) 1995
+powerbal                        // (c) 1994
+
+@source:nmk/powerins.cpp
+powerins                        // (c) 1993 Atlus (USA)
+powerinsa                       // (c) 1993 Atlus (bootleg of USA version)
+powerinsb                       // (c) 1993 Atlus (bootleg of USA version)
+powerinsc                       // (c) 1993 Atlus (bootleg of USA version)
+powerinsj                       // (c) 1993 Atlus (Japan)
+powerinspj                      // prototype (Japan)
+powerinspu                      // prototype (USA)
+
+@source:motorola/powerstack.cpp
+powerstk                        // Motorola Powerstack II
+
+@source:stm/pp.cpp
+pp                              // STM Pied Piper Communicator 1
+
+@source:zvt/pp01.cpp
+pp01                            //
+
+@source:edevices/ppmast93.cpp
+ppmast93                        // (c) 1993 Electronic Devices S.R.L.
+
+@source:snk/prehisle.cpp
+gensitou                        // A8003 'GT' (c) 1989
+prehisle                        // A8003 'GT' (c) 1989
+prehislek                       // A8003 'GT' (c) 1989
+prehisleu                       // A8003 'GT' (c) 1989
+prehisleb                       // bootleg
+
+@source:vtech/prestige.cpp
+gl6000sl                        // Genius Leader 6000SL (Germany)
+gl7007sl                        // Genius Leader 7007SL (Germany)
+glcolor                         // Genius Leader Color (Germany)
+glmcolor                        // Genius Leader Magic Color (Germany)
+glscolor                        // Genius Leader Super Color (Germany)
+pcscolor                        // PC Super Color (Spain)
+gmmc                            // Genius Master Mega Color (Germany)
+gwnf                            // Genius Winner Notebook Fun (Germany)
+prestige                        // PreComputer Prestige Elite
+snotec                          // Bandai Super Note Club (Japan)
+snotecex                        // Bandai Super Note Club EX (Japan)
+snotecu                         // Bandai Super Note Club U (Japan)
+
+@source:microkey/primo.cpp
+primoa32                        // Primo A-32
+primoa48                        // Primo A-48
+primoa64                        // Primo A-64
+primob32                        // Primo B-32
+primob48                        // Primo B-48
+primob64                        // Primo B-64
+primoc64                        // Primo C-64
+
+@source:trainer/pro80.cpp
+pro80                           //
+
+@source:misc/proconn.cpp
+pr_5xcsh                        // 5x Cash (Project)
+pr_7hvn                         // 777 Heaven (Project)
+pr_7hvna                        //
+pr_7hvnb                        //
+pr_7hvnc                        //
+pr_7hvnd                        //
+pr_7hvne                        //
+pr_7hvnf                        //
+pr_7hvng                        //
+pr_7hvnh                        //
+pr_7hvni                        //
+pr_7hvnj                        //
+pr_7hvnk                        //
+pr_7hvnl                        //
+pr_7hvnm                        //
+pr_7hvnn                        //
+pr_7hvno                        //
+pr_7hvnp                        //
+pr_7hvnq                        //
+pr_7hvnr                        //
+pr_7hvns                        //
+pr_7hvnt                        //
+pr_7hvnu                        //
+pr_alwy9                        // Always Nine (Pcp)
+pr_alwy9a                       //
+pr_barbl                        // Bars & Bells (Project)
+pr_batls                        // Battleships (Project)
+pr_batlsa                       //
+pr_batlsb                       //
+pr_bears                        // Bear Streak (Coinworld)
+pr_bearsa                       //
+pr_bearsb                       //
+pr_bearx                        // Bear X (Coinworld)
+pr_bearxa                       //
+pr_bearxb                       //
+pr_bearxc                       //
+pr_bearxd                       //
+pr_bearxe                       //
+pr_bearxf                       //
+pr_bearxg                       //
+pr_bearxh                       //
+pr_bearxi                       //
+pr_bearxj                       //
+pr_bearxk                       //
+pr_bearxl                       //
+pr_bearxlp                      //
+pr_bearxm                       //
+pr_bigdp                        // Big Dipper (Project)
+pr_bigdpa                       //
+pr_btwar                        // Beat The Warden (Project)
+pr_btwara                       //
+pr_btwarb                       //
+pr_bulbn                        // Bully's Big Night (Project)
+pr_bulbna                       //
+pr_bulbnb                       //
+pr_buljp                        // Bully's Jackpot (Project)
+pr_buljpa                       //
+pr_bulls                        // Bullseye (Project)
+pr_bullsa                       //
+pr_bullsb                       //
+pr_cas7                         // Casino Jackpot 7s (Project)
+pr_cashb                        // Cash Back (Project)
+pr_chico                        // Chico the Bandit (Project)
+pr_chicoa                       //
+pr_chicob                       //
+pr_coolm                        // Cool Million (Project)
+pr_coolma                       //
+pr_coolmb                       //
+pr_coyot                        // Crazy Coyote (Pcp)
+pr_coyota                       //
+pr_crz77                        // Crazy 777s (Project)
+pr_crzbr                        // Crazy Bars (Project)
+pr_crzpy                        // Crazy Pays (Project)
+pr_dblup                        // Double Up (Project)
+pr_fire                         // Fircecracker (Project)
+pr_flshc                        // Flash The Cash (Project)
+pr_fspot                        // Fun Spot (Coinworld)
+pr_fspota                       //
+pr_fspotb                       //
+pr_fspotc                       //
+pr_fspotd                       //
+pr_fspote                       //
+pr_fspotf                       //
+pr_fspotg                       //
+pr_ftwhl                        // Fortune Wheel (Project)
+pr_funrn                        // Fun On The Run (Project)
+pr_gdft                         // Good Fortune (Project)
+pr_gldng                        // Golden Nugget (Project)
+pr_gldnl                        // Golden Nile (Project)
+pr_gnuc                         // Golden Nugget (Coinworld)
+pr_gnuca                        //
+pr_gogld                        // Go For Gold (Project)
+pr_happy                        // Happy Days (Project)
+pr_heato                        // The Heat Is On (Project)
+pr_hiclm                        // Hi Climber (Project)
+pr_hit6                         // Hit The Six (Project)
+pr_hit6a                        //
+pr_hit6b                        //
+pr_hotcs                        // Hot Cash (Project)
+pr_hotsp                        // Hot Spots (Project)
+pr_jkpt7                        // Jackpot 7's (Project)
+pr_jkrwd                        // Jokers Wild (Project)
+pr_jumpj                        // Jumping Jacks (Project)
+pr_jumpja                       //
+pr_lday                         // 'L' Of A Day (Project)
+pr_ldaya                        //
+pr_magln                        // Magic Lines (Coinworld)
+pr_maglna                       //
+pr_medl                         // Medalist (Project)
+pr_megmn                        // Mega Money (Project)
+pr_nifty                        // Nifty Fifty (Project)
+pr_nudxs                        // Nudge XS (Project)
+pr_qksht                        // Quickshot (Maygay)
+pr_rags                         // Rags To Riches (Project)
+pr_reflx                        // Reflex (Project)
+pr_roadr                        // Road Riot (Project)
+pr_roll                         // The Roll (Project)
+pr_sevab                        // Seven's Above (Project)
+pr_sevml                        // Sevens & Melons (Project)
+pr_sptb                         // Simply The Best (Pcp)
+pr_supbr                        // Super Bars (PCP)
+pr_swop                         // Swop It (Ace)
+pr_theme                        // Theme Park (Project)
+pr_trktp                        //
+pr_trktr                        // Trick or Treat (Project)
+pr_trpx                         // Triple X (Project)
+pr_ttrai                        // Treasure Trail (Project)
+pr_upnun                        // Up & Under (Project)
+pr_walls                        // Wall Street (Project)
+pr_whlft                        // Wheel Of Fortune (Project)
+pr_wldkn                        // Wild Kings (Project)
+pr_wnstk                        // Winning Streak (Coinworld)
+
+@source:conitec/prof180x.cpp
+prof180x                        //
+prof181x                        //
+
+@source:conitec/prof80.cpp
+prof80                          //
+
+@source:dataeast/progolf.cpp
+progolf                         // (c) 1981
+progolfa                        // (c) 1981
+
+@source:sequential/prophet600.cpp
+prpht600                        // 1983 Sequential Circuits
+
+@source:ausnz/proteus.cpp
+proteus                         // Poly Proteus
+
+@source:skeleton/proteus3.cpp
+proteus3                        //
+
+@source:pc/ps2.cpp
+ibm8535_043                     // IBM PS/2 8535-043 (Model 35)
+ibm8555_081                     // IBM PS/2 8550-081 (Model 55SX)
+ibm8550_021                     // IBM PS/2 8550-021 (Model 50)
+ibm8550_061                     // IBM PS/2 8550-061 (Model 50Z)
+ibm8560                         // IBM PS/2 8560     (Model 60)
+ibm8580_071                     // IBM PS/2 8580-071 (Model 80, Type 1)
+ibm8580_111                     // IBM PS/2 8580-111 (Model 80, Type 2)
+ibm8580_a21                     // IBM PS/2 8580-A21 (Model 80, Type 3)
+
+@source:pc/ps2m30.cpp
+ibm8530_286                     // IBM PS/2 Model 30-286
+ibm8530_h31                     // IBM PS/2 8530-H31 (Model 30/286)
+
+@source:sony/ps2sony.cpp
+ps2                             // Sony Playstation 2
+
+@source:misc/psattack.cpp
+psattack                        // 2004 Uniana
+
+@source:misc/pse.cpp
+bazooka                         // (c) 1976 PSE
+bazookabr                       // (c) 1977 Taito do Brasil
+dpatrol                         // (c) 1977 PSE
+dpatrola                        // (c) 1977 PSE / Telegames
+gametree                        // (c) 1978 PSE
+
+@source:psikyo/psikyo.cpp
+btlkroad                        // (c) 1994
+btlkroadk                       // (c) 1994 (Korea)
+gunbird                         // (c) 1994
+gunbirdj                        // (c) 1994 (Japan)
+gunbirdk                        // (c) 1994 (Korea)
+s1945                           // (c) 1995 (Japan)
+s1945a                          // (c) 1995
+s1945bl                         // (c) 1995 (Hong Kong bootleg)
+s1945j                          // (c) 1995 (Japan)
+s1945k                          // (c) 1995 (Korea)
+s1945n                          // (c) 1995 (World, unprotected)
+s1945nj                         // (c) 1995 (Japan, unprotected)
+samuraia                        // (c) 1993 (World)
+sngkace                         // (c) 1993 (Japan)
+sngkacea                        // (c) 1993 (Japan)
+tengai                          // (c) 1996 (World)
+tengaij                         // (c) 1996 (Japan)
+
+@source:psikyo/psikyo4.cpp
+hgkairak                        // (c) 1998
+hotdebut                        // (c) 2000
+hotgm4ev                        // (c) 2000
+hotgmck                         // (c) 1997
+hotgmck3                        // (c) 1999
+hotgmcki                        // (c) 2001
+loderndf                        // (c) 2000
+loderndfa                       // (c) 2000
+
+@source:psikyo/psikyosh.cpp
+daraku                          // (c) 1998
+dragnblz                        // (c) 2000
+gnbarich                        // (c) 2001
+gunbird2                        // (c) 1998
+gunbird2a                       // (c) 1998
+mjgtaste                        // (c) 2002
+s1945ii                         // (c) 1997
+s1945iii                        // (c) 1999
+s1945iiibl                      // bootleg
+sbomber                         // (c) 1998
+sbombera                        // (c) 1998
+soldivid                        // (c) 1997
+soldividk                       // (c) 1997 (Korea)
+tgm2                            // (c) 2000
+tgm2p                           // (c) 2000
+
+@source:psion/psion.cpp
+psion1                          //
+psioncm                         //
+psionla                         //
+psionlam                        //
+psionlz                         //
+psionlz64                       //
+psionlz64s                      //
+psionp200                       //
+psionp350                       //
+psionp464                       //
+psionxp                         //
+
+@source:psion/psion5.cpp
+psion5mx                        //
+
+@source:capcom/psrockman.cpp
+psrockmn                        //
+
+@source:sony/psx.cpp
+psa                             // 1995 Sony PlayStation (Asia-Pacific)
+pse                             // 1995 Sony PlayStation (Europe)
+psj                             // 1994 Sony PlayStation (Japan)
+psu                             // 1995 Sony PlayStation (USA)
+
+@source:jaleco/psychic5.cpp
+bombsa                          // (c) 1988 Jaleco
+psychic5                        // (c) 1987 Jaleco
+psychic5j                       // (c) 1987 Jaleco
+
+@source:skeleton/pt68k4.cpp
+pt68k2                          //
+pt68k4                          //
+
+@source:skeleton/ptcsol.cpp
+sol20                           //
+
+@source:jaleco/pturn.cpp
+pturn                           // (c) 1984 Jaleco
+
+@source:tvgames/pubint_storyreader.cpp
+pi_stry
+pi_stry2
+
+@source:merit/pubtimed.cpp
+pubtimed                        //
+
+@source:sega/puckpkmn.cpp
+jzth                            //
+puckpkmn                        // (c) 2000 Genie
+puckpkmna                       // (c) 2000 IBS
+puckpkmnb                       // (c) 2000 IBS
+
+@source:ausnz/pulsar.cpp
+pulsarlb                        //
+
+@source:nintendo/punchout.cpp
+armwrest                        // (c) 1985
+punchita                        // bootleg
+punchout                        // (c) 1984
+punchouta                       // (c) 1984
+punchoutj                       // (c) 1984 (Japan)
+spnchout                        // (c) 1984
+spnchouta                       // (c) 1984
+spnchoutj                       // (c) 1984 (Japan)
+
+@source:casio/pv1000.cpp
+pv1000                          // Casio PV-1000
+
+@source:casio/pv2000.cpp
+pv2000                          // Casio PV-2000
+
+@source:skeleton/pv9234.cpp
+pv9234                          //
+
+@source:sony/pve500.cpp
+pve500                          // SONY PVE-500
+
+@source:skeleton/pwp14.cpp
+pwp14                           // Smith Corona PWP System 14
+
+@source:compugraphic/pwrview.cpp
+pwrview                         // Compugraphic MCS PowerView 10
+
+@source:epson/px4.cpp
+px4                             // 1985 Epson PX-4
+px4p                            // 1985 Epson PX-4+
+
+@source:epson/px8.cpp
+px8                             //
+
+@source:ussr/pyl601.cpp
+pyl601                          //
+pyl601a                         //
+
+@source:edevices/pzletime.cpp
+pzletime                        //
+
+@source:konami/qdrmfgp.cpp
+qdrmfgp                         // 1994.12 GQ460 (Japan)
+qdrmfgp2                        // 1995.09 GE557 (Japan)
+
+@source:taito/qix.cpp
+complexx                        // CX  (c) 1984 Taito America Corporation
+elecyoyo                        // YY  (c) 1982 Taito America Corporation
+elecyoyo2                       // YY  (c) 1982 Taito America Corporation
+kram                            // KS  (c) 1982 Taito America Corporation
+kram2                           // KS  (c) 1982 Taito America Corporation
+kram3                           // KS  (c) 1982 Taito America Corporation
+qix                             // LK  (c) 1981 Taito America Corporation
+qix2                            // ??  (c) 1981 Taito America Corporation
+qixa                            // LK  (c) 1981 Taito America Corporation
+qixb                            // LK  (c) 1981 Taito America Corporation
+qixo                            // LK  (c) 1981 Taito America Corporation
+sdungeon                        // SD  (c) 1981 Taito America Corporation
+sdungeona                       // SD  (c) 1981 Taito America Corporation
+slither                         // (c) 1982 Century II
+slithera                        // (c) 1982 Century II
+zookeep                         // ZA  (c) 1982 Taito America Corporation
+zookeep2                        // ZA  (c) 1982 Taito America Corporation
+zookeep3                        // ZA  (c) 1982 Taito America Corporation
+zookeepbl                       // bootleg
+
+@source:sinclair/ql.cpp
+ql                              // 1984 Sinclair QL (UK)
+ql_de                           // 1984 Sinclair QL (Germany)
+ql_dk                           // 1984 Sinclair QL (Denmark)
+ql_es                           // 1984 Sinclair QL (Spain)
+ql_fr                           // 1984 Sinclair QL (France)
+ql_gr                           // 1984 Sinclair QL (Greece)
+ql_it                           // 1984 Sinclair QL (Italy)
+ql_se                           // 1984 Sinclair QL (Sweden)
+ql_us                           // 1984 Sinclair QL (USA)
+tonto                           //
+
+@source:skeleton/qtsbc.cpp
+qtsbc                           //
+
+@source:pc/quakeat.cpp
+quake                           // (c) 19?? Lazer-Tron / iD Software
+
+@source:skeleton/controlid.cpp
+cidx628                         // 200? Control ID X628
+
+@source:atari/quantum.cpp
+quantum                         // 136016           (c) 1982        // made by Gencomp
+quantum1                        // 136016           (c) 1982        // made by Gencomp
+quantump                        // 136016           (c) 1982        // made by Gencomp
+
+@source:cvs/quasar.cpp
+quasar                          // (c) 1980 Zelco Games Italy
+quasara                         // (c) 1980 Zelco Games Italy
+
+@source:pc/queen.cpp
+queen                           //
+
+@source:nmk/quizdna.cpp
+gakupara                        // (c) 1991 NMK
+gekiretu                        // (c) 1992 Face
+quizdna                         // (c) 1992 Face
+
+@source:misc/quizo.cpp
+quizo                           // (c) 1985 Seoul Coin Corp.
+quizoa                          // (c) 1985 Seoul Coin Corp.
+
+@source:nmk/quizpani.cpp
+quizpani                        // (c) 1993 NMK
+
+@source:misc/quizpun2.cpp
+quizpun                         // (c) 1989 Space Computer System of Korea
+quizpun2                        // (c) 1989 Space Computer System of Korea
+
+@source:atari/quizshow.cpp
+quizshow                        // 005464           1976/04 [2650]
+
+@source:qume/qvt70.cpp
+qvt70                           // (c) 1992 Qume Corp.
+qvt82                           // (c) 1993 Qume Corp.
+
+@source:qume/qvt102.cpp
+qvt102                          // (c) 1983 Qume Corp.
+qvt102a                         // (c) 1983 Qume Corp.
+
+@source:qume/qvt103.cpp
+qvt103                          // (c) 1983 Qume Corp.
+
+@source:qume/qvt190.cpp
+qvt190                          // Qume Corp.
+
+@source:qume/qvt201.cpp
+qvt201                          // (c) 1986 Qume Corp.
+
+@source:epson/qx10.cpp
+qx10                            //
+
+@source:sigma/r2dtank.cpp
+r2dtank                         // (c) 1980 Sigma Ent. Inc.
+
+@source:seibu/r2dx_v33.cpp
+nzeroteam                       // (c) 1997 Seibu Kaihatsu
+nzeroteama                      //
+r2dx_v33                        // (c) 1996 Seibu Kaihatsu
+r2dx_v33_r2                     // (c) 1996 Seibu Kaihatsu
+zerotm2k                        // (c) 2000 Seibu Kaihatsu
+
+@source:rolm/r9751.cpp
+r9751                           // ROLM 9751 phone system
+
+@source:metro/rabbit.cpp
+rabbit                          // (c) 1997 Electronic Arts
+rabbita                         // (c) 1996 Electronic Arts
+rabbitj                         // (c) 1997 Electronic Arts
+rabbitjt                        // (c) 1996 Electronic Arts
+
+@source:misc/radikaldarts.cpp
+radikaldrt                      // (c) 2011? Gaelco Darts
+
+@source:ussr/radio86.cpp
+impuls03                        //
+kr03                            //
+mikron2                         //
+radio16                         //
+radio4k                         //
+radio86                         //
+radioram                        //
+radiorom                        //
+rk7007                          //
+rk700716                        //
+spektr01                        //
+
+@source:trs/radionic.cpp
+radionic                        // Komtek 1
+
+@source:seibu/raiden.cpp
+raiden                          // (c) 1990 Seibu Kaihatsu
+raidena                         // (c) 1990 Seibu Kaihatsu
+raidenb                         // (c) 1990 Seibu Kaihatsu
+raidenk                         // (c) 1990 Seibu Kaihatsu + IBL Corporation license
+raidenkb                        // (c) bootleg
+raident                         // (c) 1990 Seibu Kaihatsu + Liang HWA Electronics license
+raidenu                         // (c) 1990 Seibu Kaihatsu + Fabtek license
+raidenua                        // (c) 1990 Seibu Kaihatsu + Fabtek license
+raidenub                        // (c) 1990 Seibu Kaihatsu + Fabtek license
+
+@source:seibu/raiden_ms.cpp
+raidenm                         // bootleg
+
+@source:seibu/raiden2.cpp
+raiden2                         // (c) 1993 Seibu Kaihatsu + Fabtek license
+raiden2dx                       // (c) 1993 Seibu Kaihatsu
+raiden2e                        // (c) 1993 Seibu Kaihatsu
+raiden2eup
+raiden2ea                       // (c) 1993 Seibu Kaihatsu
+raiden2eg                       // (c) 1993 Seibu Kaihatsu + Tuning license
+raiden2es                       // (c) 1993 Seibu Kaihatsu
+raiden2eu                       // (c) 1993 Seibu Kaihatsu + Fabtek license
+raiden2eua                      // (c) 1993 Seibu Kaihatsu + Fabtek license
+raiden2eub                      // (c) 1993 Seibu Kaihatsu + Fabtek license
+raiden2f                        // (c) 1993 Seibu Kaihatsu
+raiden2g                        // (c) 1993 Seibu Kaihatsu + Tuning license
+raiden2hk                       // (c) 1993 Seibu Kaihatsu + Metrotainment license
+raiden2i                        // (c) 1993 Seibu Kaihatsu
+raiden2j                        // (c) 1993 Seibu Kaihatsu
+raiden2k                        // (c) 1993 Seibu Kaihatsu
+raiden2nl                       // (c) 1993 Seibu Kaihatsu
+raiden2sw                       // (c) 1993 Seibu Kaihats
+raiden2u                        // (c) 1993 Seibu Kaihatsu + Fabtek license
+raidendx                        // (c) 1994 Seibu Kaihatsu
+raidendxa1                      // (c) 1994 Seibu Kaihatsu + Metrotainment license
+raidendxa2                      // (c) 1994 Seibu Kaihatsu + Metrotainment license
+raidendxch                      //
+raidendxg                       // (c) 1994 Seibu Kaihatsu + Tuning license
+raidendxj                       // (c) 1994 Seibu Kaihatsu
+raidendxja                      // (c) 1994 Seibu Kaihatsu
+raidendxk                       // (c) 1994 Seibu Kaihatsu
+raidendxnl                      // (c) 1994 Seibu Kaihatsu
+raidendxpt                      // (c) 1994 Seibu Kaihatsu
+raidendxu                       // (c) 1994 Seibu Kaihatsu + Fabtek license
+xsedae                          // (c) 1995 Dream Island
+zeroteam                        // (c) 1993 Seibu Kaihatsu + Fabtek license
+zeroteama                       // (c) 1993 Seibu Kaihatsu
+zeroteamb                       // (c) 1993 Seibu Kaihatsu
+zeroteamc                       // (c) 1993 Seibu Kaihatsu + Liang Hwa license
+zeroteamd                       // (c) 1993 Seibu Kaihatsu + Dreamsoft license
+zeroteams                       // (c) 1993 Seibu Kaihatsu
+zeroteamsr                      // (c) 1993 Seibu Kaihatsu
+
+@source:dec/rainbow.cpp
+rainbow                         // 1983 DEC Rainbow 100-B
+rainbow100a                     // 1982 DEC Rainbow 100-A
+rainbow190                      // 1985 DEC Rainbow 190
+
+@source:atlus/rallypnt.cpp
+rallypnt2
+
+@source:namco/rallyx.cpp
+commsega                        // (c) 1983 Sega
+cottong                         // bootleg
+dngrtrck                        // Petaco bootleg
+gutangtn                        // GX359 (c) 1982 Konami + Sega license
+jackler                         // 1 9 8 2 (Jungler Bootleg)
+jungler                         // GX327 (c) 1981 Konami
+junglero                        // Olympia license
+junglers                        // GX327 (c) 1981 Stern
+locoboot                        // bootleg
+locomotn                        // GX359 (c) 1982 Konami + Centuri license
+nrallyx                         // (c) 1981 Namco
+nrallyxb                        // (c) 1981 Namco
+rallyx                          // (c) 1980 Namco
+rallyxa                         // (c) 1980 Namco
+rallyxm                         // (c) 1980 Midway
+rallyxmr                        // Model Racing bootleg
+savanna                         // Olympia (c) 1982 (Jungler bootleg)
+tactcian                        // GX335 (c) 1982 Sega
+tactcian2                       // GX335 (c) 1981 Sega
+
+@source:ultimachine/rambo.cpp
+metamaq2                        // Metamaquina 2 desktop 3d printer
+
+@source:atari/rampart.cpp
+rampart                         // 136082           (c) 1990
+rampart2p                       // 136082           (c) 1990
+rampart2pa                      // 136082           (c) 1990
+rampartj                        // 136082           (c) 1990 (Japan)
+
+@source:ramtek/ramtek.cpp
+bballrmt                        // (c) 1974 Ramtek
+cleanswp                        // (c) 1974 Ramtek
+hockyrmt                        // (c) 1973 Ramtek
+soccrrmt                        // (c) 1973 Ramtek
+trivia                          // (c) 1976 Ramtek
+vollyrmt                        // (c) 1973 Ramtek
+wipeormt                        // (c) 1974 Ramtek
+
+@source:taito/rastan.cpp
+rastan                          // B04 (c) 1987 Taito Corporation Japan (World)
+rastana                         // B04 (c) 1987 Taito Corporation Japan (World)
+rastanb                         // B04 (c) 1987 Taito Corporation Japan (World)
+rastanu                         // B04 (c) 1987 Taito America Corporation (US)
+rastanua                        // B04 (c) 1987 Taito America Corporation (US)
+rastanub                        // B04 (c) 1987 Taito America Corporation (US)
+rastsaga                        // B04 (c) 1987 Taito Corporation (Japan)
+rastsagaa                       // B04 (c) 1987 Taito Corporation (Japan)
+rastsagaabl                     // bootleg
+rastsagab                       // B04 (c) 1987 Taito Corporation (Japan)
+
+@source:bfm/rastersp.cpp
+fbcrazy                         // 1997
+rotr                            // 1994
+rotra                           // 1994
+
+@source:homebrew/ravens.cpp
+ravens                          //
+ravens2                         //
+
+@source:misc/rawthrillspc.cpp
+fnf                             // (c) 2004 Raw Thrills
+guitarheroac                    // (c) 2008 Raw Thrills / Activision / Konami
+
+@source:taito/rbisland.cpp
+jumping                         // bootleg
+jumpinga                        // bootleg (Seyutu)
+jumpingi                        // bootleg (Seyutu / Imnoe)
+rbisland                        // B22 (c) 1987 Taito Corporation
+rbislando                       // B22 (c) 1987 Taito Corporation
+rbislande                       // B39 (c) 1988 Taito Corporation
+
+@source:misc/rbmk.cpp
+magslot                         // (c) 2003 GMS
+rbmk                            // (c) 1998 GMS
+rbspm                           // (c) 1998 GMS
+sc2in1                          // (c) 2001 GMS
+super555                        // (c) 1999 GMS
+
+@source:namco/rbowlorama.cpp
+rbowlorama                      // (c) 2008 Cosmodog / Namco
+
+@source:regnecentralen/rc702.cpp
+rc702                           // 1979 RC702
+
+@source:regnecentralen/rc759.cpp
+rc759                           // 1984 RC759
+
+@source:misc/rcorsair.cpp
+rcorsair                        // (c) 1984 Nakasawa
+
+@source:skeleton/rd100.cpp
+rd100                           //
+
+@source:misc/re900.cpp
+bs94                            // (c) 1994 Entretenimientos GEMINIS
+re900                           // (c) 1993 Entretenimientos GEMINIS
+
+@source:dynax/realbrk.cpp
+dai2kaku                        // "522" DaiDaiKakumei (Japan)
+pkgnsh                          // "505" Pachinko Gindama Shoubu 1998 (Japan)
+pkgnshdx                        // "522" Pachinko Gindama Shoubu DX 1998 (Japan)
+realbrk                         // "600" Billiard Academy Real Break 1998 (Europe)
+realbrkj                        // "523" Billiard Academy Real Break 1998 (Japan)
+realbrkk                        // "600" Billiard Academy Real Break 1998 (Korea)
+realbrko                        // "600" Billiard Academy Real Break 1998 (Europe)
 
 @source:pinball/recel.cpp
 recel                           //

--- a/src/mame/pc/ps2.cpp
+++ b/src/mame/pc/ps2.cpp
@@ -1,21 +1,43 @@
 // license:BSD-3-Clause
-// copyright-holders:Wilbert Pol, Miodrag Milanovic, Carl
+// copyright-holders:Wilbert Pol, Miodrag Milanovic, Carl, Katherine Rohl
+
+/*****************************************************
+ * The IBM Personal System/2
+ * MCA systems
+ * 
+ * Status:
+ * 
+ * Model 50/50Z boots DOS and the reference disk. Memory ID doesn't work right.
+ * Model 80 boots DOS and the reference disk but the memory split stuff doesn't work right so it won't do diagnostics.
+ * 
+ * 16-bit MCA seems to work fine.
+ * 32-bit MCA is a work-in-progress.
+ *****************************************************/
 
 #include "emu.h"
 #include "cpu/i86/i286.h"
 #include "cpu/i386/i386.h"
 #include "machine/at.h"
+#include "machine/ibmps2.h"
 #include "machine/ram.h"
 #include "bus/isa/isa_cards.h"
-#include "bus/pc_kbd/keyboards.h"
-#include "bus/pc_kbd/pc_kbdc.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/mca_cards.h"
 #include "softlist_dev.h"
+
+#include "ps2m50.h"
+#include "ps2m80.h"
 
 // According to http://nerdlypleasures.blogspot.com/2014/04/the-original-8-bit-ide-interface.html
 // the IBM PS/2 Model 25-286 and Model 30-286 use a customised version of the XTA (8-bit IDE) harddisk interface
 
 
 namespace {
+	
+#define PLANAR_ID_M50		0xFBFF
+#define PLANAR_ID_M80_TYPE1 0xFEFF
+#define PLANAR_ID_M80_TYPE2 0xFDFF
+#define PLANAR_ID_M80_TYPE3 0xFFF9
 
 class ps2_state : public driver_device
 {
@@ -27,19 +49,36 @@ public:
 		m_ram(*this, RAM_TAG)
 	{ }
 	required_device<cpu_device> m_maincpu;
-	required_device<at_mb_device> m_mb;
+	required_device<ps2_mb_device> m_mb;
 	required_device<ram_device> m_ram;
 
-	void ps2m30286(machine_config &config);
-	void ps2386(machine_config &config);
-	void ps2386sx(machine_config &config);
-	void at_softlists(machine_config &config);
-	void ps2_16_io(address_map &map);
-	void ps2_16_map(address_map &map);
-	void ps2_32_io(address_map &map);
-	void ps2_32_map(address_map &map);
+	// Model 35
+	void ibm8535_043(machine_config &config);
+
+	// Model 50
+	void ibm8550_021(machine_config &config);
+	void ibm8550_061(machine_config &config);
+	
+	// Model 55
+	void ibm8555_081(machine_config &config);
+	void ibm8555_x61(machine_config &config);
+
+	// Model 60
+	void ibm8560(machine_config &config);
+
+	// Model 80
+	void ibm8580_071(machine_config &config);
+	void ibm8580_111(machine_config &config);
+	void ibm8580_a21(machine_config &config);
+
 protected:
 	void machine_start() override;
+	void machine_reset() override;
+
+	void at_softlists(machine_config &config);
+	void ps2_io(address_map &map);
+	void ps2_286_map(address_map &map);
+	void ps2_386_map(address_map &map);
 };
 
 void ps2_state::at_softlists(machine_config &config)
@@ -52,7 +91,7 @@ void ps2_state::at_softlists(machine_config &config)
 	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
 }
 
-void ps2_state::ps2_16_map(address_map &map)
+void ps2_state::ps2_286_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x000000, 0x09ffff).bankrw("bank10");
@@ -60,7 +99,7 @@ void ps2_state::ps2_16_map(address_map &map)
 	map(0xfe0000, 0xffffff).rom().region("bios", 0);
 }
 
-void ps2_state::ps2_32_map(address_map &map)
+void ps2_state::ps2_386_map(address_map &map)
 {
 	map.unmap_value_high();
 	map(0x00000000, 0x0009ffff).bankrw("bank10");
@@ -68,125 +107,250 @@ void ps2_state::ps2_32_map(address_map &map)
 	map(0xfffe0000, 0xffffffff).rom().region("bios", 0);
 }
 
-void ps2_state::ps2_16_io(address_map &map)
+void ps2_state::ps2_io(address_map &map)
 {
 	map.unmap_value_high();
-	map(0x0000, 0x00ff).m(m_mb, FUNC(at_mb_device::map));
+	map(0x0000, 0xffff).m(m_mb, FUNC(ps2_mb_device::map));
 }
 
-void ps2_state::ps2_32_io(address_map &map)
+void ps2_state::machine_reset()
 {
-	map.unmap_value_high();
-	map(0x0000, 0x00ff).m(m_mb, FUNC(at_mb_device::map));
+	
 }
 
 void ps2_state::machine_start()
 {
-	address_space& space = m_maincpu->space(AS_PROGRAM);
-
 	/* managed RAM */
 	membank("bank10")->set_base(m_ram->pointer());
-
-	if (m_ram->size() > 0xa0000)
-	{
-		offs_t ram_limit = 0x100000 + m_ram->size() - 0xa0000;
-		space.install_ram(0x100000,  ram_limit - 1, m_ram->pointer() + 0xa0000);
-	}
 }
 
-void ps2_state::ps2m30286(machine_config &config)
+/* 
+	PS/2 Model 35SX
+
+	80386SX-based second-generation PS/2s. 
+	
+	Based on the VLSI 82C300 chipset.
+
+	Skeleton.
+ */
+
+void ps2_state::ibm8535_043(machine_config &config)
 {
-	/* basic machine hardware */
-	i80286_cpu_device &maincpu(I80286(config, m_maincpu, 10000000));
-	maincpu.set_addrmap(AS_PROGRAM, &ps2_state::ps2_16_map);
-	maincpu.set_addrmap(AS_IO, &ps2_state::ps2_16_io);
-	maincpu.set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
-	maincpu.shutdown_callback().set("mb", FUNC(at_mb_device::shutdown));
-
-	AT_MB(config, m_mb);
-	m_mb->kbd_clk().set("kbd", FUNC(pc_kbdc_device::clock_write_from_mb));
-	m_mb->kbd_data().set("kbd", FUNC(pc_kbdc_device::data_write_from_mb));
-
-	config.set_maximum_quantum(attotime::from_hz(60));
-
-	at_softlists(config);
-
-	// FIXME: determine ISA bus clock
-	ISA16_SLOT(config, "isa1", 0, "mb:isabus", pc_isa16_cards, "vga", true);
-	ISA16_SLOT(config, "isa2", 0, "mb:isabus", pc_isa16_cards, "fdc", false);
-	ISA16_SLOT(config, "isa3", 0, "mb:isabus", pc_isa16_cards, "ide", false);
-	ISA16_SLOT(config, "isa4", 0, "mb:isabus", pc_isa16_cards, "comat", false);
-
-	pc_kbdc_device &kbd(PC_KBDC(config, "kbd", pc_at_keyboards, STR_KBD_IBM_PC_AT_84));
-	kbd.out_clock_cb().set(m_mb, FUNC(at_mb_device::kbd_clk_w));
-	kbd.out_data_cb().set(m_mb, FUNC(at_mb_device::kbd_data_w));
-
-	/* internal ram */
-	RAM(config, RAM_TAG).set_default_size("1664K").set_extra_options("2M,4M,8M,15M");
-}
-
-void ps2_state::ps2386(machine_config &config)
-{
-	I386(config, m_maincpu, 12000000);
-	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_32_map);
-	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_32_io);
+	I386SX(config, m_maincpu, 20'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
 	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
 
-	AT_MB(config, m_mb);
-	m_mb->kbd_clk().set("kbd", FUNC(pc_kbdc_device::clock_write_from_mb));
-	m_mb->kbd_data().set("kbd", FUNC(pc_kbdc_device::data_write_from_mb));
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M").set_extra_options("2M,4M,8M,15M,16M,32M,64M,128M,256M");
+
+	PS2_M50_T1_MB(config, m_mb, 20'000'000); // wrong
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
 
 	config.set_maximum_quantum(attotime::from_hz(60));
 	at_softlists(config);
-
-	// on board devices
-	ISA16_SLOT(config, "board1", 0, "mb:isabus", pc_isa16_cards, "fdcsmc", true); // FIXME: determine ISA bus clock
-	ISA16_SLOT(config, "board2", 0, "mb:isabus", pc_isa16_cards, "comat", true);
-	ISA16_SLOT(config, "board3", 0, "mb:isabus", pc_isa16_cards, "ide", true);
-	ISA16_SLOT(config, "board4", 0, "mb:isabus", pc_isa16_cards, "lpt", true);
-	// ISA cards
-	ISA16_SLOT(config, "isa1", 0, "mb:isabus", pc_isa16_cards, "svga_et4k", false);
-	ISA16_SLOT(config, "isa2", 0, "mb:isabus", pc_isa16_cards, nullptr, false);
-	ISA16_SLOT(config, "isa3", 0, "mb:isabus", pc_isa16_cards, nullptr, false);
-	ISA16_SLOT(config, "isa4", 0, "mb:isabus", pc_isa16_cards, nullptr, false);
-	ISA16_SLOT(config, "isa5", 0, "mb:isabus", pc_isa16_cards, nullptr, false);
-
-	pc_kbdc_device &kbd(PC_KBDC(config, "kbd", pc_at_keyboards, STR_KBD_MICROSOFT_NATURAL));
-	kbd.out_clock_cb().set(m_mb, FUNC(at_mb_device::kbd_clk_w));
-	kbd.out_data_cb().set(m_mb, FUNC(at_mb_device::kbd_data_w));
-
-	/* internal ram */
-	RAM(config, RAM_TAG).set_default_size("1664K").set_extra_options("2M,4M,8M,15M,16M,32M,64M,128M,256M");
 }
-
-void ps2_state::ps2386sx(machine_config &config)
-{
-	ps2386(config);
-	I386SX(config.replace(), m_maincpu, 12000000);
-	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_16_map);
-	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_16_io);
-	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
-}
-
-ROM_START( i8530286 )
-	ROM_REGION16_LE(0x20000, "bios", 0)
-	// saved from running machine
-	ROM_LOAD16_BYTE("ps2m30.0", 0x00000, 0x10000, CRC(9965a634) SHA1(c237b1760f8a4561ec47dc70fe2e9df664e56596))
-	ROM_LOAD16_BYTE("ps2m30.1", 0x00001, 0x10000, CRC(1448d3cb) SHA1(13fa26d895ce084278cd5ab1208fc16c80115ebe))
-ROM_END
 
 /*
+	PS/2 Model 50
 
-8530-H31 (Model 30/286)
-======================
-  P/N          Date
-33F5381A EC C01446 1990
+	286-based first-generation PS/2.
+ */
 
+void ps2_state::ibm8550_021(machine_config &config)
+{
+	// Model 50 (Type 1)
+
+	I80286(config, m_maincpu, 10'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_286_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M");
+
+	PS2_M50_T1_MB(config, m_mb, 10_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	m_maincpu->set_irq_acknowledge_callback(m_mb, FUNC(ps2_mb_device::inta_cb));
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+void ps2_state::ibm8550_061(machine_config &config)
+{
+	// Model 50Z (Type 2)
+
+	I80286(config, m_maincpu, 10'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_286_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M").set_extra_options("2M,4M,8M,15M,16M,32M,64M,128M,256M");
+
+	PS2_M50_T1_MB(config, m_mb, 10_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	m_maincpu->set_irq_acknowledge_callback(m_mb, FUNC(ps2_mb_device::inta_cb));
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+/*
+	PS/2 Model 55SX
+
+	80386SX-based first-generation PS/2.
+
+	Status: Skeleton.
+ */
+
+void ps2_state::ibm8555_x61(machine_config &config)
+{
+	I386SX(config, m_maincpu, 16'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M").set_extra_options("2M,4M,8M,15M,16M,32M,64M,128M,256M");
+
+	//PS2_MB(config, m_mb, 16000000);
+	//m_mb->set_cpu_tag(m_maincpu);
+	//m_mb->set_ram_tag(m_ram);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+void ps2_state::ibm8555_081(machine_config &config)
+{
+	I386SX(config, m_maincpu, 16'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M").set_extra_options("2M,4M,8M,15M,16M,32M,64M,128M,256M");
+
+	PS2_M50_T1_MB(config, m_mb, 16000000); // wrong
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+/* 	
+	PS/2 Model 60
+
+	Model 50, but in a tower case.
 */
-ROM_START( i8530h31 )
-	ROM_REGION16_LE(0x20000, "bios", 0)
-	ROM_LOAD( "33f5381a.bin", 0x00000, 0x20000, CRC(ff57057d) SHA1(d7f1777077a8df43c3c14d175b9709bd3969c4b1))
-ROM_END
+
+void ps2_state::ibm8560(machine_config &config)
+{
+	I80286(config, m_maincpu, 10'000'000);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_286_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1M");
+
+	PS2_M60_MB(config, m_mb, 10_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	m_maincpu->set_irq_acknowledge_callback(m_mb, FUNC(ps2_mb_device::inta_cb));
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+
+/*	
+	PS/2 Model 80
+
+	The Model 80 is a little weird even compared to other PS/2 systems.
+	Planar RAM is provided by two Eurocard-connector daughtercards of 1MB, 2MB, or 4MB.
+
+	The PS/2 Model 80 had three different planars over the course of its life.
+	Type 1 - 16MHz 386, max of 4MB of planar RAM, supports matched memory cycles but not 4MB cards.
+	Type 2 - 20MHz 386, max of 8MB of planar RAM.
+	Type 3 - 25MHz 386, 64K of L2 cache, max of 8MB of planar RAM, does not support 1MB memory cards.
+
+	32-bit IBM MCA memory cards are capable of operating with Matched Memory Cycles.
+	On the Type 1 planar, RAM accesses will take two 16MHz bus cycles plus one wait state.
+	On the other planars, RAM accesses will always take two 10MHz bus cycles.
+
+	Status:
+	Type 1: Memory split isn't hooked up properly, so it doesn't work right outside of DOS.
+	Type 2: Memory hardware not implemented.
+	Type 3: Totally different planar, not started yet.	
+	*/
+
+
+void ps2_state::ibm8580_071(machine_config &config)
+{
+	// IBM 8580 + Type 1 Planar = Model 071
+	I386(config, m_maincpu, 32_MHz_XTAL / 2);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+
+	RAM(config, m_ram);
+	m_ram->set_default_size("2M");
+	m_ram->set_extra_options("1M");
+
+	PS2_M80_T1_MB(config, m_mb, 32_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+void ps2_state::ibm8580_111(machine_config &config)
+{
+	// IBM 8580 + Type 2 Planar = Model 111
+	I386(config, m_maincpu, 40_MHz_XTAL / 2);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+
+	RAM(config, m_ram);
+	m_ram->set_default_size("4M");
+	m_ram->set_extra_options("1M,2M,8M");
+
+	PS2_M80_T2_MB(config, m_mb, 40_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+void ps2_state::ibm8580_a21(machine_config &config)
+{
+	// IBM 8580 + Type 3 Planar = Model A21
+	I386(config, m_maincpu, 50_MHz_XTAL / 2);
+	m_maincpu->set_addrmap(AS_PROGRAM, &ps2_state::ps2_386_map);
+	m_maincpu->set_addrmap(AS_IO, &ps2_state::ps2_io);
+	m_maincpu->set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+
+	RAM(config, m_ram);
+	m_ram->set_default_size("2M");
+	m_ram->set_extra_options("2M,4M,8M");
+
+	PS2_M80_T3_MB(config, m_mb, 50_MHz_XTAL);
+	m_mb->set_cpu_tag(m_maincpu);
+	m_mb->set_ram_tag(m_ram);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
 
 /*
 8535-043 (Model 35SX)
@@ -195,7 +359,8 @@ ROM_END
 04G2021    C26C       1991    ODD
 04G2022    9B94       1991    EVEN
 */
-ROM_START( i8535043 )
+
+ROM_START( ibm8535_043 )
 	ROM_REGION16_LE(0x20000, "bios", 0)
 	ROM_LOAD16_BYTE( "04g2021.bin", 0x00001, 0x10000, CRC(4069b2eb) SHA1(9855c84c81d1f07e1da66b1ca45c1c10c0717a90))
 	ROM_LOAD16_BYTE( "04g2022.bin", 0x00000, 0x10000, CRC(35c1af65) SHA1(7d2445cc463969c808fdd78e0a27a03db5dfc698))
@@ -216,15 +381,12 @@ IBM Personal System/2 Model 60 (8560-041 and 8560-071)
 IBM Personal System/2 Model 65 SX (8565-061 and 8565-121)
 
 */
-ROM_START( i8550021 )
+ROM_START( ibm8550_021 )
 	ROM_REGION16_LE(0x20000, "bios", 0)
 	ROM_LOAD16_BYTE( "90x7423.zm14", 0x00000, 0x8000, CRC(2c1633e0) SHA1(1af7faa526585a7cfb69e71d90a75e1f1c541586))
 	ROM_LOAD16_BYTE( "90x7426.zm16", 0x00001, 0x8000, CRC(e7c762ce) SHA1(228f67dc915d84519da7fc1a59b7f9254278f3a0))
 	ROM_LOAD16_BYTE( "90x7420.zm13", 0x10000, 0x8000, CRC(19a57cc1) SHA1(5b31ba66cd3690e651a450619a32b7210769945d))
 	ROM_LOAD16_BYTE( "90x7429.zm18", 0x10001, 0x8000, CRC(6f0120f6) SHA1(e112c291ac3d9f6507c93ac49ad26f9fd2245fd2))
-
-	ROM_REGION( 0x800, "keyboard", 0 )
-	ROM_LOAD( "72x8455.zm82", 0x000, 0x800, CRC(7da223d3) SHA1(54c52ff6c6a2310f79b2c7e6d1259be9de868f0e) )
 ROM_END
 
 /*
@@ -235,10 +397,8 @@ AMI 8935MKN     15F8365    S63512  1988
 AMI 8948MML     15F8366    S63512  1988
 
 http://ps-2.kev009.com:8081/ohlandl/8550/8550z_Planar.html
-
-
 */
-ROM_START( i8550061 )
+ROM_START( ibm8550_061 )
 	ROM_REGION16_LE(0x20000, "bios", 0)
 	ROM_LOAD16_BYTE( "15f8365.zm5", 0x00001, 0x10000, CRC(35aa3ecf) SHA1(a122531092a9cb08600b276da9c9c3ce385aab7b))
 	ROM_LOAD16_BYTE( "15f8366.zm6", 0x00000, 0x10000, CRC(11bf564d) SHA1(0dda6a7ca9294cfaab5bdf4c05973be13b2766fc))
@@ -258,10 +418,33 @@ ODD     AMI 9205MEN     92F0627 EC32680 88 --> 33F8153
 EVEN    AMI 9203MGS     92F0626 EC32680 88 --> 33F8152
 
 */
-ROM_START( i8555081 )
+ROM_START( ibm8555_081 )
 	ROM_REGION16_LE(0x20000, "bios", 0)
 	ROM_LOAD16_BYTE("33f8145.zm40", 0x00001, 0x10000, CRC(0895894c) SHA1(7cee77828867ad1bdbe0ac223bc25d23c65b28a0))
 	ROM_LOAD16_BYTE("33f8146.zm41", 0x00000, 0x10000, CRC(c6020680) SHA1(b25a64e4b2dca07c567648401100e04e89bbcddb))
+ROM_END
+
+ROM_START( ibm8555_x61 )
+	ROM_REGION16_LE(0x20000, "bios", 0)
+	ROM_LOAD16_BYTE("33f8145.zm40", 0x00001, 0x10000, CRC(0895894c) SHA1(7cee77828867ad1bdbe0ac223bc25d23c65b28a0))
+	ROM_LOAD16_BYTE("33f8146.zm41", 0x00000, 0x10000, CRC(c6020680) SHA1(b25a64e4b2dca07c567648401100e04e89bbcddb))
+ROM_END
+
+/*
+8550-021 (Model 60)
+===================
+ Code     Date       Internal
+90X7420  4/12/87 --> 90X6815
+90X7423  8/12/87 --> 90X6816
+90X7426  8/12/87 --> 90X6817
+90X7429 18/12/87 --> 90X6818
+*/
+ROM_START( ibm8560 )
+	ROM_REGION16_LE(0x20000, "bios", 0)
+	ROM_LOAD16_BYTE( "90x6816.bin", 0x00000, 0x8000, CRC(2c1633e0) SHA1(1af7faa526585a7cfb69e71d90a75e1f1c541586))
+	ROM_LOAD16_BYTE( "90x6817.bin", 0x00001, 0x8000, CRC(e7c762ce) SHA1(228f67dc915d84519da7fc1a59b7f9254278f3a0))
+	ROM_LOAD16_BYTE( "90x6815.bin", 0x10000, 0x8000, CRC(19a57cc1) SHA1(5b31ba66cd3690e651a450619a32b7210769945d))
+	ROM_LOAD16_BYTE( "90x6818.bin", 0x10001, 0x8000, CRC(6f0120f6) SHA1(e112c291ac3d9f6507c93ac49ad26f9fd2245fd2))
 ROM_END
 
 /*
@@ -273,7 +456,7 @@ AMI 8924MBL     90X8549   1987  --> 72X7554
 AMI 8924MBG     90X8550   1987  --> 72X7557
 AMI 8921MBK     90X8551   1987  --> 72X7560
 */
-ROM_START( i8580071 )
+ROM_START( ibm8580_071 )
 	ROM_REGION32_LE(0x20000, "bios", 0)
 	ROM_LOAD32_BYTE( "90x8548.bin", 0x00000, 0x8000, CRC(1f13eea5) SHA1(0bf53ad86f47db3825a713ea2e4ef23715cc4f79))
 	ROM_LOAD32_BYTE( "90x8549.bin", 0x00001, 0x8000, CRC(9e0f4a99) SHA1(b8600f04159ed281a57416274390ba9302be541b))
@@ -288,20 +471,32 @@ ROM_END
 AMI 8934MDL     15F6637  1987 --> 15F6597
 AMI 8944MDI     15F6639  1987 --> 15F6600
 */
-ROM_START( i8580111 )
+ROM_START( ibm8580_111 )
 	ROM_REGION32_LE(0x20000, "bios", 0)
 	ROM_LOAD16_BYTE( "15f6637.bin", 0x00000, 0x10000, CRC(76c36d1a) SHA1(c68d52a2e5fbd303225ebb006f91869b29ef700a))
 	ROM_LOAD16_BYTE( "15f6639.bin", 0x00001, 0x10000, CRC(82cf0f7d) SHA1(13bb39225757b89749af70e881af0228673dbe0c))
 ROM_END
 
+/*
+8580-A21 (Model 80)
+===================
+                 Code    Date    Internal
+EVEN		    64F3084  1989 --> 64F3084
+ODD			    64F3085  1989 --> 64F3085
+*/
+ROM_START( ibm8580_a21 )
+	ROM_REGION32_LE(0x20000, "bios", 0)
+	ROM_LOAD16_BYTE( "64f3084.bin", 0x00000, 0x10000, CRC(76c36d1a) SHA1(c68d52a2e5fbd303225ebb006f91869b29ef700a))
+	ROM_LOAD16_BYTE( "64f3085.bin", 0x00001, 0x10000, CRC(82cf0f7d) SHA1(13bb39225757b89749af70e881af0228673dbe0c))
+ROM_END
 } // anonymous namespace
 
-
-COMP( 1990, i8530h31, 0,        ibm5170, ps2m30286, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8530-H31 (Model 30/286)", MACHINE_NOT_WORKING )
-COMP( 1988, i8530286, i8530h31, 0,       ps2m30286, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 Model 30-286", MACHINE_NOT_WORKING )
-COMP( 198?, i8535043, 0,        ibm5170, ps2386sx,  0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8535-043 (Model 35SX)", MACHINE_NOT_WORKING )
-COMP( 198?, i8550021, i8550061, 0,       ps2m30286, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8550-021 (Model 50)", MACHINE_NOT_WORKING )
-COMP( 198?, i8550061, 0,        ibm5170, ps2m30286, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8550-061 (Model 50Z)", MACHINE_NOT_WORKING )
-COMP( 1989, i8555081, 0,        ibm5170, ps2386sx,  0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8555-081 (Model 55SX)", MACHINE_NOT_WORKING )
-COMP( 198?, i8580071, 0,        ibm5170, ps2386,    0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8580-071 (Model 80)", MACHINE_NOT_WORKING )
-COMP( 198?, i8580111, 0,        ibm5170, ps2386,    0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8580-111 (Model 80)", MACHINE_NOT_WORKING )
+COMP( 1991, ibm8535_043, 0,        		ibm5170, 	ibm8535_043, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8535-043 (Model 35SX)", MACHINE_IS_SKELETON )
+COMP( 1987, ibm8550_021, ibm8550_061, 	0,       	ibm8550_021, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8550-021 (Model 50)", MACHINE_NOT_WORKING )
+COMP( 1988, ibm8550_061, 0,        		ibm5170, 	ibm8550_061, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8550-061 (Model 50Z)", MACHINE_NOT_WORKING )
+COMP( 1990, ibm8555_x61, 0,				ibm5170,	ibm8555_x61, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8555-081 (Model 55SX)", MACHINE_IS_SKELETON);
+COMP( 1988, ibm8555_081, ibm8555_x61,	ibm5170,	ibm8555_081, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8555-X61 (Model 55SX)", MACHINE_IS_SKELETON);
+COMP( 1988, ibm8560, 	 ibm8550_021,	ibm5170,	ibm8560,     0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8560 (Model 60)", MACHINE_NOT_WORKING);
+COMP( 1987, ibm8580_071, 0,           	ibm5170, 	ibm8580_071, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8580 (Model 80, Type 1)", MACHINE_NOT_WORKING )
+COMP( 1987, ibm8580_111, ibm8580_071, 	0,       	ibm8580_111, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8580 (Model 80, Type 2)", MACHINE_NOT_WORKING )
+COMP( 1989, ibm8580_a21, ibm8580_071, 	0, 	   		ibm8580_a21, 0, ps2_state, empty_init, "International Business Machines", "IBM PS/2 8580 (Model 80, Type 3)", MACHINE_NOT_WORKING )

--- a/src/mame/pc/ps2m30.cpp
+++ b/src/mame/pc/ps2m30.cpp
@@ -1,0 +1,119 @@
+// license:BSD-3-Clause
+// copyright-holders:Wilbert Pol, Miodrag Milanovic, Carl
+
+/* The ISA PS/2s, Model 25 and Model 30. These are different enough to the MCA ones they need a different driver. */
+
+#include "emu.h"
+#include "cpu/i86/i286.h"
+#include "machine/at.h"
+#include "machine/ibmps2.h"
+#include "machine/ram.h"
+#include "bus/isa/isa_cards.h"
+#include "softlist_dev.h"
+
+// According to http://nerdlypleasures.blogspot.com/2014/04/the-original-8-bit-ide-interface.html
+// the IBM PS/2 Model 25-286 and Model 30-286 use a customised version of the XTA (8-bit IDE) harddisk interface
+
+class ps2_m30_state : public driver_device
+{
+public:
+	ps2_m30_state(const machine_config &mconfig, device_type type, const char *tag)
+		: driver_device(mconfig, type, tag),
+		m_maincpu(*this, "maincpu"),
+		m_mb(*this, "mb"),
+		m_ram(*this, RAM_TAG)
+	{ }
+	required_device<cpu_device> m_maincpu;
+	required_device<at_mb_device> m_mb;
+	required_device<ram_device> m_ram;
+
+	void ps2_base(machine_config &config);
+
+	void ps2m30286(machine_config &config);
+	void ps2386(machine_config &config);
+	void ps2386sx(machine_config &config);
+
+	void at_softlists(machine_config &config);
+	void ps2_16_io(address_map &map);
+	void ps2_16_map(address_map &map);
+protected:
+	void machine_start() override;
+};
+
+void ps2_m30_state::at_softlists(machine_config &config)
+{
+	/* software lists */
+	SOFTWARE_LIST(config, "pc_disk_list").set_original("ibm5150");
+	SOFTWARE_LIST(config, "at_disk_list").set_original("ibm5170");
+	SOFTWARE_LIST(config, "at_cdrom_list").set_original("ibm5170_cdrom");
+	SOFTWARE_LIST(config, "at_hdd_list").set_original("ibm5170_hdd");
+	SOFTWARE_LIST(config, "midi_disk_list").set_compatible("midi_flop");
+}
+
+void ps2_m30_state::ps2_16_map(address_map &map)
+{
+	map.unmap_value_high();
+	map(0x000000, 0x09ffff).bankrw("bank10");
+	map(0x0e0000, 0x0fffff).rom().region("bios", 0);
+	map(0xfe0000, 0xffffff).rom().region("bios", 0);
+}
+
+void ps2_m30_state::ps2_16_io(address_map &map)
+{
+	map.unmap_value_high();
+	map(0x0000, 0xffff).m(m_mb, FUNC(at_mb_device::map));
+}
+
+void ps2_m30_state::machine_start()
+{
+	address_space& space = m_maincpu->space(AS_PROGRAM);
+
+	/* managed RAM */
+	membank("bank10")->set_base(m_ram->pointer());
+
+	if (m_ram->size() > 0xa0000)
+	{
+		offs_t ram_limit = 0x100000 + m_ram->size() - 0xa0000;
+		space.install_ram(0x100000,  ram_limit - 1, m_ram->pointer() + 0xa0000);
+	}
+}
+
+void ps2_m30_state::ps2m30286(machine_config &config)
+{
+	/* basic machine hardware */
+	i80286_cpu_device &maincpu(I80286(config, m_maincpu, 10000000));
+	maincpu.set_addrmap(AS_PROGRAM, &ps2_m30_state::ps2_16_map);
+	maincpu.set_addrmap(AS_IO, &ps2_m30_state::ps2_16_io);
+	maincpu.set_irq_acknowledge_callback("mb:pic8259_master", FUNC(pic8259_device::inta_cb));
+	maincpu.shutdown_callback().set("mb", FUNC(at_mb_device::shutdown));
+
+	/* internal ram */
+	RAM(config, RAM_TAG).set_default_size("1664K").set_extra_options("2M,4M,8M,15M");
+
+    // These aren't MCA.
+	AT_MB(config, m_mb, 20000000);
+
+	config.set_maximum_quantum(attotime::from_hz(60));
+	at_softlists(config);
+}
+
+ROM_START( ibm8530_286 )
+	ROM_REGION16_LE(0x20000, "bios", 0)
+	// saved from running machine
+	ROM_LOAD16_BYTE("ps2m30.0", 0x00000, 0x10000, CRC(9965a634) SHA1(c237b1760f8a4561ec47dc70fe2e9df664e56596))
+	ROM_LOAD16_BYTE("ps2m30.1", 0x00001, 0x10000, CRC(1448d3cb) SHA1(13fa26d895ce084278cd5ab1208fc16c80115ebe))
+ROM_END
+
+/*
+8530-H31 (Model 30/286)
+======================
+  P/N          Date
+33F5381A EC C01446 1990
+*/
+ROM_START( ibm8530_h31 )
+	ROM_REGION16_LE(0x20000, "bios", 0)
+	ROM_LOAD( "33f5381a.bin", 0x00000, 0x20000, CRC(ff57057d) SHA1(d7f1777077a8df43c3c14d175b9709bd3969c4b1))
+ROM_END
+
+COMP( 1990, ibm8530_h31, 0,           ibm5170, ps2m30286, 0, ps2_m30_state, empty_init, "International Business Machines", "IBM PS/2 8530-H31 (Model 30/286)", MACHINE_IS_SKELETON )
+COMP( 1988, ibm8530_286, ibm8530_h31, 0,       ps2m30286, 0, ps2_m30_state, empty_init, "International Business Machines", "IBM PS/2 Model 30-286", MACHINE_IS_SKELETON )

--- a/src/mame/pc/ps2m50.cpp
+++ b/src/mame/pc/ps2m50.cpp
@@ -1,0 +1,198 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+
+/**********************************************
+ *
+ * PS/2 Model 50
+ *  - 286-based system
+ *  - 72X8299 Southbridge
+ *  - 72X7377 DMAC
+ *  - 72X7385 Bus Controller (contains the PICs, not sure what else it does)
+ * 
+ *  - Type 1 Planar
+ *  -- Model FC, Submodel 04, Revision 00
+ * 
+ *  - Type 2 Planar
+ *  -- Model FC, Submodel 04, Revision 03
+ **********************************************/
+
+#include "emu.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/mca_cards.h"
+#include "bus/mca/planar_uart.h"
+#include "bus/mca/planar_lpt.h"
+#include "bus/mca/planar_fdc.h"
+#include "bus/mca/planar_vga.h"
+#include "imagedev/floppy.h"
+#include "machine/ibmps2.h"
+#include "cpu/i86/i286.h"
+#include "formats/pc_dsk.h"
+#include "speaker.h"
+#include "xtal.h"
+
+#include "ps2m50.h"
+
+#define LOG_PORT80  0
+
+#define LOG_SYSPORTS    (1U <<  2)
+#define LOG_NVRAM       (1U <<  3)
+#define LOG_TIMERS      (1U <<  4)
+#define LOG_POST        (1U <<  5)
+#define LOG_POS         (1U <<  6)
+#define LOG_SHADOW		(1U <<	7)
+
+#define VERBOSE (LOG_SYSPORTS|LOG_NVRAM|LOG_TIMERS|LOG_POST|LOG_POS|LOG_SHADOW)
+#include "logmacro.h"
+
+#define LOGSYSPORTS(...)    LOGMASKED(LOG_SYSPORTS, __VA_ARGS__)
+#define LOGNVRAM(...)       LOGMASKED(LOG_NVRAM, __VA_ARGS__)
+#define LOGTIMERS(...)      LOGMASKED(LOG_TIMERS, __VA_ARGS__)
+#define LOGPOST(...)        LOGMASKED(LOG_POST, __VA_ARGS__)
+#define LOGPOS(...)         LOGMASKED(LOG_POS, __VA_ARGS__)
+#define LOGSHADOW(...)      LOGMASKED(LOG_SHADOW, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+DEFINE_DEVICE_TYPE(PS2_M50_T1_MB,   ps2_m50_t1_mb_device,   "ps2_m50_t1_mb",    "PS/2 Model 50 Type 1 Planar")
+DEFINE_DEVICE_TYPE(PS2_M60_MB,   	ps2_m60_mb_device,   	"ps2_m60_mb",   	"PS/2 Model 60 Planar")
+
+void ps2_m50_t1_mb_device::map(address_map &map)
+{
+	ps2_mb_device::map(map);
+}
+
+void ps2_m50_t1_mb_device::device_start()
+{
+	ps2_mb_device::device_start();
+	
+    // Install System Board RAM above 640K at 1MB.
+    // Channel RAM gets installed immediately above the end of System Board RAM.
+    m_maincpu->space(AS_PROGRAM).install_ram(0x100000, 0x15ffff, m_ram->pointer() + 0xa0000);
+}
+
+void ps2_m50_t1_mb_device::device_reset()
+{
+	ps2_mb_device::device_reset();
+}
+
+void ps2_m50_t1_mb_device::device_add_mconfig(machine_config &config)
+{
+	printf("ibm8550 device_add_config...\n");
+	ps2_mb_device::device_add_mconfig(config);
+
+	add_mca16(config);
+    add_dmac_72x7377(config);
+	add_southbridge_72x8299(config);
+
+	MCA16_SLOT(config, m_mcaslot[0], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[1], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[2], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[3], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+}
+
+void ps2_m50_t1_mb_device::device_config_complete()
+{
+	ps2_mb_device::device_config_complete();
+	printf("ibm8550 device_add_config complete...\n");
+}
+
+uint8_t ps2_m50_t1_mb_device::planar_pos_r(offs_t offset)
+{
+	LOGPOS("%s: O:%02X\n", FUNCNAME, offset);
+
+	switch(offset)
+	{
+		case MCABus::POS::ADAPTER_ID_LO: return m_planar_id & 0xFF;
+		case MCABus::POS::ADAPTER_ID_HI: return (m_planar_id & 0xFF00) >> 8;
+		case MCABus::POS::OPTION_SELECT_DATA_1: return m_io_controller->system_board_io_r();
+
+		// TODO: Figure out what the memory bits are - type 1 can only ever have 1MB onboard (2x512K 30-pin)
+		//		 this seems to get it seeing 1MB
+		case MCABus::POS::OPTION_SELECT_DATA_2: return 0b01010100 | m_system_board_memory_enabled;
+		default: return 0x00;
+	}
+}
+
+void ps2_m50_t1_mb_device::planar_pos_w(offs_t offset, uint8_t data)
+{
+	switch(offset)
+	{
+		case 2:
+		// System Board I/O Byte.
+			LOGPOS("PS/2 system board I/O enable bits now %02X\n", data);
+			m_io_controller->system_board_io_w(data);
+			break;
+		case 3:
+		// Memory Control Register
+			LOGPOS("PS/2 memory control register now %02X\n", data);
+			update_memory_control_register(data);
+			break;
+		default:
+			LOGPOS("Unhandled planar POS write: reg %02X data %02X\n", offset, data);
+	}
+}
+
+void ps2_m50_t1_mb_device::update_memory_control_register(uint8_t data)
+{
+    m_system_board_memory_enabled = BIT(data, 0);
+
+    // The system board enable/disable bit controls the low 640K.
+    if(m_system_board_memory_enabled)
+    {
+        m_maincpu->space(AS_PROGRAM).install_ram(0x000000, 0x09ffff, m_ram->pointer()); 
+    }
+    else
+    {
+        m_maincpu->space(AS_PROGRAM).unmap_readwrite(0x000000, 0x09ffff);
+    }
+}
+
+/****************************************
+ * Model 60
+ * 
+ * - Basically a Model 50 in a tower case.
+ * - 8 slots means it gains 2KB of SRAM.
+ * - Same BIOS ROM as the Model 50.
+ ****************************************/
+
+void ps2_m60_mb_device::device_start()
+{
+	ps2_m50_t1_mb_device::device_start();
+
+	m_sram = make_unique_clear<uint8_t[]>(m_sram_size);
+	m_nvram->set_base(m_sram.get(), m_sram_size);
+	save_pointer(NAME(m_sram), m_sram_size);
+}
+
+void ps2_m60_mb_device::device_reset()
+{
+	ps2_m50_t1_mb_device::device_reset();
+}
+
+void ps2_m60_mb_device::device_add_mconfig(machine_config &config)
+{
+	ps2_mb_device::device_add_mconfig(config);
+
+	add_mca16(config);
+    add_dmac_72x7377(config);
+	add_southbridge_72x8299(config);
+
+	MCA16_SLOT(config, m_mcaslot[0], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[1], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[2], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[3], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[4], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[5], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[6], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[7], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+}

--- a/src/mame/pc/ps2m50.h
+++ b/src/mame/pc/ps2m50.h
@@ -1,0 +1,55 @@
+#ifndef MAME_MACHINE_PS2M50_H
+#define MAME_MACHINE_PS2M50_H
+
+#include "machine/ibmps2.h"
+
+class ps2_m50_t1_mb_device : public ps2_mb_device
+{
+public:
+	ps2_m50_t1_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, uint16_t sram_size, uint16_t pos_id)
+		: ps2_mb_device(mconfig, tag, owner, clock, sram_size, pos_id, false)
+	{
+	}
+
+    ps2_m50_t1_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+    	: ps2_mb_device(mconfig, tag, owner, clock, 0x0000, 0xfbff, false)
+	{
+	}
+
+    virtual void 	map(address_map &map) override;
+	
+protected:
+	virtual void 	device_start() override;
+	virtual void 	device_reset() override;
+	virtual void 	device_add_mconfig(machine_config &config) override;
+    virtual void 	device_config_complete() override;
+
+	virtual uint8_t planar_pos_r(offs_t offset) override;
+	virtual void 	planar_pos_w(offs_t offset, uint8_t data) override;
+
+	virtual void	update_memory_control_register(uint8_t data);
+
+	uint8_t			m_system_board_memory_enabled;
+private:
+};
+
+class ps2_m60_mb_device : public ps2_m50_t1_mb_device
+{
+public:
+    ps2_m60_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+    	: ps2_m50_t1_mb_device(mconfig, tag, owner, clock, 0x0800, 0xf7ff)
+	{
+	}
+
+protected:
+	virtual void 	device_start() override;
+	virtual void 	device_reset() override;
+	virtual void 	device_add_mconfig(machine_config &config) override;
+
+private:
+};
+
+DECLARE_DEVICE_TYPE(PS2_M50_T1_MB, ps2_m50_t1_mb_device)
+DECLARE_DEVICE_TYPE(PS2_M60_MB, ps2_m60_mb_device)
+
+#endif

--- a/src/mame/pc/ps2m80.cpp
+++ b/src/mame/pc/ps2m80.cpp
@@ -1,0 +1,599 @@
+// license:BSD-3-Clause
+// copyright-holders:Katherine Rohl
+
+/**********************************************
+ *
+ * PS/2 Model 80
+ * 
+ * Type 1, 2401 error = BIOS is calculating display height incorrectly.
+ * 	Error occurs at E000:2824 in the type 1 BIOS
+ * 
+ * The CuRAM-16 doesn't work in a Model 80 due to the memory split logic.
+ * 
+ * Type 1: 
+ * 	- Baseline configuration.
+ *	- Requires at least 1MB of planar RAM present to POST.
+ * 	- 2MB RAM cards are not supported.
+ * 	- Parallel port is not bidirectional.
+ * 
+ * Type 2:
+ * 	- CPU speed upgraded to 40/2 = 20MHz.
+ * 	- Upgraded memory controller
+ * 		- Adds support for 2MB RAM cards, 1MB RAM still the minimum.
+ * 		- The BIOS region (E0000-FFFF0h) can now be shadowed, with the top 128K of planar RAM always mapped there.
+ * 			- When the BIOS ROM is enabled, writes to that region go to RAM.
+ * 			- When the BIOS ROM is disabled, writes are disabled and reads go to RAM.
+ * 	- The UART now supports FIFO mode.
+ *  - Parallel port is not bidirectional.
+ * 
+ * Type 3:
+ * 	- Complete redesign compared to Types 1 and 2.
+ *
+ **********************************************/
+
+#include "emu.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/hlemouse.h"
+#include "bus/rs232/null_modem.h"
+#include "bus/rs232/rs232.h"
+#include "bus/rs232/sun_kbd.h"
+#include "bus/rs232/terminal.h"
+#include "bus/mca/mca.h"
+#include "bus/mca/mca_cards.h"
+#include "bus/mca/planar_uart.h"
+#include "bus/mca/planar_lpt.h"
+#include "bus/mca/planar_fdc.h"
+#include "bus/mca/planar_vga.h"
+#include "imagedev/floppy.h"
+#include "machine/ibmps2.h"
+#include "cpu/i86/i286.h"
+#include "cpu/i386/i386.h"
+#include "formats/pc_dsk.h"
+#include "speaker.h"
+#include "xtal.h"
+
+#include "ps2m80.h"
+
+#define LOG_PORT80  0
+
+#define LOG_SYSPORTS    (1U <<  2)
+#define LOG_NVRAM       (1U <<  3)
+#define LOG_TIMERS      (1U <<  4)
+#define LOG_POST        (1U <<  5)
+#define LOG_POS         (1U <<  6)
+#define LOG_SHADOW		(1U <<	7)
+
+#define VERBOSE (LOG_SYSPORTS|LOG_NVRAM|LOG_TIMERS|LOG_POST|LOG_POS|LOG_SHADOW)
+#include "logmacro.h"
+
+#define LOGSYSPORTS(...)    LOGMASKED(LOG_SYSPORTS, __VA_ARGS__)
+#define LOGNVRAM(...)       LOGMASKED(LOG_NVRAM, __VA_ARGS__)
+#define LOGTIMERS(...)      LOGMASKED(LOG_TIMERS, __VA_ARGS__)
+#define LOGPOST(...)        LOGMASKED(LOG_POST, __VA_ARGS__)
+#define LOGPOS(...)         LOGMASKED(LOG_POS, __VA_ARGS__)
+#define LOGSHADOW(...)      LOGMASKED(LOG_SHADOW, __VA_ARGS__)
+
+#ifdef _MSC_VER
+#define FUNCNAME __func__
+#else
+#define FUNCNAME __PRETTY_FUNCTION__
+#endif
+
+DEFINE_DEVICE_TYPE(PS2_M80_T1_MB,   ps2_m80_t1_mb_device,   "ps2_m80_t1_mb",    "PS/2 Model 80 Type 1 Planar")
+DEFINE_DEVICE_TYPE(PS2_M80_T2_MB,   ps2_m80_t2_mb_device,   "ps2_m80_t2_mb",    "PS/2 Model 80 Type 2 Planar")
+DEFINE_DEVICE_TYPE(PS2_M80_T3_MB,   ps2_m80_t3_mb_device,   "ps2_m80_t3_mb",    "PS/2 Model 80 Type 3 Planar")
+
+void ps2_m80_t1_mb_device::map(address_map &map)
+{
+	ps2_mb_device::map(map);
+
+	map(0x0061, 0x0061).rw(FUNC(ps2_m80_t1_mb_device::portb_r), FUNC(ps2_m80_t1_mb_device::portb_w));
+	map(0x00e0, 0x00e0).rw(FUNC(ps2_m80_t1_mb_device::split_address_r), FUNC(ps2_m80_t1_mb_device::split_address_w));
+	map(0x00e1, 0x00e1).rw(FUNC(ps2_m80_t1_mb_device::memory_encoding_r), FUNC(ps2_m80_t1_mb_device::memory_encoding_w));
+}
+
+void ps2_m80_t1_mb_device::device_start()
+{
+	ps2_mb_device::device_start();
+
+	m_split_address_reg = 0xff;
+	m_memory_encoding_reg = 0xff;
+
+	m_memory_split_active = false;
+	m_memory_split_base = 0;
+	m_split_size = 0;
+
+	m_sram = make_unique_clear<uint8_t[]>(m_sram_size);
+	m_nvram->set_base(m_sram.get(), m_sram_size);
+	save_pointer(NAME(m_sram), m_sram_size);
+
+	// Map RAM above 1MB. Don't map RAM between 640K and 1MB.
+	if (m_ram->size() > 0x100000)
+	{
+		LOG("%s: install RAM\n", FUNCNAME);
+		address_space& space = m_maincpu->space(AS_PROGRAM);
+		offs_t ram_limit = m_ram->size() - 0x100000;
+		space.install_ram(0x100000, 0x100000 + ram_limit - 1, m_ram->pointer() + 0x100000);
+	}
+}
+
+void ps2_m80_t1_mb_device::device_reset()
+{
+	ps2_mb_device::device_reset();
+	
+    if (m_memory_split_active) disable_memory_split();
+	m_memory_encoding_reg = 0b11111111;
+    update_memory_split();
+}
+
+void ps2_m80_t1_mb_device::disable_memory_split()
+{
+	LOG("%s: Disabling memory split at %06X\n", FUNCNAME, m_memory_split_base);
+
+    address_space& space = m_maincpu->space(AS_PROGRAM);
+
+    space.unmap_readwrite(m_memory_split_base, m_memory_split_base + m_split_size - 1);
+	m_memory_split_active = false;
+}
+
+void ps2_m80_t1_mb_device::device_add_mconfig(machine_config &config)
+{
+	ps2_mb_device::device_add_mconfig(config);
+
+	add_mca32(config);
+	add_dmac_72x7377(config);
+	add_southbridge_72x8299(config);
+
+	MCA16_SLOT(config, m_mcaslot[0], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[1], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[2], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA16_SLOT(config, m_mcaslot[3], 0, m_mcabus, pc_mca16_cards, nullptr, false);
+	MCA32_SLOT(config, m_mcaslot[4], 0, m_mcabus, pc_mca16_cards, nullptr, false);   // 32
+	MCA16_SLOT(config, m_mcaslot[5], 0, m_mcabus, pc_mca16_cards, nullptr, false);   // with AVE
+	MCA32_SLOT(config, m_mcaslot[6], 0, m_mcabus, pc_mca16_cards, nullptr, false);   // 32
+	MCA32_SLOT(config, m_mcaslot[7], 0, m_mcabus, pc_mca32_cards, nullptr, false);   // 32
+}
+
+void ps2_m80_t1_mb_device::device_config_complete()
+{
+	ps2_mb_device::device_config_complete();
+}
+
+uint8_t ps2_m80_t1_mb_device::split_address_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s\n", FUNCNAME);
+	return m_split_address_reg;
+}
+
+void ps2_m80_t1_mb_device::split_address_w(uint8_t data)
+{
+	if(!machine().side_effects_disabled()) LOGPOS("*** %s: place split memory at %06X (%02X)\n", FUNCNAME, data * 0x100000, data & 0xf);
+	m_split_address_reg = data;
+
+	update_memory_split();
+}
+
+uint8_t ps2_m80_t1_mb_device::memory_encoding_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s\n", FUNCNAME);
+	return m_memory_encoding_reg;
+}
+
+void ps2_m80_t1_mb_device::memory_encoding_w(uint8_t data)
+{
+	if(!machine().side_effects_disabled()) LOGPOS("*** %s: %02X (split? %d; split 1MB at %d; ROMEN %d)\n", FUNCNAME, data,
+		!BIT(data, 3),
+		BIT(data, 2) ? 512 : 640,
+		BIT(data, 1));
+
+	m_memory_encoding_reg = data;
+
+	update_memory_split();
+}
+
+void ps2_m80_t1_mb_device::update_memory_split()
+{
+	/*
+		Type 1 motherboard memory split configuration is as follows:
+		- The configuration of the first 1MB of memory is configured by the MER at I/O port 0E1h.
+		- Bit 3
+			- When asserted:	Memory between 512K or 640K is disabled.
+			- When cleared:		Memory above 512K or 640K and below 1M is moved to the location specified in the Split Address Register.
+		- Bit 2
+			- When asserted: 	There is 512K of contiguous memory at 00000h to 7FFFFh.
+			- When cleared:  	There is 640K of contiguous memory at 00000h to 9FFFFh.
+		- Bit 1
+			- When asserted: 	Address space E0000h to FFFFFh is mapped to the BIOS.
+			- When cleared:  	Address space E0000h to FFFFFh is mapped to RAM.
+								Everything between 512K or 640K and 896K is unused.
+	 */
+
+	//LOGPOS("%s: memory encoding reg %02X\n", FUNCNAME, m_memory_encoding_reg);
+
+	static offs_t current_memory_split_end = 0x9ffff;
+
+	// Is shadow RAM enabled at entry into update_memory_split()?
+	static bool shadow_ram_enabled = false;
+	// Is the memory split enabled at entry into update_memory_split()?
+	static bool high_memory_enabled = false;
+
+	address_space& space = m_maincpu->space(AS_PROGRAM);
+
+	// We've just entered this function. Is the memory split enabled?
+	if (high_memory_enabled)
+	{
+		// Unmap the existing block if so.
+		//LOGPOS("disabling split at %06X-%06X\n", m_memory_split_base, m_memory_split_base+m_split_size-1);
+		space.unmap_readwrite(m_memory_split_base, m_memory_split_base + m_split_size - 1);
+        high_memory_enabled = false;
+	}
+
+	// Step 1: Always map low memory.
+	offs_t conventional_memory_split = BIT(m_memory_encoding_reg, 2) ? 0x7ffff : 0x9ffff;
+	space.unmap_readwrite(0, current_memory_split_end);
+	space.install_ram(0, conventional_memory_split, m_ram->pointer());
+
+	// Step 2: Are we mapping ROM?
+	if (BIT(m_memory_encoding_reg, 1))
+	{
+		// Asserted: E0000h is still the BIOS.
+		if(shadow_ram_enabled)
+		{
+			//LOGPOS("mapping ROM at %06X-%06X\n", 0xe0000, 0xfffff);
+			// RAM to ROM.
+			space.unmap_readwrite(0xe0000, 0xfffff);
+			space.install_rom(0xe0000, 0xfffff, memregion(":bios")->base());
+		}
+		else
+		{
+			// ROM to ROM.
+		}
+	}
+	else
+	{
+		// Cleared: E0000h-FFFFFh is RAM.
+		if(shadow_ram_enabled)
+		{
+			// RAM to RAM.
+		}
+		else
+		{
+			//LOGPOS("mapping RAM at 0xe0000, 0xfffff\n");
+			// ROM to RAM.
+			space.unmap_read(0xe0000, 0xfffff);
+			space.install_ram(0xe0000, 0xfffff, m_ram->pointer() + conventional_memory_split + 1);
+		}
+	}
+
+	current_memory_split_end = conventional_memory_split;
+	shadow_ram_enabled = BIT(m_memory_encoding_reg, 1);
+
+	// Are we disabling the split?
+	if(!BIT(m_memory_encoding_reg, 3))
+	{
+        if(high_memory_enabled)
+        {
+            // On to on.
+        }
+        else
+        {
+            // Off to on.
+            m_memory_split_base = (m_split_address_reg & 0x0F) * 0x100000;
+            m_split_size = BIT(m_memory_encoding_reg, 2) ? 0x80000 : 0x60000;
+
+            assert(m_memory_split_base != 0);
+
+            LOGPOS("%s: Memory split now %06X-%06X\n", FUNCNAME, m_memory_split_base, m_memory_split_base + m_split_size);
+
+            if (m_ram->size() > 0xa0000)
+            {
+                offs_t ram_limit = m_memory_split_base + m_split_size;
+                space.install_ram(m_memory_split_base, ram_limit-1, m_ram->pointer() + 0x100000 - m_split_size);
+            }
+        }
+	}
+	else
+	{
+        if(high_memory_enabled)
+        {
+            // On to off.
+            //LOGPOS("%s: Memory split now disabled\n", FUNCNAME);
+            offs_t ram_limit = m_memory_split_base + m_split_size;
+		    space.unmap_readwrite(m_memory_split_base, ram_limit-1);
+        }
+        else
+        {
+            // Off to off.
+        }
+	}
+
+	high_memory_enabled = !BIT(m_memory_encoding_reg, 3);
+}
+
+uint8_t ps2_m80_t1_mb_device::planar_pos_r(offs_t offset)
+{
+	LOGPOS("%s: O:%02X\n", FUNCNAME, offset);
+
+	switch(offset)
+	{
+		case MCABus::POS::ADAPTER_ID_LO: return m_planar_id & 0xFF;
+		case MCABus::POS::ADAPTER_ID_HI: return (m_planar_id & 0xFF00) >> 8;
+		case MCABus::POS::OPTION_SELECT_DATA_1: return m_io_controller->system_board_io_r();
+		case MCABus::POS::OPTION_SELECT_DATA_2:
+		{
+			if      (m_ram->size() == 0x100000) return 0b00001100;
+			else if (m_ram->size() == 0x200000) return 0b00000000;
+			else    fatalerror("RAM size not supported by planar");
+		}
+		default: return 0xFF;
+	}
+}
+
+void ps2_m80_t1_mb_device::planar_pos_w(offs_t offset, uint8_t data)
+{
+	switch(offset)
+	{
+		case 2:
+		// System Board I/O Byte.
+			LOGPOS("PS/2 system board I/O enable bits now %02X\n", data);
+			m_io_controller->system_board_io_w(data);
+			break;
+		case 3:
+		// Memory Control Register
+			LOGPOS("PS/2 memory control register now %02X\n", data);
+			m_memory_control = data;
+			
+			m_timer_slow_refresh->enable(0);
+			m_timer_fast_refresh->enable(0);
+
+			if(BIT(m_memory_control, 1))
+			{
+				LOGPOS("PS/2 slow refresh\n");
+				m_timer_slow_refresh->enable(1);
+			}
+			else
+			{
+				LOGPOS("PS/2 fast refresh\n");
+				m_timer_fast_refresh->enable(1);
+			}
+
+			break;
+		default:
+			LOGPOS("Unhandled planar POS write: reg %02X data %02X\n", offset, data);
+	}
+}
+
+/************************************************************/
+/* Type 2 planar											*/
+/************************************************************/
+void ps2_m80_t2_mb_device::device_start()
+{
+	ps2_m80_t1_mb_device::device_start();
+}
+
+void ps2_m80_t2_mb_device::device_reset()
+{
+	ps2_mb_device::device_reset();
+	
+	m_maincpu->space(AS_PROGRAM).install_write_handler(0xe0000, 0xfffff, write8sm_delegate(*this, FUNC(ps2_m80_t2_mb_device::shadow_bios_w)));
+
+    if (m_memory_split_active) disable_memory_split();
+	m_memory_encoding_reg = 0b11111111;
+    update_memory_split();
+
+	// Install shadow BIOS write region.
+}
+
+void ps2_m80_t2_mb_device::map(address_map &map)
+{
+	ps2_mb_device::map(map);
+
+	map(0x0061, 0x0061).rw(FUNC(ps2_m80_t2_mb_device::portb_r), FUNC(ps2_m80_t2_mb_device::portb_w));
+	map(0x00e0, 0x00e0).rw(FUNC(ps2_m80_t2_mb_device::split_address_r), FUNC(ps2_m80_t2_mb_device::split_address_w));
+	map(0x00e1, 0x00e1).rw(FUNC(ps2_m80_t2_mb_device::memory_encoding_r), FUNC(ps2_m80_t2_mb_device::memory_encoding_w));
+}
+
+uint8_t ps2_m80_t2_mb_device::planar_pos_r(offs_t offset)
+{
+	LOGPOS("%s: O:%02X\n", FUNCNAME, offset);
+
+	switch(offset)
+	{
+		case MCABus::POS::ADAPTER_ID_LO: return m_planar_id & 0xFF;
+		case MCABus::POS::ADAPTER_ID_HI: return (m_planar_id & 0xFF00) >> 8;
+		case MCABus::POS::OPTION_SELECT_DATA_1: return m_io_controller->system_board_io_r();
+		case MCABus::POS::OPTION_SELECT_DATA_2:
+		{
+			if      (m_ram->size() == 0x200000) return 0b11110010;
+			else if (m_ram->size() == 0x400000) return 0b11111010;
+			else    fatalerror("RAM size not supported by planar");
+		}
+		default: return 0xFF;
+	}
+}
+
+void ps2_m80_t2_mb_device::planar_pos_w(offs_t offset, uint8_t data)
+{
+	switch(offset)
+	{
+		case 2:
+		// System Board I/O Byte.
+			LOGPOS("PS/2 system board I/O enable bits now %02X\n", data);
+			m_io_controller->system_board_io_w(data);
+			break;
+		case 3:
+		// Memory Control Register
+			LOGPOS("PS/2 memory control register now %02X\n", data);
+			m_memory_control = data;
+			
+			m_timer_slow_refresh->enable(0);
+			m_timer_fast_refresh->enable(0);
+
+			if(BIT(m_memory_control, 1))
+			{
+				LOGPOS("PS/2 slow refresh\n");
+				m_timer_slow_refresh->enable(1);
+			}
+			else
+			{
+				LOGPOS("PS/2 fast refresh\n");
+				m_timer_fast_refresh->enable(1);
+			}
+
+			break;
+		default:
+			LOGPOS("Unhandled planar POS write: reg %02X data %02X\n", offset, data);
+	}
+}
+
+uint8_t ps2_m80_t2_mb_device::memory_encoding_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s\n", FUNCNAME);
+	return m_memory_encoding_reg;
+}
+
+void ps2_m80_t2_mb_device::memory_encoding_w(uint8_t data)
+{
+	if(!machine().side_effects_disabled()) LOGPOS("*** %s: %02X (split? %d; split 1MB at %d, ROMEN %d)\n", FUNCNAME, data,
+		!BIT(data, 3),
+		BIT(data, 2) ? 512 : 640,
+		BIT(data, 1));
+
+	m_memory_encoding_reg = data;
+
+	update_memory_split();
+}
+
+uint8_t ps2_m80_t2_mb_device::split_address_r()
+{
+	if(!machine().side_effects_disabled()) LOGPOS("%s\n", FUNCNAME);
+	return m_split_address_reg;
+}
+
+void ps2_m80_t2_mb_device::split_address_w(uint8_t data)
+{
+	// TODO: Type 2 can enable/disable the planar RAM cards with bit 4/bit 5
+
+	if(!machine().side_effects_disabled()) LOGPOS("*** %s: place split memory at %06X (%02X)\n", FUNCNAME, (data & 0xf) * 0x100000, data & 0xf);
+	m_split_address_reg = data;
+
+	update_memory_split();
+}
+
+uint8_t ps2_m80_t2_mb_device::shadow_bios_r(offs_t offset)
+{
+	// A read to this region always goes to the top of onboard RAM.
+	// LOGSHADOW("%s: reading %04X from %06X\n", FUNCNAME, m_ram->read(offset+0xe0000), offset+0xe0000);
+
+	return m_ram->read(offset+0xe0000);
+}
+
+void ps2_m80_t2_mb_device::shadow_bios_w(offs_t offset, uint8_t data)
+{
+	// A write to this region always goes to the top of onboard RAM.
+	// LOGSHADOW("%s: writing %04X to %06X\n", FUNCNAME, data, offset+0xe0000);
+
+	m_ram->write(offset+0xe0000, data);
+}
+
+void ps2_m80_t2_mb_device::update_memory_split()
+{
+	/*
+		Type 2 motherboard memory split configuration is as follows:
+		- The configuration of the first 1MB of memory is configured by the MER at I/O port 0E1h.
+		- Bit 3
+			- When asserted:	Memory between 512K or 640K is disabled.
+			- When cleared:		Memory above 512K or 640K and below 1M is moved to the location specified in the Split Address Register.
+		- Bit 2
+			- When asserted: 	There is 512K of contiguous memory at 00000h to 7FFFFh.
+			- When cleared:  	There is 640K of contiguous memory at 00000h to 9FFFFh.
+		- Bit 1
+			- When asserted: 	Address space E0000h to FFFFFh is mapped to the BIOS.
+			- When cleared:  	Address space E0000h to FFFFFh is mapped to RAM.
+			- In either case, writes to E0000h-FFFFFh are always mapped to the top 128K of the split memory.
+	 */
+
+	//LOGPOS("%s: memory encoding reg %02X\n", FUNCNAME, m_memory_encoding_reg);
+
+	static offs_t current_memory_split_end = 0x9ffff;
+
+	// Is the memory split enabled at entry into update_memory_split()?
+	static bool high_memory_enabled = false;
+
+	address_space& space = m_maincpu->space(AS_PROGRAM);
+
+	// We've just entered this function. Is the memory split enabled?
+	if (high_memory_enabled)
+	{
+		// Unmap the existing block if so.
+		//LOGPOS("disabling split at %06X-%06X\n", m_memory_split_base, m_memory_split_base+m_split_size-1);
+		space.unmap_readwrite(m_memory_split_base, m_memory_split_base + m_split_size - 1);
+        high_memory_enabled = false;
+	}
+
+	// Step 1: Always map low memory.
+	offs_t conventional_memory_split = BIT(m_memory_encoding_reg, 2) ? 0x7ffff : 0x9ffff;
+	space.unmap_readwrite(0, current_memory_split_end);
+	space.install_ram(0, conventional_memory_split, m_ram->pointer());
+
+	// Step 2: Are we mapping ROM?
+	if(BIT(m_memory_encoding_reg, 1))
+	{
+		// ROMEN 1: Reads go to ROM, writes go to RAM.
+		LOGSHADOW("%s: reads to ROM, writes to RAM\n", FUNCNAME);
+		space.unmap_readwrite(0xe0000, 0xfffff);
+		space.install_rom(0xe0000, 0xfffff, memregion(":bios")->base());
+		space.install_write_handler(0xe0000, 0xfffff, write8sm_delegate(*this, FUNC(ps2_m80_t2_mb_device::shadow_bios_w)));
+	}
+	else
+	{
+		// ROMEN 0: Reads go to RAM, writes go nowhere.
+		LOGSHADOW("%s: reads to RAM, writes disabled\n", FUNCNAME);
+		space.unmap_readwrite(0xe0000, 0xfffff);
+		space.install_read_handler(0xe0000, 0xfffff, read8sm_delegate(*this, FUNC(ps2_m80_t2_mb_device::shadow_bios_r)));
+	}
+
+	current_memory_split_end = conventional_memory_split;
+
+	// Are we disabling the split?
+	if(!BIT(m_memory_encoding_reg, 3))
+	{
+        if(high_memory_enabled)
+        {
+            // On to on.
+        }
+        else
+        {
+            // Off to on.
+            m_memory_split_base = (m_split_address_reg & 0x0F) * 0x100000;
+ 
+            m_split_size = BIT(m_memory_encoding_reg, 2) ? 0x60000 : 0x40000;
+
+            assert(m_memory_split_base != 0);
+
+            LOGPOS("%s: Memory split now %06X-%06X\n", FUNCNAME, m_memory_split_base, m_memory_split_base + m_split_size);
+
+            if (m_ram->size() > 0xa0000)
+            {
+                offs_t ram_limit = m_memory_split_base + m_split_size;
+                space.install_ram(m_memory_split_base, ram_limit-1, m_ram->pointer() + 0x100000 - 0x20000 - m_split_size);
+            }
+        }
+	}
+	else
+	{
+        if(high_memory_enabled)
+        {
+            // On to off.
+            //LOGPOS("%s: Memory split now disabled\n", FUNCNAME);
+            offs_t ram_limit = m_memory_split_base + m_split_size;
+		    space.unmap_readwrite(m_memory_split_base, ram_limit-1);
+        }
+        else
+        {
+            // Off to off.
+        }
+	}
+
+	high_memory_enabled = !BIT(m_memory_encoding_reg, 3);
+}

--- a/src/mame/pc/ps2m80.h
+++ b/src/mame/pc/ps2m80.h
@@ -1,0 +1,100 @@
+#ifndef MAME_MACHINE_PS2M80_H
+#define MAME_MACHINE_PS2M80_H
+
+#include "machine/ibmps2.h"
+
+class ps2_m80_t1_mb_device : public ps2_mb_device
+{
+public:
+	ps2_m80_t1_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock, uint16_t sram_size, uint16_t pos_id)
+		: ps2_mb_device(mconfig, tag, owner, clock, sram_size, pos_id, true)
+	{
+	}
+
+	ps2_m80_t1_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+		: ps2_mb_device(mconfig, tag, owner, clock, 0x800, 0xfeff, true)
+	{
+	}
+
+	virtual void map(address_map &map) override;
+
+	void 	irq6_w(int state);
+	
+protected:
+	virtual void device_start() override;
+	virtual void device_reset() override;
+	virtual void device_add_mconfig(machine_config &config) override;
+    virtual void device_config_complete() override;
+
+    virtual uint8_t memory_encoding_r();
+    virtual void    memory_encoding_w(uint8_t data);
+
+    virtual uint8_t split_address_r();
+    virtual void    split_address_w(uint8_t data);
+
+	virtual void 	update_memory_split();
+
+	virtual uint8_t planar_pos_r(offs_t offset) override;
+	virtual void 	planar_pos_w(offs_t offset, uint8_t data) override;
+
+    void    disable_memory_split();
+    void    enable_memory_split();
+
+	uint8_t m_split_address_reg;
+	uint8_t m_memory_encoding_reg;
+
+	bool m_memory_split_active;
+	uint32_t m_memory_split_base;
+	uint32_t m_split_size;
+
+private:
+
+};
+
+class ps2_m80_t2_mb_device : public ps2_m80_t1_mb_device
+{
+public:
+	ps2_m80_t2_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+		: ps2_m80_t1_mb_device(mconfig, tag, owner, clock, 0x800, 0xfdff)
+	{
+	}
+
+	virtual void	map(address_map &map) override;
+
+protected:
+	virtual void 	device_start() override;
+	virtual void 	device_reset() override;
+
+	virtual uint8_t planar_pos_r(offs_t offset) override;
+	virtual void 	planar_pos_w(offs_t offset, uint8_t data) override;
+
+	virtual void 	update_memory_split() override;
+
+    virtual uint8_t memory_encoding_r() override;
+    virtual void    memory_encoding_w(uint8_t data) override;
+
+    virtual uint8_t split_address_r() override;
+    virtual void    split_address_w(uint8_t data) override;
+
+private:
+	uint8_t			shadow_bios_r(offs_t offset);
+	void			shadow_bios_w(offs_t offset, uint8_t data);
+};
+
+class ps2_m80_t3_mb_device : public ps2_m80_t1_mb_device
+{
+public:
+	ps2_m80_t3_mb_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+		: ps2_m80_t1_mb_device(mconfig, tag, owner, clock, 0x2000, 0xfff9)
+	{
+	}
+protected:
+
+private:
+};
+
+DECLARE_DEVICE_TYPE(PS2_M80_T1_MB, ps2_m80_t1_mb_device)
+DECLARE_DEVICE_TYPE(PS2_M80_T2_MB, ps2_m80_t2_mb_device)
+DECLARE_DEVICE_TYPE(PS2_M80_T3_MB, ps2_m80_t3_mb_device)
+
+#endif


### PR DESCRIPTION
This is the biggest set of changes I've ever pushed so I don't know when I should be looking to put this PR in. Mostly looking for feedback atm.

- Promote several PS/2 systems from skeleton to not working.
- Support for a bunch of IBM ASICs that are used on first-gen PS/2 hardware.
- Add MCA bus and several cards, including onboard devices (FDC, UART, LPT, VGA) and cards (an example dual serial card and a skeleton SCSI controller)
- The MCA implementation is good enough for the Model 50's reference disk to autoconfigure the hardware.

The Model 50 is in the best shape since it has the simplest hardware of the lot. It boots to DOS and runs the Model 50 reference disk.
The Model 80 is somewhat worse, since it has weird memory hardware I still need to work out.
I haven't started on any others, the drivers are skeletons documenting the planar layout.

Problems remain:
- Lots of POST errors. CMOS configuration doesn't seem to stick all the way.
- Only the Model 50 and Model 80 are really supported at the moment. The rest are skeletons.
- No 32-bit MCA support.
- Lots of other things.