### PR TITLE
Fixed breakage from recent 6840PTM changes.

### DIFF
--- a/src/mame/matsushita/duet16.cpp
+++ b/src/mame/matsushita/duet16.cpp
@@ -391,7 +391,7 @@ void duet16_state::duet16(machine_config &config)
 	bgpit.out_handler<2>().set("kbusart", FUNC(i8251_device::write_txc));
 	bgpit.out_handler<2>().append("kbusart", FUNC(i8251_device::write_rxc));
 
-	ptm6840_device &itm(PTM6840(config, "itm", 0));
+	ptm6840_device &itm(PTM6840(config, "itm", 8_MHz_XTAL / 8));
 	itm.set_external_clocks(0.0, 0.0, (8_MHz_XTAL / 8).dvalue()); // C3 = 1MHz
 	itm.o3_callback().set("itm", FUNC(ptm6840_device::set_c1)); // C1 = C2 = O3
 	itm.o3_callback().append("itm", FUNC(ptm6840_device::set_c2));


### PR DESCRIPTION
-duet16: Added external PTM clock. [Ryan Holtz]

-6840ptm: Fixed one-shot behavior and timer enabling when switching to internal clock. [Ryan Holtz]