### PR TITLE
Fixing fs::cbmdos_image::enumerate_f() to properly look for single density (instead of double)

### DIFF
--- a/src/lib/formats/fs_cbmdos.cpp
+++ b/src/lib/formats/fs_cbmdos.cpp
@@ -111,7 +111,7 @@ const char *fs::cbmdos_image::description() const
 
 void fs::cbmdos_image::enumerate_f(floppy_enumerator &fe, u32 form_factor, const std::vector<u32> &variants) const
 {
-	if (has(form_factor, variants, floppy_image::FF_525, floppy_image::SSDD))
+	if (has(form_factor, variants, floppy_image::FF_525, floppy_image::SSSD))
 	{
 		fe.add(FLOPPY_D64_FORMAT, 174848, "d64_cbmdos_35", "D64 CBMDOS single-sided 35 tracks");
 		fe.add(FLOPPY_D64_FORMAT, 192256, "d64_cbmdos_40", "D64 CBMDOS single-sided 40 tracks");


### PR DESCRIPTION
This problem was identified because the file system didn't properly show up when the 'c64' driver was run, and this seems to be the correct fix.  The part of this that confuses me is that if this defect was preventing the CBMDOS fs from showing up under c64, why don't the CoCo file systems have the same problem?  Both fs_coco_rsdos.cpp and fs_coco_os9.cpp specify (seemingly incorrectly) SSDD.